### PR TITLE
fix: github action missing Trivy scan on sidecar image

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -27,10 +27,8 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
           cache-dependency-path: ./go.sum
 
-      - name: Install kvcache dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libzmq3-dev pkg-config python3-dev
+      - name: Install dependencies
+        run: sudo make install-dependencies
 
       - name: Configure CGO for Python
         run: |
@@ -58,12 +56,12 @@ jobs:
           CPATH: ${{ env.CPATH }}
           PKG_CONFIG_PATH: ${{ env.PKG_CONFIG_PATH }}
 
-      - name: Run make test
-        shell: bash 
-        run: |
-          make test
-
       - name: Run make build
         shell: bash
         run: |
           make build
+
+      - name: Run make test
+        shell: bash
+        run: |
+          make test

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -14,11 +14,12 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Set project name from repository
+      - name: Set image names
         id: version
         run: |
           repo="${GITHUB_REPOSITORY##*/}"
           echo "project_name=$repo" >> "$GITHUB_OUTPUT"
+          echo "sidecar_name=llm-d-routing-sidecar" >> "$GITHUB_OUTPUT"
 
       - name: Print project name
         run: echo "Project is ${{ steps.version.outputs.project_name }}"
@@ -52,12 +53,17 @@ jobs:
         with:
           docker-file: Dockerfile.sidecar
           tag: ${{ steps.tag.outputs.tag }}
-          image-name: llm-d-routing-sidecar
+          image-name: ${{ steps.version.outputs.sidecar_name }}
           registry: ghcr.io/llm-d
           github-token: ${{ secrets.GHCR_TOKEN }}
           prerelease: ${{ steps.tag.outputs.prerelease }}
 
-      - name: Run Trivy scan
+      - name: Run Trivy scan on EPP image
         uses: ./.github/actions/trivy-scan
         with:
           image: ghcr.io/llm-d/${{ steps.version.outputs.project_name }}:${{ steps.tag.outputs.tag }}
+
+      - name: Run Trivy scan on sidecar image
+        uses: ./.github/actions/trivy-scan
+        with:
+          image: ghcr.io/llm-d/${{ steps.version.outputs.sidecar_name }}:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -16,11 +16,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install lychee v0.18.1
-        run: |
-          curl -Ls https://github.com/lycheeverse/lychee/releases/download/lychee-v0.18.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          sudo mv lychee /usr/local/bin
-
-      - name: Run lychee on Markdown files with config
-        run: |
-          find . -name "*.md" -print0 | xargs -0 lychee --config .lychee.toml --verbose --no-progress
+      - name: Run lychee link checker
+        uses: lycheeverse/lychee-action@v2.7.0
+        with:
+          args: '--config .lychee.toml --verbose --no-progress **/*.md'
+          fail: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,10 +19,10 @@ jobs:
           days-before-close: -1
           stale-issue-label: 'lifecycle/stale'
           exempt-issue-labels: 'lifecycle/rotten'
-          stale-issue-message: 'This issue is marked as stale after 90d of inactivity. After an additional 30d of inactivity, it will be closed. To prevent this issue from being closed, add a comment or remove the `lifecycle/stale` label.'
+          stale-issue-message: 'This issue is marked as stale after 90d of inactivity. After an additional 30d of inactivity (15d to become rotten, then 15d more), it will be closed. To prevent this issue from being closed, add a comment or remove the `lifecycle/stale` label.'
           stale-pr-label: 'lifecycle/stale'
           exempt-pr-labels: 'lifecycle/rotten'
-          stale-pr-message: 'This PR is marked as stale after 21d of inactivity. After an additional 14d of inactivity, it will be closed. To prevent this PR from being closed, add a comment or remove the `lifecycle/stale` label.'
+          stale-pr-message: 'This PR is marked as stale after 21d of inactivity. After an additional 14d of inactivity (7d to become rotten, then 7d more), it will be closed. To prevent this PR from being closed, add a comment or remove the `lifecycle/stale` label.'
 
       - name: 'Mark items rotten'
         uses: actions/stale@v10


### PR DESCRIPTION
- Trivy scan should be done on both images
- move "make build" before "make test" to have quick exit
- use "make" target to install k-v cache dependency
- use Github Action than download lychee binary