### PR TITLE
refactor: Sync with llm-d-kv-cache-manager PR #161 (Update GetPodScores Signature)

### DIFF
--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -3,13 +3,11 @@ package scorer
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache/kvevents"
-	preprocessing "github.com/llm-d/llm-d-kv-cache-manager/pkg/preprocessing/chat_completions"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
@@ -118,34 +116,22 @@ func (s *PrecisePrefixCacheScorer) WithName(name string) *PrecisePrefixCacheScor
 // The returned scores are normalized to a range of 0-1.
 func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, _ *types.CycleState, request *types.LLMRequest, pods []types.Pod) map[types.Pod]float64 {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
-
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("Request is nil, skipping scoring")
 		return nil
 	}
 
-	// Extract the flattened prompt from the request
-	logger.V(logutil.DEBUG).Info("Extracting prompt from request",
-		"target_model", request.TargetModel,
-		"has_chat_completions", request.Body != nil && request.Body.ChatCompletions != nil,
-		"has_completions", request.Body != nil && request.Body.Completions != nil)
-
-	prompt, err := s.extractPrompt(ctx, request)
+	prompt, messages, err := getUserInput(request)
 	if err != nil {
-		logger.Error(err, "Failed to extract prompt from request", "target_model", request.TargetModel)
+		logger.Error(err, "Failed to get user input", "target_model", request.TargetModel)
 		return nil
 	}
 
-	logger.V(logutil.DEBUG).Info("Getting pod scores",
-		"prompt_length", len(prompt),
-		"target_model", request.TargetModel)
-
-	scores, err := s.kvCacheIndexer.GetPodScores(ctx, prompt, request.TargetModel, nil)
+	scores, err := s.kvCacheIndexer.GetPodScores(ctx, prompt, messages, request.TargetModel, nil)
 	if err != nil {
 		logger.Error(err, "Failed to get pod scores", "target_model", request.TargetModel)
 		return nil
 	}
-
 	logger.V(logutil.DEBUG).Info("Got pod scores", "scores_count", len(scores), "scores", scores, "target_model", request.TargetModel)
 
 	podToKey := func(pod types.Pod) (string, bool) {
@@ -160,114 +146,19 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, _ *types.CycleStat
 	return indexedScoresToNormalizedScoredPods(pods, podToKey, scores)
 }
 
