### PR TITLE
build: switch runtime base image from ubi to static-debian12

### DIFF
--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -24,8 +24,8 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="${LDFLAGS}" -o bin/epp cmd/epp/main.go
 
 # Runtime stage
-# Use ubi9-micro as a minimal base image
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7
+# Use distroless as a minimal base image
+FROM gcr.io/distroless/static-debian12:nonroot
 
 WORKDIR /
 

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o bin/pd-sidec
        -ldflags="${LDFLAGS} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.CommitSHA=${COMMIT_SHA} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.BuildRef=${BUILD_REF}" \
        cmd/cmd.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7
+FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /workspace/bin/pd-sidecar /app/pd-sidecar
 USER 65532:65532
 


### PR DESCRIPTION
ref: https://access.redhat.com/security/cve/cve-2026-4046

still waint for confirmation if ubi-micro is impacted