### PR TITLE
Remove duplicate error logs

### DIFF
--- a/pkg/plugins/scorer/no_hit_lru.go
+++ b/pkg/plugins/scorer/no_hit_lru.go
@@ -83,7 +83,7 @@ func NewNoHitLRU(ctx context.Context, params *NoHitLRUParameters) *NoHitLRU {
 
 	lruCache, err := lru.New[string, struct{}](lruSize)
 	if err != nil {
-		log.FromContext(ctx).Error(err, fmt.Sprintf("failed to initialize NoHitLRU scorer: could not create LRU cache with size %d: %v", lruSize, err))
+		log.FromContext(ctx).Error(err, fmt.Sprintf("failed to initialize NoHitLRU scorer: could not create LRU cache with size %d", lruSize))
 		return nil
 	}
 


### PR DESCRIPTION
Removed the duplicate `err` log by eliminating the one printed in `msg`.