### PR TITLE
Revert IGW import to 1.4.0 and update tokenizer plugin accordingly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/gateway-api v1.4.1
-	sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260316135939-f0ca6aef5114
+	sigs.k8s.io/gateway-api-inference-extension v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4i
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/gateway-api v1.4.1 h1:NPxFutNkKNa8UfLd2CMlEuhIPMQgDQ6DXNKG9sHbJU8=
 sigs.k8s.io/gateway-api v1.4.1/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
-sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260316135939-f0ca6aef5114 h1:amK+mgy2HGFcZ8mPSuzLEjPHkYINzECxBqGT1eI/EfE=
-sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260316135939-f0ca6aef5114/go.mod h1:KBw2Ke/uiMHEWHmG2th8j0dEfMEFeuzQ+Wa2CNPMfGw=
+sigs.k8s.io/gateway-api-inference-extension v1.4.0 h1:V+5u0J64qDbLYx4M/PkpsGa5bjeRjWUVybQ00axEkE0=
+sigs.k8s.io/gateway-api-inference-extension v1.4.0/go.mod h1:Z9MZpf6wdjn9iCT5Xu6Ugqh88zSa0zuDra0VqJXT7eM=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=

--- a/pkg/plugins/preparedata/tokenizer.go
+++ b/pkg/plugins/preparedata/tokenizer.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
@@ -41,12 +40,13 @@ const (
 	TokenizerPluginType = "tokenizer"
 
 	// TokenizedPromptKey is the data key advertised by this plugin to indicate
-	// that it produces a TokenizedPrompt on the LLMRequest.
+	// that it produces tokenized prompt data.
 	TokenizedPromptKey = "TokenizedPrompt"
-)
 
-// compile-time type assertion.
-var _ requestcontrol.PrepareDataPlugin = &TokenizerPlugin{}
+	// TokenizedPromptStateKey is the CycleState key used by the tokenizer scorer
+	// to store tokenized prompt data for downstream consumers.
+	TokenizedPromptStateKey = plugin.StateKey(TokenizedPromptKey)
+)
 
 // tokenizerPluginConfig holds the configuration for the tokenizer plugin.
 type tokenizerPluginConfig struct {
@@ -92,8 +92,26 @@ func NewTokenizerPlugin(ctx context.Context, config *tokenizerPluginConfig) (*To
 	}, nil
 }
 
