### PR TITLE
Fix: Remove invalid restartPolicy from initContainers in deployment

### DIFF
--- a/deploy/components/vllm-sim-pd/deployments.yaml
+++ b/deploy/components/vllm-sim-pd/deployments.yaml
@@ -104,7 +104,6 @@ spec:
         - name: sidecar-rank7
           containerPort: 8007
           protocol: TCP
-        restartPolicy: Always
         env:
         - name: POD_IP
           valueFrom:

--- a/deploy/components/vllm-sim/deployments.yaml
+++ b/deploy/components/vllm-sim/deployments.yaml
@@ -49,7 +49,6 @@ spec:
         - name: sidecar-rank7
           containerPort: 8007
           protocol: TCP
-        restartPolicy: Always
         env:
         - name: POD_IP
           valueFrom:


### PR DESCRIPTION
Fix deployment validation error by removing invalid `restartPolicy` field from initContainers

Deployment creation was failing with the following error:
 ` error when creating "STDIN": Deployment in version "v1" cannot be handled as a Deployment: strict decoding error:    unknown field "spec.template.spec.initContainers[0].restartPolicy"
`
  ## Root Cause
  The `restartPolicy: Always` field was incorrectly placed inside the `initContainers` specification in two deployment files:
  - `deploy/components/vllm-sim/deployments.yaml`
  - `deploy/components/vllm-sim-pd/deployments.yaml`

  ## Solution
  Removed the invalid `restartPolicy: Always` lines from both files.

- The `restartPolicy` field is only valid at the Pod spec level (`spec.template.spec.restartPolicy`)
   - It cannot be specified for individual containers or initContainers
   - Kubernetes Deployments have a default `restartPolicy` of "Always" at the Pod level
   - The redundant field in initContainers was unnecessary and caused API validation to fail
  

  