### PR TITLE
prefill header is set in the form of ip:port

### DIFF
--- a/pkg/plugins/pre-request/pd_prerequest.go
+++ b/pkg/plugins/pre-request/pd_prerequest.go
@@ -74,6 +74,6 @@ func (p *PrefillHeaderHandler) PreRequest(_ context.Context, request *types.LLMR
 		return // prefill profile failed to run or we chose not to run it, no-op in this case
 	}
 
-	prefillURL := net.JoinHostPort(prefillProfileRunResult.TargetPod.GetPod().Address, strconv.Itoa(targetPort))
-	request.Headers[prefillPodHeader] = prefillURL // in the form of <ip:port>
+	prefillHostPort := net.JoinHostPort(prefillProfileRunResult.TargetPod.GetPod().Address, strconv.Itoa(targetPort))
+	request.Headers[prefillPodHeader] = prefillHostPort // in the form of <ip:port>
 }

--- a/pkg/plugins/pre-request/pd_prerequest.go
+++ b/pkg/plugins/pre-request/pd_prerequest.go
@@ -74,7 +74,6 @@ func (p *PrefillHeaderHandler) PreRequest(_ context.Context, request *types.LLMR
 		return // prefill profile failed to run or we chose not to run it, no-op in this case
 	}
 
-	// TODO: should the scheme be configurable (e.g., https://)?
-	prefillURL := "http://" + net.JoinHostPort(prefillProfileRunResult.TargetPod.GetPod().Address, strconv.Itoa(targetPort))
-	request.Headers[prefillPodHeader] = prefillURL
+	prefillURL := net.JoinHostPort(prefillProfileRunResult.TargetPod.GetPod().Address, strconv.Itoa(targetPort))
+	request.Headers[prefillPodHeader] = prefillURL // in the form of <ip:port>
 }


### PR DESCRIPTION
This PR removes the protocol setting from the prefill endpoint header.
as agreed in #219 and in https://github.com/llm-d/llm-d-routing-sidecar/issues/38#issuecomment-3033538349, we move the responsibility on setting the protocol to the sidecar, where it should be possible to decide to use selected protocol. 

fix #219 