### PR TITLE
use endpoints extractor for kvevents subscription mgmt in `precise-prefix-cache-scorer`

### DIFF
--- a/deploy/config/epp-precise-prefix-cache-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-config.yaml
@@ -1,17 +1,4 @@
-# Sample EPP configuration for running with KvCache and load aware scorers.
-#
-# Recommended layout:
-#   - tokenizer (PrepareData plugin) supplies tokens via CycleState so the
-#     scorer can skip internal tokenization. Internal tokenization in
-#     indexerConfig.tokenizersPoolConfig is the legacy fallback and is being
-#     phased out.
-#   - endpoint-notification-source feeds endpoint add/delete events to the
-#     scorer (which implements EndpointExtractor) so per-pod ZMQ subscribers
-#     are torn down cleanly when pods leave the pool.
-#
-# Backwards-compatible: configs that omit the dataLayer block (or omit the
-# tokenizer plugin) continue to work — the scorer falls back to in-Score
-# subscriber discovery and to its internal tokenizer pool.
+# Sample EPP configuration with the precise-prefix-cache scorer.
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -19,12 +6,6 @@ plugins:
     parameters:
       modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
   - type: endpoint-notification-source
-  # Polling source — required for the data layer to dispatch endpoint
-  # lifecycle events. GAIE's Runtime.NewEndpoint short-circuits without a
-  # PollingDataSource configured, so no `EndpointEvent` ever fires for
-  # endpoint-notification-source on its own. The metrics source also
-  # populates per-endpoint queue/KV-cache metrics consumed by the
-  # downstream scorers.
   - type: metrics-data-source
   - type: core-metrics-extractor
   - type: single-profile-handler
@@ -35,9 +16,6 @@ plugins:
         blockSize: 64                 # must match vLLM block size
         hashSeed: "42"                # must match vLLM PYTHONHASHSEED env var
       indexerConfig:
-        # Required by the validator today; unused at runtime once the
-        # `tokenizer` plugin populates CycleState. Tracking removal alongside
-        # the deprecation of internal tokenization.
         tokenizersPoolConfig:
           modelName: hf-repo/model-name
         kvBlockIndexConfig:

--- a/deploy/config/epp-precise-prefix-cache-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-config.yaml
@@ -1,8 +1,24 @@
-# Sample EPP configuration for running with KvCache and load aware scorers
+# Sample EPP configuration for running with KvCache and load aware scorers.
 #
+# Recommended layout:
+#   - tokenizer (PrepareData plugin) supplies tokens via CycleState so the
+#     scorer can skip internal tokenization. Internal tokenization in
+#     indexerConfig.tokenizersPoolConfig is the legacy fallback and is being
+#     phased out.
+#   - endpoint-notification-source feeds endpoint add/delete events to the
+#     scorer (which implements EndpointExtractor) so per-pod ZMQ subscribers
+#     are torn down cleanly when pods leave the pool.
+#
+# Backwards-compatible: configs that omit the dataLayer block (or omit the
+# tokenizer plugin) continue to work — the scorer falls back to in-Score
+# subscriber discovery and to its internal tokenizer pool.
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
+  - type: tokenizer
+    parameters:
+      modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
+  - type: endpoint-notification-source
   - type: single-profile-handler
   - type: decode-filter
   - type: precise-prefix-cache-scorer
@@ -11,15 +27,26 @@ plugins:
         blockSize: 64                 # must match vLLM block size
         hashSeed: "42"                # must match vLLM PYTHONHASHSEED env var
       indexerConfig:
+        # Required by the validator today; unused at runtime once the
+        # `tokenizer` plugin populates CycleState. Tracking removal alongside
+        # the deprecation of internal tokenization.
+        tokenizersPoolConfig:
+          modelName: hf-repo/model-name
         kvBlockIndexConfig:
           enableMetrics: true           # enable kv-block index metrics (prometheus)
   - type: kv-cache-utilization-scorer
   - type: queue-scorer
   - type: max-score-picker
+dataLayer:
+  sources:
+    - pluginRef: endpoint-notification-source
+      extractors:
+        - pluginRef: precise-prefix-cache-scorer
 schedulingProfiles:
   - name: default
     plugins:
       - pluginRef: decode-filter
+      - pluginRef: tokenizer
       - pluginRef: precise-prefix-cache-scorer
         weight: 2.0
       - pluginRef: kv-cache-utilization-scorer

--- a/deploy/config/epp-precise-prefix-cache-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-config.yaml
@@ -19,6 +19,14 @@ plugins:
     parameters:
       modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
   - type: endpoint-notification-source
+  # Polling source — required for the data layer to dispatch endpoint
+  # lifecycle events. GAIE's Runtime.NewEndpoint short-circuits without a
+  # PollingDataSource configured, so no `EndpointEvent` ever fires for
+  # endpoint-notification-source on its own. The metrics source also
+  # populates per-endpoint queue/KV-cache metrics consumed by the
+  # downstream scorers.
+  - type: metrics-data-source
+  - type: core-metrics-extractor
   - type: single-profile-handler
   - type: decode-filter
   - type: precise-prefix-cache-scorer