-// extractPrompt extracts the flattened prompt from the request.
-// For chat completions, it renders the messages using the model's chat template.
-// For regular completions, it uses the prompt directly.
-func (s *PrecisePrefixCacheScorer) extractPrompt(ctx context.Context, request *types.LLMRequest) (string, error) {
-	logger := log.FromContext(ctx).WithName(s.typedName.String())
-
-	// If it's a chat completion request, render the chat template.
-	// The upstream API guarantees exactly one of Completions or ChatCompletions is populated,
-	// but if both appear we prefer chat completions to match request semantics.
-	if request.Body != nil && request.Body.ChatCompletions != nil && request.Body.Completions != nil {
-		logger.V(logutil.DEBUG).Info("Both chat completions and completions present; prioritizing chat completions", "target_model", request.TargetModel)
+func getUserInput(request *types.LLMRequest) (string, []byte, error) {
+	if request.Body.Completions != nil { // assumed to be valid if not nil
+		return request.Body.Completions.Prompt, nil, nil
 	}
 
-	// The upstream parser guarantees exactly one body is populated, but we defensively prioritize chat completions.
-	// If an unexpected dual payload slips through (parser regression/new client), log it and use chat semantics.
-	if request.Body != nil && request.Body.ChatCompletions != nil {
-		if request.Body.Completions != nil {
-			logger.V(logutil.DEBUG).Info("Both chat_completions and completions present; defaulting to chat completions", "target_model", request.TargetModel)
-		}
-		logger.V(logutil.DEBUG).Info("Processing chat completion request",
-			"messages_count", len(request.Body.ChatCompletions.Messages),
-			"target_model", request.TargetModel)
-
-		// Create render request
-		renderReq := &preprocessing.RenderJinjaTemplateRequest{
-			Conversations:             make([]preprocessing.ChatMessage, 0),
-			Tools:                     request.Body.ChatCompletions.Tools,
-			Documents:                 request.Body.ChatCompletions.Documents,
-			ChatTemplate:              request.Body.ChatCompletions.ChatTemplate,
-			ReturnAssistantTokensMask: request.Body.ChatCompletions.ReturnAssistantTokensMask,
-			ContinueFinalMessage:      request.Body.ChatCompletions.ContinueFinalMessage,
-			AddGenerationPrompt:       request.Body.ChatCompletions.AddGenerationPrompt,
-			ChatTemplateKWArgs:        request.Body.ChatCompletions.ChatTemplateKWArgs,
-		}
-
-		// Convert messages to the format expected by the renderer
-		for _, msg := range request.Body.ChatCompletions.Messages {
-			renderReq.Conversations = append(renderReq.Conversations, preprocessing.ChatMessage{
-				Role:    msg.Role,
-				Content: msg.Content.Raw,
-			})
-		}
-
-		// Initialize the chat templating processor
-		processor := preprocessing.NewChatTemplatingProcessor()
-		if err := processor.Initialize(); err != nil {
-			return "", fmt.Errorf("failed to initialize chat templating processor: %w", err)
-		}
-
-		// Fetch the chat template from the model
-		fetchReq := preprocessing.FetchChatTemplateRequest{
-			Model: request.TargetModel,
-		}
-		logger.V(logutil.DEBUG).Info("Fetching chat template", "model", request.TargetModel)
-		chatTemplate, chatTemplateKWArgs, err := processor.FetchChatTemplate(ctx, fetchReq)
+	if request.Body.ChatCompletions != nil { // assumed to be valid if not nil
+		// must be chat-completions request at this point, return string of entire messages
+		data, err := json.Marshal(request.Body.ChatCompletions.Messages)
 		if err != nil {
-			logger.Error(err, "Failed to fetch chat template", "model", request.TargetModel)
-			return "", fmt.Errorf("failed to fetch chat template: %w", err)
+			return "", nil, fmt.Errorf("failed to marshal chat-completions messages: %w", err)
 		}
-		logger.V(logutil.DEBUG).Info("Chat template fetched",
-			"model", request.TargetModel,
-			"template_length", len(chatTemplate),
-			"has_kwargs", len(chatTemplateKWArgs) > 0)
-
-		// Set the fetched template in the render request
-		renderReq.ChatTemplate = chatTemplate
-		renderReq.ChatTemplateKWArgs = chatTemplateKWArgs
-
-		// Render the template to get flattened prompt
-		logger.V(logutil.DEBUG).Info("Rendering chat template",
-			"conversations_count", len(renderReq.Conversations))
-		resp, err := processor.RenderChatTemplate(ctx, renderReq)
-		if err != nil {
-			logger.Error(err, "Failed to render chat template")
-			return "", fmt.Errorf("failed to render chat template: %w", err)
-		}
-
-		if len(resp.RenderedChats) == 0 {
-			logger.Error(nil, "No rendered chat returned from template rendering")
-			return "", errors.New("no rendered chat returned from template rendering")
-		}
-
-		prompt := resp.RenderedChats[0]
-		logger.V(logutil.DEBUG).Info("Chat template rendered successfully", "prompt_length", len(prompt))
-		return prompt, nil
+		return "", data, nil
 	}
 
-	// For regular completions, use the prompt directly
-	if request.Body != nil && request.Body.Completions != nil {
-		prompt := request.Body.Completions.Prompt
-		logger.V(logutil.DEBUG).Info("Using completion prompt directly", "prompt_length", len(prompt))
-		return prompt, nil
-	}
-
-	// Fallback: retain compatibility with legacy IGW versions (≤ v0.5.x) that extracted prompts
-	// directly from a raw `prompt` field (see gateway-api-inference-extension/pkg/epp/util/request/body.go).
-	if request.Body != nil {
-		// Try to marshal and extract prompt from raw data
-		if dataBytes, err := json.Marshal(request.Body); err == nil {
-			var rawData map[string]interface{}
-			if err := json.Unmarshal(dataBytes, &rawData); err == nil {
-				if prompt, ok := rawData["prompt"].(string); ok && prompt != "" {
-					logger.V(logutil.DEBUG).Info("Extracted prompt from raw data", "prompt_length", len(prompt))
-					return prompt, nil
-				}
-			}
-		}
-	}
-
-	return "", errors.New("no valid prompt found in request")
+	return "", nil, fmt.Errorf("request body must contain either completions or chat-completions")
 }


### PR DESCRIPTION
##  Summary

The signature of the `GetPodScores` function has been updated to align with the changes introduced in llm-d-kv-cache-manager PR [#161](https://github.com/llm-d/llm-d-kv-cache-manager/pull/161). This is an essential refactoring to maintain compatibility between KV Cache Manager components.

---

##  Motivation

The upstream interface for `GetPodScores` was modified to **receive additional message array information**. This change is necessary to resolve the API mismatch and secure the stability of the system when interacting with the updated KV Cache Manager.

##  Detailed Changes

The `messages []byte` argument has been added to the `GetPodScores` function signature.

* **AS-IS**: 
    `GetPodScores(ctx context.Context, prompt string, modelName string, podIdentifiers []string)`

* **TO-BE**:
    `GetPodScores(ctx context.Context, prompt string, messages []byte, modelName string, podIdentifiers []string)`

* **Change Detail**: The `messages []byte` argument is newly inserted after the `prompt string` argument.


Co-authored-by: Hyeonki Hong <hyeonki.hong@moreh.io>