### PR TITLE
feat: add pending-tokens-scorer for token-aware load balancing

### DIFF
--- a/pkg/plugins/register.go
+++ b/pkg/plugins/register.go
@@ -24,6 +24,7 @@ func RegisterAllPlugins() {
 	plugin.Register(scorer.SessionAffinityType, scorer.SessionAffinityFactory)
 	plugin.Register(scorer.ActiveRequestType, scorer.ActiveRequestFactory)
 	plugin.Register(scorer.NoHitLRUType, scorer.NoHitLRUFactory)
+	plugin.Register(scorer.PendingTokensType, scorer.PendingTokensFactory)
 	plugin.Register(models.ModelsDataSourceType, models.ModelDataSourceFactory)
 	plugin.Register(models.ModelsExtractorType, models.ModelServerExtractorFactory)
 	// pd decider plugins

--- a/pkg/plugins/scorer/pending_tokens.go
+++ b/pkg/plugins/scorer/pending_tokens.go
@@ -1,0 +1,280 @@
+package scorer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	// PendingTokensType is the type of the PendingTokens scorer.
+	PendingTokensType = "pending-tokens-scorer"
+)
+
+// PendingTokensParameters defines configuration for the PendingTokens scorer.
+type PendingTokensParameters struct {
+	// RequestTimeout defines the timeout for requests in seconds.
+	// once the request has been in-flight for this duration, it is considered to
+	// be timed out and dropped.
+	// This field accepts duration strings like "30s", "1m", "2h".
+	RequestTimeout string `json:"requestTimeout"`
+}
+
+// compile-time type assertion
+var _ scheduling.Scorer = &PendingTokens{}
+var _ requestcontrol.PreRequest = &PendingTokens{}
+var _ requestcontrol.ResponseComplete = &PendingTokens{}
+
+// PendingTokensFactory defines the factory function for the PendingTokens scorer.
+func PendingTokensFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+	parameters := PendingTokensParameters{}
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", PendingTokensType, err)
+		}
+	}
+
+	return NewPendingTokens(handle.Context(), &parameters).WithName(name), nil
+}
+
+// NewPendingTokens creates a new PendingTokens scorer.
+func NewPendingTokens(ctx context.Context, params *PendingTokensParameters) *PendingTokens {
+	requestTimeout := defaultRequestTimeout
+	logger := log.FromContext(ctx)
+
+	if params != nil && params.RequestTimeout != "" {
+		paramsRequestTimeout, err := time.ParseDuration(params.RequestTimeout)
+		if err != nil || paramsRequestTimeout <= 0 {
+			logger.Error(err, "Invalid request timeout duration, using default request timeout")
+		} else {
+			requestTimeout = paramsRequestTimeout
+			logger.Info("Using request timeout", "requestTimeout", requestTimeout)
+		}
+	}
+
+	// cache for individual requests with their own TTL
+	requestCache := ttlcache.New[string, *requestEntry](
+		ttlcache.WithTTL[string, *requestEntry](requestTimeout),
+		ttlcache.WithDisableTouchOnHit[string, *requestEntry](),
+	)
+
+	scorer := &PendingTokens{
+		typedName:      plugin.TypedName{Type: PendingTokensType},
+		requestCache:   requestCache,
+		endpointTokens: make(map[string]int),
+		requestTokens:  make(map[string]int),
+		mutex:          &sync.RWMutex{},
+	}
+	// callback to decrement count when requests expire
+	// most requests will be removed in ResponseComplete, but this ensures
+	// that we don't leak endpoint counts if ResponseComplete is not called
+	requestCache.OnEviction(func(_ context.Context, reason ttlcache.EvictionReason,
+		item *ttlcache.Item[string, *requestEntry]) {
+		if reason == ttlcache.EvictionReasonExpired {
+			entry := item.Value()
+
+			scorer.mutex.RLock()
+			tokenCount := scorer.requestTokens[entry.RequestID]
+			scorer.mutex.RUnlock()
+
+			for _, endpointName := range entry.PodNames {
+				scorer.decrementPodTokens(endpointName, tokenCount)
+			}
+
+			scorer.mutex.Lock()
+			delete(scorer.requestTokens, entry.RequestID)
+			scorer.mutex.Unlock()
+		}
+	})
+
+	go cleanCachePeriodically(ctx, requestCache, requestTimeout)
+
+	return scorer
+}
+
+// PendingTokens keeps track of pending input tokens per endpoint
+// to enable token-aware load balancing.
+type PendingTokens struct {
+	typedName plugin.TypedName
+
+	// requestCache stores individual request entries keyed by requestID
+	requestCache *ttlcache.Cache[string, *requestEntry]
+
+	// endpointTokens maintains fast lookup for request tokens per endpoint
+	endpointTokens map[string]int
+	requestTokens  map[string]int // requestID -> token count
+	mutex          *sync.RWMutex
+}
+
+// TypedName returns the typed name of the plugin.
+func (s *PendingTokens) TypedName() plugin.TypedName {
+	return s.typedName
+}
+
+// WithName sets the name of the plugin.
+func (s *PendingTokens) WithName(name string) *PendingTokens {
+	s.typedName.Name = name
+	return s
+}
+
+// Category returns how this scorer influences endpoint selection.
+func (s *PendingTokens) Category() scheduling.ScorerCategory {
+	return scheduling.Distribution
+}
+
+// Score scores endpoints based on their pending input token load.
+// normalized to a range of 0-1. Endpoints with fewer pending tokens
+// receive higher scores.
+func (s *PendingTokens) Score(ctx context.Context, _ *scheduling.CycleState, _ *scheduling.LLMRequest,
+	endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
+
+	pendingTokensByEndpoint := make(map[string]int)
+	maxTokens := 0
+	s.mutex.RLock()
+	for endpointName, tokens := range s.endpointTokens {
+		pendingTokensByEndpoint[endpointName] = tokens
+		if tokens > maxTokens {
+			maxTokens = tokens
+		}
+	}
+	s.mutex.RUnlock()
+
+	log.FromContext(ctx).V(logutil.DEBUG).Info("Pending token counts", "pendingTokens", pendingTokensByEndpoint, "maxTokens", maxTokens)
+
+	scoredEndpointsMap := make(map[scheduling.Endpoint]float64, len(endpoints))
+	for _, endpoint := range endpoints {
+		endpointName := endpoint.GetMetadata().NamespacedName.String()
+		tokens, exists := pendingTokensByEndpoint[endpointName]
+		if !exists {
+			scoredEndpointsMap[endpoint] = 1.0
+			continue
+		}
+		if maxTokens == 0 {
+			scoredEndpointsMap[endpoint] = 1.0
+			continue
+		}
+		scoredEndpointsMap[endpoint] = 1.0 - (float64(tokens) / float64(maxTokens))
+	}
+
+	log.FromContext(ctx).V(logutil.DEBUG).Info("Scored endpoints", "scores", endpointScores(scoredEndpointsMap))
+	return scoredEndpointsMap
+}
+
+// PreRequest is called before a request is sent to the target endpoint.
+// It creates a new request entry in the cache with its own TTL and
+// increments the token count for all selected endpoints for fast lookup.
+func (s *PendingTokens) PreRequest(
+	ctx context.Context,
+	request *scheduling.LLMRequest,
+	schedulingResult *scheduling.SchedulingResult,
+) {
+	debugLogger := log.FromContext(ctx).V(logutil.DEBUG)
+	tokenCount := estimateTokenCount(request)
+
+	endpointNames := make([]string, 0, len(schedulingResult.ProfileResults))
+	for profileName, profileResult := range schedulingResult.ProfileResults {
+		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
+			continue
+		}
+
+		endpointName := profileResult.TargetEndpoints[0].GetMetadata().NamespacedName.String()
+		endpointNames = append(endpointNames, endpointName)
+		s.incrementPodTokens(endpointName, tokenCount)
+		debugLogger.Info(
+			"Added request to cache",
+			"requestId", request.RequestId,
+			"endpointName", endpointName,
+			"tokenCount", tokenCount,
+			"profileName", profileName,
+		)
+	}
+
+	s.mutex.Lock()
+	s.requestTokens[request.RequestId] = tokenCount
+	s.mutex.Unlock()
+
+	// add to request cache
+	s.requestCache.Set(request.RequestId, &requestEntry{PodNames: endpointNames, RequestID: request.RequestId}, 0) // Use default TTL
+}
+
+// ResponseComplete is called after a response is sent to the client.
+// It removes the request entry from the cache and decrements
+// the token counts for all associated endpoints.
+func (s *PendingTokens) ResponseComplete(
+	ctx context.Context,
+	request *scheduling.LLMRequest,
+	_ *requestcontrol.Response,
+	targetPod *datalayer.EndpointMetadata,
+) {
+	debugLogger := log.FromContext(ctx).V(logutil.DEBUG).WithName("PendingTokens.ResponseComplete")
+	if targetPod == nil {
+		debugLogger.Info("Skipping ResponseComplete because targetPod is nil")
+		return
+	}
+
+	if item, found := s.requestCache.GetAndDelete(request.RequestId); found {
+		entry := item.Value()
+		if entry != nil {
+			s.mutex.RLock()
+			tokenCount := s.requestTokens[request.RequestId]
+			s.mutex.RUnlock()
+
+			for _, endpointName := range entry.PodNames {
+				s.decrementPodTokens(endpointName, tokenCount)
+			}
+
+			s.mutex.Lock()
+			delete(s.requestTokens, request.RequestId)
+			s.mutex.Unlock()
+		}
+	} else {
+		debugLogger.Info("Request not found in cache", "requestId", request.RequestId)
+	}
+}
+
+// incrementPodTokens increments the number of tokens for an endpoint.
+func (s *PendingTokens) incrementPodTokens(endpointName string, count int) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.endpointTokens[endpointName] += count
+}
+
+// decrementPodTokens decrements the pending token count for an endpoint and removes
+// the entry if count reaches zero.
+func (s *PendingTokens) decrementPodTokens(endpointName string, count int) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if current, exists := s.endpointTokens[endpointName]; exists {
+		if current <= count {
+			delete(s.endpointTokens, endpointName)
+		} else {
+			s.endpointTokens[endpointName] = current - count
+		}
+	}
+}
+
+// estimateTokenCount estimates the number of input tokens for a request.
+// Prefers actual token IDs if available, otherwise falls back to prompt size as a proxy.
+func estimateTokenCount(request *scheduling.LLMRequest) int {
+	if request == nil {
+		return 0
+	}
+	if request.TokenizedPrompt != nil && len(request.TokenizedPrompt.TokenIDs) > 0 {
+		return len(request.TokenizedPrompt.TokenIDs)
+	}
+	if request.Body == nil {
+		return 0
+	}
+	return len(request.Body.PromptText())
+}

