### PR TITLE
updated prefill header name to x-prefill-host-port

### DIFF
--- a/pkg/plugins/pre-request/pd_prerequest.go
+++ b/pkg/plugins/pre-request/pd_prerequest.go
@@ -16,8 +16,8 @@ import (
 const (
 	// PrefillHeaderHandlerType is the type of the PrefillHeaderHandler
 	PrefillHeaderHandlerType = "prefill-header"
-	// prefillPodHeader is the HTTP header name used to indicate Prefill worker
-	prefillPodHeader = "x-prefiller-url"
+	// prefillPodHeader is the header name used to indicate Prefill worker <ip:port>
+	prefillPodHeader = "x-prefiller-host-port"
 
 	defaultPrefillProfile = "prefill"
 )


### PR DESCRIPTION
updated prefill header name (not a url anymore) as agreed with @lionelvillard in the following discussion: https://github.com/llm-d/llm-d-routing-sidecar/pull/43#discussion_r2205730655.