### PR TITLE
Dependabot: exert finer control over package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "go"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     open-pull-requests-limit: 10
     commit-message:
       prefix: "deps(go)"
@@ -16,7 +13,20 @@ updates:
       - "dependencies"
       - "release-note-none"
     ignore:
+      # Ignore major and minor updates to Go toolchain (ensure go version is consistent in builds, actions, etc.)
+      - dependency-name: "go"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore *all* updates to GAIE package - manually update go.mod only
       - dependency-name: "sigs.k8s.io/gateway-api-inference-extension"
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+      # Ignore major and minor version updates to k8s packages
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major updates for all packages
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]        
     groups:
       go-dependencies:
         patterns:


### PR DESCRIPTION
Attempt to configure the following rules:
- only manually update GAIE
- never auto-update to new major version
- allow patch (and hence security updates) to Go toolchain (minor updates such as 1.24 -> 1.25 should be sync'ed with GH actions, etc.)
- allow patch/security for k8s packages