### PR TITLE
fix: config should use new precise-prefix-cache-scorer

### DIFF
--- a/deploy/config/sim-epp-kvcache-config.yaml
+++ b/deploy/config/sim-epp-kvcache-config.yaml
@@ -5,15 +5,12 @@ kind: EndpointPickerConfig
 plugins:
 - type: precise-prefix-cache-scorer
   parameters:
-    mode: cache_tracking
-    tokenProcessorConfig:
-      blockSize: 16                         # must match vLLM block size if not default (16)
-      hashSeed: "42"                        # must match PYTHONHASHSEED in vLLM pods
     kvEventsConfig:
       zmqEndpoint: tcp://0.0.0.0:5557
     indexerConfig:
-      prefixStoreConfig:
-        blockSize: 16 
+      tokenProcessorConfig:
+        blockSize: 16                         # must match vLLM block size if not default (16)
+        hashSeed: "42"                        # must match PYTHONHASHSEED in vLLM pods
       tokenizersPoolConfig:
         modelName: TinyLlama/TinyLlama-1.1B-Chat-v1.0  # replace value to use different model for tokenizer loading
         hf:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,11 +161,13 @@ A complete configuration might look like this:
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefix-cache-scorer
+- type: precise-prefix-cache-scorer
   parameters:
-    hashBlockSize: 5
-    maxPrefixBlocksToMatch: 256
-    lruCapacityPerServer: 31250
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 5
+      kvBlockIndexConfig:
+        maxPrefixBlocksToMatch: 256
 - type: decode-filter
 - type: max-score-picker
 - type: single-profile-handler
@@ -174,7 +176,7 @@ schedulingProfiles:
   plugins:
   - pluginRef: decode-filter
   - pluginRef: max-score-picker
-  - pluginRef: prefix-cache-scorer
+  - pluginRef: precise-prefix-cache-scorer
     weight: 50
 ```
 
@@ -465,11 +467,13 @@ Example configuration:
 
 ```yaml
 plugins:
-  - type: prefix-cache-scorer
+  - type: precise-prefix-cache-scorer
     parameters:
-      hashBlockSize: 5
-      maxPrefixBlocksToMatch: 256
-      lruCapacityPerServer: 31250
+      indexerConfig:
+        tokenProcessorConfig:
+          blockSize: 5
+        kvBlockIndexConfig:
+          maxPrefixBlocksToMatch: 256
   - type: no-hit-lru-scorer
     parameters:
       lruSize: 2048
@@ -481,7 +485,7 @@ schedulingProfiles:
     plugins:
       - pluginRef: decode-filter
       - pluginRef: max-score-picker
-      - pluginRef: prefix-cache-scorer
+      - pluginRef: precise-prefix-cache-scorer
         weight: 2
       - pluginRef: no-hit-lru-scorer
         weight: 1


### PR DESCRIPTION
# Changes
- we have rename `prefix-cache-scorer `to `precise-prefix-cache-scorer` in 0.3.0, configs need migrate from the old one to the new one with spec.
  - remove parameters.`autoTune` and parameters.`mode: cache_tracking` and `lruCapacityPerServer`
  - move `hashBlockSize`, `maxPrefixBlocksToMatch` under `indexrConfig`


# Notes
- e2e is using food-review as model, we have to keep it with the old prefix-cache-scorer for now
- `make env-dev-kind` is using certain config with food-review as default model, keep these as-is(using prefix-cache-scorer) for now.