### PR TITLE
[migration] Clear GAIE destination paths of conflicting Go files

### DIFF
--- a/pkg/common/routing/common.go
+++ b/pkg/common/routing/common.go
@@ -1,8 +1,8 @@
-// Package common contains items common to both the
-// EPP/Inference-Scheduler and the Routing Sidecar
+// Package routing contains routing constants and utilities shared between
+// the EPP/Inference-Scheduler and the Routing Sidecar.
 //
 //revive:disable:var-naming
-package common
+package routing
 
 import "net/url"
 

--- a/pkg/common/routing/common_test.go
+++ b/pkg/common/routing/common_test.go
@@ -1,8 +1,8 @@
-// Package common contains items common to both the
-// EPP/Inference-Scheduler and the Routing Sidecar
+// Package routing contains routing constants and utilities shared between
+// the EPP/Inference-Scheduler and the Routing Sidecar.
 //
 //revive:disable:var-naming
-package common
+package routing
 
 import "testing"
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 )
 
 const (
@@ -119,7 +119,7 @@ func (h *ProfileHandler) ProcessResults(_ context.Context, _ *scheduling.CycleSt
 
 	targetPod := profileResult.TargetEndpoints[0].GetMetadata()
 
-	request.Headers[common.DataParallelEndpointHeader] = net.JoinHostPort(targetPod.Address, targetPod.Port)
+	request.Headers[routing.DataParallelEndpointHeader] = net.JoinHostPort(targetPod.Address, targetPod.Port)
 
 	for _, target := range profileResult.TargetEndpoints {
 		newMetadata := target.GetMetadata().Clone()

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
@@ -274,7 +274,7 @@ func Test_ProfileHandler_ProcessResults(t *testing.T) {
 				require.Len(t, pods, 1)
 				assert.Equal(t, "9000", pods[0].GetMetadata().Port)                // overridden
 				expectedHeader := net.JoinHostPort("10.0.0.1", DefaultTestPodPort) // original
-				assert.Equal(t, expectedHeader, headers[common.DataParallelEndpointHeader])
+				assert.Equal(t, expectedHeader, headers[routing.DataParallelEndpointHeader])
 			},
 		},
 		{
@@ -287,7 +287,7 @@ func Test_ProfileHandler_ProcessResults(t *testing.T) {
 			checkResult: func(t *testing.T, res *scheduling.SchedulingResult, headers map[string]string) {
 				pod := res.ProfileResults["dp"].TargetEndpoints[0]
 				assert.Equal(t, "0", pod.GetMetadata().Port)
-				assert.Equal(t, "10.0.0.1:8080", headers[common.DataParallelEndpointHeader])
+				assert.Equal(t, "10.0.0.1:8080", headers[routing.DataParallelEndpointHeader])
 			},
 		},
 		{
@@ -303,7 +303,7 @@ func Test_ProfileHandler_ProcessResults(t *testing.T) {
 				for _, p := range pods {
 					assert.Equal(t, "8080", p.GetMetadata().Port)
 				}
-				assert.Equal(t, net.JoinHostPort("10.0.0.1", DefaultTestPodPort), headers[common.DataParallelEndpointHeader])
+				assert.Equal(t, net.JoinHostPort("10.0.0.1", DefaultTestPodPort), headers[routing.DataParallelEndpointHeader])
 			},
 		},
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 )
 
@@ -108,7 +108,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.LLM
 	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
 
 	// Prefill header
-	delete(request.Headers, common.PrefillEndpointHeader) // clear header, if already set
+	delete(request.Headers, routing.PrefillEndpointHeader) // clear header, if already set
 	prefillProfileRunResult := schedulingResult.ProfileResults[p.prefillProfile]
 	switch {
 	case prefillProfileRunResult == nil:
@@ -124,7 +124,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.LLM
 	default:
 		targetPod := prefillProfileRunResult.TargetEndpoints[0].GetMetadata()
 		prefillHostPort := net.JoinHostPort(targetPod.Address, targetPod.Port)
-		request.Headers[common.PrefillEndpointHeader] = prefillHostPort // in the form of <ip:port>
+		request.Headers[routing.PrefillEndpointHeader] = prefillHostPort // in the form of <ip:port>
 		span.SetAttributes(
 			attribute.Bool("llm_d.epp.pd.disaggregation_used", true),
 			attribute.String("llm_d.epp.pd.prefill_pod_address", targetPod.Address),
@@ -133,7 +133,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.LLM
 	}
 
 	// Encode header
-	delete(request.Headers, common.EncoderEndpointsHeader) // clear header, if already set
+	delete(request.Headers, routing.EncoderEndpointsHeader) // clear header, if already set
 	encodeProfileRunResult := schedulingResult.ProfileResults[p.encodeProfile]
 	if encodeProfileRunResult == nil {
 		span.SetAttributes(
@@ -158,7 +158,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.LLM
 		return // no target endpoints, no-op in this case
 	}
 
-	request.Headers[common.EncoderEndpointsHeader] = strings.Join(encodeHostPorts, ",")
+	request.Headers[routing.EncoderEndpointsHeader] = strings.Join(encodeHostPorts, ",")
 	span.SetAttributes(
 		attribute.Bool("llm_d.epp.encode.disaggregation_used", true),
 		attribute.String("llm_d.epp.encode.endpoints", strings.Join(encodeHostPorts, ",")),

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
@@ -14,7 +14,7 @@ import (
 	giePlugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
@@ -185,8 +185,8 @@ func TestPrefillHeaderHandlerBackwardCompat(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[common.PrefillEndpointHeader])
-	_, encodeSet := request.Headers[common.EncoderEndpointsHeader]
+	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
+	_, encodeSet := request.Headers[routing.EncoderEndpointsHeader]
 	assert.False(t, encodeSet, "encode header must not be set in PD-only scenario")
 }
 
@@ -215,7 +215,7 @@ func TestPreRequestPrefillProfileExists(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[common.PrefillEndpointHeader])
+	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
 
 func TestPreRequestPrefillProfileNotExists(t *testing.T) {
@@ -233,7 +233,7 @@ func TestPreRequestPrefillProfileNotExists(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	_, exists := request.Headers[common.PrefillEndpointHeader]
+	_, exists := request.Headers[routing.PrefillEndpointHeader]
 	assert.False(t, exists)
 }
 
@@ -243,7 +243,7 @@ func TestPreRequestClearsExistingPrefillHeader(t *testing.T) {
 
 	request := &scheduling.LLMRequest{
 		Headers: map[string]string{
-			common.PrefillEndpointHeader: "old-host:9999",
+			routing.PrefillEndpointHeader: "old-host:9999",
 		},
 	}
 
@@ -260,7 +260,7 @@ func TestPreRequestClearsExistingPrefillHeader(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[common.PrefillEndpointHeader])
+	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
 
 func TestPreRequestClearsHeaderWhenNoPrefillResult(t *testing.T) {
@@ -269,7 +269,7 @@ func TestPreRequestClearsHeaderWhenNoPrefillResult(t *testing.T) {
 
 	request := &scheduling.LLMRequest{
 		Headers: map[string]string{
-			common.PrefillEndpointHeader: "stale-host:9999",
+			routing.PrefillEndpointHeader: "stale-host:9999",
 		},
 	}
 
@@ -280,7 +280,7 @@ func TestPreRequestClearsHeaderWhenNoPrefillResult(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	val := request.Headers[common.PrefillEndpointHeader]
+	val := request.Headers[routing.PrefillEndpointHeader]
 	assert.Equal(t, "", val)
 }
 
@@ -305,7 +305,7 @@ func TestPreRequestCustomPrefillProfile(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[common.PrefillEndpointHeader])
+	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
 
 func TestPreRequestPrefillProfileNilResult(t *testing.T) {
@@ -329,7 +329,7 @@ func TestPreRequestPrefillProfileNilResult(t *testing.T) {
 	assert.NotPanics(t, func() {
 		handler.PreRequest(ctx, request, result)
 	})
-	_, exists := request.Headers[common.PrefillEndpointHeader]
+	_, exists := request.Headers[routing.PrefillEndpointHeader]
 	assert.False(t, exists)
 }
 
@@ -352,7 +352,7 @@ func TestPreRequestPrefillEmptyTargetEndpoints(t *testing.T) {
 	assert.NotPanics(t, func() {
 		handler.PreRequest(ctx, request, result)
 	})
-	_, exists := request.Headers[common.PrefillEndpointHeader]
+	_, exists := request.Headers[routing.PrefillEndpointHeader]
 	assert.False(t, exists)
 }
 
@@ -377,7 +377,7 @@ func TestPreRequestPrefillIPv6Address(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testIPv6Addr, testPort), request.Headers[common.PrefillEndpointHeader])
+	assert.Equal(t, net.JoinHostPort(testIPv6Addr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
 
 // ----- Encode tests -----
@@ -405,7 +405,7 @@ func TestPreRequestEncodeProfileExists(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[common.EncoderEndpointsHeader])
+	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
 
 func TestPreRequestEncodeProfileNotExists(t *testing.T) {
@@ -424,7 +424,7 @@ func TestPreRequestEncodeProfileNotExists(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	_, exists := request.Headers[common.EncoderEndpointsHeader]
+	_, exists := request.Headers[routing.EncoderEndpointsHeader]
 	assert.False(t, exists)
 }
 
@@ -435,7 +435,7 @@ func TestPreRequestEncodeClearsExistingHeader(t *testing.T) {
 	request := &scheduling.LLMRequest{
 		RequestId: "req-123",
 		Headers: map[string]string{
-			common.EncoderEndpointsHeader: "old-host:9999",
+			routing.EncoderEndpointsHeader: "old-host:9999",
 		},
 	}
 
@@ -452,7 +452,7 @@ func TestPreRequestEncodeClearsExistingHeader(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[common.EncoderEndpointsHeader])
+	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
 
 func TestPreRequestEncodeClearsHeaderWhenNoEncodeResult(t *testing.T) {
@@ -462,7 +462,7 @@ func TestPreRequestEncodeClearsHeaderWhenNoEncodeResult(t *testing.T) {
 	request := &scheduling.LLMRequest{
 		RequestId: "req-123",
 		Headers: map[string]string{
-			common.EncoderEndpointsHeader: "stale-host:9999",
+			routing.EncoderEndpointsHeader: "stale-host:9999",
 		},
 	}
 
@@ -473,7 +473,7 @@ func TestPreRequestEncodeClearsHeaderWhenNoEncodeResult(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	val := request.Headers[common.EncoderEndpointsHeader]
+	val := request.Headers[routing.EncoderEndpointsHeader]
 	assert.Equal(t, "", val)
 }
 
@@ -499,7 +499,7 @@ func TestPreRequestEncodeCustomProfile(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[common.EncoderEndpointsHeader])
+	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
 
 func TestPreRequestEncodeIPv6Address(t *testing.T) {
@@ -524,7 +524,7 @@ func TestPreRequestEncodeIPv6Address(t *testing.T) {
 
 	handler.PreRequest(ctx, request, result)
 
-	assert.Equal(t, net.JoinHostPort(testIPv6Addr, testPort), request.Headers[common.EncoderEndpointsHeader])
+	assert.Equal(t, net.JoinHostPort(testIPv6Addr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
 
 func TestPreRequestEncodeProfileNilResult(t *testing.T) {
@@ -548,7 +548,7 @@ func TestPreRequestEncodeProfileNilResult(t *testing.T) {
 	assert.NotPanics(t, func() {
 		handler.PreRequest(ctx, request, result)
 	})
-	_, exists := request.Headers[common.EncoderEndpointsHeader]
+	_, exists := request.Headers[routing.EncoderEndpointsHeader]
 	assert.False(t, exists)
 }
 
@@ -559,7 +559,7 @@ func TestPreRequestEncodeEmptyTargetEndpoints(t *testing.T) {
 	request := &scheduling.LLMRequest{
 		RequestId: "req-123",
 		Headers: map[string]string{
-			common.EncoderEndpointsHeader: "stale-host:9999",
+			routing.EncoderEndpointsHeader: "stale-host:9999",
 		},
 	}
 
@@ -573,7 +573,7 @@ func TestPreRequestEncodeEmptyTargetEndpoints(t *testing.T) {
 	assert.NotPanics(t, func() {
 		handler.PreRequest(ctx, request, result)
 	})
-	val := request.Headers[common.EncoderEndpointsHeader]
+	val := request.Headers[routing.EncoderEndpointsHeader]
 	assert.Equal(t, "", val)
 }
 
@@ -605,5 +605,5 @@ func TestPreRequestEncodeMultipleEndpoints(t *testing.T) {
 		net.JoinHostPort(testAddr, testPort),
 		net.JoinHostPort(addr2, testPort),
 	}, ",")
-	assert.Equal(t, expected, request.Headers[common.EncoderEndpointsHeader])
+	assert.Equal(t, expected, request.Headers[routing.EncoderEndpointsHeader])
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -17,7 +17,7 @@ import (
 	dl_prefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 )
@@ -230,7 +230,7 @@ func (h *PdProfileHandler) ProcessResults(_ context.Context, _ *scheduling.Cycle
 		// Data Parallel is active
 
 		targetEndpoint := decodeRunResults.TargetEndpoints[0].GetMetadata()
-		request.Headers[common.DataParallelEndpointHeader] = net.JoinHostPort(targetEndpoint.Address, targetEndpoint.Port)
+		request.Headers[routing.DataParallelEndpointHeader] = net.JoinHostPort(targetEndpoint.Address, targetEndpoint.Port)
 
 		updatedResult := scheduling.ProfileRunResult{
 			TargetEndpoints: []scheduling.Endpoint{},

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
@@ -14,7 +14,7 @@ import (
 	approxprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
@@ -477,7 +477,7 @@ func TestPdProfileHandler_ProcessResults(t *testing.T) {
 				assert.NotContains(t, res.ProfileResults, defaultPrefillProfile)
 				metadata := res.ProfileResults[defaultDecodeProfile].TargetEndpoints[0].GetMetadata()
 				assert.Equal(t, DefaultTestPodPort, metadata.Port)
-				assert.Empty(t, headers[common.DataParallelEndpointHeader])
+				assert.Empty(t, headers[routing.DataParallelEndpointHeader])
 			},
 		},
 		{
@@ -505,7 +505,7 @@ func TestPdProfileHandler_ProcessResults(t *testing.T) {
 				metadata := res.ProfileResults[defaultDecodeProfile].TargetEndpoints[0].GetMetadata()
 				assert.Equal(t, "9000", metadata.Port)
 
-				hostPort := headers[common.DataParallelEndpointHeader]
+				hostPort := headers[routing.DataParallelEndpointHeader]
 				assert.Equal(t, "10.0.0.1:8000", hostPort)
 			},
 		},

--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -75,7 +75,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 			openAIAPIAttr(apiType),
 		)
 
-		prefillHostPorts := r.Header.Values(common.PrefillEndpointHeader)
+		prefillHostPorts := r.Header.Values(routing.PrefillEndpointHeader)
 
 		if len(prefillHostPorts) == 1 {
 			prefillHostPorts = strings.Split(prefillHostPorts[0], ",")
@@ -123,7 +123,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 			s.logger.V(4).Info("SSRF protection: prefill target allowed", "target", prefillHostPort)
 		}
 
-		encoderHostPorts := r.Header.Values(common.EncoderEndpointsHeader)
+		encoderHostPorts := r.Header.Values(routing.EncoderEndpointsHeader)
 		if len(encoderHostPorts) == 1 {
 			encoderHostPorts = strings.Split(encoderHostPorts[0], ",")
 		}

--- a/pkg/sidecar/proxy/chat_completions_test.go
+++ b/pkg/sidecar/proxy/chat_completions_test.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"k8s.io/utils/set"
 )
 
@@ -50,27 +50,27 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 		},
 		{
 			name: "passthrough with no header value",
-			r:    &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{}}},
+			r:    &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{}}},
 
 			expectedPassthrough: true,
 		},
 		{
 			name: "default prefill to one header value",
-			r:    &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{"a"}}},
+			r:    &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{"a"}}},
 
 			expectedCode:             200,
 			expectedPrefillHostPorts: []string{"a"},
 		},
 		{
 			name: "default prefill to first header value",
-			r:    &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{"a,b"}}},
+			r:    &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{"a,b"}}},
 
 			expectedCode:             200,
 			expectedPrefillHostPorts: []string{"a"},
 		},
 		{
 			name:     "sample from comma delimited header",
-			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{"a,b"}}},
+			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{"a,b"}}},
 			sampling: true,
 
 			expectedCode:             200,
@@ -78,7 +78,7 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 		},
 		{
 			name:     "sample from comma delimited header with whitespace",
-			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{" a, b"}}},
+			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{" a, b"}}},
 			sampling: true,
 
 			expectedCode:             200,
