### PR TITLE
[Draft] Model Registry and HybridScorer

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -187,6 +187,7 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 	}
 
 	// initialize the KV-events pool
+	config.KVEventsConfig.ModelRegistry = kvCacheIndexer.ModelRegistry()
 	pool := kvevents.NewPool(config.KVEventsConfig, kvCacheIndexer.KVBlockIndex(), tokenProcessor, engineadapter.NewVLLMAdapter())
 	pool.Start(ctx)
 
@@ -376,7 +377,7 @@ func (s *Scorer) PrepareRequestData(ctx context.Context,
 	}
 
 	// 4. Compute per-pod scores using KVBlockScorer (supports device-backend weights)
-	scores, err := s.kvBlockScorer.Score(ctx, blockKeys, keyToPods)
+	scores, err := s.kvBlockScorer.Score(ctx, blockKeys, keyToPods, request.TargetModel)
 	if err != nil {
 		return fmt.Errorf("failed to score block keys: %w", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
  Integrates the Model Registry and HybridScorer into the precise prefix cache score

**Which issue(s) this PR fixes**:
These changes allow the KV block scoring to be model-aware, so that cache hit scores are computed correctly in multi-model serving environments.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
Add model-aware KV block scoring by integrating Model Registry into the KV events pool and passing target model to KVBlockScorer.Score().
```
