### PR TITLE
feat: make no-hit-lru P/D-aware

### DIFF
--- a/pkg/plugins/scorer/no_hit_lru.go
+++ b/pkg/plugins/scorer/no_hit_lru.go
@@ -292,17 +292,16 @@ func (s *NoHitLRU) PreRequest(ctx context.Context, request *types.LLMRequest, sc
 		return
 	}
 
-	s.moveTargetPodToFront(ctx, request, schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName], schedulingResult.PrimaryProfileName)
-	s.moveTargetPodToFront(ctx, request, schedulingResult.ProfileResults[defaultPrefillProfile], defaultPrefillProfile)
+	if targetProfile, ok := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]; ok && targetProfile != nil && len(targetProfile.TargetPods) != 0 {
+		s.moveTargetPodToFront(ctx, request, targetProfile, schedulingResult.PrimaryProfileName)
+	}
+	if targetProfile, ok := schedulingResult.ProfileResults[defaultPrefillProfile]; ok && targetProfile != nil && len(targetProfile.TargetPods) != 0 {
+		s.moveTargetPodToFront(ctx, request, targetProfile, defaultPrefillProfile)
+	}
 }
 
 func (s *NoHitLRU) moveTargetPodToFront(ctx context.Context, request *types.LLMRequest, targetProfile *types.ProfileRunResult, profileName string) {
 	logger := log.FromContext(ctx).V(logutil.DEBUG)
-
-	// Get the target profile's target pod
-	if targetProfile == nil || len(targetProfile.TargetPods) == 0 {
-		return
-	}
 
 	targetPod := targetProfile.TargetPods[0]
 	podName := targetPod.GetPod().NamespacedName.String()

--- a/pkg/plugins/scorer/no_hit_lru_test.go
+++ b/pkg/plugins/scorer/no_hit_lru_test.go
@@ -550,37 +550,6 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 		}
 	})
 
-	t.Run("custom prefill profile name", func(t *testing.T) {
-		// Create scorer with custom prefill profile name
-		scorer := scorer.NewNoHitLRU(ctx, &scorer.NoHitLRUParameters{
-			PrefillProfile: "custom-prefill",
-		})
-
-		req := &types.LLMRequest{RequestId: "custom-prefill-request"}
-		scorer.Score(ctx, coldPrefixState, req, prefillPods)
-
-		result := &types.SchedulingResult{
-			PrimaryProfileName: "decode",
-			ProfileResults: map[string]*types.ProfileRunResult{
-				"custom-prefill": {
-					TargetPods: []types.Pod{prefillPodA},
-				},
-				"decode": {
-					TargetPods: []types.Pod{decodePodA},
-				},
-			},
-		}
-		scorer.PreRequest(ctx, req, result)
-
-		// Verify custom prefill profile was tracked
-		req2 := &types.LLMRequest{RequestId: "custom-prefill-request-2"}
-		scores := scorer.Score(ctx, coldPrefixState, req2, prefillPods)
-
-		if scores[prefillPodB] <= scores[prefillPodA] {
-			t.Errorf("Expected prefill-b to score higher with custom profile name: %+v", scores)
-		}
-	})
-
 	t.Run("nil scheduling result - graceful handling", func(_ *testing.T) {
 		req := &types.LLMRequest{RequestId: "nil-result"}
 		scorer := scorer.NewNoHitLRU(ctx, nil)


### PR DESCRIPTION
an attempt at addressing #515. Still navigating the codebase, this has been written with obvious assistance (mostly the test cases), let me know if I got it right.

Essentially, 
- we now accept an optional `prefillProfile` config parameter in the style of [pd_prerequest.go](https://github.com/llm-d/llm-d-inference-scheduler/blob/5176573e4df75b9868b1da8bc6421cf5198e7aac/pkg/plugins/pre-request/pd_prerequest.go#L25), defaulting to `"prefill"`.
- we _unconditionally_ check and move to the front of the LRU cache the pod for the `prefillProfile` key in the `schedulingResult` after we have checked for `schedulingResult.PrimaryProfileName`

not 100% sure this is what was requested originally 😬 