### PR TITLE
Session affinity scorer

### DIFF
--- a/pkg/scheduling/plugins/scorer/session_affinity.go
+++ b/pkg/scheduling/plugins/scorer/session_affinity.go
@@ -61,6 +61,7 @@ func (s *SessionAffinity) Score(ctx *types.SchedulingContext, pods []types.Pod) 
 // PostResponse sets the session header on the response sent to the client
 // TODO: this should be using a cookie and ensure not overriding any other
 // cookie values if present.
+// Tracked in https://github.com/neuralmagic/llm-d-inference-scheduler/issues/28
 func (s *SessionAffinity) PostResponse(ctx *types.SchedulingContext, pod types.Pod) {
 	ctx.MutatedHeaders[sessionTokenHeader] = base64.StdEncoding.EncodeToString([]byte(pod.GetPod().NamespacedName.String()))
 }


### PR DESCRIPTION
Moved almost as is.
Note the comment on the use of header in `PostResponse()` method (also in #28) 
Fix #2 