### PR TITLE
fix: nodeport service overwritten

### DIFF
--- a/deploy/environments/dev/kind-istio/services.yaml
+++ b/deploy/environments/dev/kind-istio/services.yaml
@@ -7,7 +7,7 @@ metadata:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: inference-gateway
     istio.io/enable-inference-extproc: "true"
-  name: inference-gateway-istio
+  name: inference-gateway-istio-nodeport
   namespace: default
 spec:
   type: NodePort


### PR DESCRIPTION
The `NodePort` service we provide for our Inference Gateway was getting clobbered by the control-plane. This changes the name so as to avoid that.