### PR TITLE
feat(allowlist): support both v1 and v1alpha2 InferencePool APIs with flag

### DIFF
--- a/cmd/pd-sidecar/main.go
+++ b/cmd/pd-sidecar/main.go
@@ -58,6 +58,7 @@ func main() {
 	inferencePoolNamespace := flag.String("inference-pool-namespace", os.Getenv("INFERENCE_POOL_NAMESPACE"), "the Kubernetes namespace to watch for InferencePool resources (defaults to INFERENCE_POOL_NAMESPACE env var)")
 	inferencePoolName := flag.String("inference-pool-name", os.Getenv("INFERENCE_POOL_NAME"), "the specific InferencePool name to watch (defaults to INFERENCE_POOL_NAME env var)")
 	enablePrefillerSampling := flag.Bool("enable-prefiller-sampling", func() bool { b, _ := strconv.ParseBool(os.Getenv("ENABLE_PREFILLER_SAMPLING")); return b }(), "if true, the target prefill instance will be selected randomly from among the provided prefill host values")
+	poolGroup := flag.String("pool-group", proxy.DefaultPoolGroup, "group of the InferencePool this Endpoint Picker is associated with.")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine) // optional to allow zap logging control via CLI
@@ -135,7 +136,7 @@ func main() {
 	}
 
 	// Create SSRF protection validator
-	validator, err := proxy.NewAllowlistValidator(*enableSSRFProtection, *inferencePoolNamespace, *inferencePoolName)
+	validator, err := proxy.NewAllowlistValidator(*enableSSRFProtection, *poolGroup, *inferencePoolNamespace, *inferencePoolName)
 	if err != nil {
 		logger.Error(err, "failed to create SSRF protection validator")
 		return

--- a/pkg/sidecar/proxy/allowlist_test.go
+++ b/pkg/sidecar/proxy/allowlist_test.go
@@ -28,7 +28,7 @@ var _ = Describe("AllowlistValidator", func() {
 
 		BeforeEach(func() {
 			var err error
-			validator, err = NewAllowlistValidator(false, "test-namespace", "test-pool")
+			validator, err = NewAllowlistValidator(false, DefaultPoolGroup, "test-namespace", "test-pool")
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/pkg/sidecar/proxy/data_parallel_test.go
+++ b/pkg/sidecar/proxy/data_parallel_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Data Parallel support", func() {
 				DataParallelSize:          testDataParallelSize,
 			}
 			theProxy := NewProxy(strconv.Itoa(fakeProxyPort), decodeURL, cfg)
-			theProxy.allowlistValidator, err = NewAllowlistValidator(false, "", "")
+			theProxy.allowlistValidator, err = NewAllowlistValidator(false, DefaultPoolGroup, "", "")
 			Expect(err).ToNot(HaveOccurred())
 
 			err = theProxy.startDataParallel(ctx, nil, grp)

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -60,6 +60,11 @@ const (
 
 	// ConnectorSGLang enables SGLang P/D disaggregation protocol
 	ConnectorSGLang = "sglang"
+
+	// DefaultPoolGroup is the default pool group name
+	DefaultPoolGroup = "inference.networking.k8s.io"
+	// LegacyPoolGroup is the legacy pool group name
+	LegacyPoolGroup = "inference.networking.x-k8s.io"
 )
 
 // Config represents the proxy server configuration


### PR DESCRIPTION
add new `pool-group` flag to choose which inferencepool to support

fix: https://github.com/llm-d/llm-d-inference-scheduler/issues/462