-// TokenizerPlugin tokenizes the prompt in the incoming request and attaches
-// the result to the LLMRequest for downstream consumers.
+// TokenizedPromptState holds the tokenization result for a single request,
+// stored in CycleState for consumption by downstream scorers.
+// This follows the standard IGW pattern where scorers share data via CycleState
+// (same as NoHitLRU reading from prefix-cache scorer).
+type TokenizedPromptState struct {
+	TokenIDs []uint32
+}
+
+// Clone implements plugin.StateData.
+func (t *TokenizedPromptState) Clone() plugin.StateData {
+	if t == nil {
+		return nil
+	}
+	ids := make([]uint32, len(t.TokenIDs))
+	copy(ids, t.TokenIDs)
+	return &TokenizedPromptState{TokenIDs: ids}
+}
+
+// TokenizerPlugin tokenizes the prompt in the incoming request and stores
+// the result in CycleState for downstream consumers (scorers).
 type TokenizerPlugin struct {
 	typedName plugin.TypedName
 	tokenizer tokenizer
@@ -110,28 +128,10 @@ func (p *TokenizerPlugin) WithName(name string) *TokenizerPlugin {
 	return p
 }
 
-// Produces returns the data keys this plugin produces.
-func (p *TokenizerPlugin) Produces() map[string]any {
-	return map[string]any{TokenizedPromptKey: scheduling.TokenizedPrompt{}}
-}
-
-// Consumes returns the data keys this plugin requires.
-func (p *TokenizerPlugin) Consumes() map[string]any {
-	return nil
-}
-
-// PrepareRequestData tokenizes the request prompt and stores the result
-// on the LLMRequest so that scorers and filters can use it.
-// If the request already contains tokenized data, tokenization is skipped.
-// This method is fail-open: errors are logged and TokenizedPrompt is left nil.
-func (p *TokenizerPlugin) PrepareRequestData(ctx context.Context, request *scheduling.LLMRequest, pods []scheduling.Endpoint) error {
+// tokenize extracts token IDs from the request. Returns nil on error or unsupported type.
+func (p *TokenizerPlugin) tokenize(ctx context.Context, request *scheduling.LLMRequest) []uint32 {
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
 	traceLogger := logger.V(logutil.TRACE)
-
-	if request.TokenizedPrompt != nil {
-		traceLogger.Info("TokenizedPrompt already set, skipping")
-		return nil
-	}
 
 	if request.Body == nil {
 		traceLogger.Info("Request body is nil, skipping tokenization")
@@ -164,11 +164,7 @@ func (p *TokenizerPlugin) PrepareRequestData(ctx context.Context, request *sched
 	}
 
 	traceLogger.Info("Tokenization succeeded", "tokenCount", len(tokenIDs))
-	request.TokenizedPrompt = &scheduling.TokenizedPrompt{
-		TokenIDs: tokenIDs,
-	}
-
-	return nil
+	return tokenIDs
 }
 
 // chatCompletionsToRenderChatRequest converts a ChatCompletionsRequest to a

--- a/pkg/plugins/preparedata/tokenizer.go
+++ b/pkg/plugins/preparedata/tokenizer.go
@@ -45,7 +45,8 @@ const (
 
 	// TokenizedPromptStateKey is the CycleState key used by the tokenizer scorer
 	// to store tokenized prompt data for downstream consumers.
-	TokenizedPromptStateKey = plugin.StateKey(TokenizedPromptKey)
+	// Namespaced by TokenizerPluginType to avoid collisions with other plugins.
+	TokenizedPromptStateKey = plugin.StateKey(TokenizerPluginType + "." + TokenizedPromptKey)
 )
 
 // tokenizerPluginConfig holds the configuration for the tokenizer plugin.

--- a/pkg/plugins/preparedata/tokenizer_preparedata.go
+++ b/pkg/plugins/preparedata/tokenizer_preparedata.go
@@ -1,0 +1,60 @@
+//go:build gaie_tokenized_prompt
+
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preparedata
+
+import (
+	"context"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+// compile-time type assertion.
+var _ requestcontrol.PrepareDataPlugin = &TokenizerPlugin{}
+
+// Produces returns the data keys this plugin produces.
+func (p *TokenizerPlugin) Produces() map[string]any {
+	return map[string]any{TokenizedPromptKey: scheduling.TokenizedPrompt{}}
+}
+
+// Consumes returns the data keys this plugin requires.
+func (p *TokenizerPlugin) Consumes() map[string]any {
+	return nil
+}
+
+// PrepareRequestData tokenizes the request prompt and stores the result
+// on the LLMRequest so that scorers and filters can use it.
+// If the request already contains tokenized data, tokenization is skipped.
+// This method is fail-open: errors are logged and TokenizedPrompt is left nil.
+func (p *TokenizerPlugin) PrepareRequestData(ctx context.Context, request *scheduling.LLMRequest, pods []scheduling.Endpoint) error {
+	if request.TokenizedPrompt != nil {
+		return nil
+	}
+
+	tokenIDs := p.tokenize(ctx, request)
+	if tokenIDs == nil {
+		return nil
+	}
+
+	request.TokenizedPrompt = &scheduling.TokenizedPrompt{
+		TokenIDs: tokenIDs,
+	}
+
+	return nil
+}

--- a/pkg/plugins/preparedata/tokenizer_scorer.go
+++ b/pkg/plugins/preparedata/tokenizer_scorer.go
@@ -37,9 +37,8 @@ func (p *TokenizerPlugin) Category() scheduling.ScorerCategory {
 }
 
 // Score implements scheduling.Scorer. It tokenizes the request prompt, writes
-// the result to CycleState using the plugin's TypedName as key (standard IGW
-// pattern — same as how NoHitLRU reads prefix-cache scorer data), and returns
-// zero scores for all endpoints since this scorer only produces data.
+// the result to CycleState under the TokenizedPromptStateKey constant, and
+// returns zero scores for all endpoints since this scorer only produces data.
 func (p *TokenizerPlugin) Score(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.LLMRequest, pods []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
 	traceLogger := logger.V(logutil.TRACE)

--- a/pkg/plugins/preparedata/tokenizer_scorer.go
+++ b/pkg/plugins/preparedata/tokenizer_scorer.go
@@ -1,0 +1,66 @@
+//go:build !gaie_tokenized_prompt
+
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preparedata
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+// compile-time type assertion.
+var _ scheduling.Scorer = &TokenizerPlugin{}
+
+// Category implements scheduling.Scorer.
+// The tokenizer scorer is an Affinity scorer since it produces data consumed
+// by cache-locality scorers.
+func (p *TokenizerPlugin) Category() scheduling.ScorerCategory {
+	return scheduling.Affinity
+}
+
+// Score implements scheduling.Scorer. It tokenizes the request prompt, writes
+// the result to CycleState using the plugin's TypedName as key (standard IGW
+// pattern — same as how NoHitLRU reads prefix-cache scorer data), and returns
+// zero scores for all endpoints since this scorer only produces data.
+func (p *TokenizerPlugin) Score(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.LLMRequest, pods []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
+	logger := log.FromContext(ctx).WithName(p.typedName.String())
+	traceLogger := logger.V(logutil.TRACE)
+
+	// Check if tokenization data already exists in CycleState.
+	if _, err := scheduling.ReadCycleStateKey[*TokenizedPromptState](
+		cycleState, TokenizedPromptStateKey); err == nil {
+		traceLogger.Info("TokenizedPrompt already in CycleState, skipping")
+	} else {
+		tokenIDs := p.tokenize(ctx, request)
+		if tokenIDs != nil {
+			cycleState.Write(TokenizedPromptStateKey, &TokenizedPromptState{
+				TokenIDs: tokenIDs,
+			})
+		}
+	}
+
+	// Return zero scores — this scorer only produces data for downstream consumers.
+	scores := make(map[scheduling.Endpoint]float64, len(pods))
+	for _, pod := range pods {
+		scores[pod] = 0
+	}
+	return scores
+}

--- a/pkg/plugins/preparedata/tokenizer_scorer_test.go
+++ b/pkg/plugins/preparedata/tokenizer_scorer_test.go
@@ -155,8 +155,15 @@ func TestTokenizerScorer_SkipsWhenAlreadyInCycleState(t *testing.T) {
 	existing := &TokenizedPromptState{TokenIDs: []uint32{1, 2, 3}}
 	cycleState.Write(TokenizedPromptStateKey, existing)
 
-	// Use nil tokenizer — would panic if called.
-	p := newTestPlugin(nil)
+	// Use a recording mock to assert tokenizer is never called.
+	tokenizerCalled := false
+	tok := &mockTokenizer{
+		renderFunc: func(string) ([]uint32, []tokenizerTypes.Offset, error) {
+			tokenizerCalled = true
+			return nil, nil, nil
+		},
+	}
+	p := newTestPlugin(tok)
 
 	request := &scheduling.LLMRequest{
 		RequestId: "already-tokenized",
@@ -166,6 +173,8 @@ func TestTokenizerScorer_SkipsWhenAlreadyInCycleState(t *testing.T) {
 	}
 
 	p.Score(ctx, cycleState, request, testEndpoints)
+
+	assert.False(t, tokenizerCalled, "tokenizer should not be called when CycleState already has data")
 
 	// Original data should remain unchanged.
 	stored, err := scheduling.ReadCycleStateKey[*TokenizedPromptState](

--- a/pkg/plugins/preparedata/tokenizer_scorer_test.go
+++ b/pkg/plugins/preparedata/tokenizer_scorer_test.go
@@ -1,0 +1,180 @@
+//go:build !gaie_tokenized_prompt
+
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preparedata
+
+import (
+	"errors"
+	"testing"
+
+	tokenizerTypes "github.com/llm-d/llm-d-kv-cache/pkg/tokenization/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+
+	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
+)
+
+var testEndpoints = []scheduling.Endpoint{
+	scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
+			Address:        "10.0.0.1",
+			Port:           "8080",
+		},
+		nil, nil,
+	),
+}
+
+func TestTokenizerScorer_Score(t *testing.T) {
+	fakeTokenIDs := []uint32{10, 20, 30, 40}
+
+	tok := &mockTokenizer{
+		renderFunc: func(prompt string) ([]uint32, []tokenizerTypes.Offset, error) {
+			return fakeTokenIDs, nil, nil
+		},
+		renderChatFunc: func(req *tokenizerTypes.RenderChatRequest) ([]uint32, []tokenizerTypes.Offset, error) {
+			return fakeTokenIDs, nil, nil
+		},
+	}
+
+	tests := []struct {
+		name         string
+		request      *scheduling.LLMRequest
+		tokenizer    tokenizer
+		wantTokenIDs []uint32
+		wantNil      bool
+	}{
+		{
+			name:    "skips nil body",
+			request: &scheduling.LLMRequest{RequestId: "nil-body", Body: nil},
+			wantNil: true,
+		},
+		{
+			name: "skips unsupported request type",
+			request: &scheduling.LLMRequest{
+				RequestId: "unsupported",
+				Body:      &scheduling.LLMRequestBody{},
+			},
+			wantNil: true,
+		},
+		{
+			name: "tokenizes completions and writes to CycleState",
+			request: &scheduling.LLMRequest{
+				RequestId: "completions",
+				Body: &scheduling.LLMRequestBody{
+					Completions: &scheduling.CompletionsRequest{
+						Prompt: "The quick brown fox",
+					},
+				},
+			},
+			tokenizer:    tok,
+			wantTokenIDs: fakeTokenIDs,
+		},
+		{
+			name: "tokenizes chat completions and writes to CycleState",
+			request: &scheduling.LLMRequest{
+				RequestId: "chat",
+				Body: &scheduling.LLMRequestBody{
+					ChatCompletions: &scheduling.ChatCompletionsRequest{
+						Messages: []scheduling.Message{
+							{Role: "user", Content: scheduling.Content{Raw: "Hello"}},
+						},
+					},
+				},
+			},
+			tokenizer:    tok,
+			wantTokenIDs: fakeTokenIDs,
+		},
+		{
+			name: "fail-open on tokenization error",
+			request: &scheduling.LLMRequest{
+				RequestId: "fail-open",
+				Body: &scheduling.LLMRequestBody{
+					Completions: &scheduling.CompletionsRequest{Prompt: "fail"},
+				},
+			},
+			tokenizer: &mockTokenizer{
+				renderFunc: func(string) ([]uint32, []tokenizerTypes.Offset, error) {
+					return nil, nil, errors.New("tokenizer exploded")
+				},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := utils.NewTestContext(t)
+			p := newTestPlugin(tt.tokenizer)
+			cycleState := scheduling.NewCycleState()
+
+			scores := p.Score(ctx, cycleState, tt.request, testEndpoints)
+
+			// All scores should be zero (tokenizer scorer doesn't score).
+			for _, score := range scores {
+				assert.Equal(t, float64(0), score)
+			}
+
+			stored, err := scheduling.ReadCycleStateKey[*TokenizedPromptState](
+				cycleState, TokenizedPromptStateKey)
+
+			if tt.wantNil {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, stored)
+				assert.Equal(t, tt.wantTokenIDs, stored.TokenIDs)
+			}
+		})
+	}
+}
+
+func TestTokenizerScorer_SkipsWhenAlreadyInCycleState(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	cycleState := scheduling.NewCycleState()
+
+	// Pre-populate CycleState.
+	existing := &TokenizedPromptState{TokenIDs: []uint32{1, 2, 3}}
+	cycleState.Write(TokenizedPromptStateKey, existing)
+
+	// Use nil tokenizer — would panic if called.
+	p := newTestPlugin(nil)
+
+	request := &scheduling.LLMRequest{
+		RequestId: "already-tokenized",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: "hello"},
+		},
+	}
+
+	p.Score(ctx, cycleState, request, testEndpoints)
+
+	// Original data should remain unchanged.
+	stored, err := scheduling.ReadCycleStateKey[*TokenizedPromptState](
+		cycleState, TokenizedPromptStateKey)
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{1, 2, 3}, stored.TokenIDs)
+}
+
+func TestTokenizerScorer_Category(t *testing.T) {
+	p := newTestPlugin(nil)
+	assert.Equal(t, scheduling.Affinity, p.Category())
+}

--- a/pkg/plugins/preparedata/tokenizer_test.go
+++ b/pkg/plugins/preparedata/tokenizer_test.go
@@ -18,7 +18,6 @@ package preparedata
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	tokenizerTypes "github.com/llm-d/llm-d-kv-cache/pkg/tokenization/types"
@@ -95,121 +94,6 @@ func TestTokenizerPluginFactory_Validation(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, p)
-			}
-		})
-	}
-}
-
-func TestTokenizerPlugin_ProducesAndConsumes(t *testing.T) {
-	p := newTestPlugin(nil)
-
-	produces := p.Produces()
-	require.NotNil(t, produces)
-	assert.Contains(t, produces, TokenizedPromptKey)
-	assert.IsType(t, scheduling.TokenizedPrompt{}, produces[TokenizedPromptKey])
-
-	assert.Nil(t, p.Consumes())
-}
-
-func TestTokenizerPlugin_PrepareRequestData(t *testing.T) {
-	fakeTokenIDs := []uint32{10, 20, 30, 40}
-
-	tok := &mockTokenizer{
-		renderFunc: func(prompt string) ([]uint32, []tokenizerTypes.Offset, error) {
-			return fakeTokenIDs, nil, nil
-		},
-		renderChatFunc: func(req *tokenizerTypes.RenderChatRequest) ([]uint32, []tokenizerTypes.Offset, error) {
-			return fakeTokenIDs, nil, nil
-		},
-	}
-
-	tests := []struct {
-		name          string
-		request       *scheduling.LLMRequest
-		tokenizer     tokenizer
-		wantTokenIDs  []uint32
-		wantNilPrompt bool
-	}{
-		{
-			name: "skips when already tokenized",
-			request: &scheduling.LLMRequest{
-				TokenizedPrompt: &scheduling.TokenizedPrompt{TokenIDs: []uint32{1, 2, 3}},
-				Body: &scheduling.LLMRequestBody{
-					Completions: &scheduling.CompletionsRequest{Prompt: "hello"},
-				},
-			},
-			tokenizer:    nil, // would panic if called
-			wantTokenIDs: []uint32{1, 2, 3},
-		},
-		{
-			name:          "skips nil body",
-			request:       &scheduling.LLMRequest{Body: nil},
-			tokenizer:     nil,
-			wantNilPrompt: true,
-		},
-		{
-			name: "skips unsupported request type",
-			request: &scheduling.LLMRequest{
-				Body: &scheduling.LLMRequestBody{},
-			},
-			tokenizer:     nil,
-			wantNilPrompt: true,
-		},
-		{
-			name: "tokenizes completions request",
-			request: &scheduling.LLMRequest{
-				Body: &scheduling.LLMRequestBody{
-					Completions: &scheduling.CompletionsRequest{
-						Prompt: "The quick brown fox",
-					},
-				},
-			},
-			tokenizer:    tok,
-			wantTokenIDs: fakeTokenIDs,
-		},
-		{
-			name: "tokenizes chat completions request",
-			request: &scheduling.LLMRequest{
-				Body: &scheduling.LLMRequestBody{
-					ChatCompletions: &scheduling.ChatCompletionsRequest{
-						Messages: []scheduling.Message{
-							{Role: "user", Content: scheduling.Content{Raw: "Hello"}},
-						},
-					},
-				},
-			},
-			tokenizer:    tok,
-			wantTokenIDs: fakeTokenIDs,
-		},
-		{
-			name: "fail-open on tokenization error",
-			request: &scheduling.LLMRequest{
-				Body: &scheduling.LLMRequestBody{
-					Completions: &scheduling.CompletionsRequest{Prompt: "fail"},
-				},
-			},
-			tokenizer: &mockTokenizer{
-				renderFunc: func(string) ([]uint32, []tokenizerTypes.Offset, error) {
-					return nil, nil, errors.New("tokenizer exploded")
-				},
-			},
-			wantNilPrompt: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := utils.NewTestContext(t)
-			p := newTestPlugin(tt.tokenizer)
-
-			err := p.PrepareRequestData(ctx, tt.request, nil)
-			require.NoError(t, err)
-
-			if tt.wantNilPrompt {
-				assert.Nil(t, tt.request.TokenizedPrompt)
-			} else {
-				require.NotNil(t, tt.request.TokenizedPrompt)
-				assert.Equal(t, tt.wantTokenIDs, tt.request.TokenizedPrompt.TokenIDs)
 			}
 		})
 	}

