### PR TITLE
fix: Roll back automatic updates to Dockerfiles

### DIFF
--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -1,5 +1,5 @@
-# Build Stage: using Go 1.24.1 image
-FROM quay.io/projectquay/golang:1.25 AS builder
+# Build Stage: using Go 1.24 image
+FROM quay.io/projectquay/golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,5 +1,5 @@
-# Build Stage: using Go 1.25 image
-FROM quay.io/projectquay/golang:1.25 AS builder
+# Build Stage: using Go 1.24 image
+FROM quay.io/projectquay/golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG COMMIT_SHA=unknown


### PR DESCRIPTION
This PR rolls back a change that was made by automatic updates of DependBot.

In particular the GO builder image used in the build of the images of the EPP and the Sidecar were changed from 1.24 to 1.25. As for the moment we are working with GO 1.24, that update is being rolled back