### PR TITLE
docs: add integration guide for external prefill/decode workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ workloads currently.
 [Kubernetes]:https://kubernetes.io
 [Architecture Documentation]:docs/architecture.md
 [Gateway API Inference Extension (GIE)]:https://github.com/kubernetes-sigs/gateway-api-inference-extension
-[P/D Disaggregation]:docs/dp.md
+[P/D Disaggregation]:docs/disagg_pd.md
 [Gateway API]:https://github.com/kubernetes-sigs/gateway-api
 [Envoy]:https://github.com/envoyproxy/envoy
 [ext-proc]:https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -481,7 +481,7 @@ The **vLLM sidecar** handles orchestration between Prefill and Decode stages. It
 - Local memory management
 - Experimental protocol compatibility
 
-> **Note**: The detailed P/D design is available in this document: [Disaggregated Prefill/Decode in llm-d](./dp.md)
+> **Note**: The detailed P/D design is available in this document: [Disaggregated Prefill/Decode in llm-d](./disagg_pd.md)
 
 ---
 


### PR DESCRIPTION
 Add integration guide for external prefill/decode workload.
Include instructions on using `by-label` plugin in `EndpointPickerConfig`
to support custom labeling schemes (e.g., role=prefill/decode) from external systems.  

Fix https://github.com/llm-d/llm-d-inference-scheduler/issues/436 and https://github.com/llm-d/llm-d-inference-scheduler/issues/430
