### PR TITLE
fix image build with Podman

### DIFF
--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -244,17 +244,20 @@ case "${LINUX_ARCH}" in
 esac
 
 PLATFORM_ARGS=()
+SAVE_ARGS=()
 if [ "${CONTAINER_RUNTIME}" == "docker" ]; then
     PLATFORM_ARGS=("--platform" "linux/${LINUX_ARCH}")
+elif [ "${CONTAINER_RUNTIME}" == "podman" ]; then
+    SAVE_ARGS=("--format=docker-archive")
 fi
 
 for IMAGE in "${VLLM_SIMULATOR_IMAGE}" "${EPP_IMAGE}" "${SIDECAR_IMAGE}" "${UDS_TOKENIZER_IMAGE}"; do
     if ! "${CONTAINER_RUNTIME}" image inspect "${IMAGE}" > /dev/null 2>&1; then
         echo "Image ${IMAGE} not found locally, pulling..."
-        "${CONTAINER_RUNTIME}" pull "${PLATFORM_ARGS[@]}" "${IMAGE}"
+        "${CONTAINER_RUNTIME}" pull ${PLATFORM_ARGS[@]+"${PLATFORM_ARGS[@]}"} "${IMAGE}"
     fi
     echo "Loading ${IMAGE} into kind cluster..."
-    "${CONTAINER_RUNTIME}" save "${PLATFORM_ARGS[@]}" "${IMAGE}" | kind --name "${CLUSTER_NAME}" load image-archive /dev/stdin
+    "${CONTAINER_RUNTIME}" save ${PLATFORM_ARGS[@]+"${PLATFORM_ARGS[@]}"} ${SAVE_ARGS[@]+"${SAVE_ARGS[@]}"} "${IMAGE}" | kind --name "${CLUSTER_NAME}" load image-archive /dev/stdin
 done
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Running `scripts/kind-dev-env.sh` on MacOS with Podman returns the following errors:
```
./scripts/kind-dev-env.sh: line 257: PLATFORM_ARGS[@]: unbound variable
enabling experimental podman provider
ERROR: failed to load image: command "podman exec --privileged -i llm-d-inference-scheduler-dev-control-plane ctr --namespace=[k8s.io](http://k8s.io/) images import --all-platforms --digests --snapshotter=overlayfs -" failed with error: exit status 1
Command Output: ctr: unrecognized image format
make: *** [env-dev-kind] Error 1
```
**Release note**:
```release-note
NONE
```

/close #868 
