### PR TITLE
fixed by labels link in the docs example markdown

### DIFF
--- a/docs/create_new_filter.md
+++ b/docs/create_new_filter.md
@@ -7,7 +7,7 @@ This tutorial outlines the steps needed for creating and hooking a new filter
  
 The tutorial demonstrates the coding of a new filter, which selects inference
  serving Pods based on their labels. All relevant code is contained in the
- [`by_labels.go`](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/scheduling/plugins/filter/by_labels.go) file.
+ [`by_labels.go`](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/plugins/filter/by_labels.go) file.
 
 ## Introduction to filtering
 


### PR DESCRIPTION
after merging PR #179, in post merge CI found a broken link to by_labels.go in the docs markdown file.
This PR fixes the link.