### PR TITLE
Use a production version of Istio

### DIFF
--- a/deploy/components/crds-istio/istio.yaml
+++ b/deploy/components/crds-istio/istio.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: authorizationpolicies.security.istio.io
 spec:
   group: security.istio.io
@@ -775,8 +775,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: destinationrules.networking.istio.io
 spec:
   group: networking.istio.io
@@ -797,11 +797,11 @@ spec:
       jsonPath: .spec.host
       name: Host
       type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -908,10 +908,6 @@ spec:
                                 idleTimeout:
                                   description: The idle timeout for TCP connections.
                                   type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
                                 maxConnectionDuration:
                                   description: The maximum duration of a connection.
                                   type: string
@@ -1274,10 +1270,6 @@ spec:
                                       idleTimeout:
                                         description: The idle timeout for TCP connections.
                                         type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
                                       maxConnectionDuration:
                                         description: The maximum duration of a connection.
                                         type: string
@@ -1654,6 +1646,26 @@ spec:
                               - V2
                               type: string
                           type: object
+                        retryBudget:
+                          description: Specifies a limit on concurrent retries in
+                            relation to the number of active requests.
+                          properties:
+                            minRetryConcurrency:
+                              description: Specifies the minimum retry concurrency
+                                allowed for the retry budget.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                            percent:
+                              description: Specifies the limit on concurrent retries
+                                as a percentage of the sum of active requests and
+                                active pending requests.
+                              format: double
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: number
+                          type: object
                         tls:
                           description: TLS related settings for connections to the
                             upstream service.
@@ -1802,9 +1814,6 @@ spec:
                           idleTimeout:
                             description: The idle timeout for TCP connections.
                             type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
                           maxConnectionDuration:
                             description: The maximum duration of a connection.
                             type: string
@@ -2158,10 +2167,6 @@ spec:
                                 idleTimeout:
                                   description: The idle timeout for TCP connections.
                                   type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
                                 maxConnectionDuration:
                                   description: The maximum duration of a connection.
                                   type: string
@@ -2527,3833 +2532,25 @@ spec:
                         - V2
                         type: string
                     type: object
-                  tls:
-                    description: TLS related settings for connections to the upstream
-                      service.
+                  retryBudget:
+                    description: Specifies a limit on concurrent retries in relation
+                      to the number of active requests.
                     properties:
-                      caCertificates:
-                        description: 'OPTIONAL: The path to the file containing certificate
-                          authority certificates to use in verifying a presented server
-                          certificate.'
-                        type: string
-                      caCrl:
-                        description: 'OPTIONAL: The path to the file containing the
-                          certificate revocation list (CRL) to use in verifying a
-                          presented server certificate.'
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      credentialName:
-                        description: The name of the secret that holds the TLS certs
-                          for the client including the CA certificates.
-                        type: string
-                      insecureSkipVerify:
-                        description: '`insecureSkipVerify` specifies whether the proxy
-                          should skip verifying the CA signature and SAN for the server
-                          certificate corresponding to the host.'
-                        nullable: true
-                        type: boolean
-                      mode:
-                        description: |-
-                          Indicates whether connections to this port should be secured using TLS.
-
-                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS
-                          handshake.
-                        type: string
-                      subjectAltNames:
-                        description: A list of alternate names to verify the subject
-                          identity in the certificate.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  tunnel:
-                    description: Configuration of tunneling TCP over other transport
-                      or application layers for the host configured in the DestinationRule.
-                    properties:
-                      protocol:
-                        description: Specifies which protocol to use for tunneling
-                          the downstream connection.
-                        type: string
-                      targetHost:
-                        description: Specifies a host to which the downstream connection
-                          is tunneled.
-                        type: string
-                      targetPort:
-                        description: Specifies a port to which the downstream connection
-                          is tunneled.
+                      minRetryConcurrency:
+                        description: Specifies the minimum retry concurrency allowed
+                          for the retry budget.
                         maximum: 4294967295
                         minimum: 0
                         type: integer
-                    required:
-                    - targetHost
-                    - targetPort
-                    type: object
-                type: object
-              workloadSelector:
-                description: Criteria used to select the specific set of pods/VMs
-                  on which this `DestinationRule` configuration should be applied.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      maxLength: 63
-                      type: string
-                      x-kubernetes-validations:
-                      - message: wildcard not allowed in label value match
-                        rule: '!self.contains("*")'
-                    description: One or more labels that indicate a specific set of
-                      pods/VMs on which a policy should be applied.
-                    maxProperties: 4096
-                    type: object
-                    x-kubernetes-validations:
-                    - message: wildcard not allowed in label key match
-                      rule: self.all(key, !key.contains("*"))
-                    - message: key must not be empty
-                      rule: self.all(key, key.size() != 0)
-                type: object
-            required:
-            - host
-            type: object
-          status:
-            properties:
-              conditions:
-                description: Current service state of the resource.
-                items:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      format: date-time
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about
-                        last transition.
-                      type: string
-                    observedGeneration:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: Resource Generation to which the Condition refers.
-                      x-kubernetes-int-or-string: true
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                type: array
-              observedGeneration:
-                anyOf:
-                - type: integer
-                - type: string
-                x-kubernetes-int-or-string: true
-              validationMessages:
-                description: Includes any errors or warnings detected by Istio's analyzers.
-                items:
-                  properties:
-                    documentationUrl:
-                      description: A url pointing to the Istio documentation for this
-                        specific error type.
-                      type: string
-                    level:
-                      description: |-
-                        Represents how severe a message is.
-
-                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                      enum:
-                      - UNKNOWN
-                      - ERROR
-                      - WARNING
-                      - INFO
-                      type: string
-                    type:
-                      properties:
-                        code:
-                          description: A 7 character code matching `^IST[0-9]{4}$`
-                            intended to uniquely identify the message type.
-                          type: string
-                        name:
-                          description: A human-readable name for the message type.
-                          type: string
-                      type: object
-                  type: object
-                type: array
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
-        order across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection,
-              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is
-                  exported.
-                items:
-                  type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
-                type: string
-              subsets:
-                description: One or more named sets that represent individual versions
-                  of a service.
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels apply a filter over the endpoints of a service
-                        in the service registry.
-                      type: object
-                    name:
-                      description: Name of the subset.
-                      type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
-                            properties:
-                              connectionPool:
-                                properties:
-                                  http:
-                                    description: HTTP connection pool settings.
-                                    properties:
-                                      h2UpgradePolicy:
-                                        description: |-
-                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
-                                        type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of requests that
-                                          will be queued while waiting for a ready
-                                          connection pool connection.
-                                        format: int32
-                                        type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of active requests
-                                          to a destination.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream
-                                          connection pool connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConcurrentStreams:
-                                        description: The maximum number of concurrent
-                                          streams allowed for a peer on one HTTP/2
-                                          connection.
-                                        format: int32
-                                        type: integer
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per
-                                          connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        description: Maximum number of retries that
-                                          can be outstanding to all hosts in a cluster
-                                          at a given time.
-                                        format: int32
-                                        type: integer
-                                      useClientProtocol:
-                                        description: If set to true, client protocol
-                                          will be preserved while initiating connection
-                                          to backend.
-                                        type: boolean
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and
-                                      TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      idleTimeout:
-                                        description: The idle timeout for TCP connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnectionDuration:
-                                        description: The maximum duration of a connection.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP
-                                          connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE
-                                          on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between
-                                              keep-alive probes.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                          probes:
-                                            description: Maximum number of keepalive
-                                              probes to send without response before
-                                              deciding the connection is dead.
-                                            maximum: 4294967295
-                                            minimum: 0
-                                            type: integer
-                                          time:
-                                            description: The time duration a connection
-                                              needs to be idle before keep-alive probes
-                                              start being sent.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                        type: object
-                                    type: object
-                                type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer
-                                  algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - simple
-                                    - required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP
-                                          header.
-                                        type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP
-                                          query parameter.
-                                        type: string
-                                      maglev:
-                                        description: The Maglev load balancer implements
-                                          consistent hashing to backend hosts.
-                                        properties:
-                                          tableSize:
-                                            description: The table size for Maglev
-                                              hashing.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      minimumRingSize:
-                                        description: Deprecated.
-                                        minimum: 0
-                                        type: integer
-                                      ringHash:
-                                        description: The ring/modulo hash load balancer
-                                          implements consistent hashing to backend
-                                          hosts.
-                                        properties:
-                                          minimumRingSize:
-                                            description: The minimum number of virtual
-                                              nodes to use for the hash ring.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
-                                    type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/'
-                                                separated, e.g.
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                maximum: 4294967295
-                                                minimum: 0
-                                                type: integer
-                                              description: Map of upstream localities
-                                                to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: Enable locality load balancing.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              type: string
-                                            to:
-                                              description: Destination region the
-                                                traffic will fail over to when endpoints
-                                                in the 'from' region becomes unhealthy.
-                                              type: string
-                                          type: object
-                                        type: array
-                                      failoverPriority:
-                                        description: failoverPriority is an ordered
-                                          list of labels used to sort endpoints to
-                                          do priority based load balancing.
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  simple:
-                                    description: |2-
-
-
-                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                                    enum:
-                                    - UNSPECIFIED
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    - ROUND_ROBIN
-                                    - LEAST_REQUEST
-                                    type: string
-                                  warmup:
-                                    description: Represents the warmup configuration
-                                      of Service.
-                                    properties:
-                                      aggression:
-                                        description: This parameter controls the speed
-                                          of traffic increase over the warmup duration.
-                                        format: double
-                                        minimum: 1
-                                        nullable: true
-                                        type: number
-                                      duration:
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      minimumPercent:
-                                        format: double
-                                        maximum: 100
-                                        minimum: 0
-                                        nullable: true
-                                        type: number
-                                    required:
-                                    - duration
-                                    type: object
-                                  warmupDurationSecs:
-                                    description: 'Deprecated: use `warmup` instead.'
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host
-                                      is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a
-                                      host is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveLocalOriginFailures:
-                                    description: The number of consecutive locally
-                                      originated failures before ejection occurs.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep
-                                      analysis.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  maxEjectionPercent:
-                                    description: Maximum % of hosts in the load balancing
-                                      pool for the upstream service that can be ejected.
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    description: Outlier detection will be enabled
-                                      as long as the associated load balancing pool
-                                      has at least `minHealthPercent` hosts in healthy
-                                      mode.
-                                    format: int32
-                                    type: integer
-                                  splitExternalLocalOriginErrors:
-                                    description: Determines whether to distinguish
-                                      local origin failures from external errors.
-                                    type: boolean
-                                type: object
-                              port:
-                                description: Specifies the number of a port on the
-                                  destination service on which this policy is being
-                                  applied.
-                                properties:
-                                  number:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections
-                                  to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      certificate authority certificates to use in
-                                      verifying a presented server certificate.'
-                                    type: string
-                                  caCrl:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      the certificate revocation list (CRL) to use
-                                      in verifying a presented server certificate.'
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  credentialName:
-                                    description: The name of the secret that holds
-                                      the TLS certs for the client including the CA
-                                      certificates.
-                                    type: string
-                                  insecureSkipVerify:
-                                    description: '`insecureSkipVerify` specifies whether
-                                      the proxy should skip verifying the CA signature
-                                      and SAN for the server certificate corresponding
-                                      to the host.'
-                                    nullable: true
-                                    type: boolean
-                                  mode:
-                                    description: |-
-                                      Indicates whether connections to this port should be secured using TLS.
-
-                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server
-                                      during TLS handshake.
-                                    type: string
-                                  subjectAltNames:
-                                    description: A list of alternate names to verify
-                                      the subject identity in the certificate.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                            type: object
-                          maxItems: 4096
-                          type: array
-                        proxyProtocol:
-                          description: The upstream PROXY protocol settings.
-                          properties:
-                            version:
-                              description: |-
-                                The PROXY protocol version to use.
-
-                                Valid Options: V1, V2
-                              enum:
-                              - V1
-                              - V2
-                              type: string
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        tunnel:
-                          description: Configuration of tunneling TCP over other transport
-                            or application layers for the host configured in the DestinationRule.
-                          properties:
-                            protocol:
-                              description: Specifies which protocol to use for tunneling
-                                the downstream connection.
-                              type: string
-                            targetHost:
-                              description: Specifies a host to which the downstream
-                                connection is tunneled.
-                              type: string
-                            targetPort:
-                              description: Specifies a port to which the downstream
-                                connection is tunneled.
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          required:
-                          - targetHost
-                          - targetPort
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              trafficPolicy:
-                description: Traffic policies to apply (load balancing policy, connection
-                  pool sizes, outlier detection).
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: |-
-                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of requests that will be queued
-                              while waiting for a ready connection pool connection.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of active requests to a destination.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection
-                              pool connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConcurrentStreams:
-                            description: The maximum number of concurrent streams
-                              allowed for a peer on one HTTP/2 connection.
-                            format: int32
-                            type: integer
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection
-                              to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            description: Maximum number of retries that can be outstanding
-                              to all hosts in a cluster at a given time.
-                            format: int32
-                            type: integer
-                          useClientProtocol:
-                            description: If set to true, client protocol will be preserved
-                              while initiating connection to backend.
-                            type: boolean
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream
-                          connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          idleTimeout:
-                            description: The idle timeout for TCP connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnectionDuration:
-                            description: The maximum duration of a connection.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections
-                              to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket
-                              to enable TCP Keepalives.
-                            properties:
-                              interval:
-                                description: The time duration between keep-alive
-                                  probes.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                              probes:
-                                description: Maximum number of keepalive probes to
-                                  send without response before deciding the connection
-                                  is dead.
-                                maximum: 4294967295
-                                minimum: 0
-                                type: integer
-                              time:
-                                description: The time duration a connection needs
-                                  to be idle before keep-alive probes start being
-                                  sent.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                            type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - simple
-                        - required:
-                          - consistentHash
-                    - required:
-                      - simple
-                    - required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
-                        allOf:
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - ringHash
-                              - required:
-                                - maglev
-                          - required:
-                            - ringHash
-                          - required:
-                            - maglev
-                        properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
-                            properties:
-                              name:
-                                description: Name of the cookie.
-                                type: string
-                              path:
-                                description: Path to set for the cookie.
-                                type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            type: string
-                          maglev:
-                            description: The Maglev load balancer implements consistent
-                              hashing to backend hosts.
-                            properties:
-                              tableSize:
-                                description: The table size for Maglev hashing.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          minimumRingSize:
-                            description: Deprecated.
-                            minimum: 0
-                            type: integer
-                          ringHash:
-                            description: The ring/modulo hash load balancer implements
-                              consistent hashing to backend hosts.
-                            properties:
-                              minimumRingSize:
-                                description: The minimum number of virtual nodes to
-                                  use for the hash ring.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating locality, '/' separated,
-                                    e.g.
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                  description: Map of upstream localities to traffic
-                                    distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: Enable locality load balancing.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  type: string
-                                to:
-                                  description: Destination region the traffic will
-                                    fail over to when endpoints in the 'from' region
-                                    becomes unhealthy.
-                                  type: string
-                              type: object
-                            type: array
-                          failoverPriority:
-                            description: failoverPriority is an ordered list of labels
-                              used to sort endpoints to do priority based load balancing.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      simple:
-                        description: |2-
-
-
-                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                        enum:
-                        - UNSPECIFIED
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        - ROUND_ROBIN
-                        - LEAST_REQUEST
-                        type: string
-                      warmup:
-                        description: Represents the warmup configuration of Service.
-                        properties:
-                          aggression:
-                            description: This parameter controls the speed of traffic
-                              increase over the warmup duration.
-                            format: double
-                            minimum: 1
-                            nullable: true
-                            type: number
-                          duration:
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          minimumPercent:
-                            format: double
-                            maximum: 100
-                            minimum: 0
-                            nullable: true
-                            type: number
-                        required:
-                        - duration
-                        type: object
-                      warmupDurationSecs:
-                        description: 'Deprecated: use `warmup` instead.'
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
+                      percent:
+                        description: Specifies the limit on concurrent retries as
+                          a percentage of the sum of active requests and active pending
+                          requests.
+                        format: double
+                        maximum: 100
                         minimum: 0
                         nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      consecutiveLocalOriginFailures:
-                        description: The number of consecutive locally originated
-                          failures before ejection occurs.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      maxEjectionPercent:
-                        description: Maximum % of hosts in the load balancing pool
-                          for the upstream service that can be ejected.
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        description: Outlier detection will be enabled as long as
-                          the associated load balancing pool has at least `minHealthPercent`
-                          hosts in healthy mode.
-                        format: int32
-                        type: integer
-                      splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local origin
-                          failures from external errors.
-                        type: boolean
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        port:
-                          description: Specifies the number of a port on the destination
-                            service on which this policy is being applied.
-                          properties:
-                            number:
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    maxItems: 4096
-                    type: array
-                  proxyProtocol:
-                    description: The upstream PROXY protocol settings.
-                    properties:
-                      version:
-                        description: |-
-                          The PROXY protocol version to use.
-
-                          Valid Options: V1, V2
-                        enum:
-                        - V1
-                        - V2
-                        type: string
-                    type: object
-                  tls:
-                    description: TLS related settings for connections to the upstream
-                      service.
-                    properties:
-                      caCertificates:
-                        description: 'OPTIONAL: The path to the file containing certificate
-                          authority certificates to use in verifying a presented server
-                          certificate.'
-                        type: string
-                      caCrl:
-                        description: 'OPTIONAL: The path to the file containing the
-                          certificate revocation list (CRL) to use in verifying a
-                          presented server certificate.'
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      credentialName:
-                        description: The name of the secret that holds the TLS certs
-                          for the client including the CA certificates.
-                        type: string
-                      insecureSkipVerify:
-                        description: '`insecureSkipVerify` specifies whether the proxy
-                          should skip verifying the CA signature and SAN for the server
-                          certificate corresponding to the host.'
-                        nullable: true
-                        type: boolean
-                      mode:
-                        description: |-
-                          Indicates whether connections to this port should be secured using TLS.
-
-                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS
-                          handshake.
-                        type: string
-                      subjectAltNames:
-                        description: A list of alternate names to verify the subject
-                          identity in the certificate.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  tunnel:
-                    description: Configuration of tunneling TCP over other transport
-                      or application layers for the host configured in the DestinationRule.
-                    properties:
-                      protocol:
-                        description: Specifies which protocol to use for tunneling
-                          the downstream connection.
-                        type: string
-                      targetHost:
-                        description: Specifies a host to which the downstream connection
-                          is tunneled.
-                        type: string
-                      targetPort:
-                        description: Specifies a port to which the downstream connection
-                          is tunneled.
-                        maximum: 4294967295
-                        minimum: 0
-                        type: integer
-                    required:
-                    - targetHost
-                    - targetPort
-                    type: object
-                type: object
-              workloadSelector:
-                description: Criteria used to select the specific set of pods/VMs
-                  on which this `DestinationRule` configuration should be applied.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      maxLength: 63
-                      type: string
-                      x-kubernetes-validations:
-                      - message: wildcard not allowed in label value match
-                        rule: '!self.contains("*")'
-                    description: One or more labels that indicate a specific set of
-                      pods/VMs on which a policy should be applied.
-                    maxProperties: 4096
-                    type: object
-                    x-kubernetes-validations:
-                    - message: wildcard not allowed in label key match
-                      rule: self.all(key, !key.contains("*"))
-                    - message: key must not be empty
-                      rule: self.all(key, key.size() != 0)
-                type: object
-            required:
-            - host
-            type: object
-          status:
-            properties:
-              conditions:
-                description: Current service state of the resource.
-                items:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      format: date-time
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about
-                        last transition.
-                      type: string
-                    observedGeneration:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: Resource Generation to which the Condition refers.
-                      x-kubernetes-int-or-string: true
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                type: array
-              observedGeneration:
-                anyOf:
-                - type: integer
-                - type: string
-                x-kubernetes-int-or-string: true
-              validationMessages:
-                description: Includes any errors or warnings detected by Istio's analyzers.
-                items:
-                  properties:
-                    documentationUrl:
-                      description: A url pointing to the Istio documentation for this
-                        specific error type.
-                      type: string
-                    level:
-                      description: |-
-                        Represents how severe a message is.
-
-                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                      enum:
-                      - UNKNOWN
-                      - ERROR
-                      - WARNING
-                      - INFO
-                      type: string
-                    type:
-                      properties:
-                        code:
-                          description: A 7 character code matching `^IST[0-9]{4}$`
-                            intended to uniquely identify the message type.
-                          type: string
-                        name:
-                          description: A human-readable name for the message type.
-                          type: string
-                      type: object
-                  type: object
-                type: array
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
-        order across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection,
-              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is
-                  exported.
-                items:
-                  type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
-                type: string
-              subsets:
-                description: One or more named sets that represent individual versions
-                  of a service.
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels apply a filter over the endpoints of a service
-                        in the service registry.
-                      type: object
-                    name:
-                      description: Name of the subset.
-                      type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
-                            properties:
-                              connectionPool:
-                                properties:
-                                  http:
-                                    description: HTTP connection pool settings.
-                                    properties:
-                                      h2UpgradePolicy:
-                                        description: |-
-                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
-                                        type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of requests that
-                                          will be queued while waiting for a ready
-                                          connection pool connection.
-                                        format: int32
-                                        type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of active requests
-                                          to a destination.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream
-                                          connection pool connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConcurrentStreams:
-                                        description: The maximum number of concurrent
-                                          streams allowed for a peer on one HTTP/2
-                                          connection.
-                                        format: int32
-                                        type: integer
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per
-                                          connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        description: Maximum number of retries that
-                                          can be outstanding to all hosts in a cluster
-                                          at a given time.
-                                        format: int32
-                                        type: integer
-                                      useClientProtocol:
-                                        description: If set to true, client protocol
-                                          will be preserved while initiating connection
-                                          to backend.
-                                        type: boolean
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and
-                                      TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      idleTimeout:
-                                        description: The idle timeout for TCP connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnectionDuration:
-                                        description: The maximum duration of a connection.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP
-                                          connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE
-                                          on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between
-                                              keep-alive probes.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                          probes:
-                                            description: Maximum number of keepalive
-                                              probes to send without response before
-                                              deciding the connection is dead.
-                                            maximum: 4294967295
-                                            minimum: 0
-                                            type: integer
-                                          time:
-                                            description: The time duration a connection
-                                              needs to be idle before keep-alive probes
-                                              start being sent.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                        type: object
-                                    type: object
-                                type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer
-                                  algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - simple
-                                    - required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP
-                                          header.
-                                        type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP
-                                          query parameter.
-                                        type: string
-                                      maglev:
-                                        description: The Maglev load balancer implements
-                                          consistent hashing to backend hosts.
-                                        properties:
-                                          tableSize:
-                                            description: The table size for Maglev
-                                              hashing.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      minimumRingSize:
-                                        description: Deprecated.
-                                        minimum: 0
-                                        type: integer
-                                      ringHash:
-                                        description: The ring/modulo hash load balancer
-                                          implements consistent hashing to backend
-                                          hosts.
-                                        properties:
-                                          minimumRingSize:
-                                            description: The minimum number of virtual
-                                              nodes to use for the hash ring.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
-                                    type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/'
-                                                separated, e.g.
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                maximum: 4294967295
-                                                minimum: 0
-                                                type: integer
-                                              description: Map of upstream localities
-                                                to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: Enable locality load balancing.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              type: string
-                                            to:
-                                              description: Destination region the
-                                                traffic will fail over to when endpoints
-                                                in the 'from' region becomes unhealthy.
-                                              type: string
-                                          type: object
-                                        type: array
-                                      failoverPriority:
-                                        description: failoverPriority is an ordered
-                                          list of labels used to sort endpoints to
-                                          do priority based load balancing.
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  simple:
-                                    description: |2-
-
-
-                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                                    enum:
-                                    - UNSPECIFIED
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    - ROUND_ROBIN
-                                    - LEAST_REQUEST
-                                    type: string
-                                  warmup:
-                                    description: Represents the warmup configuration
-                                      of Service.
-                                    properties:
-                                      aggression:
-                                        description: This parameter controls the speed
-                                          of traffic increase over the warmup duration.
-                                        format: double
-                                        minimum: 1
-                                        nullable: true
-                                        type: number
-                                      duration:
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      minimumPercent:
-                                        format: double
-                                        maximum: 100
-                                        minimum: 0
-                                        nullable: true
-                                        type: number
-                                    required:
-                                    - duration
-                                    type: object
-                                  warmupDurationSecs:
-                                    description: 'Deprecated: use `warmup` instead.'
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host
-                                      is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a
-                                      host is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveLocalOriginFailures:
-                                    description: The number of consecutive locally
-                                      originated failures before ejection occurs.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep
-                                      analysis.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  maxEjectionPercent:
-                                    description: Maximum % of hosts in the load balancing
-                                      pool for the upstream service that can be ejected.
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    description: Outlier detection will be enabled
-                                      as long as the associated load balancing pool
-                                      has at least `minHealthPercent` hosts in healthy
-                                      mode.
-                                    format: int32
-                                    type: integer
-                                  splitExternalLocalOriginErrors:
-                                    description: Determines whether to distinguish
-                                      local origin failures from external errors.
-                                    type: boolean
-                                type: object
-                              port:
-                                description: Specifies the number of a port on the
-                                  destination service on which this policy is being
-                                  applied.
-                                properties:
-                                  number:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections
-                                  to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      certificate authority certificates to use in
-                                      verifying a presented server certificate.'
-                                    type: string
-                                  caCrl:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      the certificate revocation list (CRL) to use
-                                      in verifying a presented server certificate.'
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  credentialName:
-                                    description: The name of the secret that holds
-                                      the TLS certs for the client including the CA
-                                      certificates.
-                                    type: string
-                                  insecureSkipVerify:
-                                    description: '`insecureSkipVerify` specifies whether
-                                      the proxy should skip verifying the CA signature
-                                      and SAN for the server certificate corresponding
-                                      to the host.'
-                                    nullable: true
-                                    type: boolean
-                                  mode:
-                                    description: |-
-                                      Indicates whether connections to this port should be secured using TLS.
-
-                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server
-                                      during TLS handshake.
-                                    type: string
-                                  subjectAltNames:
-                                    description: A list of alternate names to verify
-                                      the subject identity in the certificate.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                            type: object
-                          maxItems: 4096
-                          type: array
-                        proxyProtocol:
-                          description: The upstream PROXY protocol settings.
-                          properties:
-                            version:
-                              description: |-
-                                The PROXY protocol version to use.
-
-                                Valid Options: V1, V2
-                              enum:
-                              - V1
-                              - V2
-                              type: string
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        tunnel:
-                          description: Configuration of tunneling TCP over other transport
-                            or application layers for the host configured in the DestinationRule.
-                          properties:
-                            protocol:
-                              description: Specifies which protocol to use for tunneling
-                                the downstream connection.
-                              type: string
-                            targetHost:
-                              description: Specifies a host to which the downstream
-                                connection is tunneled.
-                              type: string
-                            targetPort:
-                              description: Specifies a port to which the downstream
-                                connection is tunneled.
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          required:
-                          - targetHost
-                          - targetPort
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              trafficPolicy:
-                description: Traffic policies to apply (load balancing policy, connection
-                  pool sizes, outlier detection).
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: |-
-                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of requests that will be queued
-                              while waiting for a ready connection pool connection.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of active requests to a destination.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection
-                              pool connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConcurrentStreams:
-                            description: The maximum number of concurrent streams
-                              allowed for a peer on one HTTP/2 connection.
-                            format: int32
-                            type: integer
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection
-                              to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            description: Maximum number of retries that can be outstanding
-                              to all hosts in a cluster at a given time.
-                            format: int32
-                            type: integer
-                          useClientProtocol:
-                            description: If set to true, client protocol will be preserved
-                              while initiating connection to backend.
-                            type: boolean
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream
-                          connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          idleTimeout:
-                            description: The idle timeout for TCP connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnectionDuration:
-                            description: The maximum duration of a connection.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections
-                              to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket
-                              to enable TCP Keepalives.
-                            properties:
-                              interval:
-                                description: The time duration between keep-alive
-                                  probes.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                              probes:
-                                description: Maximum number of keepalive probes to
-                                  send without response before deciding the connection
-                                  is dead.
-                                maximum: 4294967295
-                                minimum: 0
-                                type: integer
-                              time:
-                                description: The time duration a connection needs
-                                  to be idle before keep-alive probes start being
-                                  sent.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                            type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - simple
-                        - required:
-                          - consistentHash
-                    - required:
-                      - simple
-                    - required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
-                        allOf:
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - ringHash
-                              - required:
-                                - maglev
-                          - required:
-                            - ringHash
-                          - required:
-                            - maglev
-                        properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
-                            properties:
-                              name:
-                                description: Name of the cookie.
-                                type: string
-                              path:
-                                description: Path to set for the cookie.
-                                type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            type: string
-                          maglev:
-                            description: The Maglev load balancer implements consistent
-                              hashing to backend hosts.
-                            properties:
-                              tableSize:
-                                description: The table size for Maglev hashing.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          minimumRingSize:
-                            description: Deprecated.
-                            minimum: 0
-                            type: integer
-                          ringHash:
-                            description: The ring/modulo hash load balancer implements
-                              consistent hashing to backend hosts.
-                            properties:
-                              minimumRingSize:
-                                description: The minimum number of virtual nodes to
-                                  use for the hash ring.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating locality, '/' separated,
-                                    e.g.
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                  description: Map of upstream localities to traffic
-                                    distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: Enable locality load balancing.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  type: string
-                                to:
-                                  description: Destination region the traffic will
-                                    fail over to when endpoints in the 'from' region
-                                    becomes unhealthy.
-                                  type: string
-                              type: object
-                            type: array
-                          failoverPriority:
-                            description: failoverPriority is an ordered list of labels
-                              used to sort endpoints to do priority based load balancing.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      simple:
-                        description: |2-
-
-
-                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                        enum:
-                        - UNSPECIFIED
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        - ROUND_ROBIN
-                        - LEAST_REQUEST
-                        type: string
-                      warmup:
-                        description: Represents the warmup configuration of Service.
-                        properties:
-                          aggression:
-                            description: This parameter controls the speed of traffic
-                              increase over the warmup duration.
-                            format: double
-                            minimum: 1
-                            nullable: true
-                            type: number
-                          duration:
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          minimumPercent:
-                            format: double
-                            maximum: 100
-                            minimum: 0
-                            nullable: true
-                            type: number
-                        required:
-                        - duration
-                        type: object
-                      warmupDurationSecs:
-                        description: 'Deprecated: use `warmup` instead.'
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      consecutiveLocalOriginFailures:
-                        description: The number of consecutive locally originated
-                          failures before ejection occurs.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      maxEjectionPercent:
-                        description: Maximum % of hosts in the load balancing pool
-                          for the upstream service that can be ejected.
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        description: Outlier detection will be enabled as long as
-                          the associated load balancing pool has at least `minHealthPercent`
-                          hosts in healthy mode.
-                        format: int32
-                        type: integer
-                      splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local origin
-                          failures from external errors.
-                        type: boolean
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        port:
-                          description: Specifies the number of a port on the destination
-                            service on which this policy is being applied.
-                          properties:
-                            number:
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    maxItems: 4096
-                    type: array
-                  proxyProtocol:
-                    description: The upstream PROXY protocol settings.
-                    properties:
-                      version:
-                        description: |-
-                          The PROXY protocol version to use.
-
-                          Valid Options: V1, V2
-                        enum:
-                        - V1
-                        - V2
-                        type: string
+                        type: number
                     type: object
                   tls:
                     description: TLS related settings for connections to the upstream