--- a/pkg/plugins/scorer/pending_tokens_test.go
+++ b/pkg/plugins/scorer/pending_tokens_test.go
@@ -1,0 +1,221 @@
+package scorer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+
+	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
+)
+
+func (s *PendingTokens) getPodTokens(endpointName string) int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.endpointTokens[endpointName]
+}
+
+func (s *PendingTokens) hasPodTokens(endpointName string) bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	_, exists := s.endpointTokens[endpointName]
+	return exists
+}
+
+func TestPendingTokensScorer_Score(t *testing.T) {
+	endpointA := newTestEndpoint("pod-a", 0)
+	endpointB := newTestEndpoint("pod-b", 0)
+	endpointC := newTestEndpoint("pod-c", 0)
+
+	tests := []struct {
+		name       string
+		setupCache func(*PendingTokens)
+		input      []scheduling.Endpoint
+		wantScores map[scheduling.Endpoint]float64
+	}{
+		{
+			name:       "no endpoints tracked",
+			setupCache: func(_ *PendingTokens) {},
+			input:      []scheduling.Endpoint{endpointA, endpointB, endpointC},
+			wantScores: map[scheduling.Endpoint]float64{
+				endpointA: 1.0,
+				endpointB: 1.0,
+				endpointC: 1.0,
+			},
+		},
+		{
+			name: "endpoints with different pending token counts",
+			setupCache: func(s *PendingTokens) {
+				s.mutex.Lock()
+				s.endpointTokens["default/pod-a"] = 1000
+				s.endpointTokens["default/pod-b"] = 500
+				s.mutex.Unlock()
+			},
+			input: []scheduling.Endpoint{endpointA, endpointB, endpointC},
+			wantScores: map[scheduling.Endpoint]float64{
+				endpointA: 0.0,
+				endpointB: 0.5,
+				endpointC: 1.0,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := utils.NewTestContext(t)
+			scorer := NewPendingTokens(ctx, nil)
+			test.setupCache(scorer)
+			got := scorer.Score(ctx, nil, nil, test.input)
+			assert.Equal(t, test.wantScores, got)
+		})
+	}
+}
+
+func TestPendingTokensScorer_PreRequest(t *testing.T) {
+	endpointA := newTestEndpoint("pod-a", 0)
+
+	t.Run("increments by token count not by 1", func(t *testing.T) {
+		ctx := utils.NewTestContext(t)
+		scorer := NewPendingTokens(ctx, nil)
+
+		request := &scheduling.LLMRequest{
+			RequestId: "req-1",
+			Body: &scheduling.LLMRequestBody{
+				Completions: &scheduling.CompletionsRequest{
+					Prompt: "hello",
+				},
+			},
+		}
+		result := newTestSchedulingResult(map[string]scheduling.Endpoint{
+			"default": endpointA,
+		})
+
+		scorer.PreRequest(ctx, request, result)
+
+		assert.Equal(t, 5, scorer.getPodTokens("default/pod-a"))
+	})
+}
+
+func TestPendingTokensScorer_ResponseComplete(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := NewPendingTokens(ctx, nil)
+
+	endpointA := newTestEndpoint("pod-a", 0)
+	request := &scheduling.LLMRequest{
+		RequestId: "req-1",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt: "hello",
+			},
+		},
+	}
+
+	result := newTestSchedulingResult(map[string]scheduling.Endpoint{
+		"default": endpointA,
+	})
+	scorer.PreRequest(ctx, request, result)
+
+	require.Equal(t, 5, scorer.getPodTokens("default/pod-a"))
+
+	scorer.ResponseComplete(ctx, request, &requestcontrol.Response{}, endpointA.GetMetadata())
+
+	assert.False(t, scorer.hasPodTokens("default/pod-a"),
+		"token count should be removed after ResponseComplete")
+}
+
+func TestPendingTokensScorer_TTLExpiration(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	params := &PendingTokensParameters{RequestTimeout: "1s"}
+	scorer := NewPendingTokens(ctx, params)
+
+	endpointA := newTestEndpoint("pod-a", 0)
+	request := &scheduling.LLMRequest{
+		RequestId: "req-ttl",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt: "hello",
+			},
+		},
+	}
+
+	result := newTestSchedulingResult(map[string]scheduling.Endpoint{
+		"default": endpointA,
+	})
+	scorer.PreRequest(ctx, request, result)
+
+	require.Equal(t, 5, scorer.getPodTokens("default/pod-a"))
+
+	time.Sleep(2 * time.Second)
+	scorer.requestCache.DeleteExpired()
+
+	assert.False(t, scorer.hasPodTokens("default/pod-a"),
+		"token count should be cleaned up after TTL expiration")
+}
+
+func TestPendingTokensScorer_TypedName(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := NewPendingTokens(ctx, nil)
+	assert.Equal(t, PendingTokensType, scorer.TypedName().Type)
+}
+
+func TestPendingTokensScorer_WithName(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := NewPendingTokens(ctx, nil)
+	scorer = scorer.WithName("my-scorer")
+	assert.Equal(t, "my-scorer", scorer.TypedName().Name)
+}
+
+func TestPendingTokensScorer_LoadBasedDistribution(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := NewPendingTokens(ctx, nil)
+
+	podA := newTestEndpoint("pod-a", 0)
+	podB := newTestEndpoint("pod-b", 0)
+	podC := newTestEndpoint("pod-c", 0)
+	endpoints := []scheduling.Endpoint{podA, podB, podC}
+
+	// simulate a large request already routed to pod-a (2000 tokens)
+	largeReq := &scheduling.LLMRequest{
+		RequestId: "large-req",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt: string(make([]byte, 2000)),
+			},
+		},
+	}
+	scorer.PreRequest(ctx, largeReq, newTestSchedulingResult(map[string]scheduling.Endpoint{
+		"default": podA,
+	}))
+
+	// simulate a medium request already routed to pod-b (500 tokens)
+	mediumReq := &scheduling.LLMRequest{
+		RequestId: "medium-req",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt: string(make([]byte, 500)),
+			},
+		},
+	}
+	scorer.PreRequest(ctx, mediumReq, newTestSchedulingResult(map[string]scheduling.Endpoint{
+		"default": podB,
+	}))
+
+	// score endpoints for a new incoming request given existing load
+	scores := scorer.Score(ctx, nil, nil, endpoints)
+
+	// pod-c should score highest (no load)
+	// pod-b should score middle
+	// pod-a should score lowest (most loaded)
+	assert.InDelta(t, 1.0, scores[podC], 0.0001, "unloaded pod should score 1.0")
+	assert.True(t, scores[podB] > scores[podA], "pod-b (500 tokens) should score higher than pod-a (2000 tokens)")
+	assert.InDelta(t, 0.0, scores[podA], 0.0001, "most loaded pod should score 0.0")
+	assert.InDelta(t, 0.75, scores[podB], 0.0001, "pod-b: 1.0 - (500/2000) = 0.75")
+
+	t.Logf("pod-a score: %v (2000 pending tokens)", scores[podA])
+	t.Logf("pod-b score: %v (500 pending tokens)", scores[podB])
+	t.Logf("pod-c score: %v (0 pending tokens)", scores[podC])
+}


