### PR TITLE
fix nonCachedTokens zero-value behavior description in docs

### DIFF
--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -404,7 +404,7 @@ The `prefix-based-pd-decider` plugin makes the disaggregation decision according
 **Parameter:**
 
 - `nonCachedTokens`: Number of non-cached tokens that trigger disaggregation
-  - If set to 0, disaggregation never occurs for all requests
+  - If set to 0, disaggregation never occurs for any request
 
 **Feature Gate Requirement**
 To activate this decider, ensure the following feature gate is enabled in your EndpointPickerConfig

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -404,7 +404,7 @@ The `prefix-based-pd-decider` plugin makes the disaggregation decision according
 **Parameter:**
 
 - `nonCachedTokens`: Number of non-cached tokens that trigger disaggregation
-  - If set to 0, disaggregation always occurs for all requests
+  - If set to 0, disaggregation never occurs for all requests
 
 **Feature Gate Requirement**
 To activate this decider, ensure the following feature gate is enabled in your EndpointPickerConfig


### PR DESCRIPTION
Fixes #867 

Current behavior is to never disaggregate P and D when nonCachedTokens is 0, see #691.

Documentation was updated to match the behavior.

`always-disagg-pd-decider` could be used to process disaggregated P/D for all requests.