@@ -6534,6 +2731,3884 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is
+                  exported.
+                items:
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
+                type: string
+              subsets:
+                description: One or more named sets that represent individual versions
+                  of a service.
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels apply a filter over the endpoints of a service
+                        in the service registry.
+                      type: object
+                    name:
+                      description: Name of the subset.
+                      type: string
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
+                          items:
+                            properties:
+                              connectionPool:
+                                properties:
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: |-
+                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of requests that
+                                          will be queued while waiting for a ready
+                                          connection pool connection.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of active requests
+                                          to a destination.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream
+                                          connection pool connections.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConcurrentStreams:
+                                        description: The maximum number of concurrent
+                                          streams allowed for a peer on one HTTP/2
+                                          connection.
+                                        format: int32
+                                        type: integer
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per
+                                          connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        description: Maximum number of retries that
+                                          can be outstanding to all hosts in a cluster
+                                          at a given time.
+                                        format: int32
+                                        type: integer
+                                      useClientProtocol:
+                                        description: If set to true, client protocol
+                                          will be preserved while initiating connection
+                                          to backend.
+                                        type: boolean
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and
+                                      TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      idleTimeout:
+                                        description: The idle timeout for TCP connections.
+                                        type: string
+                                      maxConnectionDuration:
+                                        description: The maximum duration of a connection.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP
+                                          connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE
+                                          on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between
+                                              keep-alive probes.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                          probes:
+                                            description: Maximum number of keepalive
+                                              probes to send without response before
+                                              deciding the connection is dead.
+                                            maximum: 4294967295
+                                            minimum: 0
+                                            type: integer
+                                          time:
+                                            description: The time duration a connection
+                                              needs to be idle before keep-alive probes
+                                              start being sent.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                        type: object
+                                    type: object
+                                type: object
+                              loadBalancer:
+                                description: Settings controlling the load balancer
+                                  algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP
+                                          header.
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP
+                                          query parameter.
+                                        type: string
+                                      maglev:
+                                        description: The Maglev load balancer implements
+                                          consistent hashing to backend hosts.
+                                        properties:
+                                          tableSize:
+                                            description: The table size for Maglev
+                                              hashing.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      minimumRingSize:
+                                        description: Deprecated.
+                                        minimum: 0
+                                        type: integer
+                                      ringHash:
+                                        description: The ring/modulo hash load balancer
+                                          implements consistent hashing to backend
+                                          hosts.
+                                        properties:
+                                          minimumRingSize:
+                                            description: The minimum number of virtual
+                                              nodes to use for the hash ring.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/'
+                                                separated, e.g.
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                maximum: 4294967295
+                                                minimum: 0
+                                                type: integer
+                                              description: Map of upstream localities
+                                                to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: Enable locality load balancing.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              type: string
+                                            to:
+                                              description: Destination region the
+                                                traffic will fail over to when endpoints
+                                                in the 'from' region becomes unhealthy.
+                                              type: string
+                                          type: object
+                                        type: array
+                                      failoverPriority:
+                                        description: failoverPriority is an ordered
+                                          list of labels used to sort endpoints to
+                                          do priority based load balancing.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  simple:
+                                    description: |2-
+
+
+                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                                    enum:
+                                    - UNSPECIFIED
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    - ROUND_ROBIN
+                                    - LEAST_REQUEST
+                                    type: string
+                                  warmup:
+                                    description: Represents the warmup configuration
+                                      of Service.
+                                    properties:
+                                      aggression:
+                                        description: This parameter controls the speed
+                                          of traffic increase over the warmup duration.
+                                        format: double
+                                        minimum: 1
+                                        nullable: true
+                                        type: number
+                                      duration:
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      minimumPercent:
+                                        format: double
+                                        maximum: 100
+                                        minimum: 0
+                                        nullable: true
+                                        type: number
+                                    required:
+                                    - duration
+                                    type: object
+                                  warmupDurationSecs:
+                                    description: 'Deprecated: use `warmup` instead.'
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host
+                                      is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a
+                                      host is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveLocalOriginFailures:
+                                    description: The number of consecutive locally
+                                      originated failures before ejection occurs.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep
+                                      analysis.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  maxEjectionPercent:
+                                    description: Maximum % of hosts in the load balancing
+                                      pool for the upstream service that can be ejected.
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    description: Outlier detection will be enabled
+                                      as long as the associated load balancing pool
+                                      has at least `minHealthPercent` hosts in healthy
+                                      mode.
+                                    format: int32
+                                    type: integer
+                                  splitExternalLocalOriginErrors:
+                                    description: Determines whether to distinguish
+                                      local origin failures from external errors.
+                                    type: boolean
+                                type: object
+                              port:
+                                description: Specifies the number of a port on the
+                                  destination service on which this policy is being
+                                  applied.
+                                properties:
+                                  number:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections
+                                  to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      certificate authority certificates to use in
+                                      verifying a presented server certificate.'
+                                    type: string
+                                  caCrl:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      the certificate revocation list (CRL) to use
+                                      in verifying a presented server certificate.'
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  credentialName:
+                                    description: The name of the secret that holds
+                                      the TLS certs for the client including the CA
+                                      certificates.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: '`insecureSkipVerify` specifies whether
+                                      the proxy should skip verifying the CA signature
+                                      and SAN for the server certificate corresponding
+                                      to the host.'
+                                    nullable: true
+                                    type: boolean
+                                  mode:
+                                    description: |-
+                                      Indicates whether connections to this port should be secured using TLS.
+
+                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server
+                                      during TLS handshake.
+                                    type: string
+                                  subjectAltNames:
+                                    description: A list of alternate names to verify
+                                      the subject identity in the certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          maxItems: 4096
+                          type: array
+                        proxyProtocol:
+                          description: The upstream PROXY protocol settings.
+                          properties:
+                            version:
+                              description: |-
+                                The PROXY protocol version to use.
+
+                                Valid Options: V1, V2
+                              enum:
+                              - V1
+                              - V2
+                              type: string
+                          type: object
+                        retryBudget:
+                          description: Specifies a limit on concurrent retries in
+                            relation to the number of active requests.
+                          properties:
+                            minRetryConcurrency:
+                              description: Specifies the minimum retry concurrency
+                                allowed for the retry budget.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                            percent:
+                              description: Specifies the limit on concurrent retries
+                                as a percentage of the sum of active requests and
+                                active pending requests.
+                              format: double
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: number
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        tunnel:
+                          description: Configuration of tunneling TCP over other transport
+                            or application layers for the host configured in the DestinationRule.
+                          properties:
+                            protocol:
+                              description: Specifies which protocol to use for tunneling
+                                the downstream connection.
+                              type: string
+                            targetHost:
+                              description: Specifies a host to which the downstream
+                                connection is tunneled.
+                              type: string
+                            targetPort:
+                              description: Specifies a port to which the downstream
+                                connection is tunneled.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          required:
+                          - targetHost
+                          - targetPort
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              trafficPolicy:
+                description: Traffic policies to apply (load balancing policy, connection
+                  pool sizes, outlier detection).
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: |-
+                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of requests that will be queued
+                              while waiting for a ready connection pool connection.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of active requests to a destination.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection
+                              pool connections.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConcurrentStreams:
+                            description: The maximum number of concurrent streams
+                              allowed for a peer on one HTTP/2 connection.
+                            format: int32
+                            type: integer
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection
+                              to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            description: Maximum number of retries that can be outstanding
+                              to all hosts in a cluster at a given time.
+                            format: int32
+                            type: integer
+                          useClientProtocol:
+                            description: If set to true, client protocol will be preserved
+                              while initiating connection to backend.
+                            type: boolean
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream
+                          connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          idleTimeout:
+                            description: The idle timeout for TCP connections.
+                            type: string
+                          maxConnectionDuration:
+                            description: The maximum duration of a connection.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections
+                              to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket
+                              to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive
+                                  probes.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                              probes:
+                                description: Maximum number of keepalive probes to
+                                  send without response before deciding the connection
+                                  is dead.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              time:
+                                description: The time duration a connection needs
+                                  to be idle before keep-alive probes start being
+                                  sent.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - simple
+                        - required:
+                          - consistentHash
+                    - required:
+                      - simple
+                    - required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
+                        properties:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
+                            properties:
+                              name:
+                                description: Name of the cookie.
+                                type: string
+                              path:
+                                description: Path to set for the cookie.
+                                type: string
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            type: string
+                          maglev:
+                            description: The Maglev load balancer implements consistent
+                              hashing to backend hosts.
+                            properties:
+                              tableSize:
+                                description: The table size for Maglev hashing.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          minimumRingSize:
+                            description: Deprecated.
+                            minimum: 0
+                            type: integer
+                          ringHash:
+                            description: The ring/modulo hash load balancer implements
+                              consistent hashing to backend hosts.
+                            properties:
+                              minimumRingSize:
+                                description: The minimum number of virtual nodes to
+                                  use for the hash ring.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
+                        type: object
+                      localityLbSetting:
+                        properties:
+                          distribute:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated,
+                                    e.g.
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                  description: Map of upstream localities to traffic
+                                    distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: Enable locality load balancing.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  type: string
+                                to:
+                                  description: Destination region the traffic will
+                                    fail over to when endpoints in the 'from' region
+                                    becomes unhealthy.
+                                  type: string
+                              type: object
+                            type: array
+                          failoverPriority:
+                            description: failoverPriority is an ordered list of labels
+                              used to sort endpoints to do priority based load balancing.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      simple:
+                        description: |2-
+
+
+                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                        enum:
+                        - UNSPECIFIED
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        - ROUND_ROBIN
+                        - LEAST_REQUEST
+                        type: string
+                      warmup:
+                        description: Represents the warmup configuration of Service.
+                        properties:
+                          aggression:
+                            description: This parameter controls the speed of traffic
+                              increase over the warmup duration.
+                            format: double
+                            minimum: 1
+                            nullable: true
+                            type: number
+                          duration:
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          minimumPercent:
+                            format: double
+                            maximum: 100
+                            minimum: 0
+                            nullable: true
+                            type: number
+                        required:
+                        - duration
+                        type: object
+                      warmupDurationSecs:
+                        description: 'Deprecated: use `warmup` instead.'
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                    type: object
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveLocalOriginFailures:
+                        description: The number of consecutive locally originated
+                          failures before ejection occurs.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      maxEjectionPercent:
+                        description: Maximum % of hosts in the load balancing pool
+                          for the upstream service that can be ejected.
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        description: Outlier detection will be enabled as long as
+                          the associated load balancing pool has at least `minHealthPercent`
+                          hosts in healthy mode.
+                        format: int32
+                        type: integer
+                      splitExternalLocalOriginErrors:
+                        description: Determines whether to distinguish local origin
+                          failures from external errors.
+                        type: boolean
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        port:
+                          description: Specifies the number of a port on the destination
+                            service on which this policy is being applied.
+                          properties:
+                            number:
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    maxItems: 4096
+                    type: array
+                  proxyProtocol:
+                    description: The upstream PROXY protocol settings.
+                    properties:
+                      version:
+                        description: |-
+                          The PROXY protocol version to use.
+
+                          Valid Options: V1, V2
+                        enum:
+                        - V1
+                        - V2
+                        type: string
+                    type: object
+                  retryBudget:
+                    description: Specifies a limit on concurrent retries in relation
+                      to the number of active requests.
+                    properties:
+                      minRetryConcurrency:
+                        description: Specifies the minimum retry concurrency allowed
+                          for the retry budget.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                      percent:
+                        description: Specifies the limit on concurrent retries as
+                          a percentage of the sum of active requests and active pending
+                          requests.
+                        format: double
+                        maximum: 100
+                        minimum: 0
+                        nullable: true
+                        type: number
+                    type: object
+                  tls:
+                    description: TLS related settings for connections to the upstream
+                      service.
+                    properties:
+                      caCertificates:
+                        description: 'OPTIONAL: The path to the file containing certificate
+                          authority certificates to use in verifying a presented server
+                          certificate.'
+                        type: string
+                      caCrl:
+                        description: 'OPTIONAL: The path to the file containing the
+                          certificate revocation list (CRL) to use in verifying a
+                          presented server certificate.'
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      credentialName:
+                        description: The name of the secret that holds the TLS certs
+                          for the client including the CA certificates.
+                        type: string
+                      insecureSkipVerify:
+                        description: '`insecureSkipVerify` specifies whether the proxy
+                          should skip verifying the CA signature and SAN for the server
+                          certificate corresponding to the host.'
+                        nullable: true
+                        type: boolean
+                      mode:
+                        description: |-
+                          Indicates whether connections to this port should be secured using TLS.
+
+                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        type: string
+                      subjectAltNames:
+                        description: A list of alternate names to verify the subject
+                          identity in the certificate.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  tunnel:
+                    description: Configuration of tunneling TCP over other transport
+                      or application layers for the host configured in the DestinationRule.
+                    properties:
+                      protocol:
+                        description: Specifies which protocol to use for tunneling
+                          the downstream connection.
+                        type: string
+                      targetHost:
+                        description: Specifies a host to which the downstream connection
+                          is tunneled.
+                        type: string
+                      targetPort:
+                        description: Specifies a port to which the downstream connection
+                          is tunneled.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                    required:
+                    - targetHost
+                    - targetPort
+                    type: object
+                type: object
+              workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `DestinationRule` configuration should be applied.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      maxLength: 63
+                      type: string
+                      x-kubernetes-validations:
+                      - message: wildcard not allowed in label value match
+                        rule: '!self.contains("*")'
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
+                    type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains("*"))
+                    - message: key must not be empty
+                      rule: self.all(key, key.size() != 0)
+                type: object
+            required:
+            - host
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Current service state of the resource.
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    observedGeneration:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Resource Generation to which the Condition refers.
+                      x-kubernetes-int-or-string: true
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                anyOf:
+                - type: integer
+                - type: string
+                x-kubernetes-int-or-string: true
+              validationMessages:
+                description: Includes any errors or warnings detected by Istio's analyzers.
+                items:
+                  properties:
+                    documentationUrl:
+                      description: A url pointing to the Istio documentation for this
+                        specific error type.
+                      type: string
+                    level:
+                      description: |-
+                        Represents how severe a message is.
+
+                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                      enum:
+                      - UNKNOWN
+                      - ERROR
+                      - WARNING
+                      - INFO
+                      type: string
+                    type:
+                      properties:
+                        code:
+                          description: A 7 character code matching `^IST[0-9]{4}$`
+                            intended to uniquely identify the message type.
+                          type: string
+                        name:
+                          description: A human-readable name for the message type.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is
+                  exported.
+                items:
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
+                type: string
+              subsets:
+                description: One or more named sets that represent individual versions
+                  of a service.
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels apply a filter over the endpoints of a service
+                        in the service registry.
+                      type: object
+                    name:
+                      description: Name of the subset.
+                      type: string
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
+                          items:
+                            properties:
+                              connectionPool:
+                                properties:
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: |-
+                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of requests that
+                                          will be queued while waiting for a ready
+                                          connection pool connection.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of active requests
+                                          to a destination.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream
+                                          connection pool connections.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConcurrentStreams:
+                                        description: The maximum number of concurrent
+                                          streams allowed for a peer on one HTTP/2
+                                          connection.
+                                        format: int32
+                                        type: integer
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per
+                                          connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        description: Maximum number of retries that
+                                          can be outstanding to all hosts in a cluster
+                                          at a given time.
+                                        format: int32
+                                        type: integer
+                                      useClientProtocol:
+                                        description: If set to true, client protocol
+                                          will be preserved while initiating connection
+                                          to backend.
+                                        type: boolean
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and
+                                      TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      idleTimeout:
+                                        description: The idle timeout for TCP connections.
+                                        type: string
+                                      maxConnectionDuration:
+                                        description: The maximum duration of a connection.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP
+                                          connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE
+                                          on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between
+                                              keep-alive probes.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                          probes:
+                                            description: Maximum number of keepalive
+                                              probes to send without response before
+                                              deciding the connection is dead.
+                                            maximum: 4294967295
+                                            minimum: 0
+                                            type: integer
+                                          time:
+                                            description: The time duration a connection
+                                              needs to be idle before keep-alive probes
+                                              start being sent.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                        type: object
+                                    type: object
+                                type: object
+                              loadBalancer:
+                                description: Settings controlling the load balancer
+                                  algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP
+                                          header.
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP
+                                          query parameter.
+                                        type: string
+                                      maglev:
+                                        description: The Maglev load balancer implements
+                                          consistent hashing to backend hosts.
+                                        properties:
+                                          tableSize:
+                                            description: The table size for Maglev
+                                              hashing.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      minimumRingSize:
+                                        description: Deprecated.
+                                        minimum: 0
+                                        type: integer
+                                      ringHash:
+                                        description: The ring/modulo hash load balancer
+                                          implements consistent hashing to backend
+                                          hosts.
+                                        properties:
+                                          minimumRingSize:
+                                            description: The minimum number of virtual
+                                              nodes to use for the hash ring.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/'
+                                                separated, e.g.
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                maximum: 4294967295
+                                                minimum: 0
+                                                type: integer
+                                              description: Map of upstream localities
+                                                to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: Enable locality load balancing.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              type: string
+                                            to:
+                                              description: Destination region the
+                                                traffic will fail over to when endpoints
+                                                in the 'from' region becomes unhealthy.
+                                              type: string
+                                          type: object
+                                        type: array
+                                      failoverPriority:
+                                        description: failoverPriority is an ordered
+                                          list of labels used to sort endpoints to
+                                          do priority based load balancing.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  simple:
+                                    description: |2-
+
+
+                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                                    enum:
+                                    - UNSPECIFIED
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    - ROUND_ROBIN
+                                    - LEAST_REQUEST
+                                    type: string
+                                  warmup:
+                                    description: Represents the warmup configuration
+                                      of Service.
+                                    properties:
+                                      aggression:
+                                        description: This parameter controls the speed
+                                          of traffic increase over the warmup duration.
+                                        format: double
+                                        minimum: 1
+                                        nullable: true
+                                        type: number
+                                      duration:
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      minimumPercent:
+                                        format: double
+                                        maximum: 100
+                                        minimum: 0
+                                        nullable: true
+                                        type: number
+                                    required:
+                                    - duration
+                                    type: object
+                                  warmupDurationSecs:
+                                    description: 'Deprecated: use `warmup` instead.'
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host
+                                      is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a
+                                      host is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveLocalOriginFailures:
+                                    description: The number of consecutive locally
+                                      originated failures before ejection occurs.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep
+                                      analysis.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  maxEjectionPercent:
+                                    description: Maximum % of hosts in the load balancing
+                                      pool for the upstream service that can be ejected.
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    description: Outlier detection will be enabled
+                                      as long as the associated load balancing pool
+                                      has at least `minHealthPercent` hosts in healthy
+                                      mode.
+                                    format: int32
+                                    type: integer
+                                  splitExternalLocalOriginErrors:
+                                    description: Determines whether to distinguish
+                                      local origin failures from external errors.
+                                    type: boolean
+                                type: object
+                              port:
+                                description: Specifies the number of a port on the
+                                  destination service on which this policy is being
+                                  applied.
+                                properties:
+                                  number:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections
+                                  to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      certificate authority certificates to use in
+                                      verifying a presented server certificate.'
+                                    type: string
+                                  caCrl:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      the certificate revocation list (CRL) to use
+                                      in verifying a presented server certificate.'
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  credentialName:
+                                    description: The name of the secret that holds
+                                      the TLS certs for the client including the CA
+                                      certificates.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: '`insecureSkipVerify` specifies whether
+                                      the proxy should skip verifying the CA signature
+                                      and SAN for the server certificate corresponding
+                                      to the host.'
+                                    nullable: true
+                                    type: boolean
+                                  mode:
+                                    description: |-
+                                      Indicates whether connections to this port should be secured using TLS.
+
+                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server
+                                      during TLS handshake.
+                                    type: string
+                                  subjectAltNames:
+                                    description: A list of alternate names to verify
+                                      the subject identity in the certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          maxItems: 4096
+                          type: array
+                        proxyProtocol:
+                          description: The upstream PROXY protocol settings.
+                          properties:
+                            version:
+                              description: |-
+                                The PROXY protocol version to use.
+
+                                Valid Options: V1, V2
+                              enum:
+                              - V1
+                              - V2
+                              type: string
+                          type: object
+                        retryBudget:
+                          description: Specifies a limit on concurrent retries in
+                            relation to the number of active requests.
+                          properties:
+                            minRetryConcurrency:
+                              description: Specifies the minimum retry concurrency
+                                allowed for the retry budget.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                            percent:
+                              description: Specifies the limit on concurrent retries
+                                as a percentage of the sum of active requests and
+                                active pending requests.
+                              format: double
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: number
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        tunnel:
+                          description: Configuration of tunneling TCP over other transport
+                            or application layers for the host configured in the DestinationRule.
+                          properties:
+                            protocol:
+                              description: Specifies which protocol to use for tunneling
+                                the downstream connection.
+                              type: string
+                            targetHost:
+                              description: Specifies a host to which the downstream
+                                connection is tunneled.
+                              type: string
+                            targetPort:
+                              description: Specifies a port to which the downstream
+                                connection is tunneled.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          required:
+                          - targetHost
+                          - targetPort
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              trafficPolicy:
+                description: Traffic policies to apply (load balancing policy, connection
+                  pool sizes, outlier detection).
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: |-
+                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of requests that will be queued
+                              while waiting for a ready connection pool connection.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of active requests to a destination.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection
+                              pool connections.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConcurrentStreams:
+                            description: The maximum number of concurrent streams
+                              allowed for a peer on one HTTP/2 connection.
+                            format: int32
+                            type: integer
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection
+                              to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            description: Maximum number of retries that can be outstanding
+                              to all hosts in a cluster at a given time.
+                            format: int32
+                            type: integer
+                          useClientProtocol:
+                            description: If set to true, client protocol will be preserved
+                              while initiating connection to backend.
+                            type: boolean
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream
+                          connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          idleTimeout:
+                            description: The idle timeout for TCP connections.
+                            type: string
+                          maxConnectionDuration:
+                            description: The maximum duration of a connection.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections
+                              to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket
+                              to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive
+                                  probes.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                              probes:
+                                description: Maximum number of keepalive probes to
+                                  send without response before deciding the connection
+                                  is dead.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              time:
+                                description: The time duration a connection needs
+                                  to be idle before keep-alive probes start being
+                                  sent.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - simple
+                        - required:
+                          - consistentHash
+                    - required:
+                      - simple
+                    - required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
+                        properties:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
+                            properties:
+                              name:
+                                description: Name of the cookie.
+                                type: string
+                              path:
+                                description: Path to set for the cookie.
+                                type: string
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            type: string
+                          maglev:
+                            description: The Maglev load balancer implements consistent
+                              hashing to backend hosts.
+                            properties:
+                              tableSize:
+                                description: The table size for Maglev hashing.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          minimumRingSize:
+                            description: Deprecated.
+                            minimum: 0
+                            type: integer
+                          ringHash:
+                            description: The ring/modulo hash load balancer implements
+                              consistent hashing to backend hosts.
+                            properties:
+                              minimumRingSize:
+                                description: The minimum number of virtual nodes to
+                                  use for the hash ring.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
+                        type: object
+                      localityLbSetting:
+                        properties:
+                          distribute:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated,
+                                    e.g.
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                  description: Map of upstream localities to traffic
+                                    distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: Enable locality load balancing.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  type: string
+                                to:
+                                  description: Destination region the traffic will
+                                    fail over to when endpoints in the 'from' region
+                                    becomes unhealthy.
+                                  type: string
+                              type: object
+                            type: array
+                          failoverPriority:
+                            description: failoverPriority is an ordered list of labels
+                              used to sort endpoints to do priority based load balancing.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      simple:
+                        description: |2-
+
+
+                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                        enum:
+                        - UNSPECIFIED
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        - ROUND_ROBIN
+                        - LEAST_REQUEST
+                        type: string
+                      warmup:
+                        description: Represents the warmup configuration of Service.
+                        properties:
+                          aggression:
+                            description: This parameter controls the speed of traffic
+                              increase over the warmup duration.
+                            format: double
+                            minimum: 1
+                            nullable: true
+                            type: number
+                          duration:
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          minimumPercent:
+                            format: double
+                            maximum: 100
+                            minimum: 0
+                            nullable: true
+                            type: number
+                        required:
+                        - duration
+                        type: object
+                      warmupDurationSecs:
+                        description: 'Deprecated: use `warmup` instead.'
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                    type: object
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveLocalOriginFailures:
+                        description: The number of consecutive locally originated
+                          failures before ejection occurs.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      maxEjectionPercent:
+                        description: Maximum % of hosts in the load balancing pool
+                          for the upstream service that can be ejected.
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        description: Outlier detection will be enabled as long as
+                          the associated load balancing pool has at least `minHealthPercent`
+                          hosts in healthy mode.
+                        format: int32
+                        type: integer
+                      splitExternalLocalOriginErrors:
+                        description: Determines whether to distinguish local origin
+                          failures from external errors.
+                        type: boolean
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        port:
+                          description: Specifies the number of a port on the destination
+                            service on which this policy is being applied.
+                          properties:
+                            number:
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    maxItems: 4096
+                    type: array
+                  proxyProtocol:
+                    description: The upstream PROXY protocol settings.
+                    properties:
+                      version:
+                        description: |-
+                          The PROXY protocol version to use.
+
+                          Valid Options: V1, V2
+                        enum:
+                        - V1
+                        - V2
+                        type: string
+                    type: object
+                  retryBudget:
+                    description: Specifies a limit on concurrent retries in relation
+                      to the number of active requests.
+                    properties:
+                      minRetryConcurrency:
+                        description: Specifies the minimum retry concurrency allowed
+                          for the retry budget.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                      percent:
+                        description: Specifies the limit on concurrent retries as
+                          a percentage of the sum of active requests and active pending
+                          requests.
+                        format: double
+                        maximum: 100
+                        minimum: 0
+                        nullable: true
+                        type: number
+                    type: object
+                  tls:
+                    description: TLS related settings for connections to the upstream
+                      service.
+                    properties:
+                      caCertificates:
+                        description: 'OPTIONAL: The path to the file containing certificate
+                          authority certificates to use in verifying a presented server
+                          certificate.'
+                        type: string
+                      caCrl:
+                        description: 'OPTIONAL: The path to the file containing the
+                          certificate revocation list (CRL) to use in verifying a
+                          presented server certificate.'
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      credentialName:
+                        description: The name of the secret that holds the TLS certs
+                          for the client including the CA certificates.
+                        type: string
+                      insecureSkipVerify:
+                        description: '`insecureSkipVerify` specifies whether the proxy
+                          should skip verifying the CA signature and SAN for the server
+                          certificate corresponding to the host.'
+                        nullable: true
+                        type: boolean
+                      mode:
+                        description: |-
+                          Indicates whether connections to this port should be secured using TLS.
+
+                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        type: string
+                      subjectAltNames:
+                        description: A list of alternate names to verify the subject
+                          identity in the certificate.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  tunnel:
+                    description: Configuration of tunneling TCP over other transport
+                      or application layers for the host configured in the DestinationRule.
+                    properties:
+                      protocol:
+                        description: Specifies which protocol to use for tunneling
+                          the downstream connection.
+                        type: string
+                      targetHost:
+                        description: Specifies a host to which the downstream connection
+                          is tunneled.
+                        type: string
+                      targetPort:
+                        description: Specifies a port to which the downstream connection
+                          is tunneled.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                    required:
+                    - targetHost
+                    - targetPort
+                    type: object
+                type: object
+              workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `DestinationRule` configuration should be applied.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      maxLength: 63
+                      type: string
+                      x-kubernetes-validations:
+                      - message: wildcard not allowed in label value match
+                        rule: '!self.contains("*")'
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
+                    type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains("*"))
+                    - message: key must not be empty
+                      rule: self.all(key, key.size() != 0)
+                type: object
+            required:
+            - host
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Current service state of the resource.
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    observedGeneration:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Resource Generation to which the Condition refers.
+                      x-kubernetes-int-or-string: true
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                anyOf:
+                - type: integer
+                - type: string
+                x-kubernetes-int-or-string: true
+              validationMessages:
+                description: Includes any errors or warnings detected by Istio's analyzers.
+                items:
+                  properties:
+                    documentationUrl:
+                      description: A url pointing to the Istio documentation for this
+                        specific error type.
+                      type: string
+                    level:
+                      description: |-
+                        Represents how severe a message is.
+
+                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                      enum:
+                      - UNKNOWN
+                      - ERROR
+                      - WARNING
+                      - INFO
+                      type: string
+                    type:
+                      properties:
+                        code:
+                          description: A 7 character code matching `^IST[0-9]{4}$`
+                            intended to uniquely identify the message type.
+                          type: string
+                        name:
+                          description: A human-readable name for the message type.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -6545,8 +6620,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: envoyfilters.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6954,8 +7029,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: gateways.networking.istio.io
 spec:
   group: networking.istio.io
