### PR TITLE
Change CI to only create a latest tagged image on releases

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -13,6 +13,9 @@ inputs:
   registry:
     required: true
     description: Container registry (e.g., ghcr.io/llm-d)
+  prerelease:
+    required: true
+    description: indicates whether or not this is a pre-release (not a release) build
 runs:
   using: "composite"
   steps:
@@ -32,9 +35,13 @@ runs:
 
     - name: Build image and push
       run: |
+        if [[ ${{ inputs.prerelease }} == "true" ]]; then
+          LATEST_TAG=""
+        else
+          LATEST_TAG="-t ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
+        fi
         docker buildx build \
           --platform linux/amd64,linux/arm64 \
           -t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }} \
-          -t ${{ inputs.registry }}/${{ inputs.image-name }}:latest \
-          --push .
+          ${LATEST_TAG} --push .
       shell: bash

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -33,6 +33,8 @@ jobs:
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
+          PRE_RELEASE=${{ github.event_name != 'release' || github.event.release.prerelease }}
+          echo "prerelease=${PRE_RELEASE}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Build and push image
@@ -42,6 +44,7 @@ jobs:
           image-name: ${{ steps.version.outputs.project_name }}
           registry: ghcr.io/llm-d
           github-token: ${{ secrets.GHCR_TOKEN }}
+          prerelease: ${{ steps.tag.outputs.prerelease }}
 
       - name: Run Trivy scan
         uses: ./.github/actions/trivy-scan


### PR DESCRIPTION
This PR changes the CI pipeline to only push an image with a label of "latest" on publishes of releases.

The image with the "latest" tag will no longer be pushed on pushes of tags and publishes on pre-release releases.

Please note that these changes have been tested in the [llm-d/llm-d-inference-sim](http://github.com/llm-d/llm-d-inference-sim) repo