### PR TITLE
Remove extra trivy params

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -28,4 +28,3 @@ runs:
         severity: 'HIGH,CRITICAL'
         exit-code: '1'
         cache-dir: .trivy  # Explicitly tell Trivy to use the cached directory
-        debug: true

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -55,10 +55,8 @@ jobs:
         uses: ./.github/actions/trivy-scan
         with:
           image: ghcr.io/llm-d/${{ inputs.epp-image-name }}:${{ inputs.tag }}
-          github-token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Run Trivy scan on sidecar image
         uses: ./.github/actions/trivy-scan
         with:
           image: ghcr.io/llm-d/${{ inputs.sidecar-image-name }}:${{ inputs.tag }}
-          github-token: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
Action was passing GH token and debug flags which are no longer needed.
The Trivy action failure was (most likely) fixed by updating the action which also updated the `trivy-setup` step.