### PR TITLE
Prevent auto updates of GIE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     labels:
       - "dependencies"
       - "release-note-none"
+    ignore:
+      - dependency-name: "sigs.k8s.io/gateway-api-inference-extension"
     groups:
       go-dependencies:
         patterns:


### PR DESCRIPTION
GIE is undergoing major changes so ensure updates are not done automatically until we settle on releases.
While both refer to the GIE, the `ignore` configuration takes precedence over `groups` section
