### PR TITLE
port auto-assign action from llm-d-kv-cache

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,0 +1,86 @@
+name: Auto Assign Reviewers
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Auto assign reviewers
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_PAT != '' && secrets.AUTO_ASSIGN_PAT || secrets.GITHUB_TOKEN }}  # Use PAT if non-empty, else GITHUB_TOKEN
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "OWNERS" ]; then
+            echo "OWNERS file not found, skipping auto-assignment"
+            exit 0
+          fi
+
+          in_auto_assign=false
+          all_reviewers=""
+
+          # Helper: normalize a reviewer (strip @ and whitespace)
+          normalize_reviewer() {
+            echo "$1" | sed -E 's/^[[:space:]]*@?//; s/[[:space:]]*$//'
+          }
+
+          # Parse OWNERS
+          while IFS= read -r line; do
+            # Skip comments/empty
+            [[ -z "${line// }" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+            # Enter auto-assign section
+            if [[ "$line" =~ ^auto-assign: ]]; then
+              in_auto_assign=true
+              continue
+            fi
+
+            # Exit auto-assign section when a new top-level key is encountered
+            if $in_auto_assign && [[ "$line" =~ ^[^[:space:]] ]]; then
+              in_auto_assign=false
+            fi
+            $in_auto_assign || continue
+
+            # Reviewer entry: collect the user directly
+            if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*([^:]+)$ ]]; then
+              reviewer=$(normalize_reviewer "$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*//')")
+              echo "Found reviewer: $reviewer"
+              all_reviewers+="$reviewer"$'\n'
+            fi
+          done < OWNERS
+
+          # De-dup, drop blanks, exclude PR author
+          mapfile -t reviewers < <(printf "%s" "$all_reviewers" | sed '/^$/d' | sort -u | grep -v -x "$PR_AUTHOR" || true)
+
+          if [ "${#reviewers[@]}" -eq 0 ]; then
+            echo "No reviewers found for auto-assignment"
+            exit 0
+          fi
+
+          echo "Assigning reviewers: ${reviewers[*]}"
+
+          # JSON array
+          payload=$(printf '%s\n' "${reviewers[@]}" | jq -R -s -c 'split("\n") | map(select(length>0))')
+
+          # Request reviewers
+          curl -sS -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+            -d "{\"reviewers\": $payload}" \
+            | jq -r '.message? // "ok"'

--- a/OWNERS
+++ b/OWNERS
@@ -15,3 +15,15 @@ reviewers:
 - nirrozenbaum
 - shmuelk
 - vMaroon
+
+# Auto-assign configuration for global assignment
+# Works in addition to GitHub's built-in CODEOWNERS functionality
+# Implemented via a custom GitHub Action
+auto-assign:
+  - elevran
+  - kfirtoledo
+  - kfswain
+  - nilig
+  - nirrozenbaum
+  - shmuelk
+  - vMaroon


### PR DESCRIPTION
## Summary

This PR adds an auto-assign action that looks at `OWNERS` file to auto assign people globally on PRs. This has been in use in llm-d-kv-cache for a while now. The action does not implement fine-grained auto-assigning, but this can be extended if useful.

The alternative is switching to `CODEOWNERS` instead of `OWNERS`, which carries the downside of having to grant reviewers who are not maintainers repository write permissions.

It currently does not trigger because `pull_request_target` checks-out code from main in order to access repository secrets, and `pull_request` triggers from my fork, lacking the secret and thus lacking permissions. If this PR was opened from a branch, it would work. It will also work after this PR is merged.