### PR TITLE
chore: update the comment to declare DefaultPrefixCacheBlockSize as bytes batch sizes instead of runes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ const (
 	DefaultPrefixCacheCapacity = 500000
 
 	prefixScorerCacheBlockSizeEnvKey = "PREFIX_SCORER_CACHE_BLOCK_SIZE"
-	// DefaultPrefixCacheBlockSize defines the default value of how many runes each block contains in the prefix cache.
+	// DefaultPrefixCacheBlockSize defines the default value of how many bytes each block contains in the prefix cache.
 	DefaultPrefixCacheBlockSize = 256
 )
 


### PR DESCRIPTION
In implementation of

https://github.com/llm-d/llm-d-inference-scheduler/blob/c31127438ec38cf6c4b0257c29b920f66cba6a96/pkg/plugins/scorer/prefix_store.go#L77-L79

the `len(prompt)` is used, and it is the same for iterating batches:

https://github.com/llm-d/llm-d-inference-scheduler/blob/c31127438ec38cf6c4b0257c29b920f66cba6a96/pkg/plugins/scorer/prefix_store.go#L99-L100

However, runes or `rune` got their own meaning in Golang, it's different from `[]byte` or `len([]byte)`.

More in general, `utf8.RuneCountInString(...)` should be used while `len(string)` is more rare, since for Emoji(s) and multi-part Unicode, `rune` provide much safer way to measure the byte length, but since I saw that in `llm-d-kv-cache-manager`,

https://github.com/llm-d/llm-d-kv-cache-manager/blob/3599c3e5eb09e396654fcab64e6a2314c43ba0cc/pkg/tokenization/prefixstore/lru_store.go#L116

`len(prompt)` and `len(promptBytes)` was used, I believe that the use of `len()` over `string` was intentional? I wasn't sure, if this is unexpected behavior, I could open up other Pull Requests to propose changes to this to use `utf8.RuneCountInString(...)`.