### PR TITLE
[cicd] Compare coverage against `main` and latest `release-*`

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -4,9 +4,14 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+  actions: read
 
 jobs:
   check-changes:
@@ -82,6 +87,59 @@ jobs:
         shell: bash
         run: make coverage-compare BASELINE_DIR=coverage/baseline
 
+      # Find the latest release-* branch (by SemVer) and download its coverage
+      # artifact so the PR can compare against the most recent release.
+      - name: Find latest release branch
+        if: github.event_name == 'pull_request'
+        id: find-releases
+        shell: bash
+        run: |
+          gh api "repos/${{ github.repository }}/branches" \
+            --paginate \
+            --jq '[.[] | select(.name | startswith("release-")) | .name][]' \
+            | sort -V | tail -1 > /tmp/release_branches.txt
+          echo "Release branches found:"
+          cat /tmp/release_branches.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Download and compare release coverage baselines
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          if [[ ! -s /tmp/release_branches.txt ]]; then
+            echo "No release branches found, skipping."
+            exit 0
+          fi
+          while IFS= read -r branch; do
+            [[ -z "$branch" ]] && continue
+            echo "Looking up latest successful run for branch: $branch"
+            run_id=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --branch "$branch" \
+              --workflow "CI - PR Checks" \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+            if [[ -z "$run_id" ]]; then
+              echo "No successful run found for $branch, skipping."
+              continue
+            fi
+            dest="coverage/release-baselines/$branch"
+            mkdir -p "$dest"
+            if gh run download "$run_id" \
+                --repo "${{ github.repository }}" \
+                --name "coverage-baseline-$branch" \
+                --dir "$dest"; then
+              make coverage-compare BASELINE_DIR="$dest" COVERAGE_LABEL="$branch"
+            else
+              echo "No coverage artifact for $branch in run $run_id, skipping."
+            fi
+          done < /tmp/release_branches.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       # Copy the freshly generated profiles into coverage/baseline so that
       # the saved path matches the restored path on future PR runs.
       - name: Stage coverage baseline for caching
@@ -97,6 +155,19 @@ jobs:
         with:
           path: coverage/baseline
           key: coverage-main
