### PR TITLE
migration scripts: improve tooling robustness

### DIFF
--- a/scripts/check-commits.sh
+++ b/scripts/check-commits.sh
@@ -10,12 +10,12 @@ BASE_BRANCH=${1:-upstream/main}
 BASE=$(git merge-base HEAD "$BASE_BRANCH")
 RANGE="$BASE..HEAD"
 
-echo "Checking $(git rev-list --count "$RANGE") commits ($BASE..HEAD)..."
+echo "Checking $(git rev-list --first-parent --count "$RANGE") commits ($BASE..HEAD)..."
 
 ERR_SIG=""
 ERR_DCO=""
 
-for commit in $(git rev-list "$RANGE"); do
+for commit in $(git rev-list --first-parent "$RANGE"); do
     HASH=$(git rev-parse --short "$commit")
     
     # 1. Check for cryptographic signature header (gpgsig)

--- a/scripts/migrate-gaie-paths.sh
+++ b/scripts/migrate-gaie-paths.sh
@@ -124,7 +124,16 @@ echo
 # Validate all pairs before touching anything
 for i in "${!SRC_PATHS[@]}"; do
   [[ -e "${SOURCE_DIR}/${SRC_PATHS[$i]}" ]] || { echo "error: '${SRC_PATHS[$i]}' not found in source repo"; exit 1; }
-  [[ -z "${SINCE_REF}" && -e "${DEST_DIR}/${DEST_PATHS[$i]}" ]] && { echo "error: '${DEST_PATHS[$i]}' already exists in destination repo"; exit 1; }
+  if [[ -z "${SINCE_REF}" ]]; then
+    while IFS= read -r -d '' src_dir; do
+      rel="${src_dir#"${SOURCE_DIR}/${SRC_PATHS[$i]}"}"
+      dest_dir="${DEST_DIR}/${DEST_PATHS[$i]}${rel}"
+      if [[ -d "${dest_dir}" ]] && find "${dest_dir}" -maxdepth 1 -name "*.go" -print -quit 2>/dev/null | grep -q .; then
+        echo "error: Go package conflict at '${DEST_PATHS[$i]}${rel}': destination already contains Go files"
+        exit 1
+      fi
+    done < <(find "${SOURCE_DIR}/${SRC_PATHS[$i]}" -type d -print0)
+  fi
 done
 
 if git -C "${DEST_DIR}" rev-parse --verify "${BRANCH_NAME}" &>/dev/null; then


### PR DESCRIPTION
Two independent fixes to the migration scripts:

- `check-commits.sh`: restrict the signed-commits check to first-parent history to avoid false failures after merging upstream GAIE history.
- `migrate-gaie-paths.sh`: replace the coarse directory-exists check with Go package conflict detection, failing only when the destination already contains .go files.