### PR TITLE
fixed broken link

### DIFF
--- a/docs/create_new_filter.md
+++ b/docs/create_new_filter.md
@@ -7,7 +7,7 @@ This tutorial outlines the steps needed for creating and hooking a new filter
  
 The tutorial demonstrates the coding of a new filter, which selects inference
  serving Pods based on their labels. All relevant code is contained in the
- [`by_labels.go`](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/plugins/filter/by_labels.go) file.
+ [`by_label_selector.go`](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/plugins/filter/by_label_selector.go) file.
 
 ## Introduction to filtering
 


### PR DESCRIPTION
PR #224 caused broken link in docs.
This was found in CI.

more details here:
https://github.com/llm-d/llm-d-inference-scheduler/actions/runs/16099198382/job/45426085543

This PR fixing the broken link to the example filter.