### PR TITLE
Address return nil,nil linter error in test mock

### DIFF
--- a/pkg/plugins/profile/pd_profile_handler_test.go
+++ b/pkg/plugins/profile/pd_profile_handler_test.go
@@ -216,7 +216,7 @@ func newMockSchedulerProfile() scheduling.SchedulerProfile {
 type mockSchedulerProfile struct{}
 
 func (p *mockSchedulerProfile) Run(_ context.Context, _ *scheduling.LLMRequest, _ *scheduling.CycleState, _ []scheduling.Endpoint) (*scheduling.ProfileRunResult, error) {
-	return nil, nil
+	return &scheduling.ProfileRunResult{}, nil
 }
 
 func TestPdProfileHandler_Pick(t *testing.T) {


### PR DESCRIPTION
avoid returning both no value and no error to caller.