### PR TITLE
Remove obsolete hashBlockSize

### DIFF
--- a/deploy/config/sim-epp-config.yaml
+++ b/deploy/config/sim-epp-config.yaml
@@ -5,7 +5,6 @@ kind: EndpointPickerConfig
 plugins:
 - type: prefix-cache-scorer
   parameters:
-    hashBlockSize: 5
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 31250
 - type: decode-filter

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -542,7 +542,6 @@ plugins:
 - type: prefill-header-handler
 - type: prefix-cache-scorer
   parameters:
-    hashBlockSize: 5
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 31250
 - type: prefill-filter
@@ -551,7 +550,6 @@ plugins:
 - type: pd-profile-handler
   parameters:
     threshold: 10
-    hashBlockSize: 5
 schedulingProfiles:
 - name: prefill
   plugins:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -862,7 +862,6 @@ kind: EndpointPickerConfig
 plugins:
 - type: prefix-cache-scorer
   parameters:
-    hashBlockSize: 10
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 256
 - type: decode-filter


### PR DESCRIPTION
The `hashBlockSize` field appears in several E2E YAML configs (e.g. simpleConfig, disaggDecodeOnlyConfig) and in architecture.md. However, it is not a valid JSON field for either struct and is silently ignored during `json.Unmarshal`

This PR removes all references of `hashBlockSize`

part of #747 