### PR TITLE
[feat] [cicd] Use distroless/static as default runtime base image

### DIFF
--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -1,3 +1,10 @@
+# BASE_IMAGE can be overridden at build time, e.g.:
+#   --build-arg BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro:9.7
+# Default is distroless/static which includes CA certs and has minimal CVE surface.
+# NOTE: if using scratch, CA certificates must be copied from the builder stage:
+#   COPY --from=go-builder /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+
 # Go build stage
 FROM --platform=${BUILDPLATFORM} quay.io/projectquay/golang:1.25 AS go-builder
 
@@ -24,8 +31,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="${LDFLAGS}" -o bin/epp cmd/epp/main.go
 
 # Runtime stage
-# Use ubi9-micro as a minimal base image
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7
+FROM ${BASE_IMAGE}
 
 WORKDIR /
 

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,3 +1,10 @@
+# BASE_IMAGE can be overridden at build time, e.g.:
+#   --build-arg BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro:9.7
+# Default is distroless/static which includes CA certs and has minimal CVE surface.
+# NOTE: if using scratch, CA certificates must be copied from the builder stage:
+#   COPY --from=builder /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+
 # Build Stage: using Go 1.25 image
 FROM --platform=${BUILDPLATFORM} quay.io/projectquay/golang:1.25 AS builder
 ARG TARGETOS
@@ -28,7 +35,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o bin/pd-sidec
        -ldflags="${LDFLAGS} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.CommitSHA=${COMMIT_SHA} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.BuildRef=${BUILD_REF}" \
        cmd/cmd.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7
+# Runtime stage
+FROM ${BASE_IMAGE}
+
 COPY --from=builder /workspace/bin/pd-sidecar /app/pd-sidecar
 USER 65532:65532
 


### PR DESCRIPTION
Use distroless:static as the base image for EPP and sidecar. The distroless/static image includes CA certs and has minimal CVE surface.

The base can be easily replaced (if needed by downstream or for a particular reason) by passing (e.g.) `--build-arg BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro:9.7` at runtime.
Note: if using `scratch`, CA certificates must be copied from the builder stage:
```dockerfile
COPY --from=go-builder /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
```

For ad-hoc debugging (e.g., filesystem inspection) use ephemeral debug containers:
```console
kubectl debug -it <pod-name> -n <namespace> \
    --image=busybox \
    --target=epp \
    -- sh
```
This attaches a throwaway container with a full shell, sharing the pod's PID/network/filesystem namespace, without baking anything into the image. The `--target` flag requires the pod to have shareProcessNamespace: true or be on a recent Kubernetes (1.25+) version.