### PR TITLE
skip lint and test when only docs change

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -9,12 +9,28 @@ on:
       - main
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'README.md'
+              - 'docs/**'
   lint-and-test:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.docs == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
-        
+
       - name: Sanity check repo contents
         run: ls -la
 


### PR DESCRIPTION
Description:
Skip lint and test when only readme and docs changes are made to reduce waste.

ref: https://github.com/llm-d/llm-d-inference-scheduler/issues/79