### PR TITLE
Support for installation of inference-sim with kv-cache enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,12 +321,18 @@ KIND_CLUSTER_NAME ?= llm-d-inference-scheduler-dev
 KIND_GATEWAY_HOST_PORT ?= 30080
 
 .PHONY: env-dev-kind
-env-dev-kind: image-build  ## Run under kind ($(KIND_CLUSTER_NAME))
-	CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
-	GATEWAY_HOST_PORT=$(KIND_GATEWAY_HOST_PORT) \
-	IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
-	EPP_TAG=$(EPP_TAG) \
-		./scripts/kind-dev-env.sh
+env-dev-kind: ## Run under kind ($(KIND_CLUSTER_NAME))
+	@if [ "$$PD_ENABLED" = "true" ] && [ "$$KV_CACHE_ENABLED" = "true" ]; then \
+		echo "Error: Both PD_ENABLED and KV_CACHE_ENABLED are true. Skipping env-dev-kind."; \
+		exit 1; \
+	else \
+		$(MAKE) image-build && \
+		CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		GATEWAY_HOST_PORT=$(KIND_GATEWAY_HOST_PORT) \
+		IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
+		EPP_TAG=$(EPP_TAG) \
+		./scripts/kind-dev-env.sh; \
+	fi
 
 .PHONY: clean-env-dev-kind
 clean-env-dev-kind:      ## Cleanup kind setup (delete cluster $(KIND_CLUSTER_NAME))

--- a/deploy/components/inference-gateway/deployments.yaml
+++ b/deploy/components/inference-gateway/deployments.yaml
@@ -32,11 +32,10 @@ spec:
         - -grpcHealthPort
         - "9003"
         env:
-        - name: PD_ENABLED
-          value: '${PD_ENABLED}'
-        - name: PD_PROMPT_LEN_THRESHOLD
-          value: '${PD_PROMPT_LEN_THRESHOLD}'
+        - name: PYTHONHASHSEED
+          value: "42"
         ports:
+        - containerPort: 5557
         - containerPort: 9002
         - containerPort: 9003
         - name: metrics
@@ -56,7 +55,11 @@ spec:
         volumeMounts:
         - name: epp-config
           mountPath: /etc/epp
+        - name: cache
+          mountPath: /cache
       volumes:
       - name: epp-config
         configMap:
           name: epp-config
+      - name: cache
+        emptyDir: {}

--- a/deploy/components/inference-gateway/services.yaml
+++ b/deploy/components/inference-gateway/services.yaml
@@ -6,8 +6,14 @@ spec:
   selector:
     app: ${EPP_NAME}
   ports:
-  - protocol: TCP
+  - name: default
+    protocol: TCP
     port: 9002
     targetPort: 9002
     appProtocol: http2
+  - name: zmq
+    protocol: TCP
+    port: 5557
+    targetPort: 5557
+    appProtocol: tcp
   type: ClusterIP

--- a/deploy/components/vllm-sim/deployments.yaml
+++ b/deploy/components/vllm-sim/deployments.yaml
@@ -21,6 +21,11 @@ spec:
         args:
         - "--port=8000"
         - "--model=${MODEL_NAME}"
+        - "--enable-kvcache=${KV_CACHE_ENABLED}"
+        - "--kv-cache-size=1024"
+        - "--block-size=16"
+        - "--zmq-endpoint=tcp://${EPP_NAME}.default.svc.cluster.local:5557"
+        - "--event-batch-size=16"
         ports:
         - name: http
           containerPort: 8000
@@ -28,3 +33,6 @@ spec:
         env:
         - name: PORT
           value: "8000"
+        - name: PYTHONHASHSEED
+          value: "42"
+

--- a/deploy/config/sim-epp-kvcache-config.yaml
+++ b/deploy/config/sim-epp-kvcache-config.yaml
@@ -1,0 +1,31 @@
+# Sample EPP configuration for running without P/D
+# with small hash block size for simulation purposes
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefix-cache-scorer
+  parameters:
+    mode: cache_tracking
+    kvEventsConfig:
+      zmqEndpoint: tcp://0.0.0.0:5557
+    indexerConfig:
+      prefixStoreConfig:
+        blockSize: 16 
+      tokenProcessorConfig:
+        blockSize: 16                         # must match vLLM block size if not default (16)
+        hashSeed: "42"                        # must match PYTHONHASHSEED in vLLM pods
+      tokenizersPoolConfig:
+        tokenizersCacheDir: "/cache/tokenizers"
+      kvBlockIndexConfig:
+        enableMetrics: false                  # enable kv-block index metrics (prometheus)
+        metricsLoggingInterval: 6000000000   # log kv-block metrics as well (1m in nanoseconds)
+- type: decode-filter
+- type: max-score-picker
+- type: single-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 10


### PR DESCRIPTION
- add example of scheduler and simulator configuration to work with kv-cache
- update kind-dev-env.sh to support model names with '/'
- disable kind environment creation with both PD_ENABLED and KV_CACHE_ENABED true