### PR TITLE
fix: github action runner not exist 

### DIFF
--- a/.github/workflows/re-run-action.yml
+++ b/.github/workflows/re-run-action.yml
@@ -8,7 +8,7 @@ jobs:
   rerun_pr_tests:
     name: rerun_pr_tests
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: estroz/rerun-actions@main
       with:


### PR DESCRIPTION
# Description

- ubuntu-20.04 is already deprecated, see https://github.com/actions/runner-images/pull/11748
- use ubunut-latest to dynamically use latest version