### PR TITLE
Add presubmit makefile target for local verification before pushing a PR

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,12 @@ Documentation for developing the inference scheduler.
 [ZeroMQ]:https://zeromq.org/
 
 > [!NOTE]
+> Before committing and pushing changes to an upstream repository, you may want to 
+> explicitly run the `make presubmit` target to avoid failing PR checks. The checks
+> are also performed as part of a GitHub action, but running locally can save time
+> and an iteration.
+
+> [!NOTE]
 > **Python is NOT required** as of v0.5.1. Tokenization is handled by a separate UDS (Unix Domain Socket) tokenizer sidecar container. Previous versions (< v0.5.1) used embedded Python tokenizers with daulet/tokenizers bindings, but these are now deprecated.
 
 ## Tokenization Architecture

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,34 @@ help: ## Print help
 
 ##@ Development
 
+.PHONY: install-hooks
+install-hooks: ## Install git hooks
+	git config core.hooksPath hooks
+
+.PHONY: presubmit
+presubmit: LINT_NEW_ONLY=true
+presubmit: git-branch-check signed-commits-check go-mod-check format lint
+
+.PHONY: git-branch-check
+git-branch-check:
+	@branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$branch" = "main" ]; then \
+		echo "ERROR: Direct push to 'main' is not allowed."; \
+		echo "Create a branch and open a PR instead."; \
+		exit 1; \
+	fi
+
+.PHONY: signed-commits-check
+signed-commits-check:
+	@./scripts/check-commits.sh upstream/main
+
+.PHONY: go-mod-check
+go-mod-check:
+	@echo "Checking go.mod/go.sum are clean..."
+	@go mod tidy
+	@git diff --exit-code go.mod go.sum || \
+	( echo "ERROR: go.mod/go.sum are not tidy. Run 'go mod tidy' and commit."; exit 1 )
+
 .PHONY: clean
 clean: ## Clean build artifacts, tools and caches
 	go clean -testcache -cache
@@ -115,10 +143,6 @@ lint: check-golangci-lint check-typos ## Run lint (use LINT_NEW_ONLY=true to onl
 		$(GOLANGCI_LINT) run; \
 	fi
 	$(TYPOS)
-
-.PHONY: install-hooks
-install-hooks: ## Install git hooks
-	git config core.hooksPath hooks
 
 .PHONY: test
 test: test-unit test-e2e ## Run all tests (unit and e2e)

--- a/scripts/check-commits.sh
+++ b/scripts/check-commits.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+# Use the first argument as the base, default to upstream/main
+BASE_BRANCH=${1:-upstream/main}
+
+# Find the merge base to define the PR range
+BASE=$(git merge-base HEAD "$BASE_BRANCH")
+RANGE="$BASE..HEAD"
+
+echo "Checking $(git rev-list --count "$RANGE") commits ($BASE..HEAD)..."
+
+ERR_SIG=""
+ERR_DCO=""
+
+for commit in $(git rev-list "$RANGE"); do
+    HASH=$(git rev-parse --short "$commit")
+    
+    # 1. Check for cryptographic signature header (gpgsig)
+    # Using cat-file bypasses the SSH/GPG verification engine entirely
+    if ! git cat-file commit "$commit" | grep -q "^gpgsig"; then
+        ERR_SIG="$ERR_SIG $HASH"
+    fi
+    
+    # 2. Check for DCO Sign-off text in the commit message
+    if ! git log -1 --format="%b" "$commit" | grep -q "Signed-off-by:"; then
+        ERR_DCO="$ERR_DCO $HASH"
+    fi
+done
+
+# Report failures
+if [ -z "$ERR_SIG" ] && [ -z "$ERR_DCO" ]; then
+    echo "All commits are cryptographically signed and have DCO sign-offs."
+    exit 0
+else
+    [ -n "$ERR_SIG" ] && echo "Missing Crypto Signature (gpgsig):$ERR_SIG"
+    [ -n "$ERR_DCO" ] && echo "Missing DCO Sign-off (Signed-off-by):$ERR_DCO"
+    echo ""
+    echo "To fix, use: git rebase --exec 'git commit --amend --no-edit -S -s' -i $BASE_BRANCH"
+    exit 1
+fi


### PR DESCRIPTION
Add Makefile target to allow consistent manual check before pushing PR, if desired. 
The goal is to capture some common issues before submitting a PR.