### PR DESCRIPTION
**Description**

Adds a new `pending-tokens-scorer` scorer plugin that scores endpoints based on pending input token load.

**Related Issues (if applicable)**

Closes #517

This scorer is particularly well-suited for prefill routing in P/D disaggregation, where output token count is unknown at scheduling time and input token load is the primary signal for distributing work across prefill nodes.

**Problem**

`ActiveRequestScorer` treats all requests as equal weight leading to uneven GPU utilization when request sizes vary.

**Approach**

Introduces a standalone scorer that maintains per-pod pending token counts: (addresses #517)

- Increments by estimated input token count in PreRequest
- Decrements in ResponseComplete (and via TTL eviction as a leak guard)
- Uses TokenizedPrompt.TokenIDs when available, falls back to prompt byte length
- Scores reflect each pod's existing backlog of pending tokens, not properties of the incoming request
- Score = 1.0 - (pod_tokens / max_tokens), so more heavily loaded pods receive lower scores

_Example_:
pod-a: 2000 pending tokens → score 0.0 [1 - (2000/2000)]
pod-b:  500 pending tokens → score 0.75 [1 - (500/2000)]
pod-c:    0 pending tokens → score 1.0 [1 - (0/2000)]

**Known limitations**

- MaxTokens is not a typed field in the framework so output token estimation is not possible at routing time; input-only estimation is a reasonable proxy, especially for prefill routing in P/D disaggregation
- In active-active HA mode, per-replica token counts will diverge (same limitation as ActiveRequestScorer)

**Testing**

- Unit tests cover scoring, lifecycle (PreRequest/ResponseComplete), and TTL-based cleanup

**Special notes for reviewers (if applicable)**

This is my first PR to `llm-d-inference-scheduler`, so I’m happy to iterate based on any feedback. Thanks!