### PR TITLE
Remove github CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Set global owners (all files)
-*       @kfirtoledo @kfswain @nilig @nirrozenbaum @shmuelk @elevran


### PR DESCRIPTION
Changing to use prow action, `.github/CODEOWNERS` can be removed as we'll be using OWNERS for automation