### PR TITLE
Add Redis password support to KV cache scorer

### DIFF
--- a/pkg/scheduling/plugins/scorer/kvcache-aware.go
+++ b/pkg/scheduling/plugins/scorer/kvcache-aware.go
@@ -17,8 +17,9 @@ import (
 const (
 	kvCacheAwareScorerName = "kvcache-aware-scorer"
 
-	kvCacheRedisEnvVar     = "KVCACHE_INDEXER_REDIS_ADDR"
-	huggingFaceTokenEnvVar = "HF_TOKEN"
+	kvCacheRedisEnvVar         = "KVCACHE_INDEXER_REDIS_ADDR"
+	kvCacheRedisPasswordEnvVar = "KVCACHE_INDEXER_REDIS_PWD"
+	huggingFaceTokenEnvVar     = "HF_TOKEN"
 )
 
 // KVCacheAwareScorer uses the KVCacheIndexer to score pods based on KVCache
@@ -40,6 +41,11 @@ func NewKVCacheAwareScorer(ctx context.Context) (plugins.Scorer, error) {
 		config.KVBlockIndexerConfig.RedisAddr = redisAddr
 	} else {
 		return nil, fmt.Errorf("environment variable %s is not set", kvCacheRedisEnvVar)
+	}
+
+	redisPassword := os.Getenv(kvCacheRedisPasswordEnvVar)
+	if redisPassword != "" {
+		config.KVBlockIndexerConfig.RedisPassword = redisAddr
 	}
 
 	hfToken := os.Getenv(huggingFaceTokenEnvVar)


### PR DESCRIPTION
Introduced handling for a new environment variable `KVCACHE_INDEXER_REDIS_PWD` to enable optional Redis password configuration. This improves flexibility for connecting to secured Redis instances.