### PR TITLE
Fixes for Steps to Build a Kubernetes Development Environment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -137,9 +137,10 @@ clusters, the `default` namespace can be used directly.
 The following will deploy all the infrastructure-level requirements (e.g. CRDs,
 Operators, etc.) to support the namespace-level development environments:
 
-Install GIE CRDs:
+Install Gateway API + GIE CRDs:
 
 ```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest/download/manifests.yaml
 ```
 

--- a/scripts/kubernetes-dev-env.sh
+++ b/scripts/kubernetes-dev-env.sh
@@ -185,10 +185,11 @@ helm upgrade --install "$VLLM_HELM_RELEASE_NAME" "$VLLM_CHART_DIR" \
   --set vllm.gpuMemoryUtilization="${VLLM_GPU_MEMORY_UTILIZATION}" \
   --set vllm.tensorParallelSize="${VLLM_TENSOR_PARALLEL_SIZE}" \
   --set persistence.enabled=true \
-  --set persistence.size="$PVC_SIZE"\
-  --set redis.nameSuffix="$REDIS_DEPLOYMENT_NAME" \
-  --set redis.service.nameSuffix="$REDIS_SVC_NAME" \
-  --set redis.service.port="$REDIS_PORT"
+  --set persistence.size="$PVC_SIZE" \
+  --set lmcache.redis.enabled=true \
+  --set lmcache.redis.nameSuffix="$REDIS_DEPLOYMENT_NAME" \
+  --set lmcache.redis.service.nameSuffix="$REDIS_SVC_NAME" \
+  --set lmcache.redis.service.port="$REDIS_PORT"
 
 echo "INFO: Deploying Gateway Environment in namespace ${NAMESPACE}, ${POOL_NAME}"
 kubectl -n "${NAMESPACE}" create configmap epp-config --from-file=epp-config.yaml=<(envsubst < "${EPP_CONFIG}") --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
This PR addresses the following issues:
1.    Adds missing Gateway API CRDs in the cluster
2.    Typos or misconfiguration for the Redis deployment

Issue # https://github.com/llm-d/llm-d-inference-scheduler/issues/258