### PR TITLE
build: add support for development on kubernetes cluster

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,16 +19,10 @@ Documentation for developing the inference scheduler.
 
 ## Kind Development Environment
 
-> [!Warning]
-> This currently requires you to have manually built the vllm
-> simulator separately on your local system. In a future iteration this will
-> be handled automatically and will not be required. The tag for the simulator
-> currently needs to be `v0.1.0`.
+The following deployment creates a [Kubernetes in Docker (KIND)] cluster with an inference scheduler using a Gateway API implementation, connected to the vLLM simulator.
+To run the deployment, use the following command:
 
-You can deploy the current scheduler with a Gateway API implementation into a
-[Kubernetes in Docker (KIND)] cluster locally with the following:
-
-```console
+```bash
 make env-dev-kind
 ```
 
@@ -36,17 +30,20 @@ This will create a `kind` cluster (or re-use an existing one) using the system's
 local container runtime and deploy the development stack into the `default`
 namespace.
 
+> [!NOTE]
+> You can download the image locally using `docker pull ghcr.io/llm-d/llm-d-inference-sim:latest`, and the script will load it from your local Docker registry.
+
 There are several ways to access the gateway:
 
 **Port forward**:
 
-```console
+```bash
 $ kubectl --context llm-d-inference-scheduler-dev port-forward service/inference-gateway 8080:80
 ```
 
 **NodePort**
 
-```console
+```bash
 # Determine the k8s node address
 $ kubectl --context llm-d-inference-scheduler-dev get node -o yaml | grep address
 # The service is accessible over port 80 of the worker IP address.
@@ -54,7 +51,7 @@ $ kubectl --context llm-d-inference-scheduler-dev get node -o yaml | grep addres
 
 **LoadBalancer**
 
-```console
+```bash
 # Install and run cloud-provider-kind:
 $ go install sigs.k8s.io/cloud-provider-kind@latest && cloud-provider-kind &
 $ kubectl --context llm-d-inference-scheduler-dev get service inference-gateway
@@ -63,7 +60,7 @@ $ kubectl --context llm-d-inference-scheduler-dev get service inference-gateway
 
 You can now make requests macthing the IP:port of one of the access mode above:
 
-```console
+```bash
 $ curl -s -w '\n' http://<IP:port>/v1/completions -H 'Content-Type: application/json' -d '{"model":"food-review","prompt":"hi","max_tokens":10,"temperature":0}' | jq
 ```
 
@@ -71,14 +68,15 @@ By default the created inference gateway, can be accessed on port 30080. This ca
 be overriden to any free port in the range of 30000 to 32767, by running the above
 command as follows:
 
-```console
+```bash
 KIND_GATEWAY_HOST_PORT=<selected-port> make env-dev-kind
 ```
 
 **Where:** &lt;selected-port&gt; is the port on your local machine you want to use to
 access the inference gatyeway.
 
-> **NOTE**: If you require significant customization of this environment beyond
+> [!NOTE]
+> If you require significant customization of this environment beyond
 > what the standard deployment provides, you can use the `deploy/components`
 > with `kustomize` to build your own highly customized environment. You can use
 > the `deploy/environments/kind` deployment as a reference for your own.
@@ -90,28 +88,30 @@ access the inference gatyeway.
 To test your changes to `llm-d-inference-scheduler` in this environment, make your changes locally
 and then re-run the deployment:
 
-```console
+```bash
 make env-dev-kind
 ```
 
 This will build images with your recent changes and load the new images to the
 cluster. By default the image tag will be `dev`. It will also load `llm-d-inference-sim` image.
 
-**NOTE:** The built image tag can be specified via the `EPP_TAG` environment variable so it is used in the deployment. For example:
+> [!NOTE]
+>The built image tag can be specified via the `EPP_TAG` environment variable so it is used in the deployment. For example:
 
-```console
+```bash
 EPP_TAG=0.0.4 make env-dev-kind
 ```
 
-**NOTE:** If you want to load a different tag of llm-d-inference-sim, you can use the environment variable `VLLM_SIMULATOR_TAG` to specify it.
+> [!NOTE]
+> If you want to load a different tag of llm-d-inference-sim, you can use the environment variable `VLLM_SIMULATOR_TAG` to specify it.
 
