### PR TITLE
Optimize TTFT: send first token immediately after prefill for streaming

### DIFF
--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -86,12 +86,8 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	maxCompletionTokensValue, maxCompletionTokensOk := completionRequest[requestFieldMaxCompletionTokens]
 
 	// Determine if client wants streaming
-	clientWantsStreaming := false
-	if streamOk {
-		if streamBool, ok := streamValue.(bool); ok {
-			clientWantsStreaming = streamBool
-		}
-	}
+	streamBool, streamBoolOk := streamValue.(bool)
+	clientWantsStreaming := streamOk && streamBoolOk && streamBool
 
 	completionRequest[requestFieldKVTransferParams] = map[string]any{
 		requestFieldDoRemoteDecode:  true,
@@ -182,7 +178,7 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 
 	// 4. Send first token to client if streaming
 	var firstTokenSentTime time.Time
-	var decodeResponseWriter http.ResponseWriter = w
+	decodeResponseWriter := w
 	if clientWantsStreaming {
 		// Convert non-streaming response to SSE format and send first chunk
 		// Remove kv_transfer_params before sending to user
@@ -260,18 +256,26 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	}
 	delete(completionRequest, requestFieldMaxTokens)
 	if maxTokensOk {
-		// Decrement by 1 since prefill already generated 1 token
-		if val, ok := maxTokensValue.(float64); ok && val > 0 {
-			completionRequest[requestFieldMaxTokens] = val - 1
+		if clientWantsStreaming {
+			// Decrement by 1 since we already sent 1 token to streaming client
+			if val, ok := maxTokensValue.(float64); ok && val > 0 {
+				completionRequest[requestFieldMaxTokens] = val - 1
+			} else {
+				completionRequest[requestFieldMaxTokens] = maxTokensValue
+			}
 		} else {
 			completionRequest[requestFieldMaxTokens] = maxTokensValue
 		}
 	}
 	delete(completionRequest, requestFieldMaxCompletionTokens)
 	if maxCompletionTokensOk {
-		// Decrement by 1 since prefill already generated 1 token
-		if val, ok := maxCompletionTokensValue.(float64); ok && val > 0 {
-			completionRequest[requestFieldMaxCompletionTokens] = val - 1
+		if clientWantsStreaming {
+			// Decrement by 1 since we already sent 1 token to streaming client
+			if val, ok := maxCompletionTokensValue.(float64); ok && val > 0 {
+				completionRequest[requestFieldMaxCompletionTokens] = val - 1
+			} else {
+				completionRequest[requestFieldMaxCompletionTokens] = maxCompletionTokensValue
+			}
 		} else {
 			completionRequest[requestFieldMaxCompletionTokens] = maxCompletionTokensValue
 		}

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -177,51 +177,63 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	s.logger.V(5).Info("received prefiller response", requestFieldKVTransferParams, pKVTransferParams)
 
 	// 4. Send first token to client if streaming
-	var firstTokenSentTime time.Time
-	decodeResponseWriter := w
+	// Channel to signal when first token has been sent and receive the timestamp
+	// Also carries any error that occurred and whether headers were sent
+	type firstTokenResult struct {
+		sentTime    time.Time
+		err         error
+		headersSent bool
+	}
+	firstTokenSent := make(chan firstTokenResult, 1)
+
 	if clientWantsStreaming {
-		// Convert non-streaming response to SSE format and send first chunk
-		// Remove kv_transfer_params before sending to user
+		// Remove kv_transfer_params before sending to user (do this before goroutine to avoid race)
 		delete(prefillerResponse, requestFieldKVTransferParams)
 
-		streamChunk, err := json.Marshal(prefillerResponse)
-		if err != nil {
-			if err := errorJSONInvalid(err, w); err != nil {
+		// Send first token in goroutine to allow parallel execution with decode prep
+		go func() {
+			streamChunk, err := json.Marshal(prefillerResponse)
+			if err != nil {
 				s.logger.Error(err, "failed to marshal streaming chunk")
+				firstTokenSent <- firstTokenResult{err: err, headersSent: false}
+				return
 			}
-			return
-		}
 
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.WriteHeader(http.StatusOK)
 
-		_, err = w.Write([]byte("data: "))
-		if err != nil {
-			s.logger.Error(err, "failed to write SSE prefix")
-			return
-		}
-		_, err = w.Write(streamChunk)
-		if err != nil {
-			s.logger.Error(err, "failed to write prefill chunk to client")
-			return
-		}
-		_, err = w.Write([]byte("\n\n"))
-		if err != nil {
-			s.logger.Error(err, "failed to write SSE suffix")
-			return
-		}
+			_, err = w.Write([]byte("data: "))
+			if err != nil {
+				s.logger.Error(err, "failed to write SSE prefix")
+				firstTokenSent <- firstTokenResult{err: err, headersSent: true}
+				return
+			}
+			_, err = w.Write(streamChunk)
+			if err != nil {
+				s.logger.Error(err, "failed to write prefill chunk to client")
+				firstTokenSent <- firstTokenResult{err: err, headersSent: true}
+				return
+			}
+			_, err = w.Write([]byte("\n\n"))
+			if err != nil {
+				s.logger.Error(err, "failed to write SSE suffix")
+				firstTokenSent <- firstTokenResult{err: err, headersSent: true}
+				return
+			}
 
-		if flusher, ok := w.(http.Flusher); ok {
-			flusher.Flush()
-		}
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
 
-		firstTokenSentTime = time.Now()
-		s.logger.V(4).Info("sent first token to client immediately after prefill")
-
-		// Wrap writer to prevent decode from re-writing headers
-		decodeResponseWriter = &headersSentWriter{ResponseWriter: w}
+			sentTime := time.Now()
+			s.logger.V(4).Info("sent first token to client immediately after prefill")
+			firstTokenSent <- firstTokenResult{sentTime: sentTime, headersSent: true}
+		}()
+	} else {
+		// For non-streaming, signal immediately that we don't need to wait
+		firstTokenSent <- firstTokenResult{}
 	}
 
 	// Decode Stage
@@ -284,6 +296,14 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 
 	dbody, err := json.Marshal(completionRequest)
 	if err != nil {
+		// Wait for goroutine to complete before returning
+		result := <-firstTokenSent
+		if result.headersSent {
+			// Headers already sent, can't send error response
+			s.logger.Error(err, "failed to marshal decode request, but response already started")
+			return
+		}
+		// Safe to send error response - headers not sent yet
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client")
 		}
@@ -293,6 +313,29 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	dreq.ContentLength = int64(len(dbody))
 
 	// 6. Forward to local decoder.
+	// Wait for first token to be sent before forwarding to decoder
+	result := <-firstTokenSent
+	if result.err != nil {
+		// First token send failed
+		if result.headersSent {
+			// Partial response already sent to client, can't recover
+			s.logger.Error(result.err, "failed to send first token after headers sent, aborting request")
+		} else {
+			// Headers not sent yet, try to send error response
+			s.logger.Error(result.err, "failed to send first token before headers sent")
+			if err := errorJSONInvalid(result.err, w); err != nil {
+				s.logger.Error(err, "failed to send error response to client")
+			}
+		}
+		return
+	}
+	firstTokenSentTime := result.sentTime
+
+	// Use wrapper to prevent duplicate WriteHeader for streaming
+	decodeResponseWriter := w
+	if clientWantsStreaming {
+		decodeResponseWriter = &headersSentWriter{ResponseWriter: w}
+	}
 
 	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
 	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeResponseWriter, dreq)

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -85,6 +85,14 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	maxTokensValue, maxTokensOk := completionRequest[requestFieldMaxTokens]
 	maxCompletionTokensValue, maxCompletionTokensOk := completionRequest[requestFieldMaxCompletionTokens]
 
+	// Determine if client wants streaming
+	clientWantsStreaming := false
+	if streamOk {
+		if streamBool, ok := streamValue.(bool); ok {
+			clientWantsStreaming = streamBool
+		}
+	}
+
 	completionRequest[requestFieldKVTransferParams] = map[string]any{
 		requestFieldDoRemoteDecode:  true,
 		requestFieldDoRemotePrefill: false,
@@ -172,6 +180,54 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 
 	s.logger.V(5).Info("received prefiller response", requestFieldKVTransferParams, pKVTransferParams)
 
+	// 4. Send first token to client if streaming
+	var firstTokenSentTime time.Time
+	var decodeResponseWriter http.ResponseWriter = w
+	if clientWantsStreaming {
+		// Convert non-streaming response to SSE format and send first chunk
+		// Remove kv_transfer_params before sending to user
+		delete(prefillerResponse, requestFieldKVTransferParams)
+
+		streamChunk, err := json.Marshal(prefillerResponse)
+		if err != nil {
+			if err := errorJSONInvalid(err, w); err != nil {
+				s.logger.Error(err, "failed to marshal streaming chunk")
+			}
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+
+		_, err = w.Write([]byte("data: "))
+		if err != nil {
+			s.logger.Error(err, "failed to write SSE prefix")
+			return
+		}
+		_, err = w.Write(streamChunk)
+		if err != nil {
+			s.logger.Error(err, "failed to write prefill chunk to client")
+			return
+		}
+		_, err = w.Write([]byte("\n\n"))
+		if err != nil {
+			s.logger.Error(err, "failed to write SSE suffix")
+			return
+		}
+
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+
+		firstTokenSentTime = time.Now()
+		s.logger.V(4).Info("sent first token to client immediately after prefill")
+
+		// Wrap writer to prevent decode from re-writing headers
+		decodeResponseWriter = &headersSentWriter{ResponseWriter: w}
+	}
+
 	// Decode Stage
 
 	ctx, decodeSpan := tracer.Start(ctx, "llm_d.pd_proxy.decode",
@@ -185,7 +241,7 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	)
 	decodeStart := time.Now()
 
-	// 1. Prepare decode request
+	// 5. Prepare decode request
 	dreq := r.Clone(ctx)
 
 	dreq.Header.Add(requestHeaderRequestID, uuidStr)
@@ -204,11 +260,21 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	}
 	delete(completionRequest, requestFieldMaxTokens)
 	if maxTokensOk {
-		completionRequest[requestFieldMaxTokens] = maxTokensValue
+		// Decrement by 1 since prefill already generated 1 token
+		if val, ok := maxTokensValue.(float64); ok && val > 0 {
+			completionRequest[requestFieldMaxTokens] = val - 1
+		} else {
+			completionRequest[requestFieldMaxTokens] = maxTokensValue
+		}
 	}
 	delete(completionRequest, requestFieldMaxCompletionTokens)
 	if maxCompletionTokensOk {
-		completionRequest[requestFieldMaxCompletionTokens] = maxCompletionTokensValue
+		// Decrement by 1 since prefill already generated 1 token
+		if val, ok := maxCompletionTokensValue.(float64); ok && val > 0 {
+			completionRequest[requestFieldMaxCompletionTokens] = val - 1
+		} else {
+			completionRequest[requestFieldMaxCompletionTokens] = maxCompletionTokensValue
+		}
 	}
 	completionRequest[requestFieldKVTransferParams] = pKVTransferParams
 
@@ -222,32 +288,37 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	dreq.Body = io.NopCloser(strings.NewReader(string(dbody)))
 	dreq.ContentLength = int64(len(dbody))
 
-	// 2. Forward to local decoder.
+	// 6. Forward to local decoder.
 
 	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
-	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(w, dreq)
+	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeResponseWriter, dreq)
 	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
 
 	if !dataParallelUsed {
 		s.logger.V(4).Info("sending request to decoder", "to", s.decoderURL.Host)
 		decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.decoderURL.Host))
-		s.decoderProxy.ServeHTTP(w, dreq)
+		s.decoderProxy.ServeHTTP(decodeResponseWriter, dreq)
 	}
 
 	decodeDuration := time.Since(decodeStart)
 	decodeSpan.SetAttributes(attribute.Float64("llm_d.pd_proxy.decode.duration_ms", float64(decodeDuration.Milliseconds())))
 
 	// Calculate end-to-end P/D timing metrics.
-	// True TTFT captures time from gateway request start to decode start, including
-	// gateway routing, scheduling, prefill, and coordination overhead that
-	// per-instance vLLM metrics miss.
+	// True TTFT captures time from gateway request start to when the first token reaches the user.
+	// For streaming clients: measures until first token is sent (after prefill).
+	// For non-streaming clients: measures until decode starts (includes KV transfer).
 	if currentSpan := trace.SpanFromContext(ctx); currentSpan.SpanContext().IsValid() {
 		var totalDuration time.Duration
 		var trueTTFT time.Duration
 		if requestStartValue := ctx.Value(requestStartTimeKey); requestStartValue != nil {
 			if requestStart, ok := requestStartValue.(time.Time); ok {
 				totalDuration = time.Since(requestStart)
-				trueTTFT = decodeStart.Sub(requestStart)
+				// Use actual first token sent time for streaming, decode start for non-streaming
+				if !firstTokenSentTime.IsZero() {
+					trueTTFT = firstTokenSentTime.Sub(requestStart)
+				} else {
+					trueTTFT = decodeStart.Sub(requestStart)
+				}
 			}
 		}
 
@@ -261,4 +332,19 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 			attribute.Float64("llm_d.pd_proxy.coordinator_overhead_ms", float64(coordinatorOverhead.Milliseconds())),
 		)
 	}
+}
+
+// headersSentWriter wraps a ResponseWriter to prevent duplicate WriteHeader calls
+// Used when headers have already been sent for streaming first token
+type headersSentWriter struct {
+	http.ResponseWriter
+}
+
+func (w *headersSentWriter) WriteHeader(statusCode int) {
+	// No-op: headers already sent
+}
+
+func (w *headersSentWriter) Write(b []byte) (int, error) {
+	// Write directly without calling WriteHeader
+	return w.ResponseWriter.Write(b)
 }


### PR DESCRIPTION
 Reduces Time To First Token (TTFT) for streaming clients by sending the first token immediately after prefill completes, before KV cache transfer to decode.

  - Convert non-streaming prefill response to SSE and forward first token to streaming clients
  - Fix token budget: decrement max_tokens by 1 for decode stage
  - Fix TTFT metrics to measure when first token actually reaches user (streaming vs non-streaming)
  - Strip internal kv_transfer_params from user-facing responses
  - Add headersSentWriter to prevent duplicate WriteHeader errors