### PR TITLE
Replace tab with spaces to avoid treating as make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ ifneq ($(shell $(PYTHON_CONFIG) --cflags 2>/dev/null),)
     # Use --ldflags --embed to get all necessary flags for linking
     PYTHON_LDFLAGS := $(shell $(PYTHON_CONFIG) --ldflags --embed)
 else
-	$(error ${PYTHON_ERROR})
+    $(error ${PYTHON_ERROR})
 endif
 
 # CGO flags with all dependencies


### PR DESCRIPTION
make was treating `<tab>$(error ...)` as target. Replaced tab with spaces.
Note that installation on Linux in **dev environment** (not CICD) is broken since `apt` and friends should run with root priviliges, For now can work around using manual install of dependencies. Created #470 