-**NOTE**: If you are working on a MacOS with Apple Silicon, it is required to add
-the environment variable `GOOS=linux`.
+> [!NOTE]
+> If you are working on a MacOS with Apple Silicon, it is required to add the environment variable `GOOS=linux`.
 
 Then do a rollout of the EPP `Deployment` so that your recent changes are
 reflected:
 
-```console
+```bash
 kubectl rollout restart deployment food-review-endpoint-picker
 ```
 
@@ -292,7 +292,7 @@ and push it:
 make image-push
 ```
 
-You can now re-deploy the environment with your changes (don't forget all
+You can now re-deploy the environment with your changes (don't forget all of
 the required environment variables):
 
 ```bash
@@ -305,26 +305,26 @@ And test the changes.
 
 To clean up the development environment and remove all deployed resources in your namespace, run:
 
-```sh
+```bash
 make clean-env-dev-kubernetes
 ```
 
 If you also want to remove the namespace entirely, run:
 
-```sh
+```bash
 kubectl delete namespace ${NAMESPACE}
 ```
 
 To uninstall the infra-stracture development:
 Uninstal GIE CRDs:
 
-```sh
+```bash
 kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest/download/manifests.yaml --ignore-not-found
 ```
 
 Uninstall kgateway:
 
-```sh
+```bash
 helm uninstall kgateway -n kgateway-system
 helm uninstall kgateway-crds -n kgateway-system
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,8 @@ Documentation for developing the inference scheduler.
 
 ## Kind Development Environment
 
-> **WARNING**: This currently requires you to have manually built the vllm
+> [!Warning]
+> This currently requires you to have manually built the vllm
 > simulator separately on your local system. In a future iteration this will
 > be handled automatically and will not be required. The tag for the simulator
 > currently needs to be `v0.1.0`.
@@ -116,46 +117,50 @@ kubectl rollout restart deployment food-review-endpoint-picker
 
 ## Kubernetes Development Environment
 
-A Kubernetes (or OpenShift) cluster can be used for development and testing.
-There is a cluster-level infrastructure deployment that needs to be managed,
-and then development environments can be created on a per-namespace basis to
-enable sharing the cluster with multiple developers (or feel free to just use
-the `default` namespace if the cluster is private/personal).
+A Kubernetes cluster can be used for development and testing.
+The setup can be split in two:
+
+- cluster-level infrastructure deployment (e.g., CRDs), and
+- deployment of development environments on a per-namespace basis
+
+This enables cluster sharing by multiple developers. In case of private/personal
+clusters, the `default` namespace can be used directly.
 
 ### Setup - Infrastructure
 
-> **WARNING**: In shared cluster situations you should probably not be
-> running this unless you're the cluster admin and you're _certain_ it's you
-> that should be running this, as this can be disruptive to other developers
+> [!CAUTION]
+> In shared cluster situations you should probably not be
+> running this unless you're the cluster admin and you're _certain_
+> that you should be running this, as this can be disruptive to other developers
 > in the cluster.
 
 The following will deploy all the infrastructure-level requirements (e.g. CRDs,
-Operators, etc) to support the namespace-level development environments:
+Operators, etc.) to support the namespace-level development environments:
 
 Install GIE CRDs:
 
 ```bash
-VERSION=v0.3.0
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$VERSION/manifests.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest/download/manifests.yaml
 ```
 
-Install Kgateway:
+Install kgateway:
 ```bash
 KGTW_VERSION=v2.0.2
 helm upgrade -i --create-namespace --namespace kgateway-system --version $KGTW_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
 helm upgrade -i --namespace kgateway-system --version $KGTW_VERSION kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set inferenceExtension.enabled=true
 ```
 
-For more details you can find in Gateway API inference [getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/)
+For more details, see the Gateway API inference Extension [getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/)
 
 ### Setup - Developer Environment
 
-> **WARNING**: This setup is currently very manual in regards to container
+> [!NOTE]
+> This setup is currently very manual in regards to container
 > images for the VLLM simulator and the EPP. It is expected that you build and
 > push images for both to your own private registry. In future iterations, we
 > will be providing automation around this to make it simpler.
 
-To deploy a development environment to the cluster you'll need to explicitly
+To deploy a development environment to the cluster, you'll need to explicitly
 provide a namespace. This can be `default` if this is your personal cluster,
 but on a shared cluster you should pick something unique. For example:
 
