### PR TITLE
Pins GH actions

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
     - name: Login to GitHub Container Registry
       run: echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -10,8 +10,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Check typos
-        uses: crate-ci/typos@v1.36.2
+        uses: crate-ci/typos@85f62a8a84f939ae994ab3763f01a0296d61a7ee # v1.36.2
 

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         
       - name: Sanity check repo contents
         run: ls -la
@@ -20,7 +20,7 @@ jobs:
         run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
 
       - name: Set up Go with cache
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache-dependency-path: ./go.sum
@@ -37,7 +37,7 @@ jobs:
         run: go mod tidy
 
       - name: Run lint checks
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: 'v2.1.6'
           args: "--config=./.golangci.yml"

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Set project name from repository
         id: version

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Install lychee v0.18.1
         run: |

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Add labels when base branch is not main
         if: github.event.pull_request.base.ref != 'main'
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: |

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -16,7 +16,7 @@ jobs:
   prow-execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
+      - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           prow-commands: "/assign

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -10,7 +10,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
+      - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:
           jobs: 'lgtm'
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -5,7 +5,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
+      - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/re-run-action.yml
+++ b/.github/workflows/re-run-action.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: estroz/rerun-actions@main
+    - uses: estroz/rerun-actions@6660c16a6581b198ac59545c06531a6077bf7be6 # main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         comment_id: ${{ github.event.comment.id }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: 'Mark stale issues'
-        uses: actions/stale@v10
+        uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10
         with:
           days-before-issue-stale: 90
           days-before-pr-stale: -1
@@ -21,7 +21,7 @@ jobs:
           stale-issue-message: 'This issue is marked as stale after 90d of inactivity. After an additional 30d of inactivity, it will be closed. To prevent this issue from being closed, add a comment or remove the `lifecycle/stale` label.'
 
       - name: 'Mark rotten issues'
-        uses: actions/stale@v10
+        uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10
         with:
           days-before-issue-stale: 30
           days-before-pr-stale: -1
@@ -31,7 +31,7 @@ jobs:
           labels-to-remove-when-stale: 'lifecycle/stale'
 
       - name: 'Close rotten issues'
-        uses: actions/stale@v10
+        uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10
         with:
           days-before-stale: -1
           days-before-issue-close: 30

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -17,7 +17,7 @@ jobs:
        contains(github.event.issue.labels.*.name, 'lifecycle/rotten'))
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: 'Remove stale labels'
         env:


### PR DESCRIPTION
We're in the process of reinforcing our GitHub Actions by requiring them to use pinned releases, in line with [security good practices](https://docs.github.com/en/actions/reference/security/secure-use). Before enforcing that we first need to update the current `uses` references to use the proper syntax.

_(PR generated semi-automatically)_