### PR TITLE
Deprecate the workaround used to support vLLM Data Parallel on Istio 1.28

### DIFF
--- a/deploy/config/dp-epp-config.yaml
+++ b/deploy/config/dp-epp-config.yaml
@@ -3,13 +3,7 @@
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: precise-prefix-cache-scorer
-  parameters:
-    indexerConfig:
-      tokenProcessorConfig:
-        blockSize: 5
-      kvBlockIndexConfig:
-        maxPrefixBlocksToMatch: 256
+- type: prefix-cache-scorer
 - type: decode-filter
 - type: max-score-picker
 - type: data-parallel-profile-handler
@@ -20,5 +14,5 @@ schedulingProfiles:
   plugins:
   - pluginRef: decode-filter
   - pluginRef: max-score-picker
-  - pluginRef: precise-prefix-cache-scorer
+  - pluginRef: prefix-cache-scorer
     weight: 2

--- a/deploy/config/pd-epp-config.yaml
+++ b/deploy/config/pd-epp-config.yaml
@@ -18,7 +18,6 @@ plugins:
     nonCachedTokens: 16
 - type: pd-profile-handler
   parameters:
-    primaryPort: ${PRIMARY_PORT}
     deciderPluginName: prefix-based-pd-decider
 schedulingProfiles:
 - name: prefill

--- a/deploy/config/sim-pd-epp-config.yaml
+++ b/deploy/config/sim-pd-epp-config.yaml
@@ -21,7 +21,6 @@ plugins:
     nonCachedTokens: 16
 - type: pd-profile-handler
   parameters:
-    primaryPort: ${PRIMARY_PORT}
     deciderPluginName: prefix-based-pd-decider
 schedulingProfiles:
 - name: prefill

--- a/pkg/plugins/profile/dp_profile_handler.go
+++ b/pkg/plugins/profile/dp_profile_handler.go
@@ -29,7 +29,7 @@ var _ scheduling.ProfileHandler = &DataParallelProfileHandler{}
 
 // DataParallelProfileHandlerFactory defines the factory function for the DataParallelProfileHandler
 func DataParallelProfileHandlerFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
-	log.FromContext(handle.Context()).Info("Deprecated: Use simple-profile-handler with Istio 1.28.1")
+	log.FromContext(handle.Context()).Info("Deprecated: Use simple-profile-handler with Istio >= 1.28.1")
 	parameters := dataParallelProfileHandlerParameters{
 		PrimaryPort: 8000,
 	}

