### PR TITLE
Add P/D coordinator Prometheus metrics

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -17,6 +17,7 @@ RUN go mod download
 COPY cmd/pd-sidecar/main.go cmd/cmd.go
 COPY pkg/sidecar pkg/sidecar
 COPY pkg/common pkg/common
+COPY pkg/metrics pkg/metrics
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
@@ -34,5 +35,7 @@ FROM registry.access.redhat.com/ubi9/ubi-micro:9.7
 WORKDIR /
 COPY --from=builder /workspace/bin/pd-sidecar /app/pd-sidecar
 USER 65532:65532
+
+EXPOSE 8000 9090
 
 ENTRYPOINT ["/app/pd-sidecar"]

--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -30,7 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/gateway-api-inference-extension/cmd/epp/runner"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
+	eppmetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/metrics/epp"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/plugins"
 )
 
@@ -39,7 +39,7 @@ func main() {
 	plugins.RegisterAllPlugins()
 
 	if err := runner.NewRunner().
-		WithCustomCollectors(metrics.GetCollectors()...).
+		WithCustomCollectors(eppmetrics.GetCollectors()...).
 		Run(ctrl.SetupSignalHandler()); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/metrics/epp/metrics.go
+++ b/pkg/metrics/epp/metrics.go
@@ -1,5 +1,5 @@
-// Package metrics provides metrics registration for the epp.
-package metrics
+// Package epp provides Prometheus metrics for the EPP (Endpoint Picker/Scheduler).
+package epp
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	// SchedulerSubsystem is the metric prefix of the package.
+	// SchedulerSubsystem is the metric prefix for EPP metrics.
 	SchedulerSubsystem = "llm_d_inference_scheduler"
 
 	// DecisionTypeDecodeOnly is for requests that are routed to decode instance only.
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	// SchedulerPDDecisionCount records request P/D decision.
+	// SchedulerPDDecisionCount records request P/D decision made by the EPP scheduler.
 	SchedulerPDDecisionCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: SchedulerSubsystem,
@@ -29,7 +29,7 @@ var (
 	)
 )
 
-// GetCollectors returns all custom collectors for the llm-d-inference-scheduler.
+// GetCollectors returns all custom collectors for the EPP.
 func GetCollectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		SchedulerPDDecisionCount,

--- a/pkg/metrics/epp/metrics_test.go
+++ b/pkg/metrics/epp/metrics_test.go
@@ -1,4 +1,4 @@
-package metrics
+package epp
 
 import (
 	"strings"

--- a/pkg/metrics/sidecar/metrics.go
+++ b/pkg/metrics/sidecar/metrics.go
@@ -1,0 +1,73 @@
+// Package sidecar provides Prometheus metrics for the P/D routing sidecar.
+package sidecar
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	compbasemetrics "k8s.io/component-base/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/metrics"
+)
+
+const (
+	// SidecarSubsystem is the metric prefix for sidecar metrics.
+	SidecarSubsystem = "llm_d_inference_scheduler"
+)
+
+var (
+	// PDProxyCoordinatorOverheadMilliseconds records sidecar coordination overhead between prefill and decode.
+	// This measures time spent in sidecar processing (JSON parsing, parameter extraction, HTTP overhead).
+	// Note: Actual KV cache transfer happens inside vLLM and is not measured by this metric.
+	PDProxyCoordinatorOverheadMilliseconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: SidecarSubsystem,
+			Name:      "pd_proxy_coordinator_overhead_milliseconds",
+			Help:      metrics.HelpMsgWithStability("Sidecar coordination overhead between prefill and decode HTTP requests (JSON processing only, excludes KV cache transfer which happens inside vLLM)", compbasemetrics.ALPHA),
+			Buckets:   []float64{1, 2, 5, 10, 20, 50, 100, 200, 500},
+		},
+		[]string{"connector"},
+	)
+
+	// PDProxyPrefillDurationMilliseconds records prefill stage duration.
+	// This is the full HTTP round-trip time to the prefill instance.
+	PDProxyPrefillDurationMilliseconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: SidecarSubsystem,
+			Name:      "pd_proxy_prefill_duration_milliseconds",
+			Help:      metrics.HelpMsgWithStability("Prefill stage HTTP round-trip duration in P/D disaggregation", compbasemetrics.ALPHA),
+			Buckets:   []float64{5, 10, 20, 50, 100, 200, 500, 1000, 2000},
+		},
+		[]string{"connector"},
+	)
+
+	// PDProxyDecodeDurationMilliseconds records decode stage duration.
+	// This is the full HTTP round-trip time to the decode instance (includes KV cache transfer inside vLLM).
+	PDProxyDecodeDurationMilliseconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: SidecarSubsystem,
+			Name:      "pd_proxy_decode_duration_milliseconds",
+			Help:      metrics.HelpMsgWithStability("Decode stage HTTP round-trip duration in P/D disaggregation (includes KV cache transfer inside vLLM)", compbasemetrics.ALPHA),
+			Buckets:   []float64{10, 50, 100, 200, 500, 1000, 2000, 5000, 10000},
+		},
+		[]string{"connector"},
+	)
+
+	// PDProxyTotalDurationMilliseconds records end-to-end request duration.
+	PDProxyTotalDurationMilliseconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: SidecarSubsystem,
+			Name:      "pd_proxy_total_duration_milliseconds",
+			Help:      metrics.HelpMsgWithStability("Total end-to-end request duration from P/D coordinator perspective", compbasemetrics.ALPHA),
+			Buckets:   []float64{20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000},
+		},
+		[]string{"connector"},
+	)
+)
+
+// GetCollectors returns all custom collectors for the P/D routing sidecar.
+func GetCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		PDProxyCoordinatorOverheadMilliseconds,
+		PDProxyPrefillDurationMilliseconds,
+		PDProxyDecodeDurationMilliseconds,
+		PDProxyTotalDurationMilliseconds,
+	}
+}

