### PR TITLE
change lmcache connector to nixlv2

### DIFF
--- a/deploy/components/vllm-sim-pd/deployments.yaml
+++ b/deploy/components/vllm-sim-pd/deployments.yaml
@@ -76,7 +76,7 @@ spec:
         args:
         - "--port=8000"
         - "--vllm-port=8200"
-        - "--connector=lmcache"
+        - "--connector=nixlv2"
         - "--secure-proxy=false"
         - "--data-parallel-size=${VLLM_DATA_PARALLEL_SIZE}"
         ports:

--- a/deploy/components/vllm-sim/deployments.yaml
+++ b/deploy/components/vllm-sim/deployments.yaml
@@ -21,7 +21,7 @@ spec:
         args:
         - "--port=8000"
         - "--vllm-port=8200"
-        - "--connector=lmcache"
+        - "--connector=nixlv2"
         - "--secure-proxy=false"
         - "--data-parallel-size=${VLLM_DATA_PARALLEL_SIZE}"
         ports:


### PR DESCRIPTION
- change `lmcache` connector to `nixlv2`, because `lmcache` connector has been marked as deprecated.