### PR TITLE
feat: add approximate scoring mode with recency-weighted scoring

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -749,6 +749,23 @@ Requires the `prepareDataPlugins` feature gate and KV events from vLLM engines.
 
 ---
 
+### Approximate Scoring Mode
+
+Approximate scoring enables prefix-cache-aware routing without KV events or a tokenizer. It uses xxhash-based prompt hashing and a self-reported LRU indexer (ported from the IGW `prefix-cache-scorer`). This is useful for model servers that don't support the KV event protocol.
+
+Enable via `precise-prefix-cache-scorer` parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `mode` | string | `"precise"` | Scoring mode: `"precise"`, `"approximate"`, or `"unified"`. |
+| `approximateConfig.blockSizeTokens` | int | `16` | Block size in tokens (converted to characters via 4x multiplier). |
+| `approximateConfig.maxPrefixBlocksToMatch` | int | `256` | Maximum prefix blocks to hash per request. |
+| `approximateConfig.lruCapacityPerServer` | int | `31250` | LRU cache capacity per pod. |
+| `approximateConfig.autoTune` | bool | `true` | Dynamically adjust block size and LRU capacity from endpoint metrics. |
+| `approximateConfig.recencyHalfLife` | duration string | (disabled) | Half-life for recency-weighted scoring (e.g. `"30s"`). |
+
+---
+
 ## Metric Scraping
 
 - Scrapers collect metrics (e.g., memory usage, active adapters)

--- a/pkg/plugins/scorer/approximate_hasher.go
+++ b/pkg/plugins/scorer/approximate_hasher.go
@@ -1,17 +1,15 @@
 package scorer
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 
 	"github.com/cespare/xxhash/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
-
-	"context"
-
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
 // ApproximateBlockHash is an xxhash64-based block hash for approximate prefix matching.

--- a/pkg/plugins/scorer/approximate_hasher.go
+++ b/pkg/plugins/scorer/approximate_hasher.go
@@ -1,0 +1,151 @@
+package scorer
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+
+	"github.com/cespare/xxhash/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+
+	"context"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+)
+
+// ApproximateBlockHash is an xxhash64-based block hash for approximate prefix matching.
+// Unlike the precise scorer's kvblock.BlockHash (SHA256, token-based), this uses
+// character-level chunking with xxhash for fast, tokenizer-free hashing.
+type ApproximateBlockHash uint64
+
+const (
+	// averageCharactersPerToken is the estimated average characters per token,
+	// used to approximate token-level block boundaries without a tokenizer.
+	averageCharactersPerToken = 4
+
+	// defaultApproxBlockSizeTokens is the default block size in tokens for approximate mode.
+	// Matches vLLM's default block size.
+	defaultApproxBlockSizeTokens = 16
+
+	// defaultApproxMaxPrefixBlocks is the maximum number of prefix blocks to hash per request.
+	defaultApproxMaxPrefixBlocks = 256
+)
+
+// hashPrompt computes rolling xxhash64 block hashes from the request prompt.
+//
+// The algorithm:
+//  1. Extract serialized user input from the request (supports 4 API types)
+//  2. Convert block size from tokens to characters (tokens * 4)
+//  3. Seed the hash chain with the model name + optional CacheSalt
+//  4. For each fixed-size character block: hash(block_content + prev_hash)
+//
+// The rolling chain ensures that identical prefixes produce identical hash sequences
+// regardless of suffix, enabling greedy longest-prefix matching.
+func hashPrompt(ctx context.Context, request *scheduling.LLMRequest, blockSizeTokens, maxPrefixBlocks int) []ApproximateBlockHash {
+	logger := log.FromContext(ctx).V(logutil.DEBUG)
+
+	if request == nil || request.Body == nil {
+		logger.Info("Request or request data is nil, skipping hashing")
+		return nil
+	}
+
+	userInput, err := getUserInputBytes(request)
+	if err != nil {
+		logger.Error(err, "Failed to get user input bytes")
+		return nil
+	}
+
+	// Convert block size from tokens to characters.
+	cacheBlockSizeChars := blockSizeTokens * averageCharactersPerToken
+
+	if len(userInput) < cacheBlockSizeChars {
+		logger.Info("Request body too small for prefix cache",
+			"size", len(userInput), "blockSizeChars", cacheBlockSizeChars)
+		return nil
+	}
+
+	// Truncate to maxPrefixBlocks to bound hashing cost.
+	if len(userInput) > cacheBlockSizeChars*maxPrefixBlocks {
+		logger.Info("Truncating input",
+			"size", len(userInput), "maxPrefixBlocks", maxPrefixBlocks,
+			"blockSizeChars", cacheBlockSizeChars)
+		userInput = userInput[:maxPrefixBlocks*cacheBlockSizeChars]
+	}
+
+	res := make([]ApproximateBlockHash, 0, len(userInput)/cacheBlockSizeChars)
+
+	// Seed the chain with model name + optional CacheSalt so that
+	// different models produce different hashes for the same prompt.
+	h := xxhash.New()
+	_, _ = h.Write([]byte(request.TargetModel))
+	if cacheSalt := request.Body.CacheSalt(); cacheSalt != "" {
+		_, _ = h.Write([]byte(cacheSalt))
+	}
+	prevBlockHash := ApproximateBlockHash(h.Sum64())
+
+	// Rolling hash chain: each block depends on the previous block's hash.
+	for i := 0; i+cacheBlockSizeChars <= len(userInput); i += cacheBlockSizeChars {
+		h.Reset()
+		_, _ = h.Write(userInput[i : i+cacheBlockSizeChars])
+		_, _ = h.Write(approxHashToBytes(prevBlockHash))
+		hash := ApproximateBlockHash(h.Sum64())
+		res = append(res, hash)
+		prevBlockHash = hash
+	}
+
+	return res
+}
+
+// getUserInputBytes extracts a serializable byte representation of the user's
+// input from the request body. Each API format is handled to produce a
+// deterministic byte sequence suitable for hashing.
+func getUserInputBytes(request *scheduling.LLMRequest) ([]byte, error) {
+	if request.Body == nil {
+		return nil, errors.New("request body is nil")
+	}
+
+	switch {
+	case request.Body.Conversations != nil:
+		return json.Marshal(request.Body.Conversations.Items)
+
+	case request.Body.Responses != nil:
+		if request.Body.Responses.Input == nil {
+			return nil, errors.New("responses request has nil input")
+		}
+		// Ordered slice ensures deterministic marshaling:
+		// instructions -> tools -> input
+		var combined []map[string]interface{}
+		if request.Body.Responses.Instructions != nil {
+			combined = append(combined, map[string]interface{}{
+				"instructions": request.Body.Responses.Instructions,
+			})
+		}
+		if request.Body.Responses.Tools != nil {
+			combined = append(combined, map[string]interface{}{
+				"tools": request.Body.Responses.Tools,
+			})
+		}
+		combined = append(combined, map[string]interface{}{
+			"input": request.Body.Responses.Input,
+		})
+		return json.Marshal(combined)
+
+	case request.Body.ChatCompletions != nil:
+		return json.Marshal(request.Body.ChatCompletions.Messages)
+
+	case request.Body.Completions != nil:
+		return []byte(request.Body.Completions.Prompt), nil
+
+	default:
+		return nil, errors.New("invalid request body: no recognized API format found")
+	}
+}
+
+// approxHashToBytes converts an ApproximateBlockHash to an 8-byte little-endian
+// representation for use in the rolling hash chain.
+func approxHashToBytes(h ApproximateBlockHash) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, uint64(h))
+	return b
+}

--- a/pkg/plugins/scorer/approximate_hasher_test.go
+++ b/pkg/plugins/scorer/approximate_hasher_test.go
@@ -1,0 +1,261 @@
+package scorer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+func TestHashPrompt_Deterministic(t *testing.T) {
+	ctx := context.Background()
+	req := &scheduling.LLMRequest{
+		TargetModel: "llama3-8b",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt: "Hello, how are you doing today? This is a test prompt for hashing.",
+			},
+		},
+	}
+
+	hashes1 := hashPrompt(ctx, req, 1, 256) // blockSize=1 token = 4 chars
+	hashes2 := hashPrompt(ctx, req, 1, 256)
+
+	require.NotEmpty(t, hashes1)
+	assert.Equal(t, hashes1, hashes2, "same input should produce same hashes")
+}
+
+func TestHashPrompt_ModelScoped(t *testing.T) {
+	ctx := context.Background()
+	prompt := "Hello, how are you doing today? This is a test prompt for hashing."
+
+	reqA := &scheduling.LLMRequest{
+		TargetModel: "model-a",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: prompt},
+		},
+	}
+	reqB := &scheduling.LLMRequest{
+		TargetModel: "model-b",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: prompt},
+		},
+	}
+
+	hashesA := hashPrompt(ctx, reqA, 1, 256)
+	hashesB := hashPrompt(ctx, reqB, 1, 256)
+
+	require.NotEmpty(t, hashesA)
+	require.Equal(t, len(hashesA), len(hashesB), "same prompt length should produce same number of blocks")
+	assert.NotEqual(t, hashesA[0], hashesB[0], "different models must produce different hashes")
+}
+
+func TestHashPrompt_CacheSalt(t *testing.T) {
+	ctx := context.Background()
+	prompt := "Hello, how are you doing today? This is a test prompt for hashing."
+
+	reqNoSalt := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: prompt},
+		},
+	}
+	reqWithSalt := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt:    prompt,
+				CacheSalt: "tenant-123",
+			},
+		},
+	}
+
+	hashesNoSalt := hashPrompt(ctx, reqNoSalt, 1, 256)
+	hashesWithSalt := hashPrompt(ctx, reqWithSalt, 1, 256)
+
+	require.NotEmpty(t, hashesNoSalt)
+	require.NotEmpty(t, hashesWithSalt)
+	assert.NotEqual(t, hashesNoSalt[0], hashesWithSalt[0], "CacheSalt must affect hashes")
+}
+
+func TestHashPrompt_TooSmall(t *testing.T) {
+	ctx := context.Background()
+	req := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt: "hi", // 2 chars < 4 chars (1 token block)
+			},
+		},
+	}
+
+	hashes := hashPrompt(ctx, req, 1, 256)
+	assert.Empty(t, hashes, "prompt shorter than block size should return nil")
+}
+
+func TestHashPrompt_MaxPrefixBlocksTruncation(t *testing.T) {
+	ctx := context.Background()
+	// Create a prompt that would produce many blocks
+	longPrompt := ""
+	for i := 0; i < 100; i++ {
+		longPrompt += "abcd" // 4 chars each = 1 block per "abcd" at blockSize=1
+	}
+
+	req := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: longPrompt},
+		},
+	}
+
+	hashesUnlimited := hashPrompt(ctx, req, 1, 100)
+	hashesLimited := hashPrompt(ctx, req, 1, 10)
+
+	assert.Equal(t, 100, len(hashesUnlimited))
+	assert.Equal(t, 10, len(hashesLimited), "should truncate to maxPrefixBlocks")
+
+	// First 10 blocks should be identical (rolling chain is prefix-stable)
+	assert.Equal(t, hashesUnlimited[:10], hashesLimited,
+		"truncated hashes should match prefix of full hashes")
+}
+
+func TestHashPrompt_BlockSizeTokens(t *testing.T) {
+	ctx := context.Background()
+	// 128 chars = 32 tokens (at 4 chars/token)
+	prompt := ""
+	for i := 0; i < 128; i++ {
+		prompt += "a"
+	}
+
+	req := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: prompt},
+		},
+	}
+
+	// blockSize=16 tokens = 64 chars → 128/64 = 2 blocks
+	hashes16 := hashPrompt(ctx, req, 16, 256)
+	assert.Equal(t, 2, len(hashes16))
+
+	// blockSize=8 tokens = 32 chars → 128/32 = 4 blocks
+	hashes8 := hashPrompt(ctx, req, 8, 256)
+	assert.Equal(t, 4, len(hashes8))
+}
+
+func TestHashPrompt_ChatCompletions(t *testing.T) {
+	ctx := context.Background()
+	// JSON marshal of messages will be > 4 chars
+	req := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			ChatCompletions: &scheduling.ChatCompletionsRequest{
+				Messages: []scheduling.Message{
+					{Role: "user", Content: scheduling.Content{Raw: "Hello, this is a fairly long message for testing block hashing behavior."}},
+				},
+			},
+		},
+	}
+
+	hashes := hashPrompt(ctx, req, 1, 256)
+	assert.NotEmpty(t, hashes, "ChatCompletions should produce hashes from JSON-marshaled messages")
+}
+
+func TestHashPrompt_NilRequest(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, hashPrompt(ctx, nil, 1, 256))
+	assert.Nil(t, hashPrompt(ctx, &scheduling.LLMRequest{}, 1, 256))
+	assert.Nil(t, hashPrompt(ctx, &scheduling.LLMRequest{Body: &scheduling.LLMRequestBody{}}, 1, 256))
+}
+
+func TestHashPrompt_RollingChainPrefix(t *testing.T) {
+	ctx := context.Background()
+
+	// Two prompts sharing the same prefix
+	shortPrompt := "aaaabbbbccccdddd" // 16 chars = 4 blocks at blockSize=1
+	longPrompt := "aaaabbbbccccddddeeeeffffgggghhhh"
+
+	reqShort := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: shortPrompt},
+		},
+	}
+	reqLong := &scheduling.LLMRequest{
+		TargetModel: "llama3",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: longPrompt},
+		},
+	}
+
+	hashesShort := hashPrompt(ctx, reqShort, 1, 256)
+	hashesLong := hashPrompt(ctx, reqLong, 1, 256)
+
+	require.Equal(t, 4, len(hashesShort))
+	require.Equal(t, 8, len(hashesLong))
+
+	// Shared prefix should produce identical hashes
+	assert.Equal(t, hashesShort, hashesLong[:4],
+		"shared prefix should produce identical hash sequence")
+}
+
+func TestGetUserInputBytes_AllAPITypes(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *scheduling.LLMRequest
+	}{
+		{
+			name: "Completions",
+			req: &scheduling.LLMRequest{
+				Body: &scheduling.LLMRequestBody{
+					Completions: &scheduling.CompletionsRequest{Prompt: "test prompt"},
+				},
+			},
+		},
+		{
+			name: "ChatCompletions",
+			req: &scheduling.LLMRequest{
+				Body: &scheduling.LLMRequestBody{
+					ChatCompletions: &scheduling.ChatCompletionsRequest{
+						Messages: []scheduling.Message{{Role: "user", Content: scheduling.Content{Raw: "hello"}}},
+					},
+				},
+			},
+		},
+		{
+			name: "Responses",
+			req: &scheduling.LLMRequest{
+				Body: &scheduling.LLMRequestBody{
+					Responses: &scheduling.ResponsesRequest{
+						Input: "test input",
+					},
+				},
+			},
+		},
+		{
+			name: "Conversations",
+			req: &scheduling.LLMRequest{
+				Body: &scheduling.LLMRequestBody{
+					Conversations: &scheduling.ConversationsRequest{
+						Items: []scheduling.ConversationItem{{Type: "message"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := getUserInputBytes(tt.req)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, b)
+		})
+	}
+}
+
+func TestGetUserInputBytes_EmptyBody(t *testing.T) {
+	_, err := getUserInputBytes(&scheduling.LLMRequest{Body: &scheduling.LLMRequestBody{}})
+	assert.Error(t, err)
+}

--- a/pkg/plugins/scorer/approximate_indexer.go
+++ b/pkg/plugins/scorer/approximate_indexer.go
@@ -162,8 +162,15 @@ func (idx *approximateIndexer) MatchLongestPrefix(hashes []ApproximateBlockHash)
 	return result
 }
 
+// weightedPrefixResult holds both the weighted score (for scoring/normalization)
+// and the integer block count (for PrefixCacheMatchInfo and PrefixCacheServers).
+type weightedPrefixResult struct {
+	WeightedScore float64
+	BlockCount    int
+}
+
 // MatchLongestPrefixWeighted finds the longest contiguous prefix match per server
-// and returns a recency-weighted score instead of a raw block count.
+// and returns both a recency-weighted score and an integer block count.
 //
 // Each matched block contributes a weight based on how recently it was recorded:
 //
@@ -173,10 +180,10 @@ func (idx *approximateIndexer) MatchLongestPrefix(hashes []ApproximateBlockHash)
 // fast old entries decay. A halfLife of 30s means an entry recorded 30s ago
 // contributes exactly 50% of a fresh entry's weight.
 //
-// This improves scoring accuracy because older self-reported entries are more
-// likely to have been evicted from the actual GPU cache.
-func (idx *approximateIndexer) MatchLongestPrefixWeighted(hashes []ApproximateBlockHash, now time.Time, halfLife time.Duration) map[ApproximateServerID]float64 {
-	result := make(map[ApproximateServerID]float64)
+// The integer block count is always the true contiguous match length, unaffected
+// by decay. The weighted score is used for scoring/normalization only.
+func (idx *approximateIndexer) MatchLongestPrefixWeighted(hashes []ApproximateBlockHash, now time.Time, halfLife time.Duration) map[ApproximateServerID]weightedPrefixResult {
+	result := make(map[ApproximateServerID]weightedPrefixResult)
 	if len(hashes) == 0 || halfLife <= 0 {
 		return result
 	}
@@ -190,7 +197,10 @@ func (idx *approximateIndexer) MatchLongestPrefixWeighted(hashes []ApproximateBl
 	active := make(map[ApproximateServerID]bool, len(firstServers))
 	for server, ts := range firstServers {
 		age := now.Sub(ts).Seconds()
-		result[server] = math.Exp(-age * math.Ln2 / halfLifeSec)
+		result[server] = weightedPrefixResult{
+			WeightedScore: math.Exp(-age * math.Ln2 / halfLifeSec),
+			BlockCount:    1,
+		}
 		active[server] = true
 	}
 
@@ -202,7 +212,10 @@ func (idx *approximateIndexer) MatchLongestPrefixWeighted(hashes []ApproximateBl
 		for server := range active {
 			if ts, has := serverTimestamps[server]; has {
 				age := now.Sub(ts).Seconds()
-				result[server] += math.Exp(-age * math.Ln2 / halfLifeSec)
+				r := result[server]
+				r.WeightedScore += math.Exp(-age * math.Ln2 / halfLifeSec)
+				r.BlockCount++
+				result[server] = r
 			} else {
 				delete(active, server)
 			}

--- a/pkg/plugins/scorer/approximate_indexer.go
+++ b/pkg/plugins/scorer/approximate_indexer.go
@@ -1,0 +1,231 @@
+package scorer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+)
+
+// ApproximateServerID identifies a model server pod by its namespaced name.
+type ApproximateServerID = k8stypes.NamespacedName
+
+// podSet is a set of server IDs.
+type podSet = map[ApproximateServerID]struct{}
+
+// approximateIndexer maintains an approximate view of which pods are likely
+// to have which prefix blocks cached. It is updated via self-reporting:
+// when the scheduler routes a request to a pod, the expected cache entries
+// are recorded in the indexer.
+//
+// Internally it uses a dual-map structure:
+//   - hashToPods: forward index from block hash to the set of pods that have it
+//   - podToLRU:   per-pod LRU cache that automatically evicts old entries and
+//     keeps hashToPods consistent via eviction callbacks
+//
+// All operations are thread-safe.
+type approximateIndexer struct {
+	mu             sync.RWMutex
+	hashToPods     map[ApproximateBlockHash]podSet
+	podToLRU       map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, struct{}]
+	defaultLRUSize int
+}
+
+// newApproximateIndexer creates a new indexer and starts a background goroutine
+// that periodically logs the indexer size metrics.
+func newApproximateIndexer(ctx context.Context, defaultLRUSize int) *approximateIndexer {
+	idx := &approximateIndexer{
+		hashToPods:     make(map[ApproximateBlockHash]podSet),
+		podToLRU:       make(map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, struct{}]),
+		defaultLRUSize: defaultLRUSize,
+	}
+	go idx.reportLRUSize(ctx)
+	return idx
+}
+
+// Add records block hashes for a server. This is called from PreRequest
+// after a routing decision to self-report the expected cache contents.
+//
+// If the pod has no LRU yet, one is created with the given capacity
+// (numGPUBlocks, or defaultLRUSize if <= 0). When the LRU is full,
+// the oldest entries are evicted and automatically removed from hashToPods.
+func (idx *approximateIndexer) Add(hashes []ApproximateBlockHash, server ApproximateServerID, numGPUBlocks int) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	podLRU, exists := idx.podToLRU[server]
+	if !exists {
+		capacity := idx.defaultLRUSize
+		if numGPUBlocks > 0 {
+			capacity = numGPUBlocks
+		}
+		podLRU, _ = lru.NewWithEvict(capacity, idx.makeEvictionFn(server))
+		idx.podToLRU[server] = podLRU
+	} else if numGPUBlocks > 0 {
+		// AutoTune: resize LRU if reported capacity changed.
+		// Resize is a no-op when size matches current capacity.
+		podLRU.Resize(numGPUBlocks)
+	}
+
+	for _, hash := range hashes {
+		podLRU.Add(hash, struct{}{})
+		if _, ok := idx.hashToPods[hash]; !ok {
+			idx.hashToPods[hash] = make(podSet)
+		}
+		idx.hashToPods[hash][server] = struct{}{}
+	}
+}
+
+// Get returns a copy of the set of servers that have the given hash cached.
+// Returns nil if no server has it.
+func (idx *approximateIndexer) Get(hash ApproximateBlockHash) podSet {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	ps, exists := idx.hashToPods[hash]
+	if !exists {
+		return nil
+	}
+	// Return a copy to avoid races on the caller side.
+	result := make(podSet, len(ps))
+	for k, v := range ps {
+		result[k] = v
+	}
+	return result
+}
+
+// MatchLongestPrefix finds the longest contiguous prefix match per server.
+// Only servers present from the very first hash are candidates. Once a server
+// misses any hash in the chain, it is permanently eliminated. This ensures
+// only truly contiguous prefixes starting from block 0 are scored.
+func (idx *approximateIndexer) MatchLongestPrefix(hashes []ApproximateBlockHash) map[ApproximateServerID]int {
+	result := make(map[ApproximateServerID]int)
+	if len(hashes) == 0 {
+		return result
+	}
+
+	// Initialize candidates from the first hash only.
+	firstServers := idx.Get(hashes[0])
+	if len(firstServers) == 0 {
+		return result
+	}
+	active := make(map[ApproximateServerID]bool, len(firstServers))
+	for server := range firstServers {
+		result[server] = 1
+		active[server] = true
+	}
+
+	// Walk remaining hashes, eliminating servers that miss any block.
+	for _, hash := range hashes[1:] {
+		cachedServers := idx.Get(hash)
+		if len(cachedServers) == 0 {
+			break
+		}
+		for server := range active {
+			if _, has := cachedServers[server]; has {
+				result[server]++
+			} else {
+				delete(active, server)
+			}
+		}
+		if len(active) == 0 {
+			break
+		}
+	}
+	return result
+}
+
+// RemovePod removes all cached entries for a server and cleans up hashToPods.
+func (idx *approximateIndexer) RemovePod(server ApproximateServerID) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	if podLRU, exists := idx.podToLRU[server]; exists {
+		// Purge triggers eviction callbacks for each entry, which
+		// clean up hashToPods.
+		podLRU.Purge()
+		delete(idx.podToLRU, server)
+	}
+}
+
+// Pods returns the set of servers currently tracked by the indexer.
+func (idx *approximateIndexer) Pods() []ApproximateServerID {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	pods := make([]ApproximateServerID, 0, len(idx.podToLRU))
+	for pod := range idx.podToLRU {
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
+// TotalEntries returns the total number of hash entries across all pods.
+func (idx *approximateIndexer) TotalEntries() int64 {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	var total int64
+	for _, podLRU := range idx.podToLRU {
+		total += int64(podLRU.Len())
+	}
+	return total
+}
+
+// makeEvictionFn returns the LRU eviction callback for a specific pod.
+// When a hash is evicted from the pod's LRU, this callback removes the pod
+// from the forward map (hashToPods). If the pod was the last server for that
+// hash, the hash entry is deleted entirely.
+//
+// IMPORTANT: The hashicorp LRU library calls onEvictedCB OUTSIDE its
+// internal lock. This callback is safe because it is only ever invoked
+// during Add(), RemovePod(), or Resize() calls, all of which hold
+// idx.mu.Lock(). Therefore the callback must NOT acquire idx.mu (it's
+// already held by the caller).
+func (idx *approximateIndexer) makeEvictionFn(server ApproximateServerID) func(ApproximateBlockHash, struct{}) {
+	return func(key ApproximateBlockHash, _ struct{}) {
+		if ps, ok := idx.hashToPods[key]; ok {
+			delete(ps, server)
+			if len(ps) == 0 {
+				delete(idx.hashToPods, key)
+			}
+		}
+	}
+}
+
+// reportLRUSize periodically logs the indexer size for observability.
+func (idx *approximateIndexer) reportLRUSize(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			idx.mu.RLock()
+			total := int64(0)
+			podCount := len(idx.podToLRU)
+			maxEntries := 0
+			for _, podLRU := range idx.podToLRU {
+				n := podLRU.Len()
+				total += int64(n)
+				if n > maxEntries {
+					maxEntries = n
+				}
+			}
+			idx.mu.RUnlock()
+
+			logger := log.FromContext(ctx).V(logutil.TRACE)
+			logger.Info("Approximate indexer size",
+				"totalEntries", total,
+				"pods", podCount,
+				"maxEntriesPerPod", maxEntries)
+		}
+	}
+}

--- a/pkg/plugins/scorer/approximate_indexer.go
+++ b/pkg/plugins/scorer/approximate_indexer.go
@@ -2,6 +2,7 @@ package scorer
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -32,7 +33,7 @@ type podSet = map[ApproximateServerID]struct{}
 type approximateIndexer struct {
 	mu             sync.RWMutex
 	hashToPods     map[ApproximateBlockHash]podSet
-	podToLRU       map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, struct{}]
+	podToLRU       map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, time.Time]
 	defaultLRUSize int
 }
 
