### PR TITLE
refactor: introduce ExtractorBase to remove forced no-op Extract from event-driven extractors

### DIFF
--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -291,13 +291,13 @@ func buildDataLayerConfig(rawDataConfig *configapi.DataLayerConfig, handle fwkpl
 		if sourcePlugin, ok := handle.Plugin(source.PluginRef).(fwkdl.DataSource); ok {
 			sourceConfig := datalayer.DataSourceConfig{
 				Plugin:     sourcePlugin,
-				Extractors: []fwkdl.Extractor{},
+				Extractors: []fwkdl.ExtractorBase{},
 			}
 			for _, extractor := range source.Extractors {
-				if extractorPlugin, ok := handle.Plugin(extractor.PluginRef).(fwkdl.Extractor); ok {
+				if extractorPlugin, ok := handle.Plugin(extractor.PluginRef).(fwkdl.ExtractorBase); ok {
 					sourceConfig.Extractors = append(sourceConfig.Extractors, extractorPlugin)
 				} else {
-					return nil, fmt.Errorf("the plugin %s is not a fwkdl.Extractor", source.PluginRef)
+					return nil, fmt.Errorf("the plugin %s is not a fwkdl.ExtractorBase", source.PluginRef)
 				}
 			}
 			cfg.Sources = append(cfg.Sources, sourceConfig)

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -96,7 +96,7 @@ func NewCollector() *Collector {
 
 // Start initiates data source collection for the endpoint.
 // All sources must implement PollingDataSource. Validation is performed by the caller.
-func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.Extractor) error {
+func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.ExtractorBase) error {
 	// Validate sources slice is not empty
 	if len(pollers) == 0 {
 		return errors.New("cannot start collector with empty sources")
@@ -111,7 +111,7 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 	return c.startCollection(ctx, ticker, ep, pollers, extractors)
 }
 
-func (c *Collector) startCollection(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.Extractor) error {
+func (c *Collector) startCollection(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.ExtractorBase) error {
 	var ready chan struct{}
 	started := false
 
@@ -121,7 +121,7 @@ func (c *Collector) startCollection(ctx context.Context, ticker Ticker, ep fwkdl
 		started = true
 		ready = make(chan struct{})
 
-		go func(endpoint fwkdl.Endpoint, sources []fwkdl.PollingDataSource, exts map[string][]fwkdl.Extractor) {
+		go func(endpoint fwkdl.Endpoint, sources []fwkdl.PollingDataSource, exts map[string][]fwkdl.ExtractorBase) {
 			logger.V(logging.DEFAULT).Info("starting collection")
 
 			defer func() {
@@ -153,8 +153,10 @@ func (c *Collector) startCollection(ctx context.Context, ticker Ticker, ep fwkdl
 						if srcExtractors, ok := exts[tn.Name]; ok && data != nil {
 							for _, ext := range srcExtractors {
 								extKey := ext.TypedName().String()
-								extErr := ext.Extract(ctx, data, endpoint)
-								logErrorTransition(logger, c.lastExtractErrors, extKey, "extract", "extractor", extErr)
+								if poller, ok := ext.(fwkdl.Extractor); ok {
+									extErr := poller.Extract(ctx, data, endpoint)
+									logErrorTransition(logger, c.lastExtractErrors, extKey, "extract", "extractor", extErr)
+								}
 							}
 						}
 					}

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -115,13 +115,23 @@ func (c *Collector) startCollection(ctx context.Context, ticker Ticker, ep fwkdl
 	var ready chan struct{}
 	started := false
 
+	// Pre-compute poll-based extractors upfront to avoid repeated type assertions in the hot loop.
+	pollingExtractors := make(map[string][]fwkdl.Extractor, len(extractors))
+	for name, exts := range extractors {
+		for _, ext := range exts {
+			if poller, ok := ext.(fwkdl.Extractor); ok {
+				pollingExtractors[name] = append(pollingExtractors[name], poller)
+			}
+		}
+	}
+
 	c.startOnce.Do(func() {
 		logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().GetIPAddress())
 		c.ctx, c.cancel = context.WithCancel(ctx)
 		started = true
 		ready = make(chan struct{})
 
-		go func(endpoint fwkdl.Endpoint, sources []fwkdl.PollingDataSource, exts map[string][]fwkdl.ExtractorBase) {
+		go func(endpoint fwkdl.Endpoint, sources []fwkdl.PollingDataSource, exts map[string][]fwkdl.Extractor) {
 			logger.V(logging.DEFAULT).Info("starting collection")
 
 			defer func() {
@@ -153,16 +163,14 @@ func (c *Collector) startCollection(ctx context.Context, ticker Ticker, ep fwkdl
 						if srcExtractors, ok := exts[tn.Name]; ok && data != nil {
 							for _, ext := range srcExtractors {
 								extKey := ext.TypedName().String()
-								if poller, ok := ext.(fwkdl.Extractor); ok {
-									extErr := poller.Extract(ctx, data, endpoint)
-									logErrorTransition(logger, c.lastExtractErrors, extKey, "extract", "extractor", extErr)
-								}
+								extErr := ext.Extract(ctx, data, endpoint)
+								logErrorTransition(logger, c.lastExtractErrors, extKey, "extract", "extractor", extErr)
 							}
 						}
 					}
 				}
 			}
-		}(ep, pollers, extractors)
+		}(ep, pollers, pollingExtractors)
 	})
 
 	if !started {

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -30,6 +30,6 @@ type Config struct {
 
 // DataSourceConfig defines the configuration of a specific DataSource
 type DataSourceConfig struct {
-	Plugin     fwkdl.DataSource  // the data source plugin instance
-	Extractors []fwkdl.Extractor // extractors defined for the data source
+	Plugin     fwkdl.DataSource      // the data source plugin instance
+	Extractors []fwkdl.ExtractorBase // extractors defined for the data source
 }

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -133,7 +133,7 @@ func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
 
 		var extractors []fwkdl.NotificationExtractor
 		if rawExts, ok := r.sourceExtractors.Load(srcName); ok {
-			raw := rawExts.([]fwkdl.Extractor)
+			raw := rawExts.([]fwkdl.ExtractorBase)
 			extractors = make([]fwkdl.NotificationExtractor, len(raw))
 			for i, e := range raw {
 				extractors[i] = e.(fwkdl.NotificationExtractor)
@@ -184,10 +184,10 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 		return endpoint
 	}
 
-	extractors := make(map[string][]fwkdl.Extractor, len(pollers))
+	extractors := make(map[string][]fwkdl.ExtractorBase, len(pollers))
 	r.sourceExtractors.Range(func(key, val any) bool {
 		srcName := key.(string)
-		exts := val.([]fwkdl.Extractor)
+		exts := val.([]fwkdl.ExtractorBase)
 		extractors[srcName] = exts
 		return true
 	})
@@ -246,7 +246,7 @@ func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger,
 		if !ok {
 			return true
 		}
-		for _, ext := range rawExts.([]fwkdl.Extractor) {
+		for _, ext := range rawExts.([]fwkdl.ExtractorBase) {
 			if epExt, ok := ext.(fwkdl.EndpointExtractor); ok {
 				if err := epExt.ExtractEndpoint(ctx, *processed); err != nil {
 					logger.Error(err, "endpoint extractor failed", "extractor", ext.TypedName())
@@ -260,7 +260,7 @@ func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger,
 // validates the compatibility of data source and configured extractors. This includes
 // expected Extractor type, source output and extractor input type compatibility and
 // optionally source specific validation.
-func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fwkdl.Extractor, disallowedExtractorType string) error {
+func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fwkdl.ExtractorBase, disallowedExtractorType string) error {
 	for _, ext := range extractors {
 		// check if disallowed extractor type
 		if disallowedExtractorType != "" && ext.TypedName().Type == disallowedExtractorType {

--- a/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
+++ b/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
@@ -43,7 +43,7 @@ func TestNewEndpointDispatchesEventWithNoPollers(t *testing.T) {
 		Sources: []DataSourceConfig{
 			{
 				Plugin:     epSrc,
-				Extractors: []fwkdl.Extractor{extractor},
+				Extractors: []fwkdl.ExtractorBase{extractor},
 			},
 		},
 	}

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -27,6 +27,7 @@ import (
 )
 
 var (
+	ExtractorBaseType         = reflect.TypeFor[ExtractorBase]()
 	ExtractorType             = reflect.TypeFor[Extractor]()
 	NotificationExtractorType = reflect.TypeFor[NotificationExtractor]()
 	NotificationEventType     = reflect.TypeFor[NotificationEvent]()
@@ -56,11 +57,20 @@ type PollingDataSource interface {
 	Poll(ctx context.Context, ep Endpoint) (any, error)
 }
 
-// Extractor transforms raw data into structured attributes.
-type Extractor interface {
+// ExtractorBase is the common base for all extractor variants.
+// It provides identity and type-compatibility information without
+// prescribing how extraction is triggered.
+type ExtractorBase interface {
 	plugin.Plugin
 	// ExpectedInputType defines the type expected by the extractor.
 	ExpectedInputType() reflect.Type
+}
+
+// Extractor transforms raw data from a PollingDataSource into structured
+// attributes. Used only with poll-based sources; the Runtime calls Extract
+// on each tick with the data returned by the source's Poll method.
+type Extractor interface {
+	ExtractorBase
 	// Extract transforms the raw data source output into a concrete structured
 	// attribute, stored on the given endpoint.
 	Extract(ctx context.Context, data any, ep Endpoint) error
@@ -71,7 +81,7 @@ type Extractor interface {
 type ValidatingDataSource interface {
 	// ValidateExtractor allows the DataSource to perform additional validation
 	// beyond the standard type compatibility checks. Return an error if validation fails.
-	ValidateExtractor(extractor Extractor) error
+	ValidateExtractor(extractor ExtractorBase) error
 }
 
 // EventType identifies the type of mutation that triggered the notification.
@@ -111,9 +121,10 @@ type NotificationSource interface {
 }
 
 // NotificationExtractor processes k8s object events pushed from a
-// NotificationSource.
+// NotificationSource. The Runtime calls ExtractNotification directly;
+// Extract from the base Extractor interface is never invoked on this type.
 type NotificationExtractor interface {
-	Extractor
+	ExtractorBase
 	// GVK returns the GroupVersionKind this extractor handles.
 	GVK() schema.GroupVersionKind
 	// ExtractNotification processes a notification event. Called synchronously
@@ -142,9 +153,10 @@ type EndpointSource interface {
 }
 
 // EndpointExtractor processes endpoint lifecycle events pushed from an
-// EndpointSource. Called synchronously by the Runtime in event order.
+// EndpointSource. The Runtime calls ExtractEndpoint directly;
+// Extract from the base Extractor interface is never invoked on this type.
 type EndpointExtractor interface {
-	Extractor
+	ExtractorBase
 	// ExtractEndpoint processes an endpoint lifecycle event.
 	ExtractEndpoint(ctx context.Context, event EndpointEvent) error
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
@@ -55,11 +55,6 @@ func (m *EndpointExtractor) ExpectedInputType() reflect.Type {
 	return fwkdl.EndpointEventReflectType
 }
 
-// Extract is the base Extractor interface method — no-op for endpoint extractors.
-func (m *EndpointExtractor) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error {
-	return nil
-}
-
 // ExtractEndpoint records the event and returns any configured error.
 func (m *EndpointExtractor) ExtractEndpoint(_ context.Context, event fwkdl.EndpointEvent) error {
 	m.mu.Lock()

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
@@ -65,11 +65,6 @@ func (m *NotificationExtractor) ExpectedInputType() reflect.Type {
 	return reflect.TypeFor[fwkdl.NotificationEvent]()
 }
 
-// Extract is the Extractor interface method — no-op for notification extractors.
-func (m *NotificationExtractor) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error {
-	return nil
-}
-
 func (m *NotificationExtractor) GVK() schema.GroupVersionKind {
 	return m.gvk
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/datasource_test.go
@@ -26,7 +26,7 @@ func TestDatasource(t *testing.T) {
 		Sources: []datalayer.DataSourceConfig{
 			{
 				Plugin:     source,
-				Extractors: []fwkdl.Extractor{extractor},
+				Extractors: []fwkdl.ExtractorBase{extractor},
 			},
 		},
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -70,11 +70,6 @@ func (p *InFlightLoadProducer) ExpectedInputType() reflect.Type {
 	return datalayer.EndpointEventReflectType
 }
 
-// Extract transforms the raw data into structured attributes (not used for notifications).
-func (p *InFlightLoadProducer) Extract(context.Context, any, datalayer.Endpoint) error {
-	return nil
-}
-
 // ExtractEndpoint handles endpoint deletion events to prune stateful trackers.
 func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datalayer.EndpointEvent) error {
 	if event.Type != datalayer.EventDelete || event.Endpoint == nil {

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -611,12 +611,6 @@ func (s *Scorer) ExpectedInputType() reflect.Type {
 	return fwkdl.EndpointEventReflectType
 }
 
-// Extract is the base Extractor entrypoint and is unused for endpoint
-// extractors — the Runtime calls ExtractEndpoint instead.
-func (s *Scorer) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error {
-	return nil
-}
-
 // ExtractEndpoint reacts to endpoint lifecycle events from the data layer's
 // endpoint-notification-source: an add/update installs a per-pod ZMQ
 // subscriber so KV-cache events flow into the index; a delete tears it down.

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -61,9 +61,6 @@ func TestScorer_EndpointExtractor_InterfaceContract(t *testing.T) {
 	assert.Equal(t, fwkdl.EndpointEventReflectType, s.ExpectedInputType(),
 		"ExpectedInputType must report EndpointEvent for data-layer compatibility checks")
 
-	// Base Extract is a documented no-op; the Runtime calls ExtractEndpoint instead.
-	require.NoError(t, s.Extract(ctx, nil, nil))
-
 	var _ fwkdl.EndpointExtractor = s
 	assert.True(t, reflect.TypeOf(s).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`EndpointExtractor` and `NotificationExtractor` both embedded `Extractor`, which requires every implementor to provide `Extract(ctx, data, ep)`, which the Runtime never calls on these types. 

Introduce `ExtractorBase`, the minimal common base for all extractor variants:
```go
type ExtractorBase interface {
    plugin.Plugin
    ExpectedInputType() reflect.Type
}
```

The poll-based `Extractor` keeps its existing shape, now embedding `ExtractorBase` instead of duplicating the base methods. `NotificationExtractor` and `EndpointExtractor` embed `ExtractorBase` instead of `Extractor`.
Removed unused Extract from real and mock plugins.

**Which issue(s) this PR fixes**:
Fixes #877.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
