### PR TITLE
Fix references to the SideCar's tag

### DIFF
--- a/deploy/components/vllm-sim-pd/kustomization.yaml
+++ b/deploy/components/vllm-sim-pd/kustomization.yaml
@@ -15,4 +15,4 @@ images:
 - name: ghcr.io/llm-d/llm-d-inference-sim
   newTag: ${VLLM_SIMULATOR_TAG}
 - name: ghcr.io/llm-d/llm-d-routing-sidecar
-  newTag: ${ROUTING_SIDECAR_TAG}
+  newTag: ${SIDECAR_TAG}

--- a/deploy/components/vllm-sim/kustomization.yaml
+++ b/deploy/components/vllm-sim/kustomization.yaml
@@ -15,5 +15,5 @@ images:
 - name: ghcr.io/llm-d/llm-d-inference-sim
   newTag: ${VLLM_SIMULATOR_TAG}
 - name: ghcr.io/llm-d/llm-d-routing-sidecar
-  newTag: ${ROUTING_SIDECAR_TAG}
+  newTag: ${SIDECAR_TAG}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -151,7 +151,7 @@ func createModelServers(withPD, withKV bool, vllmReplicas, prefillReplicas, deco
 			"${MODEL_NAME_SAFE}":      theSafeModelName,
 			"${POOL_NAME}":            poolName,
 			"${KV_CACHE_ENABLED}":     strconv.FormatBool(withKV),
-			"${ROUTING_SIDECAR_TAG}":  routingSideCarTag,
+			"${SIDECAR_TAG}":          routingSideCarTag,
 			"${VLLM_REPLICA_COUNT}":   strconv.Itoa(vllmReplicas),
 			"${VLLM_REPLICA_COUNT_D}": strconv.Itoa(decodeReplicas),
 			"${VLLM_REPLICA_COUNT_P}": strconv.Itoa(prefillReplicas),

--- a/test/e2e/yaml/vllm-sim-pd.yaml
+++ b/test/e2e/yaml/vllm-sim-pd.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       initContainers:
       - name: routing-sidecar
-        image: ghcr.io/llm-d/llm-d-routing-sidecar:${ROUTING_SIDECAR_TAG}
+        image: ghcr.io/llm-d/llm-d-routing-sidecar:${SIDECAR_TAG}
         imagePullPolicy: IfNotPresent
         args:
         - "--port=8000"


### PR DESCRIPTION
Earlier PRs changed the environment variable used for the SideCar's image tag.

A few places in the repo were missed.