### PR TITLE
Add configurable prefill port support to prefill-header-handler plugin

### DIFF
--- a/pkg/plugins/pre-request/pd_prerequest.go
+++ b/pkg/plugins/pre-request/pd_prerequest.go
@@ -24,7 +24,7 @@ const (
 
 type prefillHeaderHandlerParameters struct {
 	PrefillProfile string `json:"prefillProfile"`
-	PrefillTargetPort int `json:"prefillTargetPort,omitempty"`  // ← Optional field
+	PrefillTargetPort int `json:"prefillTargetPort,omitempty"`  // Optional field
 }
 
 // compile-time type assertion
@@ -57,7 +57,7 @@ func NewPrefillHeaderHandler(prefillProfile string, prefillTargetPort int) *Pref
 type PrefillHeaderHandler struct {
 	typedName      plugins.TypedName
 	prefillProfile string
-	prefillTargetPort int // ← 0 means "not configured"
+	prefillTargetPort int // 0 means "not configured"
 }
 
 // TypedName returns the typed name of the plugin.
@@ -82,11 +82,10 @@ func (p *PrefillHeaderHandler) PreRequest(_ context.Context, request *types.LLMR
 		return // prefill profile failed to run or we chose not to run it, no-op in this case
 	}
 
-	portToUse := targetPort                    // ← Default: use existing behavior
-	if p.prefillTargetPort > 0 {              // ← Only override if configured
+	portToUse := targetPort                    // Default: use existing behavior
+	if p.prefillTargetPort > 0 {              // Only override if configured
 		portToUse = p.prefillTargetPort
-	}	
-
+	}
 	prefillHostPort := net.JoinHostPort(prefillProfileRunResult.TargetPods[0].GetPod().Address, strconv.Itoa(portToUse))
 	request.Headers[prefillPodHeader] = prefillHostPort // in the form of <ip:port>
 }

--- a/pkg/plugins/pre-request/pd_prerequest.go
+++ b/pkg/plugins/pre-request/pd_prerequest.go
@@ -31,7 +31,6 @@ type prefillHeaderHandlerParameters struct {
 var _ requestcontrol.PreRequest = &PrefillHeaderHandler{}
 
 // PrefillHeaderHandlerFactory  defines the factory function for the PrefillHeaderHandler
-// PrefillHeaderHandlerFactory  defines the factory function for the PrefillHeaderHandler
 func PrefillHeaderHandlerFactory(name string, rawParameters json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
 	parameters := prefillHeaderHandlerParameters{
 		PrefillProfile: defaultPrefillProfile,
@@ -46,7 +45,7 @@ func PrefillHeaderHandlerFactory(name string, rawParameters json.RawMessage, _ p
 }
 
 // NewPrefillHeaderHandler initializes a new PrefillHeaderHandler and returns its pointer.
-func NewPrefillHeaderHandler(prefillProfile string) *PrefillHeaderHandler {
+func NewPrefillHeaderHandler(prefillProfile string, prefillTargetPort int) *PrefillHeaderHandler {
 	return &PrefillHeaderHandler{
 		typedName:      plugins.TypedName{Type: PrefillHeaderHandlerType},
 		prefillProfile: prefillProfile,


### PR DESCRIPTION
In prefill/decode (PD) disaggregation deployments, the prefill-header-handler plugin using the same targetPort for both the routing sidecar and prefill nodes. This resulted in incorrect x-prefiller-host-port headers being generated when prefill is running on a different port, preventing proper communication between decode and prefill workers.

Added an optional prefillTargetPort parameter to the prefill-header-handler plugin configuration. When specified, this parameter overrides the generic targetPort when constructing the x-prefiller-host-port header.