@@ -175,7 +180,8 @@ Set the default namespace for kubectl commands
 kubectl config set-context --current --namespace="${NAMESPACE}"
 ```
 
-> NOTE: If you are using OpenShift (oc CLI), use the following instead: `oc project "${NAMESPACE}"`
+> [!NOTE]
+> If you are using OpenShift (oc CLI), you can use the following instead: `oc project "${NAMESPACE}"`
 
 - Set Hugging Face token variable:
 
@@ -186,12 +192,11 @@ export HF_TOKEN="<HF_TOKEN>"
 Download the `llm-d-kv-cache-manager` repository (the instllation script and Helm chart to install the vLLM environment):
 
 ```bash
-cd .. & git clone git@github.com:llm-d/llm-d-kv-cache-manager.git
+cd .. && git clone git@github.com:llm-d/llm-d-kv-cache-manager.git
 ```
+
 If you prefer to clone it into the `/tmp` directory, make sure to update the `VLLM_CHART_DIR` environment variable:
 `export VLLM_CHART_DIR=<tmp_dir>/llm-d-kv-cache-manager/vllm-setup-helm`
-
-
 
 Once all this is set up, you can deploy the environment:
 
@@ -200,12 +205,13 @@ make env-dev-kubernetes
 ```
 
 This will deploy the entire stack to whatever namespace you chose.
