### PR TITLE
Update auto-assign logic

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Auto assign reviewers
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_PAT != '' && secrets.AUTO_ASSIGN_PAT || secrets.GITHUB_TOKEN }}  # Use PAT if non-empty, else GITHUB_TOKEN
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           REPO: ${{ github.repository }}
@@ -64,22 +64,22 @@ jobs:
             fi
           done < OWNERS
 
-          # De-dup, drop blanks, exclude PR author
-          mapfile -t reviewers < <(printf "%s" "$all_reviewers" | sed '/^$/d' | sort -u | grep -v -x "$PR_AUTHOR" || true)
+          # De-dup, drop blanks, exclude PR author, shuffle to randomize, and take the top 2
+          mapfile -t reviewers < <(printf "%s" "$all_reviewers" | sed '/^$/d' | sort -u | grep -v -x "$PR_AUTHOR" | shuf -n 2 || true)
 
           if [ "${#reviewers[@]}" -eq 0 ]; then
             echo "No reviewers found for auto-assignment"
             exit 0
           fi
 
-          echo "Assigning reviewers: ${reviewers[*]}"
+          echo "Assigning ${#reviewers[@]} reviewer(s): ${reviewers[*]}"
 
-          # JSON array
+          # Convert the reviewers array to JSON
           payload=$(printf '%s\n' "${reviewers[@]}" | jq -R -s -c 'split("\n") | map(select(length>0))')
 
           # Request reviewers
           curl -sS -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
             -d "{\"reviewers\": $payload}" \


### PR DESCRIPTION
Updated the auto PR assignment with the following:
- use only the default GH token (not PAT)
- pick two random reviewers
-  use `Bearer` authroization in GH API call

Once this is merged and works, the PAT secret can be removed.