--- a/pkg/plugins/profile/dp_profile_handler.go
+++ b/pkg/plugins/profile/dp_profile_handler.go
@@ -28,7 +28,8 @@ type dataParallelProfileHandlerParameters struct {
 var _ scheduling.ProfileHandler = &DataParallelProfileHandler{}
 
 // DataParallelProfileHandlerFactory defines the factory function for the DataParallelProfileHandler
-func DataParallelProfileHandlerFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func DataParallelProfileHandlerFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+	log.FromContext(handle.Context()).Info("Deprecated: Use simple-profile-handler with Istio 1.28.1")
 	parameters := dataParallelProfileHandlerParameters{
 		PrimaryPort: 8000,
 	}

--- a/pkg/plugins/profile/dp_profile_handler_test.go
+++ b/pkg/plugins/profile/dp_profile_handler_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
 func TestDataParallelProfileHandlerFactory(t *testing.T) {
@@ -76,7 +78,8 @@ func TestDataParallelProfileHandlerFactory(t *testing.T) {
 			if tt.jsonParams != "" {
 				rawParams = json.RawMessage(tt.jsonParams)
 			}
-			plugin, err := DataParallelProfileHandlerFactory(tt.pluginName, rawParams, nil)
+			handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
+			plugin, err := DataParallelProfileHandlerFactory(tt.pluginName, rawParams, handle)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -112,7 +115,8 @@ func TestDataParallelProfileHandlerFactoryInvalidJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := DataParallelProfileHandlerFactory("test", rawParams, nil)
+			handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
+			plugin, err := DataParallelProfileHandlerFactory("test", rawParams, handle)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)

--- a/pkg/plugins/profile/pd_profile_handler.go
+++ b/pkg/plugins/profile/pd_profile_handler.go
@@ -76,7 +76,7 @@ func PdProfileHandlerFactory(name string, rawParameters json.RawMessage, handle 
 	}
 
 	if parameters.PrimaryPort != 0 {
-		log.FromContext(handle.Context()).Info("Deprecated: primaryPort not needed with Istio 1.28.1")
+		log.FromContext(handle.Context()).Info("Deprecated: primaryPort not needed with Istio >= 1.28.1")
 		if parameters.PrimaryPort < 1 || parameters.PrimaryPort > 65535 {
 			return nil, fmt.Errorf("invalid primaryPort: must be between 1 and 65535, got %d", parameters.PrimaryPort)
 		}

--- a/pkg/plugins/profile/pd_profile_handler.go
+++ b/pkg/plugins/profile/pd_profile_handler.go
@@ -76,6 +76,7 @@ func PdProfileHandlerFactory(name string, rawParameters json.RawMessage, handle 
 	}
 
 	if parameters.PrimaryPort != 0 {
+		log.FromContext(handle.Context()).Info("Deprecated: primaryPort not needed with Istio 1.28.1")
 		if parameters.PrimaryPort < 1 || parameters.PrimaryPort > 65535 {
 			return nil, fmt.Errorf("invalid primaryPort: must be between 1 and 65535, got %d", parameters.PrimaryPort)
 		}

--- a/pkg/sidecar/proxy/data_parallel.go
+++ b/pkg/sidecar/proxy/data_parallel.go
@@ -18,6 +18,7 @@ import (
 func (s *Server) dataParallelHandler(w http.ResponseWriter, r *http.Request) bool {
 	dataParallelPodHostPort := r.Header.Get(common.DataParallelEndpointHeader)
 	if dataParallelPodHostPort != "" {
+		s.logger.Info("The use of the x-data-parallel-host-port is deprecated. Use Istio 1.28.1.")
 		handler := s.dataParallelProxies[dataParallelPodHostPort]
 		if handler != nil {
 			s.logger.V(4).Info("Data parallel routing", "to", dataParallelPodHostPort)

--- a/pkg/sidecar/proxy/data_parallel.go
+++ b/pkg/sidecar/proxy/data_parallel.go
@@ -18,7 +18,7 @@ import (
 func (s *Server) dataParallelHandler(w http.ResponseWriter, r *http.Request) bool {
 	dataParallelPodHostPort := r.Header.Get(common.DataParallelEndpointHeader)
 	if dataParallelPodHostPort != "" {
-		s.logger.Info("The use of the x-data-parallel-host-port is deprecated. Use Istio 1.28.1.")
+		s.logger.Info("The use of the x-data-parallel-host-port is deprecated. Use Istio >= 1.28.1.")
 		handler := s.dataParallelProxies[dataParallelPodHostPort]
 		if handler != nil {
 			s.logger.V(4).Info("Data parallel routing", "to", dataParallelPodHostPort)

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -93,14 +93,6 @@ if [ "${KV_CACHE_ENABLED}" == "true" ]; then
   fi
 fi
 
-# Set PRIMARY_PORT based on PD mode with data parallelism
-if [ "${PD_ENABLED}" == "\"true\"" ] && [ ${VLLM_DATA_PARALLEL_SIZE} -ne 1 ]; then
-  PRIMARY_PORT="8000"
-else
-  PRIMARY_PORT="0"
-fi
-export PRIMARY_PORT
-
 # Determine EPP config file based on feature flags
 if [ "${EXTERNAL_TOKENIZER_ENABLED}" == "true" ]; then
   # External tokenizer mode (uses precise-prefix-cache with UDS tokenizer sidecar)
@@ -111,10 +103,6 @@ elif [ "${KV_CACHE_ENABLED}" == "true" ]; then
 elif [ "${PD_ENABLED}" == "\"true\"" ]; then
   # Prefill-Decode mode
   DEFAULT_EPP_CONFIG="deploy/config/sim-pd-epp-config.yaml"
-elif [ ${VLLM_DATA_PARALLEL_SIZE} -ne 1 ]; then
-  # Data Parallel mode (only needed for Istio pre-1.28.1)
-  # Not really called in kind(docker.io/istio/pilot:1.28.1) by "make env-dev-kind"
-  DEFAULT_EPP_CONFIG="deploy/config/dp-epp-config.yaml"
 else
   # Simple mode
   DEFAULT_EPP_CONFIG="deploy/config/sim-epp-config.yaml"
@@ -263,7 +251,7 @@ TEMP_FILE=$(mktemp)
 trap "rm -f \"${TEMP_FILE}\"" EXIT
 
 kubectl --context ${KUBE_CONTEXT} delete configmap epp-config --ignore-not-found
-envsubst '$PRIMARY_PORT $MODEL_NAME' < ${EPP_CONFIG} > ${TEMP_FILE}
+envsubst '$MODEL_NAME' < ${EPP_CONFIG} > ${TEMP_FILE}
 kubectl --context ${KUBE_CONTEXT} create configmap epp-config --from-file=epp-config.yaml=${TEMP_FILE}
 
 kubectl kustomize --enable-helm  ${KUSTOMIZE_DIR} \


### PR DESCRIPTION
Istio 1.28 did not properly support Inference Gateway Extension InferencePool CRs with multiple targetPorts specified.

A work around was added to the llm-d-inference-scheduler and the llm-d-routing-sidecar.

With Istio 1.28.1 GA for some time, this work around is no longer needed. This PR marks the use of the various parts of that workaround as being deprecated and will be removed in a future release of the llm-d-inference-scheduler.

The deprecated items include:
  - The data-parallel-profile-handler. Replaced by the standard simple-profile-handler
  - The use of the targetPort parameter of the pd-profile-handler
  - The use of x-data-parallel-host-port header with the llm-d-routing-sidecar
 
 In addition support for these items has been removed from the env-dev-kind make target and its shell script.