### PR TITLE
Adds configuration file for sidecar proxy

### DIFF
--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -33,7 +33,77 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
+	"sigs.k8s.io/yaml"
 )
+
+const (
+	// Flags
+	port                    = "port"
+	vllmPort                = "vllm-port"
+	dataParallelSize        = "data-parallel-size"
+	kvConnector             = "kv-connector"
+	ecConnector             = "ec-connector"
+	enableSSRFProtection    = "enable-ssrf-protection"
+	enablePrefillerSampling = "enable-prefiller-sampling"
+	enableTLS               = "enable-tls"
+	tlsInsecureSkipVerify   = "tls-insecure-skip-verify"
+	secureServing           = "secure-proxy"
+	certPath                = "cert-path"
+	inferencePool           = "inference-pool"
+	poolGroup               = "pool-group"
+	maxIdleConnsPerHost     = "max-idle-conns-per-host"
+	inlineConfiguration     = "configuration"
+	configurationFile       = "configuration-file"
+
+	// Deprecated flags
+	connector                      = "connector"
+	prefillerUseTLS                = "prefiller-use-tls"
+	decoderUseTLS                  = "decoder-use-tls"
+	encoderUseTLS                  = "UseTLSForEncoder"
+	prefillerTLSInsecureSkipVerify = "prefiller-tls-insecure-skip-verify"
+	decoderTLSInsecureSkipVerify   = "decoder-tls-insecure-skip-verify"
+	inferencePoolNamespace         = "inference-pool-namespace"
+	inferencePoolName              = "inference-pool-name"
+
+	// Environment variables
+	envInferencePool           = "INFERENCE_POOL"
+	envInferencePoolNamespace  = "INFERENCE_POOL_NAMESPACE"
+	envInferencePoolName       = "INFERENCE_POOL_NAME"
+	envEnablePrefillerSampling = "ENABLE_PREFILLER_SAMPLING"
+
+	// Defaults
+	defaultPort             = "8000"
+	defaultVLLMPort         = "8001"
+	defaultDataParallelSize = 1
+
+	// TLS stages
+	prefillStage = "prefiller"
+	decodeStage  = "decoder"
+	encodeStage  = "encoder"
+)
+
+// yamlConfiguration represents structure of YAML configuration for sidecar proxy
+type yamlConfiguration struct {
+	Port                           int      `json:"port,omitempty"`
+	VLLMPort                       int      `json:"vllm-port,omitempty"`
+	DataParallelSize               int      `json:"data-parallel-size,omitempty"`
+	KVConnector                    string   `json:"kv-connector,omitempty"`
+	Connector                      string   `json:"connector,omitempty"`
+	ECConnector                    string   `json:"ec-connector,omitempty"`
+	EnableSSRFProtection           *bool    `json:"enable-ssrf-protection,omitempty"`
+	EnablePrefillerSampling        *bool    `json:"enable-prefiller-sampling,omitempty"`
+	SecureServing                  *bool    `json:"secure-proxy,omitempty"`
+	CertPath                       string   `json:"cert-path,omitempty"`
+	EnableTLS                      []string `json:"enable-tls,omitempty"`
+	TLSInsecureSkipVerify          []string `json:"tls-insecure-skip-verify,omitempty"`
+	PrefillerUseTLS                *bool    `json:"prefiller-use-tls,omitempty"`
+	DecoderUseTLS                  *bool    `json:"decoder-use-tls,omitempty"`
+	PrefillerTLSInsecureSkipVerify *bool    `json:"prefiller-tls-insecure-skip-verify,omitempty"`
+	DecoderTLSInsecureSkipVerify   *bool    `json:"decoder-tls-insecure-skip-verify,omitempty"`
+	InferencePool                  string   `json:"inference-pool,omitempty"`
+	PoolGroup                      string   `json:"pool-group,omitempty"`
+	MaxIdleConnsPerHost            int      `json:"max-idle-conns-per-host,omitempty"`
+}
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
 // It embeds Config which represents the complete processed runtime configuration.
@@ -60,15 +130,11 @@ type Options struct {
 	prefillerInsecureSkipVerify bool   // Deprecated: use --tls-insecure-skip-verify=prefiller instead
 	decoderInsecureSkipVerify   bool   // Deprecated: use --tls-insecure-skip-verify=decoder instead
 
-	loggingOptions zap.Options // loggingOptions holds the zap logging configuration
+	loggingOptions      zap.Options // loggingOptions holds the zap logging configuration
+	pflagSet            *pflag.FlagSet
+	inlineConfiguration string
+	fileConfiguration   string
 }
