### PR TITLE
Remove dev from branch list in PR actions

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -6,7 +6,6 @@ on:
       - main
   pull_request:
     branches:
-      - dev
       - main
 
 jobs:


### PR DESCRIPTION
cleanup of GH action - previously configured to run on `dev` and `main` branches. The `dev` branch is no longer used.