@@ -39,6 +47,9 @@ plugins:
   - type: max-score-picker
 dataLayer:
   sources:
+    - pluginRef: metrics-data-source
+      extractors:
+        - pluginRef: core-metrics-extractor
     - pluginRef: endpoint-notification-source
       extractors:
         - pluginRef: precise-prefix-cache-scorer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -501,10 +501,15 @@ To enable the data layer path, declare the source plugin and wire it under
 ```yaml
 plugins:
   - type: endpoint-notification-source
+  - type: metrics-data-source        # required, see note below
+  - type: core-metrics-extractor     # paired with metrics-data-source
   - type: precise-prefix-cache-scorer
     # ...same parameters as above
 dataLayer:
   sources:
+    - pluginRef: metrics-data-source
+      extractors:
+        - pluginRef: core-metrics-extractor
     - pluginRef: endpoint-notification-source
       extractors:
         - pluginRef: precise-prefix-cache-scorer
@@ -512,6 +517,16 @@ dataLayer:
 
 The same scorer instance serves both roles (Scorer and EndpointExtractor),
 no second factory is needed.
+
+> [!IMPORTANT]
+> The `metrics-data-source` (or any `PollingDataSource`) is required for
+> the data layer to dispatch endpoint lifecycle events. GAIE's
+> `Runtime.NewEndpoint` short-circuits without a polling source
+> configured, so an `endpoint-notification-source` on its own will never
+> fire `EndpointEvent`s. Also note that providing **any** explicit
+> `dataLayer:` block disables GAIE's auto-injection of the default
+> metrics source, so you must declare `metrics-data-source` yourself
+> when wiring custom sources.
 
 > [!NOTE]
 > The `tokenizer` PrepareData plugin is the preferred source of tokenized

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -475,6 +475,46 @@ plugins:
               tokenizersCacheDir: /tmp/tokenizers
 ```
 
+##### Pod discovery via the data layer (recommended)
+
+When `discoverPods: true`, the scorer needs to know when pods come and go so
+it can install (and tear down) per-pod ZMQ subscribers. Two mechanisms are
+supported:
+
+- **Legacy (default, backwards-compatible).** The scorer opportunistically
+  installs subscribers for every endpoint it sees during scoring. No extra
+  YAML required. Subscribers for pods that disappear are not actively
+  removed — this is the historical behavior.
+- **Data layer endpoint-notification-source (recommended).** The scorer
+  implements `EndpointExtractor` and reacts to add/delete events from the
+  data layer. This gives clean subscriber teardown when pods leave the pool
+  and avoids opportunistic subscribe-on-Score traffic.
+
+To enable the data layer path, declare the source plugin and wire it under
+`dataLayer.sources`:
+
+```yaml
+plugins:
+  - type: endpoint-notification-source
+  - type: precise-prefix-cache-scorer
+    # ...same parameters as above
+dataLayer:
+  sources:
+    - pluginRef: endpoint-notification-source
+      extractors:
+        - pluginRef: precise-prefix-cache-scorer
+```
+
+The same scorer instance serves both roles (Scorer and EndpointExtractor),
+no second factory is needed.
+
+> [!NOTE]
+> The `tokenizer` PrepareData plugin is the preferred source of tokenized
+> prompts; the scorer's internal tokenization (via
+> `indexerConfig.tokenizersPoolConfig`) is a fallback and is being phased
+> out. New configs should declare a `tokenizer` plugin and reference it in
+> the scheduling profile alongside the precise-prefix-cache-scorer.
+
 ---
 
 #### LoadAwareScorer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -490,6 +490,11 @@ supported:
   data layer. This gives clean subscriber teardown when pods leave the pool
   and avoids opportunistic subscribe-on-Score traffic.
 
