### PR TITLE
feat: add optional Prometheus monitoring to Kind dev environment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,6 +100,32 @@ KIND_GATEWAY_HOST_PORT=<selected-port> make env-dev-kind
 **Where:** &lt;selected-port&gt; is the port on your local machine you want to use to
 access the inference gatyeway.
 
+### Prometheus Monitoring
+
+To deploy Prometheus alongside the dev environment:
+
+```bash
+PROM_ENABLED=true make env-dev-kind
+```
+
+Prometheus will be accessible at `http://localhost:30090`. To use a different host port:
+
+```bash
+PROM_ENABLED=true KIND_PROM_HOST_PORT=30091 make env-dev-kind
+```
+
+> [!NOTE]
+> Port mappings are baked into the Kind cluster at creation time. If you change
+> `PROM_ENABLED` or `KIND_PROM_HOST_PORT`, you must recreate the cluster:
+> `make clean-env-dev-kind` first.
+
+### Grafana Dashboard
+
+The upstream [Inference Gateway dashboard](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/tools/dashboards/inference_gateway.json) covers EPP, inference pool, and vLLM metrics.
+
+To use it: add a Prometheus datasource pointed at `http://localhost:30090`, then import
+the JSON via **Dashboards > New > Import**. See the [Grafana installation docs](https://grafana.com/docs/grafana/latest/setup-grafana/installation/) for setup.
+
 > [!NOTE]
 > If you require significant customization of this environment beyond
 > what the standard deployment provides, you can use the `deploy/components`
@@ -157,6 +183,13 @@ The setup can be split in two:
 
 This enables cluster sharing by multiple developers. In case of private/personal
 clusters, the `default` namespace can be used directly.
+
+### RBAC and Permissions
+
+EPP is namespace-scoped. Its `Role` grants `get/watch/list` on `inferencepools`
+and `pods`, plus `create` on `tokenreviews`/`subjectaccessreviews` for metrics
+auth (`--metrics-endpoint-auth=true`, the default). To disable metrics auth and
+avoid the cluster-scoped RBAC requirement, use `--metrics-endpoint-auth=false`.
 
 ### Setup - Infrastructure
 

--- a/deploy/components/inference-gateway/services.yaml
+++ b/deploy/components/inference-gateway/services.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ${EPP_NAME}
+  labels:
+    app: ${EPP_NAME}
 spec:
   selector:
     app: ${EPP_NAME}
@@ -16,4 +18,8 @@ spec:
     port: 5557
     targetPort: 5557
     appProtocol: tcp
+  - name: metrics
+    protocol: TCP
+    port: 9090
+    targetPort: 9090
   type: ClusterIP

--- a/deploy/components/monitoring/epp-service-monitor.yaml
+++ b/deploy/components/monitoring/epp-service-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: epp-metrics
+  labels:
+    app: epp-metrics
+spec:
+  selector:
+    matchLabels:
+      app: ${EPP_NAME}
+  endpoints:
+  - port: metrics
+    interval: 15s
+    path: /metrics

--- a/deploy/components/monitoring/kustomization.yaml
+++ b/deploy/components/monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- epp-service-monitor.yaml
+- vllm-sim-pod-monitor.yaml

--- a/deploy/components/monitoring/vllm-sim-pod-monitor.yaml
+++ b/deploy/components/monitoring/vllm-sim-pod-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: vllm-sim-metrics
+  labels:
+    app: vllm-sim-metrics
+spec:
+  selector:
+    matchLabels:
+      app: ${POOL_NAME}
+  podMetricsEndpoints:
+  - port: sidecar-http
+    interval: 15s
+    path: /metrics

--- a/deploy/environments/dev/base-kind-istio/patch-deployments.yaml
+++ b/deploy/environments/dev/base-kind-istio/patch-deployments.yaml
@@ -22,3 +22,4 @@ spec:
         - "9003"
         - --config-file
         - "/etc/epp/epp-config.yaml"
+        - --metrics-endpoint-auth=false

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -71,6 +71,13 @@ export VLLM_REPLICA_COUNT="${VLLM_REPLICA_COUNT:-1}"
 # By default we are not setting up for PD
 export PD_ENABLED="\"${PD_ENABLED:-false}\""
 
+# By default we are not deploying Prometheus monitoring
+export PROM_ENABLED="${PROM_ENABLED:-false}"
+
+# Set the host port to map to the Prometheus NodePort (30090)
+: "${PROM_HOST_PORT:=30090}"
+
+
 # By default we are not setting up for KV cache
 export KV_CACHE_ENABLED="${KV_CACHE_ENABLED:-false}"
 
@@ -136,6 +143,19 @@ for cmd in kind kubectl ${CONTAINER_RUNTIME}; do
     fi
 done
 
+# Prometheus config-reloader needs sufficient inotify resources
+if [ "${PROM_ENABLED}" == "true" ]; then
+  INOTIFY_INSTANCES=$(cat /proc/sys/fs/inotify/max_user_instances)
+  if [ "${INOTIFY_INSTANCES}" -lt 512 ]; then
+    echo "Error: fs.inotify.max_user_instances is ${INOTIFY_INSTANCES} (need >= 512) for Prometheus."
+    echo ""
+    echo "  sudo sysctl -w fs.inotify.max_user_instances=512"
+    echo ""
+    echo "To persist: echo 'fs.inotify.max_user_instances=512' | sudo tee /etc/sysctl.d/99-inotify.conf"
+    exit 1
+  fi
+fi
+
 TARGET_PORTS="8000"
 
 NEW_LINE=$'\n'
@@ -154,6 +174,13 @@ export TARGET_PORTS
 if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
     echo "Cluster '${CLUSTER_NAME}' already exists, re-using"
 else
+    EXTRA_PORT_MAPPINGS=""
+    if [ "${PROM_ENABLED}" == "true" ]; then
+      EXTRA_PORT_MAPPINGS="  - containerPort: 30090
+    hostPort: ${PROM_HOST_PORT}
+    protocol: TCP"
+    fi
+
     kind create cluster --name "${CLUSTER_NAME}" --config - << EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -163,6 +190,7 @@ nodes:
   - containerPort: 30080
     hostPort: ${GATEWAY_HOST_PORT}
     protocol: TCP
+${EXTRA_PORT_MAPPINGS}
 EOF
 fi
 
@@ -273,6 +301,41 @@ kubectl --context ${KUBE_CONTEXT} -n default wait --for=condition=available --ti
 # Wait for the gateway to be ready
 kubectl --context ${KUBE_CONTEXT} wait gateway/inference-gateway --for=condition=Programmed --timeout=300s
 
+# ------------------------------------------------------------------------------
+# Prometheus Monitoring (optional)
+# ------------------------------------------------------------------------------
+
+if [ "${PROM_ENABLED}" == "true" ]; then
+  echo "Deploying Prometheus monitoring stack..."
+
+  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true
+  helm repo update prometheus-community
+
+  # Install kube-prometheus-stack (Prometheus only)
+  helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
+    --namespace monitoring --create-namespace \
+    --set grafana.enabled=false \
+    --set alertmanager.enabled=false \
+    --set kubeControllerManager.enabled=false \
+    --set kubeEtcd.enabled=false \
+    --set kubeProxy.enabled=false \
+    --set kubeScheduler.enabled=false \
+    --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+    --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
+    --set prometheus.prometheusSpec.resources.requests.memory=512Mi \
+    --set prometheus.prometheusSpec.resources.limits.memory=1Gi \
+    --set prometheus.service.type=NodePort \
+    --set prometheus.service.nodePort=30090 \
+    --kube-context ${KUBE_CONTEXT} \
+    --wait --timeout 300s
+
+  kubectl kustomize deploy/components/monitoring \
+    | envsubst '${EPP_NAME} ${POOL_NAME}' \
+    | kubectl --context ${KUBE_CONTEXT} apply -f -
+
+  echo "Prometheus monitoring deployed."
+fi
+
 cat <<EOF
 -----------------------------------------
 Deployment completed!
@@ -298,3 +361,13 @@ See DEVELOPMENT.md for additional access methods if the above fails.
 
 -----------------------------------------
 EOF
+
+if [ "${PROM_ENABLED}" == "true" ]; then
+cat <<EOF
+
+Monitoring:
+
+* Prometheus: http://localhost:${PROM_HOST_PORT}
+
+EOF
+fi


### PR DESCRIPTION
While onboarding to the Kind dev environment, I noticed there's no way to observe EPP or vLLM sim metrics without manually setting up monitoring. This adds `PROM_ENABLED=true` as an opt-in flag that deploys Prometheus into the Kind cluster.

* Add `PROM_ENABLED=true` to deploy kube-prometheus-stack (no Grafana, no alertmanager)
* Add metrics port (9090) to EPP Service + ServiceMonitor/PodMonitor for EPP and vLLM sim
* Disable metrics endpoint auth in dev (`--metrics-endpoint-auth=false`)
* Pre-flight check for inotify limits (required by prometheus-config-reloader on podman)
* Document Prometheus setup and upstream Grafana dashboard import in DEVELOPMENT.md

## Usage

```bash
PROM_ENABLED=true make env-dev-kind
# Prometheus at http://localhost:30090
```

Composable with existing flags: `PD_ENABLED=true PROM_ENABLED=true make env-dev-kind`

<img width="776" height="781" alt="image" src="https://github.com/user-attachments/assets/fe79bfdd-f0f6-4d44-b857-5dc0b9fa0a42" />
