### PR TITLE
feat(sidecar): add chunked decode

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,7 +227,7 @@ chunk continues seamlessly from where the previous one left off.
 
 ### How it works
 
-1. The sidecar receives a `/v1/chat/completions` or `/v1/completions` request at the decode stage.
+1. The sidecar receives a `/v1/chat/completions` request at the decode stage.
 2. Each chunk is dispatched as a separate request to the local decoder with `max_tokens` capped
    at `decode-chunk-size`.
 3. From the second chunk onward, `continue_final_message=true` and `add_generation_prompt=false` are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,15 +243,14 @@ chunk continues seamlessly from where the previous one left off.
 
 ### Configuration
 
-Enable chunked decode via the pd-sidecar flags:
+Enable chunked decode via the pd-sidecar flag:
 
 | Flag | Default | Description |
 |---|---|---|
-| `--enable-chunked-decode` | `false` | Enable chunked decode mode |
-| `--decode-chunk-size` | `512` | Chunk size in tokens; for best performance use a multiple of the KV cache block size |
+| `--decode-chunk-size` | `0` (disabled) | Token budget per chunk. Set to a positive integer to enable chunked decode. For best performance use a multiple of the KV cache block size. |
 
 > [!NOTE]
-> If the request's `max_tokens` / `max_completion_tokens` is less than or equal to `decode-chunk-size`,
+> If the request's `max_tokens` / `max_completion_tokens` is less than or equal to `--decode-chunk-size`,
 > the sidecar falls back to a single regular decode call without chunking.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,6 +211,51 @@ The **vLLM sidecar** handles orchestration between Encode, Prefill and Decode st
 
 ---
 