@@ -7051,6 +7126,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -7105,6 +7187,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -7118,6 +7218,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   - hosts
@@ -7201,7 +7314,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v1alpha3
@@ -7284,6 +7397,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -7338,6 +7458,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -7351,6 +7489,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   - hosts
@@ -7517,6 +7668,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -7571,6 +7729,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -7584,6 +7760,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   - hosts
@@ -7667,7 +7856,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 
@@ -7681,8 +7870,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: peerauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -8035,8 +8224,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: proxyconfigs.networking.istio.io
 spec:
   group: networking.istio.io
@@ -8189,8 +8378,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: requestauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -8315,8 +8504,6 @@ spec:
                       x-kubernetes-validations:
                       - message: must be a valid duration greater than 1ms
                         rule: duration(self) >= duration('1ms')
-                  required:
-                  - issuer
                   type: object
                   x-kubernetes-validations:
                   - message: only one of jwks or jwksUri can be set
@@ -8598,8 +8785,6 @@ spec:
                       x-kubernetes-validations:
                       - message: must be a valid duration greater than 1ms
                         rule: duration(self) >= duration('1ms')
-                  required:
-                  - issuer
                   type: object
                   x-kubernetes-validations:
                   - message: only one of jwks or jwksUri can be set
@@ -8783,8 +8968,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: serviceentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -9095,7 +9280,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -9691,7 +9876,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 
@@ -9705,8 +9890,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: sidecars.networking.istio.io
 spec:
   group: networking.istio.io
