### PR TITLE
replace map[string]bool with map[string]struct{}

### DIFF
--- a/cmd/pd-sidecar/main.go
+++ b/cmd/pd-sidecar/main.go
@@ -39,11 +39,11 @@ const (
 )
 
 var (
-	// supportedConnectors defines all valid P/D connector types
-	supportedConnectors = []string{
-		proxy.ConnectorNIXLV2,
-		proxy.ConnectorSharedStorage,
-		proxy.ConnectorSGLang,
+	// supportedConnectors defines all valid P/D KV connector types
+	supportedKVConnectors = map[string]struct{}{
+		proxy.ConnectorNIXLV2:        {},
+		proxy.ConnectorSharedStorage: {},
+		proxy.ConnectorSGLang:        {},
 	}
 
 	// supportedTLSStages defines all valid stages for TLS configuration
@@ -55,9 +55,19 @@ var (
 
 // supportedTLSStagesNames returns a slice of supported TLS stage names
 func supportedTLSStagesNames() []string {
-	names := make([]string, 0, len(supportedTLSStages))
-	for stage := range supportedTLSStages {
-		names = append(names, stage)
+	return supportedNames(supportedTLSStages)
+}
+
+// supportedKVConnectorsNames returns a slice of supported KV connector names
+func supportedKVConnectorsNames() []string {
+	return supportedNames(supportedKVConnectors)
+}
+
+// supportedNames returns a slice of supported names from the given map[string]struct{}
+func supportedNames(aMap map[string]struct{}) []string {
+	names := make([]string, 0, len(aMap))
+	for name := range aMap {
+		names = append(names, name)
 	}
 	return names
 }
@@ -76,7 +86,7 @@ func main() {
 	port := pflag.String("port", "8000", "the port the sidecar is listening on")
 	vLLMPort := pflag.String("vllm-port", "8001", "the port vLLM is listening on")
 	vLLMDataParallelSize := pflag.Int("data-parallel-size", 1, "the vLLM DATA-PARALLEL-SIZE value")
-	connector := pflag.String("connector", proxy.ConnectorNIXLV2, "the P/D connector being used. Supported: "+strings.Join(supportedConnectors, ", "))
+	connector := pflag.String("connector", proxy.ConnectorNIXLV2, "the P/D connector being used. Supported: "+strings.Join(supportedKVConnectorsNames(), ", "))
 	enableTLS := pflag.StringSlice("enable-tls", []string{}, "stages to enable TLS for. Supported: "+strings.Join(supportedTLSStagesNames(), ", ")+". Can be specified multiple times or as comma-separated values.")
 	tlsInsecureSkipVerify := pflag.StringSlice("tls-insecure-skip-verify", []string{}, "stages to skip TLS verification for. Supported: "+strings.Join(supportedTLSStagesNames(), ", ")+". Can be specified multiple times or as comma-separated values.")
 
@@ -152,18 +162,11 @@ func main() {
 	logger.Info("Proxy starting", "Built on", version.BuildRef, "From Git SHA", version.CommitSHA)
 
 	// Validate connector
-	isValidConnector := false
-	for _, validConnector := range supportedConnectors {
-		if *connector == validConnector {
-			isValidConnector = true
-			break
-		}
-	}
-	if !isValidConnector {
-		logger.Info("Error: --connector must be one of: " + strings.Join(supportedConnectors, ", "))
+	if _, ok := supportedKVConnectors[*connector]; !ok {
+		logger.Info("Error: --connector must be one of: " + strings.Join(supportedKVConnectorsNames(), ", "))
 		return
 	}
-	logger.Info("p/d connector validated", "connector", connector)
+	logger.Info("p/d KV connector validated", "connector", connector)
 
 	// Validate TLS stages
 	for _, stage := range *enableTLS {


### PR DESCRIPTION
Replaced the list of supported connectors with a map to achieve $O(1)$ lookup time.

This change is based on the [comment](https://github.com/llm-d/llm-d-inference-scheduler/pull/643#discussion_r2902050488) 
