### PR TITLE
test: add disruption e2e tests for scheduler failure scenarios

### DIFF
--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -102,7 +102,6 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			targetPod := decodePods[0]
-			survivingPod := decodePods[1]
 
 			ginkgo.By("Force-deleting decode pod " + targetPod)
 			deletePodByName(targetPod, 0)
@@ -110,11 +109,11 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			ginkgo.By("Waiting for killed pod to be replaced")
 			gomega.Eventually(podGone(targetPod, 1), podRemovalTimeout, 1*time.Second).Should(gomega.BeTrue())
 
-			ginkgo.By("Verifying new requests route to the surviving pod")
+			ginkgo.By("Verifying new requests route to a pod other than the killed one")
 			for range 5 {
 				nsHdr, podHdr, _ := runCompletion(simplePrompt, simModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
-				gomega.Expect(podHdr).Should(gomega.Equal(survivingPod))
+				gomega.Expect(podHdr).ShouldNot(gomega.Equal(targetPod))
 			}
 
 			ginkgo.By("Waiting for replacement pod to become ready")
@@ -160,15 +159,13 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			ginkgo.By(fmt.Sprintf("Force-deleting decode pod %s during the stream", targetPod))
 			deletePodByName(targetPod, 0)
 
-			select {
-			case err := <-errCh:
-				if err != nil {
-					ginkgo.By(fmt.Sprintf("Stream terminated with error: %v", err))
-				} else {
-					ginkgo.By("Stream completed before pod was killed")
-				}
-			case <-time.After(disruptionClient.Timeout + 5*time.Second):
-				ginkgo.Fail("streaming request hung after pod kill")
+			err := <-errCh
+			if err != nil {
+				ginkgo.By(fmt.Sprintf("Stream terminated with error: %v", err))
+				gomega.Expect(err).ShouldNot(gomega.MatchError(context.DeadlineExceeded),
+					"stream should fail fast on pod kill, not hang until client timeout")
+			} else {
+				ginkgo.By("Stream completed before pod was killed")
 			}
 
 			ginkgo.By("Waiting for replacement pod")
@@ -223,15 +220,11 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			ginkgo.By("Scaling deployment back up")
 			scaleDeployment(modelServers, 1)
 
-			ginkgo.By("Waiting for pod to become ready")
-			gomega.Eventually(func() int {
-				_, currentDecode := getModelServerPods(podSelector, prefillSelector, decodeSelector)
-				return len(currentDecode)
-			}, readyTimeout, 2*time.Second).Should(gomega.Equal(1))
-
 			ginkgo.By("Verifying requests succeed after recovery")
-			nsHdr, _, _ = runCompletion(simplePrompt, simModelName)
-			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
+			gomega.Eventually(func() string {
+				nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+				return nsHdr
+			}, eppRecoveryTimeout, 2*time.Second).Should(gomega.Equal(nsName))
 		})
 	})
 
@@ -321,12 +314,6 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Scaling back to 1")
 			scaleDeployment(modelServers, 1)
-
-			ginkgo.By("Waiting for pod to become ready")
-			gomega.Eventually(func() int {
-				_, currentDecode := getModelServerPods(podSelector, prefillSelector, decodeSelector)
-				return len(currentDecode)
-			}, readyTimeout, 2*time.Second).Should(gomega.Equal(1))
 
 			ginkgo.By("Waiting for traffic to observe recovery")
 			successBaseline := tc.successes()


### PR DESCRIPTION
Initial disruption test suite for the scheduler. Covers the most basic failure scenarios pod kills, pool exhaustion, EPP restart, and scale tozero under load. This is a starting point; more scenarios can be added incrementally.

Fixes: #725

## Summary

* Decode pod kill: force-delete mid-request, verify reroute to survivor and recovery
* Decode pod kill mid-stream: synchronize on response headers, kill the routed pod, assert no hang and routing recovery
* Pool exhaustion (503): scale to zero, poll until EPP returns 503, verify recovery
* EPP restart: kill EPP pod, verify requests fail during gap, verify recovery
* Scale-to-zero under load: background traffic loop during scale-down/up, verify failures then recovery