### PR TITLE
Trivy complains of user-password mismatch

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -20,8 +20,6 @@ runs:
       uses: aquasecurity/trivy-action@0.35.0
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        TRIVY_USERNAME: ${{ github.actor }}
-        TRIVY_PASSWORD: ${{ inputs.github-token }}      
       with:
         image-ref: ${{ inputs.image }}
         format: 'table'


### PR DESCRIPTION
#698 added TRIVY_USER and TRIVY_PASSWORD but no password is passed to action.

Example failure in this [action run](https://github.com/llm-d/llm-d-inference-scheduler/actions/runs/22913017287/job/66490477329):
```console
...
shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GITHUB_TOKEN: 
    TRIVY_USERNAME: elevran
    TRIVY_PASSWORD: 
    INPUT_INPUT: 
    INPUT_EXIT_CODE: 1
    ...
...
Running Trivy with options: trivy image ghcr.io/llm-d/llm-d-inference-scheduler-dev:main
2026-03-10T17:21:11Z	FATAL	Fatal error	flag error: unable to convert flags to options: the number of usernames and passwords must match
...
```