+The two paths are mutually exclusive at runtime: the first time the scorer
+receives an `ExtractEndpoint` call from the data layer, the legacy in-Score
+path turns itself off, leaving the data layer as the sole authority over
+per-pod subscriber lifecycle. No config flag is required.
+
 To enable the data layer path, declare the source plugin and wire it under
 `dataLayer.sources`:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -501,8 +501,8 @@ To enable the data layer path, declare the source plugin and wire it under
 ```yaml
 plugins:
   - type: endpoint-notification-source
-  - type: metrics-data-source        # required, see note below
-  - type: core-metrics-extractor     # paired with metrics-data-source
+  - type: metrics-data-source
+  - type: core-metrics-extractor
   - type: precise-prefix-cache-scorer
     # ...same parameters as above
 dataLayer:
@@ -517,16 +517,6 @@ dataLayer:
 
 The same scorer instance serves both roles (Scorer and EndpointExtractor),
 no second factory is needed.
-
-> [!IMPORTANT]
-> The `metrics-data-source` (or any `PollingDataSource`) is required for
-> the data layer to dispatch endpoint lifecycle events. GAIE's
-> `Runtime.NewEndpoint` short-circuits without a polling source
-> configured, so an `endpoint-notification-source` on its own will never
-> fire `EndpointEvent`s. Also note that providing **any** explicit
-> `dataLayer:` block disables GAIE's auto-injection of the default
-> metrics source, so you must declare `metrics-data-source` yourself
-> when wiring custom sources.
 
 > [!NOTE]
 > The `tokenizer` PrepareData plugin is the preferred source of tokenized

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync/atomic"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -291,6 +292,13 @@ type Scorer struct {
 
 	// speculativeEnabled controls whether speculative indexing is active.
 	speculativeEnabled bool
+
+	// extractorActive is set the first time ExtractEndpoint is invoked,
+	// signalling that the data layer's endpoint-notification-source is wired
+	// for this scorer. Once set, the legacy in-Score subscriber discovery
+	// path becomes a no-op so the data layer is the sole authority over
+	// per-pod subscriber lifecycle.
+	extractorActive atomic.Bool
 }
 
 // TypedName returns the typed name of the plugin.
@@ -602,7 +610,12 @@ func (s *Scorer) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error {
 // endpoint-notification-source: an add/update installs a per-pod ZMQ
 // subscriber so KV-cache events flow into the index; a delete tears it down.
 // No-op when DiscoverPods is disabled or the namespaced name is unavailable.
+//
+// Being called at all is also the signal that the data layer is wired for
+// this scorer; the legacy in-Score discovery path turns itself off from
+// here on.
 func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
+	s.extractorActive.Store(true)
 	if !s.kvEventsConfig.DiscoverPods || s.kvEventsConfig.PodDiscoveryConfig == nil {
 		return nil
 	}
@@ -619,6 +632,7 @@ func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent)
 		if err := s.ensureSubscriber(ctx, meta); err != nil {
 			return err
 		}
+		logger.V(logging.DEBUG).Info("Adding subscriber", "endpoint", endpointKey)
 	case fwkdl.EventDelete:
 		s.subscribersManager.RemoveSubscriber(ctx, endpointKey)
 		logger.V(logging.DEBUG).Info("Removed KV-events subscriber", "endpoint", endpointKey)
@@ -653,7 +667,13 @@ func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetad
 // endpoints presented to Score and ensures a per-pod subscriber for each.
 // Errors are logged and not returned — discovery is best-effort here, the
 // data layer remains the authoritative source when wired.
+//
+// Becomes a no-op once ExtractEndpoint has been called at least once,
+// indicating the data layer is wired and will drive subscriber lifecycle.
 func (s *Scorer) ensureSubscribersForEndpoints(ctx context.Context, endpoints []scheduling.Endpoint) {
+	if s.extractorActive.Load() {
+		return
+	}
 	if !s.kvEventsConfig.DiscoverPods || s.kvEventsConfig.PodDiscoveryConfig == nil {
 		return
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -410,6 +410,15 @@ func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, r
 		attribute.Int("llm_d.scorer.candidate_endpoints", len(endpoints)),
 	)
 
+	// Backwards-compat: opportunistically subscribe to per-pod KV events for
+	// each endpoint we see in scoring. Preferred path is the data-layer
+	// EndpointExtractor (see ExtractEndpoint), which also handles teardown
+	// when pods disappear. This in-Score path keeps existing configs that
+	// don't wire the endpoint-notification-source working without changes;
+	// EnsureSubscriber is idempotent so the two paths are safe to run
+	// together.
+	s.ensureSubscribersForEndpoints(ctx, endpoints)
+
 	// Early return if request is nil
 	if request == nil {
 		debugLogger.Info("Request is nil, skipping scoring")
@@ -607,22 +616,50 @@ func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent)
 
 	switch event.Type {
 	case fwkdl.EventAddOrUpdate:
-		if meta.Address == "" {
-			return nil
+		if err := s.ensureSubscriber(ctx, meta); err != nil {
+			return err
 		}
-		zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort)
-		if err := s.subscribersManager.EnsureSubscriber(ctx, endpointKey,
-			zmqEndpoint, s.kvEventsConfig.TopicFilter, true); err != nil {
-			logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",
-				"endpoint", endpointKey, "address", meta.Address)
-			return fmt.Errorf("ensure subscriber for %s: %w", endpointKey, err)
-		}
-		logger.V(logging.DEBUG).Info("Ensured KV-events subscriber", "endpoint", endpointKey, "zmq", zmqEndpoint)
 	case fwkdl.EventDelete:
 		s.subscribersManager.RemoveSubscriber(ctx, endpointKey)
 		logger.V(logging.DEBUG).Info("Removed KV-events subscriber", "endpoint", endpointKey)
 	}
 	return nil
+}
+
+// ensureSubscriber installs (or refreshes) a per-pod ZMQ subscriber for the
+// given endpoint metadata. Used by both the data-layer-driven extractor path
+// and the legacy in-Score backwards-compat path. Returns nil for endpoints
+// without an address — those can't be dialed.
+func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetadata) error {
+	if meta == nil || meta.Address == "" || meta.NamespacedName.Name == "" {
+		return nil
+	}
+	endpointKey := meta.NamespacedName.String()
+	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort)
+
+	logger := log.FromContext(ctx).WithName(s.typedName.String())
+	if err := s.subscribersManager.EnsureSubscriber(ctx, endpointKey,
+		zmqEndpoint, s.kvEventsConfig.TopicFilter, true); err != nil {
+		logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",
+			"endpoint", endpointKey, "address", meta.Address)
+		return fmt.Errorf("ensure subscriber for %s: %w", endpointKey, err)
+	}
+	logger.V(logging.DEBUG).Info("Ensured KV-events subscriber", "endpoint", endpointKey, "zmq", zmqEndpoint)
+	return nil
+}
+
+// ensureSubscribersForEndpoints is the backwards-compat path for configs
+// that don't wire the endpoint-notification-source: it iterates the candidate
+// endpoints presented to Score and ensures a per-pod subscriber for each.
+// Errors are logged and not returned — discovery is best-effort here, the
+// data layer remains the authoritative source when wired.
+func (s *Scorer) ensureSubscribersForEndpoints(ctx context.Context, endpoints []scheduling.Endpoint) {
+	if !s.kvEventsConfig.DiscoverPods || s.kvEventsConfig.PodDiscoveryConfig == nil {
+		return
+	}
+	for _, ep := range endpoints {
+		_ = s.ensureSubscriber(ctx, ep.GetMetadata())
+	}
 }
 
 // --- Internal helper methods ---

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -250,6 +250,7 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 		speculativeTTL:     speculativeTTL,
 		blockSizeTokens:    config.TokenProcessorConfig.BlockSize,
 		speculativeEnabled: config.SpeculativeIndexing,
+		subscriberCtx:      ctx,
 	}, nil
 }
 
@@ -299,6 +300,16 @@ type Scorer struct {
 	// path becomes a no-op so the data layer is the sole authority over
 	// per-pod subscriber lifecycle.
 	extractorActive atomic.Bool
+
+	// subscriberCtx is the long-lived context used to start ZMQ subscribers.
+	// SubscriberManager binds each subscriber's goroutine lifetime to the
+	// context passed in to EnsureSubscriber, so any caller-scoped context
+	// (e.g. the request ctx in the legacy in-Score path) would tear the
+	// subscriber down as soon as the caller returned. Using the plugin's
+	// construction-time ctx keeps subscribers alive for the EPP's lifetime,
+	// matching the original behavior of `context.Background()` in the
+	// pre-refactor code.
+	subscriberCtx context.Context
 }
 
 // TypedName returns the typed name of the plugin.
@@ -644,6 +655,9 @@ func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent)
 // given endpoint metadata. Used by both the data-layer-driven extractor path
 // and the legacy in-Score backwards-compat path. Returns nil for endpoints
 // without an address — those can't be dialed.
+//
+// The subscriber goroutine is started against subscriberCtx (plugin-lifetime),
+// not the caller ctx, so request-scoped contexts don't tear it down.
 func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetadata) error {
 	if meta == nil || meta.Address == "" || meta.NamespacedName.Name == "" {
 		return nil
@@ -652,7 +666,7 @@ func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetad
 	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort)
 
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
-	if err := s.subscribersManager.EnsureSubscriber(ctx, endpointKey,
+	if err := s.subscribersManager.EnsureSubscriber(s.subscriberCtx, endpointKey,
 		zmqEndpoint, s.kvEventsConfig.TopicFilter, true); err != nil {
 		logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",
 			"endpoint", endpointKey, "address", meta.Address)

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -659,7 +659,7 @@ func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent)
 // The subscriber goroutine is started against subscriberCtx (plugin-lifetime),
 // not the caller ctx, so request-scoped contexts don't tear it down.
 func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetadata) error {
-	if meta == nil || meta.Address == "" || meta.NamespacedName.Name == "" {
+	if meta == nil || meta.Address == "" {
 		return nil
 	}
 	endpointKey := meta.NamespacedName.String()

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -20,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
@@ -84,6 +86,7 @@ var (
 	_ scheduling.Scorer           = &Scorer{}
 	_ requestcontrol.DataProducer = &Scorer{}
 	_ requestcontrol.PreRequest   = &Scorer{}
+	_ fwkdl.EndpointExtractor     = &Scorer{}
 )
 
 // speculativeEntries holds the data needed to evict speculative entries
@@ -190,24 +193,7 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 	pool.Start(ctx)
 
 	subscribersManager := kvevents.NewSubscriberManager(pool)
-	var subscribersCache *ttlcache.Cache[string, struct{}]
 
-	// initialize the subscribers cache only if endpoint discovery is enabled
-	if config.KVEventsConfig.DiscoverPods {
-		// initialize the subscribers TTL cache
-		subscriptionTimeout := 10 * time.Minute
-		subscribersCache = ttlcache.New[string, struct{}](
-			ttlcache.WithTTL[string, struct{}](subscriptionTimeout),
-		)
-		subscribersCache.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason,
-			item *ttlcache.Item[string, struct{}],
-		) {
-			if reason == ttlcache.EvictionReasonExpired {
-				subscribersManager.RemoveSubscriber(ctx, item.Key())
-			}
-		})
-		go cleanCachePeriodically(ctx, subscribersCache, subscriptionTimeout)
-	}
 	if config.KVEventsConfig.ZMQEndpoint != "" {
 		// setup local subscriber to support global socket mode
 		if err := subscribersManager.EnsureSubscriber(ctx, "local-subscriber",
@@ -256,7 +242,6 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 		typedName:          plugin.TypedName{Type: PrecisePrefixCachePluginType},
 		kvCacheIndexer:     kvCacheIndexer,
 		kvBlockScorer:      kvBlockScorer,
-		subscribersCache:   subscribersCache,
 		subscribersManager: subscribersManager,
 		kvEventsConfig:     config.KVEventsConfig,
 		pluginState:        plugin.NewPluginState(ctx),
@@ -277,16 +262,14 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 // PreRequest to proactively populate the index with expected cache entries
 // immediately after a routing decision, closing the blind spot between the
 // routing decision and the arrival of actual KV events from the engine.
+//
+// The scorer also implements EndpointExtractor to react to endpoint lifecycle
+// events from the data layer's endpoint-notification-source: an add/update
+// installs a per-pod ZMQ subscriber, a delete removes it.
 type Scorer struct {
 	typedName      plugin.TypedName
 	kvCacheIndexer kvCacheIndexer
 
-	// until the IGW data-layer is ready to provide endpoint events,
-	// we maintain a TTL cache of known endpoints that are discovered through
-	// the scoring process. If a endpoint is not in the received endpoints list
-	// during scoring for a certain period, we consider it gone and
-	// stop its KV events subscription.
-	subscribersCache   *ttlcache.Cache[string, struct{}]
 	subscribersManager *kvevents.SubscriberManager
 	kvEventsConfig     *kvevents.Config
 
@@ -426,27 +409,6 @@ func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, r
 	span.SetAttributes(
 		attribute.Int("llm_d.scorer.candidate_endpoints", len(endpoints)),
 	)
-
-	// Handle pod discovery and subscriber management
-	if s.kvEventsConfig.DiscoverPods {
-		// update subscribers here temporarily
-		for _, endpoint := range endpoints {
-			endpointObj := endpoint.GetMetadata()
-			if endpointObj == nil {
-				continue
-			}
-			endpointKey := endpointObj.NamespacedName.String()
-			s.subscribersCache.Set(endpointKey, struct{}{}, 0) // use default TTL
-
-			if err := s.subscribersManager.EnsureSubscriber(context.Background(), endpointKey, // dont use request ctx
-				fmt.Sprintf("tcp://%s:%d", endpointObj.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort),
-				s.kvEventsConfig.TopicFilter, true); err != nil {
-				logger.Error(err, "Failed to ensure KV-events subscriber for endpoint", "endpoint", endpointKey,
-					"endpoint", endpointObj.Address)
-				continue
-			}
-		}
-	}
 
 	// Early return if request is nil
 	if request == nil {
@@ -611,6 +573,53 @@ func (s *Scorer) PreRequest(ctx context.Context,
 		"pod", speculativePod.PodIdentifier,
 		"blockKeys", len(state.blockKeys),
 		"ttl", s.speculativeTTL)
+}
+
+// --- EndpointExtractor implementation ---
+
+// ExpectedInputType declares the data type this extractor consumes.
+// Required by the data layer's source/extractor type-compatibility check.
+func (s *Scorer) ExpectedInputType() reflect.Type {
+	return fwkdl.EndpointEventReflectType
+}
+
+// Extract is the base Extractor entrypoint and is unused for endpoint
+// extractors — the Runtime calls ExtractEndpoint instead.
+func (s *Scorer) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error {
+	return nil
+}
+
+// ExtractEndpoint reacts to endpoint lifecycle events from the data layer's
+// endpoint-notification-source: an add/update installs a per-pod ZMQ
+// subscriber so KV-cache events flow into the index; a delete tears it down.
+// No-op when DiscoverPods is disabled or pod metadata is unavailable.
+func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
+	if !s.kvEventsConfig.DiscoverPods || s.kvEventsConfig.PodDiscoveryConfig == nil {
+		return nil
+	}
+	meta := event.Endpoint.GetMetadata()
+	if meta == nil || meta.Address == "" {
+		return nil
+	}
+
+	logger := log.FromContext(ctx).WithName(s.typedName.String())
+	endpointKey := meta.NamespacedName.String()
+
+	switch event.Type {
+	case fwkdl.EventAddOrUpdate:
+		zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort)
+		if err := s.subscribersManager.EnsureSubscriber(ctx, endpointKey,
+			zmqEndpoint, s.kvEventsConfig.TopicFilter, true); err != nil {
+			logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",
+				"endpoint", endpointKey, "address", meta.Address)
+			return fmt.Errorf("ensure subscriber for %s: %w", endpointKey, err)
+		}
+		logger.V(logging.DEBUG).Info("Ensured KV-events subscriber", "endpoint", endpointKey, "zmq", zmqEndpoint)
+	case fwkdl.EventDelete:
+		s.subscribersManager.RemoveSubscriber(ctx, endpointKey)
+		logger.V(logging.DEBUG).Info("Removed KV-events subscriber", "endpoint", endpointKey)
+	}
+	return nil
 }
 
 // --- Internal helper methods ---

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -592,13 +592,13 @@ func (s *Scorer) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error {
 // ExtractEndpoint reacts to endpoint lifecycle events from the data layer's
 // endpoint-notification-source: an add/update installs a per-pod ZMQ
 // subscriber so KV-cache events flow into the index; a delete tears it down.
-// No-op when DiscoverPods is disabled or pod metadata is unavailable.
+// No-op when DiscoverPods is disabled or the namespaced name is unavailable.
 func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
 	if !s.kvEventsConfig.DiscoverPods || s.kvEventsConfig.PodDiscoveryConfig == nil {
 		return nil
 	}
 	meta := event.Endpoint.GetMetadata()
-	if meta == nil || meta.Address == "" {
+	if meta == nil || meta.NamespacedName.Name == "" {
 		return nil
 	}
 
@@ -607,6 +607,9 @@ func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent)
 
 	switch event.Type {
 	case fwkdl.EventAddOrUpdate:
+		if meta.Address == "" {
+			return nil
+		}
 		zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort)
 		if err := s.subscribersManager.EnsureSubscriber(ctx, endpointKey,
 			zmqEndpoint, s.kvEventsConfig.TopicFilter, true); err != nil {

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -45,11 +45,11 @@ func newExtractorScorer(discoverPods bool) *Scorer {
 	}
 }
 
-func newEndpoint(name, addr, port string) fwkdl.Endpoint {
+func newEndpoint(name, addr string) fwkdl.Endpoint {
 	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: name},
 		Address:        addr,
-		Port:           port,
+		Port:           "8080",
 	}, nil)
 }
 
@@ -73,7 +73,7 @@ func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	ep := newEndpoint("pod-a", "10.0.0.1", "8080")
+	ep := newEndpoint("pod-a", "10.0.0.1")
 	wantKey := "ns/pod-a"
 	wantEndpoint := "tcp://10.0.0.1:5557"
 
@@ -111,7 +111,7 @@ func TestScorer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
 
 	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
-		Endpoint: newEndpoint("pod-a", "10.0.0.1", "8080"),
+		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
 
 	ids, _ := s.subscribersManager.GetActiveSubscribers()
@@ -200,7 +200,7 @@ func TestScorer_LegacyInScoreDiscovery_DisabledOnceExtractorObserved(t *testing.
 	// itself proves the source is wired.
 	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
-		Endpoint: newEndpoint("pod-x", "10.0.0.99", "8080"),
+		Endpoint: newEndpoint("pod-x", "10.0.0.99"),
 	}))
 
 	// Now Score()-time discovery should be a no-op even with fresh endpoints.
@@ -246,7 +246,7 @@ func TestScorer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscribe
 
 	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
-		Endpoint: newEndpoint("pod-a", "10.0.0.1", "8080"),
+		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
 
 	ids, _ := s.subscribersManager.GetActiveSubscribers()

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -162,6 +162,35 @@ func TestScorer_LegacyInScoreDiscovery_EnsuresSubscribers(t *testing.T) {
 		"legacy in-Score discovery must subscribe to every candidate endpoint")
 }
 
+// Once the data layer is wired (ExtractEndpoint has been called even once),
+// the legacy in-Score discovery must stop running so the data layer remains
+// the sole authority over per-pod subscriber lifecycle.
+func TestScorer_LegacyInScoreDiscovery_DisabledOnceExtractorObserved(t *testing.T) {
+	ctx := discardCtx(t)
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	// Simulate the data layer dispatching even an unrelated event — the call
+	// itself proves the source is wired.
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventDelete,
+		Endpoint: newEndpoint("pod-x", "10.0.0.99", "8080"),
+	}))
+
+	// Now Score()-time discovery should be a no-op even with fresh endpoints.
+	endpoints := []scheduling.Endpoint{
+		scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+			Address:        "10.0.0.1", Port: "8080",
+		}, nil, nil),
+	}
+	s.ensureSubscribersForEndpoints(ctx, endpoints)
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	assert.NotContains(t, ids, "ns/pod-a",
+		"legacy path must not subscribe once the data-layer extractor has been observed")
+}
+
 func TestScorer_LegacyInScoreDiscovery_DiscoverPodsDisabled(t *testing.T) {
 	ctx := discardCtx(t)
 	// Global-socket mode: per-pod subscribers must not be opened.

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -1,0 +1,123 @@
+package preciseprefixcache
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
+)
+
+// newExtractorScorer builds a minimal Scorer wired only with the bits the
+// EndpointExtractor path touches: a SubscriberManager, the kvevents config,
+// and a typed name. Skipping the full New() lets us exercise the data-layer
+// callbacks without standing up a tokenizer pool or KV index.
+func newExtractorScorer(discoverPods bool) *Scorer {
+	cfg := kvevents.DefaultConfig()
+	cfg.DiscoverPods = discoverPods
+	cfg.PodDiscoveryConfig = kvevents.DefaultPodReconcilerConfig()
+	cfg.PodDiscoveryConfig.SocketPort = 5557
+
+	return &Scorer{
+		typedName:          plugin.TypedName{Type: PrecisePrefixCachePluginType, Name: PrecisePrefixCachePluginType},
+		subscribersManager: kvevents.NewSubscriberManager(kvevents.NewPool(cfg, nil, nil, nil)),
+		kvEventsConfig:     cfg,
+	}
+}
+
+func newEndpoint(name, addr, port string) fwkdl.Endpoint {
+	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: name},
+		Address:        addr,
+		Port:           port,
+	}, nil)
+}
+
+func TestScorer_EndpointExtractor_InterfaceContract(t *testing.T) {
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(t.Context())
+
+	assert.Equal(t, fwkdl.EndpointEventReflectType, s.ExpectedInputType(),
+		"ExpectedInputType must report EndpointEvent for data-layer compatibility checks")
+
+	// Base Extract is a documented no-op; the Runtime calls ExtractEndpoint instead.
+	require.NoError(t, s.Extract(t.Context(), nil, nil))
+
+	var _ fwkdl.EndpointExtractor = s
+	assert.True(t, reflect.TypeOf(s).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
+}
+
+func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	ep := newEndpoint("pod-a", "10.0.0.1", "8080")
+	wantKey := "ns/pod-a"
+	wantEndpoint := "tcp://10.0.0.1:5557"
+
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+
+	ids, endpoints := s.subscribersManager.GetActiveSubscribers()
+	require.Equal(t, []string{wantKey}, ids, "add/update should register exactly one subscriber")
+	require.Equal(t, []string{wantEndpoint}, endpoints, "ZMQ endpoint must derive from address + SocketPort")
+
+	// Re-add is idempotent (EnsureSubscriber dedups on identical endpoint).
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+	ids, _ = s.subscribersManager.GetActiveSubscribers()
+	assert.Len(t, ids, 1, "duplicate add must not create a second subscriber")
+
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventDelete,
+		Endpoint: ep,
+	}))
+	ids, _ = s.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids, "delete should tear down the subscriber")
+}
+
+func TestScorer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	// DiscoverPods=false is the global-socket-mode toggle: per-pod discovery
+	// must be skipped so a single shared subscriber drives the index.
+	s := newExtractorScorer(false)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: newEndpoint("pod-a", "10.0.0.1", "8080"),
+	}))
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids, "no per-pod subscriber should be registered when DiscoverPods is disabled")
+}
+
+func TestScorer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	// Endpoint with empty address — nothing to subscribe to.
+	ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+	}, nil)
+
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids, "endpoints without an address must be ignored")
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -14,6 +14,7 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 // discardCtx returns a context whose logger drops everything. The kvevents
@@ -133,6 +134,51 @@ func TestScorer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
 
 	ids, _ := s.subscribersManager.GetActiveSubscribers()
 	assert.Empty(t, ids, "endpoints without an address must be ignored")
+}
+
+// Backwards-compat: configs that don't wire the endpoint-notification-source
+// rely on Score()-time subscriber discovery. Verify the legacy path still
+// installs a subscriber for each endpoint Score() sees.
+func TestScorer_LegacyInScoreDiscovery_EnsuresSubscribers(t *testing.T) {
+	ctx := discardCtx(t)
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	endpoints := []scheduling.Endpoint{
+		scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+			Address:        "10.0.0.1", Port: "8080",
+		}, nil, nil),
+		scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-b"},
+			Address:        "10.0.0.2", Port: "8080",
+		}, nil, nil),
+	}
+
+	s.ensureSubscribersForEndpoints(ctx, endpoints)
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	assert.ElementsMatch(t, []string{"ns/pod-a", "ns/pod-b"}, ids,
+		"legacy in-Score discovery must subscribe to every candidate endpoint")
+}
+
+func TestScorer_LegacyInScoreDiscovery_DiscoverPodsDisabled(t *testing.T) {
+	ctx := discardCtx(t)
+	// Global-socket mode: per-pod subscribers must not be opened.
+	s := newExtractorScorer(false)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	endpoints := []scheduling.Endpoint{
+		scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+			Address:        "10.0.0.1", Port: "8080",
+		}, nil, nil),
+	}
+
+	s.ensureSubscribersForEndpoints(ctx, endpoints)
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids)
 }
 
 // Delete events from the data layer may omit address fields. The subscriber

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -1,18 +1,30 @@
 package preciseprefixcache
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
+
+// discardCtx returns a context whose logger drops everything. The kvevents
+// subscriber spawns a background goroutine that logs via this context's
+// logger; under -race a test-bound logger writing after t.Run cleanup races
+// with the testing framework. Discarding sidesteps that without losing
+// fidelity (we don't assert on log output).
+func discardCtx(t *testing.T) context.Context {
+	t.Helper()
+	return log.IntoContext(context.Background(), logr.Discard())
+}
 
 // newExtractorScorer builds a minimal Scorer wired only with the bits the
 // EndpointExtractor path touches: a SubscriberManager, the kvevents config,
@@ -40,21 +52,22 @@ func newEndpoint(name, addr, port string) fwkdl.Endpoint {
 }
 
 func TestScorer_EndpointExtractor_InterfaceContract(t *testing.T) {
+	ctx := discardCtx(t)
 	s := newExtractorScorer(true)
-	defer s.subscribersManager.Shutdown(t.Context())
+	defer s.subscribersManager.Shutdown(ctx)
 
 	assert.Equal(t, fwkdl.EndpointEventReflectType, s.ExpectedInputType(),
 		"ExpectedInputType must report EndpointEvent for data-layer compatibility checks")
 
 	// Base Extract is a documented no-op; the Runtime calls ExtractEndpoint instead.
-	require.NoError(t, s.Extract(t.Context(), nil, nil))
+	require.NoError(t, s.Extract(ctx, nil, nil))
 
 	var _ fwkdl.EndpointExtractor = s
 	assert.True(t, reflect.TypeOf(s).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
 }
 
 func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
-	ctx := utils.NewTestContext(t)
+	ctx := discardCtx(t)
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
@@ -88,7 +101,7 @@ func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 }
 
 func TestScorer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
-	ctx := utils.NewTestContext(t)
+	ctx := discardCtx(t)
 	// DiscoverPods=false is the global-socket-mode toggle: per-pod discovery
 	// must be skipped so a single shared subscriber drives the index.
 	s := newExtractorScorer(false)
@@ -104,7 +117,7 @@ func TestScorer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
 }
 
 func TestScorer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
-	ctx := utils.NewTestContext(t)
+	ctx := discardCtx(t)
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
@@ -120,4 +133,33 @@ func TestScorer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
 
 	ids, _ := s.subscribersManager.GetActiveSubscribers()
 	assert.Empty(t, ids, "endpoints without an address must be ignored")
+}
+
+// Delete events from the data layer may omit address fields. The subscriber
+// is keyed by NamespacedName, so delete must succeed regardless of address
+// presence — otherwise stale subscribers leak when pods disappear.
+func TestScorer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscriber(t *testing.T) {
+	ctx := discardCtx(t)
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: newEndpoint("pod-a", "10.0.0.1", "8080"),
+	}))
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	require.Len(t, ids, 1, "sanity check: expected subscriber to be registered before delete")
+
+	deleteEndpoint := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+	}, nil)
+
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventDelete,
+		Endpoint: deleteEndpoint,
+	}))
+
+	ids, _ = s.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids, "delete events must remove an existing subscriber even when the address is missing")
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -41,6 +41,7 @@ func newExtractorScorer(discoverPods bool) *Scorer {
 		typedName:          plugin.TypedName{Type: PrecisePrefixCachePluginType, Name: PrecisePrefixCachePluginType},
 		subscribersManager: kvevents.NewSubscriberManager(kvevents.NewPool(cfg, nil, nil, nil)),
 		kvEventsConfig:     cfg,
+		subscriberCtx:      context.Background(),
 	}
 }
 
@@ -134,6 +135,31 @@ func TestScorer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
 
 	ids, _ := s.subscribersManager.GetActiveSubscribers()
 	assert.Empty(t, ids, "endpoints without an address must be ignored")
+}
+
+// Regression: SubscriberManager binds the subscriber goroutine's lifetime
+// to the ctx passed to EnsureSubscriber. If we naively pass the caller's
+// (request-scoped) ctx, the subscriber dies when the request ends and we
+// have to recreate it on every subsequent request — exactly what showed up
+// in production logs after the data-layer refactor. ensureSubscriber must
+// use the long-lived subscriberCtx instead.
+func TestScorer_EnsureSubscriber_SurvivesRequestCtxCancel(t *testing.T) {
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(context.Background())
+
+	// Simulate a request-scoped ctx that ends as soon as the call returns.
+	reqCtx, cancel := context.WithCancel(context.Background())
+
+	require.NoError(t, s.ensureSubscriber(reqCtx, &fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+		Address:        "10.0.0.1", Port: "8080",
+	}))
+
+	cancel() // request finishes — must not tear the subscriber down.
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	assert.ElementsMatch(t, []string{"ns/pod-a"}, ids,
+		"subscriber must outlive the caller's request-scoped context")
 }
 
 // Backwards-compat: configs that don't wire the endpoint-notification-source


### PR DESCRIPTION
## Summary

For automatic model-server KVEvents subscription mgmt, we implemented a "hack" that discovers pods on `Score` cycles until the data-layer provides notifications on endpoint creation/deletion. The latter has landed, and now is the time for the proper implementation.

Changes:
- Remove hacky endpoint tracking for subscription mgmt
- Implement `fwkdl.EndpointExtractor`
