### PR TITLE
Add GH action to check for signed and verified commits in PR

### DIFF
--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -1,7 +1,7 @@
 name: Check Signed Commits in PR
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   check-signed-commits:


### PR DESCRIPTION
Automate the check for signed and verified commits and provide instructions when missing.
This is in addition to the branch protection (which should refuse merging of unverified commits) and is mostly meant to provide help and context to committer without reviewer intervention.

Ref #150 

The action runs on [pull_request_target](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target). An interim commit ran on `pull_request` event to [verify syntax and execution](https://github.com/llm-d/llm-d-inference-scheduler/actions/runs/19825508561). 