### PR TITLE
Fix for issue #81.

### DIFF
--- a/pkg/plugins/profile/pd-profile-handler.go
+++ b/pkg/plugins/profile/pd-profile-handler.go
@@ -4,6 +4,7 @@ package profile
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
@@ -63,8 +64,9 @@ func (h *PdProfileHandler) Pick(ctx context.Context, request *types.LLMRequest, 
 	// inspect decode execution result to decide if prefil should run or not.
 	// if the request is short enough, use decode results only and don't run the prefill profile.
 	hitPercentage := h.prefixScorer.GetCachedPercentage(profileResults[decode].TargetPod.GetPod().NamespacedName.String(), request.Prompt)
+
 	if (1.0-hitPercentage)*float64(len(request.Prompt)) < float64(h.pdThreshold) {
-		log.FromContext(ctx).Info("Non-cached suffix is smaller than threshold, using decode profile only", "hitPercentage", hitPercentage)
+		log.FromContext(ctx).Info("Non-cached suffix is smaller than threshold, using decode profile only", "hitPercentage", fmt.Sprintf("%.2f%%", hitPercentage*100.0))
 		return map[string]*framework.SchedulerProfile{} // do not run prefill
 	}
 

--- a/pkg/plugins/scorer/prefix_store.go
+++ b/pkg/plugins/scorer/prefix_store.go
@@ -175,7 +175,7 @@ func (s *PrefixStore) FindMatchingPods(prompt, modelName string) map[string]int 
 		}
 
 		for _, pod := range b.Pods.Keys() {
-			matchedPods[pod.String()]++
+			matchedPods[pod.String()] += s.cacheBlockSize
 		}
 	}
 


### PR DESCRIPTION
https://github.com/llm-d/llm-d-inference-scheduler/issues/81

Simplest solution is to just change the definition of matching pod score in the prefix store to be equal to the number of matched characters (matching blocks times cachedBlockSize). The pod scoring and matching functionality
will continue to work with this definition plus now the existing log message that displays the candidate pod scores will now display the number of prompt characters that were tested to match, which also addresses functionality being requested in the issue. If there is some other reason to keep the score as the number of matching cachedBlocks instead of the number of matched runes/ characters, let me know. 

An example log seen during testing this fix was as follows:
{"level":"Level(-4)","ts":"2025-06-23T22:03:32Z","logger":"prefix-aware-scorer","caller":"scorer/prefix_aware.go:72","msg":"Got pod scores","x-request-id":"e3df4a6e-8d95-42bf-917b-0ed21ca756b6","model":"food-review","resolvedTargetModel":"food-review","criticality":"Critical","scores":{"default/food-review-vllm-sim-5bfdb4f94f-85j5p":80}}

Here the 80 refers to the number of matching characters whereas earlier it was printing the internal score which would not be clear to someone viewing the logs as to how that relates to the number of matching prompt chracters.
