### PR TITLE
fix: make 'install-dependencies' and 'build' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,24 +69,24 @@ PYTHON_VERSION := 3.12
 PYTHON_CONFIG ?= $(shell command -v python$(PYTHON_VERSION)-config || command -v python3-config)
 ifeq ($(PYTHON_CONFIG),)
 	ifeq ($(TARGETOS),darwin)
-		# macOS: Find Homebrew's python-config script for the most reliable flags.
-		BREW_PREFIX := $(shell command -v brew >/dev/null 2>&1 && brew --prefix python@$(PYTHON_VERSION) 2>/dev/null)
-		PYTHON_CONFIG ?= $(BREW_PREFIX)/bin/python$(PYTHON_VERSION)-config
-		PYTHON_ERROR := "Could not execute 'python$(PYTHON_VERSION)-config'. Please ensure Python is installed correctly with: 'brew install python@$(PYTHON_VERSION)' or install python3.12 manually."
+        # macOS: Find Homebrew's python-config script for the most reliable flags.
+        BREW_PREFIX := $(shell command -v brew >/dev/null 2>&1 && brew --prefix python@$(PYTHON_VERSION) 2>/dev/null)
+        PYTHON_CONFIG ?= $(BREW_PREFIX)/bin/python$(PYTHON_VERSION)-config
+        PYTHON_ERROR := "Could not execute 'python$(PYTHON_VERSION)-config'. Please ensure Python is installed correctly with: 'brew install python@$(PYTHON_VERSION)' or install python3.12 manually."
 	else ifeq ($(TARGETOS),linux)
-		# Linux: Use standard system tools to find flags.
-		PYTHON_ERROR := "Python $(PYTHON_VERSION) development headers not found. Please install with: 'sudo apt install python$(PYTHON_VERSION)-dev' or 'sudo dnf install python$(PYTHON_VERSION)-devel'"
+        # Linux: Use standard system tools to find flags.
+        PYTHON_ERROR := "Python $(PYTHON_VERSION) development headers not found. Please install with: 'sudo apt install python$(PYTHON_VERSION)-dev' or 'sudo dnf install python$(PYTHON_VERSION)-devel'"
 	else
-		PYTHON_ERROR := "you should set up PYTHON_CONFIG variable manually"
+        PYTHON_ERROR := "you should set up PYTHON_CONFIG variable manually"
 	endif
 endif
 
 ifneq ($(shell $(PYTHON_CONFIG) --cflags 2>/dev/null),)
-	PYTHON_CFLAGS := $(shell $(PYTHON_CONFIG) --cflags)
-	# Use --ldflags --embed to get all necessary flags for linking
-	PYTHON_LDFLAGS := $(shell $(PYTHON_CONFIG) --ldflags --embed)
+    PYTHON_CFLAGS := $(shell $(PYTHON_CONFIG) --cflags)
+    # Use --ldflags --embed to get all necessary flags for linking
+    PYTHON_LDFLAGS := $(shell $(PYTHON_CONFIG) --ldflags --embed)
 else
-	$(error ${PYTHON_ERROR})
+    $(error $(PYTHON_ERROR))
 endif
 
 # CGO flags with all dependencies


### PR DESCRIPTION
# Description
- create a new target `'check-dependencies`' and fix check
   - `dnf list installed` only show avaiable package not the ones installed. use `rpm` instead for the check.
- when running "make test-*" only check not do real install depdencies
- better instruction requies user to `sudo` before run `'install-dependencies'`
- add fallback when "sudo" Go not in the PATH, "go env" wont work, use "uname" to get OS and ARCH
- fix "make build" as it is missing CGO_CFLAGS CGO_LDFLAGS
- add "python3.x-dev/python3.x-devel" as dependencies for "make build"

Ref: https://github.com/llm-d/llm-d-inference-scheduler/issues/470

