### PR TITLE
fixed a bug where typos check is checking go.mod and go.sum

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,5 +5,11 @@ vLLM = "vLLM"
 IST = "IST"
 
 [files]
-extend-exclude = ["*.png", "*.jpg", "deploy/"]
+extend-exclude = [
+    "*.png", 
+    "*.jpg", 
+    "deploy/",
+    "go.mod",
+    "go.sum",
+]
 


### PR DESCRIPTION
This is blocking PR #320 to sync with IGW latest RC.
we should exclude go.sum and go.mod from typos check