### PR TITLE
Fix multi-architecture image issues with Kind

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -120,23 +120,24 @@ func setupK8sCluster() {
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
 
-	kindLoad("ghcr.io/llm-d/llm-d-inference-sim:" + vllmSimTag)
-	kindLoad("ghcr.io/llm-d/llm-d-inference-scheduler:" + eppTag)
-	kindLoad("ghcr.io/llm-d/llm-d-routing-sidecar:" + routingSideCarTag)
+	kindLoadImage("ghcr.io/llm-d/llm-d-inference-sim:" + vllmSimTag)
+	kindLoadImage("ghcr.io/llm-d/llm-d-inference-scheduler:" + eppTag)
+	kindLoadImage("ghcr.io/llm-d/llm-d-routing-sidecar:" + routingSideCarTag)
 }
 
-func kindLoad(image string) {
+func kindLoadImage(image string) {
 	tempDir := ginkgo.GinkgoT().TempDir()
+	target := tempDir + "/docker.tar"
 
 	ginkgo.By(fmt.Sprintf("Loading %s into the cluster e2e-tests", image))
 
 	command := exec.Command("docker", "save", "--platform", "linux/"+runtime.GOARCH,
-		"--output", tempDir+"/docker.tar", image)
+		"--output", target, image)
 	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
 
-	command = exec.Command("kind", "--name", "e2e-tests", "load", "image-archive", tempDir+"/docker.tar")
+	command = exec.Command("kind", "--name", "e2e-tests", "load", "image-archive", target)
 	session, err = gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))


### PR DESCRIPTION
Newer versions of Kind use containerd under the covers in the simulated K8S nodes.

There is a known incompatibility between Docker and containerd with respect to multi-platform images. Docker doesn't pull al of the layers of such images. It only pulls the layers that are applicable to the platform (i.e. AMD64 or ARM64) in question. Containerd then issues an error about missing layers.

See https://github.com/kubernetes-sigs/kind/issues/3795 for more details.

This PR replaces the command `kind load docker-image...` with `docker save` and `kind load image-archive`. The docker save is done specifying the local platform, to only save for the appropriate platform.