### PR TITLE
Missed change to the Go code coverage output file names in the Makefile refactoring

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage
-          path: coverage.out # Make sure to use the same file name you chose for the "-coverprofile" in the "make test" step
+          path: coverage-*.out # Make sure to use the same file name you chose for the "-coverprofile" in the "make test" step
 
       - name: Run make build
         shell: bash


### PR DESCRIPTION
CI needs to upload coverage-*.out (i.e. coverage-epp.out and coverage-sidecar.out) and not simply coverage.out when it is trying to archive the code coverage output files for potential later comparisons.