### PR TITLE
Check for the absence of the 'made with Bob' comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,12 @@ lint: check-golangci-lint check-typos ## Run lint (use LINT_NEW_ONLY=true to onl
 		$(GOLANGCI_LINT) run; \
 	fi
 	$(TYPOS)
+	@if grep -rni --exclude-dir=.git --exclude-dir=bin --exclude-dir=vendor --exclude-dir=node_modules --binary-files=without-match "made with bob" . | grep -v "grep.*made with bob" ; then \
+		echo ""; \
+		echo "ERROR: Found prohibited Bob-related comments in the codebase!"; \
+		echo "Please remove these comments."; \
+		exit 1; \
+	fi
 
 .PHONY: test
 test: test-unit test-e2e ## Run all tests (unit and e2e)

--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/**
+/*
  * This file is adapted from Gateway API Inference Extension
  * Original source: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/cmd/epp/main.go
  * Licensed under the Apache License, Version 2.0


### PR DESCRIPTION
A popular internal IBM code generation tool called Bob typically appends a comment—"made with Bob"—to the final line of any file it creates or edits. 

This lint check ensures that this specific message is absent from the codebase.