### PR TITLE
fix(ci): update Trivy to v0.69.2

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -3,13 +3,14 @@ description: Scan container image with Trivy
 inputs:
   image:
     required: true
+    description: Image to scan
 runs:
   using: "composite"
   steps:
     - name: Install Trivy
       run: |
-        wget https://github.com/aquasecurity/trivy/releases/download/v0.44.1/trivy_0.44.1_Linux-64bit.deb
-        sudo dpkg -i trivy_0.44.1_Linux-64bit.deb
+        wget https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_Linux-64bit.deb
+        sudo dpkg -i trivy_0.69.2_Linux-64bit.deb
       shell: bash
 
 


### PR DESCRIPTION
The v0.44.1 release was removed from GitHub, causing 404 errors in the trivy-scan action. Update to the latest available version.