### PR TITLE
fix: Rename config to `kv-cache-utilization-scorer` from `kv-cache-scorer`

### DIFF
--- a/deploy/config/epp-precise-prefix-cache-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-config.yaml
@@ -13,7 +13,7 @@ plugins:
           hashSeed: "42"                # must match vLLM PYTHONHASHSEED env var
         kvBlockIndexConfig:
           enableMetrics: true           # enable kv-block index metrics (prometheus)
-  - type: kv-cache-scorer # kv-cache-utilization
+  - type: kv-cache-utilization-scorer
   - type: queue-scorer
   - type: max-score-picker
 schedulingProfiles:
@@ -22,7 +22,7 @@ schedulingProfiles:
       - pluginRef: decode-filter
       - pluginRef: precise-prefix-cache-scorer
         weight: 2.0
-      - pluginRef: kv-cache-scorer
+      - pluginRef: kv-cache-utilization-scorer
         weight: 1.0
       - pluginRef: queue-scorer
         weight: 1.0


### PR DESCRIPTION
After the https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1238, 
Rename config to `kv-cache-utilization-scorer` from `kv-cache-scorer`