### PR TITLE
Add workflows to automate aged issues management

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,38 @@
+name: 'Mark stale issues'
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: 'Mark stale issues'
+        uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 90
+          days-before-pr-stale: -1
+          days-before-close: -1
+          stale-issue-label: 'lifecycle/stale'
+          exempt-issue-labels: 'lifecycle/rotten'
+
+      - name: 'Mark rotten issues'
+        uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          days-before-pr-stale: -1
+          days-before-close: -1
+          stale-issue-label: 'lifecycle/rotten'
+          only-labels: 'lifecycle/stale'
+          labels-to-remove-when-stale: 'lifecycle/stale'
+
+      - name: 'Close rotten issues'
+        uses: actions/stale@v9
+        with:
+          days-before-stale: -1
+          days-before-issue-close: 30
+          days-before-pr-close: -1
+          stale-issue-label: 'lifecycle/rotten'

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -1,0 +1,27 @@
+name: 'Unstale Issue'
+
+on:
+  issues:
+    types: [ reopened ]
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  remove-stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: >-
+      github.event.issue.state == 'open' &&
+      (contains(github.event.issue.labels.*.name, 'lifecycle/stale') || 
+       contains(github.event.issue.labels.*.name, 'lifecycle/rotten'))
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+
+      - name: 'Remove stale labels'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Removing 'stale' label from issue #${{ github.event.issue.number }}"
+          gh issue edit ${{ github.event.issue.number }} --remove-label "lifecycle/stale,lifecycle/rotten"


### PR DESCRIPTION
The PR is a result of https://github.com/llm-d/llm-d-inference-scheduler/issues/274.

### Description

Explaining each of the workflows added:
* **stale.yaml** implementing the '**(90d) lifecycle/stale -> (30d) lifecycle/rotten -> (30d) close an issue**' issue flow via [actions/stale](https://github.com/actions/stale). The most practical way to run the workflow is via a cron job scheduled at some time.
* **unstale.yaml** my handwritten workflow created as an add-on to **stale.yaml** to have a real-time reaction to whenever a 'stale' or 'rotten' issue becomes active again. So, it quickly removes the irrelevant label. It's small, focused, and efficient in terms of GitHub API calls. The current definition of 'active' refers to the issue being reopened or any comment being added to it. We can extend it with more GitHub events if you wish (e.g., issue: labeled, assigned, etc). See the [full list](https://docs.github.com/en/webhooks/webhook-events-and-payloads#issues) of issue events. 

### Things to consider
1. **stale.yaml** is configured to run daily at 1:00 UTC. Please, pick the cron value that would work best for you.
2. **operations-per-run** parameter of actions/stale. If I understand it correctly, it's essentially the number of API calls made to GitHub (such as get batch issue, add/remove label, and so on). If it fails to process all issues in one run, it will proceed on the next run. The default value is 30.
3. The workflows mentioned above have been **tested** in my personal repo - https://github.com/anoruxylene/github-issue-managing-test. Feel free to check it out if that makes any sense.