### PR TITLE
Fix for flaky sites during lychee md link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -7,7 +7,8 @@ exclude = [
 timeout = 20
 
 # Retry failed links (helpful for flaky sites)
-retry_count = 3
+max_retries = 5
+retry_wait_time = 2
 
 # Accept non-200 status codes (429: rate limits)
 accept = [200, 429]


### PR DESCRIPTION
`retry_count` is not a valid configuration:
https://lychee.cli.rs/guides/config/