### PR TITLE
Enable major version updates to gh actions

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to GitHub Container Registry
       run: echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,9 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "sigs.k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore major updates for all packages
+      # Ignore major updates for all Go packages
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]        
+        update-types: ["version-update:semver-major"]
     groups:
       go-dependencies:
         patterns:
@@ -46,8 +46,13 @@ updates:
       - "release-note-none"
     commit-message:
       prefix: "deps(actions)"
+    # No "ignore" block here: This allows major version updates
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
-  # 3. Docker base image updates (e.g., for Dockerfile FROM lines)
+  # 3. Docker base image updates
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Update the dependabot configuration to allow major semver updates to GH actions. Manually upgrade docker/setup-buildx-action to v4 until the update cycle runs.