@@ -9842,9 +10027,6 @@ spec:
                       idleTimeout:
                         description: The idle timeout for TCP connections.
                         type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
                       maxConnectionDuration:
                         description: The maximum duration of a connection.
                         type: string
@@ -9968,9 +10150,6 @@ spec:
                             idleTimeout:
                               description: The idle timeout for TCP connections.
                               type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
                             maxConnectionDuration:
                               description: The maximum duration of a connection.
                               type: string
@@ -10060,6 +10239,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -10114,6 +10300,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -10127,6 +10331,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   type: object
@@ -10259,7 +10476,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v1alpha3
@@ -10384,9 +10601,6 @@ spec:
                       idleTimeout:
                         description: The idle timeout for TCP connections.
                         type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
                       maxConnectionDuration:
                         description: The maximum duration of a connection.
                         type: string
@@ -10510,9 +10724,6 @@ spec:
                             idleTimeout:
                               description: The idle timeout for TCP connections.
                               type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
                             maxConnectionDuration:
                               description: The maximum duration of a connection.
                               type: string
@@ -10602,6 +10813,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -10656,6 +10874,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -10669,6 +10905,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   type: object
@@ -10926,9 +11175,6 @@ spec:
                       idleTimeout:
                         description: The idle timeout for TCP connections.
                         type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
                       maxConnectionDuration:
                         description: The maximum duration of a connection.
                         type: string
