### PR TITLE
[cicd[ Make coverage comparison optional

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -22,11 +22,11 @@ jobs:
           filters: |
             src:
               - '**/*.go'
-              - '**/*.py'
               - Dockerfile.epp
               - Dockerfile.sidecar
               - Makefile*
               - go.mod
+              - scripts/**
   lint-and-test:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.src == 'true' }}
@@ -77,6 +77,7 @@ jobs:
 
       - name: Compare coverage against main baseline
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         shell: bash
         run: make coverage-compare BASELINE_DIR=coverage/baseline
 

--- a/scripts/compare-coverage.sh
+++ b/scripts/compare-coverage.sh
@@ -22,12 +22,12 @@ THRESHOLD="${3:-0}"
 # extract_total <profile.out> → percentage as a bare number, e.g. "72.4"
 extract_total() {
     local profile="$1"
-    if [[ ! -f "$profile" ]]; then
+    if [[ ! -s "$profile" ]]; then
         echo ""
         return
     fi
     go tool cover -func="$profile" 2>/dev/null \
-        | awk '/^total:/{gsub(/%/,"",$NF); print $NF}'
+        | awk '/^total:/{gsub(/%/,"",$NF); print $NF}' || true
 }
 
 # delta_str <base> <cur> → e.g. "+1.2" or "-0.5" or "0.0"

--- a/scripts/compare-coverage.sh
+++ b/scripts/compare-coverage.sh
@@ -57,7 +57,7 @@ for f in "$BASELINE_DIR"/*.out "$CURRENT_DIR"/*.out; do
     [[ -f "$f" ]] || continue
     name=$(basename "$f" .out)
     # deduplicate
-    if [[ ! " ${all_names[*]} " =~ " ${name} " ]]; then
+    if [[ ! " ${all_names[*]-} " =~ " ${name} " ]]; then
         all_names+=("$name")
     fi
 done


### PR DESCRIPTION
- integrate #760 for MacOS compatibility (authored by @roytman)
- Make the compare step `continue-on-error: true` in action so coverage comparison is advisory and does not fail the test
- harden extract_total by changing `go tool cover` invocation to not silently swallow failures. Instead it produces an empty string which results in "missing baseline" message. This was possibly the reason for CICD failure.

Fix #759 

