### PR TITLE
Deprecate PluginState usage in favor of CycleState

### DIFF
--- a/pkg/plugins/scorer/no_hit_lru.go
+++ b/pkg/plugins/scorer/no_hit_lru.go
@@ -114,7 +114,11 @@ type NoHitLRU struct {
 	typedName             plugin.TypedName
 	lruCache              *lru.Cache[string, struct{}] // endpoint name -> dummy value (we only care about order)
 	prefixPluginTypedName plugin.TypedName
-	pluginState           *plugin.PluginState
+	// Deprecated: pluginState is used to share cold-request state between
+	// Score and PreRequest. This should be replaced with CycleState once the
+	// upstream PreRequest interface accepts CycleState. See:
+	// https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2657
+	pluginState *plugin.PluginState
 }
 
 // TypedName returns the typed name of the plugin.
@@ -258,7 +262,8 @@ func (s *NoHitLRU) Score(ctx context.Context, cycleState *scheduling.CycleState,
 
 	isCold := s.isColdRequest(ctx, cycleState)
 
-	// Store the cold request state in plugin state for PreRequest to use
+	// Store the cold request state in plugin state for PreRequest to use.
+	// Deprecated: migrate to CycleState once PreRequest receives it upstream.
 	coldState := &coldRequestState{isCold: isCold}
 	s.pluginState.Write(request.RequestId, plugin.StateKey(s.typedName.String()), coldState)
 
@@ -281,7 +286,8 @@ func (s *NoHitLRU) PreRequest(ctx context.Context, request *scheduling.LLMReques
 		return
 	}
 
-	// Read the cold request state we stored in Score
+	// Read the cold request state we stored in Score.
+	// Deprecated: reads from PluginState; migrate to CycleState once PreRequest receives it upstream.
 	coldState, err := plugin.ReadPluginStateKey[*coldRequestState](s.pluginState, request.RequestId, plugin.StateKey(s.typedName.String()))
 	// After fetching the cold state, drop it from the plugin state immediately (otherwise it will hang around until it becomes stale).
 	s.pluginState.Delete(request.RequestId)

--- a/pkg/plugins/scorer/precise_prefix_cache.go
+++ b/pkg/plugins/scorer/precise_prefix_cache.go
@@ -291,8 +291,12 @@ type PrecisePrefixCacheScorer struct {
 	subscribersManager *kvevents.SubscriberManager
 	kvEventsConfig     *kvevents.Config
 
-	// pluginState stores per-request data (block keys, scores) shared
+	// Deprecated: pluginState stores per-request data (block keys, scores) shared
 	// between PrepareRequestData, Score, and PreRequest extension points.
+	// This should be replaced with CycleState once the upstream IGW interfaces
+	// (PrepareDataPlugin.PrepareRequestData and requestcontrol.PreRequest) are
+	// updated to accept CycleState. See:
+	// https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2657
 	pluginState *plugin.PluginState
 
 	// speculativeCache tracks speculative entries added to the index so that
@@ -393,7 +397,8 @@ func (s *PrecisePrefixCacheScorer) PrepareRequestData(ctx context.Context,
 		ep.Put(dl_prefix.PrefixCacheMatchInfoKey, dl_prefix.NewPrefixCacheMatchInfo(matchLen, len(blockKeys), blockSize))
 	}
 
-	// 6. Save to PluginState for Score() and PreRequest()
+	// 6. Save to PluginState for Score() and PreRequest().
+	// Deprecated: migrate to CycleState once PrepareRequestData receives it upstream.
 	s.pluginState.Write(request.RequestId, stateKey, &precisePluginState{
 		blockKeys: blockKeys,
 		scores:    scores,
@@ -464,7 +469,9 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *schedu
 		span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
 	}
 
-	// Try to reuse pre-computed scores from PrepareRequestData
+	// Try to reuse pre-computed scores from PrepareRequestData.
+	// Deprecated: reads from PluginState; migrate to CycleState once
+	// PrepareRequestData writes to CycleState upstream.
 	var scores map[string]float64
 	if pluginStateData, err := plugin.ReadPluginStateKey[*precisePluginState](
 		s.pluginState, request.RequestId, stateKey); err == nil {
@@ -552,7 +559,8 @@ func (s *PrecisePrefixCacheScorer) PreRequest(ctx context.Context,
 
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 
-	// 1. Read block keys from PluginState
+	// 1. Read block keys from PluginState.
+	// Deprecated: migrate to CycleState once PreRequest receives it upstream.
 	state, err := plugin.ReadPluginStateKey[*precisePluginState](
 		s.pluginState, request.RequestId, stateKey)
 	if err != nil {


### PR DESCRIPTION
## Summary

Mark all `PluginState` usages as deprecated per the upstream community agreement in [kubernetes-sigs/gateway-api-inference-extension#2657](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2657). Closes #786.

Draft PR — looking for feedback on the approach before investing in follow-up removal work.

## Background

The upstream GIE community agreed ([comment](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2657#issuecomment-4105836840)) to deprecate `PluginState` and expand `CycleState` scope to cover the full request lifecycle. `PluginState` uses request-ID-keyed storage with a background cleanup goroutine, while `CycleState` is request-scoped and needs no cleanup.

## Current PluginState usages in this repo

| Plugin | What's shared | Between | File |
|--------|--------------|---------|------|
| `PrecisePrefixCacheScorer` | Block keys + scores | `PrepareRequestData` → `Score` → `PreRequest` | `precise_prefix_cache.go` |
| `NoHitLRU` | Cold-request state | `Score` → `PreRequest` | `no_hit_lru.go` |

## What this PR does

Adds deprecation comments on all `PluginState` field declarations and every `Read`/`Write`/`Delete` call site, referencing the upstream issue and explaining what blocks full removal.

## What blocks full removal

The upstream plugin interfaces do not yet pass `CycleState` to:
- `PrepareDataPlugin.PrepareRequestData(ctx, request, pods)` — no `CycleState` param
- `requestcontrol.PreRequest(ctx, request, schedulingResult)` — no `CycleState` param

Once those interfaces are updated upstream, the migration is straightforward:
- Replace `pluginState.Write(requestID, key, val)` → `cycleState.Write(key, val)`
- Replace `pluginState.Read(requestID, key)` → `cycleState.Read(key)`
- Remove the `pluginState` field and its `NewPluginState(ctx)` initialization (eliminates the cleanup goroutine)

## Changes

- `pkg/plugins/scorer/precise_prefix_cache.go` — Deprecation comments on field, `PrepareRequestData` write, `Score` read, and `PreRequest` read
- `pkg/plugins/scorer/no_hit_lru.go` — Deprecation comments on field, `Score` write, and `PreRequest` read