### PR TITLE
Add lint exclusions from GAIE

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,10 @@ linters:
     - unparam
     - unused
     - unconvert
+  exclusions:
+    presets:
+      - comments        # suppress missing comment violations on packages and exported symbols
+      - std-error-handling  # suppress unchecked errors on well-known stdlib patterns (e.g. Close())
   settings:
     revive: # see https://github.com/mgechev/revive#available-rules for all options
       rules:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test

**What this PR does / why we need it**:
Relax linter configuration to ignore most of errors found on GAIE code to be merged.
Specifically:
- do not error on missing package and exported symbols comments
- ignore error checking on common standard library patterns (e.g., `defer body.Close()` on HTTP request body)

**Which issue(s) this PR fixes**:
Refs #832

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