+## Chunked Decode (Experimental)
+
+Chunked decode is an experimental feature of the pd-sidecar that splits the decode stage into a
+sequence of shorter decode calls, each capped at a configurable token budget.
+It applies at the decode stage regardless of whether P/D disaggregation is in use.
+After each chunk the generated text is appended to the conversation context so the next
+chunk continues seamlessly from where the previous one left off.
+
+### Why to use it
+
+- Improve average Time-To-First-Token among all requests
+- Prevent head-of-line blocking by long requests in run-to-completion
+- Get more predictable execution time
+
+### How it works
+
+1. The sidecar receives a `/v1/chat/completions` or `/v1/completions` request at the decode stage.
+2. Each chunk is dispatched as a separate request to the local decoder with `max_tokens` capped
+   at `decode-chunk-size`.
+3. From the second chunk onward, `continue_final_message=true` and `add_generation_prompt=false` are
+   set so the model continues the existing assistant turn rather than starting a new one. The
+   generated text from the previous chunk is also appended to the request context.
+4. Generation stops when the model returns a terminal `finish_reason` (anything other than `length`),
+   or when the original token budget is exhausted.
+5. For **non-streaming** requests, all chunk outputs are concatenated and returned as a single
+   response. The `usage` field reports the original `prompt_tokens` (from the first chunk) and the
+   total `completion_tokens` across all chunks.
+6. For **streaming** requests, each chunk's tokens are re-emitted as SSE delta events in real time,
+   and a `[DONE]` sentinel closes the stream once all chunks are complete.
+
+### Configuration
+
+Enable chunked decode via the pd-sidecar flags:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--enable-chunked-decode` | `false` | Enable chunked decode mode |
+| `--decode-chunk-size` | `512` | Chunk size in tokens; for best performance use a multiple of the KV cache block size |
+
+> [!NOTE]
+> If the request's `max_tokens` / `max_completion_tokens` is less than or equal to `decode-chunk-size`,
+> the sidecar falls back to a single regular decode call without chunking.
+
+---
+
 ## InferencePool & InferenceModel Design
 
 ### Current Assumptions

--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -180,7 +180,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 
 		s.logger.V(4).Info("no prefiller or encoder, using decoder only")
 		if !s.forwardDataParallel || !s.dataParallelHandler(w, r) {
-			if s.config.EnableChunkedDecode {
+			if s.config.DecodeChunkSize > 0 {
 				s.runChunkedDecode(w, r)
 				return
 			}

--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -180,6 +180,10 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 
 		s.logger.V(4).Info("no prefiller or encoder, using decoder only")
 		if !s.forwardDataParallel || !s.dataParallelHandler(w, r) {
+			if s.config.EnableChunkedDecode {
+				s.runChunkedDecode(w, r)
+				return
+			}
 			s.decoderProxy.ServeHTTP(w, r)
 		}
 	}

--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -180,7 +180,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 
 		s.logger.V(4).Info("no prefiller or encoder, using decoder only")
 		if !s.forwardDataParallel || !s.dataParallelHandler(w, r) {
-			if s.config.DecodeChunkSize > 0 {
+			if s.config.DecodeChunkSize > 0 && r.URL.Path == ChatCompletionsPath {
 				s.runChunkedDecode(w, r)
 				return
 			}

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"time"
 
@@ -101,6 +102,10 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 		}
 	}
 
+	// Snapshot the original request map before prefill mutations so the
+	// fallback-to-decode path can dispatch with the correct original fields.
+	originalRequest := maps.Clone(completionRequest)
+
 	completionRequest[requestFieldKVTransferParams] = map[string]any{
 		requestFieldDoRemoteDecode:  true,
 		requestFieldDoRemotePrefill: false,
@@ -154,8 +159,8 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 
 		if shouldFallbackToDecode(pw) {
 			s.logger.Info("fallback to decode", "request_id", uuidStr)
-			r.Body = io.NopCloser(bytes.NewReader(original))
-			s.decoderProxy.ServeHTTP(w, r)
+			fallbackReq := cloneRequestWithBody(r, original)
+			s.dispatchDecode(w, fallbackReq, originalRequest)
 		} else {
 			for key, values := range pw.Header() {
 				for _, v := range values {
@@ -257,7 +262,7 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	if !dataParallelUsed {
 		s.logger.V(4).Info("sending request to decoder", "to", s.config.DecoderURL.Host)
 		decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host))
-		s.decoderProxy.ServeHTTP(decodeWriter, dreq)
+		s.dispatchDecode(decodeWriter, dreq, completionRequest)
 	}
 	if err := finalizeDecodeWriter(); err != nil {
 		s.logger.Error(err, "failed to flush cached token response writer")

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -39,22 +39,15 @@ const (
 	sseDataPrefix = "data: "
 	sseDone       = "data: [DONE]"
 
-	// legacyChunkPrefix is prepended to each chunk's generated text when
-	// appending to a legacy completions prompt for continuation.
-	legacyChunkPrefix = " Assistant: "
-
 	responseFieldUsage            = "usage"
 	responseFieldCompletionTokens = "completion_tokens"
 	responseFieldPromptTokens     = "prompt_tokens"
 	responseFieldTotalTokens      = "total_tokens"
 	responseFieldMessage          = "message"
-	responseFieldText             = "text"
-	responseFieldLogprobs         = "logprobs"
 	responseFieldIndex            = "index"
 	responseFieldDelta            = "delta"
 
 	requestFieldMessages = "messages"
-	requestFieldPrompt   = "prompt"
 	requestFieldRole     = "role"
 	requestFieldContent  = "content"
 
@@ -62,11 +55,12 @@ const (
 )
 
 // dispatchDecode routes a fully-prepared decode request to either chunked
-// decode or the regular decoder proxy. Chunked decode is used when
-// s.config.DecodeChunkSize > 0. completionRequest is the already-parsed JSON
-// map; callers that hold it should use this instead of calling s.decoderProxy directly.
+// decode or the regular decoder proxy. Chunked decode is only used for
+// chat completions requests when s.config.DecodeChunkSize > 0.
+// completionRequest is the already-parsed JSON map; callers that hold it
+// should use this instead of calling s.decoderProxy directly.
 func (s *Server) dispatchDecode(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) {
-	if s.config.DecodeChunkSize > 0 {
+	if s.config.DecodeChunkSize > 0 && r.URL.Path == ChatCompletionsPath {
 		s.runChunkedDecodeFromMap(w, r, completionRequest)
 		return
 	}
@@ -96,7 +90,6 @@ func (s *Server) runChunkedDecode(w http.ResponseWriter, r *http.Request) {
 }
 
 // runChunkedDecodeFromMap executes chunked decode given an already-parsed completionRequest map.
-// Both chat completions and legacy completions APIs are supported.
 // Non-streaming: accumulated chunks are reassembled into a single JSON response.
 // Streaming: each chunk is re-emitted as an SSE event; [DONE] closes the stream.
 func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) {
@@ -141,6 +134,16 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 	decodeStart := time.Now()
 
 	for {
+		if ctx.Err() != nil {
+			if streamingEnabled && chunkIndex > 0 {
+				fmt.Fprintf(w, "%s\n\n", sseDone) //nolint:errcheck
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+			}
+			return
+		}
+
 		remaining := remainingTokens(originalMaxTokens, totalTokens)
 		if remaining == 0 {
 			s.logger.V(4).Info("chunked decode: token budget exhausted", "totalTokens", totalTokens)
@@ -250,7 +253,25 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 		attribute.Float64("llm_d.pd_proxy.chunked_decode.duration_ms", float64(time.Since(decodeStart).Milliseconds())),
 	)
 
+	// Corrected cumulative usage: prompt_tokens from first chunk, completion_tokens summed.
+	cumulativeUsage := map[string]any{
+		responseFieldPromptTokens:     originalPromptTokens,
+		responseFieldCompletionTokens: totalTokens,
+		responseFieldTotalTokens:      originalPromptTokens + totalTokens,
+	}
+
 	if streamingEnabled {
+		// Emit corrected cumulative usage as a final event before [DONE]
+		// when multiple chunks were produced (individual chunk usage is stripped).
+		if chunkIndex > 1 && lastResponse != nil {
+			usageEvent := map[string]any{
+				responseFieldUsage:   cumulativeUsage,
+				responseFieldChoices: []any{},
+			}
+			if data, err := json.Marshal(usageEvent); err == nil {
+				fmt.Fprintf(w, "%s%s\n\n", sseDataPrefix, data) //nolint:errcheck
+			}
+		}
 		fmt.Fprintf(w, "%s\n\n", sseDone) //nolint:errcheck
 		if flusher, ok := w.(http.Flusher); ok {
 			flusher.Flush()
@@ -267,12 +288,7 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Fix usage: prompt_tokens from first chunk, completion_tokens summed across all chunks.
-	if usage, ok := lastResponse[responseFieldUsage].(map[string]any); ok {
-		usage[responseFieldPromptTokens] = originalPromptTokens
-		usage[responseFieldCompletionTokens] = totalTokens
-		usage[responseFieldTotalTokens] = originalPromptTokens + totalTokens
-	}
+	lastResponse[responseFieldUsage] = cumulativeUsage
 
 	if choices, ok := lastResponse[responseFieldChoices].([]any); ok && len(choices) > 0 {
 		choice := maps.Clone(choices[0].(map[string]any))
@@ -281,8 +297,6 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 			msg = maps.Clone(msg)
 			msg[requestFieldContent] = fullText
 			choice[responseFieldMessage] = msg
-		} else {
-			choice[responseFieldText] = fullText
 		}
 		lastResponse[responseFieldChoices] = []any{choice}
 	}
@@ -377,12 +391,7 @@ func emitSSEChunk(w http.ResponseWriter, chunkResponse map[string]any) error {
 				responseFieldIndex:        choice[responseFieldIndex],
 				responseFieldFinishReason: choice[responseFieldFinishReason],
 			}
-			if _, isChatCompletion := choice[responseFieldMessage]; isChatCompletion {
-				streamChoice[responseFieldDelta] = map[string]any{requestFieldContent: text, requestFieldRole: roleAssistant}
-			} else {
-				streamChoice[responseFieldText] = text
-				streamChoice[responseFieldLogprobs] = choice[responseFieldLogprobs]
-			}
+			streamChoice[responseFieldDelta] = map[string]any{requestFieldContent: text, requestFieldRole: roleAssistant}
 			streamChoices = append(streamChoices, streamChoice)
 		}
 		streamChunk[responseFieldChoices] = streamChoices
@@ -411,12 +420,8 @@ func firstChoice(response map[string]any) map[string]any {
 	return choice
 }
 
-// extractChoiceText returns the generated text from a choice object,
-// handling both chat completions (message.content) and legacy (text).
+// extractChoiceText returns the generated text from a choice's message.content.
 func extractChoiceText(choice map[string]any) string {
-	if text, ok := choice[responseFieldText].(string); ok {
-		return text
-	}
 	if msg, ok := choice[responseFieldMessage].(map[string]any); ok {
 		if content, ok := msg[requestFieldContent].(string); ok {
 			return content
@@ -427,23 +432,15 @@ func extractChoiceText(choice map[string]any) string {
 
 // appendChunkToRequest appends the generated text from a chunk to the request
 // so the next chunk continues from where this one left off.
-// For chat completions: appends {"role":"assistant","content":text} to messages.
-// For legacy completions: appends text to the prompt string.
 func appendChunkToRequest(req map[string]any, text string) {
 	if text == "" {
 		return
 	}
-	if messages, ok := req[requestFieldMessages].([]any); ok {
-		req[requestFieldMessages] = append(messages, map[string]any{
-			requestFieldRole:    roleAssistant,
-			requestFieldContent: text,
-		})
-		return
-	}
-	// Legacy completions: append generated text to prompt with assistant prefix.
-	if prompt, ok := req[requestFieldPrompt].(string); ok {
-		req[requestFieldPrompt] = prompt + legacyChunkPrefix + text
-	}
+	messages, _ := req[requestFieldMessages].([]any)
+	req[requestFieldMessages] = append(messages, map[string]any{
+		requestFieldRole:    roleAssistant,
+		requestFieldContent: text,
+	})
 }
 
 // toInt converts a JSON number value (float64, int, or json.Number) to int.

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -57,6 +57,8 @@ const (
 	requestFieldPrompt   = "prompt"
 	requestFieldRole     = "role"
 	requestFieldContent  = "content"
+
+	roleAssistant = "assistant"
 )
 
 // dispatchDecode routes a fully-prepared decode request to either chunked
@@ -267,11 +269,9 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 
 	// Fix usage: prompt_tokens from first chunk, completion_tokens summed across all chunks.
 	if usage, ok := lastResponse[responseFieldUsage].(map[string]any); ok {
-		usage = maps.Clone(usage)
 		usage[responseFieldPromptTokens] = originalPromptTokens
 		usage[responseFieldCompletionTokens] = totalTokens
 		usage[responseFieldTotalTokens] = originalPromptTokens + totalTokens
-		lastResponse[responseFieldUsage] = usage
 	}
 
 	if choices, ok := lastResponse[responseFieldChoices].([]any); ok && len(choices) > 0 {
@@ -378,7 +378,7 @@ func emitSSEChunk(w http.ResponseWriter, chunkResponse map[string]any) error {
 				responseFieldFinishReason: choice[responseFieldFinishReason],
 			}
 			if _, isChatCompletion := choice[responseFieldMessage]; isChatCompletion {
-				streamChoice[responseFieldDelta] = map[string]any{requestFieldContent: text, requestFieldRole: "assistant"}
+				streamChoice[responseFieldDelta] = map[string]any{requestFieldContent: text, requestFieldRole: roleAssistant}
 			} else {
 				streamChoice[responseFieldText] = text
 				streamChoice[responseFieldLogprobs] = choice[responseFieldLogprobs]
@@ -435,7 +435,7 @@ func appendChunkToRequest(req map[string]any, text string) {
 	}
 	if messages, ok := req[requestFieldMessages].([]any); ok {
 		req[requestFieldMessages] = append(messages, map[string]any{
-			requestFieldRole:    "assistant",
+			requestFieldRole:    roleAssistant,
 			requestFieldContent: text,
 		})
 		return

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -1,0 +1,461 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// finishReasonLength is the finish reason when max_tokens was reached.
+	finishReasonLength = "length"
+
+	sseDataPrefix = "data: "
+	sseDone       = "data: [DONE]"
+
+	// legacyChunkPrefix is prepended to each chunk's generated text when
+	// appending to a legacy completions prompt for continuation.
+	legacyChunkPrefix = " Assistant: "
+
+	responseFieldUsage            = "usage"
+	responseFieldCompletionTokens = "completion_tokens"
+	responseFieldPromptTokens     = "prompt_tokens"
+	responseFieldTotalTokens      = "total_tokens"
+	responseFieldMessage          = "message"
+	responseFieldText             = "text"
+	responseFieldLogprobs         = "logprobs"
+	responseFieldIndex            = "index"
+	responseFieldDelta            = "delta"
+
+	requestFieldMessages = "messages"
+	requestFieldPrompt   = "prompt"
+	requestFieldRole     = "role"
+	requestFieldContent  = "content"
+)
+
+// dispatchDecode routes a fully-prepared decode request to either chunked
+// decode or the regular decoder proxy based on s.config.EnableChunkedDecode.
+// completionRequest is the already-parsed JSON map; callers that hold it
+// should use this instead of calling s.decoderProxy directly.
+func (s *Server) dispatchDecode(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) {
+	if s.config.EnableChunkedDecode {
+		s.runChunkedDecodeFromMap(w, r, completionRequest)
+		return
+	}
+	s.decoderProxy.ServeHTTP(w, r)
+}
+
+// runChunkedDecode reads and parses the body, then delegates to
+// runChunkedDecodeFromMap.
+func (s *Server) runChunkedDecode(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close() //nolint:errcheck
+	original, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error())) //nolint:errcheck
+		return
+	}
+
+	var completionRequest map[string]any
+	if err := json.Unmarshal(original, &completionRequest); err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	s.runChunkedDecodeFromMap(w, cloneRequestWithBody(r, original), completionRequest)
+}
+
+// runChunkedDecodeFromMap executes chunked decode given an already-parsed completionRequest map.
+// Both chat completions and legacy completions APIs are supported.
+// Non-streaming: accumulated chunks are reassembled into a single JSON response.
+// Streaming: each chunk is re-emitted as an SSE event; [DONE] closes the stream.
+func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) {
+	s.logger.V(4).Info("running chunked decode", "chunkSize", s.config.DecodeChunkSize)
+
+	ctx, span := telemetry.Tracer().Start(r.Context(), "llm_d.pd_proxy.chunked_decode",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	streamingEnabled, _ := completionRequest[requestFieldStream].(bool)
+	originalMaxTokens := resolveMaxTokens(completionRequest)
+
+	span.SetAttributes(
+		attribute.Int("llm_d.pd_proxy.chunked_decode.chunk_size", s.config.DecodeChunkSize),
+		attribute.Bool("llm_d.pd_proxy.chunked_decode.streaming", streamingEnabled),
+	)
+
+	// If the token budget fits within a single chunk, skip chunking entirely.
+	if originalMaxTokens > 0 && originalMaxTokens <= s.config.DecodeChunkSize {
+		s.logger.V(4).Info("chunked decode: token budget <= chunk size, using regular decode",
+			"maxTokens", originalMaxTokens, "chunkSize", s.config.DecodeChunkSize)
+		s.decoderProxy.ServeHTTP(w, r)
+		return
+	}
+
+	if streamingEnabled {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Transfer-Encoding", "chunked")
+	}
+
+	var (
+		totalTokens          int
+		chunkIndex           int
+		lastResponse         map[string]any
+		originalPromptTokens int
+		textAccum            strings.Builder
+	)
+
+	decodeStart := time.Now()
+
+	for {
+		remaining := remainingTokens(originalMaxTokens, totalTokens)
+		if remaining == 0 {
+			s.logger.V(4).Info("chunked decode: token budget exhausted", "totalTokens", totalTokens)
+			break
+		}
+
+		chunkBudget := s.config.DecodeChunkSize
+		if remaining > 0 && remaining < chunkBudget {
+			chunkBudget = remaining
+		}
+
+		chunkReq := maps.Clone(completionRequest)
+		chunkReq[requestFieldMaxTokens] = chunkBudget
+		chunkReq[requestFieldMaxCompletionTokens] = chunkBudget
+		chunkReq[requestFieldStream] = false
+		delete(chunkReq, requestFieldStreamOptions)
+
+		// From the second chunk onward: remove KV transfer params and instruct
+		// to continue the last assistant message rather than start a new one.
+		if chunkIndex > 0 {
+			delete(chunkReq, requestFieldKVTransferParams)
+			chunkReq[requestFieldContinueFinalMessage] = true
+			chunkReq[requestFieldAddGenerationPrompt] = false
+		}
+
+		chunkBody, err := json.Marshal(chunkReq)
+		if err != nil {
+			if err := errorJSONInvalid(err, w); err != nil {
+				s.logger.Error(err, "failed to send error response to client")
+			}
+			return
+		}
+
+		s.logger.V(4).Info("chunked decode: dispatching chunk",
+			"chunk", chunkIndex, "chunkBudget", chunkBudget, "totalTokensSoFar", totalTokens)
+
+		bw := &bufferedResponseWriter{}
+		s.decoderProxy.ServeHTTP(bw, cloneRequestWithBody(r.WithContext(ctx), chunkBody))
+
+		if isHTTPError(bw.statusCode) {
+			s.logger.Error(fmt.Errorf("chunk %d failed with status %d", chunkIndex, bw.statusCode),
+				"chunked decode chunk error", "statusCode", bw.statusCode)
+			span.SetStatus(codes.Error, "chunk decode failed")
+			maps.Copy(w.Header(), bw.headers)
+			w.WriteHeader(bw.statusCode)
+			w.Write(bw.bodyBytes()) //nolint:errcheck
+			return
+		}
+
+		var chunkResponse map[string]any
+		if err := json.Unmarshal(bw.bodyBytes(), &chunkResponse); err != nil {
+			s.logger.Error(err, "failed to unmarshal chunk response", "chunk", chunkIndex)
+			if err := errorInternalServerError(err, w); err != nil {
+				s.logger.Error(err, "failed to send error response to client")
+			}
+			return
+		}
+
+		lastResponse = chunkResponse
+		chunkTokens := countTokensInResponse(chunkResponse)
+		totalTokens += chunkTokens
+		if chunkIndex == 0 {
+			originalPromptTokens = extractPromptTokens(chunkResponse)
+		}
+		chunkIndex++
+
+		s.logger.V(4).Info("chunked decode: chunk complete", "chunkTokens", chunkTokens, "totalTokens", totalTokens)
+
+		finishReason := extractFinishReason(chunkResponse)
+		chunkText := extractChoiceText(firstChoice(chunkResponse))
+
+		if streamingEnabled {
+			if err := emitSSEChunk(w, chunkResponse); err != nil {
+				s.logger.Error(err, "failed to write SSE chunk to client")
+				return
+			}
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		} else {
+			textAccum.WriteString(chunkText)
+		}
+
+		if finishReason != "" && finishReason != finishReasonLength {
+			s.logger.V(4).Info("chunked decode: terminal finish reason, stopping",
+				"finishReason", finishReason, "chunks", chunkIndex)
+			break
+		}
+
+		// Guard against infinite loop: if the chunk produced no tokens and no
+		// text there is nothing to continue from.
+		if chunkTokens == 0 && chunkText == "" {
+			s.logger.Info("chunked decode: empty chunk with no tokens, stopping to avoid infinite loop",
+				"chunk", chunkIndex)
+			break
+		}
+
+		// Append the generated text to the request so the next chunk continues
+		// from where this one left off.
+		s.logger.V(5).Info("chunked decode: appending chunk text to request", "chunkText", chunkText)
+		appendChunkToRequest(completionRequest, chunkText)
+	}
+
+	span.SetAttributes(
+		attribute.Int("llm_d.pd_proxy.chunked_decode.chunks", chunkIndex),
+		attribute.Int("llm_d.pd_proxy.chunked_decode.total_tokens", totalTokens),
+		attribute.Float64("llm_d.pd_proxy.chunked_decode.duration_ms", float64(time.Since(decodeStart).Milliseconds())),
+	)
+
+	if streamingEnabled {
+		fmt.Fprintf(w, "%s\n\n", sseDone) //nolint:errcheck
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		return
+	}
+
+	// Non-streaming: reassemble the full response.
+	// overwrite choices with the text accumulated across all chunks.
+	if lastResponse == nil {
+		if err := errorInternalServerError(errors.New("no chunks produced"), w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	// Fix usage: prompt_tokens from first chunk, completion_tokens summed across all chunks.
+	if usage, ok := lastResponse[responseFieldUsage].(map[string]any); ok {
+		usage = maps.Clone(usage)
+		usage[responseFieldPromptTokens] = originalPromptTokens
+		usage[responseFieldCompletionTokens] = totalTokens
+		usage[responseFieldTotalTokens] = originalPromptTokens + totalTokens
+		lastResponse[responseFieldUsage] = usage
+	}
+
+	if choices, ok := lastResponse[responseFieldChoices].([]any); ok && len(choices) > 0 {
+		choice := maps.Clone(choices[0].(map[string]any))
+		fullText := textAccum.String()
+		if msg, ok := choice[responseFieldMessage].(map[string]any); ok {
+			msg = maps.Clone(msg)
+			msg[requestFieldContent] = fullText
+			choice[responseFieldMessage] = msg
+		} else {
+			choice[responseFieldText] = fullText
+		}
+		lastResponse[responseFieldChoices] = []any{choice}
+	}
+
+	respBody, err := json.Marshal(lastResponse)
+	if err != nil {
+		if err := errorInternalServerError(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBody) //nolint:errcheck
+}
+
+// resolveMaxTokens returns the effective max-tokens limit from the request map.
+// Prefers max_completion_tokens (OpenAI v1) over max_tokens (legacy).
+// Returns -1 when neither field is set (no explicit limit).
+func resolveMaxTokens(req map[string]any) int {
+	for _, field := range []string{requestFieldMaxCompletionTokens, requestFieldMaxTokens} {
+		if v, ok := req[field]; ok {
+			if n, ok := toInt(v); ok && n > 0 {
+				return n
+			}
+		}
+	}
+	return -1
+}
+
+// remainingTokens returns how many more tokens may be generated.
+// Returns -1 for no cap, 0 when the budget is exhausted.
+func remainingTokens(budget, used int) int {
+	if budget < 0 {
+		return -1
+	}
+	if used >= budget {
+		return 0
+	}
+	return budget - used
+}
+
+// countTokensInResponse returns completion_tokens from the usage field, or 0.
+func countTokensInResponse(response map[string]any) int {
+	if usage, ok := response[responseFieldUsage].(map[string]any); ok {
+		if n, ok := toInt(usage[responseFieldCompletionTokens]); ok {
+			return n
+		}
+	}
+	return 0
+}
+
+// extractPromptTokens returns prompt_tokens from the usage field, or 0.
+func extractPromptTokens(response map[string]any) int {
+	if usage, ok := response[responseFieldUsage].(map[string]any); ok {
+		if n, ok := toInt(usage[responseFieldPromptTokens]); ok {
+			return n
+		}
+	}
+	return 0
+}
+
+// extractFinishReason returns finish_reason or "".
+func extractFinishReason(response map[string]any) string {
+	choices, ok := response[responseFieldChoices].([]any)
+	if !ok || len(choices) == 0 {
+		return ""
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return ""
+	}
+	reason, _ := choice[responseFieldFinishReason].(string)
+	return reason
+}
+
+// emitSSEChunk writes one SSE data event to w, converting a buffered
+// non-streaming response into a streaming delta event (chat or legacy).
+func emitSSEChunk(w http.ResponseWriter, chunkResponse map[string]any) error {
+	streamChunk := maps.Clone(chunkResponse)
+
+	if choices, _ := chunkResponse[responseFieldChoices].([]any); len(choices) > 0 {
+		streamChoices := make([]any, 0, len(choices))
+		for _, c := range choices {
+			choice, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			text := extractChoiceText(choice)
+			streamChoice := map[string]any{
+				responseFieldIndex:        choice[responseFieldIndex],
+				responseFieldFinishReason: choice[responseFieldFinishReason],
+			}
+			if _, isChatCompletion := choice[responseFieldMessage]; isChatCompletion {
+				streamChoice[responseFieldDelta] = map[string]any{requestFieldContent: text, requestFieldRole: "assistant"}
+			} else {
+				streamChoice[responseFieldText] = text
+				streamChoice[responseFieldLogprobs] = choice[responseFieldLogprobs]
+			}
+			streamChoices = append(streamChoices, streamChoice)
+		}
+		streamChunk[responseFieldChoices] = streamChoices
+	}
+
+	// Omit usage on intermediate chunks (finish_reason == length or absent).
+	if fr := extractFinishReason(chunkResponse); fr == "" || fr == finishReasonLength {
+		delete(streamChunk, responseFieldUsage)
+	}
+
+	data, err := json.Marshal(streamChunk)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "%s%s\n\n", sseDataPrefix, data)
+	return err
+}
+
+// firstChoice returns choices[0] from a response map, or nil.
+func firstChoice(response map[string]any) map[string]any {
+	choices, ok := response[responseFieldChoices].([]any)
+	if !ok || len(choices) == 0 {
+		return nil
+	}
+	choice, _ := choices[0].(map[string]any)
+	return choice
+}
+
+// extractChoiceText returns the generated text from a choice object,
+// handling both chat completions (message.content) and legacy (text).
+func extractChoiceText(choice map[string]any) string {
+	if text, ok := choice[responseFieldText].(string); ok {
+		return text
+	}
+	if msg, ok := choice[responseFieldMessage].(map[string]any); ok {
+		if content, ok := msg[requestFieldContent].(string); ok {
+			return content
+		}
+	}
+	return ""
+}
+
+// appendChunkToRequest appends the generated text from a chunk to the request
+// so the next chunk continues from where this one left off.
+// For chat completions: appends {"role":"assistant","content":text} to messages.
+// For legacy completions: appends text to the prompt string.
+func appendChunkToRequest(req map[string]any, text string) {
+	if text == "" {
+		return
+	}
+	if messages, ok := req[requestFieldMessages].([]any); ok {
+		req[requestFieldMessages] = append(messages, map[string]any{
+			requestFieldRole:    "assistant",
+			requestFieldContent: text,
+		})
+		return
+	}
+	// Legacy completions: append generated text to prompt with assistant prefix.
+	if prompt, ok := req[requestFieldPrompt].(string); ok {
+		req[requestFieldPrompt] = prompt + legacyChunkPrefix + text
+	}
+}
+
+// toInt converts a JSON number value (float64, int, or json.Number) to int.
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case float64:
+		return int(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return int(i), err == nil
+	}
+	return 0, false
+}

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -60,11 +60,11 @@ const (
 )
 
 // dispatchDecode routes a fully-prepared decode request to either chunked
-// decode or the regular decoder proxy based on s.config.EnableChunkedDecode.
-// completionRequest is the already-parsed JSON map; callers that hold it
-// should use this instead of calling s.decoderProxy directly.
+// decode or the regular decoder proxy. Chunked decode is used when
+// s.config.DecodeChunkSize > 0. completionRequest is the already-parsed JSON
+// map; callers that hold it should use this instead of calling s.decoderProxy directly.
 func (s *Server) dispatchDecode(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) {
-	if s.config.EnableChunkedDecode {
+	if s.config.DecodeChunkSize > 0 {
 		s.runChunkedDecodeFromMap(w, r, completionRequest)
 		return
 	}

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -261,9 +261,9 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 	}
 
 	if streamingEnabled {
-		// Emit corrected cumulative usage as a final event before [DONE]
-		// when multiple chunks were produced (individual chunk usage is stripped).
-		if chunkIndex > 1 && lastResponse != nil {
+		// Emit corrected cumulative usage as a final event before [DONE].
+		// Individual chunk events have usage stripped by emitSSEChunk.
+		if lastResponse != nil {
 			usageEvent := map[string]any{
 				responseFieldUsage:   cumulativeUsage,
 				responseFieldChoices: []any{},
@@ -397,10 +397,7 @@ func emitSSEChunk(w http.ResponseWriter, chunkResponse map[string]any) error {
 		streamChunk[responseFieldChoices] = streamChoices
 	}
 
-	// Omit usage on intermediate chunks (finish_reason == length or absent).
-	if fr := extractFinishReason(chunkResponse); fr == "" || fr == finishReasonLength {
-		delete(streamChunk, responseFieldUsage)
-	}
+	delete(streamChunk, responseFieldUsage)
 
 	data, err := json.Marshal(streamChunk)
 	if err != nil {

--- a/pkg/sidecar/proxy/decode_test.go
+++ b/pkg/sidecar/proxy/decode_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
@@ -45,7 +44,7 @@ type chunkedTestInfo struct {
 // serves decodeResponses in order; any extra request gets a 500.
 func newChunkedTestSetup(chunkSize int, decodeResponses []string) *chunkedTestInfo {
 	var reqIdx int
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return newChunkedTestSetupWithHandler(chunkSize, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if reqIdx >= len(decodeResponses) {
 			http.Error(w, "unexpected request", http.StatusInternalServerError)
 			return
@@ -54,6 +53,12 @@ func newChunkedTestSetup(chunkSize int, decodeResponses []string) *chunkedTestIn
 		fmt.Fprint(w, decodeResponses[reqIdx]) //nolint:errcheck
 		reqIdx++
 	}))
+}
+
+// newChunkedTestSetupWithHandler is like newChunkedTestSetup but accepts a
+// custom backend handler for tests that need to inspect or alter requests.
+func newChunkedTestSetupWithHandler(chunkSize int, handler http.Handler) *chunkedTestInfo {
+	backend := httptest.NewServer(handler)
 	DeferCleanup(backend.Close)
 
 	decoderURL, _ := url.Parse(backend.URL)
@@ -74,8 +79,7 @@ func newChunkedTestSetup(chunkSize int, decodeResponses []string) *chunkedTestIn
 		_ = proxy.Start(ctx)
 		stoppedCh <- struct{}{}
 	}()
-	time.Sleep(200 * time.Millisecond)
-	Expect(proxy.addr).ToNot(BeNil())
+	<-proxy.readyCh
 
 	return &chunkedTestInfo{
 		proxy:     proxy,
@@ -197,7 +201,7 @@ var _ = Describe("Chunked Decode", func() {
 				chatResponse("world", "stop", 9, 5),
 			}
 
-			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ti := newChunkedTestSetupWithHandler(5, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				b, _ := io.ReadAll(r.Body)
 				if reqIdx == 1 {
 					json.Unmarshal(b, &secondReqBody) //nolint:errcheck
@@ -206,25 +210,9 @@ var _ = Describe("Chunked Decode", func() {
 				fmt.Fprint(w, responses[reqIdx]) //nolint:errcheck
 				reqIdx++
 			}))
-			DeferCleanup(backend.Close)
+			defer ti.stop()
 
-			decoderURL, _ := url.Parse(backend.URL)
-			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, DecodeChunkSize: 5}
-			proxy := NewProxy(cfg)
-
-			ctx := newTestContext()
-			ctx, cancelFn := context.WithCancel(ctx)
-			stoppedCh := make(chan struct{})
-			go func() {
-				defer GinkgoRecover()
-				_ = proxy.Start(ctx)
-				stoppedCh <- struct{}{}
-			}()
-			time.Sleep(200 * time.Millisecond)
-			Expect(proxy.addr).ToNot(BeNil())
-			proxyAddr := "http://" + proxy.addr.String()
-
-			resp := doPost(proxyAddr, ChatCompletionsPath,
+			resp := doPost(ti.addr, ChatCompletionsPath,
 				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":10}`)
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -234,39 +222,18 @@ var _ = Describe("Chunked Decode", func() {
 			lastMsg := msgs[1].(map[string]any)
 			Expect(lastMsg[requestFieldRole]).To(Equal("assistant"))
 			Expect(lastMsg[requestFieldContent]).To(Equal("hello "))
-
-			cancelFn()
-			<-stoppedCh
 		})
 
 		It("propagates decode backend error to client", func() {
-			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ti := newChunkedTestSetupWithHandler(5, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadGateway)
 				fmt.Fprint(w, `{"error":"backend down"}`) //nolint:errcheck
 			}))
