### PR TITLE
Move typo checking from tools makefile to main, under lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ lint: check-golangci-lint check-typos ## Run lint (use LINT_NEW_ONLY=true to onl
 		printf "\033[33mChecking all code (LINT_NEW_ONLY=false, default)\033[0m\n"; \
 		$(GOLANGCI_LINT) run; \
 	fi
-	$(TYPOS)
+	@echo "Checking for spelling errors with typos..."
+	@$(TYPOS) --format brief
 
 .PHONY: test
 test: test-unit test-e2e ## Run all tests (unit and e2e)

--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -200,5 +200,3 @@ check-typos:
 	  echo "ERROR: typos is not installed."; \
 	  echo "Run: make install-typos (or install-tools)"; \
 	  exit 1; }
-	@echo "Checking for spelling errors with typos..."
-	@$(TYPOS) --format brief


### PR DESCRIPTION
Makefile for tools should only check for availability of tools and install them if missing.
Moved the actual typo check under `lint` in main Makefile (it was already calling `check-typos` - the previous makefile location - as a dependency)