### PR TITLE
update Makefile to run e2e tests locally with Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,14 @@ GO_BUILD_CACHE_VOL ?= llm-d-gobuildcache
 
 # Common flags for running the builder container: mounts source, Go caches, and runs as current user.
 # Podman rootless requires --userns=keep-id to correctly map host UID; docker uses -u directly.
+# Rootful Podman (e.g. Podman machine on macOS) does not support --userns=keep-id with --network=host.
 ifeq ($(CONTAINER_RUNTIME),podman)
+PODMAN_ROOTLESS := $(shell podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null)
+ifeq ($(PODMAN_ROOTLESS),true)
 BUILDER_USER_FLAGS = --userns=keep-id
+else
+BUILDER_USER_FLAGS =
+endif
 else
 BUILDER_USER_FLAGS = -u $$(id -u):$$(id -g)
 endif
@@ -72,10 +78,11 @@ BUILDER_CLUSTER_FLAGS = --network=host \
 # Mount the container runtime socket and set CONTAINER_HOST so podman --remote
 # inside the builder can talk to the host's container runtime.
 ifeq ($(CONTAINER_RUNTIME),podman)
-CONTAINER_SOCK ?= $(or $(shell podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null),/run/podman/podman.sock)
+CONTAINER_SOCK ?= $(or $(shell podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null | sed 's|^unix://||'),/run/podman/podman.sock)
 BUILDER_SOCK_FLAGS = --security-opt label=disable \
 	-v $(CONTAINER_SOCK):$(CONTAINER_SOCK) \
 	-e CONTAINER_HOST=unix://$(CONTAINER_SOCK) \
+	-e DOCKER_HOST=unix://$(CONTAINER_SOCK) \
 	-e CONTAINER_RUNTIME=podman \
 	-e KIND_EXPERIMENTAL_PROVIDER=podman
 else


### PR DESCRIPTION
After PR #521, when a Mac user with Podman tries to execute make test-e2e, the tests fail with the error:
```
podman run --rm --userns=keep-id -v $(pwd):/app:Z -w /app -v llm-d-gomodcache:/go/pkg/mod -v llm-d-gobuildcache:/go/cache --network=host --security-opt label=disable -v unix:///run/podman/podman.sock:unix:///run/podman/podman.sock -e CONTAINER_HOST=unix://unix:///run/podman/podman.sock -e CONTAINER_RUNTIME=podman -e KIND_EXPERIMENTAL_PROVIDER=podman -e EPP_IMAGE=[ghcr.io/llm-d/llm-d-inference-scheduler:dev](http://ghcr.io/llm-d/llm-d-inference-scheduler:dev) -e VLLM_SIMULATOR_IMAGE=[ghcr.io/llm-d/llm-d-inference-sim:v0.7.1](http://ghcr.io/llm-d/llm-d-inference-sim:v0.7.1) -e SIDECAR_IMAGE=[ghcr.io/llm-d/llm-d-routing-sidecar:dev](http://ghcr.io/llm-d/llm-d-routing-sidecar:dev) -e UDS_TOKENIZER_IMAGE=[ghcr.io/llm-d/llm-d-uds-tokenizer:dev](http://ghcr.io/llm-d/llm-d-uds-tokenizer:dev) \
		[ghcr.io/llm-d/llm-d-builder:dev](http://ghcr.io/llm-d/llm-d-builder:dev) ./test/scripts/run_e2e.sh
Error: unix:///run/podman/podman.sock:unix:///run/podman/podman.sock: incorrect volume format, should be [host-dir:]ctr-dir[:option]
make: *** [test-e2e] Error 125
```
This PR fixes the issue.

CC: @elevran , @shmuelk 