### PR TITLE
fix: Fixes for Data Parallel support when also running with Prefix Disaggregation

### DIFF
--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -57,7 +57,7 @@ func (s *Server) chatCompletionsHandler(w http.ResponseWriter, r *http.Request) 
 	if len(prefillHostPort) == 0 {
 		s.logger.V(4).Info("skip disaggregated prefill")
 
-		if s.forwardDataParallel && !s.dataParallelHandler(w, r) {
+		if !s.forwardDataParallel || !s.dataParallelHandler(w, r) {
 			s.decoderProxy.ServeHTTP(w, r)
 		}
 		return

--- a/pkg/sidecar/proxy/connector_lmcache.go
+++ b/pkg/sidecar/proxy/connector_lmcache.go
@@ -84,7 +84,8 @@ func (s *Server) runLMCacheProtocol(w http.ResponseWriter, r *http.Request, pref
 	// Forward original request to local decoder
 
 	r.Body = io.NopCloser(strings.NewReader(string(original)))
-	if s.forwardDataParallel && !s.dataParallelHandler(w, r) {
+	if !s.forwardDataParallel || !s.dataParallelHandler(w, r) {
+		s.logger.V(4).Info("sending request to decoder", "to", s.decoderURL.Host)
 		s.decoderProxy.ServeHTTP(w, r)
 	}
 }

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -168,7 +168,8 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	// 2. Forward to local decoder.
 
 	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
-	if s.forwardDataParallel && !s.dataParallelHandler(w, dreq) {
+	if !s.forwardDataParallel || !s.dataParallelHandler(w, dreq) {
+		s.logger.V(4).Info("sending request to decoder", "to", s.decoderURL.Host)
 		s.decoderProxy.ServeHTTP(w, dreq)
 	}
 }

--- a/pkg/sidecar/proxy/data_parallel.go
+++ b/pkg/sidecar/proxy/data_parallel.go
@@ -77,6 +77,7 @@ func (s *Server) startDataParallel(ctx context.Context, cert *tls.Certificate, g
 			clone.forwardDataParallel = false
 			// Configure handlers
 			clone.handler = clone.createRoutes()
+			clone.setConnector()
 
 			return clone.startHTTP(ctx, cert)
 		})

--- a/pkg/sidecar/proxy/data_parallel.go
+++ b/pkg/sidecar/proxy/data_parallel.go
@@ -53,11 +53,11 @@ func (s *Server) startDataParallel(ctx context.Context, cert *tls.Certificate, g
 		decoderPort := strconv.Itoa(baseDecoderPort + idx + 1)
 		rankPort := strconv.Itoa(basePort + idx + 1)
 		hostPort := net.JoinHostPort(podIP, rankPort)
-		rankURL, err := url.Parse(s.decoderURL.Scheme + "://localhost:" + decoderPort)
+		decoderURL, err := url.Parse(s.decoderURL.Scheme + "://localhost:" + decoderPort)
 		if err != nil {
 			return err
 		}
-		handler := s.createDecoderProxyHandler(rankURL, s.config.DecoderInsecureSkipVerify)
+		handler := s.createDecoderProxyHandler(decoderURL, s.config.DecoderInsecureSkipVerify)
 		s.dataParallelProxies[hostPort] = handler
 	}
 

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -126,16 +126,8 @@ func NewProxy(port string, decodeURL *url.URL, config Config) *Server {
 		forwardDataParallel: true,
 		prefillSamplerFn:    rand.Intn,
 	}
-	switch config.Connector {
-	case ConnectorLMCache:
-		server.runConnectorProtocol = server.runLMCacheProtocol
-	case ConnectorSGLang:
-		server.runConnectorProtocol = server.runSGLangProtocol
-	case ConnectorNIXLV2:
-		fallthrough
-	default:
-		server.runConnectorProtocol = server.runNIXLProtocolV2
-	}
+
+	server.setConnector()
 
 	if config.PrefillerUseTLS {
 		server.prefillerURLPrefix = "https://"
@@ -175,9 +167,24 @@ func (s *Server) Clone() *Server {
 		allowlistValidator:   s.allowlistValidator,
 		runConnectorProtocol: s.runConnectorProtocol,
 		decoderProxy:         s.decoderProxy,
+		prefillerURLPrefix:   s.prefillerURLPrefix,
 		prefillerProxies:     s.prefillerProxies,
 		dataParallelProxies:  s.dataParallelProxies,
 		forwardDataParallel:  s.forwardDataParallel,
+	}
+}
+
+func (s *Server) setConnector() {
+
+	switch s.config.Connector {
+	case ConnectorLMCache:
+		s.runConnectorProtocol = s.runLMCacheProtocol
+	case ConnectorSGLang:
+		s.runConnectorProtocol = s.runSGLangProtocol
+	case ConnectorNIXLV2:
+		fallthrough
+	default:
+		s.runConnectorProtocol = s.runNIXLProtocolV2
 	}
 }
 


### PR DESCRIPTION
This PR fixes issues with the ability to run Data Parallel (DP) and Prefix Dis-aggregation (PD) together.

In particular it better enables the case where the special DP header isn't used.