### PR TITLE
fix: broken link after refactoring

### DIFF
--- a/docs/create_new_filter.md
+++ b/docs/create_new_filter.md
@@ -7,7 +7,7 @@ This tutorial outlines the steps needed for creating and hooking a new filter
  
 The tutorial demonstrates the coding of a new filter, which selects inference
  serving Pods based on their labels. All relevant code is contained in the
- [`by_label_selector.go`](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/plugins/filter/by_label_selector.go) file.
+ [`bylabel`](https://github.com/llm-d/llm-d-inference-scheduler/tree/main/pkg/epp/framework/plugins/scheduling/filter/bylabel) package.
 
 ## Introduction to filtering
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind documentation

**What this PR does / why we need it**:
after https://github.com/llm-d/llm-d-inference-scheduler/pull/827 the link in the docs is not valid causing Markdown Link Checker workflow failed

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
