### PR TITLE
fixing cross builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ ifndef KV_CACHE_MANAGER_TOKEN
 	$(error "KV_CACHE_MANAGER_TOKEN is not set")
 endif
 	$(CONTAINER_TOOL) build \
+		--platform $(TARGETOS)/$(TARGETARCH) \
  		--build-arg TARGETOS=$(TARGETOS) \
 		--build-arg TARGETARCH=$(TARGETARCH) \
 		--build-arg KV_CACHE_MANAGER_TOKEN=$(KV_CACHE_MANAGER_TOKEN) \


### PR DESCRIPTION
Cross builds were failing in the process of rebuilding from my ENV when adjusting blocksize to test prefix aware routing demo.

Issue: `platform` was not specified on the container, so it was pulling `aarch64` base images. Then all the go build stuff would target linux/amd64 on top of an `aarch64` image causing cross build issues. When specifying same platform to the image builds we get success.

Tested with:
```bash
GIT_NM_USER=*** KV_CACHE_MANAGER_TOKEN=ghp_*** TARGETOS=linux TARGETARCH=amd64 make image-build
```

Builds on mac.