### PR TITLE
Optimized request prefill error messages

### DIFF
--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -142,3 +142,11 @@ func (s *Server) createDecoderProxyHandler(decoderURL *url.URL, decoderInsecureS
 func isHTTPError(statusCode int) bool {
 	return statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices
 }
+
+// shouldFallbackToDecode returns false for client error 4xx status codes (400–451). For all other status codes, it returns true.
+func shouldFallbackToDecode(pw *bufferedResponseWriter) bool {
+	if pw.statusCode >= http.StatusBadRequest && pw.statusCode <= http.StatusUnavailableForLegalReasons {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
fix: https://github.com/llm-d/llm-d-inference-scheduler/issues/637

The complete error message should be returned to the upstream rather than just an HTTP code.

- Before

```bash
~# curl -s http://inference-gateway-istio.lzj.svc.cluster.local:80/v1/chat/completions       -H "Content-Type: application/json"       -d '{
                "model": "Qwen/Qwen3-0.6B",
                "messages": [
                        {
                                "role": "user",
                                "content": [
                                        {
                                                "type": "text",
                                                "text": "Describe this image in one sentence."
                                        },
                                        {
                                                "type": "image_url",
                                                "image_url": {
                                                        "url": "https://cdn2.thecatapi.com/images/dui.jpg"
                                                }
                                        }
                                ]
                        }
                ]
        }'|jq .

```

- Now

```bash
curl -s http://inference-gateway-istio.lzj.svc.cluster.local:80/v1/chat/completions       -H "Content-Type: application/json"       -d '{
                "model": "Qwen/Qwen3-0.6B",
                "messages": [
                        {
                                "role": "user",
                                "content": [
                                        {
                                                "type": "text",
                                                "text": "Describe this image in one sentence."
                                        },
                                        {
                                                "type": "image_url",
                                                "image_url": {
                                                        "url": "https://cdn2.thecatapi.com/images/dui.jpg"
                                                }
                                        }
                                ]
                        }
                ]
        }'|jq .
{
  "error": {
    "code": 400,
    "message": "/model-cache/Qwen3-0.6B is not a multimodal model None",
    "param": null,
    "type": "BadRequestError"
  }
}
```