### PR TITLE
Support image build with different base via Maefile and document runtime debugging

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,10 @@ Documentation for developing the inference scheduler.
     - [Prometheus Monitoring](#prometheus-monitoring)
     - [Grafana Dashboard](#grafana-dashboard)
     - [Development Cycle](#development-cycle)
+    - [Debugging](#debugging)
     - [Inference Disaggregation Modes](#inference-disaggregation-modes)
+      - [1. Prefill/Decode (P/D) Disaggregation](#1-prefilldecode-pd-disaggregation)
+      - [2. Encode/Prefill/Decode (E/P/D) Disaggregation](#2-encodeprefilldecode-epd-disaggregation)
     - [Cleanup](#cleanup)
   - [Running Tests](#running-tests)
     - [Unit Tests](#unit-tests)
@@ -184,6 +187,72 @@ kubectl rollout restart deployment tinyllama-1-1b-chat-v1-0-endpoint-picker
 > ```bash
 > VLLM_SIMULATOR_TAG=<tag> make env-dev-kind
 > ```
+
+### Debugging
+
+**Building a debug image**
+
+Debug symbols are stripped by default (`-s -w`). To build an image with symbols preserved
+(required for `dlv` or other debuggers), clear `LDFLAGS`:
+
+```bash
+LDFLAGS="" make image-build-epp
+```
+
+To use a non-default runtime base image (e.g. a UBI variant or a debug-capable image),
+set `BASE_IMAGE`:
+
+```bash
+BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro:9.7 make image-build-epp
+```
+
+Both overrides can be combined:
+
+```bash
+LDFLAGS="" BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro:9.7 make image-build-epp
+```
+
+> [!NOTE]
+> The default base image is `gcr.io/distroless/static:nonroot`. If you switch to `scratch`,
+> you must copy CA certificates from the builder stage manually - see the comments in
+> `Dockerfile.epp` for guidance.
+
+**Attaching an ephemeral debug container**
+
+The distroless runtime image has no shell. For ad-hoc inspection (filesystem, processes,
+network), attach an ephemeral container without modifying the image:
+
+```bash
+kubectl debug -it <pod-name> -n <namespace> \
+    --image=busybox \
+    --target=epp \
+    -- sh
+```
+
+This creates a throwaway container that shares the pod's PID/network/filesystem namespace.
+Ephemeral container support requires Kubernetes 1.23+.
+
+To connect `dlv` to a running EPP process, build and deploy a debug image first (see above),
+then attach `dlv` via the ephemeral container:
+
+```bash
+# 1. Build and load the debug image
+LDFLAGS="" make image-build-epp
+kind load docker-image $(EPP_IMAGE) --name llm-d-inference-scheduler-dev
+
+# 2. Restart the deployment to pick up the new image
+kubectl rollout restart deployment tinyllama-1-1b-chat-v1-0-endpoint-picker
+
+# 3. Attach dlv in an ephemeral container
+kubectl debug -it <pod-name> -n <namespace> \
+    --image=ghcr.io/go-delve/delve:latest \
+    --target=epp \
+    -- dlv attach 1
+```
+
+> [!NOTE]
+> `dlv attach 1` assumes the EPP binary is PID 1. Confirm with `ps` in a `busybox`
+> ephemeral container if the pod runs additional processes.
 
 ### Inference Disaggregation Modes
 

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,11 @@ BUILDER_RUN_CLUSTER = $(CONTAINER_RUNTIME) run $(BUILDER_RUN_FLAGS) $(BUILDER_CL
 # Override locally to build a debuggable image: LDFLAGS="" make image-build-epp
 LDFLAGS ?= -s -w
 
+# Optional: override the runtime base image used in container builds.
+# When set, passed as --build-arg BASE_IMAGE=<value> to the container build.
+# Example: BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro:9.7 make image-build-epp
+BASE_IMAGE ?=
+
 # test packages
 epp_TEST_PACKAGES = $$(go list ./... | grep -v /test/ | grep -v ./pkg/sidecar/ | tr '\n' ' ')
 sidecar_TEST_PACKAGES = ./pkg/sidecar/...
@@ -327,6 +332,7 @@ image-build-%: check-container-tool ## Build Container image using $(CONTAINER_R
 		--build-arg COMMIT_SHA=${GIT_COMMIT_SHA} \
 		--build-arg BUILD_REF=${BUILD_REF} \
 		--build-arg LDFLAGS="$(LDFLAGS)" \
+		$(if $(BASE_IMAGE),--build-arg BASE_IMAGE="$(BASE_IMAGE)") \
 		-t $($*_IMAGE) -f Dockerfile.$* .
 
 BUILDER_STAMP = build/.builder.stamp


### PR DESCRIPTION
- Extend Makefile to directly support a different base image via an environment variable.
- Add debugging section to DEVELOPMENT.md