### PR TITLE
DEVELOPMENT.md minor fixes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,7 @@ Documentation for developing the inference scheduler.
 - [Golang] `v1.24`+
 - [Docker] (or [Podman])
 - [Kubernetes in Docker (KIND)]
+- [Kustomize]
 
 [Make]:https://www.gnu.org/software/make/
 [Golang]:https://go.dev/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,13 +14,14 @@ Documentation for developing the inference scheduler.
 [Docker]:https://www.docker.com/
 [Podman]:https://podman.io/
 [Kubernetes in Docker (KIND)]:https://github.com/kubernetes-sigs/kind
+[Kustomize]:https://kubectl.docs.kubernetes.io/installation/kustomize/
 
 ## Kind Development Environment
 
-> **WARNING**: This current requires you to have manually built the vllm
+> **WARNING**: This currently requires you to have manually built the vllm
 > simulator separately on your local system. In a future iteration this will
 > be handled automatically and will not be required. The tag for the simulator
-> currently needs to be `0.0.4`.
+> currently needs to be `v0.1.0`.
 
 You can deploy the current scheduler with a Gateway API implementation into a
 [Kubernetes in Docker (KIND)] cluster locally with the following:
@@ -84,7 +85,7 @@ access the inference gatyeway.
 
 ### Development Cycle
 
-To test your changes to `llm-d-inferernce-scheduler` in this environment, make your changes locally
+To test your changes to `llm-d-inference-scheduler` in this environment, make your changes locally
 and then re-run the deployment:
 
 ```console


### PR DESCRIPTION
Hello, I'm fairly new to the llm-d community but found some small issues trying to get started. Upon following the DEVELOPMENT.md instructions, I ran into a few issues running `make env-dev-kind`. Namely, on a Fedora 41 system, I found that:
- Kustomize requires an explicit installation aside from kubectl or else you would get an error saying kustomize was not found
- `llm-d-inference-sim` by default required a tag of `v0.1.0` as shown here after having built a sim docker image with the tag `0.0.4`:
```+ kind --name llm-d-inference-scheduler-dev load docker-image ghcr.io/llm-d/llm-d-inference-sim:v0.1.0
ERROR: image: "ghcr.io/llm-d/llm-d-inference-sim:v0.1.0" not present locally
make: *** [Makefile:291: env-dev-kind] Error 1
```