--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -677,9 +677,8 @@ func (s *PrecisePrefixCacheScorer) getBlockSizeTokens() int {
 
 // getScores retrieves the endpoint scores from the KV-cache indexer
 // based on the provided LLM request.
-// If the request already has TokenizedPrompt set (e.g. by an external tokenizer
-// PrepareData plugin), it calls ScoreTokens directly, bypassing
-// prompt/chat tokenization.
+// If tokenized prompt data is found in CycleState (written by the tokenizer
+// scorer plugin), it calls ScoreTokens directly, bypassing prompt/chat tokenization.
 // Otherwise, chat completions and regular completions are tokenized internally.
 func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.LLMRequest) (map[string]float64, error) {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())

--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -25,6 +25,7 @@ import (
 	dl_prefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/plugins/preparedata"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 )
 
@@ -472,7 +473,7 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *schedu
 	} else {
 		// Fallback: compute scores directly (backward compatible path).
 		var scoreErr error
-		scores, scoreErr = s.getScores(ctx, request)
+		scores, scoreErr = s.getScores(ctx, cycleState, request)
 		if scoreErr != nil {
 			logger.Error(scoreErr, "Failed to get endpoint scores")
 			span.SetStatus(codes.Error, scoreErr.Error())
@@ -680,7 +681,7 @@ func (s *PrecisePrefixCacheScorer) getBlockSizeTokens() int {
 // PrepareData plugin), it calls ScoreTokens directly, bypassing
 // prompt/chat tokenization.
 // Otherwise, chat completions and regular completions are tokenized internally.
-func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *scheduling.LLMRequest) (map[string]float64, error) {
+func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.LLMRequest) (map[string]float64, error) {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 	traceLogger := logger.V(logutil.TRACE)
 
@@ -688,10 +689,12 @@ func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *sched
 		"isChatCompletions", request.Body != nil && request.Body.ChatCompletions != nil,
 		"isCompletions", request.Body != nil && request.Body.Completions != nil)
 
-	if request.TokenizedPrompt != nil && len(request.TokenizedPrompt.TokenIDs) > 0 {
-		traceLogger.Info("tokens already in the request, skipping tokenization")
+	// Read tokenized prompt from CycleState, written by the tokenizer scorer plugin.
+	if tp, err := scheduling.ReadCycleStateKey[*preparedata.TokenizedPromptState](
+		cycleState, preparedata.TokenizedPromptStateKey); err == nil && len(tp.TokenIDs) > 0 {
+		traceLogger.Info("tokens found in CycleState, skipping tokenization")
 
-		scores, err := s.kvCacheIndexer.ScoreTokens(ctx, request.TokenizedPrompt.TokenIDs, request.TargetModel, nil)
+		scores, err := s.kvCacheIndexer.ScoreTokens(ctx, tp.TokenIDs, request.TargetModel, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get endpoint scores for tokens: %w", err)
 		}

--- a/pkg/plugins/scorer/precise_prefix_cache_tokenized_test.go
+++ b/pkg/plugins/scorer/precise_prefix_cache_tokenized_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/plugins/preparedata"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
@@ -98,15 +99,18 @@ func TestPrecisePrefixCacheScorer_UsesTokenizedPrompt(t *testing.T) {
 		},
 	}
 
+	// Write tokenized prompt to CycleState (as the tokenizer scorer would).
+	cycleState := scheduling.NewCycleState()
+	cycleState.Write(preparedata.TokenizedPromptStateKey, &preparedata.TokenizedPromptState{
+		TokenIDs: tokenIDs,
+	})
+
 	request := &scheduling.LLMRequest{
 		RequestId:   "test-tokenized",
 		TargetModel: "test-model",
-		TokenizedPrompt: &scheduling.TokenizedPrompt{
-			TokenIDs: tokenIDs,
-		},
 	}
 
-	scorer.Score(ctx, scheduling.NewCycleState(), request, testEndpoints)
+	scorer.Score(ctx, cycleState, request, testEndpoints)
 
 	require.Equal(t, tokenIDs, capturedTokens)
 	require.Equal(t, "test-model", capturedModel)
@@ -131,17 +135,20 @@ func TestPrecisePrefixCacheScorer_SkipsTokenizedPromptWhenEmpty(t *testing.T) {
 		},
 	}
 
+	// Write empty token IDs to CycleState.
+	cycleState := scheduling.NewCycleState()
+	cycleState.Write(preparedata.TokenizedPromptStateKey, &preparedata.TokenizedPromptState{
+		TokenIDs: []uint32{},
+	})
+
 	request := &scheduling.LLMRequest{
 		RequestId:   "test-skip-empty",
 		TargetModel: "test-model",
-		TokenizedPrompt: &scheduling.TokenizedPrompt{
-			TokenIDs: []uint32{},
-		},
 		Body: &scheduling.LLMRequestBody{
 			Completions: &scheduling.CompletionsRequest{Prompt: "hello"},
 		},
 	}
 
-	scorer.Score(ctx, scheduling.NewCycleState(), request, testEndpoints)
+	scorer.Score(ctx, cycleState, request, testEndpoints)
 	assert.False(t, fromTokensCalled, "ScoreTokens should not be called with empty TokenIDs")
 }


### PR DESCRIPTION
## Summary
- import IGW 1.4.0
- turn tokenizer PrepareData plugin into a scorer and wrap the latter in no-build flag