### PR TITLE
[Build]: Update clean-env-dev-kind target  in Makefile and fix vllm-sim image version 

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,7 +92,7 @@ make env-dev-kind
 ```
 
 This will build images with your recent changes and load the new images to the
-cluster. By default the image tag will be `dev`. It will also load llm-d-inference-sim, using a tag of `dev` by default.
+cluster. By default the image tag will be `dev`. It will also load `llm-d-inference-sim` image.
 
 **NOTE:** The built image tag can be specified via the `EPP_TAG` environment variable so it is used in the deployment. For example:
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-integration: download-tokenizer
 post-deploy-test: ## Run post deployment tests
 	echo Success!
 	@echo "Post-deployment tests passed."
-	
+
 .PHONY: lint
 lint: check-golangci-lint ## Run lint
 	@printf "\033[33;1m==== Running linting ====\033[0m\n"
@@ -138,7 +138,7 @@ install-k8s: check-kubectl check-kustomize check-envsubst ## Install on Kubernet
 	echo "Kubernetes installation complete."; \
 	echo "To use the app, run:"; \
 	echo "alias $(PROJECT_NAME)='kubectl exec -n $(NAMESPACE) -it $$POD -- /app/$(PROJECT_NAME)'"
-	
+
 .PHONY: uninstall-k8s
 uninstall-k8s: check-kubectl check-kustomize check-envsubst ## Uninstall from Kubernetes
 	export PROJECT_NAME=${PROJECT_NAME}
@@ -165,7 +165,7 @@ install-openshift: check-kubectl check-kustomize check-envsubst ## Install on Op
 	@POD=$$(kubectl get pod -l app=$(PROJECT_NAME)-statefulset -n $(NAMESPACE) -o jsonpath='{.items[0].metadata.name}'); \
 	echo "OpenShift installation complete."; \
 	echo "To use the app, run:"; \
-	echo "alias $(PROJECT_NAME)='kubectl exec -n $(NAMESPACE) -it $$POD -- /app/$(PROJECT_NAME)'" 
+	echo "alias $(PROJECT_NAME)='kubectl exec -n $(NAMESPACE) -it $$POD -- /app/$(PROJECT_NAME)'"
 
 .PHONY: uninstall-openshift
 uninstall-openshift: check-kubectl check-kustomize check-envsubst ## Uninstall from OpenShift
@@ -213,7 +213,7 @@ check-tools: \
   check-envsubst \
   check-container-tool \
   check-kubectl \
-  check-buildah 
+  check-buildah
 	@echo "✅ All required tools are installed."
 
 .PHONY: check-go
@@ -297,3 +297,8 @@ env-dev-kind: image-build
 	IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
 	EPP_TAG=$(EPP_TAG) \
 		./scripts/kind-dev-env.sh
+
+.PHONY: clean-env-dev-kind
+clean-env-dev-kind: check-kubectl check-kustomize check-envsubst
+	@echo "INFO: cleaning up kind cluster $(KIND_CLUSTER_NAME)"
+	kind delete cluster --name $(KIND_CLUSTER_NAME)

--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,6 @@ env-dev-kind: image-build
 		./scripts/kind-dev-env.sh
 
 .PHONY: clean-env-dev-kind
-clean-env-dev-kind: check-kubectl check-kustomize check-envsubst
+clean-env-dev-kind:
 	@echo "INFO: cleaning up kind cluster $(KIND_CLUSTER_NAME)"
 	kind delete cluster --name $(KIND_CLUSTER_NAME)

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -26,7 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${VLLM_SIMULATOR_IMAGE:=llm-d-inference-sim}"
 
 # Set a default VLLM_SIMULATOR_TAG if not provided
-export VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-dev}"
+export VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-v0.1.0}"
 
 # Set a default EPP_IMAGE if not provided
 : "${EPP_IMAGE:=llm-d-inference-scheduler}"


### PR DESCRIPTION
This PR includes:
  - Add clean-env-dev-kind target to the makefile
  - Fix vllm-sim image version (use the official one-dev is not compiled from this git)
  That makes the target ```env-dev-kind``` run properly.