@@ -11052,9 +11298,6 @@ spec:
                             idleTimeout:
                               description: The idle timeout for TCP connections.
                               type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
                             maxConnectionDuration:
                               description: The maximum duration of a connection.
                               type: string
@@ -11144,6 +11387,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -11198,6 +11448,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -11211,6 +11479,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   type: object
@@ -11343,7 +11624,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 
@@ -11357,8 +11638,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: telemetries.telemetry.istio.io
 spec:
   group: telemetry.istio.io
@@ -12281,8 +12562,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: virtualservices.networking.istio.io
 spec:
   group: networking.istio.io
@@ -12967,6 +13248,13 @@ spec:
                             request.
                           format: int32
                           type: integer
+                        backoff:
+                          description: Specifies the minimum duration between retry
+                            attempts.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                         perTryTimeout:
                           description: Timeout per attempt for a given request, including
                             the initial call and any retries.
@@ -13340,7 +13628,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -14012,6 +14300,13 @@ spec:
                             request.
                           format: int32
                           type: integer
+                        backoff:
+                          description: Specifies the minimum duration between retry
+                            attempts.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                         perTryTimeout:
                           description: Timeout per attempt for a given request, including
                             the initial call and any retries.
@@ -15057,6 +15352,13 @@ spec:
                             request.
                           format: int32
                           type: integer
