### PR TITLE
Remove endpointslices from RBAC

### DIFF
--- a/deploy/components/inference-gateway/rbac.yaml
+++ b/deploy/components/inference-gateway/rbac.yaml
@@ -29,14 +29,6 @@ rules:
   - "watch"
   - "list"
 - apiGroups:
-  - "discovery.k8s.io"
-  resources:
-  - "endpointslices"
-  verbs:
-  - "get"
-  - "watch"
-  - "list"
-- apiGroups:
   - "authentication.k8s.io"
   resources:
   - "tokenreviews"

--- a/test/sidecar/config/nixl/pod-read-role.yaml
+++ b/test/sidecar/config/nixl/pod-read-role.yaml
@@ -28,14 +28,6 @@ rules:
       - watch
       - list
   - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
       - authentication.k8s.io
     resources:
       - tokenreviews


### PR DESCRIPTION
EndpointSlice are not used by sidecar or inference-scheduler - seems to be a copy error from IGW where some k8s test require access to EndpointSlice.
The endpointslice access control is kept for Istio control plane.  