+
+      # Upload coverage profiles as a named artifact for release branches.
+      # Retrieved by PRs to compare against the most recent release.
+      - name: Upload coverage artifact (release branches)
+        if: >-
+          github.event_name == 'push' &&
+          startsWith(github.ref, 'refs/heads/release-')
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-baseline-${{ github.ref_name }}
+          path: coverage/*.out
+          retention-days: 400
+          overwrite: true
 
       - name: Run make test-e2e
         shell: bash

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -352,6 +352,21 @@ To compare against a different ref:
 make coverage-compare BASE_REF=release-0.5
 ```
 
+To compare against multiple baselines in one session:
+
+```bash
+make test-unit
+make coverage-compare                                              # vs main
+make coverage-compare BASE_REF=release-0.6 COVERAGE_LABEL=release-0.6
+```
+
+If a worktree for the target ref already exists locally it is reused and not removed afterwards. A newly created worktree is always cleaned up after the comparison.
+
+> [!NOTE]
+> CI runs the same comparison automatically on every PR: one report against `main`
+> and one against the most recent `release-*` branch. Both appear in the GitHub
+> Actions Job Summary for the run.
+
 ## Tokenization Architecture
 
 > [!NOTE]

--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ post-deploy-test: ## Run post deployment tests
 
 COVERAGE_DIR       ?= coverage
 COVERAGE_THRESHOLD ?= 0
+COVERAGE_LABEL     ?= main
 BASE_REF           ?= main
 
 .PHONY: test-coverage
@@ -282,23 +283,31 @@ coverage-report: image-build-builder ## Generate HTML coverage reports (open cov
 	done'
 
 .PHONY: coverage-compare
-coverage-compare: image-build-builder ## Compare coverage vs baseline (BASELINE_DIR=path or BASE_REF=git-ref, default main)
+coverage-compare: image-build-builder ## Compare coverage vs baseline (BASELINE_DIR=path or BASE_REF=git-ref, default main; COVERAGE_LABEL=label)
 	@if [ -n "$(BASELINE_DIR)" ]; then \
-	    ./scripts/compare-coverage.sh "$(BASELINE_DIR)" "$(COVERAGE_DIR)" "$(COVERAGE_THRESHOLD)"; \
+	    ./scripts/compare-coverage.sh "$(BASELINE_DIR)" "$(COVERAGE_DIR)" "$(COVERAGE_THRESHOLD)" "$(COVERAGE_LABEL)"; \
 	else \
 	    printf "\033[33;1m==== Building Baseline Coverage from $(BASE_REF) ====\033[0m\n"; \
-	    WORKTREE=$$(mktemp -d); \
-	    git worktree add --quiet "$$WORKTREE" "$(BASE_REF)"; \
+	    EXISTING=$$(git worktree list --porcelain \
+	        | awk '/^worktree /{wt=$$2} /^branch refs\/heads\/$(BASE_REF)$$/{print wt}'); \
+	    if [ -n "$$EXISTING" ]; then \
+	        WORKTREE="$$EXISTING"; CLEANUP=0; \
+	    else \
+	        WORKTREE=$$(mktemp -u /tmp/cov-baseline-XXXXXX); \
+	        git worktree add --quiet "$$WORKTREE" "$(BASE_REF)"; \
+	        CLEANUP=1; \
+	    fi; \
+	    mkdir -p "$(COVERAGE_DIR)/baseline"; \
 	    $(CONTAINER_RUNTIME) run $(BUILDER_RUN_FLAGS) \
-	        -v "$$WORKTREE":/baseline:Z -w /baseline \
+	        -v "$$WORKTREE":/baseline:Z \
 	        $(BUILDER_IMAGE) sh -c " \
-	            mkdir -p $(COVERAGE_DIR)/baseline && \
-	            go test -race -coverprofile=$(COVERAGE_DIR)/baseline/epp.out -covermode=atomic \
+	            cd /baseline && \
+	            go test -race -coverprofile=/app/$(COVERAGE_DIR)/baseline/epp.out -covermode=atomic \
 	                $$(go list ./... | grep -v /test/ | grep -v ./pkg/sidecar/ | tr '\n' ' ') && \
-	            go test -race -coverprofile=$(COVERAGE_DIR)/baseline/sidecar.out -covermode=atomic \
+	            go test -race -coverprofile=/app/$(COVERAGE_DIR)/baseline/sidecar.out -covermode=atomic \
 	                ./pkg/sidecar/..."; \
-	    git worktree remove --force "$$WORKTREE"; \
-	    ./scripts/compare-coverage.sh "$(COVERAGE_DIR)/baseline" "$(COVERAGE_DIR)" "$(COVERAGE_THRESHOLD)"; \
+	    [ "$$CLEANUP" -eq 1 ] && git worktree remove --force "$$WORKTREE"; \
+	    ./scripts/compare-coverage.sh "$(COVERAGE_DIR)/baseline" "$(COVERAGE_DIR)" "$(COVERAGE_THRESHOLD)" "$(COVERAGE_LABEL)"; \
 	fi
 
 

--- a/scripts/compare-coverage.sh
+++ b/scripts/compare-coverage.sh
@@ -1,23 +1,25 @@
 #!/usr/bin/env bash
-# compare-coverage.sh <baseline-dir> <current-dir> [threshold]
+# compare-coverage.sh <baseline-dir> <current-dir> [threshold] [label]
 #
 # Compares Go coverage profiles between a baseline and the current run.
 # Outputs a markdown table to stdout and, when running in GitHub Actions,
 # appends it to $GITHUB_STEP_SUMMARY so it appears in the Job Summary.
 #
 # Usage:
-#   ./scripts/compare-coverage.sh coverage/baseline coverage/ 0
+#   ./scripts/compare-coverage.sh coverage/baseline coverage/ 0 main
 #
 # Arguments:
 #   baseline-dir  Directory containing baseline *.out coverage profiles
 #   current-dir   Directory containing current *.out coverage profiles
 #   threshold     Optional minimum total coverage % (default: 0, report only)
+#   label         Optional baseline label for the report heading (default: main)
 
 set -euo pipefail
 
 BASELINE_DIR="${1:?baseline-dir required}"
 CURRENT_DIR="${2:?current-dir required}"
 THRESHOLD="${3:-0}"
+LABEL="${4:-main}"
 
 # extract_total <profile.out> → percentage as a bare number, e.g. "72.4"
 extract_total() {
@@ -100,7 +102,7 @@ for name in "${all_names[@]}"; do
     rows+="| \`$name\` | $base_fmt | $cur_fmt | $delta% | $status |\n"
 done
 
-output="$(printf '## Coverage Report\n\n| Component | Baseline | Current | Delta | Status |\n|-----------|----------|---------|-------|--------|\n%b' "$rows")"
+output="$(printf '## Coverage Report vs %s\n\n| Component | Baseline | Current | Delta | Status |\n|-----------|----------|---------|-------|--------|\n%b' "$LABEL" "$rows")"
 if [[ "$THRESHOLD" -gt 0 ]]; then
     output+="$(printf '\n> Minimum threshold: **%s%%**' "$THRESHOLD")"
 fi


### PR DESCRIPTION
- Upload release coverage as artifact for future reference
- On every PR merge to main, compare coverage vs main and latest release branch. Both reports are avaialble in the action output.