# Test
on local Fedora43 first delete dependencies
```
>sudo dnf remove zeromq-devel
```
check go env variables:
```
>go env 
bash: go: command not found...
Packages providing this file are:
'gcc-go'
'golang-bin'

>uname -s
Linux

>uname -m
x86_64
```
run as non-root user:
```
>make check-dependencies
```
got `ERROR: Missing dependencies. Please run 'sudo make install-dependencies'`
```
>sudo make install-dependencies
[sudo] password for wenzhou: 
Checking and installing development dependencies...
✅ ZMQ and gcc-c++ are already installed.
```
verify:
```
>make check-dependencies 
✅ All dependencies are installed.

>rpm -q zeromq-devel
zeromq-devel-4.3.5-22.fc43.x86_64

>dnf -q list installed zeromq-devel
Installed packages
zeromq-devel.x86_64 4.3.5-22.fc43 fedora

Available packages
zeromq-devel.i686   4.3.5-22.fc43 fedora
```


before PR
```
>make build
bash: --: invalid option
Usage:  bash [GNU long option] [option] ...
        bash [GNU long option] [option] script-file ...
GNU long options:
        --debug
        --debugger
        --dump-po-strings
        --dump-strings
        --help
        --init-file
        --login
        --noediting
        --noprofile
        --norc
        --posix
        --pretty-print
        --rcfile
        --rpm-requires
        --restricted
        --verbose
        --version
Shell options:
        -ilrsD or -c command or -O shopt_option         (invocation only)
        -abefhkmnptuvxBCEHPT or -o option
Makefile:87: *** "Python 3.12 development headers not found. Please install with: 'sudo apt install python3.12-dev' or 'sudo dnf install python3.12-devel'".  Stop.
```
then adding python3.12-devel into "install-dependencies" or manual run "sudo dnf install python3.12-devel"
```
>make build
✅ All dependencies are installed.
==== Building ====
go build -ldflags="-extldflags '-L/home/wenzhou/upstream/llm-d/llm-d-inference-scheduler/lib'" -o bin/epp cmd/epp/main.go
# github.com/llm-d/llm-d-kv-cache-manager/pkg/preprocessing/chat_completions
In file included from ../../../go/pkg/mod/github.com/llm-d/llm-d-kv-cache-manager@v0.4.0/pkg/preprocessing/chat_completions/cgo_functions.go:27:
./cgo_functions.h:20:10: fatal error: Python.h: No such file or directory
   20 | #include <Python.h>
      |          ^~~~~~~~~~
compilation terminated.
make: *** [Makefile:181: build-epp] Error 1
```
after adding `CGO_CFLAGS=$($*_CGO_CFLAGS) CGO_LDFLAGS=$($*_CGO_LDFLAGS)`


```
>make build
✅ All dependencies are installed.
==== Building ====
CGO_CFLAGS="-I/usr/include/python3.12 -I/usr/include/python3.12  -fno-strict-overflow -Wsign-compare -fcf-protection -fexceptions   -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fcf-protection -fexceptions  '-I/home/wenzhou/upstream/llm-d/llm-d-inference-scheduler/lib'" CGO_LDFLAGS=" -L/usr/lib64 -lpython3.12 -ldl  -lm   '-L/home/wenzhou/upstream/llm-d/llm-d-inference-scheduler/lib' -ltokenizers -ldl -lm" go build -ldflags="-extldflags '-L/home/wenzhou/upstream/llm-d/llm-d-inference-scheduler/lib'" -o bin/epp cmd/epp/main.go
# github.com/llm-d/llm-d-kv-cache-manager/pkg/preprocessing/chat_completions
cgo_functions.c: In function ‘Py_InitializeGo’:
cgo_functions.c:74:9: warning: ‘PyEval_InitThreads’ is deprecated [-Wdeprecated-declarations]
   74 |         PyEval_InitThreads();
      |         ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/python3.12/Python.h:95,
                 from cgo_functions.h:20,
                 from cgo_functions.c:19:
/usr/include/python3.12/ceval.h:132:37: note: declared here
  132 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
      |                                     ^~~~~~~~~~~~~~~~~~
==== Building ====
CGO_CFLAGS= CGO_LDFLAGS= go build  -o bin/pd-sidecar cmd/pd-sidecar/main.go
```