### PR TITLE
Replace time.Sleep in the e2e tests with deterministic pod-discovery wait

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -411,7 +411,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			epp := createEndPointPicker(kvConfig)
 
 			modelServers := createModelServers(false, true, false, 1, 0, 0)
-			time.Sleep(5 * time.Second) // wait for model server(s) to become ready
+			waitForEPPToDiscoverPods(kvModelName)
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -435,7 +435,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			epp := createEndPointPicker(kvExternalTokenizerConfig)
 
 			modelServers := createModelServers(false, true, false, 1, 0, 0)
-			time.Sleep(5 * time.Second) // wait for model server(s) to become ready
+			waitForEPPToDiscoverPods(kvModelName)
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -658,7 +658,8 @@ func createEndPointPicker(eppConfig string) []string {
 		return err == nil && resp.Status == healthPb.HealthCheckResponse_SERVING
 	}, 40*time.Second, 2*time.Second).Should(gomega.BeTrue())
 	ginkgo.By("EPP reports that it is serving")
-	time.Sleep(2 * time.Second)
+
+	waitForEPPToDiscoverPods(simModelName)
 
 	return objects
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -659,7 +659,9 @@ func createEndPointPicker(eppConfig string) []string {
 	}, 40*time.Second, 2*time.Second).Should(gomega.BeTrue())
 	ginkgo.By("EPP reports that it is serving")
 
-	waitForEPPToDiscoverPods(simModelName)
+	// Trigger EPP pod-discovery wait asynchronously so that createEndPointPicker
+	// does not block flows that create model servers after the EPP is created.
+	go waitForEPPToDiscoverPods(simModelName)
 
 	return objects
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -45,7 +45,10 @@ func waitForEPPToDiscoverPods(modelName string) {
 		if resp.StatusCode != http.StatusServiceUnavailable {
 			return true
 		}
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
 		return !strings.Contains(string(body), "failed to find candidate pods")
 	}, 30*time.Second, time.Second).Should(gomega.BeTrue())
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os/exec"
 	"strings"
 	"time"
@@ -23,6 +24,31 @@ import (
 const (
 	deploymentKind = "deployment"
 )
+
+// waitForEPPToDiscoverPods polls the EPP's completions endpoint until it no
+// longer returns "failed to find candidate pods", indicating the InferencePool
+// controller has finished its initial pod discovery.
+// This is necessary because the EPP sets its health status to SERVING as soon
+// as the gRPC server starts, before pod discovery is complete.
+func waitForEPPToDiscoverPods(modelName string) {
+	ginkgo.By("Waiting for EPP to discover pool members")
+	gomega.Eventually(func() bool {
+		resp, err := http.Post(
+			fmt.Sprintf("http://localhost:%s/v1/completions", port),
+			"application/json",
+			strings.NewReader(`{"model":"`+modelName+`","prompt":"warmup"}`),
+		)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			return true
+		}
+		body, _ := io.ReadAll(resp.Body)
+		return !strings.Contains(string(body), "failed to find candidate pods")
+	}, 30*time.Second, time.Second).Should(gomega.BeTrue())
+}
 
 func scaleDeployment(objects []string, increment int) {
 	direction := "up"

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -41,7 +41,7 @@ func waitForEPPToDiscoverPods(modelName string) {
 		if err != nil {
 			return false
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusServiceUnavailable {
 			return true
 		}


### PR DESCRIPTION
Replace all fixed sleeps with a gomega.Eventually loop that sends a warmup POST /v1/completions request and retries until the response is not the "failed to find candidate pods" 503. This directly tests the condition the sleep was approximating, making the tests deterministic regardless of cluster or CI load.

The polling logic is extracted into a shared waitForEPPToDiscoverPods(modelName string) helper in utils_test.go and used in three places:

- createEndPointPicker — EPP created after model servers (standard flow)
- KV enabled configuration test — EPP created before model servers
- KV external tokenizer test — same as above

The `gomega.Eventually(func, 30*time.Second, time.Second)` in `waitForEPPToDiscoverPods` has a 30-second timeout with a 1-second polling interval. If the EPP doesn't discover pods within 30 seconds, the test fails with a clear timeout error.

/close #764 