### PR TITLE
add a hold label when PRs are pushed to branch other than main

### DIFF
--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -1,0 +1,17 @@
+name: Label non-main PRs
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add labels when base branch is not main
+        if: github.event.pull_request.base.ref != 'main'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            do-not-merge/hold


### PR DESCRIPTION
add a hold label automatically if someone pushes mistakenly a PR against a branch other than main (e.g., to a release branch).
recently, a PR was merged by mistake to release 1.0 branch in IGW.
As a result, the maintainers team decided to have automated marking of such PRs (that are targeting branch other than main), with an appropriate hold label.
This PR adds hold labels, making sure the maintainers team doesn't miss it if it happens here as well.
(same PR pushed also to IGW)