+                        backoff:
+                          description: Specifies the minimum duration between retry
+                            attempts.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                         perTryTimeout:
                           description: Timeout per attempt for a given request, including
                             the initial call and any retries.
@@ -15430,7 +15732,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 
@@ -15444,8 +15746,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: wasmplugins.extensions.istio.io
 spec:
   group: extensions.istio.io
@@ -15480,10 +15782,11 @@ spec:
                 description: |-
                   Specifies the failure behavior for the plugin due to fatal errors.
 
-                  Valid Options: FAIL_CLOSE, FAIL_OPEN
+                  Valid Options: FAIL_CLOSE, FAIL_OPEN, FAIL_RELOAD
                 enum:
                 - FAIL_CLOSE
                 - FAIL_OPEN
+                - FAIL_RELOAD
                 type: string
               imagePullPolicy:
                 description: |-
@@ -15806,8 +16109,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: workloadentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -15980,7 +16283,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -16300,7 +16603,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 
@@ -16312,8 +16615,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
   name: workloadgroups.networking.istio.io
 spec:
   group: networking.istio.io
@@ -16634,7 +16937,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -17250,7 +17553,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 

--- a/deploy/components/istio-control-plane/configmaps.yaml
+++ b/deploy/components/istio-control-plane/configmaps.yaml
@@ -17,14 +17,15 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: llm-d-gateway
     operator.istio.io/component: Pilot
     release: istio
   name: istio-llm-d-gateway
   namespace: llm-d-istio-system
+
 ---
 apiVersion: v1
 data:
