### PR TITLE
Update Trivy scan to run newer version with explicit auth tokens

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -17,10 +17,15 @@ runs:
           ${{ runner.os }}-trivy-
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.29.0
+      uses: aquasecurity/trivy-action@0.35.0
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        TRIVY_USERNAME: ${{ github.actor }}
+        TRIVY_PASSWORD: ${{ inputs.github-token }}      
       with:
         image-ref: ${{ inputs.image }}
         format: 'table'
         severity: 'HIGH,CRITICAL'
         exit-code: '1'
         cache-dir: .trivy  # Explicitly tell Trivy to use the cached directory
+        debug: true

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -55,8 +55,10 @@ jobs:
         uses: ./.github/actions/trivy-scan
         with:
           image: ghcr.io/llm-d/${{ inputs.epp-image-name }}:${{ inputs.tag }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Run Trivy scan on sidecar image
         uses: ./.github/actions/trivy-scan
         with:
           image: ghcr.io/llm-d/${{ inputs.sidecar-image-name }}:${{ inputs.tag }}
+          github-token: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
Container builds are [failing](https://github.com/llm-d/llm-d-inference-scheduler/actions/runs/22897737313/job/66436075858), likley due to trivy scan failing to initialize: 
```console
Run echo "installing Trivy binary"
installing Trivy binary
aquasecurity/trivy info checking GitHub for tag 'v0.57.1'
aquasecurity/trivy info found version: 0.57.1 for v0.57.1/Linux/64bit
Error: Process completed with exit code 1.
```

- update to a newer trivy action
- explictly pass GHCR token to avoid rate limits on container registry
- enable debug (should be removed once we fix/understand the failure)