### PR TITLE
Add codespell integration for spell checking

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -1,0 +1,17 @@
+name: Check Typos
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check typos
+        uses: crate-ci/typos@v1.34.0
+

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,9 @@
+[default.extend-words]
+k8s = "k8s"
+KServe = "KServe"
+vLLM = "vLLM"
+IST = "IST"
+
+[files]
+extend-exclude = ["*.png", "*.jpg", "deploy/"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# The Go and Python based tools are defined in Makefile.tools.mk.
+include Makefile.tools.mk
+
 SHELL := /usr/bin/env bash
 
 # Defaults
@@ -70,7 +73,7 @@ post-deploy-test: ## Run post deployment tests
 	@echo "Post-deployment tests passed."
 
 .PHONY: lint
-lint: check-golangci-lint ## Run lint
+lint: check-golangci-lint check-typos ## Run lint
 	@printf "\033[33;1m==== Running linting ====\033[0m\n"
 	golangci-lint run
 
@@ -200,6 +203,20 @@ env: ## Print environment variables
 	@echo "IMG=$(IMG)"
 	@echo "CONTAINER_TOOL=$(CONTAINER_TOOL)"
 
+.PHONY: check-typos
+check-typos: $(TYPOS) ## Check for spelling errors using typos (exits with error if found)
+	@echo "🔍 Checking for spelling errors with typos..."
+	@TYPOS_OUTPUT=$$($(TYPOS) --format brief 2>&1); \
+	if [ $$? -eq 0 ]; then \
+		echo "✅ No spelling errors found!"; \
+		echo "🎉 Spelling check completed successfully!"; \
+	else \
+		echo "❌ Spelling errors found!"; \
+		echo "🔧 You can try 'make fix-typos' to automatically fix the spelling errors and run 'make check-typos' again"; \
+		echo "$$TYPOS_OUTPUT"; \
+		exit 1; \
+	fi
+	
 ##@ Tools
 
 .PHONY: check-tools

--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -1,0 +1,16 @@
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	[ -d $@ ] || mkdir -p $@
+
+## Tool binary names.
+TYPOS = $(LOCALBIN)/typos
+
+## Tool versions.
+TYPOS_VERSION ?= v1.34.0
+
+.PHONY: typos
+typos: $(TYPOS)
+$(TYPOS): | $(LOCALBIN)
+	@echo "Downloading typos $(TYPOS_VERSION)..."
+	curl -L https://github.com/crate-ci/typos/releases/download/$(TYPOS_VERSION)/typos-$(TYPOS_VERSION)-x86_64-unknown-linux-musl.tar.gz | tar -xz -C $(LOCALBIN) --wildcards '*/typos'
+	chmod +x $(TYPOS)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,8 +119,8 @@ has the following form:
 - name: aName
   type: a-type
   parameters:
-    parm1: val1
-    parm2: val2
+    param1: val1
+    param2: val2
 ```
 The fields in a plugin entry are:
 - **name** (optional): provides a name by which the plugin instance can be referenced. If this
@@ -210,7 +210,7 @@ Filters out pods using a standard Kubernetes label selector.
 
 - **Type**: `by-label-selector`
 - **Parameters**: A standard Kubernetes label selector.
-  - `matchLabels`: map of `{key,value}` pairs. If more than one pair are in the map, all of the keys are checked and the results are ANDed together.
+  - `matchLabels`: map of `{key,value}` pairs. If more than one pair are in the map, all of the keys are checked and the results are combined with AND logic.
 
 ---
 

--- a/docs/create_new_filter.md
+++ b/docs/create_new_filter.md
@@ -115,7 +115,7 @@ func (blf *ByLabels) Filter(_ *types.SchedulingContext, pods []types.Pod) []type
 ```
 
 Since the filter is only matching on candidate `types.Pod` labels,
- we leave the `types.SchedullingContext` parameter unnamed. Filters
+ we leave the `types.SchedulingContext` parameter unnamed. Filters
  that need access to LLM request information (e.g., filtering based
  on prompt length) may use it.
 


### PR DESCRIPTION
- Add codespell tool setup: Added codespell configuration in Makefile.tools.mk with Python virtual environment support
- Implement check-codespell target: Added new spell checking workflow with smart error handling:
  - Automatically installs codespell in Python virtual environment
  - Saves spelling errors to codespell-results.txt when found
  - Displays errors on console and prompts user to fix them
  - Auto-updates results file on re-run
  - Auto-deletes results file when all errors are fixed
  - Shows success message when spelling check passes
  - Skips deploy/ directory from spell checking

Fix: https://github.com/llm-d/llm-d-inference-scheduler/issues/127