### PR TITLE
build: make build should use CGO_CFLAGS, CGO_LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ build: build-epp build-sidecar ## Build the project
 .PHONY: build-%
 build-%: check-go download-tokenizer ## Build the project
 	@printf "\033[33;1m==== Building ====\033[0m\n"
-	go build $($*_LDFLAGS) -o bin/$($*_NAME) cmd/$($*_NAME)/main.go
+	CGO_CFLAGS=${$*_CGO_CFLAGS} CGO_LDFLAGS=${$*_CGO_LDFLAGS} go build $($*_LDFLAGS) -o bin/$($*_NAME) cmd/$($*_NAME)/main.go
 
 ##@ Container Build/Push
 


### PR DESCRIPTION
On my machine (macOS, M3, Python 3.12 via brew) `make build` would fail to find the include to `Python.h`:

```
go build -ldflags="-extldflags '-L/Users/evacchi/Devel/github.com/llm-d/llm-d-inference-scheduler/lib'" -o bin/epp cmd/epp/main.go
# github.com/llm-d/llm-d-kv-cache-manager/pkg/preprocessing/chat_completions
In file included from ../../../../go/pkg/mod/github.com/llm-d/llm-d-kv-cache-manager@v0.4.0/pkg/preprocessing/chat_completions/cgo_functions.go:27:
./cgo_functions.h:20:10: fatal error: 'Python.h' file not found
   20 | #include <Python.h>
      |          ^~~~~~~~~~
1 error generated.
make: *** [build-epp] Error 1
```

the trivial fix should be to prefix `go build...` with `CGO_CFLAGS=${$*_CGO_CFLAGS} CGO_LDFLAGS=${$*_CGO_LDFLAGS}` as it is done for `test-unit-%`

