### PR TITLE
[bug] fix CONTAINER_TOOL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,14 @@ IMAGE_TAG_BASE ?= quay.io/llm-d/$(PROJECT_NAME)
 IMG = $(IMAGE_TAG_BASE):$(DEV_VERSION)
 NAMESPACE ?= hc4ai-operator
 
-CONTAINER_TOOL := $(shell command -v docker >/dev/null 2>&1 && echo docker || command -v podman >/dev/null 2>&1 && echo podman || echo "")
+CONTAINER_TOOL := $(shell \
+	if command -v docker >/dev/null 2>&1; then \
+		echo docker; \
+	elif command -v podman >/dev/null 2>&1; then \
+		echo podman; \
+	else \
+		echo ""; \
+	fi)
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
 PLATFORMS ?= linux/amd64 # linux/arm64 # linux/s390x,linux/ppc64le
 


### PR DESCRIPTION
The original line seems fine at a glance, but `&&` and `||` have lower precedence than  expected in shell logic.
In some shells or environments, `command -v podman` might still run even after docker test succeeds, due to how the make shell handles command substitutions. Also, in a Makefile, using shell inside `$(shell ...)` can sometimes interpret spaces/newlines in odd ways.

Consequently, this results (on my Ubuntu, bash) in `CONTAINER_TOOL` set to `docker podman` even though only docker is installed.

CC: @clubanderson in case the same expression appears across repo's