### PR TITLE
Clear prefill target header if set in incoming request

### DIFF
--- a/pkg/plugins/pre-request/pd_prerequest.go
+++ b/pkg/plugins/pre-request/pd_prerequest.go
@@ -69,6 +69,10 @@ func (p *PrefillHeaderHandler) WithName(name string) *PrefillHeaderHandler {
 
 // PreRequest wires prefill SchedulerProfile result into a header to indicate prefill worker
 func (p *PrefillHeaderHandler) PreRequest(_ context.Context, request *types.LLMRequest, schedulingResult *types.SchedulingResult, targetPort int) {
+	if _, found := request.Headers[prefillPodHeader]; found {
+		request.Headers[prefillPodHeader] = "" // clear header, if already set
+	}
+
 	prefillProfileRunResult, exists := schedulingResult.ProfileResults[p.prefillProfile]
 	if !exists {
 		return // prefill profile failed to run or we chose not to run it, no-op in this case

--- a/pkg/plugins/profile/pd_profile_handler.go
+++ b/pkg/plugins/profile/pd_profile_handler.go
@@ -100,8 +100,8 @@ func (h *PdProfileHandler) Pick(ctx context.Context, cycleState *types.CycleStat
 	}
 
 	// if we're here that means decode profile ran successfully, and we have additional profile configured that didn't run yet,
-	// which means PD is enabled (otherwise, prefil profile is not configured at all and this profile handler is not used).
-	// inspect decode execution result to decide if prefil should run or not.
+	// which means PD is enabled (otherwise, prefill profile is not configured at all and this profile handler is not used).
+	// inspect decode execution result to decide if prefill should run or not.
 	// if the request is short enough, use decode results only and don't run the prefill profile.
 	hitPercentagePrefix := 0.0 // default to 0, meaning no prefix cache hit
 	prefixState, err := types.ReadCycleStateKey[*prefix.SchedulingContextState](cycleState, prefix.PrefixCachePluginType)


### PR DESCRIPTION
Fixes #242 

This sets the prefill target header to an empty string value (an alternative would be to use a safe sentinel values such as `<stripped>`).

A possibly better fix would have been to respond to the gateway (Envoy) with `remove_headers` mutation but GIE currently supports only `set_headers` mutations, so clearing the user provided values seems like the best option given the available functionality.

The PR also includes an unrelated typo fix which I saw while reading related code.