@@ -66,7 +67,9 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
-        {{ $nativeSidecar := (or (and (not (isset .ObjectMeta.Annotations `sidecar.istio.io/nativeSidecar`)) (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true")) (eq (index .ObjectMeta.Annotations `sidecar.istio.io/nativeSidecar`) "true")) }}
+        {{ $tproxy := (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) }}
+        {{ $capNetBindService := (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) }}
+        {{ $nativeSidecar := ne (index .ObjectMeta.Annotations `sidecar.istio.io/nativeSidecar` | default (printf "%t" .NativeSidecars)) "false" }}
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
         metadata:
@@ -136,7 +139,7 @@ data:
             - "-z"
             - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
             - "-u"
-            - {{ .ProxyUID | default "1337" | quote }}
+            - {{ if $tproxy }} "1337" {{ else }} {{ .ProxyUID | default "1337" | quote }} {{ end }}
             - "-m"
             - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
             - "-i"
@@ -181,6 +184,9 @@ data:
             {{ else if .Values.global.proxy_init.forceApplyIptables -}}
             - "--force-apply"
             {{ end -}}
+            {{ if .Values.global.nativeNftables -}}
+            - "--native-nftables"
+            {{ end -}}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
           {{- if .ProxyConfig.ProxyMetadata }}
             env:
@@ -209,8 +215,8 @@ data:
               runAsUser: 0
             {{- else }}
               readOnlyRootFilesystem: true
-              runAsGroup: {{ .ProxyGID | default "1337" }}
-              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ if $tproxy }} 1337 {{ else }} {{ .ProxyGID | default "1337" }} {{ end }}
+              runAsUser: {{ if $tproxy }} 1337 {{ else }} {{ .ProxyUID | default "1337" }} {{ end }}
               runAsNonRoot: true
             {{- end }}
           {{ end -}}
@@ -417,12 +423,12 @@ data:
               {{- else }}
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               capabilities:
-                {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+                {{ if or $tproxy $capNetBindService -}}
                 add:
-                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
+                {{ if $tproxy -}}
                 - NET_ADMIN
                 {{- end }}
-                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
+                {{ if $capNetBindService -}}
                 - NET_BIND_SERVICE
                 {{- end }}
                 {{- end }}
@@ -430,13 +436,14 @@ data:
                 - ALL
               privileged: {{ .Values.global.proxy.privileged }}
               readOnlyRootFilesystem: true
-              runAsGroup: {{ .ProxyGID | default "1337" }}
-              {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+              {{ if or $tproxy $capNetBindService -}}
               runAsNonRoot: false
               runAsUser: 0
+              runAsGroup: 1337
               {{- else -}}
               runAsNonRoot: true
               runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               {{- end }}
               {{- end }}
             resources:
@@ -457,6 +464,8 @@ data:
             {{- if eq .Values.global.pilotCertProvider "istiod" }}
             - mountPath: /var/run/secrets/istio
               name: istiod-ca-cert
+            - mountPath: /var/run/secrets/istio/crl
+              name: istio-ca-crl
             {{- end }}
             - mountPath: /var/lib/istio/data
               name: istio-data
@@ -530,9 +539,21 @@ data:
                   audience: {{ .Values.global.sds.token.aud }}
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
+          {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+            projected:
+              sources:
+              - clusterTrustBundle:
+                  name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                  path: root-cert.pem
+          {{- else }}
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
           {{- end }}
+          {{- end }}
+          - name: istio-ca-crl
+            configMap:
+              name: istio-ca-crl
+              optional: true
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
           - name: istio-certs
@@ -703,6 +724,10 @@ data:
             - name: ISTIO_META_OWNER
               value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
             {{- end}}
+            {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - name: ISTIO_BOOTSTRAP_OVERRIDE
+              value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
+            {{- end }}
             {{- if .Values.global.meshID }}
             - name: ISTIO_META_MESH_ID
               value: "{{ .Values.global.meshID }}"
@@ -746,6 +771,10 @@ data:
             {{- end }}
             - mountPath: /var/lib/istio/data
               name: istio-data
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - mountPath: /etc/istio/custom-bootstrap
+              name: custom-bootstrap-volume
+            {{- end }}
             # SDS channel between istioagent and Envoy
             - mountPath: /etc/istio/proxy
               name: istio-envoy
@@ -760,7 +789,7 @@ data:
             - name: istio-podinfo
               mountPath: /etc/istio/pod
           volumes:
-          - emptyDir: {}
+          - emptyDir:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
@@ -771,6 +800,11 @@ data:
           {{- else}}
           - emptyDir: {}
             name: workload-certs
+          {{- end }}
+          {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+          - name: custom-bootstrap-volume
+            configMap:
+              name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
           {{- end }}
           # SDS channel between istioagent and Envoy
           - emptyDir:
@@ -796,8 +830,16 @@ data:
                   audience: {{ .Values.global.sds.token.aud }}
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
+          {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+            projected:
+              sources:
+              - clusterTrustBundle:
+                  name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                  path: root-cert.pem
+          {{- else }}
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+          {{- end }}
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
@@ -1167,8 +1209,16 @@ data:
                   audience: {{ .Values.global.sds.token.aud }}
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
+          {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+            projected:
+              sources:
+              - clusterTrustBundle:
+                  name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                  path: root-cert.pem
+          {{- else }}
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+          {{- end }}
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
@@ -1228,7 +1278,7 @@ data:
               .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
-                "gateway.istio.io/managed" "istio.io-mesh-controller"
+                "gateway.istio.io/managed" .ControllerLabel
               ) | nindent 4 }}
           ownerReferences:
           - apiVersion: gateway.networking.k8s.io/v1beta1
@@ -1261,7 +1311,7 @@ data:
                   .InfrastructureLabels
                   (strdict
                     "gateway.networking.k8s.io/gateway-name" .Name
-                    "gateway.istio.io/managed" "istio.io-mesh-controller"
+                    "gateway.istio.io/managed" .ControllerLabel
                   ) | nindent 8}}
             spec:
               {{- if .Values.global.waypoint.affinity }}
@@ -1483,9 +1533,17 @@ data:
                       audience: istio-ca
                       expirationSeconds: 43200
                       path: istio-token
-              - configMap:
-                  name: istio-ca-root-cert
-                name: istiod-ca-cert
+              - name: istiod-ca-cert
+              {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+                projected:
+                  sources:
+                  - clusterTrustBundle:
+                      name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                      path: root-cert.pem
+              {{- else }}
+                configMap:
+                  name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+              {{- end }}
               {{- if .Values.global.imagePullSecrets }}
               imagePullSecrets:
                 {{- range .Values.global.imagePullSecrets }}
@@ -1534,6 +1592,53 @@ data:
           {{- end }}
           type: {{ .ServiceType | quote }}
         ---
+        apiVersion: autoscaling/v2
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name:  {{.DeploymentName | quote}}
+          maxReplicas: 1
+        ---
+        apiVersion: policy/v1
+        kind: PodDisruptionBudget
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          selector:
+            matchLabels:
+              gateway.networking.k8s.io/gateway-name: {{.Name|quote}}
       kube-gateway: |
         apiVersion: v1
         kind: ServiceAccount
@@ -1836,8 +1941,16 @@ data:
                       audience: {{ .Values.global.sds.token.aud }}
               {{- if eq .Values.global.pilotCertProvider "istiod" }}
               - name: istiod-ca-cert
+              {{- if eq ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+                projected:
+                  sources:
+                  - clusterTrustBundle:
+                      name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                      path: root-cert.pem
+              {{- else }}
                 configMap:
-                  name: istio-ca-root-cert
+                  name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+              {{- end }}
               {{- end }}
               {{- if .Values.global.imagePullSecrets }}
               imagePullSecrets:
@@ -1880,6 +1993,53 @@ data:
           {{- end }}
           type: {{ .ServiceType | quote }}
         ---
+        apiVersion: autoscaling/v2
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name:  {{.DeploymentName | quote}}
+          maxReplicas: 1
+        ---
+        apiVersion: policy/v1
+        kind: PodDisruptionBudget
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          selector:
+            matchLabels:
+              gateway.networking.k8s.io/gateway-name: {{.Name|quote}}
   values: |-
     {
       "gateways": {
@@ -1901,7 +2061,7 @@ data:
           }
         },
         "externalIstiod": false,
-        "hub": "quay.io/rh-ee-sutt/istio-testing",
+        "hub": "docker.io/istio",
         "imagePullPolicy": "",
         "imagePullSecrets": [],
         "istioNamespace": "llm-d-istio-system",
@@ -1916,9 +2076,9 @@ data:
         "meshNetworks": {},
         "mountMtlsCerts": false,
         "multiCluster": {
-          "clusterName": "",
-          "enabled": false
+          "clusterName": ""
         },
+        "nativeNftables": false,
         "network": "",
         "omitSidecarInjectorConfigMap": false,
         "operatorManageWebhooks": false,
@@ -1971,7 +2131,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d",
+        "tag": "1.27.1",
         "variant": "",
         "waypoint": {
           "affinity": {},
@@ -1994,7 +2154,8 @@ data:
         "cni": {
           "enabled": false,
           "provider": "default"
-        }
+        },
+        "env": {}
       },
       "revision": "llm-d-gateway",
       "sidecarInjectorWebhook": {
@@ -2015,11 +2176,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: llm-d-gateway
     operator.istio.io/component: Pilot
     release: istio
   name: istio-sidecar-injector-llm-d-gateway
   namespace: llm-d-istio-system
+

--- a/deploy/components/istio-control-plane/deployments.yaml
+++ b/deploy/components/istio-control-plane/deployments.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: llm-d-gateway
@@ -37,8 +37,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: istiod
         app.kubernetes.io/part-of: istio
-        app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-        helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+        app.kubernetes.io/version: 1.27.1
+        helm.sh/chart: istiod-1.27.1
         install.operator.istio.io/owning-resource: unknown
         istio: istiod
         istio.io/dataplane-mode: none
@@ -88,6 +88,7 @@ spec:
         - name: GOMEMLIMIT
           valueFrom:
             resourceFieldRef:
+              divisor: "1"
               resource: limits.memory
         - name: GOMAXPROCS
           valueFrom:
@@ -96,7 +97,9 @@ spec:
               resource: limits.cpu
         - name: PLATFORM
           value: ""
-        image: quay.io/rh-ee-sutt/istio-testing/pilot:1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+        - name: ENABLE_GATEWAY_API_INFERENCE_EXTENSION
+          value: "true"
+        image: docker.io/istio/pilot:1.27.1
         name: discovery
         ports:
         - containerPort: 8080
@@ -182,3 +185,4 @@ spec:
           name: istio-ca-root-cert
           optional: true
         name: istio-csr-ca-configmap
+

--- a/deploy/components/istio-control-plane/hpa.yaml
+++ b/deploy/components/istio-control-plane/hpa.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: llm-d-gateway
     operator.istio.io/component: Pilot
@@ -29,3 +29,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod-llm-d-gateway
+

--- a/deploy/components/istio-control-plane/policies.yaml
+++ b/deploy/components/istio-control-plane/policies.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: llm-d-gateway
@@ -22,3 +22,4 @@ spec:
     matchLabels:
       app: istiod
       istio.io/rev: llm-d-gateway
+

--- a/deploy/components/istio-control-plane/rbac.yaml
+++ b/deploy/components/istio-control-plane/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-reader
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istio-reader-clusterrole-llm-d-gateway-llm-d-istio-system
 rules:
@@ -111,6 +111,7 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -121,8 +122,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istiod-clusterrole-llm-d-gateway-llm-d-istio-system
 rules:
@@ -275,12 +276,21 @@ rules:
   - create
 - apiGroups:
   - gateway.networking.k8s.io
+  - gateway.networking.x-k8s.io
   resources:
   - '*'
   verbs:
   - get
   - watch
   - list
+- apiGroups:
+  - gateway.networking.x-k8s.io
+  resources:
+  - xbackendtrafficpolicies/status
+  - xlistenersets/status
+  verbs:
+  - update
+  - patch
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -346,6 +356,7 @@ rules:
   - get
   - watch
   - list
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -356,8 +367,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istiod-gateway-controller-llm-d-gateway-llm-d-istio-system
 rules:
@@ -365,6 +376,30 @@ rules:
   - apps
   resources:
   - deployments
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
   verbs:
   - get
   - watch
@@ -397,6 +432,7 @@ rules:
   - patch
   - create
   - delete
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -407,8 +443,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-reader
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istio-reader-clusterrole-llm-d-gateway-llm-d-istio-system
 roleRef:
@@ -419,6 +455,7 @@ subjects:
 - kind: ServiceAccount
   name: istio-reader-service-account
   namespace: llm-d-istio-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -429,8 +466,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istiod-clusterrole-llm-d-gateway-llm-d-istio-system
 roleRef:
@@ -441,6 +478,7 @@ subjects:
 - kind: ServiceAccount
   name: istiod-llm-d-gateway
   namespace: llm-d-istio-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -451,8 +489,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istiod-gateway-controller-llm-d-gateway-llm-d-istio-system
 roleRef:
@@ -463,6 +501,7 @@ subjects:
 - kind: ServiceAccount
   name: istiod-llm-d-gateway
   namespace: llm-d-istio-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -473,8 +512,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istiod-llm-d-gateway
   namespace: llm-d-istio-system
@@ -511,6 +550,7 @@ rules:
   - update
   - patch
   - create
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -521,8 +561,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istiod-llm-d-gateway
   namespace: llm-d-istio-system
@@ -534,3 +574,4 @@ subjects:
 - kind: ServiceAccount
   name: istiod-llm-d-gateway
   namespace: llm-d-istio-system
+

--- a/deploy/components/istio-control-plane/service-accounts.yaml
+++ b/deploy/components/istio-control-plane/service-accounts.yaml
@@ -7,11 +7,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-reader
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: base-1.27.1
     release: istio
   name: istio-reader-service-account
   namespace: llm-d-istio-system
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -22,8 +23,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     release: istio
   name: istiod-llm-d-gateway
   namespace: llm-d-istio-system
+

--- a/deploy/components/istio-control-plane/services.yaml
+++ b/deploy/components/istio-control-plane/services.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: llm-d-gateway
@@ -34,3 +34,4 @@ spec:
   selector:
     app: istiod
     istio.io/rev: llm-d-gateway
+

--- a/deploy/components/istio-control-plane/webhooks.yaml
+++ b/deploy/components/istio-control-plane/webhooks.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     istio: istiod
     istio.io/rev: llm-d-gateway
     release: istio
@@ -43,6 +43,7 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -53,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27.1
+    helm.sh/chart: istiod-1.27.1
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: llm-d-gateway
     operator.istio.io/component: Pilot
@@ -133,3 +134,72 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: istiod-llm-d-gateway
+      namespace: llm-d-istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  name: namespace.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio-injection
+      operator: In
+      values:
+      - enabled
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: istiod-llm-d-gateway
+      namespace: llm-d-istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  name: object.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio-injection
+      operator: DoesNotExist
+    - key: istio.io/rev
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: In
+      values:
+      - "true"
+    - key: istio.io/rev
+      operator: DoesNotExist
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+


### PR DESCRIPTION
This PR replaces the use of a privately built and patched Istio used in the `env-dev-kind` make target. This make target brings up an end to end system running under Kind that uses Istio for the data plane.

In particular Istio is upgraded to 1.27.1

Fixes #333.