### PR TITLE
move scheduler pd unittests to the new locations

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
@@ -1,4 +1,4 @@
-package pd_test
+package disagg_test
 
 import (
 	"context"

--- a/pkg/scheduling/pd/doc.go
+++ b/pkg/scheduling/pd/doc.go
@@ -1,2 +1,0 @@
-// Package pd implements disaggregated Prefill/Decode scheduling
-package pd


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind cleanup
-->
/kind cleanup

**What this PR does / why we need it**:
Following the plugin refactoring in PR https://github.com/llm-d/llm-d-inference-scheduler/pull/827, the scheduler/pd unit tests were left in their old location. They should be moved to the new location to maintain consistency.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #847 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
