### PR TITLE
Add Prow GitHub Actions

### DIFF
--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -1,0 +1,37 @@
+# Run specified actions or jobs for issue and PR comments
+
+name: "Prow github actions"
+on:
+  issue_comment:
+    types: [created]
+
+# Grant additional permissions to the GITHUB_TOKEN
+permissions:
+  # Allow labeling issues
+  issues: write
+  # Allow adding a review to a pull request
+  pull-requests: write
+
+jobs:
+  prow-execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          prow-commands: "/assign
+            /unassign
+            /approve
+            /retitle
+            /area
+            /kind
+            /priority
+            /remove
+            /lgtm
+            /close
+            /reopen
+            /lock
+            /milestone
+            /hold
+            /cc
+            /uncc"

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -1,0 +1,18 @@
+# This Github workflow will check every hour for PRs with the lgtm label and will attempt to automatically merge them.
+# If the hold label is present, it will block automatic merging.
+
+name: "Prow merge on lgtm label"
+on:
+  schedule:
+  - cron: "*/5 * * * *" # every 5 minutes
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: 'lgtm'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          merge-method: 'squash'
+          

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,0 +1,11 @@
+name: Run Jobs on PR
+on: pull_request
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/re-run-action.yml
+++ b/.github/workflows/re-run-action.yml
@@ -1,0 +1,16 @@
+name: Re-Run PR tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_pr_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: estroz/rerun-actions@main
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        comment_id: ${{ github.event.comment.id }}

--- a/.prowlabels.yaml
+++ b/.prowlabels.yaml
@@ -1,0 +1,11 @@
+# Labels for labeling issues and pull requests using GitHub prow action.
+kind:
+  - 'bug'
+  - 'security'
+  - 'feature'
+  - 'docs'
+
+priority:
+  - 'p0'
+  - 'p1'
+  - 'p2'

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- llm-d-inference-scheduler-maintainers
+
+reviewers:
+- llm-d-inference-scheduler-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,19 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file should be kept in sync with k/org.
+
+aliases:
+  llm-d-inference-scheduler-maintainers:
+  - elevran
+  - kfirtoledo
+  - kfswain
+  - nilig
+  - nirrozenbaum
+  - shmuelk
+
+  llm-d-inference-scheduler-reviewers:
+  - elevran
+  - kfirtoledo
+  - kfswain
+  - nilig
+  - nirrozenbaum
+  - shmuelk


### PR DESCRIPTION
Issue: https://github.com/llm-d/llm-d-inference-scheduler/issues/148

This commit adds GitHub Actions workflows for Prow CI/CD pipeline, including the following files:
- Prow GitHub workflow
- PR auto-merge workflow
- PR LGTM removal workflow
- Re-run action workflow
- Prow labels configuration
- OWNERS file
