### PR TITLE
Enhancement: return 503 instead of 502 when decode node is not ready

### DIFF
--- a/pkg/sidecar/proxy/errors.go
+++ b/pkg/sidecar/proxy/errors.go
@@ -30,6 +30,8 @@ type errorResponse struct {
 	Code    int    `json:"code"`
 }
 
+const decoderServiceUnavailableResponseJSON = `{"object":"error","message":"The decode node is not ready. Please check that the vLLM service is running and the port configuration is correct.","type":"ServiceUnavailable","param":"","code":503}`
+
 func errorJSONInvalid(err error, w http.ResponseWriter) error {
 	// Simulate vLLM error
 


### PR DESCRIPTION
## Description

Enhancement https://github.com/llm-d/llm-d-inference-scheduler/issues/402 Improve error handling in the sidecar proxy to provide clearer feedback when
the decode node (vLLM) is not ready.

## Changes

- Return `503 Service Unavailable` instead of `502` when ECONNREFUSED occurs
- Add structured error response with clear message
- Enhance error logging