### PR TITLE
fix(tokenizer): use Encode instead of Render

### DIFF
--- a/pkg/plugins/preparedata/tokenizer.go
+++ b/pkg/plugins/preparedata/tokenizer.go
@@ -32,7 +32,7 @@ import (
 )
 
 type tokenizer interface {
-	Render(prompt string) ([]uint32, []tokenizerTypes.Offset, error)
+	Encode(prompt string, addSpecialTokens bool) ([]uint32, []tokenizerTypes.Offset, error)
 	RenderChat(req *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error)
 }
 
@@ -178,8 +178,8 @@ func (p *TokenizerPlugin) tokenize(ctx context.Context, request *scheduling.LLMR
 
 	switch {
 	case request.Body.Completions != nil:
-		traceLogger.Info("Calling Render for completions", "prompt", request.Body.Completions.Prompt)
-		tokenIDs, _, err = p.tokenizer.Render(request.Body.Completions.Prompt)
+		traceLogger.Info("Calling Encode for completions", "prompt", request.Body.Completions.Prompt)
+		tokenIDs, _, err = p.tokenizer.Encode(request.Body.Completions.Prompt, true)
 	case request.Body.ChatCompletions != nil:
 		renderReq := ChatCompletionsToRenderChatRequest(request.Body.ChatCompletions)
 		traceLogger.Info("Calling RenderChat for chat completions", "messageCount", len(request.Body.ChatCompletions.Messages))

--- a/pkg/plugins/preparedata/tokenizer_scorer_test.go
+++ b/pkg/plugins/preparedata/tokenizer_scorer_test.go
@@ -48,7 +48,7 @@ func TestTokenizerScorer_Score(t *testing.T) {
 	fakeTokenIDs := []uint32{10, 20, 30, 40}
 
 	tok := &mockTokenizer{
-		renderFunc: func(prompt string) ([]uint32, []tokenizerTypes.Offset, error) {
+		encodeFunc: func(prompt string, addSpecialTokens bool) ([]uint32, []tokenizerTypes.Offset, error) {
 			return fakeTokenIDs, nil, nil
 		},
 		renderChatFunc: func(req *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error) {
@@ -113,7 +113,7 @@ func TestTokenizerScorer_Score(t *testing.T) {
 				},
 			},
 			tokenizer: &mockTokenizer{
-				renderFunc: func(string) ([]uint32, []tokenizerTypes.Offset, error) {
+				encodeFunc: func(string, bool) ([]uint32, []tokenizerTypes.Offset, error) {
 					return nil, nil, errors.New("tokenizer exploded")
 				},
 			},
@@ -159,7 +159,7 @@ func TestTokenizerScorer_SkipsWhenAlreadyInCycleState(t *testing.T) {
 	// Use a recording mock to assert tokenizer is never called.
 	tokenizerCalled := false
 	tok := &mockTokenizer{
-		renderFunc: func(string) ([]uint32, []tokenizerTypes.Offset, error) {
+		encodeFunc: func(string, bool) ([]uint32, []tokenizerTypes.Offset, error) {
 			tokenizerCalled = true
 			return nil, nil, nil
 		},
@@ -277,12 +277,12 @@ func TestTokenizerScorer_RenderChat_ForwardsStructuredContent(t *testing.T) {
 	assert.Equal(t, fakeMMFeatures.MMHashes, stored.MMFeatures.MMHashes)
 }
 
-func TestTokenizerScorer_Render_NilMMFeatures(t *testing.T) {
+func TestTokenizerScorer_Encode_NilMMFeatures(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	fakeTokenIDs := []uint32{10, 20, 30}
 
 	tok := &mockTokenizer{
-		renderFunc: func(prompt string) ([]uint32, []tokenizerTypes.Offset, error) {
+		encodeFunc: func(prompt string, addSpecialTokens bool) ([]uint32, []tokenizerTypes.Offset, error) {
 			return fakeTokenIDs, nil, nil
 		},
 	}

--- a/pkg/plugins/preparedata/tokenizer_test.go
+++ b/pkg/plugins/preparedata/tokenizer_test.go
@@ -31,12 +31,12 @@ import (
 )
 
 type mockTokenizer struct {
-	renderFunc     func(prompt string) ([]uint32, []tokenizerTypes.Offset, error)
+	encodeFunc     func(prompt string, addSpecialTokens bool) ([]uint32, []tokenizerTypes.Offset, error)
 	renderChatFunc func(req *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error)
 }
 
-func (m *mockTokenizer) Render(prompt string) ([]uint32, []tokenizerTypes.Offset, error) {
-	return m.renderFunc(prompt)
+func (m *mockTokenizer) Encode(prompt string, addSpecialTokens bool) ([]uint32, []tokenizerTypes.Offset, error) {
+	return m.encodeFunc(prompt, addSpecialTokens)
 }
 
 func (m *mockTokenizer) RenderChat(req *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error) {


### PR DESCRIPTION
The UDS tokenizer server does not implement the RenderCompletion gRPC method, causing 'Unimplemented' errors for plain completion requests. Switch to using Encode which calls the Tokenize RPC that the server supports.