### PR TITLE
Refactor: 🚀 replace with ubi9/ubi-micro image to reduce the manager image size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ ENV GOOS=${TARGETOS:-linux}
 ENV GOARCH=${TARGETARCH}
 RUN go build -a -o bin/epp -ldflags="-extldflags '-L$(pwd)/lib'" cmd/epp/main.go
 
-# Use ubi9 as a minimal base image to package the manager binary
-# Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5 for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+# Use ubi9 as a micro base image to package the manager binary
+# Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58 for more details
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/bin/epp /app/epp
 USER 65532:65532


### PR DESCRIPTION
Replace with ubi9/ubi-micro image to reduce the manager image size (307MB -> 120MB). Related to https://github.com/llm-d/llm-d-inference-scheduler/issues/152

Before:
```
ghcr.io/llm-d/llm-d-inference-scheduler      v0.1.0        b728c15282bc   6 weeks ago          307MB
```

After:
```
ghcr.io/llm-d/llm-d-inference-scheduler        dev       368eb23253d3   About a minute ago   120MB
```
