### PR TITLE
(2/2) Import igw@v1.5.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/gateway-api v1.5.1
-	sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260324083816-c5a0052e14a4
+	sigs.k8s.io/gateway-api-inference-extension v1.5.0-rc.1
 )
 
 require (

--- a/pkg/plugins/multi/context_length_aware.go
+++ b/pkg/plugins/multi/context_length_aware.go
@@ -237,7 +237,7 @@ func estimateContextLength(request *scheduling.LLMRequest) int {
 
 	// Handle regular completions
 	if request.Body.Completions != nil {
-		totalChars += len(request.Body.Completions.Prompt)
+		totalChars += len(request.Body.Completions.Prompt.PlainText())
 	}
 
 	// Convert characters to approximate token count

--- a/pkg/plugins/multi/context_length_aware_test.go
+++ b/pkg/plugins/multi/context_length_aware_test.go
@@ -278,7 +278,7 @@ func TestContextLengthAwareWithTokenizedPromptInCycleState(t *testing.T) {
 		TargetModel: "test-model",
 		Body: &scheduling.LLMRequestBody{
 			Completions: &scheduling.CompletionsRequest{
-				Prompt: "some prompt text",
+				Prompt: scheduling.Prompt{Raw: "some prompt text"},
 			},
 		},
 	}
@@ -314,7 +314,7 @@ func TestContextLengthAwareFallbackWithoutTokenizedPrompt(t *testing.T) {
 		TargetModel: "test-model",
 		Body: &scheduling.LLMRequestBody{
 			Completions: &scheduling.CompletionsRequest{
-				Prompt: prompt,
+				Prompt: scheduling.Prompt{Raw: prompt},
 			},
 		},
 	}

--- a/pkg/plugins/preparedata/tokenizer.go
+++ b/pkg/plugins/preparedata/tokenizer.go
@@ -178,8 +178,8 @@ func (p *TokenizerPlugin) tokenize(ctx context.Context, request *scheduling.LLMR
 
 	switch {
 	case request.Body.Completions != nil:
-		traceLogger.Info("Calling Render for completions", "prompt", request.Body.Completions.Prompt)
-		tokenIDs, _, err = p.tokenizer.Render(request.Body.Completions.Prompt)
+		traceLogger.Info("Calling Render for completions", "prompt", request.Body.Completions.Prompt.PlainText())
+		tokenIDs, _, err = p.tokenizer.Render(request.Body.Completions.Prompt.PlainText())
 	case request.Body.ChatCompletions != nil:
 		renderReq := ChatCompletionsToRenderChatRequest(request.Body.ChatCompletions)
 		traceLogger.Info("Calling RenderChat for chat completions", "messageCount", len(request.Body.ChatCompletions.Messages))

--- a/pkg/plugins/preparedata/tokenizer_scorer_test.go
+++ b/pkg/plugins/preparedata/tokenizer_scorer_test.go
@@ -82,7 +82,7 @@ func TestTokenizerScorer_Score(t *testing.T) {
 				RequestId: "completions",
 				Body: &scheduling.LLMRequestBody{
 					Completions: &scheduling.CompletionsRequest{
-						Prompt: "The quick brown fox",
+						Prompt: scheduling.Prompt{Raw: "The quick brown fox"},
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func TestTokenizerScorer_Score(t *testing.T) {
 			request: &scheduling.LLMRequest{
 				RequestId: "fail-open",
 				Body: &scheduling.LLMRequestBody{
-					Completions: &scheduling.CompletionsRequest{Prompt: "fail"},
+					Completions: &scheduling.CompletionsRequest{Prompt: scheduling.Prompt{Raw: "fail"}},
 				},
 			},
 			tokenizer: &mockTokenizer{
@@ -169,7 +169,7 @@ func TestTokenizerScorer_SkipsWhenAlreadyInCycleState(t *testing.T) {
 	request := &scheduling.LLMRequest{
 		RequestId: "already-tokenized",
 		Body: &scheduling.LLMRequestBody{
-			Completions: &scheduling.CompletionsRequest{Prompt: "hello"},
+			Completions: &scheduling.CompletionsRequest{Prompt: scheduling.Prompt{Raw: "hello"}},
 		},
 	}
 
@@ -292,7 +292,7 @@ func TestTokenizerScorer_Render_NilMMFeatures(t *testing.T) {
 	request := &scheduling.LLMRequest{
 		RequestId: "text-completions",
 		Body: &scheduling.LLMRequestBody{
-			Completions: &scheduling.CompletionsRequest{Prompt: "hello"},
+			Completions: &scheduling.CompletionsRequest{Prompt: scheduling.Prompt{Raw: "hello"}},
 		},
 	}
 

--- a/pkg/plugins/profile/disagg_profile_handler_test.go
+++ b/pkg/plugins/profile/disagg_profile_handler_test.go
@@ -67,7 +67,7 @@ func profileNames(m map[string]scheduling.SchedulerProfile) []string {
 func completionsRequest(prompt string) *scheduling.LLMRequest {
 	return &scheduling.LLMRequest{
 		Body: &scheduling.LLMRequestBody{
-			Completions: &scheduling.CompletionsRequest{Prompt: prompt},
+			Completions: &scheduling.CompletionsRequest{Prompt: scheduling.Prompt{Raw: prompt}},
 		},
 	}
 }
@@ -95,7 +95,7 @@ func chatRequest(hasImage, hasVideo, hasAudio bool) *scheduling.LLMRequest {
 
 // withPrompt adds a completions body to a chat request so the PD decider can estimate tokens.
 func withPrompt(req *scheduling.LLMRequest, prompt string) *scheduling.LLMRequest {
-	req.Body.Completions = &scheduling.CompletionsRequest{Prompt: prompt}
+	req.Body.Completions = &scheduling.CompletionsRequest{Prompt: scheduling.Prompt{Raw: prompt}}
 	return req
 }
 
@@ -404,7 +404,7 @@ func TestDisaggProfileHandler_Pick_PD(t *testing.T) {
 			h := NewDisaggProfileHandler(defaultDecodeProfile, defaultPrefillProfile, "",
 				decider, nil)
 
-			inputTokens := len(req.Body.Completions.Prompt) / AverageCharactersPerToken
+			inputTokens := len(req.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken
 			injectPrefixCache(tt.profileResults, tt.cachedTokens, inputTokens)
 
 			got := h.Pick(ctx, nil, req, profiles, tt.profileResults)
@@ -463,7 +463,7 @@ func TestDisaggProfileHandler_Pick_PD_Series(t *testing.T) {
 				want         []string
 			}{
 				{short, 0, []string{defaultPrefillProfile}},
-				{short, len(short.Body.Completions.Prompt) / AverageCharactersPerToken, []string{}},
+				{short, len(short.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken, []string{}},
 			},
 		},
 		{
@@ -475,7 +475,7 @@ func TestDisaggProfileHandler_Pick_PD_Series(t *testing.T) {
 				want         []string
 			}{
 				{short, 0, []string{defaultPrefillProfile}},
-				{long, len(short.Body.Completions.Prompt) / AverageCharactersPerToken, []string{defaultPrefillProfile}},
+				{long, len(short.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken, []string{defaultPrefillProfile}},
 			},
 		},
 	}
@@ -492,7 +492,7 @@ func TestDisaggProfileHandler_Pick_PD_Series(t *testing.T) {
 				results := map[string]*scheduling.ProfileRunResult{
 					defaultDecodeProfile: makeProfileRunResult("pod1"),
 				}
-				inputTokens := len(step.req.Body.Completions.Prompt) / AverageCharactersPerToken
+				inputTokens := len(step.req.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken
 				injectPrefixCache(results, step.cachedTokens, inputTokens)
 				got := h.Pick(ctx, &scheduling.CycleState{}, step.req, profiles, results)
 				assert.ElementsMatch(t, step.want, profileNames(got))
@@ -910,7 +910,7 @@ func TestDisaggProfileHandler_Pick_EPD_Full(t *testing.T) {
 
 			inputTokens := 0
 			if tt.req.Body.Completions != nil {
-				inputTokens = len(tt.req.Body.Completions.Prompt) / AverageCharactersPerToken
+				inputTokens = len(tt.req.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken
 			} else if tt.req.Body.ChatCompletions != nil {
 				b, _ := json.Marshal(tt.req.Body.ChatCompletions.Messages)
 				inputTokens = len(b) / AverageCharactersPerToken
@@ -1136,7 +1136,7 @@ func TestDisaggProfileHandler_Pick_NilDeciders(t *testing.T) {
 
 			// Inject prefix cache if needed for PD decider
 			if tt.req.Body.Completions != nil {
-				inputTokens := len(tt.req.Body.Completions.Prompt) / AverageCharactersPerToken
+				inputTokens := len(tt.req.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken
 				injectPrefixCache(tt.results, 0, inputTokens)
 			}
 

--- a/pkg/plugins/profile/pd_profile_handler.go
+++ b/pkg/plugins/profile/pd_profile_handler.go
@@ -25,7 +25,7 @@ import (
 const (
 	// PdProfileHandlerType is a legacy alias for DisaggProfileHandlerType.
 	PdProfileHandlerType     = "pd-profile-handler"
-	defaultPrefixPluginType  = prefix.PrefixCachePluginType
+	defaultPrefixPluginType  = prefix.PrefixCacheScorerPluginType
 	defaultDeciderPluginName = PrefixBasedPDDeciderPluginType
 )
 

--- a/pkg/plugins/profile/pd_profile_handler_test.go
+++ b/pkg/plugins/profile/pd_profile_handler_test.go
@@ -217,7 +217,7 @@ func createRequest(prompt string) *scheduling.LLMRequest {
 	return &scheduling.LLMRequest{
 		Body: &scheduling.LLMRequestBody{
 			Completions: &scheduling.CompletionsRequest{
-				Prompt: prompt,
+				Prompt: scheduling.Prompt{Raw: prompt},
 			},
 		},
 	}
@@ -257,16 +257,16 @@ func TestPdProfileHandler_Pick(t *testing.T) {
 		{
 			name:                 "decode not executed yet → run decode",
 			nonCachedTokensLimit: 10,
-			prefixPluginType:     prefix.PrefixCachePluginType,
-			prefixPluginName:     prefix.PrefixCachePluginType,
+			prefixPluginType:     prefix.PrefixCacheScorerPluginType,
+			prefixPluginName:     prefix.PrefixCacheScorerPluginType,
 			profileResults:       map[string]*scheduling.ProfileRunResult{},
 			expectedProfiles:     []string{defaultDecodeProfile},
 		},
 		{
 			name:                 "decode failed (nil result) → run nothing",
 			nonCachedTokensLimit: 10,
-			prefixPluginType:     prefix.PrefixCachePluginType,
-			prefixPluginName:     prefix.PrefixCachePluginType,
+			prefixPluginType:     prefix.PrefixCacheScorerPluginType,
+			prefixPluginName:     prefix.PrefixCacheScorerPluginType,
 			profileResults: map[string]*scheduling.ProfileRunResult{
 				defaultDecodeProfile: nil,
 			},
@@ -275,8 +275,8 @@ func TestPdProfileHandler_Pick(t *testing.T) {
 		{
 			name:                 "all profiles already executed → run nothing",
 			nonCachedTokensLimit: 10,
-			prefixPluginType:     prefix.PrefixCachePluginType,
-			prefixPluginName:     prefix.PrefixCachePluginType,
+			prefixPluginType:     prefix.PrefixCacheScorerPluginType,
+			prefixPluginName:     prefix.PrefixCacheScorerPluginType,
 			profileResults: map[string]*scheduling.ProfileRunResult{
 				defaultDecodeProfile:  newMockProfileRunResult(DefaultTestPodPort, "pod1"),
 				defaultPrefillProfile: newMockProfileRunResult(DefaultTestPodPort, "pod2"),
@@ -289,8 +289,8 @@ func TestPdProfileHandler_Pick(t *testing.T) {
 			// In this case: prompt length is 35 chars (8 tokens), cached length is 2 tokens -> disaggregated prefill should trigger
 			nonCachedTokensLimit: 4,
 			cachedTokens:         2,
-			prefixPluginType:     prefix.PrefixCachePluginType,
-			prefixPluginName:     prefix.PrefixCachePluginType,
+			prefixPluginType:     prefix.PrefixCacheScorerPluginType,
+			prefixPluginName:     prefix.PrefixCacheScorerPluginType,
 			profileResults: map[string]*scheduling.ProfileRunResult{
 				defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
 			},
@@ -302,8 +302,8 @@ func TestPdProfileHandler_Pick(t *testing.T) {
 			// In this case: prompt length is 35 chars (8 tokens), cached length is 5 tokens -> skip prefill
 			nonCachedTokensLimit: 4,
 			cachedTokens:         5,
-			prefixPluginType:     prefix.PrefixCachePluginType,
-			prefixPluginName:     prefix.PrefixCachePluginType,
+			prefixPluginType:     prefix.PrefixCacheScorerPluginType,
+			prefixPluginName:     prefix.PrefixCacheScorerPluginType,
 			profileResults: map[string]*scheduling.ProfileRunResult{
 				defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
 			},
@@ -327,7 +327,7 @@ func TestPdProfileHandler_Pick(t *testing.T) {
 			assert.NoError(t, err)
 
 			// set prefix to the given cached tokens number for pod "pod1" in decode profile results
-			inputTokens := len(request.Body.Completions.Prompt) / AverageCharactersPerToken
+			inputTokens := len(request.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken
 
 			for profileName, profileRes := range tt.profileResults {
 				if profileName == defaultDecodeProfile && profileRes != nil {
@@ -377,7 +377,7 @@ func TestPdProfileHandler_PickSeries(t *testing.T) {
 				expectedProfiles: []string{defaultPrefillProfile},
 			}, {
 				request:          request,
-				cachedTokens:     len(request.Body.Completions.Prompt) / AverageCharactersPerToken,
+				cachedTokens:     len(request.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken,
 				expectedProfiles: []string{},
 			}},
 		}, {
@@ -391,7 +391,7 @@ func TestPdProfileHandler_PickSeries(t *testing.T) {
 				expectedProfiles: []string{defaultPrefillProfile},
 			}, {
 				request:          longerRequest,
-				cachedTokens:     len(request.Body.Completions.Prompt) / AverageCharactersPerToken,
+				cachedTokens:     len(request.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken,
 				expectedProfiles: []string{},
 			}},
 		}, {
@@ -405,7 +405,7 @@ func TestPdProfileHandler_PickSeries(t *testing.T) {
 				expectedProfiles: []string{defaultPrefillProfile},
 			}, {
 				request:          longRequest,
-				cachedTokens:     len(request.Body.Completions.Prompt) / AverageCharactersPerToken,
+				cachedTokens:     len(request.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken,
 				expectedProfiles: []string{defaultPrefillProfile},
 			}},
 		},
@@ -419,8 +419,8 @@ func TestPdProfileHandler_PickSeries(t *testing.T) {
 			handler, err := NewPdProfileHandler(
 				defaultPrefillProfile,
 				defaultDecodeProfile,
-				prefix.PrefixCachePluginType,
-				prefix.PrefixCachePluginType,
+				prefix.PrefixCacheScorerPluginType,
+				prefix.PrefixCacheScorerPluginType,
 				0,
 				deciderPlugin,
 			)
@@ -431,7 +431,7 @@ func TestPdProfileHandler_PickSeries(t *testing.T) {
 				cs := &scheduling.CycleState{}
 
 				// set prefix to the given cached tokens number for pod "pod1" in decode profile results
-				inputTokens := len(innerTest.request.Body.Completions.Prompt) / AverageCharactersPerToken
+				inputTokens := len(innerTest.request.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken
 
 				for profileName, profileRes := range profileResults {
 					if profileName == defaultDecodeProfile && profileRes != nil {
@@ -519,8 +519,8 @@ func TestPdProfileHandler_ProcessResults(t *testing.T) {
 			handler, err := NewPdProfileHandler(
 				defaultPrefillProfile,
 				defaultDecodeProfile,
-				prefix.PrefixCachePluginType,
-				prefix.PrefixCachePluginType,
+				prefix.PrefixCacheScorerPluginType,
+				prefix.PrefixCacheScorerPluginType,
 				tt.primaryPort,
 				deciderPlugin,
 			)

--- a/pkg/plugins/profile/prefix_based_pd_decider.go
+++ b/pkg/plugins/profile/prefix_based_pd_decider.go
@@ -153,7 +153,7 @@ func getUserInputLenInTokens(request *scheduling.LLMRequest) (int, error) {
 		return 0, errors.New("request or request body is nil")
 	}
 	if request.Body.Completions != nil {
-		return len(request.Body.Completions.Prompt) / AverageCharactersPerToken, nil
+		return len(request.Body.Completions.Prompt.PlainText()) / AverageCharactersPerToken, nil
 	}
 	if request.Body.ChatCompletions == nil {
 		return 0, errors.New("request has neither completions nor chat completions body")

--- a/pkg/plugins/scorer/no_hit_lru.go
+++ b/pkg/plugins/scorer/no_hit_lru.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 )
 
@@ -66,7 +67,7 @@ func NoHitLRUFactory(name string, rawParameters json.RawMessage, handle plugin.H
 	}
 
 	if parameters.PrefixPluginName == "" {
-		parameters.PrefixPluginName = prefix.PrefixCachePluginType
+		parameters.PrefixPluginName = prefix.PrefixCacheScorerPluginType
 	}
 
 	// Note: We don't enforce that the prefix plugin exists here
@@ -77,8 +78,8 @@ func NoHitLRUFactory(name string, rawParameters json.RawMessage, handle plugin.H
 
 // NewNoHitLRU creates a new NoHitLRU scorer
 func NewNoHitLRU(ctx context.Context, params *NoHitLRUParameters) *NoHitLRU {
-	prefixPluginType := prefix.PrefixCachePluginType
-	prefixPluginName := prefix.PrefixCachePluginType
+	prefixPluginType := prefix.PrefixCacheScorerPluginType
+	prefixPluginName := prefix.PrefixCacheScorerPluginType
 	lruSize := defaultLRUSize
 
 	if params != nil {
@@ -140,7 +141,7 @@ func (s *NoHitLRU) isColdRequest(ctx context.Context, cycleState *scheduling.Cyc
 
 	// Read prefix cache state to determine if this is a cold request
 	// This is treated as an optimization - if the state isn't available, we assume cold request
-	prefixState, err := scheduling.ReadCycleStateKey[*prefix.SchedulingContextState](cycleState, plugin.StateKey(s.prefixPluginTypedName.String()))
+	prefixState, err := scheduling.ReadCycleStateKey[*approximateprefix.SchedulingContextState](cycleState, plugin.StateKey(s.prefixPluginTypedName.String()))
 
 	if err != nil {
 		logger.Info("No prefix cache state found, treating as cold request for LRU optimization", "error", err)

--- a/pkg/plugins/scorer/no_hit_lru_test.go
+++ b/pkg/plugins/scorer/no_hit_lru_test.go
@@ -12,6 +12,7 @@ import (
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/plugins/scorer"
@@ -82,7 +83,6 @@ func TestNoHitLRUFactoryDependencyValidation(t *testing.T) {
 			name: "prefix plugin present - should work",
 			handle: func() *fakeHandle {
 				h := newFakeHandle(utils.NewTestContext(t))
-				h.AddPlugin(prefix.PrefixCachePluginType, &stubPlugin{name: plugin.TypedName{Type: prefix.PrefixCachePluginType, Name: prefix.PrefixCachePluginType}})
 				return h
 			}(),
 			expectError: false,
@@ -142,7 +142,7 @@ func TestNoHitLRUScorer(t *testing.T) {
 		scorer      scheduling.Scorer
 		req         *scheduling.LLMRequest
 		input       []scheduling.Endpoint
-		prefixState *prefix.SchedulingContextState
+		prefixState *approximateprefix.SchedulingContextState
 		wantScores  map[scheduling.Endpoint]float64
 		description string
 	}{
@@ -153,8 +153,8 @@ func TestNoHitLRUScorer(t *testing.T) {
 				TargetModel: "test-model",
 			},
 			input: []scheduling.Endpoint{endpointA, endpointB, endpointC},
-			prefixState: &prefix.SchedulingContextState{
-				PrefixCacheServers: make(map[prefix.ServerID]int), // empty = cold request
+			prefixState: &approximateprefix.SchedulingContextState{
+				PrefixCacheServers: make(map[approximateprefix.ServerID]int), // empty = cold request
 			},
 			wantScores: map[scheduling.Endpoint]float64{
 				endpointA: 1.0, // All never-used endpoints get high scores
@@ -170,8 +170,8 @@ func TestNoHitLRUScorer(t *testing.T) {
 				TargetModel: "test-model",
 			},
 			input: []scheduling.Endpoint{endpointA, endpointB, endpointC},
-			prefixState: &prefix.SchedulingContextState{
-				PrefixCacheServers: map[prefix.ServerID]int{
+			prefixState: &approximateprefix.SchedulingContextState{
+				PrefixCacheServers: map[approximateprefix.ServerID]int{
 					{Name: "server1", Namespace: "default"}: 5, // non-empty = cache hit
 				},
 			},
@@ -189,8 +189,8 @@ func TestNoHitLRUScorer(t *testing.T) {
 				TargetModel: "test-model",
 			},
 			input: []scheduling.Endpoint{endpointA},
-			prefixState: &prefix.SchedulingContextState{
-				PrefixCacheServers: make(map[prefix.ServerID]int), // empty = cold request
+			prefixState: &approximateprefix.SchedulingContextState{
+				PrefixCacheServers: make(map[approximateprefix.ServerID]int), // empty = cold request
 			},
 			wantScores: map[scheduling.Endpoint]float64{
 				endpointA: 1.0, // Single endpoint gets max score
@@ -204,8 +204,8 @@ func TestNoHitLRUScorer(t *testing.T) {
 			// Create cycle state and set prefix state
 			cycleState := &scheduling.CycleState{}
 			if test.prefixState != nil {
-				cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCachePluginType,
-					Name: prefix.PrefixCachePluginType}.String()), test.prefixState)
+				cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCacheScorerPluginType,
+					Name: prefix.PrefixCacheScorerPluginType}.String()), test.prefixState)
 			}
 
 			got := test.scorer.Score(utils.NewTestContext(t), cycleState, test.req, test.input)
@@ -236,12 +236,12 @@ func TestNoHitLRUBasicFunctionality(t *testing.T) {
 	endpoints := []scheduling.Endpoint{endpointA, endpointB}
 
 	// Test basic scoring for cold request (no crashes, returns valid scores)
-	coldPrefixState := &prefix.SchedulingContextState{
-		PrefixCacheServers: make(map[prefix.ServerID]int), // empty = cold request
+	coldPrefixState := &approximateprefix.SchedulingContextState{
+		PrefixCacheServers: make(map[approximateprefix.ServerID]int), // empty = cold request
 	}
 	cycleState := &scheduling.CycleState{}
-	cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCachePluginType,
-		Name: prefix.PrefixCachePluginType}.String()), coldPrefixState)
+	cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCacheScorerPluginType,
+		Name: prefix.PrefixCacheScorerPluginType}.String()), coldPrefixState)
 
 	scores := scorer.Score(ctx, cycleState, &scheduling.LLMRequest{}, endpoints)
 
@@ -304,10 +304,10 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	endpoints := []scheduling.Endpoint{endpointA, endpointB, endpointC}
 
 	primaryProfile := "primary-profile"
-	toPrefixState := func(entries map[prefix.ServerID]int) *scheduling.CycleState {
+	toPrefixState := func(entries map[approximateprefix.ServerID]int) *scheduling.CycleState {
 		cycle := &scheduling.CycleState{}
-		cycle.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCachePluginType,
-			Name: prefix.PrefixCachePluginType}.String()), &prefix.SchedulingContextState{PrefixCacheServers: entries})
+		cycle.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCacheScorerPluginType,
+			Name: prefix.PrefixCacheScorerPluginType}.String()), &approximateprefix.SchedulingContextState{PrefixCacheServers: entries})
 		return cycle
 	}
 
@@ -326,7 +326,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	assertHighestScoredPod := func(expectedEndpoint scheduling.Endpoint, testName string) {
 		t.Helper()
 		coldReq := &scheduling.LLMRequest{RequestId: testName + "-scoring-check"}
-		scores := scorer.Score(ctx, toPrefixState(make(map[prefix.ServerID]int)), coldReq, endpoints)
+		scores := scorer.Score(ctx, toPrefixState(make(map[approximateprefix.ServerID]int)), coldReq, endpoints)
 
 		highestScore := -1.0
 		var highestEndpoint scheduling.Endpoint
@@ -348,7 +348,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 
 	t.Run("initial cold request seeds cache", func(_ *testing.T) {
 		coldReqA := &scheduling.LLMRequest{RequestId: "cold-1"}
-		scorer.Score(ctx, toPrefixState(make(map[prefix.ServerID]int)), coldReqA, endpoints)
+		scorer.Score(ctx, toPrefixState(make(map[approximateprefix.ServerID]int)), coldReqA, endpoints)
 		scorer.PreRequest(ctx, coldReqA, requestToEndpoint(endpointA))
 		// After endpointA handles a cold request, other endpoints should score higher for new cold requests
 		assertHighestScoredPod(endpointB, "after-endpointA-used")
@@ -356,7 +356,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 
 	t.Run("unused endpoints rank above existing ones", func(t *testing.T) {
 		coldReqCheck := &scheduling.LLMRequest{RequestId: "cold-check"}
-		coldScores := scorer.Score(ctx, toPrefixState(make(map[prefix.ServerID]int)), coldReqCheck, endpoints)
+		coldScores := scorer.Score(ctx, toPrefixState(make(map[approximateprefix.ServerID]int)), coldReqCheck, endpoints)
 		if coldScores[endpointB] <= coldScores[endpointA] {
 			t.Fatalf("expected endpoint-b to outrank endpoint-a after endpoint-a handled previous cold request, scores=%+v", coldScores)
 		}
@@ -370,7 +370,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 
 	t.Run("warm request leaves LRU untouched", func(t *testing.T) {
 		warmReq := &scheduling.LLMRequest{RequestId: "warm-1"}
-		warmState := map[prefix.ServerID]int{
+		warmState := map[approximateprefix.ServerID]int{
 			{Name: "server1", Namespace: "default"}: 1,
 		}
 		warmScores := scorer.Score(ctx, toPrefixState(warmState), warmReq, endpoints)
@@ -381,7 +381,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 		}
 		scorer.PreRequest(ctx, warmReq, requestToEndpoint(endpointB))
 		postWarmReq := &scheduling.LLMRequest{RequestId: "cold-after-warm"}
-		postWarmScores := scorer.Score(ctx, toPrefixState(make(map[prefix.ServerID]int)), postWarmReq, endpoints)
+		postWarmScores := scorer.Score(ctx, toPrefixState(make(map[approximateprefix.ServerID]int)), postWarmReq, endpoints)
 		if postWarmScores[endpointB] <= postWarmScores[endpointA] {
 			t.Fatalf("expected warm request to leave ordering unchanged, scores=%+v", postWarmScores)
 		}
@@ -390,7 +390,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	t.Run("second cold request rotates to endpointB", func(_ *testing.T) {
 		// Simulate endpointB handling a cold request
 		coldReqB := &scheduling.LLMRequest{RequestId: "cold-2"}
-		scorer.Score(ctx, toPrefixState(make(map[prefix.ServerID]int)), coldReqB, endpoints)
+		scorer.Score(ctx, toPrefixState(make(map[approximateprefix.ServerID]int)), coldReqB, endpoints)
 		scorer.PreRequest(ctx, coldReqB, requestToEndpoint(endpointB))
 		// Now endpointC should score highest since both endpointA and endpointB have been used
 		assertHighestScoredPod(endpointC, "after-endpointB-used")
@@ -399,7 +399,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	t.Run("third cold request rotates back to endpointA", func(_ *testing.T) {
 		// Simulate endpointC handling a cold request
 		coldReqC := &scheduling.LLMRequest{RequestId: "cold-3"}
-		scorer.Score(ctx, toPrefixState(make(map[prefix.ServerID]int)), coldReqC, endpoints)
+		scorer.Score(ctx, toPrefixState(make(map[approximateprefix.ServerID]int)), coldReqC, endpoints)
 		scorer.PreRequest(ctx, coldReqC, requestToEndpoint(endpointC))
 		// Now endpointA should score highest again (LRU rotation)
 		assertHighestScoredPod(endpointA, "after-endpointC-used")
@@ -419,9 +419,9 @@ func TestNoHitLRUEdgeCases(t *testing.T) {
 	t.Run("empty endpoints list", func(t *testing.T) {
 		emptyEndpoints := []scheduling.Endpoint{}
 		cycleState := &scheduling.CycleState{}
-		cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCachePluginType,
-			Name: prefix.PrefixCachePluginType}.String()), &prefix.SchedulingContextState{
-			PrefixCacheServers: make(map[prefix.ServerID]int), // cold request
+		cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCacheScorerPluginType,
+			Name: prefix.PrefixCacheScorerPluginType}.String()), &approximateprefix.SchedulingContextState{
+			PrefixCacheServers: make(map[approximateprefix.ServerID]int), // cold request
 		})
 
 		scores := scorer.Score(ctx, cycleState, &scheduling.LLMRequest{}, emptyEndpoints)
@@ -433,9 +433,9 @@ func TestNoHitLRUEdgeCases(t *testing.T) {
 
 	t.Run("nil endpoints list", func(t *testing.T) {
 		cycleState := &scheduling.CycleState{}
-		cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCachePluginType,
-			Name: prefix.PrefixCachePluginType}.String()), &prefix.SchedulingContextState{
-			PrefixCacheServers: make(map[prefix.ServerID]int), // cold request
+		cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCacheScorerPluginType,
+			Name: prefix.PrefixCacheScorerPluginType}.String()), &approximateprefix.SchedulingContextState{
+			PrefixCacheServers: make(map[approximateprefix.ServerID]int), // cold request
 		})
 
 		scores := scorer.Score(ctx, cycleState, &scheduling.LLMRequest{}, nil)
@@ -451,9 +451,9 @@ func TestNoHitLRUEdgeCases(t *testing.T) {
 	t.Run("single endpoint returns 1.0", func(t *testing.T) {
 		endpoints := []scheduling.Endpoint{endpointA}
 		cycleState := &scheduling.CycleState{}
-		cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCachePluginType,
-			Name: prefix.PrefixCachePluginType}.String()), &prefix.SchedulingContextState{
-			PrefixCacheServers: make(map[prefix.ServerID]int), // cold request
+		cycleState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCacheScorerPluginType,
+			Name: prefix.PrefixCacheScorerPluginType}.String()), &approximateprefix.SchedulingContextState{
+			PrefixCacheServers: make(map[approximateprefix.ServerID]int), // cold request
 		})
 
 		scores := scorer.Score(ctx, cycleState, &scheduling.LLMRequest{}, endpoints)
@@ -493,8 +493,9 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 	decodeEndpoints := []scheduling.Endpoint{decodeEndpointA, decodeEndpointB}
 
 	coldPrefixState := &scheduling.CycleState{}
-	coldPrefixState.Write(plugin.StateKey(prefix.PrefixCachePluginType), &prefix.SchedulingContextState{
-		PrefixCacheServers: make(map[prefix.ServerID]int), // empty = cold request
+	coldPrefixState.Write(plugin.StateKey(plugin.TypedName{Type: prefix.PrefixCacheScorerPluginType,
+		Name: prefix.PrefixCacheScorerPluginType}.String()), &approximateprefix.SchedulingContextState{
+		PrefixCacheServers: make(map[approximateprefix.ServerID]int), // empty = cold request
 	})
 
 	ctx := context.Background()

--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	dl_prefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer/prefix"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/plugins/preparedata"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
@@ -497,9 +497,8 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *schedu
 	}
 
 	// Write prefix cache state to cycle state.
-	prefixCacheState := &prefix.SchedulingContextState{
-		PrefixHashes:       []prefix.BlockHash{},
-		PrefixCacheServers: map[prefix.ServerID]int{},
+	prefixCacheState := &approximateprefix.SchedulingContextState{
+		PrefixCacheServers: map[approximateprefix.ServerID]int{},
 	}
 	for _, endpoint := range endpoints {
 		key, ok := endpointToKey(endpoint)
@@ -507,7 +506,7 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *schedu
 			continue
 		}
 		if s, exists := scores[key]; exists && s > 0 {
-			prefixCacheState.PrefixCacheServers[prefix.ServerID(endpoint.GetMetadata().NamespacedName)] = int(s)
+			prefixCacheState.PrefixCacheServers[approximateprefix.ServerID(endpoint.GetMetadata().NamespacedName)] = int(s)
 		}
 	}
 	cycleState.Write(plugin.StateKey(s.typedName.String()), prefixCacheState)
@@ -636,7 +635,7 @@ func (s *PrecisePrefixCacheScorer) computeBlockKeys(ctx context.Context,
 
 	// Regular completions path
 	if request.Body.Completions != nil {
-		return s.kvCacheIndexer.ComputeBlockKeys(ctx, nil, request.Body.Completions.Prompt, request.TargetModel)
+		return s.kvCacheIndexer.ComputeBlockKeys(ctx, nil, request.Body.Completions.Prompt.PlainText(), request.TargetModel)
 	}
 
 	return nil, nil
@@ -713,7 +712,7 @@ func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, cycleState *sc
 
 	// For regular completions, use the prompt directly
 	if request.Body != nil && request.Body.Completions != nil {
-		prompt := request.Body.Completions.Prompt
+		prompt := request.Body.Completions.Prompt.PlainText()
 		traceLogger.Info("Using completion prompt directly", "promptLength", len(prompt))
 
 		scores, err := s.kvCacheIndexer.GetPodScores(ctx, nil, prompt, request.TargetModel, nil)

--- a/pkg/plugins/scorer/precise_prefix_cache_tokenized_test.go
+++ b/pkg/plugins/scorer/precise_prefix_cache_tokenized_test.go
@@ -226,7 +226,7 @@ func TestPrecisePrefixCacheScorer_SkipsTokenizedPromptWhenEmpty(t *testing.T) {
 		RequestId:   "test-skip-empty",
 		TargetModel: "test-model",
 		Body: &scheduling.LLMRequestBody{
-			Completions: &scheduling.CompletionsRequest{Prompt: "hello"},
+			Completions: &scheduling.CompletionsRequest{Prompt: scheduling.Prompt{Raw: "hello"}},
 		},
 	}
 

--- a/pkg/plugins/scorer/precise_prefix_cache_uds_test.go
+++ b/pkg/plugins/scorer/precise_prefix_cache_uds_test.go
@@ -132,7 +132,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				TargetModel: "test-model",
 				Body: &scheduling.LLMRequestBody{
 					Completions: &scheduling.CompletionsRequest{
-						Prompt: prompt,
+						Prompt: scheduling.Prompt{Raw: prompt},
 					},
 				},
 			},
@@ -145,7 +145,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					require.NoError(t, err)
 				}()
 
-				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt)
+				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.PlainText())
 				require.NoError(t, err)
 
 				tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
@@ -317,7 +317,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				TargetModel: "test-model",
 				Body: &scheduling.LLMRequestBody{
 					Completions: &scheduling.CompletionsRequest{
-						Prompt: prompt,
+						Prompt: scheduling.Prompt{Raw: prompt},
 					},
 				},
 			},
@@ -330,7 +330,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					require.NoError(t, err)
 				}()
 
-				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt)
+				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.PlainText())
 				require.NoError(t, err)
 
 				tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
@@ -388,7 +388,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				TargetModel: "test-model",
 				Body: &scheduling.LLMRequestBody{
 					Completions: &scheduling.CompletionsRequest{
-						Prompt: prompt,
+						Prompt: scheduling.Prompt{Raw: prompt},
 					},
 				},
 			},
@@ -401,7 +401,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					require.NoError(t, err)
 				}()
 
-				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt)
+				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.PlainText())
 				require.NoError(t, err)
 
 				tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
@@ -462,7 +462,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				TargetModel: "test-model",
 				Body: &scheduling.LLMRequestBody{
 					Completions: &scheduling.CompletionsRequest{
-						Prompt: "This prompt has never been cached before on any endpoint.",
+						Prompt: scheduling.Prompt{Raw: "This prompt has never been cached before on any endpoint."},
 					},
 				},
 			},
@@ -510,7 +510,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				TargetModel: "test-model",
 				Body: &scheduling.LLMRequestBody{
 					Completions: &scheduling.CompletionsRequest{
-						Prompt: prompt,
+						Prompt: scheduling.Prompt{Raw: prompt},
 					},
 				},
 			},
@@ -523,7 +523,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					require.NoError(t, err)
 				}()
 
-				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt)
+				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.PlainText())
 				require.NoError(t, err)
 
 				tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())

--- a/pkg/scheduling/pd/scheduler_test.go
+++ b/pkg/scheduling/pd/scheduler_test.go
@@ -3,7 +3,6 @@ package pd_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
@@ -107,7 +106,7 @@ func TestPDSchedule(t *testing.T) {
 				TargetModel: "any-model",
 				Body: &fwkschd.LLMRequestBody{
 					Completions: &fwkschd.CompletionsRequest{
-						Prompt: "12345678901",
+						Prompt: fwkschd.Prompt{Raw: "12345678901"},
 					},
 				},
 			},
@@ -121,7 +120,7 @@ func TestPDSchedule(t *testing.T) {
 				TargetModel: "critical",
 				Body: &fwkschd.LLMRequestBody{
 					Completions: &fwkschd.CompletionsRequest{
-						Prompt: "12345678901",
+						Prompt: fwkschd.Prompt{Raw: "12345678901"},
 					},
 				},
 			},
@@ -136,7 +135,7 @@ func TestPDSchedule(t *testing.T) {
 				TargetModel: "critical",
 				Body: &fwkschd.LLMRequestBody{
 					Completions: &fwkschd.CompletionsRequest{
-						Prompt: "12345678901",
+						Prompt: fwkschd.Prompt{Raw: "12345678901"},
 					},
 				},
 			},
@@ -151,7 +150,7 @@ func TestPDSchedule(t *testing.T) {
 				TargetModel: "critical",
 				Body: &fwkschd.LLMRequestBody{
 					Completions: &fwkschd.CompletionsRequest{
-						Prompt: "12345678906",
+						Prompt: fwkschd.Prompt{Raw: "12345678906"},
 					},
 				},
 			},
@@ -167,7 +166,7 @@ func TestPDSchedule(t *testing.T) {
 				TargetModel: "critical",
 				Body: &fwkschd.LLMRequestBody{
 					Completions: &fwkschd.CompletionsRequest{
-						Prompt: "12345",
+						Prompt: fwkschd.Prompt{Raw: "12345"},
 					},
 				},
 			},
@@ -184,7 +183,7 @@ func TestPDSchedule(t *testing.T) {
 				TargetModel: "critical",
 				Body: &fwkschd.LLMRequestBody{
 					Completions: &fwkschd.CompletionsRequest{
-						Prompt: "12345678901",
+						Prompt: fwkschd.Prompt{Raw: "12345678901"},
 					},
 				},
 			},
@@ -216,7 +215,7 @@ func TestPDSchedule(t *testing.T) {
 				TargetModel: "critical",
 				Body: &fwkschd.LLMRequestBody{
 					Completions: &fwkschd.CompletionsRequest{
-						Prompt: "1234567890123456789012345678901234567890",
+						Prompt: fwkschd.Prompt{Raw: "1234567890123456789012345678901234567890"},
 					},
 				},
 			},
@@ -235,7 +234,7 @@ func TestPDSchedule(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			//  initialize scheduler with config
-			prefixScorer, err := prefix.New(ctx, prefix.Config{AutoTune: false, BlockSizeTokens: 2, MaxPrefixBlocksToMatch: 256, LRUCapacityPerServer: 31250})
+			prefixScorer, err := prefix.New(ctx)
 			assert.NoError(t, err, "Prefix plugin creation returned unexpected error")
 
 			prefillSchedulerProfile := scheduling.NewSchedulerProfile().
@@ -263,7 +262,7 @@ func TestPDSchedule(t *testing.T) {
 			})
 			scheduler := scheduling.NewSchedulerWithConfig(schedulerConfig)
 
-			inputTokens := len(test.req.Body.Completions.Prompt) / profile.AverageCharactersPerToken
+			inputTokens := len(test.req.Body.Completions.Prompt.PlainText()) / profile.AverageCharactersPerToken
 			for _, pod := range test.input {
 				pod.Put(dl_prefix.PrefixCacheMatchInfoKey, dl_prefix.NewPrefixCacheMatchInfo(0, inputTokens, 1))
 			}
@@ -277,10 +276,6 @@ func TestPDSchedule(t *testing.T) {
 				t.Errorf("Unexpected output (-want +got): %v", diff)
 			}
 			if test.wantRes2 != nil { // Checking the prefix match in the decode pod.
-				// make sure prefix plugin stores the prefix hit in cache, so we can test it in the following schedule call
-				prefixScorer.PreRequest(ctx, test.req, got)
-				time.Sleep(time.Second)
-
 				// update number of cached tokens "stored" in the first schedule execution
 				for _, pod := range test.input {
 					pod.Put(dl_prefix.PrefixCacheMatchInfoKey, dl_prefix.NewPrefixCacheMatchInfo(inputTokens, inputTokens, 1))

--- a/test/config/prefix_cache_mode_test.go
+++ b/test/config/prefix_cache_mode_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestPrecisePrefixCacheScorer(t *testing.T) {
+	if _, err := os.Stat("/tmp/tokenizer/tokenizer-uds.socket"); os.IsNotExist(err) {
+		t.Skip("UDS tokenizer socket not available, skipping test")
+	}
+
 	tests := []struct {
 		name       string
 		pluginName string
@@ -33,6 +37,9 @@ plugins:
   parameters:
     kvEventsConfig:
       zmqEndpoint: "tcp://localhost:5557"
+    indexerConfig:
+      tokenizersPoolConfig:
+        modelName: "test-model"
 - name: profileHandler
   type: single-profile-handler
 schedulingProfiles:


### PR DESCRIPTION
Import igw@v1.5.0-rc.1.

This is based on #806

Changes resolved are:
1. the approximate prefix cache is split in to different packages https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2453
2. Support prompt array https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2724