### PR TITLE
test: add fuzz test for parseContextRange

### DIFF
--- a/pkg/plugins/multi/context_length_aware_fuzz_test.go
+++ b/pkg/plugins/multi/context_length_aware_fuzz_test.go
@@ -1,0 +1,48 @@
+package multi
+
+import (
+	"testing"
+)
+
+func FuzzParseContextRange(f *testing.F) {
+	// Seed corpus: valid formats
+	f.Add("0-2048")
+	f.Add("2048-8192")
+	f.Add("0-0")
+	f.Add("100-100")
+
+	// Seed corpus: edge cases and invalid inputs
+	f.Add("")
+	f.Add("-")
+	f.Add("abc")
+	f.Add("1-2-3")
+	f.Add("-1-100")
+	f.Add("100--1")
+	f.Add("999999999999999999999-1")
+	f.Add("  0  -  2048  ")
+	f.Add("0-")
+	f.Add("-0")
+	f.Add("0-100-200")
+	f.Add("100-50")
+	f.Add("abc-100")
+
+	f.Fuzz(func(t *testing.T, rangeStr string) {
+		r, err := parseContextRange(rangeStr)
+		if err != nil {
+			return
+		}
+
+		// Invariant: min must not exceed max
+		if r.min > r.max {
+			t.Errorf("parseContextRange(%q) returned min (%d) > max (%d)", rangeStr, r.min, r.max)
+		}
+
+		// Context lengths should be non-negative
+		if r.min < 0 {
+			t.Errorf("parseContextRange(%q) accepted negative min value: %d", rangeStr, r.min)
+		}
+		if r.max < 0 {
+			t.Errorf("parseContextRange(%q) accepted negative max value: %d", rangeStr, r.max)
+		}
+	})
+}


### PR DESCRIPTION
## What
Add fuzz test for `parseContextRange` in the context-length-aware scheduling plugin.

## Why
`parseContextRange` processes pod label values to determine context length routing.
While unit tests cover 5 cases, fuzz testing validates robustness against
arbitrary/malformed inputs at scale (500K+ executions, zero panics, zero invariant violations).

Fuzz test verifies:
- No panics on any input
- Parsed results maintain min <= max invariant
- Non-negative context length values

## Testing
- `go test -fuzz=FuzzParseContextRange -fuzztime=60s ./pkg/plugins/multi/` — PASS (533K executions)
- All existing tests pass: `go test ./pkg/plugins/multi/` — PASS