### PR TITLE
Fixing imagePullPolicy for Kind Development Environment

### DIFF
--- a/deploy/components/inference-gateway/deployments.yaml
+++ b/deploy/components/inference-gateway/deployments.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: epp
         image: ghcr.io/llm-d/llm-d-inference-scheduler:latest
-        imagePullPolicy: Always
+        imagePullPolicy: Never
         args:
         - -poolName
         - "${POOL_NAME}"


### PR DESCRIPTION
This PR fixes the  imagePullPolicy in the [instructions](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/DEVELOPMENT.md) to build a Kind Development Environment for local testing of the inference scheduler. 

Issue: https://github.com/llm-d/llm-d-inference-scheduler/issues/251