@@ -41,7 +42,7 @@ type approximateIndexer struct {
 func newApproximateIndexer(ctx context.Context, defaultLRUSize int) *approximateIndexer {
 	idx := &approximateIndexer{
 		hashToPods:     make(map[ApproximateBlockHash]podSet),
-		podToLRU:       make(map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, struct{}]),
+		podToLRU:       make(map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, time.Time]),
 		defaultLRUSize: defaultLRUSize,
 	}
 	go idx.reportLRUSize(ctx)
@@ -73,7 +74,7 @@ func (idx *approximateIndexer) Add(hashes []ApproximateBlockHash, server Approxi
 	}
 
 	for _, hash := range hashes {
-		podLRU.Add(hash, struct{}{})
+		podLRU.Add(hash, time.Now())
 		if _, ok := idx.hashToPods[hash]; !ok {
 			idx.hashToPods[hash] = make(podSet)
 		}
@@ -95,6 +96,27 @@ func (idx *approximateIndexer) Get(hash ApproximateBlockHash) podSet {
 	result := make(podSet, len(ps))
 	for k, v := range ps {
 		result[k] = v
+	}
+	return result
+}
+
+// GetWithTimestamp returns the set of servers with their recorded timestamps
+// for the given hash. Returns nil if no server has it.
+func (idx *approximateIndexer) GetWithTimestamp(hash ApproximateBlockHash) map[ApproximateServerID]time.Time {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	ps, exists := idx.hashToPods[hash]
+	if !exists {
+		return nil
+	}
+	result := make(map[ApproximateServerID]time.Time, len(ps))
+	for server := range ps {
+		if podLRU, ok := idx.podToLRU[server]; ok {
+			if ts, ok := podLRU.Peek(hash); ok {
+				result[server] = ts
+			}
+		}
 	}
 	return result
 }
@@ -129,6 +151,58 @@ func (idx *approximateIndexer) MatchLongestPrefix(hashes []ApproximateBlockHash)
 		for server := range active {
 			if _, has := cachedServers[server]; has {
 				result[server]++
+			} else {
+				delete(active, server)
+			}
+		}
+		if len(active) == 0 {
+			break
+		}
+	}
+	return result
+}
+
+// MatchLongestPrefixWeighted finds the longest contiguous prefix match per server
+// and returns a recency-weighted score instead of a raw block count.
+//
+// Each matched block contributes a weight based on how recently it was recorded:
+//
+//	weight = exp(-age * ln2 / halfLife)
+//
+// where age = time since the block was self-reported, and halfLife controls how
+// fast old entries decay. A halfLife of 30s means an entry recorded 30s ago
+// contributes exactly 50% of a fresh entry's weight.
+//
+// This improves scoring accuracy because older self-reported entries are more
+// likely to have been evicted from the actual GPU cache.
+func (idx *approximateIndexer) MatchLongestPrefixWeighted(hashes []ApproximateBlockHash, now time.Time, halfLife time.Duration) map[ApproximateServerID]float64 {
+	result := make(map[ApproximateServerID]float64)
+	if len(hashes) == 0 || halfLife <= 0 {
+		return result
+	}
+
+	// Initialize candidates from the first hash.
+	firstServers := idx.GetWithTimestamp(hashes[0])
+	if len(firstServers) == 0 {
+		return result
+	}
+	halfLifeSec := halfLife.Seconds()
+	active := make(map[ApproximateServerID]bool, len(firstServers))
+	for server, ts := range firstServers {
+		age := now.Sub(ts).Seconds()
+		result[server] = math.Exp(-age * math.Ln2 / halfLifeSec)
+		active[server] = true
+	}
+
+	for _, hash := range hashes[1:] {
+		serverTimestamps := idx.GetWithTimestamp(hash)
+		if len(serverTimestamps) == 0 {
+			break
+		}
+		for server := range active {
+			if ts, has := serverTimestamps[server]; has {
+				age := now.Sub(ts).Seconds()
+				result[server] += math.Exp(-age * math.Ln2 / halfLifeSec)
 			} else {
 				delete(active, server)
 			}
@@ -187,8 +261,8 @@ func (idx *approximateIndexer) TotalEntries() int64 {
 // during Add(), RemovePod(), or Resize() calls, all of which hold
 // idx.mu.Lock(). Therefore the callback must NOT acquire idx.mu (it's
 // already held by the caller).
-func (idx *approximateIndexer) makeEvictionFn(server ApproximateServerID) func(ApproximateBlockHash, struct{}) {
-	return func(key ApproximateBlockHash, _ struct{}) {
+func (idx *approximateIndexer) makeEvictionFn(server ApproximateServerID) func(ApproximateBlockHash, time.Time) {
+	return func(key ApproximateBlockHash, _ time.Time) {
 		if ps, ok := idx.hashToPods[key]; ok {
 			delete(ps, server)
 			if len(ps) == 0 {

--- a/pkg/plugins/scorer/approximate_indexer_test.go
+++ b/pkg/plugins/scorer/approximate_indexer_test.go
@@ -3,6 +3,7 @@ package scorer
 import (
 	"sync"
 	"testing"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func newTestIndexer(size int) *approximateIndexer {
 	// Create indexer without background goroutine for tests.
 	return &approximateIndexer{
 		hashToPods:     make(map[ApproximateBlockHash]podSet),
-		podToLRU:       make(map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, struct{}]),
+		podToLRU:       make(map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, time.Time]),
 		defaultLRUSize: size,
 	}
 }
@@ -310,4 +311,79 @@ func TestApproxIndexer_GetReturnsCopy(t *testing.T) {
 	// Original should be intact
 	ps2 := idx.Get(1)
 	assert.Contains(t, ps2, server)
+}
+
+func TestApproxIndexer_GetWithTimestamp(t *testing.T) {
+	idx := newTestIndexer(100)
+	server := serverID("pod-a")
+
+	before := time.Now()
+	idx.Add([]ApproximateBlockHash{1}, server, 0)
+	after := time.Now()
+
+	ts := idx.GetWithTimestamp(1)
+	require.Len(t, ts, 1)
+	assert.True(t, !ts[server].Before(before) && !ts[server].After(after),
+		"timestamp should be between before and after Add()")
+
+	// Non-existent hash
+	assert.Nil(t, idx.GetWithTimestamp(999))
+}
+
+func TestApproxIndexer_MatchLongestPrefixWeighted(t *testing.T) {
+	idx := newTestIndexer(100)
+	server := serverID("pod-a")
+
+	// Add hashes with known timestamps
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, server, 0)
+
+	now := time.Now()
+	halfLife := 30 * time.Second
+
+	// All entries are fresh (just added) → weights should be close to 1.0 each
+	result := idx.MatchLongestPrefixWeighted([]ApproximateBlockHash{1, 2, 3}, now, halfLife)
+	// 3 blocks, each ~1.0 weight → total ~3.0
+	assert.InDelta(t, 3.0, result[server], 0.1,
+		"fresh entries should have weights close to 1.0 each")
+}
+
+func TestApproxIndexer_MatchLongestPrefixWeighted_Decay(t *testing.T) {
+	idx := newTestIndexer(100)
+	server := serverID("pod-a")
+
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, server, 0)
+
+	// Simulate scoring 30 seconds later (exactly one half-life)
+	futureNow := time.Now().Add(30 * time.Second)
+	halfLife := 30 * time.Second
+
+	result := idx.MatchLongestPrefixWeighted([]ApproximateBlockHash{1, 2, 3}, futureNow, halfLife)
+	// age ≈ 30s, halfLife = 30s → weight per block ≈ 0.5
+	// total ≈ 3 * 0.5 = 1.5
+	assert.InDelta(t, 1.5, result[server], 0.1,
+		"at exactly one half-life, each block should contribute ~0.5")
+}
+
+func TestApproxIndexer_MatchLongestPrefixWeighted_Empty(t *testing.T) {
+	idx := newTestIndexer(100)
+	result := idx.MatchLongestPrefixWeighted(nil, time.Now(), 30*time.Second)
+	assert.Empty(t, result)
+
+	result = idx.MatchLongestPrefixWeighted([]ApproximateBlockHash{1}, time.Now(), 0)
+	assert.Empty(t, result, "zero half-life should return empty")
+}
+
+func TestApproxIndexer_MatchLongestPrefixWeighted_MidStreamJoin(t *testing.T) {
+	idx := newTestIndexer(100)
+	serverA := serverID("pod-a")
+	serverC := serverID("pod-c")
+
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, serverA, 0)
+	idx.Add([]ApproximateBlockHash{2, 3}, serverC, 0) // missing first hash
+
+	result := idx.MatchLongestPrefixWeighted(
+		[]ApproximateBlockHash{1, 2, 3}, time.Now(), 30*time.Second)
+
+	assert.Greater(t, result[serverA], 0.0, "serverA should have score")
+	assert.Equal(t, 0.0, result[serverC], "serverC missing first hash should have 0")
 }

--- a/pkg/plugins/scorer/approximate_indexer_test.go
+++ b/pkg/plugins/scorer/approximate_indexer_test.go
@@ -1,0 +1,313 @@
+package scorer
+
+import (
+	"sync"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func newTestIndexer(size int) *approximateIndexer {
+	// Create indexer without background goroutine for tests.
+	return &approximateIndexer{
+		hashToPods:     make(map[ApproximateBlockHash]podSet),
+		podToLRU:       make(map[ApproximateServerID]*lru.Cache[ApproximateBlockHash, struct{}]),
+		defaultLRUSize: size,
+	}
+}
+
+func serverID(name string) ApproximateServerID {
+	return k8stypes.NamespacedName{Namespace: "default", Name: name}
+}
+
+func TestApproxIndexer_AddAndGet(t *testing.T) {
+	idx := newTestIndexer(100)
+
+	server1 := serverID("pod-a")
+	server2 := serverID("pod-b")
+
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, server1, 0)
+	idx.Add([]ApproximateBlockHash{2, 3, 4}, server2, 0)
+
+	// Hash 1: only server1
+	ps := idx.Get(1)
+	require.Len(t, ps, 1)
+	assert.Contains(t, ps, server1)
+
+	// Hash 2, 3: both servers
+	ps = idx.Get(2)
+	require.Len(t, ps, 2)
+	assert.Contains(t, ps, server1)
+	assert.Contains(t, ps, server2)
+
+	// Hash 4: only server2
+	ps = idx.Get(4)
+	require.Len(t, ps, 1)
+	assert.Contains(t, ps, server2)
+
+	// Hash 5: nobody
+	ps = idx.Get(5)
+	assert.Nil(t, ps)
+}
+
+func TestApproxIndexer_LRUEviction(t *testing.T) {
+	// LRU capacity = 2 per pod
+	idx := newTestIndexer(2)
+	server := serverID("pod-a")
+
+	// Add hashes 1, 2 (fills capacity)
+	idx.Add([]ApproximateBlockHash{1, 2}, server, 0)
+	assert.NotNil(t, idx.Get(1))
+	assert.NotNil(t, idx.Get(2))
+
+	// Add hash 3 → should evict hash 1 (LRU)
+	idx.Add([]ApproximateBlockHash{3}, server, 0)
+	assert.Nil(t, idx.Get(1), "hash 1 should be evicted from LRU")
+	assert.NotNil(t, idx.Get(2))
+	assert.NotNil(t, idx.Get(3))
+}
+
+func TestApproxIndexer_LRUEviction_CleansHashToPods(t *testing.T) {
+	idx := newTestIndexer(2)
+	server1 := serverID("pod-a")
+	server2 := serverID("pod-b")
+
+	// Both servers have hash 1
+	idx.Add([]ApproximateBlockHash{1}, server1, 0)
+	idx.Add([]ApproximateBlockHash{1}, server2, 0)
+	require.Len(t, idx.Get(1), 2)
+
+	// Evict hash 1 from server1 by filling its LRU
+	idx.Add([]ApproximateBlockHash{2, 3}, server1, 0)
+
+	// Hash 1 should still exist for server2
+	ps := idx.Get(1)
+	require.Len(t, ps, 1)
+	assert.Contains(t, ps, server2)
+}
+
+func TestApproxIndexer_NumGPUBlocksOverride(t *testing.T) {
+	idx := newTestIndexer(100) // default capacity = 100
+
+	server := serverID("pod-a")
+
+	// Override with numGPUBlocks=2
+	idx.Add([]ApproximateBlockHash{1, 2}, server, 2)
+	assert.NotNil(t, idx.Get(1))
+	assert.NotNil(t, idx.Get(2))
+
+	// Adding 3 should evict 1 (capacity=2 from numGPUBlocks override)
+	idx.Add([]ApproximateBlockHash{3}, server, 2)
+	assert.Nil(t, idx.Get(1), "should evict due to numGPUBlocks=2 capacity")
+}
+
+func TestApproxIndexer_RemovePod(t *testing.T) {
+	idx := newTestIndexer(100)
+	server1 := serverID("pod-a")
+	server2 := serverID("pod-b")
+
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, server1, 0)
+	idx.Add([]ApproximateBlockHash{2, 3, 4}, server2, 0)
+
+	// Remove server1
+	idx.RemovePod(server1)
+
+	// Hash 1: was only in server1, should be gone entirely
+	assert.Nil(t, idx.Get(1))
+
+	// Hash 2, 3: should now only have server2
+	ps := idx.Get(2)
+	require.Len(t, ps, 1)
+	assert.Contains(t, ps, server2)
+
+	// Hash 4: still server2
+	assert.NotNil(t, idx.Get(4))
+
+	// server1 should not be in Pods()
+	pods := idx.Pods()
+	assert.Len(t, pods, 1)
+	assert.Equal(t, server2, pods[0])
+}
+
+func TestApproxIndexer_MatchLongestPrefix(t *testing.T) {
+	idx := newTestIndexer(100)
+	server1 := serverID("pod-a")
+	server2 := serverID("pod-b")
+
+	// server1 has blocks [1, 2, 3]
+	// server2 has blocks [1, 2]
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, server1, 0)
+	idx.Add([]ApproximateBlockHash{1, 2}, server2, 0)
+
+	// Query with [1, 2, 3, 4]
+	// - At hash 1: both servers match
+	// - At hash 2: both servers match
+	// - At hash 3: only server1 matches (but server2 also increments to 2 since it won't be updated past here)
+	// - At hash 4: nobody matches → stop
+	result := idx.MatchLongestPrefix([]ApproximateBlockHash{1, 2, 3, 4})
+
+	// server1 should have 3 (matched blocks 1, 2, 3)
+	assert.Equal(t, 3, result[server1])
+	// server2 should have 2 (matched blocks 1, 2; hash 3 had no cachedServers including server2, but wait...)
+	// Actually: at hash 3, Get(3) returns {server1} only. len > 0, so we continue.
+	// server2 doesn't have hash 3, so it's NOT incremented. server1 gets 3.
+	// At hash 4, Get(4) returns nil, so we stop.
+	assert.Equal(t, 2, result[server2])
+}
+
+func TestApproxIndexer_MatchLongestPrefix_Gap(t *testing.T) {
+	idx := newTestIndexer(100)
+	server := serverID("pod-a")
+
+	// Server has blocks [1, 3] but NOT block 2
+	idx.Add([]ApproximateBlockHash{1, 3}, server, 0)
+
+	// Query [1, 2, 3]: should stop at hash 2 (gap)
+	result := idx.MatchLongestPrefix([]ApproximateBlockHash{1, 2, 3})
+	assert.Equal(t, 1, result[server], "should stop at first gap")
+}
+
+func TestApproxIndexer_MatchLongestPrefix_MultiServerGap(t *testing.T) {
+	idx := newTestIndexer(100)
+	serverA := serverID("pod-a")
+	serverB := serverID("pod-b")
+
+	// serverA has blocks [0, 2] (gap at block 1)
+	// serverB has blocks [0, 1, 2] (contiguous)
+	idx.Add([]ApproximateBlockHash{0, 2}, serverA, 0)
+	idx.Add([]ApproximateBlockHash{0, 1, 2}, serverB, 0)
+
+	result := idx.MatchLongestPrefix([]ApproximateBlockHash{0, 1, 2})
+
+	// serverA: contiguous prefix is only block 0 (gap at block 1 eliminates it)
+	assert.Equal(t, 1, result[serverA], "serverA should only count contiguous prefix (block 0)")
+	// serverB: all 3 blocks contiguous
+	assert.Equal(t, 3, result[serverB], "serverB should count all 3 contiguous blocks")
+}
+
+func TestApproxIndexer_MatchLongestPrefix_MidStreamJoin(t *testing.T) {
+	idx := newTestIndexer(100)
+	serverA := serverID("pod-a")
+	serverC := serverID("pod-c")
+
+	// serverA has blocks [1, 2, 3] (contiguous from start)
+	// serverC has blocks [2, 3] only (missing block 1 — joins mid-stream)
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, serverA, 0)
+	idx.Add([]ApproximateBlockHash{2, 3}, serverC, 0)
+
+	result := idx.MatchLongestPrefix([]ApproximateBlockHash{1, 2, 3})
+
+	// serverA: all 3 contiguous from start
+	assert.Equal(t, 3, result[serverA])
+	// serverC: NOT present at first hash → should NOT be counted at all
+	assert.Equal(t, 0, result[serverC], "server missing first hash should have 0 score")
+}
+
+func TestApproxIndexer_MatchLongestPrefix_CrossElimination(t *testing.T) {
+	idx := newTestIndexer(100)
+	serverA := serverID("pod-a")
+	serverB := serverID("pod-b")
+
+	// serverA has [1, 2, 4] (gap at 3)
+	// serverB has [1, 3, 4] (gap at 2)
+	idx.Add([]ApproximateBlockHash{1, 2, 4}, serverA, 0)
+	idx.Add([]ApproximateBlockHash{1, 3, 4}, serverB, 0)
+
+	result := idx.MatchLongestPrefix([]ApproximateBlockHash{1, 2, 3, 4})
+
+	// serverA: present at hash 1 and 2, but missing 3 → eliminated → score 2
+	assert.Equal(t, 2, result[serverA])
+	// serverB: present at hash 1, missing hash 2 → eliminated → score 1
+	assert.Equal(t, 1, result[serverB])
+}
+
+func TestApproxIndexer_MatchLongestPrefix_Empty(t *testing.T) {
+	idx := newTestIndexer(100)
+
+	// No data in indexer
+	result := idx.MatchLongestPrefix([]ApproximateBlockHash{1, 2, 3})
+	assert.Empty(t, result)
+
+	// Empty hashes
+	result = idx.MatchLongestPrefix(nil)
+	assert.Empty(t, result)
+}
+
+func TestApproxIndexer_Pods(t *testing.T) {
+	idx := newTestIndexer(100)
+
+	assert.Empty(t, idx.Pods())
+
+	server1 := serverID("pod-a")
+	server2 := serverID("pod-b")
+
+	idx.Add([]ApproximateBlockHash{1}, server1, 0)
+	idx.Add([]ApproximateBlockHash{2}, server2, 0)
+
+	pods := idx.Pods()
+	assert.Len(t, pods, 2)
+}
+
+func TestApproxIndexer_TotalEntries(t *testing.T) {
+	idx := newTestIndexer(100)
+
+	assert.Equal(t, int64(0), idx.TotalEntries())
+
+	idx.Add([]ApproximateBlockHash{1, 2, 3}, serverID("pod-a"), 0)
+	idx.Add([]ApproximateBlockHash{4, 5}, serverID("pod-b"), 0)
+
+	assert.Equal(t, int64(5), idx.TotalEntries())
+}
+
+func TestApproxIndexer_ConcurrentAddRemovePod(t *testing.T) {
+	// Stress test for race conditions
+	for i := 0; i < 100; i++ {
+		idx := newTestIndexer(10)
+		server := serverID("pod-a")
+		hashes := []ApproximateBlockHash{1, 2, 3, 4, 5}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			idx.Add(hashes, server, 0)
+		}()
+
+		go func() {
+			defer wg.Done()
+			idx.RemovePod(server)
+		}()
+
+		wg.Wait()
+
+		// After both goroutines complete, verify consistency:
+		// If pod was removed, no hash should reference it.
+		idx.mu.RLock()
+		_, podExists := idx.podToLRU[server]
+		for hash, ps := range idx.hashToPods {
+			if _, hasPod := ps[server]; hasPod && !podExists {
+				t.Errorf("iteration %d: hash %d references removed pod %s", i, hash, server.Name)
+			}
+		}
+		idx.mu.RUnlock()
+	}
+}
+
+func TestApproxIndexer_GetReturnsCopy(t *testing.T) {
+	idx := newTestIndexer(100)
+	server := serverID("pod-a")
+
+	idx.Add([]ApproximateBlockHash{1}, server, 0)
+
+	// Get should return a copy; mutating it shouldn't affect the indexer
+	ps := idx.Get(1)
+	delete(ps, server)
+
+	// Original should be intact
+	ps2 := idx.Get(1)
+	assert.Contains(t, ps2, server)
+}

--- a/pkg/plugins/scorer/approximate_indexer_test.go
+++ b/pkg/plugins/scorer/approximate_indexer_test.go
@@ -334,17 +334,16 @@ func TestApproxIndexer_MatchLongestPrefixWeighted(t *testing.T) {
 	idx := newTestIndexer(100)
 	server := serverID("pod-a")
 
-	// Add hashes with known timestamps
 	idx.Add([]ApproximateBlockHash{1, 2, 3}, server, 0)
 
 	now := time.Now()
 	halfLife := 30 * time.Second
 
-	// All entries are fresh (just added) → weights should be close to 1.0 each
 	result := idx.MatchLongestPrefixWeighted([]ApproximateBlockHash{1, 2, 3}, now, halfLife)
-	// 3 blocks, each ~1.0 weight → total ~3.0
-	assert.InDelta(t, 3.0, result[server], 0.1,
+	r := result[server]
+	assert.InDelta(t, 3.0, r.WeightedScore, 0.1,
 		"fresh entries should have weights close to 1.0 each")
+	assert.Equal(t, 3, r.BlockCount, "block count should be 3")
 }
 
 func TestApproxIndexer_MatchLongestPrefixWeighted_Decay(t *testing.T) {
@@ -353,15 +352,14 @@ func TestApproxIndexer_MatchLongestPrefixWeighted_Decay(t *testing.T) {
 
 	idx.Add([]ApproximateBlockHash{1, 2, 3}, server, 0)
 
-	// Simulate scoring 30 seconds later (exactly one half-life)
 	futureNow := time.Now().Add(30 * time.Second)
 	halfLife := 30 * time.Second
 
 	result := idx.MatchLongestPrefixWeighted([]ApproximateBlockHash{1, 2, 3}, futureNow, halfLife)
-	// age ≈ 30s, halfLife = 30s → weight per block ≈ 0.5
-	// total ≈ 3 * 0.5 = 1.5
-	assert.InDelta(t, 1.5, result[server], 0.1,
+	r := result[server]
+	assert.InDelta(t, 1.5, r.WeightedScore, 0.1,
 		"at exactly one half-life, each block should contribute ~0.5")
+	assert.Equal(t, 3, r.BlockCount, "block count should still be 3 regardless of decay")
 }
 
 func TestApproxIndexer_MatchLongestPrefixWeighted_Empty(t *testing.T) {
@@ -379,11 +377,13 @@ func TestApproxIndexer_MatchLongestPrefixWeighted_MidStreamJoin(t *testing.T) {
 	serverC := serverID("pod-c")
 
 	idx.Add([]ApproximateBlockHash{1, 2, 3}, serverA, 0)
-	idx.Add([]ApproximateBlockHash{2, 3}, serverC, 0) // missing first hash
+	idx.Add([]ApproximateBlockHash{2, 3}, serverC, 0)
 
 	result := idx.MatchLongestPrefixWeighted(
 		[]ApproximateBlockHash{1, 2, 3}, time.Now(), 30*time.Second)
 
-	assert.Greater(t, result[serverA], 0.0, "serverA should have score")
-	assert.Equal(t, 0.0, result[serverC], "serverC missing first hash should have 0")
+	assert.Greater(t, result[serverA].WeightedScore, 0.0, "serverA should have score")
+	assert.Equal(t, 3, result[serverA].BlockCount, "serverA should have 3 blocks")
+	assert.Zero(t, result[serverC].WeightedScore, "serverC missing first hash should have 0")
+	assert.Zero(t, result[serverC].BlockCount, "serverC should have 0 blocks")
 }

--- a/pkg/plugins/scorer/approximate_mode_test.go
+++ b/pkg/plugins/scorer/approximate_mode_test.go
@@ -3,6 +3,7 @@ package scorer
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -410,4 +411,49 @@ func TestModeConfig_InvalidMode(t *testing.T) {
 	}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+// TestApproximateMode_RecencyWeighted tests that recency-weighted scoring
+// gives lower scores to older self-reported entries.
+func TestApproximateMode_RecencyWeighted(t *testing.T) {
+	ctx := context.Background()
+	scorer, err := New(ctx, PrecisePrefixCachePluginConfig{
+		Mode: ModeApproximate,
+		ApproximateConfig: &ApproximateConfig{
+			BlockSizeTokens:        1,
+			MaxPrefixBlocksToMatch: 256,
+			LRUCapacityPerServer:   100,
+			AutoTune:               false,
+			RecencyHalfLife:         "30s",
+		},
+	}, nil)
+	require.NoError(t, err)
+	assert.Greater(t, scorer.approxRecencyHalfLife, time.Duration(0),
+		"recency half-life should be parsed")
+
+	endpoints := []scheduling.Endpoint{
+		testEndpoint("pod-a", "10.0.0.1", "8080"),
+	}
+
+	// Route a request to populate the indexer
+	req1 := completionsRequest("aaaabbbbccccdddd")
+	req1.RequestId = "req-1"
+	_ = scorer.PrepareRequestData(ctx, req1, endpoints)
+	scorer.Score(ctx, scheduling.NewCycleState(), req1, endpoints)
+	scorer.PreRequest(ctx, req1, &scheduling.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"default": {TargetEndpoints: []scheduling.Endpoint{endpoints[0]}},
+		},
+	})
+
+	// Score immediately — should be close to 1.0 (fresh entries)
+	req2 := completionsRequest("aaaabbbbccccdddd")
+	req2.RequestId = "req-2"
+	_ = scorer.PrepareRequestData(ctx, req2, endpoints)
+	freshScores := scorer.Score(ctx, scheduling.NewCycleState(), req2, endpoints)
+
+	// The score should be > 0 and <= 1.0
+	assert.Greater(t, freshScores[endpoints[0]], 0.0, "fresh entry should have positive score")
+	assert.LessOrEqual(t, freshScores[endpoints[0]], 1.0, "score should be <= 1.0")
 }

--- a/pkg/plugins/scorer/approximate_mode_test.go
+++ b/pkg/plugins/scorer/approximate_mode_test.go
@@ -1,0 +1,413 @@
+package scorer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+// newApproxScorer creates a PrecisePrefixCacheScorer in approximate mode for tests.
+func newApproxScorer(t *testing.T) *PrecisePrefixCacheScorer {
+	t.Helper()
+	ctx := context.Background()
+
+	scorer, err := New(ctx, PrecisePrefixCachePluginConfig{
+		Mode: ModeApproximate,
+		ApproximateConfig: &ApproximateConfig{
+			BlockSizeTokens:        1, // 1 token = 4 chars for easy testing
+			MaxPrefixBlocksToMatch: 256,
+			LRUCapacityPerServer:   100,
+			AutoTune:               false,
+		},
+	}, nil)
+	require.NoError(t, err)
+	return scorer
+}
+
+func testEndpoint(name, addr, port string) scheduling.Endpoint {
+	return scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: name},
+			Address:        addr,
+			Port:           port,
+		},
+		&fwkdl.Metrics{},
+		nil,
+	)
+}
+
+func completionsRequest(prompt string) *scheduling.LLMRequest {
+	return &scheduling.LLMRequest{
+		RequestId:   "test-req-1",
+		TargetModel: "test-model",
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{Prompt: prompt},
+		},
+	}
+}
+
+// TestApproximateMode_NewScorer verifies approximate mode creates successfully
+// without tokenizer or KV events config.
+func TestApproximateMode_NewScorer(t *testing.T) {
+	scorer := newApproxScorer(t)
+
+	assert.Equal(t, ModeApproximate, scorer.mode)
+	assert.NotNil(t, scorer.approxIndexer)
+	assert.NotNil(t, scorer.approxPluginState)
+	assert.Nil(t, scorer.kvCacheIndexer, "approximate mode should not initialize kvCacheIndexer")
+	assert.Nil(t, scorer.kvEventsConfig, "approximate mode should not initialize kvEventsConfig")
+}
+
+// TestApproximateMode_E2E tests the full approximate mode flow:
+// PrepareRequestData → Score → PreRequest → Score (with learned cache)
+func TestApproximateMode_E2E(t *testing.T) {
+	scorer := newApproxScorer(t)
+
+	endpoints := []scheduling.Endpoint{
+		testEndpoint("pod-a", "10.0.0.1", "8080"),
+		testEndpoint("pod-b", "10.0.0.2", "8080"),
+	}
+
+	// Prompt: 16 chars = 4 blocks at blockSize=1 (4 chars/block)
+	request := completionsRequest("aaaabbbbccccdddd")
+
+	// --- Phase 1: First request, empty indexer ---
+	cycleState := scheduling.NewCycleState()
+	err := scorer.PrepareRequestData(context.Background(), request, endpoints)
+	require.NoError(t, err)
+
+	scores := scorer.Score(context.Background(), cycleState, request, endpoints)
+	// No data in indexer yet, all scores should be 0
+	for _, ep := range endpoints {
+		assert.Equal(t, 0.0, scores[ep], "first request should have no cache hits")
+	}
+
+	// Simulate routing to pod-a
+	scorer.PreRequest(context.Background(), request, &scheduling.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"default": {
+				TargetEndpoints: []scheduling.Endpoint{endpoints[0]}, // pod-a
+			},
+		},
+	})
+
+	// --- Phase 2: Second request with same prefix, should hit pod-a ---
+	request2 := completionsRequest("aaaabbbbccccdddd")
+	request2.RequestId = "test-req-2"
+
+	cycleState2 := scheduling.NewCycleState()
+	err = scorer.PrepareRequestData(context.Background(), request2, endpoints)
+	require.NoError(t, err)
+
+	scores2 := scorer.Score(context.Background(), cycleState2, request2, endpoints)
+
+	// pod-a should have score > 0 (cache hit from self-report)
+	// pod-b should have score 0
+	assert.InDelta(t, 1.0, scores2[endpoints[0]], 0.01, "pod-a should have full cache hit (4/4 blocks)")
+	assert.InDelta(t, 0.0, scores2[endpoints[1]], 0.01, "pod-b should have no cache hit")
+}
+
+// TestApproximateMode_SharedPrefix tests that two requests sharing a prefix
+// both benefit from the cached prefix.
+func TestApproximateMode_SharedPrefix(t *testing.T) {
+	scorer := newApproxScorer(t)
+
+	endpoints := []scheduling.Endpoint{
+		testEndpoint("pod-a", "10.0.0.1", "8080"),
+	}
+
+	// First request: "aaaabbbbccccdddd" → 4 blocks
+	req1 := completionsRequest("aaaabbbbccccdddd")
+	req1.RequestId = "req-1"
+
+	cycleState := scheduling.NewCycleState()
+	_ = scorer.PrepareRequestData(context.Background(), req1, endpoints)
+	scorer.Score(context.Background(), cycleState, req1, endpoints)
+	scorer.PreRequest(context.Background(), req1, &scheduling.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"default": {TargetEndpoints: []scheduling.Endpoint{endpoints[0]}},
+		},
+	})
+
+	// Second request shares prefix but has different suffix
+	req2 := completionsRequest("aaaabbbbccccddddeeeeffffgggghhhh")
+	req2.RequestId = "req-2"
+
+	cycleState2 := scheduling.NewCycleState()
+	_ = scorer.PrepareRequestData(context.Background(), req2, endpoints)
+	scores := scorer.Score(context.Background(), cycleState2, req2, endpoints)
+
+	// 4 out of 8 blocks match → score = 4/8 = 0.5
+	assert.InDelta(t, 0.5, scores[endpoints[0]], 0.01,
+		"shared prefix should give partial score")
+}
+
+// TestApproximateMode_ModelScoped tests that different models don't share cache.
+func TestApproximateMode_ModelScoped(t *testing.T) {
+	scorer := newApproxScorer(t)
+
+	endpoints := []scheduling.Endpoint{
+		testEndpoint("pod-a", "10.0.0.1", "8080"),
+	}
+
+	prompt := "aaaabbbbccccdddd"
+
+	// Route a request for model-a
+	req1 := &scheduling.LLMRequest{
+		RequestId:   "req-1",
+		TargetModel: "model-a",
+		Body:        &scheduling.LLMRequestBody{Completions: &scheduling.CompletionsRequest{Prompt: prompt}},
+	}
+	cycleState := scheduling.NewCycleState()
+	_ = scorer.PrepareRequestData(context.Background(), req1, endpoints)
+	scorer.Score(context.Background(), cycleState, req1, endpoints)
+	scorer.PreRequest(context.Background(), req1, &scheduling.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"default": {TargetEndpoints: []scheduling.Endpoint{endpoints[0]}},
+		},
+	})
+
+	// Now request same prompt but different model
+	req2 := &scheduling.LLMRequest{
+		RequestId:   "req-2",
+		TargetModel: "model-b",
+		Body:        &scheduling.LLMRequestBody{Completions: &scheduling.CompletionsRequest{Prompt: prompt}},
+	}
+	cycleState2 := scheduling.NewCycleState()
+	_ = scorer.PrepareRequestData(context.Background(), req2, endpoints)
+	scores := scorer.Score(context.Background(), cycleState2, req2, endpoints)
+
+	assert.Equal(t, 0.0, scores[endpoints[0]],
+		"different model should have no cache hit even with same prompt")
+}
+
+// TestApproximateMode_PreRequestPDDisaggregation tests that P/D disaggregation
+// records both primary and prefill endpoints.
+func TestApproximateMode_PreRequestPDDisaggregation(t *testing.T) {
+	scorer := newApproxScorer(t)
+
+	podA := testEndpoint("pod-a", "10.0.0.1", "8080")
+	podB := testEndpoint("pod-b", "10.0.0.2", "8080")
+	endpoints := []scheduling.Endpoint{podA, podB}
+
+	req := completionsRequest("aaaabbbbccccdddd")
+	_ = scorer.PrepareRequestData(context.Background(), req, endpoints)
+	scorer.Score(context.Background(), scheduling.NewCycleState(), req, endpoints)
+
+	// Route with both primary (pod-a) and prefill (pod-b)
+	scorer.PreRequest(context.Background(), req, &scheduling.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"default":  {TargetEndpoints: []scheduling.Endpoint{podA}},
+			"prefill":  {TargetEndpoints: []scheduling.Endpoint{podB}},
+		},
+	})
+
+	// Both pods should have cache entries now
+	req2 := completionsRequest("aaaabbbbccccdddd")
+	req2.RequestId = "req-2"
+	_ = scorer.PrepareRequestData(context.Background(), req2, endpoints)
+	scores := scorer.Score(context.Background(), scheduling.NewCycleState(), req2, endpoints)
+
+	assert.Greater(t, scores[podA], 0.0, "primary pod should have cache hit")
+	assert.Greater(t, scores[podB], 0.0, "prefill pod should have cache hit")
+}
+
+// TestApproximateMode_NilRequest tests graceful handling of nil/empty requests.
+func TestApproximateMode_NilRequest(t *testing.T) {
+	scorer := newApproxScorer(t)
+	endpoints := []scheduling.Endpoint{testEndpoint("pod-a", "10.0.0.1", "8080")}
+
+	// nil request
+	err := scorer.PrepareRequestData(context.Background(), nil, endpoints)
+	assert.NoError(t, err)
+
+	scores := scorer.Score(context.Background(), scheduling.NewCycleState(), nil, endpoints)
+	assert.Nil(t, scores)
+}
+
+// TestApproximateMode_TooShortPrompt tests that prompts shorter than block size are skipped.
+func TestApproximateMode_TooShortPrompt(t *testing.T) {
+	scorer := newApproxScorer(t)
+	endpoints := []scheduling.Endpoint{testEndpoint("pod-a", "10.0.0.1", "8080")}
+
+	// "hi" = 2 chars < 4 chars (1 token block)
+	req := completionsRequest("hi")
+
+	err := scorer.PrepareRequestData(context.Background(), req, endpoints)
+	assert.NoError(t, err)
+
+	scores := scorer.Score(context.Background(), scheduling.NewCycleState(), req, endpoints)
+	assert.Nil(t, scores, "too-short prompt should produce nil scores")
+}
+
+// TestApproximateMode_DefaultConfig tests that default config is applied when ApproximateConfig is nil.
+func TestApproximateMode_DefaultConfig(t *testing.T) {
+	ctx := context.Background()
+	scorer, err := New(ctx, PrecisePrefixCachePluginConfig{
+		Mode: ModeApproximate,
+		// No ApproximateConfig → should use defaults
+	}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, defaultApproxBlockSizeTokens, scorer.approxBlockSize)
+	assert.Equal(t, defaultApproxMaxPrefixBlocks, scorer.approxMaxBlocks)
+	assert.True(t, scorer.approxAutoTune)
+}
+
+// TestModeConfig_Validation tests mode configuration.
+func TestModeConfig_Validation(t *testing.T) {
+	ctx := context.Background()
+
+	// Approximate mode should work without indexerConfig/tokenizer
+	scorer, err := New(ctx, PrecisePrefixCachePluginConfig{
+		Mode: ModeApproximate,
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ModeApproximate, scorer.mode)
+
+	// Default mode should be precise
+	_, err = New(ctx, PrecisePrefixCachePluginConfig{}, nil)
+	// This will fail because precise mode requires tokenizer config.
+	// That's expected — precise mode needs a real indexer.
+	assert.Error(t, err, "precise mode without indexer config should fail")
+}
+
+// TestApproximateMode_PluginStateIsolation tests that approximate mode uses
+// its own PluginState key, not conflicting with precise mode.
+func TestApproximateMode_PluginStateIsolation(t *testing.T) {
+	assert.NotEqual(t, stateKey, approxStateKey,
+		"precise and approximate mode should use different PluginState keys")
+}
+
+// TestApproximateMode_Produces tests that the plugin declares the correct data keys.
+func TestApproximateMode_Produces(t *testing.T) {
+	scorer := newApproxScorer(t)
+	produces := scorer.Produces()
+	assert.Contains(t, produces, "PrefixCacheMatchInfoKey")
+}
+
+// TestApproximateMode_Category tests that the plugin returns Affinity category.
+func TestApproximateMode_Category(t *testing.T) {
+	scorer := newApproxScorer(t)
+	assert.Equal(t, scheduling.Affinity, scorer.Category())
+}
+
+// TestCombineScores tests the score combination logic for unified mode.
+func TestCombineScores(t *testing.T) {
+	epA := testEndpoint("pod-a", "10.0.0.1", "8080")
+	epB := testEndpoint("pod-b", "10.0.0.2", "8080")
+
+	precise := map[scheduling.Endpoint]float64{epA: 0.3, epB: 0.8}
+	approx := map[scheduling.Endpoint]float64{epA: 0.7, epB: 0.2}
+
+	combined := combineScores(precise, approx)
+	assert.Equal(t, 0.7, combined[epA], "should take max(0.3, 0.7)")
+	assert.Equal(t, 0.8, combined[epB], "should take max(0.8, 0.2)")
+}
+
+func TestCombineScores_NilInputs(t *testing.T) {
+	epA := testEndpoint("pod-a", "10.0.0.1", "8080")
+
+	scores := map[scheduling.Endpoint]float64{epA: 0.5}
+
+	assert.Equal(t, scores, combineScores(nil, scores))
+	assert.Equal(t, scores, combineScores(scores, nil))
+	assert.Nil(t, combineScores(nil, nil))
+}
+
+func TestCombineScores_AsymmetricEndpoints(t *testing.T) {
+	epA := testEndpoint("pod-a", "10.0.0.1", "8080")
+	epB := testEndpoint("pod-b", "10.0.0.2", "8080")
+
+	// precise only knows about epA, approximate knows about both
+	precise := map[scheduling.Endpoint]float64{epA: 0.5}
+	approx := map[scheduling.Endpoint]float64{epA: 0.3, epB: 0.7}
+
+	combined := combineScores(precise, approx)
+	assert.Equal(t, 0.5, combined[epA], "should keep precise for epA (0.5 > 0.3)")
+	assert.Equal(t, 0.7, combined[epB], "should add epB from approximate")
+}
+
+func TestCombineScores_PreciseUndifferentiated(t *testing.T) {
+	epA := testEndpoint("pod-a", "10.0.0.1", "8080")
+	epB := testEndpoint("pod-b", "10.0.0.2", "8080")
+
+	// precise has no differentiation (all 1.0 from min-max normalization of all-zeros)
+	precise := map[scheduling.Endpoint]float64{epA: 1.0, epB: 1.0}
+	approx := map[scheduling.Endpoint]float64{epA: 0.8, epB: 0.2}
+
+	combined := combineScores(precise, approx)
+	// When precise is undifferentiated, approximate scores should be used directly
+	assert.Equal(t, 0.8, combined[epA], "should use approximate when precise is undifferentiated")
+	assert.Equal(t, 0.2, combined[epB], "should use approximate when precise is undifferentiated")
+}
+
+// TestApproximateMode_E2E_ExactScores verifies exact score values, not just > 0.
+func TestApproximateMode_E2E_ExactScores(t *testing.T) {
+	scorer := newApproxScorer(t)
+
+	endpoints := []scheduling.Endpoint{
+		testEndpoint("pod-a", "10.0.0.1", "8080"),
+		testEndpoint("pod-b", "10.0.0.2", "8080"),
+	}
+
+	// 16 chars = 4 blocks at blockSize=1 (4 chars/block)
+	req1 := completionsRequest("aaaabbbbccccdddd")
+	req1.RequestId = "req-1"
+
+	cycleState := scheduling.NewCycleState()
+	_ = scorer.PrepareRequestData(context.Background(), req1, endpoints)
+	scorer.Score(context.Background(), cycleState, req1, endpoints)
+	scorer.PreRequest(context.Background(), req1, &scheduling.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"default": {TargetEndpoints: []scheduling.Endpoint{endpoints[0]}},
+		},
+	})
+
+	// Second request — same prompt, full cache hit on pod-a
+	req2 := completionsRequest("aaaabbbbccccdddd")
+	req2.RequestId = "req-2"
+	_ = scorer.PrepareRequestData(context.Background(), req2, endpoints)
+	scores := scorer.Score(context.Background(), scheduling.NewCycleState(), req2, endpoints)
+
+	assert.InDelta(t, 1.0, scores[endpoints[0]], 0.01, "pod-a should have full cache hit (4/4)")
+	assert.InDelta(t, 0.0, scores[endpoints[1]], 0.01, "pod-b should have no cache hit")
+}
+
+// TestApproximateMode_PreRequest_NilSchedulingResult tests that nil scheduling result doesn't panic.
+func TestApproximateMode_PreRequest_NilSchedulingResult(t *testing.T) {
+	scorer := newApproxScorer(t)
+	endpoints := []scheduling.Endpoint{testEndpoint("pod-a", "10.0.0.1", "8080")}
+
+	req := completionsRequest("aaaabbbbccccdddd")
+	_ = scorer.PrepareRequestData(context.Background(), req, endpoints)
+	scorer.Score(context.Background(), scheduling.NewCycleState(), req, endpoints)
+
+	// Should not panic with empty scheduling result
+	assert.NotPanics(t, func() {
+		scorer.PreRequest(context.Background(), req, &scheduling.SchedulingResult{
+			PrimaryProfileName: "default",
+			ProfileResults:     map[string]*scheduling.ProfileRunResult{},
+		})
+	})
+}
+
+// TestModeConfig_InvalidMode tests that invalid mode strings are rejected.
+func TestModeConfig_InvalidMode(t *testing.T) {
+	ctx := context.Background()
+	_, err := New(ctx, PrecisePrefixCachePluginConfig{
+		Mode: "invalid-mode",
+	}, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mode")
+}

--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -14,7 +14,6 @@ import (
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents/engineadapter"
 	"github.com/llm-d/llm-d-kv-cache/pkg/tokenization/types"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -40,11 +39,27 @@ const (
 	defaultSpeculativeTTL = 2 * time.Second
 
 	// stateKey is the PluginState key used to share data between
-	// PrepareRequestData, Score, and PreRequest.
+	// PrepareRequestData, Score, and PreRequest for precise mode.
 	stateKey = plugin.StateKey("prefix-cache-state")
+
+	// approxStateKey is the PluginState key for approximate mode data.
+	approxStateKey = plugin.StateKey("approx-prefix-cache-state")
 
 	// experimentalPrefillProfile is the profile name for P/D disaggregation mode.
 	experimentalPrefillProfile = "prefill"
+
+	// Scoring mode constants.
+	ModePrecise     = "precise"
+	ModeApproximate = "approximate"
+	ModeUnified     = "unified"
+
+	// defaultPodCleanupInterval is the interval for removing inactive pods
+	// from the approximate indexer.
+	defaultPodCleanupInterval = 2 * time.Minute
+
+	// defaultApproxLRUCapacity is the default LRU capacity per server for approximate mode.
+	// Sized for H100 80GB: ~64GB HBM for cache → 500K tokens → 31.25K blocks at block size 16.
+	defaultApproxLRUCapacity = 31250
 )
 
 type kvCacheIndexer interface {
@@ -57,27 +72,66 @@ type kvCacheIndexer interface {
 // PrecisePrefixCachePluginConfig holds the configuration for the
 // PrecisePrefixCacheScorer plugin.
 type PrecisePrefixCachePluginConfig struct {
+	// Mode selects the scoring mode:
+	//   "precise"     - KV events + tokenizer (default, current behavior)
+	//   "approximate" - xxhash + self-reported LRU (no KV events/tokenizer needed)
+	//   "unified"     - both modes combined
+	// If empty, defaults to "precise".
+	Mode string `json:"mode"`
 	// TokenProcessorConfig holds the configuration for the `kvblock.TokenProcessor` which is
 	// used to process tokens into KV-block keys.
+	// Only used in "precise" and "unified" modes.
 	TokenProcessorConfig *kvblock.TokenProcessorConfig `json:"tokenProcessorConfig"`
 	// IndexerConfig holds the configuration for the `kvcache.Indexer` which is
 	// used to score endpoints based on the KV-cache index state.
+	// Only used in "precise" and "unified" modes.
 	IndexerConfig *kvcache.Config `json:"indexerConfig"`
 	// KVEventsConfig holds the configuration for the `kvevents.Pool` which is
 	// used to subscribe to KV-cache events and update the internal KV-cache
 	// index state.
+	// Only used in "precise" and "unified" modes.
 	KVEventsConfig *kvevents.Config `json:"kvEventsConfig"`
 	// SpeculativeIndexing enables speculative indexing. When true, the plugin
 	// proactively adds predicted cache entries to the index immediately after
 	// a routing decision (via PrepareRequestData and PreRequest), closing the
 	// blind spot between routing and KV event arrival.
 	// When false, only confirmed KV events populate the index.
+	// Only used in "precise" and "unified" modes.
 	SpeculativeIndexing bool `json:"speculativeIndexing"`
 	// SpeculativeTTL is the time-to-live for speculative index entries.
 	// After this duration, speculative entries are evicted from the index.
 	// If empty, defaultSpeculativeTTL is used. Only used when SpeculativeIndexing is true.
 	// Accepts Go duration strings (e.g. "2s", "500ms").
 	SpeculativeTTL string `json:"speculativeTTL"`
+	// ApproximateConfig holds configuration for approximate scoring mode.
+	// Only used when Mode is "approximate" or "unified".
+	ApproximateConfig *ApproximateConfig `json:"approximateConfig"`
+}
+
+// ApproximateConfig holds configuration for the approximate scoring mode.
+type ApproximateConfig struct {
+	// BlockSizeTokens is the block size in tokens. Each block is approximately
+	// blockSizeTokens * 4 characters wide. Default: 16.
+	BlockSizeTokens int `json:"blockSizeTokens"`
+	// MaxPrefixBlocksToMatch limits how many blocks to hash per request.
+	// Longer prefixes are truncated. Default: 256.
+	MaxPrefixBlocksToMatch int `json:"maxPrefixBlocksToMatch"`
+	// LRUCapacityPerServer is the maximum number of LRU entries per pod.
+	// Default: 31250 (sized for H100 80GB).
+	LRUCapacityPerServer int `json:"lruCapacityPerServer"`
+	// AutoTune enables dynamic block size and LRU capacity from endpoint metrics.
+	// Default: true.
+	AutoTune bool `json:"autoTune"`
+}
+
+// defaultApproximateConfig returns a default ApproximateConfig.
+func defaultApproximateConfig() *ApproximateConfig {
+	return &ApproximateConfig{
+		BlockSizeTokens:        defaultApproxBlockSizeTokens,
+		MaxPrefixBlocksToMatch: defaultApproxMaxPrefixBlocks,
+		LRUCapacityPerServer:   defaultApproxLRUCapacity,
+		AutoTune:               true,
+	}
 }
 
 // compile-time type assertions
@@ -115,6 +169,29 @@ func (s *precisePluginState) Clone() plugin.StateData {
 	}
 }
 
+// approximatePluginState holds data shared between PrepareRequestData, Score,
+// and PreRequest for approximate mode via PluginState.
+type approximatePluginState struct {
+	hashes       []ApproximateBlockHash
+	serverScores map[ApproximateServerID]int // server → longest prefix match in blocks
+	totalBlocks  int
+}
+
+// Clone implements plugin.StateData.
+func (s *approximatePluginState) Clone() plugin.StateData {
+	hashes := make([]ApproximateBlockHash, len(s.hashes))
+	copy(hashes, s.hashes)
+	scores := make(map[ApproximateServerID]int, len(s.serverScores))
+	for k, v := range s.serverScores {
+		scores[k] = v
+	}
+	return &approximatePluginState{
+		hashes:       hashes,
+		serverScores: scores,
+		totalBlocks:  s.totalBlocks,
+	}
+}
+
 // PrecisePrefixCachePluginFactory defines the factory function for creating
 // a new instance of the PrefixCacheTrackingPlugin.
 func PrecisePrefixCachePluginFactory(name string, rawParameters json.RawMessage,
@@ -136,12 +213,19 @@ func PrecisePrefixCachePluginFactory(name string, rawParameters json.RawMessage,
 		}
 	}
 
-	// Validate model name is set
-	if parameters.IndexerConfig == nil || parameters.IndexerConfig.TokenizersPoolConfig == nil || parameters.IndexerConfig.TokenizersPoolConfig.ModelName == "" {
-		return nil, errors.New("modelName is required in indexerConfig.tokenizersPoolConfig")
+	mode := parameters.Mode
+	if mode == "" {
+		mode = ModePrecise
 	}
 
-	scorer, err := New(handle.Context(), parameters)
+	// Validate model name is set for modes that require precise scoring.
+	if mode == ModePrecise || mode == ModeUnified {
+		if parameters.IndexerConfig == nil || parameters.IndexerConfig.TokenizersPoolConfig == nil || parameters.IndexerConfig.TokenizersPoolConfig.ModelName == "" {
+			return nil, errors.New("modelName is required in indexerConfig.tokenizersPoolConfig for precise/unified mode")
+		}
+	}
+
+	scorer, err := New(handle.Context(), parameters, handle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s plugin: %w", PrecisePrefixCachePluginType, err)
 	}
@@ -150,28 +234,71 @@ func PrecisePrefixCachePluginFactory(name string, rawParameters json.RawMessage,
 }
 
 // New initializes a new prefix Plugin and returns its pointer.
-// It sets up the `kvcache.Indexer` and `kvevents.Pool`
-// based on the provided configuration. The `kvevents.Pool` is started
-// in a goroutine to listen for KV-cache events and update the internal
-// KV-cache index state. The `kvcache.Indexer` is also started in a goroutine
-// to score endpoints based on the KV-cache index state.
+// It sets up components based on the configured mode:
+//   - "precise": KV events + tokenizer + optional speculative indexing
+//   - "approximate": xxhash + self-reported LRU (no KV events/tokenizer)
+//   - "unified": both modes combined
 //
-// If the configuration is invalid or if the indexer fails to initialize,
-// an error is returned.
-func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePrefixCacheScorer, error) {
+// The handle parameter is optional and only required for approximate/unified
+// modes (provides PodList for inactive pod cleanup). Pass nil for precise-only.
+func New(ctx context.Context, config PrecisePrefixCachePluginConfig, handle plugin.Handle) (*PrecisePrefixCacheScorer, error) {
+	mode := config.Mode
+	if mode == "" {
+		mode = ModePrecise
+	}
+
+	switch mode {
+	case ModePrecise, ModeApproximate, ModeUnified:
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid mode %q: must be one of %q, %q, %q",
+			mode, ModePrecise, ModeApproximate, ModeUnified)
+	}
+
+	scorer := &PrecisePrefixCacheScorer{
+		typedName: plugin.TypedName{Type: PrecisePrefixCachePluginType},
+		mode:      mode,
+	}
+
+	// --- Precise mode initialization ---
+	if mode == ModePrecise || mode == ModeUnified {
+		if err := scorer.initPrecise(ctx, config); err != nil {
+			return nil, err
+		}
+	}
+
+	// --- Approximate mode initialization ---
+	if mode == ModeApproximate || mode == ModeUnified {
+		scorer.initApproximate(ctx, config, handle)
+	}
+
+	// For approximate-only mode, we still need pluginState and blockSizeTokens.
+	if scorer.pluginState == nil {
+		scorer.pluginState = plugin.NewPluginState(ctx)
+	}
+	if scorer.blockSizeTokens == 0 {
+		scorer.blockSizeTokens = defaultApproxBlockSizeTokens
+	}
+
+	return scorer, nil
+}
+
+// initPrecise sets up KV events, tokenizer, speculative cache, and subscribers
+// for precise scoring mode. This is the existing Phase 1 initialization.
+func (s *PrecisePrefixCacheScorer) initPrecise(ctx context.Context, config PrecisePrefixCachePluginConfig) error {
 	if config.TokenProcessorConfig == nil {
 		config.TokenProcessorConfig = kvblock.DefaultTokenProcessorConfig()
 	}
 
 	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(config.TokenProcessorConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create token processor: %w", err)
+		return fmt.Errorf("failed to create token processor: %w", err)
 	}
 
 	// initialize the indexer
 	kvCacheIndexer, err := kvcache.NewKVCacheIndexer(ctx, config.IndexerConfig, tokenProcessor)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create `kvcache.Indexer`: %w", err)
+		return fmt.Errorf("failed to create `kvcache.Indexer`: %w", err)
 	}
 
 	go kvCacheIndexer.Run(ctx)
@@ -183,7 +310,7 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 	}
 	kvBlockScorer, err := kvcache.NewKVBlockScorer(scorerConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create KVBlockScorer: %w", err)
+		return fmt.Errorf("failed to create KVBlockScorer: %w", err)
 	}
 
 	// initialize the KV-events pool
@@ -195,7 +322,6 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 
 	// initialize the subscribers cache only if endpoint discovery is enabled
 	if config.KVEventsConfig.DiscoverPods {
-		// initialize the subscribers TTL cache
 		subscriptionTimeout := 10 * time.Minute
 		subscribersCache = ttlcache.New[string, struct{}](
 			ttlcache.WithTTL[string, struct{}](subscriptionTimeout),
@@ -210,10 +336,9 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 		go cleanCachePeriodically(ctx, subscribersCache, subscriptionTimeout)
 	}
 	if config.KVEventsConfig.ZMQEndpoint != "" {
-		// setup local subscriber to support global socket mode
 		if err := subscribersManager.EnsureSubscriber(ctx, "local-subscriber",
 			config.KVEventsConfig.ZMQEndpoint, config.KVEventsConfig.TopicFilter, false); err != nil {
-			return nil, fmt.Errorf("failed to create local subscriber for global socket mode: %w", err)
+			return fmt.Errorf("failed to create local subscriber for global socket mode: %w", err)
 		}
 	}
 
@@ -222,10 +347,9 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 	var speculativeTTL time.Duration
 	if config.SpeculativeIndexing {
 		if config.SpeculativeTTL != "" {
-			var err error
 			speculativeTTL, err = time.ParseDuration(config.SpeculativeTTL)
 			if err != nil {
-				return nil, fmt.Errorf("invalid speculativeTTL %q: %w", config.SpeculativeTTL, err)
+				return fmt.Errorf("invalid speculativeTTL %q: %w", config.SpeculativeTTL, err)
 			}
 		}
 		if speculativeTTL <= 0 {
@@ -243,9 +367,6 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 			}
 			entries := item.Value()
 			for _, reqKey := range entries.blockKeys {
-				// Evict speculative entries from the index.
-				// Speculative entries were added without engineKey mapping (nil engineKeys),
-				// so we use RequestKey type to evict by requestKey directly.
 				//nolint:errcheck // best-effort cleanup on TTL expiry
 				kvCacheIndexer.KVBlockIndex().Evict(context.Background(), reqKey, kvblock.RequestKey, entries.podEntries)
 			}
@@ -253,19 +374,47 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 		go cleanCachePeriodically(ctx, speculativeCache, speculativeTTL)
 	}
 
-	return &PrecisePrefixCacheScorer{
-		typedName:          plugin.TypedName{Type: PrecisePrefixCachePluginType},
-		kvCacheIndexer:     kvCacheIndexer,
-		kvBlockScorer:      kvBlockScorer,
-		subscribersCache:   subscribersCache,
-		subscribersManager: subscribersManager,
-		kvEventsConfig:     config.KVEventsConfig,
-		pluginState:        plugin.NewPluginState(ctx),
-		speculativeCache:   speculativeCache,
-		speculativeTTL:     speculativeTTL,
-		blockSizeTokens:    config.TokenProcessorConfig.BlockSize,
-		speculativeEnabled: config.SpeculativeIndexing,
-	}, nil
+	s.kvCacheIndexer = kvCacheIndexer
+	s.kvBlockScorer = kvBlockScorer
+	s.subscribersCache = subscribersCache
+	s.subscribersManager = subscribersManager
+	s.kvEventsConfig = config.KVEventsConfig
+	s.pluginState = plugin.NewPluginState(ctx)
+	s.speculativeCache = speculativeCache
+	s.speculativeTTL = speculativeTTL
+	s.blockSizeTokens = config.TokenProcessorConfig.BlockSize
+	s.speculativeEnabled = config.SpeculativeIndexing
+
+	return nil
+}
+
+// initApproximate sets up the xxhash-based indexer and inactive pod cleanup
+// for approximate scoring mode.
+func (s *PrecisePrefixCacheScorer) initApproximate(ctx context.Context, config PrecisePrefixCachePluginConfig, handle plugin.Handle) {
+	approxCfg := config.ApproximateConfig
+	if approxCfg == nil {
+		approxCfg = defaultApproximateConfig()
+	}
+	if approxCfg.BlockSizeTokens <= 0 {
+		approxCfg.BlockSizeTokens = defaultApproxBlockSizeTokens
+	}
+	if approxCfg.MaxPrefixBlocksToMatch <= 0 {
+		approxCfg.MaxPrefixBlocksToMatch = defaultApproxMaxPrefixBlocks
+	}
+	if approxCfg.LRUCapacityPerServer <= 0 {
+		approxCfg.LRUCapacityPerServer = defaultApproxLRUCapacity
+	}
+
+	s.approxIndexer = newApproximateIndexer(ctx, approxCfg.LRUCapacityPerServer)
+	s.approxBlockSize = approxCfg.BlockSizeTokens
+	s.approxMaxBlocks = approxCfg.MaxPrefixBlocksToMatch
+	s.approxAutoTune = approxCfg.AutoTune
+	s.approxPluginState = plugin.NewPluginState(ctx)
+
+	// Start inactive pod cleanup goroutine if handle is available.
+	if handle != nil {
+		go s.cleanUpInactivePods(ctx, handle)
+	}
 }
 
 // PrecisePrefixCacheScorer implements the framework.Scorer interface.
@@ -309,6 +458,27 @@ type PrecisePrefixCacheScorer struct {
 
 	// speculativeEnabled controls whether speculative indexing is active.
 	speculativeEnabled bool
+
+	// --- Approximate mode fields ---
+
+	// mode is the active scoring mode: "precise", "approximate", or "unified".
+	mode string
+
+	// approxIndexer is the self-reported LRU indexer for approximate mode.
+	approxIndexer *approximateIndexer
+
+	// approxBlockSize is the block size in tokens for approximate hashing.
+	approxBlockSize int
+
+	// approxMaxBlocks is the max prefix blocks to hash per request.
+	approxMaxBlocks int
+
+	// approxAutoTune enables dynamic block size from endpoint metrics.
+	approxAutoTune bool
+
+	// approxPluginState stores per-request data for approximate mode,
+	// separate from the precise mode pluginState to avoid key collisions in unified mode.
+	approxPluginState *plugin.PluginState
 }
 
 // TypedName returns the typed name of the plugin.
@@ -344,18 +514,35 @@ func (s *PrecisePrefixCacheScorer) Consumes() map[string]any {
 // PrepareRequestData computes block keys, looks up the index, and stores
 // per-endpoint prefix match information. The computed block keys and scores
 // are saved to PluginState for reuse by Score() and PreRequest().
-// This is a no-op when speculative indexing is disabled.
 func (s *PrecisePrefixCacheScorer) PrepareRequestData(ctx context.Context,
 	request *scheduling.LLMRequest, endpoints []scheduling.Endpoint) error {
-	if !s.speculativeEnabled {
-		return nil
-	}
-
-	logger := log.FromContext(ctx).WithName(s.typedName.String())
-
 	if request == nil || request.Body == nil {
 		return nil
 	}
+
+	switch s.mode {
+	case ModeApproximate:
+		return s.prepareDataApproximate(ctx, request, endpoints)
+	case ModeUnified:
+		// Always run precise in unified mode so endpoint PrefixCacheMatchInfo
+		// and PluginState reflect precise hits. Errors are non-fatal.
+		if err := s.prepareDataPrecise(ctx, request, endpoints); err != nil {
+			log.FromContext(ctx).WithName(s.typedName.String()).Error(err,
+				"Precise PrepareRequestData failed, continuing with approximate")
+		}
+		return s.prepareDataApproximate(ctx, request, endpoints)
+	default: // ModePrecise
+		if !s.speculativeEnabled {
+			return nil
+		}
+		return s.prepareDataPrecise(ctx, request, endpoints)
+	}
+}
+
+// prepareDataPrecise is the existing precise mode PrepareRequestData logic.
+func (s *PrecisePrefixCacheScorer) prepareDataPrecise(ctx context.Context,
+	request *scheduling.LLMRequest, endpoints []scheduling.Endpoint) error {
+	logger := log.FromContext(ctx).WithName(s.typedName.String())
 
 	// 1. Compute block keys from the request
 	blockKeys, err := s.computeBlockKeys(ctx, request)
@@ -399,47 +586,144 @@ func (s *PrecisePrefixCacheScorer) PrepareRequestData(ctx context.Context,
 		scores:    scores,
 	})
 
-	logger.V(logutil.TRACE).Info("PrepareRequestData completed",
+	logger.V(logutil.TRACE).Info("PrepareRequestData (precise) completed",
 		"blockKeys", len(blockKeys), "scores", scores)
+
+	return nil
+}
+
+// prepareDataApproximate hashes the prompt with xxhash, matches against
+// the self-reported LRU indexer, and stores per-endpoint match info.
+func (s *PrecisePrefixCacheScorer) prepareDataApproximate(ctx context.Context,
+	request *scheduling.LLMRequest, endpoints []scheduling.Endpoint) error {
+	logger := log.FromContext(ctx).WithName(s.typedName.String())
+
+	blockSize := s.getApproxBlockSize(endpoints)
+	hashes := hashPrompt(ctx, request, blockSize, s.approxMaxBlocks)
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	// Match longest prefix in local LRU indexer
+	serverMatches := s.approxIndexer.MatchLongestPrefix(hashes)
+
+	// Store PrefixCacheMatchInfo on endpoints.
+	// In unified mode, only overwrite if approximate has a better match
+	// (more cached tokens) than what precise already wrote.
+	for _, ep := range endpoints {
+		md := ep.GetMetadata()
+		if md == nil {
+			continue
+		}
+		serverID := ApproximateServerID(md.NamespacedName)
+		matchLen := serverMatches[serverID]
+		approxInfo := dl_prefix.NewPrefixCacheMatchInfo(matchLen, len(hashes), blockSize)
+
+		if s.mode == ModeUnified {
+			if existing, ok := ep.Get(dl_prefix.PrefixCacheMatchInfoKey); ok {
+				if existingInfo, ok := existing.(*dl_prefix.PrefixCacheMatchInfo); ok {
+					if existingInfo.MatchBlocks()*existingInfo.BlockSizeTokens() >= approxInfo.MatchBlocks()*approxInfo.BlockSizeTokens() {
+						continue // keep precise result
+					}
+				}
+			}
+		}
+		ep.Put(dl_prefix.PrefixCacheMatchInfoKey, approxInfo)
+	}
+
+	// Save to PluginState for Score() and PreRequest()
+	s.approxPluginState.Write(request.RequestId, approxStateKey, &approximatePluginState{
+		hashes:       hashes,
+		serverScores: serverMatches,
+		totalBlocks:  len(hashes),
+	})
+
+	logger.V(logutil.TRACE).Info("PrepareRequestData (approximate) completed",
+		"hashes", len(hashes), "serverMatches", fmt.Sprintf("%v", serverMatches))
 
 	return nil
 }
 
 // --- Scorer implementation ---
 
-// Score scores the provided endpoint based on the KVCache index state.
+// Score scores the provided endpoint based on cache index state.
 // The returned scores are normalized to a range of 0-1.
-// If PrepareRequestData was called beforehand, Score reuses the pre-computed
-// results from PluginState. Otherwise, it falls back to computing scores
-// directly via getScores (backward compatible).
 func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.LLMRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
-	// Start tracing span for scoring operation
 	tracer := telemetry.Tracer()
 	ctx, span := tracer.Start(ctx, "llm_d.epp.scorer.prefix_cache",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
 
+	span.SetAttributes(
+		attribute.Int("llm_d.scorer.candidate_endpoints", len(endpoints)),
+		attribute.String("llm_d.scorer.mode", s.mode),
+	)
+
+	if request == nil {
+		span.SetAttributes(attribute.String("llm_d.scorer.result", "skipped_nil_request"))
+		return nil
+	}
+	if request.TargetModel != "" {
+		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
+	}
+	if request.RequestId != "" {
+		span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
+	}
+
+	var normalizedScores map[scheduling.Endpoint]float64
+
+	switch s.mode {
+	case ModeApproximate:
+		normalizedScores = s.scoreApproximate(ctx, cycleState, request, endpoints)
+	case ModeUnified:
+		precise := s.scorePrecise(ctx, cycleState, request, endpoints)
+		approx := s.scoreApproximate(ctx, cycleState, request, endpoints)
+		normalizedScores = combineScores(precise, approx)
+		// Merge approximate hits into cycleState so downstream plugins (e.g. no_hit_lru)
+		// see the combined cache state, not just precise hits.
+		s.mergeApproxIntoCycleState(cycleState, request, endpoints)
+	default: // ModePrecise
+		normalizedScores = s.scorePrecise(ctx, cycleState, request, endpoints)
+	}
+
+	// Calculate score distribution for observability
+	if len(normalizedScores) > 0 {
+		maxScore := 0.0
+		totalScore := 0.0
+		for _, score := range normalizedScores {
+			if score > maxScore {
+				maxScore = score
+			}
+			totalScore += score
+		}
+		avgScore := totalScore / float64(len(normalizedScores))
+		span.SetAttributes(
+			attribute.Float64("llm_d.scorer.score.max", maxScore),
+			attribute.Float64("llm_d.scorer.score.avg", avgScore),
+			attribute.Int("llm_d.scorer.endpoints_scored", len(normalizedScores)),
+		)
+	}
+
+	return normalizedScores
+}
+
+// scorePrecise is the existing precise scoring logic.
+func (s *PrecisePrefixCacheScorer) scorePrecise(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.LLMRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 	debugLogger := logger.V(logutil.DEBUG)
 
-	// Set initial attributes
-	span.SetAttributes(
-		attribute.Int("llm_d.scorer.candidate_endpoints", len(endpoints)),
-	)
-
 	// Handle pod discovery and subscriber management
-	if s.kvEventsConfig.DiscoverPods {
-		// update subscribers here temporarily
+	if s.kvEventsConfig != nil && s.kvEventsConfig.DiscoverPods {
 		for _, endpoint := range endpoints {
 			endpointObj := endpoint.GetMetadata()
 			if endpointObj == nil {
 				continue
 			}
 			endpointKey := endpointObj.NamespacedName.String()
-			s.subscribersCache.Set(endpointKey, struct{}{}, 0) // use default TTL
+			s.subscribersCache.Set(endpointKey, struct{}{}, 0)
 
-			if err := s.subscribersManager.EnsureSubscriber(context.Background(), endpointKey, // dont use request ctx
+			if err := s.subscribersManager.EnsureSubscriber(context.Background(), endpointKey,
 				fmt.Sprintf("tcp://%s:%d", endpointObj.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort),
 				s.kvEventsConfig.TopicFilter, true); err != nil {
 				logger.Error(err, "Failed to ensure KV-events subscriber for endpoint", "endpoint", endpointKey,
@@ -449,21 +733,6 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *schedu
 		}
 	}
 
-	// Early return if request is nil
-	if request == nil {
-		debugLogger.Info("Request is nil, skipping scoring")
-		span.SetAttributes(attribute.String("llm_d.scorer.result", "skipped_nil_request"))
-		return nil
-	}
-
-	// Set optional request attributes
-	if request.TargetModel != "" {
-		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
-	}
-	if request.RequestId != "" {
-		span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
-	}
-
 	// Try to reuse pre-computed scores from PrepareRequestData
 	var scores map[string]float64
 	if pluginStateData, err := plugin.ReadPluginStateKey[*precisePluginState](
@@ -471,28 +740,20 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *schedu
 		scores = pluginStateData.scores
 		debugLogger.Info("Reusing pre-computed scores from PrepareRequestData")
 	} else {
-		// Fallback: compute scores directly (backward compatible path).
 		var scoreErr error
 		scores, scoreErr = s.getScores(ctx, cycleState, request)
 		if scoreErr != nil {
 			logger.Error(scoreErr, "Failed to get endpoint scores")
-			span.SetStatus(codes.Error, scoreErr.Error())
 			return nil
 		}
 	}
-	debugLogger.Info("Got endpoint scores", "scores", scores)
-
-	// Track scoring statistics
-	span.SetAttributes(
-		attribute.Int("llm_d.scorer.scores_computed", len(scores)),
-	)
+	debugLogger.Info("Got endpoint scores (precise)", "scores", scores)
 
 	endpointToKey := func(endpoint scheduling.Endpoint) (string, bool) {
 		metadata := endpoint.GetMetadata()
 		if metadata == nil {
 			return "", false
 		}
-
 		return fmt.Sprintf("%s:%s", metadata.Address, metadata.Port), true
 	}
 
@@ -506,53 +767,189 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *schedu
 		if !ok {
 			continue
 		}
-		if s, exists := scores[key]; exists && s > 0 {
-			prefixCacheState.PrefixCacheServers[prefix.ServerID(endpoint.GetMetadata().NamespacedName)] = int(s)
+		if sc, exists := scores[key]; exists && sc > 0 {
+			prefixCacheState.PrefixCacheServers[prefix.ServerID(endpoint.GetMetadata().NamespacedName)] = int(sc)
 		}
 	}
 	cycleState.Write(plugin.StateKey(s.typedName.String()), prefixCacheState)
 
-	normalizedScores := indexedScoresToNormalizedScoredPods(endpoints, endpointToKey, scores)
+	return indexedScoresToNormalizedScoredPods(endpoints, endpointToKey, scores)
+}
 
-	// Calculate score distribution for observability
-	if len(normalizedScores) > 0 {
-		maxScore := 0.0
-		totalScore := 0.0
-		for _, score := range normalizedScores {
-			if score > maxScore {
-				maxScore = score
-			}
-			totalScore += score
+// scoreApproximate scores endpoints using the self-reported LRU indexer.
+func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.LLMRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
+	logger := log.FromContext(ctx).WithName(s.typedName.String())
+
+	// Try PluginState first (from PrepareRequestData)
+	var serverMatches map[ApproximateServerID]int
+	var totalBlocks int
+
+	if state, err := plugin.ReadPluginStateKey[*approximatePluginState](
+		s.approxPluginState, request.RequestId, approxStateKey); err == nil {
+		serverMatches = state.serverScores
+		totalBlocks = state.totalBlocks
+		logger.V(logutil.DEBUG).Info("Reusing pre-computed approximate scores")
+	} else {
+		// Fallback: compute inline
+		blockSize := s.getApproxBlockSize(endpoints)
+		hashes := hashPrompt(ctx, request, blockSize, s.approxMaxBlocks)
+		if len(hashes) == 0 {
+			return nil
 		}
-		avgScore := totalScore / float64(len(normalizedScores))
+		serverMatches = s.approxIndexer.MatchLongestPrefix(hashes)
+		totalBlocks = len(hashes)
 
-		span.SetAttributes(
-			attribute.Float64("llm_d.scorer.score.max", maxScore),
-			attribute.Float64("llm_d.scorer.score.avg", avgScore),
-			attribute.Int("llm_d.scorer.endpoints_scored", len(normalizedScores)),
-		)
+		// Save for PreRequest
+		s.approxPluginState.Write(request.RequestId, approxStateKey, &approximatePluginState{
+			hashes:       hashes,
+			serverScores: serverMatches,
+			totalBlocks:  totalBlocks,
+		})
 	}
 
-	return normalizedScores
+	if totalBlocks == 0 {
+		return nil
+	}
+
+	// Write prefix cache state to cycle state (same format as precise).
+	prefixCacheState := &prefix.SchedulingContextState{
+		PrefixHashes:       []prefix.BlockHash{},
+		PrefixCacheServers: map[prefix.ServerID]int{},
+	}
+
+	result := make(map[scheduling.Endpoint]float64, len(endpoints))
+	for _, ep := range endpoints {
+		md := ep.GetMetadata()
+		if md == nil {
+			continue
+		}
+		serverID := ApproximateServerID(md.NamespacedName)
+		matchLen := serverMatches[serverID]
+		result[ep] = float64(matchLen) / float64(totalBlocks)
+
+		if matchLen > 0 {
+			prefixCacheState.PrefixCacheServers[prefix.ServerID(md.NamespacedName)] = matchLen
+		}
+	}
+
+	// Only write to cycleState if we're in approximate-only mode (avoid conflict with precise).
+	if s.mode == ModeApproximate {
+		cycleState.Write(plugin.StateKey(s.typedName.String()), prefixCacheState)
+	}
+
+	return result
+}
+
+// combineScores merges precise and approximate scores for unified mode.
+//
+// When precise scores show no differentiation (all equal — which happens when
+// min-max normalization maps all-zero raw scores to all-1.0), we use
+// approximate scores directly. Otherwise we take the max per endpoint.
+// This prevents precise all-1.0 scores from masking approximate cache signals.
+func combineScores(precise, approx map[scheduling.Endpoint]float64) map[scheduling.Endpoint]float64 {
+	if len(precise) == 0 {
+		return approx
+	}
+	if len(approx) == 0 {
+		return precise
+	}
+
+	// Check if precise scores are all identical (no differentiation).
+	// This happens when min-max normalization maps all-zero raw scores to all-1.0.
+	// In that case, precise adds no signal, so use approximate scores directly.
+	// Only applies when there are 2+ endpoints (single endpoint is trivially "all same").
+	if len(precise) >= 2 {
+		preciseUndifferentiated := true
+		var firstScore float64
+		first := true
+		for _, ps := range precise {
+			if first {
+				firstScore = ps
+				first = false
+				continue
+			}
+			if ps != firstScore {
+				preciseUndifferentiated = false
+				break
+			}
+		}
+		if preciseUndifferentiated {
+			return approx
+		}
+	}
+
+	combined := make(map[scheduling.Endpoint]float64, len(precise))
+	for ep, ps := range precise {
+		combined[ep] = ps
+	}
+	for ep, as := range approx {
+		if as > combined[ep] {
+			combined[ep] = as
+		}
+	}
+	return combined
+}
+
+// mergeApproxIntoCycleState reads the approximate PluginState and merges any
+// approximate hits into the existing cycleState written by scorePrecise.
+// This ensures downstream plugins (e.g. no_hit_lru) see the combined view.
+func (s *PrecisePrefixCacheScorer) mergeApproxIntoCycleState(cycleState *scheduling.CycleState, request *scheduling.LLMRequest, endpoints []scheduling.Endpoint) {
+	state, err := plugin.ReadPluginStateKey[*approximatePluginState](
+		s.approxPluginState, request.RequestId, approxStateKey)
+	if err != nil || len(state.serverScores) == 0 {
+		return
+	}
+
+	// Read existing state written by scorePrecise.
+	existing, readErr := scheduling.ReadCycleStateKey[*prefix.SchedulingContextState](
+		cycleState, plugin.StateKey(s.typedName.String()))
+	if readErr != nil {
+		return
+	}
+
+	// Merge approximate hits: take max of precise vs approximate per server.
+	for _, ep := range endpoints {
+		md := ep.GetMetadata()
+		if md == nil {
+			continue
+		}
+		sid := prefix.ServerID(md.NamespacedName)
+		approxMatch := state.serverScores[ApproximateServerID(md.NamespacedName)]
+		if approxMatch > existing.PrefixCacheServers[sid] {
+			existing.PrefixCacheServers[sid] = approxMatch
+		}
+	}
+	cycleState.Write(plugin.StateKey(s.typedName.String()), existing)
 }
 
 // --- PreRequest implementation ---
 
-// PreRequest records speculative entries in the index for the selected endpoint
-// immediately after the scheduling decision. This closes the blind spot between
-// the routing decision and the arrival of actual KV events from the engine.
-// The speculative entries are associated with a TTL and will be automatically
-// evicted when the TTL expires.
-// This is a no-op when speculative indexing is disabled.
+// PreRequest records cache entries after a scheduling decision.
+// In precise mode, it adds speculative entries to the KV index.
+// In approximate mode, it self-reports routing decisions to the LRU indexer.
 func (s *PrecisePrefixCacheScorer) PreRequest(ctx context.Context,
 	request *scheduling.LLMRequest, schedulingResult *scheduling.SchedulingResult) {
-	if !s.speculativeEnabled {
-		return
+	switch s.mode {
+	case ModeApproximate:
+		s.preRequestApproximate(ctx, request, schedulingResult)
+	case ModeUnified:
+		if s.speculativeEnabled {
+			s.preRequestPrecise(ctx, request, schedulingResult)
+		}
+		s.preRequestApproximate(ctx, request, schedulingResult)
+	default: // ModePrecise
+		if !s.speculativeEnabled {
+			return
+		}
+		s.preRequestPrecise(ctx, request, schedulingResult)
 	}
+}
 
+// preRequestPrecise adds speculative entries to the precise KV index.
+func (s *PrecisePrefixCacheScorer) preRequestPrecise(ctx context.Context,
+	request *scheduling.LLMRequest, schedulingResult *scheduling.SchedulingResult) {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 
-	// 1. Read block keys from PluginState
 	state, err := plugin.ReadPluginStateKey[*precisePluginState](
 		s.pluginState, request.RequestId, stateKey)
 	if err != nil {
@@ -566,14 +963,12 @@ func (s *PrecisePrefixCacheScorer) PreRequest(ctx context.Context,
 		return
 	}
 
-	// 2. Get target endpoint from scheduling result
 	primaryResult := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
 	if primaryResult == nil || len(primaryResult.TargetEndpoints) == 0 {
 		return
 	}
 	targetEndpoint := primaryResult.TargetEndpoints[0]
 
-	// 3. Build speculative pod entry and add to index
 	targetMeta := targetEndpoint.GetMetadata()
 	speculativePod := kvblock.PodEntry{
 		PodIdentifier: fmt.Sprintf("%s:%s", targetMeta.Address, targetMeta.Port),
@@ -583,14 +978,12 @@ func (s *PrecisePrefixCacheScorer) PreRequest(ctx context.Context,
 	allPodEntries := []kvblock.PodEntry{speculativePod}
 
 	index := s.kvCacheIndexer.KVBlockIndex()
-	// Pass nil engineKeys: speculative entries only need requestKey -> PodEntry mapping.
-	// Engine keys will be linked later when confirmed KV events arrive.
 	if err := index.Add(ctx, nil, state.blockKeys, []kvblock.PodEntry{speculativePod}); err != nil {
 		logger.Error(err, "Failed to add speculative entries to index",
 			"pod", speculativePod.PodIdentifier)
 	}
 
-	// 4. Handle P/D disaggregation: also add speculative entry for prefill endpoint
+	// Handle P/D disaggregation
 	if pr, exists := schedulingResult.ProfileResults[experimentalPrefillProfile]; exists && len(pr.TargetEndpoints) > 0 {
 		prefillMeta := pr.TargetEndpoints[0].GetMetadata()
 		prefillPod := kvblock.PodEntry{
@@ -604,7 +997,6 @@ func (s *PrecisePrefixCacheScorer) PreRequest(ctx context.Context,
 		allPodEntries = append(allPodEntries, prefillPod)
 	}
 
-	// 5. Register in TTL cache for automatic eviction
 	s.speculativeCache.Set(request.RequestId, &speculativeEntries{
 		blockKeys:  state.blockKeys,
 		podEntries: allPodEntries,
@@ -615,6 +1007,52 @@ func (s *PrecisePrefixCacheScorer) PreRequest(ctx context.Context,
 		"pod", speculativePod.PodIdentifier,
 		"blockKeys", len(state.blockKeys),
 		"ttl", s.speculativeTTL)
+}
+
+// preRequestApproximate records the routing decision in the self-reported LRU indexer.
+func (s *PrecisePrefixCacheScorer) preRequestApproximate(ctx context.Context,
+	request *scheduling.LLMRequest, schedulingResult *scheduling.SchedulingResult) {
+	logger := log.FromContext(ctx).WithName(s.typedName.String())
+
+	state, err := plugin.ReadPluginStateKey[*approximatePluginState](
+		s.approxPluginState, request.RequestId, approxStateKey)
+	if err != nil || len(state.hashes) == 0 {
+		return
+	}
+	s.approxPluginState.Delete(request.RequestId)
+
+	primaryResult := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
+	if primaryResult == nil || len(primaryResult.TargetEndpoints) == 0 {
+		return
+	}
+
+	targetMeta := primaryResult.TargetEndpoints[0].GetMetadata()
+	server := ApproximateServerID(targetMeta.NamespacedName)
+	numGPUBlocks := 0
+	if s.approxAutoTune {
+		if m := primaryResult.TargetEndpoints[0].GetMetrics(); m != nil {
+			numGPUBlocks = m.CacheNumGPUBlocks
+		}
+	}
+	s.approxIndexer.Add(state.hashes, server, numGPUBlocks)
+
+	// P/D disaggregation: also record for prefill endpoint
+	if pr, exists := schedulingResult.ProfileResults[experimentalPrefillProfile]; exists && len(pr.TargetEndpoints) > 0 {
+		prefillMeta := pr.TargetEndpoints[0].GetMetadata()
+		prefillServer := ApproximateServerID(prefillMeta.NamespacedName)
+		prefillGPUBlocks := 0
+		if s.approxAutoTune {
+			if m := pr.TargetEndpoints[0].GetMetrics(); m != nil {
+				prefillGPUBlocks = m.CacheNumGPUBlocks
+			}
+		}
+		s.approxIndexer.Add(state.hashes, prefillServer, prefillGPUBlocks)
+	}
+
+	logger.V(logutil.TRACE).Info("Recorded approximate routing decision",
+		"requestID", request.RequestId,
+		"server", server,
+		"hashes", len(state.hashes))
 }
 
 // --- Internal helper methods ---
@@ -724,4 +1162,45 @@ func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, cycleState *sc
 	}
 
 	return nil, errors.New("no valid input found in request")
+}
+
+// --- Approximate mode helpers ---
+
+// getApproxBlockSize returns the block size for approximate hashing,
+// optionally using endpoint metrics if AutoTune is enabled.
+func (s *PrecisePrefixCacheScorer) getApproxBlockSize(endpoints []scheduling.Endpoint) int {
+	if s.approxAutoTune && len(endpoints) > 0 {
+		if m := endpoints[0].GetMetrics(); m != nil && m.CacheBlockSize > 0 {
+			return m.CacheBlockSize
+		}
+	}
+	return s.approxBlockSize
+}
+
+// cleanUpInactivePods periodically removes pods from the approximate indexer
+// that are no longer in the active pod list.
+func (s *PrecisePrefixCacheScorer) cleanUpInactivePods(ctx context.Context, handle plugin.Handle) {
+	ticker := time.NewTicker(defaultPodCleanupInterval)
+	defer ticker.Stop()
+
+	logger := log.FromContext(ctx).WithName(s.typedName.String())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			activePods := make(map[ApproximateServerID]struct{})
+			for _, pod := range handle.PodList() {
+				activePods[ApproximateServerID(pod)] = struct{}{}
+			}
+			for _, tracked := range s.approxIndexer.Pods() {
+				if _, active := activePods[tracked]; !active {
+					s.approxIndexer.RemovePod(tracked)
+					logger.V(logutil.VERBOSE).Info("Removed inactive pod from approximate indexer",
+						"pod", tracked)
+				}
+			}
+		}
+	}
 }

--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -182,7 +181,8 @@ func (s *precisePluginState) Clone() plugin.StateData {
 // and PreRequest for approximate mode via PluginState.
 type approximatePluginState struct {
 	hashes       []ApproximateBlockHash
-	serverScores map[ApproximateServerID]float64 // server → score (block count or weighted)
+	serverScores map[ApproximateServerID]float64 // server → score (block count or weighted) for scoring
+	blockCounts  map[ApproximateServerID]int     // server → integer contiguous block count for match info
 	totalBlocks  int
 }
 
@@ -194,9 +194,14 @@ func (s *approximatePluginState) Clone() plugin.StateData {
 	for k, v := range s.serverScores {
 		scores[k] = v
 	}
+	counts := make(map[ApproximateServerID]int, len(s.blockCounts))
+	for k, v := range s.blockCounts {
+		counts[k] = v
+	}
 	return &approximatePluginState{
 		hashes:       hashes,
 		serverScores: scores,
+		blockCounts:  counts,
 		totalBlocks:  s.totalBlocks,
 	}
 }
@@ -635,17 +640,26 @@ func (s *PrecisePrefixCacheScorer) prepareDataApproximate(ctx context.Context,
 	// Match longest prefix in local LRU indexer.
 	// Use recency-weighted scoring when half-life is configured.
 	var serverScores map[ApproximateServerID]float64
+	var blockCounts map[ApproximateServerID]int
 	if s.approxRecencyHalfLife > 0 {
-		serverScores = s.approxIndexer.MatchLongestPrefixWeighted(hashes, time.Now(), s.approxRecencyHalfLife)
+		weighted := s.approxIndexer.MatchLongestPrefixWeighted(hashes, time.Now(), s.approxRecencyHalfLife)
+		serverScores = make(map[ApproximateServerID]float64, len(weighted))
+		blockCounts = make(map[ApproximateServerID]int, len(weighted))
+		for k, v := range weighted {
+			serverScores[k] = v.WeightedScore
+			blockCounts[k] = v.BlockCount
+		}
 	} else {
 		intScores := s.approxIndexer.MatchLongestPrefix(hashes)
 		serverScores = make(map[ApproximateServerID]float64, len(intScores))
+		blockCounts = make(map[ApproximateServerID]int, len(intScores))
 		for k, v := range intScores {
 			serverScores[k] = float64(v)
+			blockCounts[k] = v
 		}
 	}
 
-	// Store PrefixCacheMatchInfo on endpoints.
+	// Store PrefixCacheMatchInfo on endpoints using integer block counts.
 	// In unified mode, only overwrite if approximate has a better match
 	// (more cached tokens) than what precise already wrote.
 	for _, ep := range endpoints {
@@ -654,7 +668,7 @@ func (s *PrecisePrefixCacheScorer) prepareDataApproximate(ctx context.Context,
 			continue
 		}
 		sid := ApproximateServerID(md.NamespacedName)
-		matchLen := int(math.Round(serverScores[sid]))
+		matchLen := blockCounts[sid]
 		approxInfo := dl_prefix.NewPrefixCacheMatchInfo(matchLen, len(hashes), blockSize)
 
 		if s.mode == ModeUnified {
@@ -673,6 +687,7 @@ func (s *PrecisePrefixCacheScorer) prepareDataApproximate(ctx context.Context,
 	s.approxPluginState.Write(request.RequestId, approxStateKey, &approximatePluginState{
 		hashes:       hashes,
 		serverScores: serverScores,
+		blockCounts:  blockCounts,
 		totalBlocks:  len(hashes),
 	})
 
@@ -820,11 +835,13 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 
 	// Try PluginState first (from PrepareRequestData)
 	var serverScores map[ApproximateServerID]float64
+	var blockCounts map[ApproximateServerID]int
 	var totalBlocks int
 
 	if state, err := plugin.ReadPluginStateKey[*approximatePluginState](
 		s.approxPluginState, request.RequestId, approxStateKey); err == nil {
 		serverScores = state.serverScores
+		blockCounts = state.blockCounts
 		totalBlocks = state.totalBlocks
 		logger.V(logutil.DEBUG).Info("Reusing pre-computed approximate scores")
 	} else {
@@ -836,12 +853,20 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 		}
 
 		if s.approxRecencyHalfLife > 0 {
-			serverScores = s.approxIndexer.MatchLongestPrefixWeighted(hashes, time.Now(), s.approxRecencyHalfLife)
+			weighted := s.approxIndexer.MatchLongestPrefixWeighted(hashes, time.Now(), s.approxRecencyHalfLife)
+			serverScores = make(map[ApproximateServerID]float64, len(weighted))
+			blockCounts = make(map[ApproximateServerID]int, len(weighted))
+			for k, v := range weighted {
+				serverScores[k] = v.WeightedScore
+				blockCounts[k] = v.BlockCount
+			}
 		} else {
 			intScores := s.approxIndexer.MatchLongestPrefix(hashes)
 			serverScores = make(map[ApproximateServerID]float64, len(intScores))
+			blockCounts = make(map[ApproximateServerID]int, len(intScores))
 			for k, v := range intScores {
 				serverScores[k] = float64(v)
+				blockCounts[k] = v
 			}
 		}
 		totalBlocks = len(hashes)
@@ -850,6 +875,7 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 		s.approxPluginState.Write(request.RequestId, approxStateKey, &approximatePluginState{
 			hashes:       hashes,
 			serverScores: serverScores,
+			blockCounts:  blockCounts,
 			totalBlocks:  totalBlocks,
 		})
 	}
@@ -858,7 +884,7 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 		return nil
 	}
 
-	// Write prefix cache state to cycle state (same format as precise).
+	// Write prefix cache state to cycle state using integer block counts.
 	prefixCacheState := &prefix.SchedulingContextState{
 		PrefixHashes:       []prefix.BlockHash{},
 		PrefixCacheServers: map[prefix.ServerID]int{},
@@ -874,8 +900,8 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 		score := serverScores[sid]
 		result[ep] = score / float64(totalBlocks)
 
-		if score > 0 {
-			prefixCacheState.PrefixCacheServers[prefix.ServerID(md.NamespacedName)] = int(math.Round(score))
+		if bc := blockCounts[sid]; bc >= 1 {
+			prefixCacheState.PrefixCacheServers[prefix.ServerID(md.NamespacedName)] = bc
 		}
 	}
 
@@ -954,14 +980,14 @@ func (s *PrecisePrefixCacheScorer) mergeApproxIntoCycleState(cycleState *schedul
 		return
 	}
 
-	// Merge approximate hits: take max of precise vs approximate per server.
+	// Merge approximate hits using integer block counts.
 	for _, ep := range endpoints {
 		md := ep.GetMetadata()
 		if md == nil {
 			continue
 		}
 		sid := prefix.ServerID(md.NamespacedName)
-		approxMatch := int(math.Round(state.serverScores[ApproximateServerID(md.NamespacedName)]))
+		approxMatch := state.blockCounts[ApproximateServerID(md.NamespacedName)]
 		if approxMatch > existing.PrefixCacheServers[sid] {
 			existing.PrefixCacheServers[sid] = approxMatch
 		}
@@ -1059,6 +1085,10 @@ func (s *PrecisePrefixCacheScorer) preRequestPrecise(ctx context.Context,
 // preRequestApproximate records the routing decision in the self-reported LRU indexer.
 func (s *PrecisePrefixCacheScorer) preRequestApproximate(ctx context.Context,
 	request *scheduling.LLMRequest, schedulingResult *scheduling.SchedulingResult) {
+	if request == nil || schedulingResult == nil || len(schedulingResult.ProfileResults) == 0 {
+		return
+	}
+
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 
 	state, err := plugin.ReadPluginStateKey[*approximatePluginState](

--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -122,6 +123,14 @@ type ApproximateConfig struct {
 	// AutoTune enables dynamic block size and LRU capacity from endpoint metrics.
 	// Default: true.
 	AutoTune bool `json:"autoTune"`
+	// RecencyHalfLife enables recency-weighted scoring when set to a positive duration.
+	// Older self-reported entries decay exponentially: weight = exp(-age * ln2 / halfLife).
+	// A half-life of 30s means an entry recorded 30s ago contributes 50% of a fresh
+	// entry's weight. This improves accuracy because older entries are more likely to
+	// have been evicted from the actual GPU cache.
+	// If empty or zero, standard block-count scoring is used (no decay).
+	// Accepts Go duration strings (e.g. "30s", "1m").
+	RecencyHalfLife string `json:"recencyHalfLife"`
 }
 
 // defaultApproximateConfig returns a default ApproximateConfig.
@@ -173,7 +182,7 @@ func (s *precisePluginState) Clone() plugin.StateData {
 // and PreRequest for approximate mode via PluginState.
 type approximatePluginState struct {
 	hashes       []ApproximateBlockHash
-	serverScores map[ApproximateServerID]int // server → longest prefix match in blocks
+	serverScores map[ApproximateServerID]float64 // server → score (block count or weighted)
 	totalBlocks  int
 }
 
@@ -181,7 +190,7 @@ type approximatePluginState struct {
 func (s *approximatePluginState) Clone() plugin.StateData {
 	hashes := make([]ApproximateBlockHash, len(s.hashes))
 	copy(hashes, s.hashes)
-	scores := make(map[ApproximateServerID]int, len(s.serverScores))
+	scores := make(map[ApproximateServerID]float64, len(s.serverScores))
 	for k, v := range s.serverScores {
 		scores[k] = v
 	}
@@ -411,6 +420,21 @@ func (s *PrecisePrefixCacheScorer) initApproximate(ctx context.Context, config P
 	s.approxAutoTune = approxCfg.AutoTune
 	s.approxPluginState = plugin.NewPluginState(ctx)
 
+	if approxCfg.RecencyHalfLife != "" {
+		hl, err := time.ParseDuration(approxCfg.RecencyHalfLife)
+		if err != nil {
+			log.FromContext(ctx).WithName(s.typedName.String()).Error(err,
+				"Invalid recencyHalfLife, falling back to unweighted scoring",
+				"recencyHalfLife", approxCfg.RecencyHalfLife)
+		} else if hl <= 0 {
+			log.FromContext(ctx).WithName(s.typedName.String()).Info(
+				"Non-positive recencyHalfLife, using unweighted scoring",
+				"recencyHalfLife", approxCfg.RecencyHalfLife)
+		} else {
+			s.approxRecencyHalfLife = hl
+		}
+	}
+
 	// Start inactive pod cleanup goroutine if handle is available.
 	if handle != nil {
 		go s.cleanUpInactivePods(ctx, handle)
@@ -475,6 +499,10 @@ type PrecisePrefixCacheScorer struct {
 
 	// approxAutoTune enables dynamic block size from endpoint metrics.
 	approxAutoTune bool
+
+	// approxRecencyHalfLife is the half-life for recency-weighted scoring.
+	// Zero means disabled (use standard block-count scoring).
+	approxRecencyHalfLife time.Duration
 
 	// approxPluginState stores per-request data for approximate mode,
 	// separate from the precise mode pluginState to avoid key collisions in unified mode.
@@ -604,8 +632,18 @@ func (s *PrecisePrefixCacheScorer) prepareDataApproximate(ctx context.Context,
 		return nil
 	}
 
-	// Match longest prefix in local LRU indexer
-	serverMatches := s.approxIndexer.MatchLongestPrefix(hashes)
+	// Match longest prefix in local LRU indexer.
+	// Use recency-weighted scoring when half-life is configured.
+	var serverScores map[ApproximateServerID]float64
+	if s.approxRecencyHalfLife > 0 {
+		serverScores = s.approxIndexer.MatchLongestPrefixWeighted(hashes, time.Now(), s.approxRecencyHalfLife)
+	} else {
+		intScores := s.approxIndexer.MatchLongestPrefix(hashes)
+		serverScores = make(map[ApproximateServerID]float64, len(intScores))
+		for k, v := range intScores {
+			serverScores[k] = float64(v)
+		}
+	}
 
 	// Store PrefixCacheMatchInfo on endpoints.
 	// In unified mode, only overwrite if approximate has a better match
@@ -615,8 +653,8 @@ func (s *PrecisePrefixCacheScorer) prepareDataApproximate(ctx context.Context,
 		if md == nil {
 			continue
 		}
-		serverID := ApproximateServerID(md.NamespacedName)
-		matchLen := serverMatches[serverID]
+		sid := ApproximateServerID(md.NamespacedName)
+		matchLen := int(math.Round(serverScores[sid]))
 		approxInfo := dl_prefix.NewPrefixCacheMatchInfo(matchLen, len(hashes), blockSize)
 
 		if s.mode == ModeUnified {
@@ -634,12 +672,12 @@ func (s *PrecisePrefixCacheScorer) prepareDataApproximate(ctx context.Context,
 	// Save to PluginState for Score() and PreRequest()
 	s.approxPluginState.Write(request.RequestId, approxStateKey, &approximatePluginState{
 		hashes:       hashes,
-		serverScores: serverMatches,
+		serverScores: serverScores,
 		totalBlocks:  len(hashes),
 	})
 
 	logger.V(logutil.TRACE).Info("PrepareRequestData (approximate) completed",
-		"hashes", len(hashes), "serverMatches", fmt.Sprintf("%v", serverMatches))
+		"hashes", len(hashes), "serverScores", fmt.Sprintf("%v", serverScores))
 
 	return nil
 }
@@ -781,12 +819,12 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 
 	// Try PluginState first (from PrepareRequestData)
-	var serverMatches map[ApproximateServerID]int
+	var serverScores map[ApproximateServerID]float64
 	var totalBlocks int
 
 	if state, err := plugin.ReadPluginStateKey[*approximatePluginState](
 		s.approxPluginState, request.RequestId, approxStateKey); err == nil {
-		serverMatches = state.serverScores
+		serverScores = state.serverScores
 		totalBlocks = state.totalBlocks
 		logger.V(logutil.DEBUG).Info("Reusing pre-computed approximate scores")
 	} else {
@@ -796,13 +834,22 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 		if len(hashes) == 0 {
 			return nil
 		}
-		serverMatches = s.approxIndexer.MatchLongestPrefix(hashes)
+
+		if s.approxRecencyHalfLife > 0 {
+			serverScores = s.approxIndexer.MatchLongestPrefixWeighted(hashes, time.Now(), s.approxRecencyHalfLife)
+		} else {
+			intScores := s.approxIndexer.MatchLongestPrefix(hashes)
+			serverScores = make(map[ApproximateServerID]float64, len(intScores))
+			for k, v := range intScores {
+				serverScores[k] = float64(v)
+			}
+		}
 		totalBlocks = len(hashes)
 
 		// Save for PreRequest
 		s.approxPluginState.Write(request.RequestId, approxStateKey, &approximatePluginState{
 			hashes:       hashes,
-			serverScores: serverMatches,
+			serverScores: serverScores,
 			totalBlocks:  totalBlocks,
 		})
 	}
@@ -823,12 +870,12 @@ func (s *PrecisePrefixCacheScorer) scoreApproximate(ctx context.Context, cycleSt
 		if md == nil {
 			continue
 		}
-		serverID := ApproximateServerID(md.NamespacedName)
-		matchLen := serverMatches[serverID]
-		result[ep] = float64(matchLen) / float64(totalBlocks)
+		sid := ApproximateServerID(md.NamespacedName)
+		score := serverScores[sid]
+		result[ep] = score / float64(totalBlocks)
 
-		if matchLen > 0 {
-			prefixCacheState.PrefixCacheServers[prefix.ServerID(md.NamespacedName)] = matchLen
+		if score > 0 {
+			prefixCacheState.PrefixCacheServers[prefix.ServerID(md.NamespacedName)] = int(math.Round(score))
 		}
 	}
 
@@ -914,7 +961,7 @@ func (s *PrecisePrefixCacheScorer) mergeApproxIntoCycleState(cycleState *schedul
 			continue
 		}
 		sid := prefix.ServerID(md.NamespacedName)
-		approxMatch := state.serverScores[ApproximateServerID(md.NamespacedName)]
+		approxMatch := int(math.Round(state.serverScores[ApproximateServerID(md.NamespacedName)]))
 		if approxMatch > existing.PrefixCacheServers[sid] {
 			existing.PrefixCacheServers[sid] = approxMatch
 		}

--- a/pkg/plugins/scorer/precise_prefix_cache_test.go
+++ b/pkg/plugins/scorer/precise_prefix_cache_test.go
@@ -568,7 +568,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 			prefixCacheScorer, err := New(ctx, PrecisePrefixCachePluginConfig{
 				IndexerConfig:  kvcacheConfig,
 				KVEventsConfig: kvevents.DefaultConfig(),
-			})
+			}, nil)
 			require.NoError(t, err)
 			require.NotNil(t, prefixCacheScorer)
 
@@ -625,7 +625,7 @@ func newTestScorer(t *testing.T) *PrecisePrefixCacheScorer {
 		KVEventsConfig:      kvevents.DefaultConfig(),
 		SpeculativeIndexing: true,
 		SpeculativeTTL:      "5s",
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, scorer)
 	return scorer
@@ -862,7 +862,7 @@ func TestSpeculativeEntriesEvictOnTTL(t *testing.T) {
 		KVEventsConfig:      kvevents.DefaultConfig(),
 		SpeculativeIndexing: true,
 		SpeculativeTTL:      "200ms",
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	prompt := "One morning, when Gregor Samsa woke from troubled dreams, " +

--- a/pkg/plugins/scorer/precise_prefix_cache_uds_test.go
+++ b/pkg/plugins/scorer/precise_prefix_cache_uds_test.go
@@ -576,7 +576,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 			prefixCacheScorer, err := New(ctx, PrecisePrefixCachePluginConfig{
 				IndexerConfig:  kvcacheConfig,
 				KVEventsConfig: kvevents.DefaultConfig(),
-			})
+			}, nil)
 			require.NoError(t, err)
 			require.NotNil(t, prefixCacheScorer)
 
@@ -790,7 +790,7 @@ func TestMMPipeline_ScoreTokensWithExtraFeatures_UDS(t *testing.T) {
 	prefixCacheScorer, err := New(ctx, PrecisePrefixCachePluginConfig{
 		IndexerConfig:  kvcacheConfig,
 		KVEventsConfig: kvevents.DefaultConfig(),
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// 4. Populate index with MM-tainted block keys.


### PR DESCRIPTION
Part of https://github.com/llm-d/llm-d-kv-cache/issues/353

## Summary
- Add `mode` field to `precise-prefix-cache-scorer` supporting three modes: `precise` (default), `approximate`, and `unified`
- Port IGW approximate scorer logic (xxhash + self-reported LRU) into the unified scorer as a fallback mode that works without KV events or tokenizer
- Additionally, add recency-weighted scoring to improve approximate mode accuracy beyond the original IGW scorer

## Details

Implements the **Adaptability** goal from the [design doc](https://github.com/llm-d/llm-d-kv-cache/issues/353): port existing approximate prefix cache scorer configurability to the unified `prefix-cache-scorer`, and allow configuring it to run in approximate mode.

Builds on speculative indexing work in #659.

### Approximate Hasher (`approximate_hasher.go`)
- Rolling xxhash64 chain for prompt hashing (ported from IGW `prefix-cache-scorer`)
- Model-scoped with CacheSalt support for tenant isolation
- All 4 API types: Completions, ChatCompletions, Responses, Conversations

### Approximate Indexer (`approximate_indexer.go`)
- Dual-map LRU: `hashToPods` (forward lookup) + `podToLRU` (per-pod LRU with eviction callbacks) (ported from IGW `prefix-cache-scorer`)
- Self-reported: routing decisions recorded in PreRequest, no KV events needed
- AutoTune: dynamic block size and LRU capacity from endpoint metrics
- Inactive pod cleanup (2-minute interval)

### Recency-Weighted Scoring (new, not in IGW)
- Each matched block contributes `weight = exp(-age * ln2 / halfLife)` instead of flat count
- Configurable via `recencyHalfLife` (e.g. `"30s"` means 50% weight at 30s age)
- Addresses the main weakness of approximate scoring: older self-reported entries that are likely evicted from GPU cache contribute less
- Disabled by default; standard block-count scoring when not configured

### Mode Integration
- `PrepareRequestData`, `Score`, `PreRequest` dispatch by mode
- `approximate` mode skips KV events and tokenizer initialization entirely
- `unified` mode runs both paths, takes max score per endpoint
- P/D disaggregation supported in all modes
- Backward compatible: omitting `mode` defaults to `precise`

## Configuration

### Mode: `approximate` (no KV events/tokenizer needed)
```yaml
plugins:
- type: precise-prefix-cache-scorer
  parameters:
    mode: "approximate"
    approximateConfig:
      blockSizeTokens: 16
      maxPrefixBlocksToMatch: 256
      lruCapacityPerServer: 31250
      autoTune: true
      recencyHalfLife: "30s"
```

###Mode: precise (default, existing behavior)

```yaml
plugins:
- type: precise-prefix-cache-scorer
  parameters:
    mode: "precise"              # optional, this is the default
    speculativeIndexing: true
    speculativeTTL: "2s"
    tokenProcessorConfig:
      blockSize: 16
      hashSeed: "12345"
    indexerConfig:
      tokenizersPoolConfig:
        modelName: hf-repo/model-name
    kvEventsConfig:
      topicFilter: "kv@"
      zmqEndpoint: "tcp://*:5557"
```

###Mode: unified (both precise + approximate)

```yaml
plugins:
- type: precise-prefix-cache-scorer
  parameters:
    mode: "unified"
    speculativeIndexing: true
    speculativeTTL: "2s"
    approximateConfig:
      blockSizeTokens: 16
      autoTune: true
      recencyHalfLife: "30s"
    tokenProcessorConfig:
      blockSize: 16
      hashSeed: "12345"
    indexerConfig:
      tokenizersPoolConfig:
        modelName: hf-repo/model-name
    kvEventsConfig:
      topicFilter: "kv@"
      zmqEndpoint: "tcp://*:5557"
```
See docs/architecture.md for parameter descriptions.