--- a/pkg/metrics/sidecar/metrics_test.go
+++ b/pkg/metrics/sidecar/metrics_test.go
@@ -1,0 +1,39 @@
+package sidecar
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestPDProxyCoordinatorOverheadMilliseconds(t *testing.T) {
+	connector := "lmcache"
+
+	// Observe some values
+	PDProxyCoordinatorOverheadMilliseconds.WithLabelValues(connector).Observe(3.0)
+	PDProxyCoordinatorOverheadMilliseconds.WithLabelValues(connector).Observe(7.0)
+	PDProxyCoordinatorOverheadMilliseconds.WithLabelValues(connector).Observe(25.0)
+
+	expected := `
+		# HELP llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds [ALPHA] Sidecar coordination overhead between prefill and decode HTTP requests (JSON processing only, excludes KV cache transfer which happens inside vLLM)
+		# TYPE llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds histogram
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="1"} 0
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="2"} 0
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="5"} 1
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="10"} 2
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="20"} 2
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="50"} 3
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="100"} 3
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="200"} 3
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="500"} 3
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_bucket{connector="lmcache",le="+Inf"} 3
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_sum{connector="lmcache"} 35
+		llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds_count{connector="lmcache"} 3
+	`
+
+	if err := testutil.CollectAndCompare(PDProxyCoordinatorOverheadMilliseconds, strings.NewReader(expected),
+		"llm_d_inference_scheduler_pd_proxy_coordinator_overhead_milliseconds"); err != nil {
+		t.Errorf("PDProxyCoordinatorOverheadMilliseconds test failed: %v", err)
+	}
+}

--- a/pkg/plugins/profile/pd_profile_handler.go
+++ b/pkg/plugins/profile/pd_profile_handler.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
+	eppmetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/metrics/epp"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
@@ -163,12 +163,12 @@ func (h *PdProfileHandler) Pick(ctx context.Context, cycleState *types.CycleStat
 
 		if (1.0-hitPercentagePrefix)*float64(len(userInput)) < float64(h.pdThreshold) {
 			log.FromContext(ctx).Info("Non-cached suffix is smaller than threshold, using decode profile only", "hitPercentage", hitPercentagePrefix)
-			metrics.RecordPDDecision(request.TargetModel, metrics.DecisionTypeDecodeOnly)
+			eppmetrics.RecordPDDecision(request.TargetModel, eppmetrics.DecisionTypeDecodeOnly)
 			return map[string]*framework.SchedulerProfile{} // do not run prefill
 		}
 	}
 
-	metrics.RecordPDDecision(request.TargetModel, metrics.DecisionTypePrefillDecode)
+	eppmetrics.RecordPDDecision(request.TargetModel, eppmetrics.DecisionTypePrefillDecode)
 	// run the prefill profile
 	return map[string]*framework.SchedulerProfile{
 		h.prefillProfile: profiles[h.prefillProfile],


### PR DESCRIPTION
Add Prometheus histogram metrics to track P/D disaggregation performance from the coordinator's perspective. These metrics capture the true end-to-end latency that vLLM instances cannot see individually.