### PR TITLE
Configure dependabot ignores Go version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "go"      
+      - dependency-name: "go"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     open-pull-requests-limit: 10
     commit-message:
       prefix: "deps(go)"


### PR DESCRIPTION
Currently, dependabot updates `go.mod` with new Go versions. This has unintended and undesirable side effects, such as failing linting (see #520 lint failure for example).
The change explicitly configures dependabot to ignore Go version updates via its configuration file.