### PR TITLE
Cleanup End to End test framework

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -182,15 +182,6 @@ func kindLoadImage(image string) {
 	_, err := exec.LookPath(containerRuntime)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Could not find %s in PATH", containerRuntime)
 
-	// Pull the image first to ensure it's available locally
-	ginkgo.By(fmt.Sprintf("Pulling image %s if not available locally", image))
-	pullCommand := exec.Command(containerRuntime, "pull", image)
-	pullSession, pullErr := gexec.Start(pullCommand, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
-	if pullErr == nil {
-		// Wait for pull to complete, but don't fail if image already exists or can't be pulled
-		gomega.Eventually(pullSession).WithTimeout(600 * time.Second).Should(gexec.Exit())
-	}
-
 	saveArgs := []string{"save", "--output", target}
 	if containerRuntime == "docker" {
 		// The platform flag is required for docker save to work but it is an unsupported flag for podman

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -171,7 +171,6 @@ func setupK8sCluster() {
 	kindLoadImage(vllmSimImage)
 	kindLoadImage(eppImage)
 	kindLoadImage(sideCarImage)
-	kindLoadImage(vllmSimImage)
 }
 
 func kindLoadImage(image string) {


### PR DESCRIPTION
This PR cleans up the "framework" used by the end to end tests.

In particular it:

1. Deletes a duplicated load of the vLLM Simulator image
2. Deletes a forced Pull of the images needed from the code. This code is not needed for two reasons:
     1. The Makefile target test-e2e has a pre-requisite target of image-pull, which runs a scripts that verifies that the needed images are in the local directory.
     2. The code causes a pull of images from the remote repository even if an image with the appropriate tag exists locally.