-**Note:** The model and images of each componet can  be replaced. See [Environment Configuration](#environment-configuration) for model settings.
+> [!NOTE]
+> The model and images of each componet can  be replaced. See [Environment Configuration](#environment-configuration) for model settings.
 
-You can test by exposing the inference `Gateway` via port-forward:
+You can test by exposing the `inference gateway` via port-forward:
 
 ```bash
-kubectl port-forward service/inference-gateway 8080:80
+kubectl port-forward service/inference-gateway 8080:80 -n "${NAMESPACE}"
 ```
 
 And making requests with `curl`:
@@ -215,6 +221,9 @@ curl -s -w '\n' http://localhost:8080/v1/completions -H 'Content-Type: applicati
   -d '{"model":"meta-llama/Llama-3.1-8B-Instruct","prompt":"hi","max_tokens":10,"temperature":0}' | jq
 ```
 
+> [!NOTE]
+> If the response is empty or contains an error, jq may output a cryptic error. You can run the command without jq to debug raw responses.
+
 #### Environment Configurateion
 
 **1. Setting the EPP image and tag:**
@@ -222,8 +231,8 @@ curl -s -w '\n' http://localhost:8080/v1/completions -H 'Content-Type: applicati
 You can optionally set a custom EPP image (otherwise, the default will be used):
 
 ```bash
-export EPP_IMAGE="<YOUR_REGISTRY>/<YOUR_IMAGE>"
 export EPP_TAG="<YOUR_TAG>"
+export EPP_IMAGE="<YOUR_REGISTRY>/<YOUR_IMAGE>"
 ```
 
 **2. Setting the vLLM replicas:**
@@ -234,7 +243,7 @@ You can optionally set the vllm replicas:
 export VLLM_REPLICA_COUNT=2
 ```
 
-**3. Setting the model name and label:**
+**3. Setting the model name:**
 
 You can replace the model name that will be used in the system.
 
@@ -244,41 +253,36 @@ export MODEL_NAME="${MODEL_NAME:-mistralai/Mistral-7B-Instruct-v0.2}"
 
 **4. Additional environment settings:**
 
-More Setting of environment variables can be found in the `scripts/kubernetes-dev-env.sh`.
-
-
+More environment variable settings can be found in the `scripts/kubernetes-dev-env.sh`.
 
 #### Development Cycle
 
-> **WARNING**: This is a very manual process at the moment. We expect to make
+> [!Warning]
+> This is a very manual process at the moment. We expect to make
 > this more automated in future iterations.
 
 Make your changes locally and commit them. Then select an image tag based on
-the `git` SHA:
+the `git` SHA and set your private registry:
 
 ```bash
 export EPP_TAG=$(git rev-parse HEAD)
+export IMAGE_REGISTRY="quay.io/<my-id>"
 ```
 
-Build the image:
+Build the image and tag the image for your private registry:
 
 ```bash
-DEV_VERSION=$EPP_TAG make image-build
+make image-build
 ```
 
-Tag the image for your private registry and push it:
+and push it:
 
 ```bash
-$CONTAINER_RUNTIME tag quay.io/llm-d/llm-d-gateway-api-inference-extension/epp:$TAG \
-    <MY_REGISTRY>/<MY_IMAGE>:$EPP_TAG
-$CONTAINER_RUNTIME push <MY_REGISTRY>/<MY_IMAGE>:$EPP_TAG
+make image-push
 ```
 
-> **NOTE**: `$CONTAINER_RUNTIME` can be configured or replaced with whatever your
-> environment's standard container runtime is (e.g. `podman`, `docker`).
-
-Then you can re-deploy the environment with the new changes (don't forget all
-the required env vars):
+You can now re-deploy the environment with your changes (don't forget all
+the required environment variables):
 
 ```bash
 make env-dev-kubernetes
@@ -299,3 +303,19 @@ If you also want to remove the namespace entirely, run:
 ```sh
 kubectl delete namespace ${NAMESPACE}
 ```
+
+To uninstall the infra-stracture development:
+Uninstal GIE CRDs:
+
+```sh
+kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest/download/manifests.yaml --ignore-not-found
+```
+
+Uninstall kgateway:
+
+```sh
+helm uninstall kgateway -n kgateway-system
+helm uninstall kgateway-crds -n kgateway-system
+```
+
+For more details, see the Gateway API inference Extension [getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -248,7 +248,18 @@ export VLLM_REPLICA_COUNT=2
 You can replace the model name that will be used in the system.
 
 ```bash
-export MODEL_NAME="${MODEL_NAME:-mistralai/Mistral-7B-Instruct-v0.2}"
+export MODEL_NAME=mistralai/Mistral-7B-Instruct-v0.2
+```
+
+If you need to deploy a larger model, update the vLLM-related parameters according to the model's requirements. For example:
+
+```bash
+export MODEL_NAME=meta-llama/Llama-3.1-70B-Instruct
+export PVC_SIZE=200Gi
+export VLLM_MEMORY_RESOURCES=100Gi
+export VLLM_GPU_MEMORY_UTILIZATION=0.95
+export VLLM_TENSOR_PARALLEL_SIZE=2
+export VLLM_GPU_COUNT_PER_INSTANCE=2
 ```
 
 **4. Additional environment settings:**

--- a/Makefile
+++ b/Makefile
@@ -301,11 +301,10 @@ clean-env-dev-kind:      ## Cleanup kind setup (delete cluster $(KIND_CLUSTER_NA
 
 
 # Kubernetes Development Environment - Deploy
-# This target deploys the GIE stack in a specific namespace for development and testing.
+# This target deploys the inference scheduler stack in a specific namespace for development and testing.
 .PHONY: env-dev-kubernetes
 env-dev-kubernetes: check-kubectl check-kustomize check-envsubst
 	IMAGE_REGISTRY=$(IMAGE_REGISTRY) ./scripts/kubernetes-dev-env.sh 2>&1
-	@echo "INFO: Development environment deployed to namespace $(NAMESPACE)"
 
 # Kubernetes Development Environment - Teardown
 .PHONY: clean-env-dev-kubernetes

--- a/Makefile
+++ b/Makefile
@@ -298,3 +298,17 @@ env-dev-kind: image-build  ## Run under kind ($(KIND_CLUSTER_NAME))
 clean-env-dev-kind:      ## Cleanup kind setup (delete cluster $(KIND_CLUSTER_NAME))
 	@echo "INFO: cleaning up kind cluster $(KIND_CLUSTER_NAME)"
 	kind delete cluster --name $(KIND_CLUSTER_NAME)
+
+
+# Kubernetes Development Environment - Deploy
+# This target deploys the GIE stack in a specific namespace for development and testing.
+.PHONY: env-dev-kubernetes
+env-dev-kubernetes: check-kubectl check-kustomize check-envsubst
+	IMAGE_REGISTRY=$(IMAGE_REGISTRY) ./scripts/kubernetes-dev-env.sh 2>&1
+	@echo "INFO: Development environment deployed to namespace $(NAMESPACE)"
+
+# Kubernetes Development Environment - Teardown
+.PHONY: clean-env-dev-kubernetes
+clean-env-dev-kubernetes: check-kubectl check-kustomize check-envsubst
+	@CLEAN=true ./scripts/kubernetes-dev-env.sh 2>&1
+	@echo "INFO: Finished cleanup of development environment for namespace $(NAMESPACE)"

--- a/deploy/components/inference-gateway/inference-models.yaml
+++ b/deploy/components/inference-gateway/inference-models.yaml
@@ -1,7 +1,7 @@
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferenceModel
 metadata:
-  name: ${MODEL_NAME}
+  name: ${MODEL_NAME_SAFE}
 spec:
   modelName: ${MODEL_NAME}
   criticality: Critical

--- a/deploy/components/vllm-sim/deployments.yaml
+++ b/deploy/components/vllm-sim/deployments.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${MODEL_NAME}-vllm-sim
+  name: ${MODEL_NAME_SAFE}-vllm-sim
   labels:
     app: ${POOL_NAME}
 spec:

--- a/deploy/environments/dev/kubernetes-kgateway/gateway-parameters.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/gateway-parameters.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: custom-gw-params
+spec:
+  kube:
+    envoyContainer:
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: "${PROXY_UID}"
+    service:
+      type: ${GATEWAY_SERVICE_TYPE}
+      extraLabels:
+        gateway: custom
+    podTemplate:
+      extraLabels:
+        gateway: custom
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault

--- a/deploy/environments/dev/kubernetes-kgateway/kustomization.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${NAMESPACE}
+
+resources:
+- secret.yaml
+- ../../../components/inference-gateway/
+- gateway-parameters.yaml
+
+images:
+- name: quay.io/llm-d/gateway-api-inference-extension
+  newName: ${EPP_IMAGE}
+  newTag: ${EPP_TAG}
+
+patches:
+- path: patch-deployments.yaml
+- path: patch-gateways.yaml

--- a/deploy/environments/dev/kubernetes-kgateway/kustomization.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/kustomization.yaml
@@ -8,11 +8,6 @@ resources:
 - ../../../components/inference-gateway/
 - gateway-parameters.yaml
 
-images:
-- name: quay.io/llm-d/gateway-api-inference-extension
-  newName: ${EPP_IMAGE}
-  newTag: ${EPP_TAG}
-
 patches:
 - path: patch-deployments.yaml
 - path: patch-gateways.yaml

--- a/deploy/environments/dev/kubernetes-kgateway/patch-deployments.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/patch-deployments.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${EPP_NAME}
+spec:
+  template:
+    spec:
+      containers:
+      - name: epp
+        args:
+        - -poolName
+        - ${POOL_NAME}
+        - -poolNamespace
+        - ${NAMESPACE}
+        - -v
+        - "4"
+        - --zap-encoder
+        - "json"
+        - -grpcPort
+        - "9002"
+        - -grpcHealthPort
+        - "9003"
+        env:
+          - name: KVCACHE_INDEXER_REDIS_ADDR
+            value: ${REDIS_HOST}:${REDIS_PORT}
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-token
+                key: ${HF_SECRET_KEY}
+          - name: ENABLE_KVCACHE_AWARE_SCORER
+            value: "true"
+          - name: KVCACHE_AWARE_SCORER_WEIGHT
+            value: "2.0"
+          - name: ENABLE_LOAD_AWARE_SCORER
+            value: "true"
+          - name: LOAD_AWARE_SCORER_WEIGHT
+            value: "1.0"

--- a/deploy/environments/dev/kubernetes-kgateway/patch-deployments.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/patch-deployments.yaml
@@ -7,6 +7,7 @@ spec:
     spec:
       containers:
       - name: epp
+        image: ${EPP_IMAGE}:${EPP_TAG}
         args:
         - -poolName
         - ${POOL_NAME}

--- a/deploy/environments/dev/kubernetes-kgateway/patch-gateways.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/patch-gateways.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: inference-gateway
+spec:
+  gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      name: custom-gw-params
+      group: gateway.kgateway.dev
+      kind: GatewayParameters

--- a/deploy/environments/dev/kubernetes-kgateway/secret.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/secret.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/component: secret
 type: Opaque
 stringData:
-  token: ${HF_TOKEN2}
+  token: ${HF_TOKEN}

--- a/deploy/environments/dev/kubernetes-kgateway/secret.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: secret
+type: Opaque
+stringData:
+  token: ${HF_TOKEN2}

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -36,9 +36,9 @@ export EPP_TAG="${EPP_TAG:-dev}"
 
 # Set the model name to deploy
 export MODEL_NAME="${MODEL_NAME:-food-review}"
-
+export MODEL_NAME_SAFE=$(echo "${MODEL_NAME}" | tr '[:upper:]' '[:lower:]' | tr ' /_.' '-')
 # Set the endpoint-picker to deploy
-export EPP_NAME="${EPP_NAME:-${MODEL_NAME}-enpoint-picker}"
+export EPP_NAME="${EPP_NAME:-${MODEL_NAME}-endpoint-picker}"
 
 # Set the default routing side car image tag
 export ROUTING_SIDECAR_TAG="${ROUTING_SIDECAR_TAG:-0.0.6}"

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -36,6 +36,7 @@ export EPP_TAG="${EPP_TAG:-dev}"
 
 # Set the model name to deploy
 export MODEL_NAME="${MODEL_NAME:-food-review}"
+# Safe model name for Kubernetes resources (lowercase, hyphenated)
 export MODEL_NAME_SAFE=$(echo "${MODEL_NAME}" | tr '[:upper:]' '[:lower:]' | tr ' /_.' '-')
 # Set the endpoint-picker to deploy
 export EPP_NAME="${EPP_NAME:-${MODEL_NAME}-endpoint-picker}"
@@ -166,7 +167,7 @@ else
 fi
 
 kustomize build --enable-helm  ${KUSTOMIZE_DIR} \
-	| envsubst '${POOL_NAME} ${MODEL_NAME} ${EPP_NAME} ${EPP_TAG} ${VLLM_SIMULATOR_TAG} \
+	| envsubst '${POOL_NAME} ${MODEL_NAME} ${MODEL_NAME_SAFE} ${EPP_NAME} ${EPP_TAG} ${VLLM_SIMULATOR_TAG} \
   ${PD_ENABLED} ${ROUTING_SIDECAR_TAG} ${VLLM_REPLICA_COUNT} ${VLLM_REPLICA_COUNT_P} ${VLLM_REPLICA_COUNT_D}' \
   | kubectl --context ${KUBE_CONTEXT} apply -f -
 

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -26,7 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${VLLM_SIMULATOR_IMAGE:=llm-d-inference-sim}"
 
 # Set a default VLLM_SIMULATOR_TAG if not provided
-export VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-v0.1.0}"
+export VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-latest}"
 
 # Set a default EPP_IMAGE if not provided
 : "${EPP_IMAGE:=llm-d-inference-scheduler}"
@@ -133,7 +133,10 @@ kubectl --context ${KUBE_CONTEXT} -n local-path-storage wait --for=condition=Rea
 if [ "${CONTAINER_RUNTIME}" == "podman" ]; then
 	podman save ${IMAGE_REGISTRY}/${VLLM_SIMULATOR_IMAGE}:${VLLM_SIMULATOR_TAG} -o /dev/stdout | kind --name ${CLUSTER_NAME} load image-archive /dev/stdin
 else
-	kind --name ${CLUSTER_NAME} load docker-image ${IMAGE_REGISTRY}/${VLLM_SIMULATOR_IMAGE}:${VLLM_SIMULATOR_TAG}
+	if docker image inspect "${IMAGE_REGISTRY}/${VLLM_SIMULATOR_IMAGE}:${VLLM_SIMULATOR_TAG}" > /dev/null 2>&1; then
+		echo "INFO: Loading image into KIND cluster..."
+		kind --name ${CLUSTER_NAME} load docker-image ${IMAGE_REGISTRY}/${VLLM_SIMULATOR_IMAGE}:${VLLM_SIMULATOR_TAG}
+	fi
 fi
 
 # Load the ext_proc endpoint-picker image into the cluster

--- a/scripts/kubernetes-dev-env.sh
+++ b/scripts/kubernetes-dev-env.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# This shell script deploys a Kubernetes or OpenShift cluster with an
+# KGateway-based Gateway API implementation fully configured. It deploys the
+# vllm simulator, which it exposes with a Gateway -> HTTPRoute -> InferencePool.
+# The Gateway is configured with the a filter for the ext_proc endpoint picker.
+
+set -eux
+
+# ------------------------------------------------------------------------------
+# Variables
+# ------------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export CLEAN="${CLEAN:-false}"
+
+# Validate required inputs
+if [[ -z "${NAMESPACE:-}" ]]; then
+  echo "ERROR: NAMESPACE environment variable is not set."
+  exit 1
+fi
+
+export VLLM_CHART_DIR="${VLLM_CHART_DIR:-../llm-d-kv-cache-manager/vllm-setup-helm}"
+# Check that Chart.yaml exists
+if [[ ! -f "$VLLM_CHART_DIR/Chart.yaml" ]]; then
+  echo "Chart.yaml not found in $VLLM_CHART_DIR"
+  exit 1
+fi
+
+# Default image registry for pulling deployment images
+export IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io/llm-d}"
+
+# -----------------------------------------------------------------------------
+# Model Configuration
+# -----------------------------------------------------------------------------
+
+# Full Hugging Face model name to deploy
+export MODEL_NAME="${MODEL_NAME:-meta-llama/Llama-3.1-8B-Instruct}"
+
+# Extract model family (e.g., "meta-llama" from "meta-llama/Llama-3.1-8B-Instruct")
+export MODEL_FAMILY="${MODEL_NAME%%/*}"
+
+# Extract model ID (e.g., "Llama-3.1-8B-Instruct")
+export MODEL_ID="${MODEL_NAME##*/}"
+
+# Safe model name for Kubernetes resources (lowercase, hyphenated)
+export MODEL_NAME_SAFE=$(echo "${MODEL_ID}" | tr '[:upper:]' '[:lower:]' | tr ' /_.' '-')
+
+# -----------------------------------------------------------------------------
+# GIE Configuration
+# -----------------------------------------------------------------------------
+
+# Kubernetes service type for the gateway (e.g., NodePort, ClusterIP, LoadBalancer)
+export GATEWAY_SERVICE_TYPE="${GATEWAY_SERVICE_TYPE:-NodePort}"
+
+# Host port that maps to Gateway's service (used for NodePort)
+export GATEWAY_HOST_PORT="${GATEWAY_HOST_PORT:-30080}"
+
+# Inference pool name to register model-serving pods under
+export POOL_NAME="${POOL_NAME:-${MODEL_NAME_SAFE}-inference-pool}"
+
+
+# -----------------------------------------------------------------------------
+# EPP Configuration
+# -----------------------------------------------------------------------------
+
+# Endpoint Picker (EPP) deployment name
+export EPP_NAME="${EPP_NAME:-${MODEL_NAME_SAFE}-endpoint-picker}"
+
+# EPP container image name
+export EPP_IMAGE="${EPP_IMAGE:-llm-d-inference-scheduler}"
+
+# EPP image tag
+export EPP_TAG="${EPP_TAG:-v0.1.0}"
+
+# Whether Prompt/Document (P/D) mode is enabled for this deployment
+export PD_ENABLED="\"${PD_ENABLED:-false}\""
+
+# Token length threshold to trigger P/D logic
+export PD_PROMPT_LEN_THRESHOLD="\"${PD_PROMPT_LEN_THRESHOLD:-10}\""
+
+# Redis deployment name
+export REDIS_DEPLOYMENT_NAME="${REDIS_DEPLOYMENT_NAME:-lookup-server}"
+
+# Redis service name
+export REDIS_SVC_NAME="${REDIS_SVC_NAME:-${REDIS_DEPLOYMENT_NAME}-service}"
+
+# Redis FQDN for internal Kubernetes communication
+export REDIS_HOST="${REDIS_HOST:-${REDIS_SVC_NAME}.${NAMESPACE}.svc.cluster.local}"
+
+# Redis port
+export REDIS_PORT="${REDIS_PORT:-8100}"
+
+# Hugging Face access token
+export HF_TOKEN2="${HF_TOKEN}"  # Save original (unencoded) for optional use
+export HF_TOKEN=$(echo -n "${HF_TOKEN}" | base64 | tr -d '\n')
+
+# Key in the secret under which the HF token is stored
+export HF_SECRET_KEY="${HF_SECRET_KEY:-token}"
+
+# -----------------------------------------------------------------------------
+# vLLM Configuration
+# -----------------------------------------------------------------------------
+
+# Helm release name for vLLM
+export VLLM_HELM_RELEASE_NAME="${VLLM_HELM_RELEASE_NAME:-vllm}"
+
+# Persistent volume claim size
+export PVC_SIZE="${PVC_SIZE:-40Gi}"
+
+# CPU request per vLLM replica
+export VLLM_CPU_RESOURCES="${VLLM_CPU_RESOURCES:-10}"
+
+# Number of vLLM replicas
+export VLLM_REPLICA_COUNT="${VLLM_REPLICA_COUNT:-3}"
+
+# vLLM deployment name (derived from release + model)
+export VLLM_DEPLOYMENT_NAME="${VLLM_HELM_RELEASE_NAME}-${MODEL_NAME_SAFE}"
+
+# ------------------------------------------------------------------------------
+# Deployment
+# ------------------------------------------------------------------------------
+
+kubectl create namespace ${NAMESPACE} 2>/dev/null || true
+
+# Hack to deal with KGateways broken OpenShift support
+export PROXY_UID=$(kubectl get namespace ${NAMESPACE} -o json | jq -e -r '.metadata.annotations["openshift.io/sa.scc.uid-range"]' | perl -F'/' -lane 'print $F[0]+1');
+
+# Detect if the cluster is OpenShift by checking for the 'route.openshift.io' API group
+IS_OPENSHIFT=false
+if kubectl api-resources 2>/dev/null | grep -q 'route.openshift.io'; then
+  IS_OPENSHIFT=true
+fi
+
+set -o pipefail
+
+if [[ "$CLEAN" == "true" ]]; then
+  echo "INFO: CLEANING environment in namespace ${NAMESPACE}"
+  # Delete inference schedulare and gateway resources.
+  kustomize build deploy/environments/dev/kubernetes-kgateway | envsubst > temp_delet.yaml
+  kustomize build deploy/environments/dev/kubernetes-kgateway | envsubst | kubectl -n "${NAMESPACE}" delete --ignore-not-found=true -f -
+  # Delete vllm resources.
+  helm uninstall vllm --namespace c3
+  exit 0
+fi
+
+echo "INFO: Deploying vLLM Environment in namespace ${NAMESPACE}"
+if [[ "${IS_OPENSHIFT}" == "true" ]]; then
+  if command -v oc &>/dev/null; then
+    # Grant the 'default' service account permission to run containers as any user (disables UID restrictions)
+    oc adm policy add-scc-to-user anyuid -z default -n "${NAMESPACE}"
+    echo "INFO: OpenShift cluster detected – granted 'anyuid' SCC to the 'default' service account in namespace '${NAMESPACE}'."
+  fi
+fi
+
+# Run Helm upgrade/install vllm
+echo "INFO: Deploying vLLM Environment in namespace ${NAMESPACE}, ${POOL_NAME}"
+helm upgrade --install "$VLLM_HELM_RELEASE_NAME" "$VLLM_CHART_DIR" \
+  --namespace c3 \
+  --set secret.create=true \
+  --set secret.hfTokenValue="$HF_TOKEN2" \
+  --set vllm.poolLabelValue="$POOL_NAME" \
+  --set vllm.model.name="$MODEL_NAME" \
+  --set vllm.model.label="$MODEL_NAME_SAFE" \
+  --set vllm.replicaCount="$VLLM_REPLICA_COUNT" \
+  --set vllm.resources.requests.cpu="$VLLM_CPU_RESOURCES" \
+  --set persistence.enabled=true \
+  --set persistence.size="$PVC_SIZE"\
+  --set redis.nameSuffix="$REDIS_DEPLOYMENT_NAME" \
+  --set redis.service.nameSuffix="$REDIS_SVC_NAME" \
+  --set redis.service.port="$REDIS_PORT"
+
+echo "INFO: Deploying Gateway Environment in namespace ${NAMESPACE}, ${POOL_NAME}"
+kustomize build deploy/environments/dev/kubernetes-kgateway | envsubst | kubectl -n "${NAMESPACE}" apply -f -
+
+echo "INFO: Waiting for resources in namespace ${NAMESPACE} to become ready"
+# Wait for gateway resources
+kubectl -n "${NAMESPACE}" wait deployment/${EPP_NAME} --for=condition=Available --timeout=60s
+kubectl -n "${NAMESPACE}" wait gateway/inference-gateway --for=condition=Programmed --timeout=60s
+kubectl -n "${NAMESPACE}" wait deployment/inference-gateway --for=condition=Available --timeout=60s
+
+# Wait for vllm resources
+kubectl -n "${NAMESPACE}" wait deployment/${VLLM_HELM_RELEASE_NAME}-${REDIS_DEPLOYMENT_NAME} --for=condition=Available --timeout=60s
+kubectl -n "${NAMESPACE}" wait deployment/${VLLM_HELM_RELEASE_NAME}-${VLLM_DEPLOYMENT_NAME} --for=condition=Available --timeout=240s


### PR DESCRIPTION
Add support for development on a Kubernetes cluster using scripts/kubernetes-dev-env.sh.
The script will be created in the namespace user gateway+EPP+VLLM for development.
In addition, adding two Makefiles to target for deployment and cleaning: `env-dev-kubernetes` and `clean-env-dev-kubernetes `