### PR TITLE
Fix: Remove reference to the missing make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ image-build-%: check-container-tool ## Build Docker image ## Build Docker image 
 image-push: image-push-epp image-push-sidecar ## Push Docker images to registry
 
 .PHONY: image-push-%
-image-push-%: check-container-tool load-version-json ## Push Docker image to registry
+image-push-%: check-container-tool ## Push Docker image to registry
 	@printf "\033[33;1m==== Pushing Docker image $($*_IMAGE) ====\033[0m\n"
 	$(CONTAINER_TOOL) push $($*_IMAGE)
 


### PR DESCRIPTION
This PR removes reference to the missing target ` load-version-json` in the Makefile.

Before this fix:
$ make image-push
make: *** No rule to make target 'image-push-epp', needed by 'image-push'.  Stop.

After:
$ make image-push
==== Pushing Docker image ... ====