### PR TITLE
[WIP] build: uplift Go version to 1.25

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@ Documentation for developing the inference scheduler.
 ## Requirements
 
 - [Make] `v4`+
-- [Golang] `v1.24`+
+- [Golang] `v1.25`+
 - [Docker] (or [Podman])
 - [Kubernetes in Docker (KIND)]
 - [Kustomize]

--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -1,6 +1,6 @@
 ## Minimal runtime Dockerfile (microdnf-only, no torch, wrapper in site-packages)
-# Build Stage: using Go 1.24 image
-FROM quay.io/projectquay/golang:1.24 AS builder
+# Build Stage: using Go 1.25 image
+FROM quay.io/projectquay/golang:1.25 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,5 +1,5 @@
-# Build Stage: using Go 1.24 image
-FROM quay.io/projectquay/golang:1.24 AS builder
+# Build Stage: using Go 1.25 image
+FROM quay.io/projectquay/golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG COMMIT_SHA=unknown

--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ check-ginkgo:
 .PHONY: check-golangci-lint
 check-golangci-lint:
 	@command -v golangci-lint >/dev/null 2>&1 || { \
-	  echo "❌ golangci-lint is not installed. Install from https://golangci-lint.run/usage/install/"; exit 1; }
+	  echo "❌ golangci-lint is not installed. Install from https://golangci-lint.run/docs/welcome/install/"; exit 1; }
 
 .PHONY: check-kustomize
 check-kustomize:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/llm-d/llm-d-inference-scheduler
 
-go 1.24.1
-
-toolchain go1.24.2
+go 1.25
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/pkg/sidecar/proxy/data_parallel_test.go
+++ b/pkg/sidecar/proxy/data_parallel_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
 	sidecarmock "github.com/llm-d/llm-d-inference-scheduler/test/sidecar/mock"
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils"
+	"github.com/llm-d/llm-d-inference-scheduler/test/testnet"
 )
 
 const (
@@ -30,7 +30,7 @@ var _ = Describe("Data Parallel support", func() {
 			// proxy.startDataParallel starts listeners on the ports following
 			// the proxy's main port. To avoid problems, get a free port and
 			// tell the proxy that it is listening on that port minus one.
-			freePort, err := testutils.GetFreePort()
+			freePort, err := testnet.GetFreePort()
 			Expect(err).ToNot(HaveOccurred())
 			tmpPort, err := strconv.Atoi(freePort)
 			fakeProxyPort := tmpPort - 1

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -271,10 +271,11 @@ func createInferencePool(numTargetPorts int, toDelete bool) []string {
 	}
 
 	infPoolYaml := testutils.ReadYaml(inferExtManifest)
-	targetPorts := ""
+	var targetPortsBuilder strings.Builder
 	for idx := range numTargetPorts {
-		targetPorts += fmt.Sprintf("\n  - number: %d", 8000+idx)
+		targetPortsBuilder.WriteString(fmt.Sprintf("\n  - number: %d", 8000+idx))
 	}
+	targetPorts := targetPortsBuilder.String()
 	infPoolYaml = substituteMany(infPoolYaml,
 		map[string]string{
 			"${POOL_NAME}":    poolName,

--- a/test/testnet/network.go
+++ b/test/testnet/network.go
@@ -1,7 +1,5 @@
-// Package utils contains utilities for testing
-//
-//revive:disable:var-naming
-package utils
+// Package testnet contains network utilities for testing
+package testnet
 
 //revive:enable:var-naming
 


### PR DESCRIPTION
# Changelog
- fix lint issues
- update link

# NOTE      
Do not merge till [GIE](kubernetes-sigs/gateway-api-inference-extension/) uplift to 1.25
relate to https://github.com/llm-d/llm-d-inference-scheduler/pull/458