### PR TITLE
Use trivy action for image scanning

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -1,20 +1,26 @@
 name: Trivy Scan
-description: Scan container image with Trivy
+description: Scan container image with official Aqua Security Trivy action
 inputs:
   image:
     required: true
-    description: Image to scan
+    description: "Image to scan (e.g., 'my-repo/my-image:latest')"
 runs:
   using: "composite"
   steps:
-    - name: Install Trivy
-      run: |
-        wget https://github.com/aquasecurity/trivy/releases/download/v0.69.2/trivy_0.69.2_Linux-64bit.deb
-        sudo dpkg -i trivy_0.69.2_Linux-64bit.deb
-      shell: bash
+    - name: Cache Trivy DB
+      uses: actions/cache@v4
+      with:
+        path: .trivy
+        # Use a key that changes daily or weekly to ensure the DB stays fresh
+        key: ${{ runner.os }}-trivy-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-trivy-
 
-
-    - name: Scan image
-      run: |
-        trivy image --severity HIGH,CRITICAL --no-progress ${{ inputs.image }}
-      shell: bash
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.29.0
+      with:
+        image-ref: ${{ inputs.image }}
+        format: 'table'
+        severity: 'HIGH,CRITICAL'
+        exit-code: '1'
+        cache-dir: .trivy  # Explicitly tell Trivy to use the cached directory


### PR DESCRIPTION
Use the official Aqua security Trivy action, with vulnerability DB caching (GH caches expire with time/size limits).