@@ -86,7 +86,7 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 		},
 		{
 			name:     "sample from duplicate values",
-			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{"a,a"}}},
+			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{"a,a"}}},
 			sampling: true,
 
 			expectedCode:             200,
@@ -94,7 +94,7 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 		},
 		{
 			name:     "sample from multiple header values",
-			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{"a", "b"}}},
+			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{"a", "b"}}},
 			sampling: true,
 
 			expectedCode:             200,
@@ -102,14 +102,14 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 		},
 		{
 			name:     "sample from empty header value",
-			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{""}}},
+			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{""}}},
 			sampling: true,
 
 			expectedPassthrough: true,
 		},
 		{
 			name:     "sample from multiple empty header values",
-			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(common.PrefillEndpointHeader): []string{"", ""}}},
+			r:        &http.Request{Header: http.Header{http.CanonicalHeaderKey(routing.PrefillEndpointHeader): []string{"", ""}}},
 			sampling: true,
 
 			expectedPassthrough: true,
@@ -173,8 +173,8 @@ func TestServer_responsesHandler(t *testing.T) {
 }
 
 func TestServer_encoderEndpointRouting(t *testing.T) {
-	encoderHeader := http.CanonicalHeaderKey(common.EncoderEndpointsHeader)
-	prefillHeader := http.CanonicalHeaderKey(common.PrefillEndpointHeader)
+	encoderHeader := http.CanonicalHeaderKey(routing.EncoderEndpointsHeader)
+	prefillHeader := http.CanonicalHeaderKey(routing.PrefillEndpointHeader)
 
 	tests := []struct {
 		name string

--- a/pkg/sidecar/proxy/connector_nixlv2_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_test.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
 )
@@ -62,7 +62,7 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 		Expect(err).ToNot(HaveOccurred())
-		req.Header.Add(common.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
 		rp, err := http.DefaultClient.Do(req)
 		Expect(err).ToNot(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ResponsesPath, strings.NewReader(body))
 		Expect(err).ToNot(HaveOccurred())
-		req.Header.Add(common.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
 		rp, err := http.DefaultClient.Do(req)
 		Expect(err).ToNot(HaveOccurred())
@@ -195,7 +195,7 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ResponsesPath, strings.NewReader(body))
 		Expect(err).ToNot(HaveOccurred())
-		req.Header.Add(common.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
 		rp, err := http.DefaultClient.Do(req)
 		Expect(err).ToNot(HaveOccurred())
@@ -246,7 +246,7 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ResponsesPath, strings.NewReader(body))
 		Expect(err).ToNot(HaveOccurred())
-		req.Header.Add(common.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
 		rp, err := http.DefaultClient.Do(req)
 		Expect(err).ToNot(HaveOccurred())
@@ -340,7 +340,7 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ResponsesPath, strings.NewReader(body))
 		Expect(err).ToNot(HaveOccurred())
-		req.Header.Add(common.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
 		rp, err := http.DefaultClient.Do(req)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/sidecar/proxy/connector_sglang_test.go
+++ b/pkg/sidecar/proxy/connector_sglang_test.go
@@ -26,7 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
 )
@@ -68,7 +68,7 @@ var _ = Describe("SGLang Connector", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		prefillHostPort := testInfo.prefillBackend.URL[len("http://"):]
-		req.Header.Add(common.PrefillEndpointHeader, prefillHostPort)
+		req.Header.Add(routing.PrefillEndpointHeader, prefillHostPort)
 
 		rp, err := http.DefaultClient.Do(req)
 		Expect(err).ToNot(HaveOccurred())
@@ -159,7 +159,7 @@ var _ = Describe("SGLang Connector", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		prefillHostPort := testInfo.prefillBackend.URL[len("http://"):]
-		req.Header.Add(common.PrefillEndpointHeader, prefillHostPort)
+		req.Header.Add(routing.PrefillEndpointHeader, prefillHostPort)
 
 		// Submit request. This will complete as soon as fastDecode completes.
 		rp, err := http.DefaultClient.Do(req)

--- a/pkg/sidecar/proxy/connector_test.go
+++ b/pkg/sidecar/proxy/connector_test.go
@@ -25,7 +25,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/test/sidecar/mock"
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
@@ -80,7 +80,7 @@ var _ = Describe("Common Connector tests", func() {
 
 				req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 				Expect(err).ToNot(HaveOccurred())
-				req.Header.Add(common.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+				req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
 				rp, err := http.DefaultClient.Do(req)
 				Expect(err).ToNot(HaveOccurred())
@@ -140,7 +140,7 @@ var _ = Describe("Common Connector tests", func() {
 
 				req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 				Expect(err).ToNot(HaveOccurred())
-				req.Header.Add(common.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+				req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
 				rp, err := http.DefaultClient.Do(req)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/sidecar/proxy/data_parallel.go
+++ b/pkg/sidecar/proxy/data_parallel.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -16,7 +16,7 @@ import (
 // dataParallelHandler checks if Data Parallel handling is needed.
 // Returns true if Data Parallel processing was needed
 func (s *Server) dataParallelHandler(w http.ResponseWriter, r *http.Request) bool {
-	dataParallelPodHostPort := r.Header.Get(common.DataParallelEndpointHeader)
+	dataParallelPodHostPort := r.Header.Get(routing.DataParallelEndpointHeader)
 	if dataParallelPodHostPort != "" {
 		s.logger.Info("The use of the x-data-parallel-host-port is deprecated. Use Istio >= 1.28.1.")
 		handler := s.dataParallelProxies[dataParallelPodHostPort]

--- a/pkg/sidecar/proxy/data_parallel_test.go
+++ b/pkg/sidecar/proxy/data_parallel_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"    // nolint:revive
 	"golang.org/x/sync/errgroup"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	sidecarmock "github.com/llm-d/llm-d-inference-scheduler/test/sidecar/mock"
 	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
@@ -83,7 +83,7 @@ var _ = Describe("Data Parallel support", func() {
 			Expect(int(rank0Handler.RequestCount.Load())).To(Equal(1))
 			Expect(int(rank1Handler.RequestCount.Load())).To(Equal(0))
 
-			req.Header.Add(common.DataParallelEndpointHeader, "127.0.0.1:"+strconv.Itoa(fakeProxyPort+1))
+			req.Header.Add(routing.DataParallelEndpointHeader, "127.0.0.1:"+strconv.Itoa(fakeProxyPort+1))
 			resp = httptest.NewRecorder()
 			proxyHandler.ServeHTTP(resp, req)
 			Expect(int(rank0Handler.RequestCount.Load())).To(Equal(1))

--- a/pkg/sidecar/proxy/proxy_test.go
+++ b/pkg/sidecar/proxy/proxy_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/test/sidecar/mock"
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
@@ -196,7 +196,7 @@ var _ = Describe("Reverse Proxy", func() {
 
 				req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 				Expect(err).ToNot(HaveOccurred())
-				req.Header.Add(common.PrefillEndpointHeader, prefillBackend.URL)
+				req.Header.Add(routing.PrefillEndpointHeader, prefillBackend.URL)
 
 				_, err = http.DefaultClient.Do(req)
 				Expect(err).ToNot(HaveOccurred())
@@ -269,7 +269,7 @@ var _ = Describe("Reverse Proxy", func() {
 
 				req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 				Expect(err).ToNot(HaveOccurred())
-				req.Header.Add(common.PrefillEndpointHeader, prefillBackend.URL[len("http://"):])
+				req.Header.Add(routing.PrefillEndpointHeader, prefillBackend.URL[len("http://"):])
 
 				_, err = http.DefaultClient.Do(req)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/telemetry/tracing.go
+++ b/pkg/telemetry/tracing.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/common"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
@@ -65,7 +65,7 @@ func InitTracing(ctx context.Context) (func(context.Context) error, error) {
 
 	// Strip http:// or https:// prefix if present
 	// otlptracegrpc.WithEndpoint() expects host:port only
-	endpoint = common.StripScheme(endpoint)
+	endpoint = routing.StripScheme(endpoint)
 
 	logger.Info("Initializing OpenTelemetry tracing", "endpoint", endpoint, "service", serviceName)
 

--- a/scripts/migrate-gaie-paths.sh
+++ b/scripts/migrate-gaie-paths.sh
@@ -128,8 +128,10 @@ for i in "${!SRC_PATHS[@]}"; do
     while IFS= read -r -d '' src_dir; do
       rel="${src_dir#"${SOURCE_DIR}/${SRC_PATHS[$i]}"}"
       dest_dir="${DEST_DIR}/${DEST_PATHS[$i]}${rel}"
-      if [[ -d "${dest_dir}" ]] && find "${dest_dir}" -maxdepth 1 -name "*.go" -print -quit 2>/dev/null | grep -q .; then
-        echo "error: Go package conflict at '${DEST_PATHS[$i]}${rel}': destination already contains Go files"
+      if [[ -d "${dest_dir}" ]] && \
+           find "${src_dir}" -maxdepth 1 -name "*.go" -print -quit 2>/dev/null | grep -q . && \
+           find "${dest_dir}" -maxdepth 1 -name "*.go" -print -quit 2>/dev/null | grep -q .; then
+        echo "error: Go package conflict at '${DEST_PATHS[$i]}${rel}': both source and destination contain Go files"
         exit 1
       fi
     done < <(find "${SOURCE_DIR}/${SRC_PATHS[$i]}" -type d -print0)

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
 const (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,7 +22,7 @@ import (
 	infextv1a2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
 const (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
 const (

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"google.golang.org/grpc"

--- a/test/utils/k8s_objects.go
+++ b/test/utils/k8s_objects.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package igw wraps sigs.k8s.io/gateway-api-inference-extension/test/utils and
-// adds back DeleteObjects which was removed in v1.5.0.
-package igw
+// Package utils provides test utilities for the llm-d inference scheduler.
+// DeleteObjects and getClientObject restore the function removed from
+// sigs.k8s.io/gateway-api-inference-extension/test/utils in v1.5.0.
+package utils
 
 import (
 	"strings"


### PR DESCRIPTION
Preparatory changes required before running `scripts/migrate-gaie-paths.sh` to bring GAIE code in-tree. Two genuine Go-package conflicts and one script false-positive are resolved here so the migration can run cleanly.

- `pkg/common/`: GAIE's `pkg/common/` contains Go files that would land in the same package as existing `pkg/common/common.go` so move to `pkg/common/routing/`, reflecting that these are EPP-sidecar routing constants, not a general-purpose "common" bag.
- `test/utils/igw/`: moved to `test/utils/k8s_objects.go` to avoid later conflict with GAIE's `test/utils` landing as `test/utils/igw`.
- fix migration script: require both the *source* and destination directories to have Go files for conflict.