-			DeferCleanup(backend.Close)
+			defer ti.stop()
 
-			decoderURL, _ := url.Parse(backend.URL)
-			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, DecodeChunkSize: 5}
-			proxy := NewProxy(cfg)
-
-			ctx := newTestContext()
-			ctx, cancelFn := context.WithCancel(ctx)
-			stoppedCh := make(chan struct{})
-			go func() {
-				defer GinkgoRecover()
-				_ = proxy.Start(ctx)
-				stoppedCh <- struct{}{}
-			}()
-			time.Sleep(200 * time.Millisecond)
-			Expect(proxy.addr).ToNot(BeNil())
-
-			resp := doPost("http://"+proxy.addr.String(), ChatCompletionsPath,
+			resp := doPost(ti.addr, ChatCompletionsPath,
 				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":10}`)
 			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
-
-			cancelFn()
-			<-stoppedCh
 		})
 	})
 

--- a/pkg/sidecar/proxy/decode_test.go
+++ b/pkg/sidecar/proxy/decode_test.go
@@ -259,14 +259,25 @@ var _ = Describe("Chunked Decode", func() {
 				}
 			}
 
-			// Two chunk data events + [DONE]
-			Expect(events).To(HaveLen(3))
-			Expect(events[2]).To(Equal(sseDone))
+			// Two chunk data events + usage event + [DONE]
+			Expect(events).To(HaveLen(4))
+			Expect(events[3]).To(Equal(sseDone))
 
 			var first map[string]any
 			Expect(json.Unmarshal([]byte(strings.TrimPrefix(events[0], sseDataPrefix)), &first)).To(Succeed())
 			delta := first["choices"].([]any)[0].(map[string]any)[responseFieldDelta].(map[string]any)
 			Expect(delta[requestFieldContent]).To(Equal("hello "))
