### PR TITLE
Check the CONTAINER_TOOL value and use it in the e2e test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,9 +293,16 @@ check-envsubst:
 
 .PHONY: check-container-tool
 check-container-tool:
-	@command -v $(CONTAINER_TOOL) >/dev/null 2>&1 || { \
-	  echo "❌ $(CONTAINER_TOOL) is not installed."; \
-	  echo "🔧 Try: sudo apt install $(CONTAINER_TOOL) OR brew install $(CONTAINER_TOOL)"; exit 1; }
+	@if [ -z "$(CONTAINER_TOOL)" ]; then \
+		echo "❌ Error: No container tool detected. Please install docker or podman."; \
+		exit 1; \
+	elif ! command -v $(CONTAINER_TOOL) >/dev/null 2>&1; then \
+		echo "❌ Error: '$(CONTAINER_TOOL)' is not installed or not in your PATH."; \
+		echo "🔧 Try: sudo apt install $(CONTAINER_TOOL) OR brew install $(CONTAINER_TOOL)"; \
+		exit 1; \
+	else \
+		echo "✅ Container tool '$(CONTAINER_TOOL)' found."; \
+	fi
 
 .PHONY: check-kubectl
 check-kubectl:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ TYPOS_ARCH = $(TYPOS_TARGET_ARCH)-unknown-linux-musl
 endif
 
 CONTAINER_TOOL := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; } || echo "")
+export CONTAINER_TOOL
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
 PLATFORMS ?= linux/amd64 # linux/arm64 # linux/s390x,linux/ppc64le
 

--- a/test/scripts/run_e2e.sh
+++ b/test/scripts/run_e2e.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Use the CONTAINER_TOOL from the environment, or default to docker if it's not set.
+CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
+echo "Using container tool: ${CONTAINER_TOOL}"
+
 # Set a default EPP_TAG if not provided
 export EPP_TAG="${EPP_TAG:-dev}"
 
@@ -9,27 +13,27 @@ export VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-v0.4.0}"
 # Set the default routing side car image tag
 export ROUTING_SIDECAR_TAG="${ROUTING_SIDECAR_TAG:-v0.2.0}"
 
-SIMTAG=$(docker images | grep ghcr.io/llm-d/llm-d-inference-sim | awk '{print $2}' | grep ${VLLM_SIMULATOR_TAG})
+SIMTAG=$(${CONTAINER_TOOL} images | grep ghcr.io/llm-d/llm-d-inference-sim | awk '{print $2}' | grep ${VLLM_SIMULATOR_TAG})
 if [[ "${SIMTAG}" != "${VLLM_SIMULATOR_TAG}" ]]; then
-  docker pull ghcr.io/llm-d/llm-d-inference-sim:${VLLM_SIMULATOR_TAG}
+  ${CONTAINER_TOOL} pull ghcr.io/llm-d/llm-d-inference-sim:${VLLM_SIMULATOR_TAG}
   if [[ $? != 0 ]]; then
     echo "Failed to pull ghcr.io/llm-d/llm-d-inference-sim:${VLLM_SIMULATOR_TAG}"
     exit 1
   fi
 fi
 
-EPPTAG=$(docker images | grep ghcr.io/llm-d/llm-d-inference-scheduler | awk '{print $2}' | grep ${EPP_TAG})
+EPPTAG=$(${CONTAINER_TOOL} images | grep ghcr.io/llm-d/llm-d-inference-scheduler | awk '{print $2}' | grep ${EPP_TAG})
 if [[ "${EPPTAG}" != "${EPP_TAG}" ]]; then
-  docker pull ghcr.io/llm-d/llm-d-inference-scheduler:${EPP_TAG}
+  ${CONTAINER_TOOL} pull ghcr.io/llm-d/llm-d-inference-scheduler:${EPP_TAG}
   if [[ $? != 0 ]]; then
     echo "Failed to pull ghcr.io/llm-d/llm-d-inference-scheduler:${EPP_TAG}"
     exit 1
   fi
 fi
 
-SIDECARTAG=$(docker images | grep ghcr.io/llm-d/llm-d-routing-sidecar | awk '{print $2}' | grep ${ROUTING_SIDECAR_TAG})
+SIDECARTAG=$(${CONTAINER_TOOL} images | grep ghcr.io/llm-d/llm-d-routing-sidecar | awk '{print $2}' | grep ${ROUTING_SIDECAR_TAG})
 if [[ "${SIDECARTAG}" != "${ROUTING_SIDECAR_TAG}" ]]; then
-  docker pull ghcr.io/llm-d/llm-d-routing-sidecar:${ROUTING_SIDECAR_TAG}
+  ${CONTAINER_TOOL} pull ghcr.io/llm-d/llm-d-routing-sidecar:${ROUTING_SIDECAR_TAG}
   if [[ $? != 0 ]]; then
     echo "Failed to pull ghcr.io/llm-d/llm-d-routing-sidecar:${ROUTING_SIDECAR_TAG}"
     exit 1


### PR DESCRIPTION
## Description
- Add a more robust check for the check-container-tool make target to catch empty CONTAINER_TOOL values
- Change the run_e2e.sh script to use the CONTAINER_TOOL value, defaulting to docker if it is unset

## How Has This Been Tested?
```
$ make check-container-tool 
✅ Container tool 'podman' found.
```
 (this is correct for my system)

```
$ make test-e2e
✅ Container tool 'podman' found.
==== Building Docker image ghcr.io/llm-d/llm-d-inference-scheduler:dev ====
podman build \
```

Other cases:
Manually set CONTAINER_TOOL := ""
```
$ make check-container-tool 
❌ Error: No container tool detected. Please install docker or podman.
make: *** [Makefile:297: check-container-tool] Error 1
```

Manually set CONTAINER_TOOL := "docker"
```
$ make check-container-tool 
❌ Error: 'docker' is not installed or not in your PATH.
🔧 Try: sudo apt install docker OR brew install docker
make: *** [Makefile:297: check-container-tool] Error 1
```
 (this is correct for my system)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Allow selection of container tool via CONTAINER_TOOL, propagated to sub-commands.
  - Added check-builder target to validate and report the selected builder.

- Improvements
  - Enhanced container tool checks with clearer validation and guidance when the tool is missing or not in PATH.

- Tests
  - E2E script now honors CONTAINER_TOOL (defaulting to docker), prints the chosen tool, and uses it for image operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->