-
-const (
-	// TLS stages
-	prefillStage = "prefiller"
-	decodeStage  = "decoder"
-	encodeStage  = "encoder"
-)
 
 var (
 	// supportedKVConnectors defines all valid P/D KV connector types
@@ -98,23 +164,23 @@ var (
 // NewOptions returns a new Options struct initialized with default values.
 func NewOptions() *Options {
 	enablePrefillerSampling := false
-	if val, err := strconv.ParseBool(os.Getenv("ENABLE_PREFILLER_SAMPLING")); err == nil {
+	if val, err := strconv.ParseBool(os.Getenv(envEnablePrefillerSampling)); err == nil {
 		enablePrefillerSampling = val
 	}
 
 	return &Options{
 		Config: Config{
-			Port:                    "8000",
-			DataParallelSize:        1,
+			Port:                    defaultPort,
+			DataParallelSize:        defaultDataParallelSize,
 			SecureServing:           true,
 			EnablePrefillerSampling: enablePrefillerSampling,
 			MaxIdleConnsPerHost:     defaultMaxIdleConnsPerHost,
 			PoolGroup:               DefaultPoolGroup,
-			InferencePoolNamespace:  os.Getenv("INFERENCE_POOL_NAMESPACE"),
-			InferencePoolName:       os.Getenv("INFERENCE_POOL_NAME"),
+			InferencePoolNamespace:  os.Getenv(envInferencePoolNamespace),
+			InferencePoolName:       os.Getenv(envInferencePoolName),
 		},
-		vllmPort:      "8001",
-		inferencePool: os.Getenv("INFERENCE_POOL"),
+		vllmPort:      defaultVLLMPort,
+		inferencePool: os.Getenv(envInferencePool),
 		connector:     KVConnectorNIXLV2,
 	}
 }
@@ -122,47 +188,51 @@ func NewOptions() *Options {
 // AddFlags binds the Options fields to command-line flags on the given FlagSet.
 // It also sets up zap logging flags and integrates Go flags with pflag.
 func (opts *Options) AddFlags(fs *pflag.FlagSet) {
+	if opts.pflagSet == nil {
+		opts.pflagSet = fs
+	}
+	goFlagSet := flag.NewFlagSet("goFlagSet", flag.ContinueOnError)
 	// Add logging flags to the standard flag set
-	opts.loggingOptions.BindFlags(flag.CommandLine)
-
+	opts.loggingOptions.BindFlags(goFlagSet)
 	// Add Go flags to pflag (for zap options compatibility)
-	fs.AddGoFlagSet(flag.CommandLine)
-
-	fs.StringVar(&opts.Port, "port", opts.Port, "the port the sidecar is listening on")
-	fs.StringVar(&opts.vllmPort, "vllm-port", opts.vllmPort, "the port vLLM is listening on")
-	fs.IntVar(&opts.DataParallelSize, "data-parallel-size", opts.DataParallelSize, "the vLLM DATA-PARALLEL-SIZE value")
-	fs.StringVar(&opts.KVConnector, "kv-connector", opts.KVConnector,
+	fs.AddGoFlagSet(goFlagSet)
+	fs.StringVar(&opts.Port, port, opts.Port, "the port the sidecar is listening on")
+	fs.StringVar(&opts.vllmPort, vllmPort, opts.vllmPort, "the port vLLM is listening on")
+	fs.IntVar(&opts.DataParallelSize, dataParallelSize, opts.DataParallelSize, "the vLLM DATA-PARALLEL-SIZE value")
+	fs.StringVar(&opts.KVConnector, kvConnector, opts.KVConnector,
 		"the KV protocol between prefiller and decoder. Supported: "+supportedKVConnectorNamesStr)
-	fs.StringVar(&opts.ECConnector, "ec-connector", opts.ECConnector,
+	fs.StringVar(&opts.ECConnector, ecConnector, opts.ECConnector,
 		"the EC protocol between encoder and prefiller (for EPD mode). Supported: "+supportedECConnectorNamesStr+". Leave empty to skip encoder stage.")
-	fs.BoolVar(&opts.SecureServing, "secure-proxy", opts.SecureServing, "Enables secure proxy. Defaults to true.")
-	fs.StringVar(&opts.CertPath, "cert-path", opts.CertPath, "The path to the certificate for secure proxy. The certificate and private key files are assumed to be named tls.crt and tls.key, respectively. If not set, and secureProxy is enabled, then a self-signed certificate is used (for testing).")
-	fs.BoolVar(&opts.EnableSSRFProtection, "enable-ssrf-protection", opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")
-	fs.BoolVar(&opts.EnablePrefillerSampling, "enable-prefiller-sampling", opts.EnablePrefillerSampling, "if true, the target prefill instance will be selected randomly from among the provided prefill host values")
-	fs.StringVar(&opts.PoolGroup, "pool-group", opts.PoolGroup, "group of the InferencePool this Endpoint Picker is associated with.")
+	fs.BoolVar(&opts.SecureServing, secureServing, opts.SecureServing, "Enables secure proxy. Defaults to true.")
+	fs.StringVar(&opts.CertPath, certPath, opts.CertPath, "The path to the certificate for secure proxy. The certificate and private key files are assumed to be named tls.crt and tls.key, respectively. If not set, and secureProxy is enabled, then a self-signed certificate is used (for testing).")
+	fs.BoolVar(&opts.EnableSSRFProtection, enableSSRFProtection, opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")
+	fs.BoolVar(&opts.EnablePrefillerSampling, enablePrefillerSampling, opts.EnablePrefillerSampling, "if true, the target prefill instance will be selected randomly from among the provided prefill host values")
+	fs.StringVar(&opts.PoolGroup, poolGroup, opts.PoolGroup, "group of the InferencePool this Endpoint Picker is associated with.")
 
-	fs.StringSliceVar(&opts.enableTLS, "enable-tls", opts.enableTLS, "stages to enable TLS for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
-	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, "tls-insecure-skip-verify", opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
-	fs.StringVar(&opts.inferencePool, "inference-pool", opts.inferencePool, "InferencePool in namespace/name or name format (e.g., default/my-pool or my-pool). A single name implies the 'default' namespace. Can also use INFERENCE_POOL env var.")
+	fs.StringSliceVar(&opts.enableTLS, enableTLS, opts.enableTLS, "stages to enable TLS for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
+	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, tlsInsecureSkipVerify, opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
+	fs.StringVar(&opts.inferencePool, inferencePool, opts.inferencePool, "InferencePool in namespace/name or name format (e.g., default/my-pool or my-pool). A single name implies the 'default' namespace. Can also use INFERENCE_POOL env var.")
 
 	// Deprecated flags - kept for backward compatibility
-	fs.StringVar(&opts.connector, "connector", opts.connector, "Deprecated: use --kv-connector instead. The P/D connector being used. Supported: "+supportedKVConnectorNamesStr)
-	_ = fs.MarkDeprecated("connector", "use --kv-connector instead")
+	fs.StringVar(&opts.connector, connector, opts.connector, "Deprecated: use --kv-connector instead. The P/D connector being used. Supported: "+supportedKVConnectorNamesStr)
+	_ = fs.MarkDeprecated(connector, "use --kv-connector instead")
 
-	fs.BoolVar(&opts.prefillerUseTLS, "prefiller-use-tls", opts.prefillerUseTLS, "Deprecated: use --enable-tls=prefiller instead. Whether to use TLS when sending requests to prefillers.")
-	_ = fs.MarkDeprecated("prefiller-use-tls", "use --enable-tls=prefiller instead")
+	fs.BoolVar(&opts.prefillerUseTLS, prefillerUseTLS, opts.prefillerUseTLS, "Deprecated: use --enable-tls=prefiller instead. Whether to use TLS when sending requests to prefillers.")
+	_ = fs.MarkDeprecated(prefillerUseTLS, "use --enable-tls=prefiller instead")
 	fs.BoolVar(&opts.decoderUseTLS, "decoder-use-tls", opts.decoderUseTLS, "Deprecated: use --enable-tls=decoder instead. Whether to use TLS when sending requests to the decoder.")
-	_ = fs.MarkDeprecated("decoder-use-tls", "use --enable-tls=decoder instead")
-	fs.BoolVar(&opts.prefillerInsecureSkipVerify, "prefiller-tls-insecure-skip-verify", opts.prefillerInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=prefiller instead. Skip TLS verification for requests to prefiller.")
-	_ = fs.MarkDeprecated("prefiller-tls-insecure-skip-verify", "use --tls-insecure-skip-verify=prefiller instead")
-	fs.BoolVar(&opts.decoderInsecureSkipVerify, "decoder-tls-insecure-skip-verify", opts.decoderInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=decoder instead. Skip TLS verification for requests to decoder.")
-	_ = fs.MarkDeprecated("decoder-tls-insecure-skip-verify", "use --tls-insecure-skip-verify=decoder instead")
+	_ = fs.MarkDeprecated(decoderUseTLS, "use --enable-tls=decoder instead")
+	fs.BoolVar(&opts.prefillerInsecureSkipVerify, prefillerTLSInsecureSkipVerify, opts.prefillerInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=prefiller instead. Skip TLS verification for requests to prefiller.")
+	_ = fs.MarkDeprecated(prefillerTLSInsecureSkipVerify, "use --tls-insecure-skip-verify=prefiller instead")
+	fs.BoolVar(&opts.decoderInsecureSkipVerify, decoderTLSInsecureSkipVerify, opts.decoderInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=decoder instead. Skip TLS verification for requests to decoder.")
+	_ = fs.MarkDeprecated(decoderTLSInsecureSkipVerify, "use --tls-insecure-skip-verify=decoder instead")
 
-	fs.StringVar(&opts.InferencePoolNamespace, "inference-pool-namespace", opts.InferencePoolNamespace, "Deprecated: use --inference-pool instead. The Kubernetes namespace for the InferencePool (defaults to INFERENCE_POOL_NAMESPACE env var)")
-	_ = fs.MarkDeprecated("inference-pool-namespace", "use --inference-pool instead")
-	fs.StringVar(&opts.InferencePoolName, "inference-pool-name", opts.InferencePoolName, "Deprecated: use --inference-pool instead. The specific InferencePool name (defaults to INFERENCE_POOL_NAME env var)")
-	_ = fs.MarkDeprecated("inference-pool-name", "use --inference-pool instead")
+	fs.StringVar(&opts.InferencePoolNamespace, inferencePoolNamespace, opts.InferencePoolNamespace, "Deprecated: use --inference-pool instead. The Kubernetes namespace for the InferencePool (defaults to INFERENCE_POOL_NAMESPACE env var)")
+	_ = fs.MarkDeprecated(inferencePoolNamespace, "use --inference-pool instead")
+	fs.StringVar(&opts.InferencePoolName, inferencePoolName, opts.InferencePoolName, "Deprecated: use --inference-pool instead. The specific InferencePool name (defaults to INFERENCE_POOL_NAME env var)")
+	_ = fs.MarkDeprecated(inferencePoolName, "use --inference-pool instead")
 	fs.IntVar(&opts.MaxIdleConnsPerHost, "max-idle-conns-per-host", opts.MaxIdleConnsPerHost, "max idle keep-alive connections per host for reverse proxy transports; set to at least the expected concurrency")
+	fs.StringVar(&opts.inlineConfiguration, inlineConfiguration, "", "Sidecar configuration in YAML provided as inline specification. Example `--configuration={port: 8085, vllm-port: 8203}. Inline configuration and file configuration are mutually exclusive.`")
+	fs.StringVar(&opts.fileConfiguration, configurationFile, "", "Path to file which contains sidecar configuration in YAML. Example `--configuration-file=/etc/config/sidecar-config.yaml`. Inline configuration and file configuration are mutually exclusive.")
 }
 
 // validateStages checks if all stages in the slice are valid according to the supportedStages map
@@ -176,10 +246,14 @@ func validateStages(stages []string, supportedStages map[string]struct{}, flagNa
 }
 
 // Complete performs post-processing of parsed command-line arguments.
-// It handles migration from deprecated flags, parses the InferencePool field,
-// computes boolean TLS fields, and builds Config.DecoderURL.
+// It extracts YAML configuration (if provided), handles migration from deprecated flags,
+// parses the InferencePool field, computes boolean TLS fields, and builds Config.DecoderURL.
 // After Complete(), opts.Config is fully populated.
 func (opts *Options) Complete() error {
+	if err := opts.extractYAMLConfiguration(); err != nil {
+		return err
+	}
+
 	// Migrate deprecated connector flag to KVConnector
 	if opts.connector != "" && opts.KVConnector == "" {
 		opts.KVConnector = opts.connector
@@ -322,4 +396,124 @@ func (opts *Options) NewLogger() logr.Logger {
 		zap.UseFlagOptions(&opts.loggingOptions),
 		zap.Encoder(zapcore.NewJSONEncoder(config)),
 	)
+}
+
+// extractYAMLConfiguration extracts sidecar configuration (if provided)
+// from `--configuration` and `--configuration-file` parameters
+func (opts *Options) extractYAMLConfiguration() error {
+	var yamlConfiguration yamlConfiguration
+	var yamlData []byte
+	var err error
+
+	switch {
+	case opts.inlineConfiguration != "" && opts.fileConfiguration != "":
+		return fmt.Errorf("flags --%s and --%s are mutually exclusive", inlineConfiguration, configurationFile)
+
+	case opts.inlineConfiguration != "":
+		yamlData = []byte(opts.inlineConfiguration)
+
+	case opts.fileConfiguration != "":
+		yamlData, err = os.ReadFile(opts.fileConfiguration)
+		if err != nil {
+			return fmt.Errorf("failed to read sidecar configuration from file: %w", err)
+		}
+	}
+
+	if yamlData == nil {
+		return nil
+	}
+
+	// fail on unknown YAML fields
+	if err := yaml.UnmarshalStrict(yamlData, &yamlConfiguration); err != nil {
+		return fmt.Errorf("failed to unmarshal sidecar configuration: %w", err)
+	}
+
+	opts.mergeYAMLConfiguration(yamlConfiguration)
+	return nil
+}
+
+// mergeYAMLConfiguration merges provided yamlConfiguration into Options struct,
+// respecting precedence of command-line flags (i.e., YAML values are only applied if corresponding flag was not explicitly set by user)
+func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
+	if cfg.Port != 0 && !opts.isFlagSet(port) {
+		opts.Port = strconv.Itoa(cfg.Port)
+	}
+	if cfg.VLLMPort != 0 && !opts.isFlagSet(vllmPort) {
+		opts.vllmPort = strconv.Itoa(cfg.VLLMPort)
+	}
+	if cfg.DataParallelSize != 0 && !opts.isFlagSet(dataParallelSize) {
+		opts.DataParallelSize = cfg.DataParallelSize
+	}
+	if cfg.MaxIdleConnsPerHost != 0 && !opts.isFlagSet(maxIdleConnsPerHost) {
+		opts.MaxIdleConnsPerHost = cfg.MaxIdleConnsPerHost
+	}
+
+	if cfg.KVConnector != "" && !opts.isFlagSet(kvConnector) {
+		opts.KVConnector = cfg.KVConnector
+	}
+	if cfg.Connector != "" && !opts.isFlagSet(connector) {
+		opts.connector = cfg.Connector
+	}
+	if cfg.ECConnector != "" && !opts.isFlagSet(ecConnector) {
+		opts.ECConnector = cfg.ECConnector
+	}
+
+	if cfg.EnableSSRFProtection != nil && !opts.isFlagSet(enableSSRFProtection) {
+		opts.EnableSSRFProtection = *cfg.EnableSSRFProtection
+	}
+	if cfg.EnablePrefillerSampling != nil && !opts.isFlagSet(enablePrefillerSampling) {
+		opts.EnablePrefillerSampling = *cfg.EnablePrefillerSampling
+	}
+
+	if cfg.SecureServing != nil && !opts.isFlagSet(secureServing) {
+		opts.SecureServing = *cfg.SecureServing
+	}
+	if cfg.CertPath != "" && !opts.isFlagSet(certPath) {
+		opts.CertPath = cfg.CertPath
+	}
+
+	if len(cfg.EnableTLS) > 0 && !opts.isFlagSet(enableTLS) {
+		opts.enableTLS = cfg.EnableTLS
+	}
+	if len(cfg.TLSInsecureSkipVerify) > 0 && !opts.isFlagSet(tlsInsecureSkipVerify) {
+		opts.tlsInsecureSkipVerify = cfg.TLSInsecureSkipVerify
+	}
+
+	// update prefiller/decoder TLS settings from deprecated YAML fields if corresponding new fields are not set by user via flags
+	// (i.e., prefillerUseTLS only applies if --enable-tls and --prefiller-use-tls are not set,
+	// and decoderUseTLS only applies if --enable-tls and --decoder-use-tls are not set)
+	if cfg.PrefillerUseTLS != nil && !opts.isFlagSet(enableTLS) && !opts.isFlagSet(prefillerUseTLS) {
+		opts.prefillerUseTLS = *cfg.PrefillerUseTLS
+	}
+	if cfg.DecoderUseTLS != nil && !opts.isFlagSet(enableTLS) && !opts.isFlagSet(decoderUseTLS) {
+		opts.decoderUseTLS = *cfg.DecoderUseTLS
+	}
+
+	// update prefiller/decoder TLS insecure skip verify settings from deprecated YAML fields if corresponding new fields are not set by user via flags
+	// (i.e., prefillerTLSInsecureSkipVerify only applies if --tls-insecure-skip-verify and --prefiller-tls-insecure-skip-verify are not set,
+	// and decoderTLSInsecureSkipVerify only applies if --tls-insecure-skip-verify and --decoder-tls-insecure-skip-verify are not set)
+	if cfg.PrefillerTLSInsecureSkipVerify != nil && !opts.isFlagSet(prefillerTLSInsecureSkipVerify) && !opts.isFlagSet(tlsInsecureSkipVerify) {
+		opts.prefillerInsecureSkipVerify = *cfg.PrefillerTLSInsecureSkipVerify
+	}
+	if cfg.DecoderTLSInsecureSkipVerify != nil && !opts.isFlagSet(decoderTLSInsecureSkipVerify) && !opts.isFlagSet(tlsInsecureSkipVerify) {
+		opts.decoderInsecureSkipVerify = *cfg.DecoderTLSInsecureSkipVerify
+	}
+
+	if cfg.InferencePool != "" && !opts.isFlagSet(inferencePool) {
+		opts.inferencePool = cfg.InferencePool
+	}
+	if cfg.PoolGroup != "" && !opts.isFlagSet(poolGroup) {
+		opts.PoolGroup = cfg.PoolGroup
+	}
+}
+
+// isFlagSet returns true if flag was set by user
+func (opts *Options) isFlagSet(parameter string) bool {
+	if opts.pflagSet != nil {
+		flag := opts.pflagSet.Lookup(parameter)
+		if flag != nil && flag.Changed {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -17,8 +17,506 @@ limitations under the License.
 package proxy
 
 import (
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
+
+func writeTempYAML(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func createConfigWithValidYAML(t *testing.T) string {
+	t.Helper()
+	return writeTempYAML(t, "valid.yaml", `
+port: 8100
+vllm-port: 8200
+data-parallel-size: 5
+kv-connector: "sglang"
+connector: "nixlv2"
+ec-connector: "ec-example"
+enable-ssrf-protection: true
+enable-prefiller-sampling: true
+enable-tls:
+- prefiller
+- decoder
+prefiller-use-tls: false
+tls-insecure-skip-verify:
+- prefiller
+decoder-tls-insecure-skip-verify: true
+secure-proxy: false
+cert-path: "/etc/certificates-file"
+inference-pool: "file-ns/inference-pool-file"
+pool-group: "pool-group-file"
+max-idle-conns-per-host: 300
+`)
+}
+
+func createConfigWithUnknownKeys(t *testing.T) string {
+	t.Helper()
+	return writeTempYAML(t, "valid.yaml", `
+port: 8100
+vllm-port: 8200
+unknown-key: 1001
+`)
+}
+
+func createConfigWithInvalidYAML(t *testing.T) string {
+	t.Helper()
+	return writeTempYAML(t, "invalid.yaml", `
+port: 8100
+invalid-yaml,
+`)
+}
+
+func TestSidecarConfiguration(t *testing.T) {
+	// --- inline YAML for testing ---
+	inlineYAML :=
+		`{
+		port: 8011,
+		vllm-port: 8021,
+		data-parallel-size: 3,
+		kv-connector: sglang,
+		connector: nixlv2,
+		ec-connector: ec-example,
+		enable-ssrf-protection: true,
+		enable-prefiller-sampling: true,
+		enable-tls: ['prefiller', 'decoder'],
+		prefiller-use-tls: false,
+		decoder-use-tls: true,
+		tls-insecure-skip-verify: ['decoder'],
+		prefiller-tls-insecure-skip-verify: true,
+		secure-proxy: false,
+		cert-path: '/etc/certificates-inline',
+		inference-pool: inline-ns/inference-pool-inline,
+		pool-group: pool-group-inline,
+		max-idle-conns-per-host: 200
+	}`
+	invalidInlineYAML := "{port: 8200, invalid-yaml}"
+
+	// -- file YAML for testing ---
+	validYAMLPath := createConfigWithValidYAML(t)
+	invalidYAMLPath := createConfigWithInvalidYAML(t)
+	unknownKeysYAMLPath := createConfigWithUnknownKeys(t)
+
+	tests := []struct {
+		name          string
+		expected      func(*Options)
+		expectedError error
+		inputFlags    map[string]any
+		inputEnvVar   map[string]any
+	}{
+		{
+			name: "inline YAML overrides default",
+			inputFlags: map[string]any{
+				inlineConfiguration: &inlineYAML,
+			},
+			expected: func(o *Options) {
+				o.Port = "8011"
+				o.vllmPort = "8021"
+				o.DataParallelSize = 3
+				o.MaxIdleConnsPerHost = 200
+
+				o.KVConnector = KVConnectorSGLang
+				o.connector = KVConnectorNIXLV2
+				o.ECConnector = ECExampleConnector
+
+				o.EnableSSRFProtection = true
+				o.EnablePrefillerSampling = true
+
+				o.enableTLS = []string{prefillStage, decodeStage}
+				o.UseTLSForPrefiller = true
+				o.UseTLSForDecoder = true
+				o.UseTLSForEncoder = false
+
+				o.tlsInsecureSkipVerify = []string{prefillStage, decodeStage}
+				o.InsecureSkipVerifyForPrefiller = true
+				o.InsecureSkipVerifyForDecoder = true
+				o.InsecureSkipVerifyForEncoder = false
+
+				o.SecureServing = false
+				o.CertPath = "/etc/certificates-inline"
+
+				o.inferencePool = "inline-ns/inference-pool-inline"
+				o.InferencePoolNamespace = "inline-ns"
+				o.InferencePoolName = "inference-pool-inline"
+				o.PoolGroup = "pool-group-inline"
+
+				o.inlineConfiguration = inlineYAML
+				o.fileConfiguration = ""
+			},
+			expectedError: nil,
+		},
+		{
+			name: "file YAML overrides default",
+			inputFlags: map[string]any{
+				configurationFile: validYAMLPath,
+			},
+			expected: func(o *Options) {
+				o.Port = "8100"
+				o.vllmPort = "8200"
+				o.DataParallelSize = 5
+				o.MaxIdleConnsPerHost = 300
+
+				o.KVConnector = KVConnectorSGLang
+				o.ECConnector = ECExampleConnector
+
+				o.EnableSSRFProtection = true
+				o.EnablePrefillerSampling = true
+
+				o.enableTLS = []string{prefillStage, decodeStage}
+				o.UseTLSForPrefiller = true
+				o.UseTLSForDecoder = true
+				o.UseTLSForEncoder = false
+
+				o.tlsInsecureSkipVerify = []string{prefillStage, decodeStage}
+				o.InsecureSkipVerifyForPrefiller = true
+				o.InsecureSkipVerifyForDecoder = true
+				o.InsecureSkipVerifyForEncoder = false
+
+				o.SecureServing = false
+				o.CertPath = "/etc/certificates-file"
+
+				o.inferencePool = "file-ns/inference-pool-file"
+				o.InferencePoolNamespace = "file-ns"
+				o.InferencePoolName = "inference-pool-file"
+				o.PoolGroup = "pool-group-file"
+
+				o.inlineConfiguration = ""
+				o.fileConfiguration = validYAMLPath
+			},
+			expectedError: nil,
+		},
+		{
+			name: "flags override inline YAML",
+			inputFlags: map[string]any{
+				port:                    "8111",
+				vllmPort:                "8222",
+				dataParallelSize:        2,
+				kvConnector:             KVConnectorSGLang,
+				ecConnector:             ECExampleConnector,
+				enableSSRFProtection:    true,
+				enablePrefillerSampling: true,
+				enableTLS:               &[]string{prefillStage},
+				tlsInsecureSkipVerify:   &[]string{prefillStage},
+				secureServing:           false,
+				certPath:                "/etc/certificates",
+				inferencePool:           "ns/inference-pool",
+				poolGroup:               "pool-group",
+				inlineConfiguration:     &inlineYAML,
+			},
+			expected: func(o *Options) {
+				o.Port = "8111"
+				o.vllmPort = "8222"
+				o.DataParallelSize = 2
+				o.MaxIdleConnsPerHost = 200
+
+				o.KVConnector = KVConnectorSGLang
+				o.ECConnector = ECExampleConnector
+
+				o.EnableSSRFProtection = true
+				o.EnablePrefillerSampling = true
+
+				o.enableTLS = []string{prefillStage}
+				o.UseTLSForPrefiller = true
+				o.UseTLSForDecoder = false
+				o.UseTLSForEncoder = false
+
+				o.tlsInsecureSkipVerify = []string{prefillStage}
+				o.InsecureSkipVerifyForPrefiller = true
+				o.InsecureSkipVerifyForDecoder = false
+				o.InsecureSkipVerifyForEncoder = false
+
+				o.SecureServing = false
+				o.CertPath = "/etc/certificates"
+
+				o.inferencePool = "ns/inference-pool"
+				o.InferencePoolNamespace = "ns"
+				o.InferencePoolName = "inference-pool"
+				o.PoolGroup = "pool-group"
+
+				o.inlineConfiguration = inlineYAML
+				o.fileConfiguration = ""
+			},
+			expectedError: nil,
+		},
+		{
+			name: "flags override file YAML",
+			inputFlags: map[string]any{
+				port:                    "8111",
+				vllmPort:                "8222",
+				dataParallelSize:        2,
+				kvConnector:             KVConnectorSGLang,
+				ecConnector:             ECExampleConnector,
+				enableSSRFProtection:    true,
+				enablePrefillerSampling: true,
+				enableTLS:               &[]string{prefillStage},
+				tlsInsecureSkipVerify:   &[]string{prefillStage},
+				secureServing:           false,
+				certPath:                "/etc/certificates",
+				inferencePool:           "ns/inference-pool",
+				poolGroup:               "pool-group",
+				configurationFile:       validYAMLPath,
+				maxIdleConnsPerHost:     400,
+			},
+			expected: func(o *Options) {
+				o.Port = "8111"
+				o.vllmPort = "8222"
+				o.DataParallelSize = 2
+				o.MaxIdleConnsPerHost = 400
+
+				o.KVConnector = KVConnectorSGLang
+				o.ECConnector = ECExampleConnector
+
+				o.EnableSSRFProtection = true
+				o.EnablePrefillerSampling = true
+
+				o.enableTLS = []string{prefillStage}
+				o.UseTLSForPrefiller = true
+				o.UseTLSForDecoder = false
+				o.UseTLSForEncoder = false
+
+				o.tlsInsecureSkipVerify = []string{prefillStage}
+				o.InsecureSkipVerifyForPrefiller = true
+				o.InsecureSkipVerifyForDecoder = false
+				o.InsecureSkipVerifyForEncoder = false
+
+				o.SecureServing = false
+				o.CertPath = "/etc/certificates"
+
+				o.inferencePool = "ns/inference-pool"
+				o.InferencePoolNamespace = "ns"
+				o.InferencePoolName = "inference-pool"
+				o.PoolGroup = "pool-group"
+
+				o.inlineConfiguration = ""
+				o.fileConfiguration = validYAMLPath
+			},
+			expectedError: nil,
+		},
+		{
+			name: "invalid inline YAML ",
+			inputFlags: map[string]any{
+				inlineConfiguration: invalidInlineYAML,
+			},
+			expectedError: errors.New("failed to unmarshal sidecar configuration"),
+		},
+		{
+			name: "invalid file YAML",
+			inputFlags: map[string]any{
+				configurationFile: invalidYAMLPath,
+			},
+			expectedError: errors.New("failed to unmarshal sidecar configuration"),
+		},
+		{
+			name: "unknown keys in YAML",
+			inputFlags: map[string]any{
+				configurationFile: unknownKeysYAMLPath,
+			},
+			expectedError: errors.New("failed to unmarshal sidecar configuration"),
+		},
+		{
+			name: "both inline and file YAML",
+			inputFlags: map[string]any{
+				inlineConfiguration: inlineYAML,
+				configurationFile:   validYAMLPath,
+			},
+			expectedError: fmt.Errorf("flags --%s and --%s are mutually exclusive", inlineConfiguration, configurationFile),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setEnv(t, tt.inputEnvVar)
+
+			opts, testPFlagSet := newTestOptions(t)
+
+			for name, value := range tt.inputFlags {
+				setFlag(t, testPFlagSet, name, value)
+			}
+
+			require.NoError(t, testPFlagSet.Parse(nil))
+
+			err := opts.Complete()
+			if tt.expectedError != nil {
+				require.ErrorContains(t, err, tt.expectedError.Error(), "Error should be: %v, got: %v", tt.expectedError, err)
+				return
+			}
+
+			require.NoError(t, err, "Complete() error: %v", err)
+			require.NoError(t, opts.Validate(), "Validate() error: %v", err)
+
+			expected := NewOptions()
+			if tt.expected != nil {
+				tt.expected(expected)
+			}
+
+			compareOptions(t, expected, opts)
+		})
+	}
+}
+
+func newTestOptions(t *testing.T) (*Options, *pflag.FlagSet) {
+	t.Helper()
+
+	opts := NewOptions()
+
+	goFlagSet := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	pFlagSet := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+
+	opts.loggingOptions.BindFlags(goFlagSet)
+	opts.AddFlags(pFlagSet)
+	pFlagSet.AddGoFlagSet(goFlagSet)
+
+	return opts, pFlagSet
+}
+
+func compareOptions(t *testing.T, expected, actual *Options) {
+	t.Helper()
+
+	assertEqual := func(name string, expected, actual any) {
+		require.Equal(t, expected, actual,
+			"expected %v to be %v but got %v", name, expected, actual)
+	}
+	assertSlice := func(name string, expected, actual []string) {
+		ok, missing, extra := compareSlices(expected, actual)
+		require.True(t, ok,
+			"%s mismatch:\nexpected: %v\ngot: %v\nextra: %v\nmissing: %v",
+			name, expected, actual, extra, missing)
+	}
+
+	assertEqual(port, expected.Port, actual.Port)
+	assertEqual(vllmPort, expected.vllmPort, actual.vllmPort)
+	assertEqual(dataParallelSize, expected.DataParallelSize, actual.DataParallelSize)
+	assertEqual(maxIdleConnsPerHost, expected.MaxIdleConnsPerHost, actual.MaxIdleConnsPerHost)
+
+	assertEqual(kvConnector, expected.KVConnector, actual.KVConnector)
+	assertEqual(ecConnector, expected.ECConnector, actual.ECConnector)
+
+	assertEqual(enableSSRFProtection, expected.EnableSSRFProtection, actual.EnableSSRFProtection)
+	assertEqual(enablePrefillerSampling, expected.EnablePrefillerSampling, actual.EnablePrefillerSampling)
+
+	assertEqual(prefillerUseTLS, expected.UseTLSForPrefiller, actual.UseTLSForPrefiller)
+	assertEqual(decoderUseTLS, expected.UseTLSForDecoder, actual.UseTLSForDecoder)
+	assertEqual(encoderUseTLS, expected.UseTLSForEncoder, actual.UseTLSForEncoder)
+
+	assertEqual(prefillerTLSInsecureSkipVerify, expected.InsecureSkipVerifyForPrefiller, actual.InsecureSkipVerifyForPrefiller)
+	assertEqual(decoderTLSInsecureSkipVerify, expected.InsecureSkipVerifyForDecoder, actual.InsecureSkipVerifyForDecoder)
+	assertEqual("InsecureSkipVerifyForEncoder", expected.InsecureSkipVerifyForEncoder, actual.InsecureSkipVerifyForEncoder)
+
+	assertSlice(enableTLS, expected.enableTLS, actual.enableTLS)
+	assertSlice(tlsInsecureSkipVerify, expected.tlsInsecureSkipVerify, actual.tlsInsecureSkipVerify)
+
+	assertEqual(certPath, expected.CertPath, actual.CertPath)
+	assertEqual(secureServing, expected.SecureServing, actual.SecureServing)
+
+	assertEqual(inferencePool, expected.inferencePool, actual.inferencePool)
+	assertEqual(inferencePoolNamespace, expected.InferencePoolNamespace, actual.InferencePoolNamespace)
+	assertEqual(inferencePoolName, expected.InferencePoolName, actual.InferencePoolName)
+	assertEqual(poolGroup, expected.PoolGroup, actual.PoolGroup)
+
+	assertEqual(inlineConfiguration, expected.inlineConfiguration, actual.inlineConfiguration)
+	assertEqual(configurationFile, expected.fileConfiguration, actual.fileConfiguration)
+
+	assertEqual("decoderURL", calculateURL(t, expected.UseTLSForDecoder, expected.vllmPort), actual.DecoderURL)
+}
+
+// setEnv sets environment variables for testing and ensures they are cleaned up after the test finishes
+func setEnv(t *testing.T, env map[string]any) {
+	t.Helper()
+	for k, v := range env {
+		switch val := v.(type) {
+		case string:
+			t.Setenv(k, val)
+		case bool:
+			t.Setenv(k, strconv.FormatBool(val))
+		case int:
+			t.Setenv(k, strconv.Itoa(val))
+		default:
+			require.FailNow(t, "unsupported env var type", "key=%s type=%T", k, v)
+		}
+	}
+}
+
+// setFlag sets command-line flags for testing and fails the test if the flag name is unknown or if the value type is unsupported
+func setFlag(t *testing.T, fs *pflag.FlagSet, name string, value any) {
+	t.Helper()
+	if fs.Lookup(name) == nil {
+		require.FailNow(t, "unknown flag", "flag=%s", name)
+	}
+	switch v := value.(type) {
+	case string:
+		require.NoError(t, fs.Set(name, v))
+	case int:
+		require.NoError(t, fs.Set(name, strconv.Itoa(v)))
+	case float64:
+		require.NoError(t, fs.Set(name, fmt.Sprintf("%v", v)))
+	case bool:
+		require.NoError(t, fs.Set(name, strconv.FormatBool(v)))
+	case *string:
+		require.NoError(t, fs.Set(name, *v))
+	case *[]string:
+		require.NoError(t, fs.Set(name, strings.Join(*v, ",")))
+	case []string:
+		require.NoError(t, fs.Set(name, strings.Join(v, ",")))
+	default:
+		require.FailNow(t, "unsupported flag type", "flag=%s type=%T", name, value)
+	}
+}
+
+// calculateURL calculates decoder URL
+func calculateURL(t *testing.T, useTLSForDecoder bool, vllmport string) *url.URL {
+	expectedScheme := "http"
+	if useTLSForDecoder {
+		expectedScheme = schemeHTTPS
+	}
+	expectedURL, err := url.Parse(expectedScheme + "://localhost:" + vllmport)
+	require.NoError(t, err)
+	return expectedURL
+}
+
+// compareSlices returns:
+// 1. true when two slices contain same elements irrespective of order
+// 2. false when two slices contain different elements and
+// - what elements are missing in `got` slice compared to `expected` slice
+// - what elements are extra in `got` slice compared to `expected` slice
+func compareSlices(expected, got []string) (bool, []string, []string) {
+	temp := make(map[string]int)
+	var missing []string
+	var extra []string
+	if len(expected) == 0 && len(got) == 0 {
+		return true, nil, nil
+	}
+	for _, v := range expected {
+		temp[v]++
+	}
+	for _, v := range got {
+		temp[v]--
+	}
+	for k, v := range temp {
+		if v > 0 {
+			for i := 0; i < v; i++ {
+				missing = append(missing, k)
+			}
+		} else if v < 0 {
+			for i := 0; i < -v; i++ {
+				extra = append(extra, k)
+			}
+		}
+	}
+	return len(missing) == 0 && len(extra) == 0, missing, extra
+}
 
 func TestNewOptionsWithEnvVars(t *testing.T) {
 	// Set environment variables - t.Setenv automatically handles cleanup


### PR DESCRIPTION
### Resolves 

1. #634 

### Changes

1. Adds ability to configure sidecar proxy through YAML.
 
2. YAML configuration can be provided via command line flags `--configuration` and/or `--configuration-file`.

3. YAML configuration provided via `--configuration` is given higher priority.

4. `--configuration` enables sidecar configuration YAML to be provided as inline specification. 
Example: `--configuration={port: 8085, vllm-port: 8203, connector: sglang}`.

6. `--configuration-file` enables sidecar configuration YAML to be provided as file. 
Example: `--configuration-file=/etc/config/sidecar-config.yaml`.

```sidecarconfig.yaml
port: 8083
vllm-port: 8201
connector: "sglang"
secure-proxy: false
```

8. Configuration file is mounted as file at /etc/config/sidecar-config.yaml.

9. Sidecar configuration priority (as specified [here](https://github.com/llm-d/llm-d-inference-scheduler/pull/683/changes#r2901536829)):
    - Command-line flags (highest precedence)
    - Inline specification / Configuration file
    - Environment variables
    - Built-in defaults (lowest precedence)

### Tests

This PR contains unit tests

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add sidecar configuration specified via either `--configuration-file <path>` or  `--configuration "<text>"`. Both YAML and JSON formats are allowed. Configuration field names are the same as the CLI flags. CLI has priority over the configuration file or text.
```