+
+			// Verify cumulative usage in the final usage event.
+			var usageEvent map[string]any
+			Expect(json.Unmarshal([]byte(strings.TrimPrefix(events[2], sseDataPrefix)), &usageEvent)).To(Succeed())
+			usage := usageEvent["usage"].(map[string]any)
+			promptTokens, _ := toInt(usage["prompt_tokens"])
+			completionTokens, _ := toInt(usage["completion_tokens"])
+			totalTokens, _ := toInt(usage["total_tokens"])
+			Expect(promptTokens).To(Equal(5))
+			Expect(completionTokens).To(Equal(10))
+			Expect(totalTokens).To(Equal(15))
 		})
 	})
 
@@ -299,12 +310,6 @@ var _ = Describe("Chunked Decode", func() {
 			last := msgs[1].(map[string]any)
 			Expect(last[requestFieldRole]).To(Equal("assistant"))
 			Expect(last[requestFieldContent]).To(Equal("hello"))
-		})
-
-		It("appendChunkToRequest appends to legacy prompt with prefix", func() {
-			req := map[string]any{requestFieldPrompt: "Tell me a story"}
-			appendChunkToRequest(req, "Once upon a time")
-			Expect(req[requestFieldPrompt]).To(Equal("Tell me a story" + legacyChunkPrefix + "Once upon a time"))
 		})
 
 		It("appendChunkToRequest is a no-op for empty text", func() {

--- a/pkg/sidecar/proxy/decode_test.go
+++ b/pkg/sidecar/proxy/decode_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" // nolint:revive
+	. "github.com/onsi/gomega"    // nolint:revive
+)
+
+// chunkedTestInfo holds a running proxy backed by a controlled decode backend.
+type chunkedTestInfo struct {
+	proxy     *Server
+	backend   *httptest.Server
+	addr      string // "http://host:port" of the proxy
+	cancelFn  context.CancelFunc
+	stoppedCh chan struct{}
+}
+
+// newChunkedTestSetup starts a proxy with chunked decode enabled. The backend
+// serves decodeResponses in order; any extra request gets a 500.
+func newChunkedTestSetup(chunkSize int, decodeResponses []string) *chunkedTestInfo {
+	var reqIdx int
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqIdx >= len(decodeResponses) {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, decodeResponses[reqIdx]) //nolint:errcheck
+		reqIdx++
+	}))
+	DeferCleanup(backend.Close)
+
+	decoderURL, _ := url.Parse(backend.URL)
+	cfg := Config{
+		Port:                "0",
+		DecoderURL:          decoderURL,
+		KVConnector:         KVConnectorNIXLV2,
+		EnableChunkedDecode: true,
+		DecodeChunkSize:     chunkSize,
+	}
+	proxy := NewProxy(cfg)
+
+	ctx := newTestContext()
+	ctx, cancelFn := context.WithCancel(ctx)
+	stoppedCh := make(chan struct{})
+
+	go func() {
+		defer GinkgoRecover()
+		_ = proxy.Start(ctx)
+		stoppedCh <- struct{}{}
+	}()
+	time.Sleep(200 * time.Millisecond)
+	Expect(proxy.addr).ToNot(BeNil())
+
+	return &chunkedTestInfo{
+		proxy:     proxy,
+		backend:   backend,
+		addr:      "http://" + proxy.addr.String(),
+		cancelFn:  cancelFn,
+		stoppedCh: stoppedCh,
+	}
+}
+
+func (ti *chunkedTestInfo) stop() {
+	ti.cancelFn()
+	<-ti.stoppedCh
+}
+
+// chatResponse builds a minimal non-streaming chat completion JSON response.
+func chatResponse(content, finishReason string, promptTokens, completionTokens int) string {
+	resp := map[string]any{
+		"id":      "test-id",
+		"object":  "chat.completion",
+		"model":   "test-model",
+		"created": 1234567890,
+		"choices": []any{
+			map[string]any{
+				"index":         0,
+				"finish_reason": finishReason,
+				"message":       map[string]any{"role": "assistant", "content": content},
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     promptTokens,
+			"completion_tokens": completionTokens,
+			"total_tokens":      promptTokens + completionTokens,
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+// doPost sends a POST request to the proxy and returns the response.
+func doPost(addr, path, body string) *http.Response {
+	req, err := http.NewRequest(http.MethodPost, addr+path, strings.NewReader(body))
+	Expect(err).ToNot(HaveOccurred())
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).ToNot(HaveOccurred())
+	return resp
+}
+
+var _ = Describe("Chunked Decode", func() {
+
+	Describe("non-streaming", func() {
+
+		It("falls back to regular decode when budget fits in one chunk", func() {
+			// chunk size 512, max_tokens 10 → single pass, no chunking
+			ti := newChunkedTestSetup(512, []string{
+				chatResponse("hello world", "stop", 5, 10),
+			})
+			defer ti.stop()
+
+			resp := doPost(ti.addr, ChatCompletionsPath,
+				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":10}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var body map[string]any
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			content := body["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)["content"]
+			Expect(content).To(Equal("hello world"))
+		})
+
+		It("reassembles two chunks into a single response with correct usage", func() {
+			// chunk size 5, max_tokens 10 → two chunks
+			ti := newChunkedTestSetup(5, []string{
+				chatResponse("hello ", "length", 8, 5),
+				chatResponse("world", "stop", 9, 5),
+			})
+			defer ti.stop()
+
+			resp := doPost(ti.addr, ChatCompletionsPath,
+				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":10}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var body map[string]any
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+
+			content := body["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)["content"]
+			Expect(content).To(Equal("hello world"))
+
+			usage := body["usage"].(map[string]any)
+			promptTokens, _ := toInt(usage["prompt_tokens"])
+			completionTokens, _ := toInt(usage["completion_tokens"])
+			totalTokens, _ := toInt(usage["total_tokens"])
+			Expect(promptTokens).To(Equal(8))
+			Expect(completionTokens).To(Equal(10))
+			Expect(totalTokens).To(Equal(18))
+		})
+
+		It("stops early on terminal finish reason before budget is exhausted", func() {
+			// chunk size 5, max_tokens 20 → first chunk returns "stop"
+			ti := newChunkedTestSetup(5, []string{
+				chatResponse("done", "stop", 5, 3),
+			})
+			defer ti.stop()
+
+			resp := doPost(ti.addr, ChatCompletionsPath,
+				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":20}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var body map[string]any
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			content := body["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)["content"]
+			Expect(content).To(Equal("done"))
+		})
+
+		It("appends assistant message to messages on second chunk", func() {
+			var secondReqBody map[string]any
+			var reqIdx int
+			responses := []string{
+				chatResponse("hello ", "length", 5, 5),
+				chatResponse("world", "stop", 9, 5),
+			}
+
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				if reqIdx == 1 {
+					json.Unmarshal(b, &secondReqBody) //nolint:errcheck
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, responses[reqIdx]) //nolint:errcheck
+				reqIdx++
+			}))
+			DeferCleanup(backend.Close)
+
+			decoderURL, _ := url.Parse(backend.URL)
+			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, EnableChunkedDecode: true, DecodeChunkSize: 5}
+			proxy := NewProxy(cfg)
+
+			ctx := newTestContext()
+			ctx, cancelFn := context.WithCancel(ctx)
+			stoppedCh := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				_ = proxy.Start(ctx)
+				stoppedCh <- struct{}{}
+			}()
+			time.Sleep(200 * time.Millisecond)
+			Expect(proxy.addr).ToNot(BeNil())
+			proxyAddr := "http://" + proxy.addr.String()
+
+			resp := doPost(proxyAddr, ChatCompletionsPath,
+				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":10}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			Expect(secondReqBody).ToNot(BeNil())
+			msgs := secondReqBody[requestFieldMessages].([]any)
+			Expect(msgs).To(HaveLen(2))
+			lastMsg := msgs[1].(map[string]any)
+			Expect(lastMsg[requestFieldRole]).To(Equal("assistant"))
+			Expect(lastMsg[requestFieldContent]).To(Equal("hello "))
+
+			cancelFn()
+			<-stoppedCh
+		})
+
+		It("propagates decode backend error to client", func() {
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+				fmt.Fprint(w, `{"error":"backend down"}`) //nolint:errcheck
+			}))
+			DeferCleanup(backend.Close)
+
+			decoderURL, _ := url.Parse(backend.URL)
+			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, EnableChunkedDecode: true, DecodeChunkSize: 5}
+			proxy := NewProxy(cfg)
+
+			ctx := newTestContext()
+			ctx, cancelFn := context.WithCancel(ctx)
+			stoppedCh := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				_ = proxy.Start(ctx)
+				stoppedCh <- struct{}{}
+			}()
+			time.Sleep(200 * time.Millisecond)
+			Expect(proxy.addr).ToNot(BeNil())
+
+			resp := doPost("http://"+proxy.addr.String(), ChatCompletionsPath,
+				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":10}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+
+			cancelFn()
+			<-stoppedCh
+		})
+	})
+
+	Describe("streaming", func() {
+
+		It("emits one SSE event per chunk and terminates with [DONE]", func() {
+			ti := newChunkedTestSetup(5, []string{
+				chatResponse("hello ", "length", 5, 5),
+				chatResponse("world", "stop", 9, 5),
+			})
+			defer ti.stop()
+
+			resp := doPost(ti.addr, ChatCompletionsPath,
+				`{"messages":[{"role":"user","content":"Hi"}],"max_tokens":10,"stream":true}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Header.Get("Content-Type")).To(Equal("text/event-stream"))
+
+			var events []string
+			scanner := bufio.NewScanner(resp.Body)
+			for scanner.Scan() {
+				if line := scanner.Text(); strings.HasPrefix(line, "data: ") {
+					events = append(events, line)
+				}
+			}
+
+			// Two chunk data events + [DONE]
+			Expect(events).To(HaveLen(3))
+			Expect(events[2]).To(Equal(sseDone))
+
+			var first map[string]any
+			Expect(json.Unmarshal([]byte(strings.TrimPrefix(events[0], sseDataPrefix)), &first)).To(Succeed())
+			delta := first["choices"].([]any)[0].(map[string]any)[responseFieldDelta].(map[string]any)
+			Expect(delta[requestFieldContent]).To(Equal("hello "))
+		})
+	})
+
+	Describe("helper functions", func() {
+
+		It("resolveMaxTokens prefers max_completion_tokens over max_tokens", func() {
+			req := map[string]any{requestFieldMaxTokens: float64(50), requestFieldMaxCompletionTokens: float64(100)}
+			Expect(resolveMaxTokens(req)).To(Equal(100))
+		})
+
+		It("resolveMaxTokens returns -1 when neither field is set", func() {
+			Expect(resolveMaxTokens(map[string]any{})).To(Equal(-1))
+		})
+
+		It("remainingTokens returns -1 for unlimited budget", func() {
+			Expect(remainingTokens(-1, 100)).To(Equal(-1))
+		})
+
+		It("remainingTokens returns 0 when budget is exhausted", func() {
+			Expect(remainingTokens(10, 10)).To(Equal(0))
+		})
+
+		It("appendChunkToRequest appends assistant message to chat messages", func() {
+			req := map[string]any{
+				requestFieldMessages: []any{map[string]any{requestFieldRole: "user", requestFieldContent: "Hi"}},
+			}
+			appendChunkToRequest(req, "hello")
+			msgs := req[requestFieldMessages].([]any)
+			Expect(msgs).To(HaveLen(2))
+			last := msgs[1].(map[string]any)
+			Expect(last[requestFieldRole]).To(Equal("assistant"))
+			Expect(last[requestFieldContent]).To(Equal("hello"))
+		})
+
+		It("appendChunkToRequest appends to legacy prompt with prefix", func() {
+			req := map[string]any{requestFieldPrompt: "Tell me a story"}
+			appendChunkToRequest(req, "Once upon a time")
+			Expect(req[requestFieldPrompt]).To(Equal("Tell me a story" + legacyChunkPrefix + "Once upon a time"))
+		})
+
+		It("appendChunkToRequest is a no-op for empty text", func() {
+			req := map[string]any{requestFieldMessages: []any{}}
+			appendChunkToRequest(req, "")
+			Expect(req[requestFieldMessages].([]any)).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/sidecar/proxy/decode_test.go
+++ b/pkg/sidecar/proxy/decode_test.go
@@ -58,11 +58,10 @@ func newChunkedTestSetup(chunkSize int, decodeResponses []string) *chunkedTestIn
 
 	decoderURL, _ := url.Parse(backend.URL)
 	cfg := Config{
-		Port:                "0",
-		DecoderURL:          decoderURL,
-		KVConnector:         KVConnectorNIXLV2,
-		EnableChunkedDecode: true,
-		DecodeChunkSize:     chunkSize,
+		Port:            "0",
+		DecoderURL:      decoderURL,
+		KVConnector:     KVConnectorNIXLV2,
+		DecodeChunkSize: chunkSize,
 	}
 	proxy := NewProxy(cfg)
 
@@ -210,7 +209,7 @@ var _ = Describe("Chunked Decode", func() {
 			DeferCleanup(backend.Close)
 
 			decoderURL, _ := url.Parse(backend.URL)
-			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, EnableChunkedDecode: true, DecodeChunkSize: 5}
+			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, DecodeChunkSize: 5}
 			proxy := NewProxy(cfg)
 
 			ctx := newTestContext()
@@ -248,7 +247,7 @@ var _ = Describe("Chunked Decode", func() {
 			DeferCleanup(backend.Close)
 
 			decoderURL, _ := url.Parse(backend.URL)
-			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, EnableChunkedDecode: true, DecodeChunkSize: 5}
+			cfg := Config{Port: "0", DecoderURL: decoderURL, KVConnector: KVConnectorNIXLV2, DecodeChunkSize: 5}
 			proxy := NewProxy(cfg)
 
 			ctx := newTestContext()

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -52,6 +52,7 @@ const (
 	inferencePool           = "inference-pool"
 	poolGroup               = "pool-group"
 	maxIdleConnsPerHost     = "max-idle-conns-per-host"
+	decodeChunkSize         = "decode-chunk-size"
 	inlineConfiguration     = "configuration"
 	configurationFile       = "configuration-file"
 
@@ -103,6 +104,7 @@ type yamlConfiguration struct {
 	InferencePool                  string   `json:"inference-pool,omitempty"`
 	PoolGroup                      string   `json:"pool-group,omitempty"`
 	MaxIdleConnsPerHost            int      `json:"max-idle-conns-per-host,omitempty"`
+	DecodeChunkSize                int      `json:"decode-chunk-size,omitempty"`
 }
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
@@ -209,7 +211,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.EnableSSRFProtection, enableSSRFProtection, opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")
 	fs.BoolVar(&opts.EnablePrefillerSampling, enablePrefillerSampling, opts.EnablePrefillerSampling, "if true, the target prefill instance will be selected randomly from among the provided prefill host values")
 	fs.StringVar(&opts.PoolGroup, poolGroup, opts.PoolGroup, "group of the InferencePool this Endpoint Picker is associated with.")
-	fs.IntVar(&opts.DecodeChunkSize, "decode-chunk-size", opts.DecodeChunkSize, "enables chunked decode mode when > 0; value is the token budget per chunk. For best performance should be a multiple of the block size.")
+	fs.IntVar(&opts.DecodeChunkSize, decodeChunkSize, opts.DecodeChunkSize, "enables chunked decode mode when > 0; value is the token budget per chunk. For best performance should be a multiple of the block size.")
 
 	fs.StringSliceVar(&opts.enableTLS, enableTLS, opts.enableTLS, "stages to enable TLS for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
 	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, tlsInsecureSkipVerify, opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
@@ -511,6 +513,9 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	}
 	if cfg.PoolGroup != "" && !opts.isFlagSet(poolGroup) {
 		opts.PoolGroup = cfg.PoolGroup
+	}
+	if cfg.DecodeChunkSize != 0 && !opts.isFlagSet(decodeChunkSize) {
+		opts.DecodeChunkSize = cfg.DecodeChunkSize
 	}
 }
 

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -178,7 +178,7 @@ func NewOptions() *Options {
 			PoolGroup:               DefaultPoolGroup,
 			InferencePoolNamespace:  os.Getenv(envInferencePoolNamespace),
 			InferencePoolName:       os.Getenv(envInferencePoolName),
-			DecodeChunkSize:         0, // 0 disables chunked decode
+			DecodeChunkSize:         0,
 		},
 		vllmPort:      defaultVLLMPort,
 		inferencePool: os.Getenv(envInferencePool),

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -136,6 +136,10 @@ type Options struct {
 	fileConfiguration   string
 }
 
+const (
+	// defaultDecodeChunkSize is the default decode chunk size in tokens.
+	defaultDecodeChunkSize = 512
+)
 var (
 	// supportedKVConnectors defines all valid P/D KV connector types
 	supportedKVConnectors = map[string]struct{}{
@@ -178,6 +182,8 @@ func NewOptions() *Options {
 			PoolGroup:               DefaultPoolGroup,
 			InferencePoolNamespace:  os.Getenv(envInferencePoolNamespace),
 			InferencePoolName:       os.Getenv(envInferencePoolName),
+			EnableChunkedDecode:     false,
+			DecodeChunkSize:         defaultDecodeChunkSize,
 		},
 		vllmPort:      defaultVLLMPort,
 		inferencePool: os.Getenv(envInferencePool),
@@ -208,6 +214,8 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.EnableSSRFProtection, enableSSRFProtection, opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")
 	fs.BoolVar(&opts.EnablePrefillerSampling, enablePrefillerSampling, opts.EnablePrefillerSampling, "if true, the target prefill instance will be selected randomly from among the provided prefill host values")
 	fs.StringVar(&opts.PoolGroup, poolGroup, opts.PoolGroup, "group of the InferencePool this Endpoint Picker is associated with.")
+	fs.BoolVar(&opts.EnableChunkedDecode, "enable-chunked-decode", opts.EnableChunkedDecode, "if true, enables chunked decode mode (default: false)")
+	fs.IntVar(&opts.DecodeChunkSize, "decode-chunk-size", opts.DecodeChunkSize, fmt.Sprintf("decode chunk size in tokens; for best performance should be a multiple of the block size (default: %d)", defaultDecodeChunkSize))
 
 	fs.StringSliceVar(&opts.enableTLS, enableTLS, opts.enableTLS, "stages to enable TLS for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
 	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, tlsInsecureSkipVerify, opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
@@ -348,6 +356,11 @@ func (opts *Options) Validate() error {
 				return errors.New("--inference-pool cannot have empty namespace or name")
 			}
 		}
+	}
+
+	// Validate chunked decode
+	if opts.EnableChunkedDecode && opts.DecodeChunkSize <= 0 {
+		return fmt.Errorf("--decode-chunk-size must be a positive integer, got %d", opts.DecodeChunkSize)
 	}
 
 	// Validate SSRF protection requirements

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -136,10 +136,6 @@ type Options struct {
 	fileConfiguration   string
 }
 
-const (
-	// defaultDecodeChunkSize is the default decode chunk size in tokens.
-	defaultDecodeChunkSize = 512
-)
 var (
 	// supportedKVConnectors defines all valid P/D KV connector types
 	supportedKVConnectors = map[string]struct{}{
@@ -182,8 +178,7 @@ func NewOptions() *Options {
 			PoolGroup:               DefaultPoolGroup,
 			InferencePoolNamespace:  os.Getenv(envInferencePoolNamespace),
 			InferencePoolName:       os.Getenv(envInferencePoolName),
-			EnableChunkedDecode:     false,
-			DecodeChunkSize:         defaultDecodeChunkSize,
+			DecodeChunkSize:         0, // 0 disables chunked decode
 		},
 		vllmPort:      defaultVLLMPort,
 		inferencePool: os.Getenv(envInferencePool),
@@ -214,8 +209,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.EnableSSRFProtection, enableSSRFProtection, opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")
 	fs.BoolVar(&opts.EnablePrefillerSampling, enablePrefillerSampling, opts.EnablePrefillerSampling, "if true, the target prefill instance will be selected randomly from among the provided prefill host values")
 	fs.StringVar(&opts.PoolGroup, poolGroup, opts.PoolGroup, "group of the InferencePool this Endpoint Picker is associated with.")
-	fs.BoolVar(&opts.EnableChunkedDecode, "enable-chunked-decode", opts.EnableChunkedDecode, "if true, enables chunked decode mode (default: false)")
-	fs.IntVar(&opts.DecodeChunkSize, "decode-chunk-size", opts.DecodeChunkSize, fmt.Sprintf("decode chunk size in tokens; for best performance should be a multiple of the block size (default: %d)", defaultDecodeChunkSize))
+	fs.IntVar(&opts.DecodeChunkSize, "decode-chunk-size", opts.DecodeChunkSize, "enables chunked decode mode when > 0; value is the token budget per chunk. For best performance should be a multiple of the block size.")
 
 	fs.StringSliceVar(&opts.enableTLS, enableTLS, opts.enableTLS, "stages to enable TLS for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
 	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, tlsInsecureSkipVerify, opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
@@ -359,8 +353,8 @@ func (opts *Options) Validate() error {
 	}
 
 	// Validate chunked decode
-	if opts.EnableChunkedDecode && opts.DecodeChunkSize <= 0 {
-		return fmt.Errorf("--decode-chunk-size must be a positive integer, got %d", opts.DecodeChunkSize)
+	if opts.DecodeChunkSize < 0 {
+		return fmt.Errorf("--decode-chunk-size must be a non-negative integer (0 disables chunked decode), got %d", opts.DecodeChunkSize)
 	}
 
 	// Validate SSRF protection requirements

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -61,6 +61,7 @@ cert-path: "/etc/certificates-file"
 inference-pool: "file-ns/inference-pool-file"
 pool-group: "pool-group-file"
 max-idle-conns-per-host: 300
+decode-chunk-size: 128
 `)
 }
 
@@ -102,7 +103,8 @@ func TestSidecarConfiguration(t *testing.T) {
 		cert-path: '/etc/certificates-inline',
 		inference-pool: inline-ns/inference-pool-inline,
 		pool-group: pool-group-inline,
-		max-idle-conns-per-host: 200
+		max-idle-conns-per-host: 200,
+		decode-chunk-size: 256
 	}`
 	invalidInlineYAML := "{port: 8200, invalid-yaml}"
 
@@ -154,6 +156,8 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.InferencePoolName = "inference-pool-inline"
 				o.PoolGroup = "pool-group-inline"
 
+				o.DecodeChunkSize = 256
+
 				o.inlineConfiguration = inlineYAML
 				o.fileConfiguration = ""
 			},
@@ -193,6 +197,8 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.InferencePoolNamespace = "file-ns"
 				o.InferencePoolName = "inference-pool-file"
 				o.PoolGroup = "pool-group-file"
+
+				o.DecodeChunkSize = 128
 
 				o.inlineConfiguration = ""
 				o.fileConfiguration = validYAMLPath
@@ -247,6 +253,8 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.InferencePoolName = "inference-pool"
 				o.PoolGroup = "pool-group"
 
+				o.DecodeChunkSize = 256
+
 				o.inlineConfiguration = inlineYAML
 				o.fileConfiguration = ""
 			},
@@ -300,6 +308,8 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.InferencePoolNamespace = "ns"
 				o.InferencePoolName = "inference-pool"
 				o.PoolGroup = "pool-group"
+
+				o.DecodeChunkSize = 128
 
 				o.inlineConfiguration = ""
 				o.fileConfiguration = validYAMLPath
@@ -425,6 +435,8 @@ func compareOptions(t *testing.T, expected, actual *Options) {
 	assertEqual(inferencePoolNamespace, expected.InferencePoolNamespace, actual.InferencePoolNamespace)
 	assertEqual(inferencePoolName, expected.InferencePoolName, actual.InferencePoolName)
 	assertEqual(poolGroup, expected.PoolGroup, actual.PoolGroup)
+
+	assertEqual(decodeChunkSize, expected.DecodeChunkSize, actual.DecodeChunkSize)
 
 	assertEqual(inlineConfiguration, expected.inlineConfiguration, actual.inlineConfiguration)
 	assertEqual(configurationFile, expected.fileConfiguration, actual.fileConfiguration)

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -177,9 +177,8 @@ type Config struct {
 	// PoolGroup is the API group of the InferencePool resource.
 	PoolGroup string
 
-	// EnableChunkedDecode enables chunked decode mode.
-	EnableChunkedDecode bool
-	// DecodeChunkSize is the decode chunk size in tokens.
+	// DecodeChunkSize is the token budget per decode chunk.
+	// Chunked decode is enabled when this value is > 0.
 	DecodeChunkSize int
 }
 

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -42,19 +42,21 @@ const (
 
 	requestHeaderRequestID = "x-request-id"
 
-	requestFieldKVTransferParams    = "kv_transfer_params"
-	requestFieldMaxTokens           = "max_tokens"
-	requestFieldMaxCompletionTokens = "max_completion_tokens"
-	requestFieldMaxOutputTokens     = "max_output_tokens" // Used by Responses API
-	requestFieldDoRemotePrefill     = "do_remote_prefill"
-	requestFieldDoRemoteDecode      = "do_remote_decode"
-	requestFieldRemoteBlockIDs      = "remote_block_ids"
-	requestFieldRemoteEngineID      = "remote_engine_id"
-	requestFieldRemoteHost          = "remote_host"
-	requestFieldRemotePort          = "remote_port"
-	requestFieldStream              = "stream"
-	requestFieldStreamOptions       = "stream_options"
-	requestFieldCacheHitThreshold   = "cache_hit_threshold"
+	requestFieldKVTransferParams     = "kv_transfer_params"
+	requestFieldMaxTokens            = "max_tokens"
+	requestFieldMaxCompletionTokens  = "max_completion_tokens"
+	requestFieldMaxOutputTokens      = "max_output_tokens" // Used by Responses API
+	requestFieldDoRemotePrefill      = "do_remote_prefill"
+	requestFieldDoRemoteDecode       = "do_remote_decode"
+	requestFieldRemoteBlockIDs       = "remote_block_ids"
+	requestFieldRemoteEngineID       = "remote_engine_id"
+	requestFieldRemoteHost           = "remote_host"
+	requestFieldRemotePort           = "remote_port"
+	requestFieldStream               = "stream"
+	requestFieldStreamOptions        = "stream_options"
+	requestFieldCacheHitThreshold    = "cache_hit_threshold"
+	requestFieldContinueFinalMessage = "continue_final_message"
+	requestFieldAddGenerationPrompt  = "add_generation_prompt"
 
 	responseFieldChoices      = "choices"
 	responseFieldFinishReason = "finish_reason"
@@ -174,6 +176,11 @@ type Config struct {
 	InferencePoolName string
 	// PoolGroup is the API group of the InferencePool resource.
 	PoolGroup string
+
+	// EnableChunkedDecode enables chunked decode mode.
+	EnableChunkedDecode bool
+	// DecodeChunkSize is the decode chunk size in tokens.
+	DecodeChunkSize int
 }
 
 // MarshalJSON implements json.Marshaler for Config.


### PR DESCRIPTION
Adds experimental chunked decode to the pd-sidecar proxy. When enabled,
the decode stage is split into a sequence of shorter decode calls, each
capped at a configurable token budget (`--decode-chunk-size`). After each
chunk, the generated text is appended to the conversation context so the
next chunk continues seamlessly.

The feature applies at the decode stage regardless of whether P/D
disaggregation is in use.

## Test and support plan
- Tested e2e for decode-only setups with vLLM and SGLang inference servers.
- Tested e2e for PD disaggregation setup with vLLM (kv-connector=nixlv2).
- Not supported for PD disaggregation setup with SGLang (kv-connector=sglang) due to a known SGLang limitation that may be addressed in the future.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Introduce chunked decode via a sidecar CLI flag, splitting long token generation into multiple bounded iterations.
To enable add `--decode-chunk-size=<size>`. The chunk size should relatively large (512 or more) and be a multiple of the block size.
```

## How to enable
```yaml
--decode-chunk-size=512   # should be a multiple of the block size
```
