### PR TITLE
Build images use Go builtin cross compilation

### DIFF
--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -1,5 +1,5 @@
 # Go build stage
-FROM quay.io/projectquay/golang:1.25 AS go-builder
+FROM --platform=${BUILDPLATFORM} quay.io/projectquay/golang:1.25 AS go-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,5 +1,5 @@
 # Build Stage: using Go 1.25 image
-FROM quay.io/projectquay/golang:1.25 AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/projectquay/golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG COMMIT_SHA=unknown


### PR DESCRIPTION
Currently the multi-platform docker images are built using Qemu. This is slow when building for a non-native platform (ie arm64 built on amd64) and prevents amd64 images from being built on arm64 platforms (due to Qemu issues).

This PR causes the build to always use the local platform when building, but use Go's builtin cross compilation capabilities to produce the correct executables.