### PR TITLE
🌱 Replace local governance workflows with llm-d-infra callers

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -1,17 +1,8 @@
 name: Check Typos
-
 on:
   pull_request:
   push:
 
 jobs:
   typos:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Check typos
-        uses: crate-ci/typos@v1.43.0
-
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@main

--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -1,20 +1,9 @@
-name: Check Signed Commits in PR
-
-on:
-  pull_request_target:
+name: Check Signed Commits
+on: pull_request_target
 
 jobs:
-  check-signed-commits:
-    name: Check signed commits in PR
-    runs-on: ubuntu-latest
+  signed-commits:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
     permissions:
       contents: read
-      pull-requests: write # Required to post comments on PRs
-    steps:
-      - name: Check signed commits in PR
-        uses: 1Password/check-signed-commits-action@v1 # Use the action
-        with:
-          comment: |
-            🚨 Unsigned commits detected! Please sign your commits.
-
-            For instructions on how to set up GPG/SSH signing and verify your commits, please see [GitHub Documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+      pull-requests: write

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,23 +1,11 @@
-name: Markdown Link Checker
-
+name: Markdown Link Check
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  lychee:
-    name: Check Markdown Links
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run lychee link checker
-        uses: lycheeverse/lychee-action@v2.7.0
-        with:
-          args: '--config .lychee.toml --verbose --no-progress **/*.md'
-          fail: true
+  links:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@main

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -1,17 +1,8 @@
-name: Label non-main PRs
-
+name: Non-Main Gatekeeper
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  add-label:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add labels when base branch is not main
-        if: github.event.pull_request.base.ref != 'main'
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            do-not-merge/hold
+  gatekeeper:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -1,37 +1,15 @@
-# Run specified actions or jobs for issue and PR comments
-
-name: "Prow github actions"
+name: Prow Commands
 on:
   issue_comment:
     types: [created]
 
-# Grant additional permissions to the GITHUB_TOKEN
 permissions:
-  # Allow labeling issues
   issues: write
-  # Allow adding a review to a pull request
   pull-requests: write
 
 jobs:
-  prow-execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          prow-commands: "/assign
-            /unassign
-            /approve
-            /retitle
-            /area
-            /kind
-            /priority
-            /remove
-            /lgtm
-            /close
-            /reopen
-            /lock
-            /milestone
-            /hold
-            /cc
-            /uncc"
+  prow:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -1,18 +1,8 @@
-# This Github workflow will check every 5m for PRs with the lgtm label and will attempt to automatically merge them.
-# If the hold label is present, it will block automatic merging.
-
-name: "Prow merge on lgtm label"
+name: Prow Auto-merge
 on:
   schedule:
-  - cron: "*/5 * * * *" # every 5 minutes
+    - cron: "*/5 * * * *"
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          jobs: 'lgtm'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          merge-method: 'squash'
-          
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,11 +1,6 @@
-name: Run Jobs on PR
+name: Prow Remove LGTM
 on: pull_request
 
 jobs:
-  execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          jobs: lgtm
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+  remove-lgtm:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,47 +1,11 @@
-name: 'Mark stale issues'
-
+name: Mark Stale Issues
 on:
   schedule:
     - cron: '0 1 * * *'
 
 jobs:
-  stale-issues:
-    runs-on: ubuntu-latest
+  stale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
     permissions:
       issues: write
       pull-requests: write
-    steps:
-      - name: 'Mark stale issues and PRs'
-        uses: actions/stale@v10
-        with:
-          days-before-issue-stale: 90
-          days-before-pr-stale: 21
-          days-before-close: -1
-          stale-issue-label: 'lifecycle/stale'
-          exempt-issue-labels: 'lifecycle/rotten'
-          stale-issue-message: 'This issue is marked as stale after 90d of inactivity. After an additional 30d of inactivity (15d to become rotten, then 15d more), it will be closed. To prevent this issue from being closed, add a comment or remove the `lifecycle/stale` label.'
-          stale-pr-label: 'lifecycle/stale'
-          exempt-pr-labels: 'lifecycle/rotten'
-          stale-pr-message: 'This PR is marked as stale after 21d of inactivity. After an additional 14d of inactivity (7d to become rotten, then 7d more), it will be closed. To prevent this PR from being closed, add a comment or remove the `lifecycle/stale` label.'
-
-      - name: 'Mark items rotten'
-        uses: actions/stale@v10
-        with:
-          days-before-issue-stale: 15
-          days-before-pr-stale: 7
-          days-before-close: -1
-          stale-issue-label: 'lifecycle/rotten'
-          stale-pr-label: 'lifecycle/rotten'
-          only-labels: 'lifecycle/stale'
-          labels-to-remove-when-stale: 'lifecycle/stale'
-
-      - name: 'Close rotten items'
-        uses: actions/stale@v10
-        with:
-          days-before-stale: -1
-          days-before-issue-close: 15
-          days-before-pr-close: 7
-          stale-issue-label: 'lifecycle/rotten'
-          stale-issue-message: 'This issue is being closed after 120d of inactivity.'
-          stale-pr-label: 'lifecycle/rotten'
-          stale-pr-message: 'This PR is being closed after 35d of inactivity.'

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -1,27 +1,12 @@
-name: 'Unstale Issue'
-
+name: Unstale Issues
 on:
   issues:
-    types: [ reopened ]
+    types: [reopened]
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 jobs:
-  remove-stale:
-    runs-on: ubuntu-latest
+  unstale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
     permissions:
       issues: write
-    if: >-
-      github.event.issue.state == 'open' &&
-      (contains(github.event.issue.labels.*.name, 'lifecycle/stale') || 
-       contains(github.event.issue.labels.*.name, 'lifecycle/rotten'))
-    steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@v6
-
-      - name: 'Remove stale labels'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Removing 'stale' label from issue #${{ github.event.issue.number }}"
-          gh issue edit ${{ github.event.issue.number }} --remove-label "lifecycle/stale,lifecycle/rotten"


### PR DESCRIPTION
## Summary
- Replace all 9 local governance workflows with thin callers to `llm-d/llm-d-infra` reusable workflows
- Covers: Prow commands, automerge, remove-lgtm, stale/unstale, signed-commits, typos, md-link-check, non-main-gatekeeper
- Net reduction of ~163 lines of duplicated workflow logic

This is a companion to PR #613 (pre-commit config). That PR adds pre-commit; this PR migrates governance workflows.

## Test plan
- [ ] Verify Prow commands (`/lgtm`, `/approve`) still work
- [ ] Confirm stale/unstale behavior is unchanged
- [ ] Verify signed-commits check still runs

Depends on: https://github.com/llm-d/llm-d-infra/pull/2 (already merged)