### PR TITLE
Update to latest upstream-sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 toolchain go1.24.2
 
-replace sigs.k8s.io/gateway-api-inference-extension => github.com/neuralmagic/gateway-api-inference-extension v0.0.0-20250507165421-b1a63e386383
+replace sigs.k8s.io/gateway-api-inference-extension => github.com/neuralmagic/gateway-api-inference-extension v0.0.0-20250508070031-fd1ddfa1c42e
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/neuralmagic/gateway-api-inference-extension v0.0.0-20250507165421-b1a63e386383 h1:XuMOWYDWNRuk3lbTtpUooDGmblFot5OkFQD01y1Ib4c=
-github.com/neuralmagic/gateway-api-inference-extension v0.0.0-20250507165421-b1a63e386383/go.mod h1:wMmJREvsRwqKlhMEmsAHxwZpbsP6UYdffgumHq298rE=
+github.com/neuralmagic/gateway-api-inference-extension v0.0.0-20250508070031-fd1ddfa1c42e h1:Elmase7enyqesfPAirT6LWrnl0DafFjINDQVnxDTRnU=
+github.com/neuralmagic/gateway-api-inference-extension v0.0.0-20250508070031-fd1ddfa1c42e/go.mod h1:qRPXOlVZzeSDeh+ExJqF/h4Tv5cus8SLhE+Qnpe882Y=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=

--- a/pkg/scheduling/plugins/scorer/load_aware_scorer_test.go
+++ b/pkg/scheduling/plugins/scorer/load_aware_scorer_test.go
@@ -89,7 +89,6 @@ func TestLoadBasedScorer(t *testing.T) {
 					},
 					Score: 0.5,
 				},
-				MutatedHeaders: map[string]string{},
 			},
 		},
 	}

--- a/pkg/scheduling/plugins/scorer/session_affinity.go
+++ b/pkg/scheduling/plugins/scorer/session_affinity.go
@@ -63,5 +63,5 @@ func (s *SessionAffinity) Score(ctx *types.SchedulingContext, pods []types.Pod) 
 // cookie values if present.
 // Tracked in https://github.com/neuralmagic/llm-d-inference-scheduler/issues/28
 func (s *SessionAffinity) PostResponse(ctx *types.SchedulingContext, pod types.Pod) {
-	ctx.MutatedHeaders[sessionTokenHeader] = base64.StdEncoding.EncodeToString([]byte(pod.GetPod().NamespacedName.String()))
+	ctx.Req.Headers[sessionTokenHeader] = base64.StdEncoding.EncodeToString([]byte(pod.GetPod().NamespacedName.String()))
 }


### PR DESCRIPTION
- Removed ScheduleWithContext
- tests do NOT check headers yet, as they moved to the Request.Headers object