### PR TITLE
[fix] Added custom LevelEncoder for sidecar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
 	go.opentelemetry.io/otel/sdk v1.42.0
 	go.opentelemetry.io/otel/trace v1.42.0
+	go.uber.org/zap v1.27.1
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.79.3
 	k8s.io/api v0.35.3
@@ -114,7 +115,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -28,7 +28,10 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
@@ -283,7 +286,37 @@ func (opts *Options) Validate() error {
 	return nil
 }
 
-// NewLogger returns a logger configured from the Options logging flags.
+// customLevelEncoder maps negative Zap levels to human-readable names that
+// match the project's verbosity constants (VERBOSE=3, DEBUG=4, TRACE=5).
+// Without this, controller-runtime's zap bridge emits all V(n) calls as
+// "debug" in JSON output, which is misleading for V(1)–V(3) (verbose info).
+func customLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+	if l >= 0 {
+		zapcore.LowercaseLevelEncoder(l, enc)
+		return
+	}
+	switch l {
+	case zapcore.Level(-1 * logutil.DEBUG): // V(4) → "debug"
+		enc.AppendString("debug")
+	case zapcore.Level(-1 * logutil.TRACE): // V(5) → "trace"
+		enc.AppendString("trace")
+	default:
+		if l >= zapcore.Level(-1*logutil.VERBOSE) { // V(1)–V(3) → "info"
+			enc.AppendString("info")
+		} else { // V(6+) → "trace"
+			enc.AppendString("trace")
+		}
+	}
+}
+
+// NewLogger returns a logger configured from the Options logging flags,
+// with a custom level encoder that maps verbosity levels to their semantic
+// names instead of always rendering V(n) as "debug".
 func (opts *Options) NewLogger() logr.Logger {
-	return zap.New(zap.UseFlagOptions(&opts.loggingOptions))
+	config := uberzap.NewProductionEncoderConfig()
+	config.EncodeLevel = customLevelEncoder
+	return zap.New(
+		zap.UseFlagOptions(&opts.loggingOptions),
+		zap.Encoder(zapcore.NewJSONEncoder(config)),
+	)
 }


### PR DESCRIPTION
Add custon level encode (ported from GIE PR #2712) and updated `NewLogger()` to inject it via `zap.Encoder()`