### PR TITLE
move sidecar/latencypredictorasync into predictedlatency

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/OWNERS
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kaushikmitr

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/README.md
@@ -1,0 +1,48 @@
+# latencypredictorclient
+
+Go client for the [llm-d-latency-predictor](https://github.com/llm-d/llm-d-latency-predictor)
+Python service, which predicts per-request latency (TTFT / TPOT) for LLM
+inference and is trained online from observed request metrics.
+
+This client is used by the `predictedlatency` data producer plugin to fetch
+predictions during scheduling and to stream training samples back to the
+Python server.
+
+## What it does
+
+- **Prediction.** Issues bulk HTTP prediction calls to one or more
+  prediction server URLs (`PredictionURLs`), with a coalescing layer that
+  merges concurrent callers of `PredictBulkStrict` into a single batched
+  HTTP request (`CoalesceWindow`, `MaxBulkSize`).
+- **Training.** Buffers `TrainingEntry` samples locally and periodically
+  flushes them to the training server (`TrainingURL`) on `FlushInterval`,
+  downsampling to `MaxSampleSize` when the buffer grows large.
+- **Model snapshot caching.** Periodically pulls the trained model
+  itself from the Python server — coefficients (Bayesian Ridge),
+  serialized trees (XGBoost), and bucket counts — on
+  `MetricsRefreshInterval`, and caches it locally. (The server exposes
+  this via a `/metrics`-style endpoint; the artifacts are not sent
+  along with prediction requests.)
+- **Local vs. remote inference.** With the cached snapshot, Bayesian
+  Ridge predictions run in-process from the cached coefficients, no
+  HTTP hop per request. XGBoost and LightGBM predictions go over HTTP
+  via bulk prediction calls.
+
+Configuration can be supplied programmatically via `Config` or loaded from
+environment variables via `ConfigFromEnv()`. See [types.go](types.go) for
+the full set of knobs.
+
+## Entry points
+
+- `New(cfg, logger) *Predictor` — construct a client. Spawns two
+  background goroutines (flush loop + coalescing dispatcher).
+- `Start(ctx) error` — prime the predictor with initial server status and
+  model info.
+- `PredictBulkStrict`, `AddTrainingEntry`, and related methods — see
+  [prediction.go](prediction.go), [training.go](training.go).
+
+## Tests
+
+`tests/` contains a standalone load-test harness (`main.go`) that drives
+the client against a running predictor server. It is a `package main`
+binary, not part of the scheduler build.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/coalescer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/coalescer.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictorclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+)
+
+// batchSubmission represents a single caller's request to PredictBulkStrict
+// waiting to be coalesced with other concurrent callers.
+type batchSubmission struct {
+	requests []PredictionRequest
+	resultCh chan batchResult
+}
+
+// batchResult carries the response (or error) back to the caller.
+type batchResult struct {
+	response *BulkPredictionResponse
+	err      error
+}
+
+// coalesceDispatcher is a background goroutine that accumulates PredictBulkStrict
+// submissions and dispatches them as a single mega-batch HTTP call once either:
+//   - the coalesce window expires (e.g. 5ms since first queued item), or
+//   - the accumulated row count reaches MaxCoalescedRows (if > 0).
+//
+// Batches are dispatched asynchronously (in a goroutine) so the dispatcher
+// never blocks waiting for an HTTP response. Concurrency is capped by
+// MaxConcurrentDispatches via a semaphore.
+func (p *Predictor) coalesceDispatcher() {
+	defer p.wg.Done()
+
+	var pending []*batchSubmission
+	var totalRows int
+	var timerCh <-chan time.Time
+	var timer *time.Timer
+
+	dispatch := func() {
+		if len(pending) == 0 {
+			return
+		}
+		batch := pending
+		pending = nil
+		totalRows = 0
+
+		// Acquire semaphore slot inside a goroutine so the dispatcher is never
+		// blocked and can keep accumulating new submissions while HTTP calls are
+		// in flight.
+		go func() {
+			select {
+			case <-p.dispatchSem:
+			case <-p.done:
+				for _, sub := range batch {
+					sub.resultCh <- batchResult{err: errors.New("predictor shutting down")}
+				}
+				return
+			}
+			defer func() { p.dispatchSem <- struct{}{} }()
+			p.dispatchBatch(batch)
+		}()
+	}
+
+	for {
+		select {
+		case sub := <-p.coalesceCh:
+			pending = append(pending, sub)
+			totalRows += len(sub.requests)
+
+			// Start the coalesce window timer on the first submission
+			if timer == nil {
+				timer = time.NewTimer(p.config.CoalesceWindow)
+				timerCh = timer.C
+			}
+
+			// Early dispatch if row cap is set and reached
+			if p.config.MaxCoalescedRows > 0 && totalRows >= p.config.MaxCoalescedRows {
+				timer.Stop()
+				timer = nil
+				timerCh = nil
+				dispatch()
+			}
+
+		case <-timerCh:
+			// Coalesce window expired — dispatch whatever we have
+			timer = nil
+			timerCh = nil
+			dispatch()
+
+		case <-p.done:
+			// Shutting down — reject all pending submissions
+			if timer != nil {
+				timer.Stop()
+			}
+			for _, sub := range pending {
+				sub.resultCh <- batchResult{err: errors.New("predictor shutting down")}
+			}
+			return
+		}
+	}
+}
+
+// dispatchBatch merges all pending submissions into one HTTP call, then fans
+// the results back to each individual caller.
+func (p *Predictor) dispatchBatch(submissions []*batchSubmission) {
+	// Merge all requests and track each caller's slice boundaries
+	var totalReqs int
+	for _, sub := range submissions {
+		totalReqs += len(sub.requests)
+	}
+	allRequests := make([]PredictionRequest, 0, totalReqs)
+	offsets := make([]int, len(submissions))
+	counts := make([]int, len(submissions))
+
+	offset := 0
+	for i, sub := range submissions {
+		offsets[i] = offset
+		counts[i] = len(sub.requests)
+		allRequests = append(allRequests, sub.requests...)
+		offset += len(sub.requests)
+	}
+
+	p.logger.V(logutil.DEBUG).Info("Dispatching coalesced batch",
+		"callers", len(submissions),
+		"total_items", len(allRequests))
+
+	// Make one HTTP call with the mega-batch
+	ctx, cancel := context.WithTimeout(context.Background(), p.config.HTTPTimeout)
+	defer cancel()
+
+	resp, err := p.doPredictBulkStrictHTTP(ctx, allRequests)
+
+	// Fan out results to each caller
+	for i, sub := range submissions {
+		if err != nil {
+			sub.resultCh <- batchResult{err: err}
+			continue
+		}
+
+		start := offsets[i]
+		end := start + counts[i]
+
+		// Guard against response length mismatch
+		if end > len(resp.Predictions) {
+			sub.resultCh <- batchResult{err: fmt.Errorf(
+				"coalesced response too short: expected items [%d:%d] but got %d predictions",
+				start, end, len(resp.Predictions))}
+			continue
+		}
+
+		// Slice out this caller's portion of the response
+		callerPredictions := make([]PredictionResponse, counts[i])
+		copy(callerPredictions, resp.Predictions[start:end])
+
+		sub.resultCh <- batchResult{
+			response: &BulkPredictionResponse{
+				Predictions:           callerPredictions,
+				TotalRequests:         counts[i],
+				SuccessfulPredictions: counts[i],
+				FailedPredictions:     0,
+				ProcessingTimeMs:      resp.ProcessingTimeMs,
+			},
+		}
+	}
+}
+
+// doPredictBulkStrictHTTP performs the raw HTTP call for a strict bulk prediction.
+// This is the internal method used by both the direct and coalesced paths.
+func (p *Predictor) doPredictBulkStrictHTTP(ctx context.Context, requests []PredictionRequest) (*BulkPredictionResponse, error) {
+	payload := BulkPredictionRequest{Requests: requests}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bulk prediction request: %w", err)
+	}
+
+	predictionURL := p.getRandomPredictionURL()
+	url := predictionURL + "/predict/bulk/strict"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bulk prediction request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call bulk prediction endpoint %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("bulk prediction server returned non-200 status: %d %s, body: %s",
+			resp.StatusCode, resp.Status, string(body))
+	}
+
+	var bulkResp BulkPredictionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&bulkResp); err != nil {
+		return nil, fmt.Errorf("failed to decode bulk prediction response: %w", err)
+	}
+
+	return &bulkResp, nil
+}
+
+// submitCoalesced sends a set of prediction requests through the coalescer
+// and blocks until the coalesced result is available.
+func (p *Predictor) submitCoalesced(ctx context.Context, requests []PredictionRequest) (*BulkPredictionResponse, error) {
+	sub := &batchSubmission{
+		requests: requests,
+		resultCh: make(chan batchResult, 1),
+	}
+
+	select {
+	case p.coalesceCh <- sub:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-p.done:
+		return nil, errors.New("predictor shutting down")
+	}
+
+	select {
+	case result := <-sub.resultCh:
+		return result.response, result.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictorclient
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// --- Predictor Client ---
+
+type Predictor struct {
+	config     *Config
+	httpClient *http.Client
+	logger     logr.Logger
+	rng        *rand.Rand
+
+	metricsMu     sync.RWMutex
+	cachedMetrics *MetricsResponse
+	modelInfo     *ModelInfo
+	serverStatus  *ServerStatusResponse
+
+	bufferMu sync.Mutex
+	pending  []TrainingEntry
+
+	coalesceCh  chan *batchSubmission
+	dispatchSem chan struct{} // semaphore limiting concurrent HTTP dispatches
+
+	wg   sync.WaitGroup
+	done chan struct{}
+}
+
+func New(config *Config, logger logr.Logger) *Predictor {
+	if config == nil {
+		config = ConfigFromEnv()
+	}
+	maxDispatches := config.MaxConcurrentDispatches
+	sem := make(chan struct{}, maxDispatches)
+	for range maxDispatches {
+		sem <- struct{}{}
+	}
+
+	p := &Predictor{
+		config:      config,
+		httpClient:  &http.Client{Timeout: config.HTTPTimeout},
+		logger:      logger.WithName("latency-predictor-client"),
+		rng:         rand.New(rand.NewSource(time.Now().UnixNano())),
+		done:        make(chan struct{}),
+		coalesceCh:  make(chan *batchSubmission, 1024),
+		dispatchSem: sem,
+	}
+	p.wg.Add(2)
+	go p.backgroundLoop()
+	go p.coalesceDispatcher()
+	return p
+}
+
+// Start initializes the predictor by fetching server status and model info.
+func (p *Predictor) Start(ctx context.Context) error {
+	// Get initial server status
+	if err := p.refreshServerStatus(ctx); err != nil {
+		p.logger.Error(err, "failed to get initial server status (will retry in background)")
+	}
+
+	// Get initial model info if training server is available
+	if err := p.refreshModelInfo(ctx); err != nil {
+		p.logger.Error(err, "failed to get initial model info (will retry in background)")
+	}
+
+	p.logger.Info("Latency predictor async client started.",
+		"training_url", p.config.TrainingURL,
+		"prediction_urls", p.config.PredictionURLs,
+		"max_sample_size", p.config.MaxSampleSize,
+		"flush_interval", p.config.FlushInterval,
+		"use_native_xgboost", p.config.UseNativeXGBoost,
+		"max_bulk_size", p.config.MaxBulkSize)
+	return nil
+}
+
+// Stop stops background work, then does a final flush/refresh.
+func (p *Predictor) Stop(ctx context.Context) {
+	close(p.done)
+	p.wg.Wait() // Wait for the background loop to finish
+	// final flush & refresh
+	p.flushTraining(ctx)
+	p.refreshMetrics(ctx)
+	p.logger.Info("Latency predictor async client stopped.")
+}
+
+// backgroundLoop runs flush & refresh at configured intervals.
+func (p *Predictor) backgroundLoop() {
+	defer p.wg.Done()
+	flushTicker := time.NewTicker(p.config.FlushInterval)
+	metricsTicker := time.NewTicker(p.config.MetricsRefreshInterval)
+	defer flushTicker.Stop()
+	defer metricsTicker.Stop()
+
+	for {
+		select {
+		case <-flushTicker.C:
+			// ✅ Create context with timeout for background flush
+			ctx, cancel := context.WithTimeout(context.Background(), p.config.HTTPTimeout)
+			p.flushTraining(ctx)
+			cancel()
+		case <-metricsTicker.C:
+			// ✅ Create context with timeout for background refresh
+			ctx, cancel := context.WithTimeout(context.Background(), p.config.HTTPTimeout)
+			p.refreshMetrics(ctx)
+			if err := p.refreshServerStatus(ctx); err != nil {
+				p.logger.Error(err, "failed to refresh server status during background refresh")
+			}
+			cancel()
+		case <-p.done:
+			return
+		}
+	}
+}
+
+// GetXGBoostTrees returns the cached XGBoost tree data. It does not fetch new data.
+func (p *Predictor) GetXGBoostTrees(ctx context.Context) (*XGBoostTrees, error) {
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+	if p.cachedMetrics == nil || p.cachedMetrics.XGBoostTrees == nil {
+		return nil, errors.New("no cached XGBoost trees available")
+	}
+	return p.cachedMetrics.XGBoostTrees, nil
+}
+
+// GetModelInfo fetches the latest model info from the training server.
+func (p *Predictor) GetModelInfo(ctx context.Context) (*ModelInfo, error) {
+	if err := p.refreshModelInfo(ctx); err != nil {
+		return nil, err
+	}
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+
+	return p.modelInfo, nil
+}
+
+// GetCachedMetrics returns the last metrics fetched. The bool indicates if a value is cached.
+func (p *Predictor) GetCachedMetrics() (*MetricsResponse, bool) {
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+	if p.cachedMetrics == nil {
+		return nil, false
+	}
+	return p.cachedMetrics, true
+}
+
+// IsXGBoostReady returns true if native XGBoost models are loaded and ready.
+func (p *Predictor) IsXGBoostReady() bool {
+	return p.modelInfo != nil && p.modelInfo.ModelType == xgBoostModelType
+}
+
+// IsLightGBMReady returns true if LightGBM models are available via HTTP.
+func (p *Predictor) IsLightGBMReady() bool {
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+	return p.modelInfo != nil && p.modelInfo.ModelType == gbmModelType && len(p.config.PredictionURLs) > 0
+}
+
+// IsBayesianRidgeReady returns true if Bayesian Ridge coefficients are cached.
+func (p *Predictor) IsBayesianRidgeReady() bool {
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+	return p.cachedMetrics != nil && p.cachedMetrics.Coefficients != nil
+}
+
+// GetCurrentModelType returns the current model type from cached server status or model info.
+func (p *Predictor) GetCurrentModelType() string {
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+
+	// Prefer server status if available
+	if p.serverStatus != nil {
+		return p.serverStatus.ModelType
+	}
+
+	if p.modelInfo == nil {
+		return ""
+	}
+	return p.modelInfo.ModelType
+}
+
+// GetCurrentQuantile returns the current quantile from server status or defaults to 0.9
+func (p *Predictor) GetCurrentQuantile() float64 {
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+
+	// Prefer server status if available
+	if p.serverStatus != nil && p.serverStatus.Quantile > 0 {
+		return p.serverStatus.Quantile
+	}
+
+	if p.modelInfo != nil && p.modelInfo.Quantile > 0 {
+		return p.modelInfo.Quantile
+	}
+
+	return 0.9 // Default quantile
+}
+
+// GetCurrentObjectiveType returns the current objective type from server status or defaults to "quantile".
+// Returns ObjectiveQuantile ("quantile") for backward compatibility with servers that don't report objective_type.
+func (p *Predictor) GetCurrentObjectiveType() string {
+	p.metricsMu.RLock()
+	defer p.metricsMu.RUnlock()
+
+	if p.serverStatus != nil && p.serverStatus.ObjectiveType != "" {
+		return p.serverStatus.ObjectiveType
+	}
+
+	if p.modelInfo != nil && p.modelInfo.ObjectiveType != "" {
+		return p.modelInfo.ObjectiveType
+	}
+
+	return ObjectiveQuantile
+}
+
+// IsReady returns true if a prediction method is ready based on the current model type.
+func (p *Predictor) IsReady() bool {
+	switch p.GetCurrentModelType() {
+	case bayesianRidgeModelType:
+		return p.IsBayesianRidgeReady()
+	case xgBoostModelType:
+		// Ready if we have prediction URLs for HTTP calls
+		return len(p.config.PredictionURLs) > 0
+	case gbmModelType:
+		// Ready if we have prediction URLs for HTTP calls
+		return p.IsLightGBMReady()
+	default:
+		return false
+	}
+}
+
+// GetPredictionURLs returns the list of configured prediction URLs for debugging/monitoring.
+func (p *Predictor) GetPredictionURLs() []string {
+	return p.config.PredictionURLs
+}
+
+// GetTrainingURL returns the configured training URL for debugging/monitoring.
+func (p *Predictor) GetTrainingURL() string {
+	return p.config.TrainingURL
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async_test.go
@@ -1,0 +1,2271 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictorclient
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+func TestLatencyPredictorIntegration(t *testing.T) {
+	// Setup logger
+	zapLog, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+	logger := zapr.NewLogger(zapLog)
+
+	// Check if server URLs are set
+	predictionURLs := os.Getenv("PREDICTION_SERVER_URL")
+	trainingURL := os.Getenv("TRAINING_SERVER_URL")
+
+	if predictionURLs == "" {
+		t.Skip("PREDICTION_SERVER_URL not set, skipping integration test")
+	}
+	if trainingURL == "" {
+		// Fallback to first prediction URL for training if not set
+		urls := strings.Split(predictionURLs, ",")
+		if len(urls) > 0 {
+			trainingURL = strings.TrimSpace(urls[0])
+		} else {
+			t.Skip("No valid URLs available for testing")
+		}
+	}
+
+	// Parse prediction URLs
+	urls := strings.Split(predictionURLs, ",")
+	parsedPredictionURLs := make([]string, 0, len(urls))
+	for _, url := range urls {
+		parsedPredictionURLs = append(parsedPredictionURLs, strings.TrimSpace(url))
+	}
+
+	// Create config with the actual server URLs
+	config := &Config{
+		TrainingURL:            trainingURL,
+		PredictionURLs:         parsedPredictionURLs,
+		MaxSampleSize:          1000,
+		FlushInterval:          500 * time.Millisecond, // Shorter for testing
+		MetricsRefreshInterval: 1 * time.Second,        // Longer for metrics
+		UseNativeXGBoost:       true,
+		HTTPTimeout:            30 * time.Second, // Longer timeout for tests
+		MaxBulkSize:            50,               // Test bulk size
+	}
+
+	// Create predictor
+	predictor := New(config, logger)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		predictor.Stop(ctx) // ✅ Pass context to Stop()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Start the predictor
+	err = predictor.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start predictor: %v", err)
+	}
+
+	t.Run("TestModelInfo", func(t *testing.T) {
+		testModelInfo(t, ctx, predictor)
+	})
+
+	t.Run("TestBulkTrainingData", func(t *testing.T) {
+		testBulkTrainingData(t, predictor)
+	})
+
+	t.Run("TestPrediction", func(t *testing.T) {
+		testPrediction(t, ctx, predictor)
+	})
+
+	t.Run("TestBulkPredictions", func(t *testing.T) {
+		testBulkPredictions(t, ctx, predictor)
+	})
+
+	t.Run("TestBulkPredictionsStrict", func(t *testing.T) {
+		testBulkPredictionsStrict(t, ctx, predictor)
+	})
+
+	t.Run("TestPredictionWithPrefixCache", func(t *testing.T) {
+		testPredictionWithPrefixCache(t, ctx, predictor)
+	})
+
+	t.Run("TestHTTPFallbackPrediction", func(t *testing.T) {
+		testHTTPFallbackPrediction(t, ctx, predictor)
+	})
+
+	t.Run("TestLightGBMSupport", func(t *testing.T) {
+		testLightGBMSupport(t, ctx, predictor)
+	})
+
+	t.Run("TestPredictionPerformance", func(t *testing.T) {
+		testPredictionPerformance(t, ctx, predictor)
+	})
+
+	t.Run("TestBulkPredictionPerformance", func(t *testing.T) {
+		testBulkPredictionPerformance(t, ctx, predictor)
+	})
+
+	t.Run("TestHTTPOnlyPerformance", func(t *testing.T) {
+		testHTTPOnlyPerformance(t, ctx)
+	})
+
+	t.Run("TestXGBoostJSONStructure", func(t *testing.T) {
+		testXGBoostJSONStructure(t, ctx, predictor)
+	})
+
+	t.Run("TestHTTPOnlyPrediction", func(t *testing.T) {
+		testHTTPOnlyPrediction(t, ctx)
+	})
+
+	t.Run("TestMetricsRetrieval", func(t *testing.T) {
+		testMetricsRetrieval(t, ctx, predictor)
+	})
+
+	t.Run("TestLoadBalancing", func(t *testing.T) {
+		testLoadBalancing(t, ctx, predictor)
+	})
+
+	t.Run("TestPrefixCacheValidation", func(t *testing.T) {
+		testPrefixCacheValidation(t, predictor)
+	})
+
+	t.Run("TestPredictionConstructors", func(t *testing.T) {
+		testPredictionConstructors(t)
+	})
+}
+
+func testModelInfo(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing model info retrieval...")
+
+	modelInfo, err := predictor.GetModelInfo(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get model info: %v", err)
+	}
+
+	t.Logf("Model Info - Type: %s, ObjectiveType: %s, Model Status: %v, Quantile: %.2f",
+		modelInfo.ModelType, modelInfo.ObjectiveType, modelInfo.ModelStatus, modelInfo.Quantile)
+
+	if modelInfo.ModelType == "" {
+		t.Error("Model type should not be empty")
+	}
+
+	// Store model type for other tests
+	currentModelType := predictor.GetCurrentModelType()
+	t.Logf("Current model type from predictor: %s", currentModelType)
+
+	// Log URLs being used
+	t.Logf("Training URL: %s", predictor.GetTrainingURL())
+	t.Logf("Prediction URLs: %v", predictor.GetPredictionURLs())
+}
+
+func testBulkTrainingData(t *testing.T, predictor *Predictor) {
+	t.Log("Testing bulk training data submission with prefix cache score...")
+
+	// Generate 1000 random training entries including prefix cache scores
+	entries := generateTrainingEntries(1000)
+
+	err := predictor.AddTrainingDataBulk(entries)
+	if err != nil {
+		t.Fatalf("Failed to add bulk training data: %v", err)
+	}
+
+	t.Logf("Successfully added %d training entries to buffer (with prefix cache scores)", len(entries))
+
+	// Wait a bit for the background flush to occur
+	time.Sleep(2 * time.Second)
+
+	t.Log("Training data should have been flushed to training server")
+}
+
+func testPrediction(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing prediction functionality...")
+
+	// Log current predictor state
+	t.Logf("Predictor state:")
+	t.Logf("  Current model type: %s", predictor.GetCurrentModelType())
+	t.Logf("  Current objective type: %s", predictor.GetCurrentObjectiveType())
+	t.Logf("  Current quantile: %.2f", predictor.GetCurrentQuantile())
+	t.Logf("  Overall ready: %t", predictor.IsReady())
+	t.Logf("  XGBoost ready: %t", predictor.IsXGBoostReady())
+	t.Logf("  LightGBM ready: %t", predictor.IsLightGBMReady())
+	t.Logf("  Bayesian Ridge ready: %t", predictor.IsBayesianRidgeReady())
+
+	// Wait for models to be ready
+	maxWait := 30 * time.Second
+	waitTime := 100 * time.Millisecond
+	elapsed := time.Duration(0)
+
+	for elapsed < maxWait {
+		if predictor.IsReady() {
+			break
+		}
+		time.Sleep(waitTime)
+		elapsed += waitTime
+	}
+
+	if !predictor.IsReady() {
+		t.Log("Warning: Predictor not ready after waiting, attempting prediction anyway")
+	}
+
+	// Create a sample prediction request with prefix cache score
+	req := PredictionRequest{
+		KVCachePercentage:  0.755, // 75.5% as a fraction
+		InputTokenLength:   512,
+		NumRequestWaiting:  3,
+		NumRequestRunning:  2,
+		NumTokensGenerated: 100,
+		PrefixCacheScore:   0.8, // 80% prefix cache hit rate
+	}
+
+	t.Logf("Making prediction request: %+v", req)
+
+	response, err := predictor.Predict(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to make prediction: %v", err)
+	}
+
+	t.Logf("Prediction Response:")
+	t.Logf("  TTFT: %.2f ms (uncertainty: %.2f)", response.TTFT, response.TTFTUncertainty)
+	t.Logf("  TPOT: %.2f ms (uncertainty: %.2f)", response.TPOT, response.TPOTUncertainty)
+	t.Logf("  TTFT Bounds: [%.2f, %.2f]", response.TTFTPredictionBounds[0], response.TTFTPredictionBounds[1])
+	t.Logf("  TPOT Bounds: [%.2f, %.2f]", response.TPOTPredictionBounds[0], response.TPOTPredictionBounds[1])
+	t.Logf("  Model Type: %s", response.ModelType)
+	t.Logf("  Objective Type: %s", response.ObjectiveType)
+	t.Logf("  Quantile: %.2f", response.Quantile)
+	t.Logf("  Predicted At: %s", response.PredictedAt.Format(time.RFC3339))
+
+	// Validate response
+	if response.TTFT <= 0 {
+		t.Error("TTFT should be positive")
+	}
+	if response.TPOT <= 0 {
+		t.Error("TPOT should be positive")
+	}
+	if response.ModelType == "" {
+		t.Error("Model type should not be empty")
+	}
+	if response.Quantile <= 0 || response.Quantile >= 1 {
+		t.Errorf("Quantile should be between 0 and 1, got: %.2f", response.Quantile)
+	}
+
+	// Test multiple predictions to ensure consistency
+	t.Log("Testing multiple predictions with varying prefix cache scores...")
+	for i := range 5 {
+		testReq := PredictionRequest{
+			KVCachePercentage:  float64(50+i*10) / 100.0, // Convert percentage to fraction
+			InputTokenLength:   256 + i*128,
+			NumRequestWaiting:  i,
+			NumRequestRunning:  1 + i,
+			NumTokensGenerated: 50 + i*25,
+			PrefixCacheScore:   float64(i*20) / 100.0, // Vary prefix cache from 0% to 80%
+		}
+
+		resp, err := predictor.Predict(ctx, testReq)
+		if err != nil {
+			t.Errorf("Prediction %d failed: %v", i+1, err)
+			continue
+		}
+
+		t.Logf("Prediction %d: TTFT=%.2f, TPOT=%.2f (prefix_cache=%.1f%%, quantile=%.2f)",
+			i+1, resp.TTFT, resp.TPOT, testReq.PrefixCacheScore*100, resp.Quantile)
+	}
+}
+
+func testBulkPredictions(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing bulk predictions with error tolerance...")
+
+	if !predictor.IsReady() {
+		t.Skip("Predictor not ready for bulk prediction testing")
+	}
+
+	// Create multiple prediction requests
+	requests := make([]PredictionRequest, 10)
+	for i := range 10 {
+		requests[i] = PredictionRequest{
+			KVCachePercentage:  float64(40+i*5) / 100.0, // 40% to 85%
+			InputTokenLength:   200 + i*50,              // 200 to 650
+			NumRequestWaiting:  i % 5,                   // 0 to 4
+			NumRequestRunning:  (i % 3) + 1,             // 1 to 3
+			NumTokensGenerated: 25 + i*10,               // 25 to 115
+			PrefixCacheScore:   float64(i) / 9.0,        // 0.0 to 1.0
+		}
+	}
+
+	t.Logf("Making bulk prediction request with %d requests", len(requests))
+
+	bulkResponse, err := predictor.PredictBulk(ctx, requests)
+	if err != nil {
+		t.Fatalf("Bulk prediction failed: %v", err)
+	}
+
+	t.Logf("Bulk Prediction Response:")
+	t.Logf("  Total Requests: %d", bulkResponse.TotalRequests)
+	t.Logf("  Successful: %d", bulkResponse.SuccessfulPredictions)
+	t.Logf("  Failed: %d", bulkResponse.FailedPredictions)
+	t.Logf("  Processing Time: %.2f ms", bulkResponse.ProcessingTimeMs)
+
+	if bulkResponse.TotalRequests != len(requests) {
+		t.Errorf("Expected %d total requests, got %d", len(requests), bulkResponse.TotalRequests)
+	}
+
+	if bulkResponse.SuccessfulPredictions != len(bulkResponse.Predictions) {
+		t.Errorf("Successful count (%d) doesn't match predictions length (%d)",
+			bulkResponse.SuccessfulPredictions, len(bulkResponse.Predictions))
+	}
+
+	// Validate each prediction in the response
+	for i, prediction := range bulkResponse.Predictions {
+		if prediction.TTFT <= 0 {
+			t.Errorf("Prediction %d: TTFT should be positive, got %.2f", i, prediction.TTFT)
+		}
+		if prediction.TPOT <= 0 {
+			t.Errorf("Prediction %d: TPOT should be positive, got %.2f", i, prediction.TPOT)
+		}
+		if prediction.ModelType == "" {
+			t.Errorf("Prediction %d: Model type should not be empty", i)
+		}
+
+		t.Logf("  Prediction %d: TTFT=%.2f, TPOT=%.2f, quantile=%.2f",
+			i+1, prediction.TTFT, prediction.TPOT, prediction.Quantile)
+	}
+
+	// Test performance expectation
+	avgTimePerPrediction := bulkResponse.ProcessingTimeMs / float64(bulkResponse.SuccessfulPredictions)
+	t.Logf("Average time per prediction: %.2f ms", avgTimePerPrediction)
+
+	if avgTimePerPrediction > 100 { // Bulk should be more efficient
+		t.Logf("Note: Bulk prediction averaging %.2f ms per request (may be acceptable)", avgTimePerPrediction)
+	} else {
+		t.Logf("✓ Good bulk prediction performance: %.2f ms per request", avgTimePerPrediction)
+	}
+}
+
+func testBulkPredictionsStrict(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing strict bulk predictions...")
+
+	if !predictor.IsReady() {
+		t.Skip("Predictor not ready for strict bulk prediction testing")
+	}
+
+	// Create valid prediction requests
+	requests := make([]PredictionRequest, 5)
+	for i := range 5 {
+		requests[i] = PredictionRequest{
+			KVCachePercentage:  0.6,
+			InputTokenLength:   300 + i*100,
+			NumRequestWaiting:  i,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 50,
+			PrefixCacheScore:   float64(i) / 4.0, // 0.0 to 1.0
+		}
+	}
+
+	t.Logf("Making strict bulk prediction request with %d requests", len(requests))
+
+	bulkResponse, err := predictor.PredictBulkStrict(ctx, requests)
+	if err != nil {
+		t.Fatalf("Strict bulk prediction failed: %v", err)
+	}
+
+	t.Logf("Strict Bulk Prediction Response:")
+	t.Logf("  Total Requests: %d", bulkResponse.TotalRequests)
+	t.Logf("  Successful: %d", bulkResponse.SuccessfulPredictions)
+	t.Logf("  Failed: %d", bulkResponse.FailedPredictions)
+	t.Logf("  Processing Time: %.2f ms", bulkResponse.ProcessingTimeMs)
+
+	// In strict mode, we expect all requests to succeed or the entire batch to fail
+	if bulkResponse.FailedPredictions > 0 {
+		t.Errorf("Strict bulk prediction should not have partial failures, got %d failed",
+			bulkResponse.FailedPredictions)
+	}
+
+	if bulkResponse.SuccessfulPredictions != len(requests) {
+		t.Errorf("Expected all %d requests to succeed, got %d",
+			len(requests), bulkResponse.SuccessfulPredictions)
+	}
+
+	// Test bulk size limits
+	t.Log("Testing bulk size limits...")
+	largeRequests := make([]PredictionRequest, 150) // Over the limit
+	for i := range largeRequests {
+		largeRequests[i] = requests[0] // Use a valid request template
+	}
+
+	_, err = predictor.PredictBulkStrict(ctx, largeRequests)
+	if err == nil {
+		t.Error("Expected error for oversized bulk request, but got none")
+	} else {
+		t.Logf("✓ Correctly rejected oversized bulk request: %v", err)
+	}
+}
+
+func testLightGBMSupport(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing LightGBM support...")
+
+	currentModelType := predictor.GetCurrentModelType()
+	t.Logf("Current model type: %s", currentModelType)
+
+	if currentModelType == gbmModelType {
+		t.Log("Testing LightGBM-specific functionality...")
+
+		// Test LightGBM readiness
+		isReady := predictor.IsLightGBMReady()
+		t.Logf("LightGBM ready: %t", isReady)
+
+		if isReady {
+			// Test LightGBM prediction
+			req := PredictionRequest{
+				KVCachePercentage:  0.7,
+				InputTokenLength:   400,
+				NumRequestWaiting:  2,
+				NumRequestRunning:  1,
+				NumTokensGenerated: 60,
+				PrefixCacheScore:   0.8,
+			}
+
+			response, err := predictor.Predict(ctx, req)
+			if err != nil {
+				t.Errorf("LightGBM prediction failed: %v", err)
+			} else {
+				t.Logf("LightGBM prediction successful: TTFT=%.2f, TPOT=%.2f",
+					response.TTFT, response.TPOT)
+
+				if response.ModelType != gbmModelType {
+					t.Errorf("Expected model type 'lightgbm', got '%s'", response.ModelType)
+				}
+			}
+		} else {
+			t.Log("LightGBM not ready, skipping LightGBM-specific tests")
+		}
+	} else {
+		t.Logf("Current model type is %s, not LightGBM. LightGBM-specific tests skipped.", currentModelType)
+	}
+
+	// Test that the client handles all model types properly
+	t.Log("Verifying model type handling...")
+	switch currentModelType {
+	case bayesianRidgeModelType:
+		t.Log("✓ Bayesian Ridge model type recognized")
+	case xgBoostModelType:
+		t.Log("✓ XGBoost model type recognized")
+	case gbmModelType:
+		t.Log("✓ LightGBM model type recognized")
+	default:
+		t.Logf("⚠ Unknown model type: %s", currentModelType)
+	}
+}
+
+func testPredictionWithPrefixCache(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing prefix cache score impact on predictions...")
+
+	if !predictor.IsReady() {
+		t.Skip("Predictor not ready for prefix cache testing")
+	}
+
+	// Test with different prefix cache scores to see impact
+	baseRequest := PredictionRequest{
+		KVCachePercentage:  0.6,
+		InputTokenLength:   500,
+		NumRequestWaiting:  3,
+		NumRequestRunning:  2,
+		NumTokensGenerated: 75,
+	}
+
+	prefixCacheScores := []float64{0.0, 0.2, 0.4, 0.6, 0.8, 1.0}
+	ttftResults := make([]float64, 0, len(prefixCacheScores))
+	quantileResults := make([]float64, 0, len(prefixCacheScores))
+
+	for _, prefixScore := range prefixCacheScores {
+		req := baseRequest
+		req.PrefixCacheScore = prefixScore
+
+		response, err := predictor.Predict(ctx, req)
+		if err != nil {
+			t.Errorf("Prediction failed for prefix cache score %.1f: %v", prefixScore, err)
+			continue
+		}
+
+		ttftResults = append(ttftResults, response.TTFT)
+		quantileResults = append(quantileResults, response.Quantile)
+		t.Logf("Prefix cache %.0f%%: TTFT=%.2f ms, TPOT=%.2f ms, quantile=%.2f",
+			prefixScore*100, response.TTFT, response.TPOT, response.Quantile)
+	}
+
+	// Verify quantile consistency
+	if len(quantileResults) > 1 {
+		firstQuantile := quantileResults[0]
+		for i, q := range quantileResults {
+			if abs(q-firstQuantile) > 0.01 {
+				t.Errorf("Quantile inconsistency: prediction %d has quantile %.2f, expected %.2f",
+					i, q, firstQuantile)
+			}
+		}
+		t.Log("✓ Quantile values consistent across predictions")
+	}
+
+	// Analyze the relationship between prefix cache and TTFT
+	if len(ttftResults) >= 2 {
+		t.Log("Prefix cache impact analysis:")
+		lowCacheTTFT := ttftResults[0]                   // 0% prefix cache
+		highCacheTTFT := ttftResults[len(ttftResults)-1] // 100% prefix cache
+		difference := highCacheTTFT - lowCacheTTFT
+
+		t.Logf("  TTFT at 0%% prefix cache: %.2f ms", lowCacheTTFT)
+		t.Logf("  TTFT at 100%% prefix cache: %.2f ms", highCacheTTFT)
+		t.Logf("  Difference: %.2f ms", difference)
+
+		if predictor.GetCurrentModelType() == bayesianRidgeModelType {
+			// For Bayesian Ridge, we expect to see the linear relationship
+			if difference > 5 {
+				t.Logf("✓ Detected prefix cache impact: %.2f ms difference", difference)
+			} else {
+				t.Logf("ℹ Small prefix cache impact: %.2f ms difference", difference)
+			}
+		}
+	}
+}
+
+func testHTTPFallbackPrediction(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing HTTP fallback prediction...")
+
+	modelType := predictor.GetCurrentModelType()
+	if modelType == bayesianRidgeModelType {
+		t.Skip("HTTP fallback test not applicable for Bayesian Ridge")
+	}
+
+	// Test prediction with HTTP fallback including prefix cache score
+	req := PredictionRequest{
+		KVCachePercentage:  0.8, // 80% as a fraction
+		InputTokenLength:   1024,
+		NumRequestWaiting:  5,
+		NumRequestRunning:  3,
+		NumTokensGenerated: 150,
+		PrefixCacheScore:   0.9, // 90% prefix cache hit rate
+	}
+
+	t.Logf("Making HTTP prediction request: %+v", req)
+
+	response, err := predictor.Predict(ctx, req)
+	if err != nil {
+		t.Fatalf("HTTP prediction failed: %v", err)
+	}
+
+	t.Logf("HTTP Prediction Response:")
+	t.Logf("  TTFT: %.2f ms", response.TTFT)
+	t.Logf("  TPOT: %.2f ms", response.TPOT)
+	t.Logf("  Model Type: %s", response.ModelType)
+	t.Logf("  Quantile: %.2f", response.Quantile)
+	t.Logf("  Prefix Cache Score Used: %.1f%%", req.PrefixCacheScore*100)
+
+	// Validate that we got a reasonable response
+	if response.TTFT <= 0 {
+		t.Error("TTFT should be positive")
+	}
+	if response.TPOT <= 0 {
+		t.Error("TPOT should be positive")
+	}
+
+	// The model type should indicate the correct type
+	if response.ModelType == "" {
+		t.Error("Model type should not be empty")
+	}
+
+	t.Logf("Successfully tested HTTP prediction with prefix cache")
+}
+
+func testPredictionPerformance(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing prediction performance (target: < 300ms) with prefix cache scores...")
+
+	// Ensure predictor is ready
+	if !predictor.IsReady() {
+		t.Skip("Predictor not ready for performance test")
+	}
+
+	req := PredictionRequest{
+		KVCachePercentage:  0.6, // 60% as a fraction
+		InputTokenLength:   768,
+		NumRequestWaiting:  2,
+		NumRequestRunning:  1,
+		NumTokensGenerated: 80,
+		PrefixCacheScore:   0.7, // 70% prefix cache hit rate
+	}
+
+	// Warm up with a few predictions
+	for i := range 3 {
+		_, err := predictor.Predict(ctx, req)
+		if err != nil {
+			t.Fatalf("Warmup prediction %d failed: %v", i+1, err)
+		}
+	}
+
+	// Test multiple predictions and measure time
+	const numTests = 10
+	const avgDurationMs = 250
+
+	var totalDuration time.Duration
+	var maxSingleDuration time.Duration
+	var minSingleDuration = time.Hour // Initialize to large value
+
+	t.Logf("Running %d prediction performance tests...", numTests)
+
+	for i := range numTests {
+		// Vary prefix cache score for each test
+		testReq := req
+		testReq.PrefixCacheScore = float64(i) / float64(numTests-1) // 0.0 to 1.0
+
+		start := time.Now()
+
+		response, err := predictor.Predict(ctx, testReq)
+
+		duration := time.Since(start)
+		totalDuration += duration
+
+		if err != nil {
+			t.Errorf("Prediction %d failed: %v", i+1, err)
+			continue
+		}
+
+		// Track min/max durations
+		if duration > maxSingleDuration {
+			maxSingleDuration = duration
+		}
+		if duration < minSingleDuration {
+			minSingleDuration = duration
+		}
+
+		durationMs := float64(duration.Nanoseconds()) / 1e6
+		t.Logf("Prediction %d: %.2fms - TTFT: %.1fms, TPOT: %.1fms (prefix: %.0f%%, quantile: %.2f)",
+			i+1, durationMs, response.TTFT, response.TPOT, testReq.PrefixCacheScore*100, response.Quantile)
+	}
+
+	// Calculate statistics
+	avgDuration := totalDuration / numTests
+	avgMs := float64(avgDuration.Nanoseconds()) / 1e6
+	maxMs := float64(maxSingleDuration.Nanoseconds()) / 1e6
+	minMs := float64(minSingleDuration.Nanoseconds()) / 1e6
+
+	t.Logf("Performance Results:")
+	t.Logf("  Average: %.2fms", avgMs)
+	t.Logf("  Minimum: %.2fms", minMs)
+	t.Logf("  Maximum: %.2fms", maxMs)
+	t.Logf("  Target:  < %dms", avgDurationMs)
+
+	// Overall performance check
+	if avgMs > avgDurationMs {
+		t.Errorf("Average prediction time %.2fms exceeded target of %dms", avgMs, avgDurationMs)
+	} else {
+		t.Logf("✅ Performance target met: avg %.2fms < %dms", avgMs, avgDurationMs)
+	}
+
+	// Check for consistency (max shouldn't be too much higher than average)
+	if maxMs > avgMs*3 {
+		t.Logf("⚠️  High variance detected: max %.2fms is %.1fx the average", maxMs, maxMs/avgMs)
+	} else {
+		t.Logf("✅ Good consistency: max %.2fms is %.1fx the average", maxMs, maxMs/avgMs)
+	}
+}
+
+func testBulkPredictionPerformance(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing bulk prediction performance...")
+
+	if !predictor.IsReady() {
+		t.Skip("Predictor not ready for bulk performance test")
+	}
+
+	// Create batch of prediction requests
+	const batchSize = 20
+	requests := make([]PredictionRequest, batchSize)
+	for i := range batchSize {
+		requests[i] = PredictionRequest{
+			KVCachePercentage:  0.6 + float64(i%5)*0.05,           // Vary between 0.6 and 0.8
+			InputTokenLength:   300 + i*10,                        // Vary input length
+			NumRequestWaiting:  i % 4,                             // 0 to 3
+			NumRequestRunning:  (i % 2) + 1,                       // 1 to 2
+			NumTokensGenerated: 50 + i*2,                          // Vary generated tokens
+			PrefixCacheScore:   float64(i) / float64(batchSize-1), // 0.0 to 1.0
+		}
+	}
+
+	// Warm up
+	warmupRequests := requests[:3]
+	_, err := predictor.PredictBulk(ctx, warmupRequests)
+	if err != nil {
+		t.Fatalf("Warmup bulk prediction failed: %v", err)
+	}
+
+	// Performance test
+	const numTests = 5
+	var totalDuration time.Duration
+	var totalRequests int
+	var totalSuccessful int
+
+	t.Logf("Running %d bulk prediction performance tests with %d requests each...", numTests, batchSize)
+
+	for i := range numTests {
+		start := time.Now()
+
+		response, err := predictor.PredictBulk(ctx, requests)
+
+		duration := time.Since(start)
+		totalDuration += duration
+
+		if err != nil {
+			t.Errorf("Bulk prediction %d failed: %v", i+1, err)
+			continue
+		}
+
+		totalRequests += response.TotalRequests
+		totalSuccessful += response.SuccessfulPredictions
+
+		durationMs := float64(duration.Nanoseconds()) / 1e6
+		avgPerRequest := durationMs / float64(response.SuccessfulPredictions)
+
+		t.Logf("Bulk test %d: %.2fms total, %.2fms per request (%d/%d successful)",
+			i+1, durationMs, avgPerRequest, response.SuccessfulPredictions, response.TotalRequests)
+	}
+
+	// Calculate bulk performance statistics
+	avgTotalDuration := totalDuration / numTests
+	avgTotalMs := float64(avgTotalDuration.Nanoseconds()) / 1e6
+	avgPerRequest := avgTotalMs / float64(batchSize)
+
+	t.Logf("Bulk Performance Results:")
+	t.Logf("  Average total time: %.2fms", avgTotalMs)
+	t.Logf("  Average per request: %.2fms", avgPerRequest)
+	t.Logf("  Success rate: %.1f%%", float64(totalSuccessful)/float64(totalRequests)*100)
+
+	// Compare with single prediction performance target
+	singlePredictionTarget := 250.0                         // ms
+	bulkEfficiencyThreshold := singlePredictionTarget * 0.7 // Bulk should be more efficient
+
+	switch {
+	case avgPerRequest <= bulkEfficiencyThreshold:
+		t.Logf("✅ Bulk predictions are efficient: %.2fms per request < %.2fms threshold",
+			avgPerRequest, bulkEfficiencyThreshold)
+	case avgPerRequest <= singlePredictionTarget:
+		t.Logf("✓ Bulk predictions acceptable: %.2fms per request < %.2fms single target",
+			avgPerRequest, singlePredictionTarget)
+	default:
+		t.Errorf("❌ Bulk predictions slow: %.2fms per request > %.2fms target",
+			avgPerRequest, singlePredictionTarget)
+	}
+}
+
+func testHTTPOnlyPerformance(t *testing.T, ctx context.Context) {
+	t.Log("Testing HTTP-only prediction performance (no native XGBoost interference) with prefix cache...")
+
+	predictionURLs := os.Getenv("PREDICTION_SERVER_URL")
+	trainingURL := os.Getenv("TRAINING_SERVER_URL")
+	if predictionURLs == "" {
+		t.Skip("PREDICTION_SERVER_URL not set")
+	}
+	if trainingURL == "" {
+		// Use first prediction URL as fallback
+		urls := strings.Split(predictionURLs, ",")
+		if len(urls) > 0 {
+			trainingURL = strings.TrimSpace(urls[0])
+		} else {
+			t.Skip("No valid URLs available for testing")
+		}
+	}
+
+	// Parse prediction URLs
+	urls := strings.Split(predictionURLs, ",")
+	parsedPredictionURLs := make([]string, 0, len(urls))
+	for _, url := range urls {
+		parsedPredictionURLs = append(parsedPredictionURLs, strings.TrimSpace(url))
+	}
+
+	// Create a dedicated HTTP-only predictor for clean performance testing
+	zapLog, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+	logger := zapr.NewLogger(zapLog)
+
+	httpOnlyConfig := &Config{
+		TrainingURL:            trainingURL,
+		PredictionURLs:         parsedPredictionURLs,
+		MaxSampleSize:          1000,
+		FlushInterval:          1 * time.Second, // Long interval to avoid interference
+		MetricsRefreshInterval: 1 * time.Second, // Longer for metrics
+		UseNativeXGBoost:       false,           // Force HTTP-only
+		HTTPTimeout:            5 * time.Second, // Reasonable timeout
+		MaxBulkSize:            50,
+	}
+
+	httpPredictor := New(httpOnlyConfig, logger)
+	defer func() {
+		// ✅ Pass context to Stop()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		httpPredictor.Stop(stopCtx)
+	}()
+
+	err = httpPredictor.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start HTTP-only predictor: %v", err)
+	}
+
+	// Wait for readiness
+	time.Sleep(1 * time.Second)
+
+	// Wait for coefficients to be cached
+	maxWaitTime := 10 * time.Second
+	waitInterval := 200 * time.Millisecond
+	elapsed := time.Duration(0)
+
+	for elapsed < maxWaitTime {
+		if httpPredictor.IsReady() {
+			break
+		}
+		time.Sleep(waitInterval)
+		elapsed += waitInterval
+	}
+
+	if !httpPredictor.IsReady() {
+		t.Skip("model not ready yet")
+	}
+
+	req := PredictionRequest{
+		KVCachePercentage:  0.65,
+		InputTokenLength:   512,
+		NumRequestWaiting:  1,
+		NumRequestRunning:  2,
+		NumTokensGenerated: 100,
+		PrefixCacheScore:   0.75, // 75% prefix cache hit rate
+	}
+
+	// Warm up
+	for i := range 2 {
+		_, err := httpPredictor.Predict(ctx, req)
+		if err != nil {
+			t.Fatalf("HTTP warmup prediction %d failed: %v", i+1, err)
+		}
+	}
+
+	// Performance test
+	const numTests = 15
+	const targetMs = 250
+
+	var durations []time.Duration
+	var successful int
+
+	t.Logf("Running %d HTTP-only prediction tests...", numTests)
+
+	for i := range numTests {
+		// Vary prefix cache for each test
+		testReq := req
+		testReq.PrefixCacheScore = 0.5 + (float64(i)/float64(numTests-1))*0.5 // 0.5 to 1.0
+
+		start := time.Now()
+
+		response, err := httpPredictor.Predict(ctx, testReq)
+
+		duration := time.Since(start)
+		durations = append(durations, duration)
+
+		if err != nil {
+			t.Errorf("HTTP prediction %d failed: %v", i+1, err)
+			continue
+		}
+
+		successful++
+		durationMs := float64(duration.Nanoseconds()) / 1e6
+
+		status := "✅"
+
+		t.Logf("%s Test %d: %.1fms (TTFT: %.0fms, TPOT: %.0fms, prefix: %.0f%%, quantile: %.2f)",
+			status, i+1, durationMs, response.TTFT, response.TPOT, testReq.PrefixCacheScore*100, response.Quantile)
+	}
+
+	// Calculate statistics
+	if len(durations) == 0 {
+		t.Fatal("No successful predictions to analyze")
+	}
+
+	var total time.Duration
+	min := durations[0]
+	max := durations[0]
+
+	for _, d := range durations {
+		total += d
+		if d < min {
+			min = d
+		}
+		if d > max {
+			max = d
+		}
+	}
+
+	avg := total / time.Duration(len(durations))
+	avgMs := float64(avg.Nanoseconds()) / 1e6
+	minMs := float64(min.Nanoseconds()) / 1e6
+	maxMs := float64(max.Nanoseconds()) / 1e6
+
+	// Count fast predictions
+	fastCount := 0
+	for _, d := range durations {
+		if float64(d.Nanoseconds())/1e6 <= targetMs {
+			fastCount++
+		}
+	}
+
+	t.Logf("\n📊 HTTP-Only Performance Summary:")
+	t.Logf("  Success Rate: %d/%d (%.1f%%)", successful, numTests, float64(successful)/float64(numTests)*100)
+	t.Logf("  Average: %.1fms", avgMs)
+	t.Logf("  Minimum: %.1fms", minMs)
+	t.Logf("  Maximum: %.1fms", maxMs)
+	t.Logf("  Under %dms: %d/%d (%.1f%%)", targetMs, fastCount, len(durations), float64(fastCount)/float64(len(durations))*100)
+
+	// Performance assertions
+	if successful < numTests {
+		t.Errorf("Some predictions failed: %d/%d successful", successful, numTests)
+	}
+
+	if avgMs <= targetMs {
+		t.Logf("✅ PASS: Average response time %.1fms ≤ %dms target", avgMs, targetMs)
+	} else {
+		t.Errorf("❌ FAIL: Average response time %.1fms > %dms target", avgMs, targetMs)
+	}
+
+	// Check that at least 80% of requests are under target
+	fastPercentage := float64(fastCount) / float64(len(durations)) * 100
+	if fastPercentage >= 80 {
+		t.Logf("✅ PASS: %.1f%% of requests under %dms (≥80%% target)", fastPercentage, targetMs)
+	} else {
+		t.Errorf("❌ FAIL: Only %.1f%% of requests under %dms (<80%% target)", fastPercentage, targetMs)
+	}
+}
+
+func testHTTPOnlyPrediction(t *testing.T, ctx context.Context) {
+	t.Log("Testing HTTP-only prediction (bypassing native XGBoost) with prefix cache...")
+
+	// Create a predictor with native XGBoost disabled to force HTTP usage
+	predictionURLs := os.Getenv("PREDICTION_SERVER_URL")
+	trainingURL := os.Getenv("TRAINING_SERVER_URL")
+	if predictionURLs == "" {
+		t.Skip("PREDICTION_SERVER_URL not set")
+	}
+	if trainingURL == "" {
+		// Use first prediction URL as fallback
+		urls := strings.Split(predictionURLs, ",")
+		if len(urls) > 0 {
+			trainingURL = strings.TrimSpace(urls[0])
+		} else {
+			t.Skip("No valid URLs available for testing")
+		}
+	}
+
+	// Parse prediction URLs
+	urls := strings.Split(predictionURLs, ",")
+	parsedPredictionURLs := make([]string, 0, len(urls))
+	for _, url := range urls {
+		parsedPredictionURLs = append(parsedPredictionURLs, strings.TrimSpace(url))
+	}
+
+	zapLog, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+	logger := zapr.NewLogger(zapLog)
+
+	httpOnlyConfig := &Config{
+		TrainingURL:            trainingURL,
+		PredictionURLs:         parsedPredictionURLs,
+		MaxSampleSize:          1000,
+		FlushInterval:          1 * time.Second,
+		MetricsRefreshInterval: 1 * time.Second, // Longer for metrics
+		UseNativeXGBoost:       false,           // Force HTTP fallback
+		HTTPTimeout:            30 * time.Second,
+		MaxBulkSize:            25,
+	}
+
+	httpPredictor := New(httpOnlyConfig, logger)
+	defer func() {
+		// ✅ Pass context to Stop()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		httpPredictor.Stop(stopCtx)
+	}()
+
+	err = httpPredictor.Start(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start HTTP-only predictor: %v", err)
+	}
+
+	// Wait a moment for startup and coefficient caching
+	time.Sleep(3 * time.Second)
+
+	// Ensure coefficients are ready
+	maxWait := 10 * time.Second
+	waited := time.Duration(0)
+	for waited < maxWait {
+		if httpPredictor.IsReady() {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+		waited += 500 * time.Millisecond
+	}
+
+	if !httpPredictor.IsReady() {
+		t.Skip("Model not ready yet")
+	}
+
+	// Test prediction using HTTP only with prefix cache
+	req := PredictionRequest{
+		KVCachePercentage:  0.6, // 60% as a fraction
+		InputTokenLength:   256,
+		NumRequestWaiting:  1,
+		NumRequestRunning:  2,
+		NumTokensGenerated: 75,
+		PrefixCacheScore:   0.85, // 85% prefix cache hit rate
+	}
+
+	t.Logf("Making HTTP-only prediction request: %+v", req)
+
+	response, err := httpPredictor.Predict(ctx, req)
+	if err != nil {
+		t.Fatalf("HTTP-only prediction failed: %v", err)
+	}
+
+	t.Logf("HTTP-Only Prediction Response:")
+	t.Logf("  TTFT: %.2f ms", response.TTFT)
+	t.Logf("  TPOT: %.2f ms", response.TPOT)
+	t.Logf("  Model Type: %s", response.ModelType)
+	t.Logf("  Quantile: %.2f", response.Quantile)
+	t.Logf("  TTFT Uncertainty: %.2f", response.TTFTUncertainty)
+	t.Logf("  TPOT Uncertainty: %.2f", response.TPOTUncertainty)
+	t.Logf("  Prefix Cache Score Used: %.1f%%", req.PrefixCacheScore*100)
+
+	// Validate response
+	if response.TTFT <= 0 {
+		t.Error("TTFT should be positive")
+	}
+	if response.TPOT <= 0 {
+		t.Error("TPOT should be positive")
+	}
+
+	// Test multiple HTTP-only predictions with varying prefix cache
+	t.Log("Testing multiple HTTP-only predictions with different prefix cache scores...")
+	for i := range 3 {
+		testReq := PredictionRequest{
+			KVCachePercentage:  float64(30+i*20) / 100.0,
+			InputTokenLength:   128 + i*256,
+			NumRequestWaiting:  i,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 25 + i*50,
+			PrefixCacheScore:   float64(60+i*20) / 100.0, // 60%, 80%, 100%
+		}
+
+		resp, err := httpPredictor.Predict(ctx, testReq)
+		if err != nil {
+			t.Errorf("HTTP-only prediction %d failed: %v", i+1, err)
+			continue
+		}
+
+		t.Logf("HTTP-only prediction %d: TTFT=%.2f, TPOT=%.2f (prefix: %.0f%%, quantile: %.2f)",
+			i+1, resp.TTFT, resp.TPOT, testReq.PrefixCacheScore*100, resp.Quantile)
+	}
+
+	t.Log("Successfully tested HTTP-only predictions with prefix cache")
+}
+
+func testLoadBalancing(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing load balancing across multiple prediction URLs with prefix cache...")
+
+	predictionURLs := predictor.GetPredictionURLs()
+	if len(predictionURLs) <= 1 {
+		t.Skip("Need multiple prediction URLs to test load balancing")
+	}
+
+	t.Logf("Testing load balancing across %d prediction URLs: %v", len(predictionURLs), predictionURLs)
+
+	// Make multiple predictions to test load balancing
+	const numPredictions = 20
+	req := PredictionRequest{
+		KVCachePercentage:  0.7,
+		InputTokenLength:   512,
+		NumRequestWaiting:  2,
+		NumRequestRunning:  1,
+		NumTokensGenerated: 100,
+		PrefixCacheScore:   0.8, // 80% prefix cache hit rate
+	}
+
+	successfulPredictions := 0
+	for i := range numPredictions {
+		// Vary prefix cache score across requests
+		testReq := req
+		testReq.PrefixCacheScore = 0.5 + (float64(i)/float64(numPredictions-1))*0.5 // 0.5 to 1.0
+
+		response, err := predictor.Predict(ctx, testReq)
+		if err != nil {
+			t.Logf("Prediction %d failed: %v", i+1, err)
+			continue
+		}
+
+		successfulPredictions++
+		t.Logf("Prediction %d: TTFT=%.2f, TPOT=%.2f (prefix: %.0f%%, quantile: %.2f)",
+			i+1, response.TTFT, response.TPOT, testReq.PrefixCacheScore*100, response.Quantile)
+	}
+
+	successRate := float64(successfulPredictions) / float64(numPredictions) * 100
+	t.Logf("Load balancing test results: %d/%d successful (%.1f%%)", successfulPredictions, numPredictions, successRate)
+
+	if successRate < 80 {
+		t.Errorf("Low success rate in load balancing test: %.1f%% < 80%%", successRate)
+	} else {
+		t.Logf("✅ Load balancing test successful with %.1f%% success rate", successRate)
+	}
+}
+
+func testPrefixCacheValidation(t *testing.T, predictor *Predictor) {
+	t.Log("Testing prefix cache score validation...")
+
+	// Test valid prefix cache scores
+	validScores := []float64{0.0, 0.25, 0.5, 0.75, 1.0}
+	for _, score := range validScores {
+		req := PredictionRequest{
+			KVCachePercentage:  0.5,
+			InputTokenLength:   100,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 10,
+			PrefixCacheScore:   score,
+		}
+
+		err := predictor.ValidatePredictionRequest(req)
+		if err != nil {
+			t.Errorf("Valid prefix cache score %.2f should not cause validation error: %v", score, err)
+		}
+	}
+
+	// Test invalid prefix cache scores
+	invalidScores := []float64{-0.1, -1.0, 1.1, 2.0}
+	for _, score := range invalidScores {
+		req := PredictionRequest{
+			KVCachePercentage:  0.5,
+			InputTokenLength:   100,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 10,
+			PrefixCacheScore:   score,
+		}
+
+		err := predictor.ValidatePredictionRequest(req)
+		if err == nil {
+			t.Errorf("Invalid prefix cache score %.2f should cause validation error", score)
+		} else {
+			t.Logf("✓ Invalid prefix cache score %.2f correctly rejected: %v", score, err)
+		}
+	}
+
+	// Test training entry validation
+	validEntry := TrainingEntry{
+		KVCachePercentage:  0.6,
+		InputTokenLength:   200,
+		NumRequestWaiting:  2,
+		NumRequestRunning:  1,
+		NumTokensGenerated: 20,
+		ActualTTFT:         50.0,
+		ActualTPOT:         15.0,
+		PrefixCacheScore:   0.8,
+		Timestamp:          time.Now(),
+	}
+
+	err := predictor.ValidateTrainingEntry(validEntry)
+	if err != nil {
+		t.Errorf("Valid training entry should not cause validation error: %v", err)
+	}
+
+	// Test invalid training entry
+	invalidEntry := validEntry
+	invalidEntry.PrefixCacheScore = 1.5 // Invalid
+
+	err = predictor.ValidateTrainingEntry(invalidEntry)
+	if err == nil {
+		t.Error("Invalid training entry should cause validation error")
+	} else {
+		t.Logf("✓ Invalid training entry correctly rejected: %v", err)
+	}
+
+	t.Log("✅ Prefix cache validation tests completed")
+}
+
+func testPredictionConstructors(t *testing.T) {
+	t.Log("Testing prediction and training entry constructors with prefix cache...")
+
+	// Test valid prediction request constructor
+	req, err := NewPredictionRequest(
+		0.7,  // kv_cache_percentage
+		500,  // input_token_length
+		3,    // num_request_waiting
+		2,    // num_request_running
+		100,  // num_tokens_generated
+		0.85, // prefix_cache_score
+	)
+	if err != nil {
+		t.Errorf("Valid prediction request constructor failed: %v", err)
+	} else {
+		t.Logf("✓ Created prediction request: TTFT features with %.0f%% prefix cache", req.PrefixCacheScore*100)
+	}
+
+	// Test invalid prediction request constructor
+	_, err = NewPredictionRequest(
+		0.7, // kv_cache_percentage
+		500, // input_token_length
+		3,   // num_request_waiting
+		2,   // num_request_running
+		100, // num_tokens_generated
+		1.5, // prefix_cache_score (invalid)
+	)
+	if err == nil {
+		t.Error("Invalid prediction request constructor should have failed")
+	} else {
+		t.Logf("✓ Invalid prediction request correctly rejected: %v", err)
+	}
+
+	// Test valid training entry constructor
+	entry, err := NewTrainingEntry(
+		0.6,  // kv_cache_percentage
+		300,  // input_token_length
+		2,    // num_request_waiting
+		1,    // num_request_running
+		50,   // num_tokens_generated
+		45.5, // actual_ttft_ms
+		12.3, // actual_tpot_ms
+		0.75, // prefix_cache_score
+	)
+	if err != nil {
+		t.Errorf("Valid training entry constructor failed: %v", err)
+	} else {
+		t.Logf("✓ Created training entry: TTFT=%.1fms, TPOT=%.1fms, prefix cache=%.0f%%",
+			entry.ActualTTFT, entry.ActualTPOT, entry.PrefixCacheScore*100)
+	}
+
+	// Test invalid training entry constructor
+	_, err = NewTrainingEntry(
+		0.6,  // kv_cache_percentage
+		300,  // input_token_length
+		2,    // num_request_waiting
+		1,    // num_request_running
+		50,   // num_tokens_generated
+		45.5, // actual_ttft_ms
+		12.3, // actual_tpot_ms
+		-0.1, // prefix_cache_score (invalid)
+	)
+	if err == nil {
+		t.Error("Invalid training entry constructor should have failed")
+	} else {
+		t.Logf("✓ Invalid training entry correctly rejected: %v", err)
+	}
+
+	t.Log("✅ Constructor validation tests completed")
+}
+
+func testXGBoostJSONStructure(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing XGBoost JSON structure from server...")
+
+	if predictor.GetCurrentModelType() != xgBoostModelType {
+		t.Skip("This test is specific to XGBoost model type")
+	}
+
+	// Get raw trees to examine structure
+	trees, err := predictor.GetXGBoostTrees(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get XGBoost trees: %v", err)
+	}
+
+	if len(trees.TTFTTrees) == 0 {
+		t.Fatal("No TTFT trees available")
+	}
+
+	// Examine the first tree structure
+	firstTree := trees.TTFTTrees[0]
+	t.Logf("First TTFT tree structure: %T", firstTree)
+
+	// Convert to map to examine fields
+	if treeMap, ok := firstTree.(map[string]any); ok {
+		t.Log("First tree fields:")
+		for key, value := range treeMap {
+			switch key {
+			case "split":
+				t.Logf("  %s: %T = %v", key, value, value)
+			case "children":
+				if value != nil {
+					if children, ok := value.([]any); ok {
+						// This is the unique execution path for valid children
+						t.Logf("  %s: []interface{} with %d children", key, len(children))
+						// Examine first child
+						if len(children) > 0 {
+							if childMap, ok := children[0].(map[string]any); ok {
+								for childKey, childValue := range childMap {
+									if childKey == "split" {
+										t.Logf("    child[0].%s: %T = %v", childKey, childValue, childValue)
+									}
+								}
+							}
+						}
+					} else {
+						// Fallback if type assertion fails
+						t.Logf("  %s: %T = %v", key, value, value)
+					}
+				} else {
+					// Fallback if value is nil
+					t.Logf("  %s: %T = %v", key, value, value)
+				}
+			default:
+				t.Logf("  %s: %T = %v", key, value, value)
+			}
+		}
+	}
+
+	// Try to understand why the conversion is failing
+	t.Log("Analyzing conversion issue...")
+	if len(trees.TTFTTrees) > 0 {
+		// Test the conversion function manually
+		testConvertXGBoostJSON(t, trees.TTFTTrees[0])
+	}
+
+	t.Log("XGBoost JSON structure analysis complete")
+}
+
+// Helper function to test the conversion logic
+func testConvertXGBoostJSON(t *testing.T, tree any) {
+	featureMap := map[string]int{
+		"kv_cache_percentage":  0,
+		"input_token_length":   1,
+		"num_request_waiting":  2,
+		"num_request_running":  3,
+		"num_tokens_generated": 4,
+		"prefix_cache_score":   5, // Added prefix cache score mapping
+	}
+
+	t.Log("Testing XGBoost JSON conversion...")
+
+	treeMap, ok := tree.(map[string]any)
+	if !ok {
+		t.Log("Tree is not a map[string]interface{}")
+		return
+	}
+
+	// Check if split field exists and what type it is
+	if split, exists := treeMap["split"]; exists {
+		t.Logf("Split field exists: %T = %v", split, split)
+
+		switch splitVal := split.(type) {
+		case string:
+			t.Logf("Split is string: '%s'", splitVal)
+			if featureIdx, found := featureMap[splitVal]; found {
+				t.Logf("Found feature index for '%s': %d", splitVal, featureIdx)
+			} else {
+				t.Logf("Feature '%s' not found in feature map", splitVal)
+			}
+		case float64:
+			t.Logf("Split is float64: %v (already numeric, no conversion needed)", splitVal)
+		case int:
+			t.Logf("Split is int: %v (already numeric, no conversion needed)", splitVal)
+		default:
+			t.Logf("Split is unexpected type: %T = %v", splitVal, splitVal)
+		}
+	} else {
+		t.Log("Split field does not exist")
+	}
+}
+
+func testMetricsRetrieval(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing metrics retrieval...")
+
+	modelType := predictor.GetCurrentModelType()
+	quantile := predictor.GetCurrentQuantile()
+	t.Logf("Testing metrics for model type: %s, quantile: %.2f", modelType, quantile)
+
+	switch modelType {
+	case bayesianRidgeModelType:
+		testBayesianRidgeMetrics(t, ctx, predictor)
+	case xgBoostModelType:
+		testXGBoostMetrics(t, ctx, predictor)
+	case gbmModelType:
+		testLightGBMMetrics(t, ctx, predictor)
+	default:
+		t.Logf("Unknown model type %s, testing cached metrics only", modelType)
+	}
+
+	// Test cached metrics
+	cachedMetrics, hasCached := predictor.GetCachedMetrics()
+	if hasCached {
+		t.Logf("Cached metrics available - Model Type: %s", cachedMetrics.ModelType)
+		if len(cachedMetrics.RawMetrics) > 0 {
+			t.Logf("Raw metrics length: %d characters", len(cachedMetrics.RawMetrics))
+		}
+	} else {
+		t.Log("No cached metrics available")
+	}
+
+	// Test readiness status
+	t.Logf("Predictor readiness status:")
+	t.Logf("  Overall Ready: %t", predictor.IsReady())
+	t.Logf("  XGBoost Ready: %t", predictor.IsXGBoostReady())
+	t.Logf("  LightGBM Ready: %t", predictor.IsLightGBMReady())
+	t.Logf("  Bayesian Ridge Ready: %t", predictor.IsBayesianRidgeReady())
+}
+
+func testBayesianRidgeMetrics(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing Bayesian Ridge specific metrics with prefix cache support...")
+
+	metrics, err := predictor.GetMetrics(ctx)
+	if err != nil {
+		t.Errorf("Failed to get Bayesian Ridge metrics: %v", err)
+		return
+	}
+
+	if metrics.Coefficients == nil {
+		t.Error("Bayesian Ridge coefficients should not be nil")
+		return
+	}
+
+	t.Logf("TTFT Coefficients (should include prefix_cache_score):")
+	t.Logf("  Intercept: %.6f", metrics.Coefficients.TTFTIntercept)
+	for feature, coeff := range metrics.Coefficients.TTFTCoeffs {
+		t.Logf("  %s: %.6f", feature, coeff)
+	}
+
+	t.Logf("TPOT Coefficients (should NOT include prefix_cache_score):")
+	t.Logf("  Intercept: %.6f", metrics.Coefficients.TPOTIntercept)
+	for feature, coeff := range metrics.Coefficients.TPOTCoeffs {
+		t.Logf("  %s: %.6f", feature, coeff)
+	}
+
+	// Validate prefix cache score is in TTFT but not TPOT
+	if _, hasPrefixCache := metrics.Coefficients.TTFTCoeffs["prefix_cache_score"]; hasPrefixCache {
+		t.Log("✓ TTFT model includes prefix_cache_score coefficient")
+	} else {
+		t.Log("ℹ TTFT model does not include prefix_cache_score coefficient (may not be trained yet)")
+	}
+
+	if _, hasPrefixCache := metrics.Coefficients.TPOTCoeffs["prefix_cache_score"]; hasPrefixCache {
+		t.Error("❌ TPOT model should NOT include prefix_cache_score coefficient")
+	} else {
+		t.Log("✓ TPOT model correctly excludes prefix_cache_score coefficient")
+	}
+
+	// Test individual coefficient and bucket retrieval
+	coeffs, err := predictor.GetModelCoefficients(ctx)
+	if err != nil {
+		t.Errorf("Failed to get model coefficients: %v", err)
+	} else {
+		t.Logf("Retrieved coefficients separately: %d TTFT, %d TPOT features",
+			len(coeffs.TTFTCoeffs), len(coeffs.TPOTCoeffs))
+	}
+
+	buckets, err := predictor.GetBucketCounts(ctx)
+	if err != nil {
+		t.Errorf("Failed to get bucket counts: %v", err)
+	} else {
+		t.Logf("Retrieved bucket counts: %d TTFT, %d TPOT buckets",
+			len(buckets.TTFTBuckets), len(buckets.TPOTBuckets))
+	}
+}
+
+func testXGBoostMetrics(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing XGBoost specific metrics...")
+
+	// Wait a bit for XGBoost models to potentially load
+	time.Sleep(3 * time.Second)
+
+	trees, err := predictor.GetXGBoostTrees(ctx)
+	if err != nil {
+		t.Errorf("Failed to get XGBoost trees: %v", err)
+		return
+	}
+
+	t.Logf("XGBoost Trees:")
+	t.Logf("  TTFT Trees: %d", len(trees.TTFTTrees))
+	t.Logf("  TPOT Trees: %d", len(trees.TPOTTrees))
+
+	if len(trees.TTFTTrees) == 0 {
+		t.Error("Expected at least one TTFT tree")
+	}
+	if len(trees.TPOTTrees) == 0 {
+		t.Error("Expected at least one TPOT tree")
+	}
+
+	// Test native XGBoost readiness
+	if predictor.IsXGBoostReady() {
+		t.Log("Native XGBoost models are ready for local prediction")
+	} else {
+		t.Log("Native XGBoost models not ready, will use HTTP fallback")
+	}
+}
+
+func testLightGBMMetrics(t *testing.T, ctx context.Context, predictor *Predictor) {
+	t.Log("Testing LightGBM specific metrics...")
+
+	// For LightGBM, we primarily use HTTP calls, so test the HTTP connectivity
+	if predictor.IsLightGBMReady() {
+		t.Log("LightGBM models are ready via HTTP")
+
+		// Test a simple prediction to ensure the HTTP endpoint works
+		req := PredictionRequest{
+			KVCachePercentage:  0.6,
+			InputTokenLength:   300,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 50,
+			PrefixCacheScore:   0.7,
+		}
+
+		_, err := predictor.Predict(ctx, req)
+		if err != nil {
+			t.Errorf("LightGBM test prediction failed: %v", err)
+		} else {
+			t.Log("✓ LightGBM HTTP prediction working")
+		}
+	} else {
+		t.Log("LightGBM models not ready")
+	}
+}
+
+// generateTrainingEntries creates random training data for testing with prefix cache scores
+func generateTrainingEntries(count int) []TrainingEntry {
+	entries := make([]TrainingEntry, count)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := range count {
+		// Generate TTFT and TPOT using a simple equation based on features, plus some noise
+		kv := rng.Float64() // 0.0 to 1.0
+		inputLen := rng.Intn(2048) + 1
+		waiting := rng.Intn(20)
+		running := rng.Intn(10) + 1
+		generated := rng.Intn(500) + 1
+		prefixCache := rng.Float64() // 0.0 to 1.0
+
+		// Updated equations to include prefix cache impact on TTFT:
+		// TTFT includes prefix cache, TPOT does not
+		ttft := 100 + 2*float64(inputLen) + 10*kv + 5*float64(waiting) + 30*prefixCache + rng.NormFloat64()*20
+		tpot := 20 + 0.5*float64(generated) + 2*float64(running) + rng.NormFloat64()*5 + 9*kv
+
+		entries[i] = TrainingEntry{
+			KVCachePercentage:  kv,
+			InputTokenLength:   inputLen,
+			NumRequestWaiting:  waiting,
+			NumRequestRunning:  running,
+			NumTokensGenerated: generated,
+			ActualTTFT:         ttft,
+			ActualTPOT:         tpot,
+			PrefixCacheScore:   prefixCache, // Added prefix cache score
+			Timestamp:          time.Now().Add(-time.Duration(rng.Intn(3600)) * time.Second),
+		}
+	}
+
+	return entries
+}
+
+// Benchmark test for prediction performance with prefix cache
+func BenchmarkPrediction(b *testing.B) {
+	predictionURLs := os.Getenv("PREDICTION_SERVER_URL")
+	trainingURL := os.Getenv("TRAINING_SERVER_URL")
+	if predictionURLs == "" {
+		b.Skip("PREDICTION_SERVER_URL not set, skipping benchmark")
+	}
+	if trainingURL == "" {
+		// Use first prediction URL as fallback
+		urls := strings.Split(predictionURLs, ",")
+		if len(urls) > 0 {
+			trainingURL = strings.TrimSpace(urls[0])
+		} else {
+			b.Skip("No valid URLs available for benchmarking")
+		}
+	}
+
+	// Parse prediction URLs
+	urls := strings.Split(predictionURLs, ",")
+	parsedPredictionURLs := make([]string, 0, len(urls))
+	for _, url := range urls {
+		parsedPredictionURLs = append(parsedPredictionURLs, strings.TrimSpace(url))
+	}
+
+	logger := logr.Discard() // Silent logger for benchmark
+	config := &Config{
+		TrainingURL:            trainingURL,
+		PredictionURLs:         parsedPredictionURLs,
+		MaxSampleSize:          1000,
+		FlushInterval:          1 * time.Second, // Long interval for benchmark
+		MetricsRefreshInterval: 1 * time.Second,
+		UseNativeXGBoost:       true,
+		HTTPTimeout:            10 * time.Second,
+		MaxBulkSize:            100,
+	}
+
+	predictor := New(config, logger)
+	defer func() {
+		// ✅ Pass context to Stop()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		predictor.Stop(stopCtx)
+	}()
+
+	ctx := context.Background()
+	err := predictor.Start(ctx)
+	if err != nil {
+		b.Fatalf("Failed to start predictor: %v", err)
+	}
+
+	// Wait for predictor to be ready
+	for range 100 {
+		if predictor.IsReady() {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	req := PredictionRequest{
+		KVCachePercentage:  0.75, // 75% as a fraction
+		InputTokenLength:   512,
+		NumRequestWaiting:  2,
+		NumRequestRunning:  1,
+		NumTokensGenerated: 100,
+		PrefixCacheScore:   0.8, // 80% prefix cache hit rate
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := predictor.Predict(ctx, req)
+			if err != nil {
+				b.Errorf("Prediction failed: %v", err)
+			}
+		}
+	})
+}
+
+// Benchmark test for bulk prediction performance
+func BenchmarkBulkPrediction(b *testing.B) {
+	predictionURLs := os.Getenv("PREDICTION_SERVER_URL")
+	trainingURL := os.Getenv("TRAINING_SERVER_URL")
+	if predictionURLs == "" {
+		b.Skip("PREDICTION_SERVER_URL not set, skipping benchmark")
+	}
+	if trainingURL == "" {
+		urls := strings.Split(predictionURLs, ",")
+		if len(urls) > 0 {
+			trainingURL = strings.TrimSpace(urls[0])
+		} else {
+			b.Skip("No valid URLs available for benchmarking")
+		}
+	}
+
+	// Parse prediction URLs
+	urls := strings.Split(predictionURLs, ",")
+	parsedPredictionURLs := make([]string, 0, len(urls))
+	for _, url := range urls {
+		parsedPredictionURLs = append(parsedPredictionURLs, strings.TrimSpace(url))
+	}
+
+	logger := logr.Discard()
+	config := &Config{
+		TrainingURL:            trainingURL,
+		PredictionURLs:         parsedPredictionURLs,
+		MaxSampleSize:          1000,
+		FlushInterval:          1 * time.Second,
+		MetricsRefreshInterval: 1 * time.Second,
+		UseNativeXGBoost:       true,
+		HTTPTimeout:            10 * time.Second,
+		MaxBulkSize:            50,
+	}
+
+	predictor := New(config, logger)
+	defer func() {
+		// ✅ Pass context to Stop()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		predictor.Stop(stopCtx)
+	}()
+
+	ctx := context.Background()
+	err := predictor.Start(ctx)
+	if err != nil {
+		b.Fatalf("Failed to start predictor: %v", err)
+	}
+
+	for range 100 {
+		if predictor.IsReady() {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Create batch of requests
+	const batchSize = 20
+	requests := make([]PredictionRequest, batchSize)
+	for i := range batchSize {
+		requests[i] = PredictionRequest{
+			KVCachePercentage:  0.6 + float64(i%5)*0.05,
+			InputTokenLength:   300 + i*10,
+			NumRequestWaiting:  i % 4,
+			NumRequestRunning:  (i % 2) + 1,
+			NumTokensGenerated: 50 + i*2,
+			PrefixCacheScore:   float64(i) / float64(batchSize-1),
+		}
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := predictor.PredictBulk(ctx, requests)
+			if err != nil {
+				b.Errorf("Bulk prediction failed: %v", err)
+			}
+		}
+	})
+}
+
+// Test to verify config loading from environment
+func TestConfigFromEnv(t *testing.T) {
+	// Save original env vars
+	originalLatencyURL := os.Getenv("PREDICTION_SERVER_URL")
+	originalTrainingURL := os.Getenv("TRAINING_SERVER_URL")
+	originalSample := os.Getenv("LATENCY_MAX_SAMPLE_SIZE")
+	originalInterval := os.Getenv("LATENCY_FLUSH_INTERVAL_SEC")
+	originalNative := os.Getenv("LATENCY_USE_NATIVE_XGBOOST")
+	originalTimeout := os.Getenv("LATENCY_HTTP_TIMEOUT_SEC")
+	originalBulkSize := os.Getenv("LATENCY_MAX_BULK_SIZE")
+
+	// Set test env vars
+	os.Setenv("PREDICTION_SERVER_URL", "http://pred1.example.com,http://pred2.example.com,http://pred3.example.com")
+	os.Setenv("TRAINING_SERVER_URL", "http://training.example.com")
+	os.Setenv("LATENCY_MAX_SAMPLE_SIZE", "500")
+	os.Setenv("LATENCY_FLUSH_INTERVAL_SEC", "5")
+	os.Setenv("LATENCY_USE_NATIVE_XGBOOST", "false")
+	os.Setenv("LATENCY_HTTP_TIMEOUT_SEC", "20")
+	os.Setenv("LATENCY_MAX_BULK_SIZE", "75")
+
+	defer func() {
+		// Restore original env vars (handle empty strings properly)
+		if originalLatencyURL != "" {
+			os.Setenv("PREDICTION_SERVER_URL", originalLatencyURL)
+		} else {
+			os.Unsetenv("PREDICTION_SERVER_URL")
+		}
+		if originalTrainingURL != "" {
+			os.Setenv("TRAINING_SERVER_URL", originalTrainingURL)
+		} else {
+			os.Unsetenv("TRAINING_SERVER_URL")
+		}
+		if originalSample != "" {
+			os.Setenv("LATENCY_MAX_SAMPLE_SIZE", originalSample)
+		} else {
+			os.Unsetenv("LATENCY_MAX_SAMPLE_SIZE")
+		}
+		if originalInterval != "" {
+			os.Setenv("LATENCY_FLUSH_INTERVAL_SEC", originalInterval)
+		} else {
+			os.Unsetenv("LATENCY_FLUSH_INTERVAL_SEC")
+		}
+		if originalNative != "" {
+			os.Setenv("LATENCY_USE_NATIVE_XGBOOST", originalNative)
+		} else {
+			os.Unsetenv("LATENCY_USE_NATIVE_XGBOOST")
+		}
+		if originalTimeout != "" {
+			os.Setenv("LATENCY_HTTP_TIMEOUT_SEC", originalTimeout)
+		} else {
+			os.Unsetenv("LATENCY_HTTP_TIMEOUT_SEC")
+		}
+		if originalBulkSize != "" {
+			os.Setenv("LATENCY_MAX_BULK_SIZE", originalBulkSize)
+		} else {
+			os.Unsetenv("LATENCY_MAX_BULK_SIZE")
+		}
+	}()
+
+	config := ConfigFromEnv()
+
+	// Test training URL
+	if config.TrainingURL != "http://training.example.com" {
+		t.Errorf("Expected TrainingURL to be 'http://training.example.com', got '%s'", config.TrainingURL)
+	}
+
+	// Test prediction URLs
+	expectedPredictionURLs := []string{
+		"http://pred1.example.com",
+		"http://pred2.example.com",
+		"http://pred3.example.com",
+	}
+	if len(config.PredictionURLs) != len(expectedPredictionURLs) {
+		t.Errorf("Expected %d prediction URLs, got %d", len(expectedPredictionURLs), len(config.PredictionURLs))
+	}
+	for i, expected := range expectedPredictionURLs {
+		if i >= len(config.PredictionURLs) || config.PredictionURLs[i] != expected {
+			t.Errorf("Expected PredictionURLs[%d] to be '%s', got '%s'", i, expected, config.PredictionURLs[i])
+		}
+	}
+
+	// Test other config values
+	if config.MaxSampleSize != 500 {
+		t.Errorf("Expected MaxSampleSize to be 500, got %d", config.MaxSampleSize)
+	}
+	if config.FlushInterval != 5*time.Second {
+		t.Errorf("Expected FlushInterval to be 5s, got %v", config.FlushInterval)
+	}
+	if config.MetricsRefreshInterval != 60*time.Second {
+		t.Errorf("Expected MetricsRefreshInterval to be 60s, got %v", config.MetricsRefreshInterval)
+	}
+	if config.UseNativeXGBoost != false {
+		t.Errorf("Expected UseNativeXGBoost to be false, got %t", config.UseNativeXGBoost)
+	}
+	if config.HTTPTimeout != 20*time.Second {
+		t.Errorf("Expected HTTPTimeout to be 20s, got %v", config.HTTPTimeout)
+	}
+	if config.MaxBulkSize != 75 {
+		t.Errorf("Expected MaxBulkSize to be 75, got %d", config.MaxBulkSize)
+	}
+}
+
+// Helper function for absolute value
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// Test comprehensive bulk prediction functionality
+func TestBulkPredictionValidation(t *testing.T) {
+	t.Log("Testing bulk prediction validation...")
+
+	predictor := &Predictor{
+		config: &Config{MaxBulkSize: 5},
+	}
+
+	// Test empty request list
+	_, err := predictor.PredictBulk(context.Background(), []PredictionRequest{})
+	if err == nil {
+		t.Error("Expected error for empty request list")
+	} else {
+		t.Logf("✓ Correctly rejected empty request list: %v", err)
+	}
+
+	// Test oversized request list
+	oversizedRequests := make([]PredictionRequest, 10) // Over the limit of 5
+	for i := range oversizedRequests {
+		oversizedRequests[i] = PredictionRequest{
+			KVCachePercentage:  0.5,
+			InputTokenLength:   100,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 10,
+			PrefixCacheScore:   0.5,
+		}
+	}
+
+	_, err = predictor.PredictBulk(context.Background(), oversizedRequests)
+	if err == nil {
+		t.Error("Expected error for oversized request list")
+	} else {
+		t.Logf("✓ Correctly rejected oversized request list: %v", err)
+	}
+
+	// Test invalid request in the list
+	invalidRequests := []PredictionRequest{
+		{
+			KVCachePercentage:  0.5,
+			InputTokenLength:   100,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 10,
+			PrefixCacheScore:   0.5,
+		},
+		{
+			KVCachePercentage:  1.5, // Invalid
+			InputTokenLength:   100,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 10,
+			PrefixCacheScore:   0.5,
+		},
+	}
+
+	_, err = predictor.PredictBulk(context.Background(), invalidRequests)
+	if err == nil {
+		t.Error("Expected error for invalid request in list")
+	} else {
+		t.Logf("✓ Correctly rejected list with invalid request: %v", err)
+	}
+
+	t.Log("✅ Bulk prediction validation tests completed")
+}
+
+// Test comprehensive prefix cache integration
+func TestPrefixCacheIntegration(t *testing.T) {
+	t.Log("Testing comprehensive prefix cache integration...")
+
+	// Test all components work together with prefix cache
+	zapLog, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+	logger := zapr.NewLogger(zapLog)
+
+	// Use a minimal config that doesn't require network calls
+	config := &Config{
+		TrainingURL:            "http://mock-training.local",
+		PredictionURLs:         []string{"http://mock-prediction.local"},
+		MaxSampleSize:          100,
+		FlushInterval:          1 * time.Hour, // Very long interval to avoid network calls
+		MetricsRefreshInterval: 1 * time.Hour, // Very long interval to avoid network calls
+		UseNativeXGBoost:       false,
+		HTTPTimeout:            5 * time.Second,
+		MaxBulkSize:            10,
+	}
+
+	predictor := New(config, logger)
+
+	// Manually stop background processes without triggering final flush/refresh
+	defer func() {
+		// Stop background loop without calling Stop() which does final flush
+		close(predictor.done)
+		predictor.wg.Wait()
+		t.Log("Background processes stopped without network calls")
+	}()
+
+	// Test training entries with prefix cache can be created and validated
+	entries := make([]TrainingEntry, 5)
+	for i := range 5 {
+		entry, err := NewTrainingEntry(
+			float64(i)/10.0,   // kv_cache_percentage
+			100+i*50,          // input_token_length
+			i%3,               // num_request_waiting
+			1,                 // num_request_running (always > 0)
+			10+i*5,            // num_tokens_generated
+			50.0+float64(i)*5, // actual_ttft_ms
+			10.0+float64(i)*2, // actual_tpot_ms
+			float64(i)/4.0,    // prefix_cache_score (0.0 to 1.0)
+		)
+		if err != nil {
+			t.Fatalf("Failed to create training entry %d: %v", i, err)
+		}
+		entries[i] = entry
+
+		t.Logf("Entry %d: prefix_cache=%.1f%%, ttft=%.1f, tpot=%.1f",
+			i, entry.PrefixCacheScore*100, entry.ActualTTFT, entry.ActualTPOT)
+	}
+
+	// Add training data to buffer (won't flush due to long interval)
+	err = predictor.AddTrainingDataBulk(entries)
+	if err != nil {
+		t.Fatalf("Failed to add training entries: %v", err)
+	}
+	t.Log("✓ Successfully added training entries with prefix cache scores to buffer")
+
+	// Test prediction requests with prefix cache can be created and validated
+	requests := make([]PredictionRequest, 3)
+	for i := range 3 {
+		req, err := NewPredictionRequest(
+			float64(i*20)/100.0, // kv_cache_percentage
+			200+i*100,           // input_token_length
+			i%2,                 // num_request_waiting
+			1,                   // num_request_running (always > 0)
+			20+i*10,             // num_tokens_generated
+			float64(i)/2.0,      // prefix_cache_score
+		)
+		if err != nil {
+			t.Fatalf("Failed to create prediction request %d: %v", i, err)
+		}
+		requests[i] = req
+
+		err = predictor.ValidatePredictionRequest(req)
+		if err != nil {
+			t.Errorf("Valid prediction request %d failed validation: %v", i, err)
+		}
+
+		t.Logf("Request %d: prefix_cache=%.1f%%, kv_cache=%.1f%%, input_len=%d",
+			i, req.PrefixCacheScore*100, req.KVCachePercentage*100, req.InputTokenLength)
+	}
+	t.Log("✓ Successfully created and validated prediction requests with prefix cache")
+
+	// Test validation edge cases
+	edgeCases := []struct {
+		name        string
+		prefixCache float64
+		shouldPass  bool
+	}{
+		{"Zero prefix cache", 0.0, true},
+		{"Max prefix cache", 1.0, true},
+		{"Negative prefix cache", -0.1, false},
+		{"Over-max prefix cache", 1.1, false},
+	}
+
+	for _, tc := range edgeCases {
+		req := PredictionRequest{
+			KVCachePercentage:  0.5,
+			InputTokenLength:   100,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 10,
+			PrefixCacheScore:   tc.prefixCache,
+		}
+
+		err := predictor.ValidatePredictionRequest(req)
+		switch {
+		case tc.shouldPass && err != nil:
+			t.Errorf("Edge case '%s' should pass but failed: %v", tc.name, err)
+		case !tc.shouldPass && err == nil:
+			t.Errorf("Edge case '%s' should fail but passed", tc.name)
+		default:
+			t.Logf("✓ Edge case '%s' handled correctly", tc.name)
+		}
+	}
+
+	// Test that we can access the configuration
+	t.Logf("Configuration validation:")
+	t.Logf("  Training URL: %s", predictor.GetTrainingURL())
+	t.Logf("  Prediction URLs: %v", predictor.GetPredictionURLs())
+	t.Logf("  Max Bulk Size: %d", config.MaxBulkSize)
+
+	// Validate configuration consistency
+	if len(predictor.GetPredictionURLs()) != len(config.PredictionURLs) {
+		t.Errorf("Prediction URLs mismatch: expected %d, got %d",
+			len(config.PredictionURLs), len(predictor.GetPredictionURLs()))
+	}
+
+	if predictor.GetTrainingURL() != config.TrainingURL {
+		t.Errorf("Training URL mismatch: expected %s, got %s",
+			config.TrainingURL, predictor.GetTrainingURL())
+	}
+
+	// Test data structure integrity
+	t.Log("Validating data structure integrity...")
+
+	// Check that training entries maintain their prefix cache scores
+	for i, entry := range entries {
+		expectedPrefixCache := float64(i) / 4.0
+		if abs(entry.PrefixCacheScore-expectedPrefixCache) > 0.001 {
+			t.Errorf("Training entry %d prefix cache score mismatch: expected %.3f, got %.3f",
+				i, expectedPrefixCache, entry.PrefixCacheScore)
+		}
+	}
+
+	// Check that prediction requests maintain their prefix cache scores
+	for i, req := range requests {
+		expectedPrefixCache := float64(i) / 2.0
+		if abs(req.PrefixCacheScore-expectedPrefixCache) > 0.001 {
+			t.Errorf("Prediction request %d prefix cache score mismatch: expected %.3f, got %.3f",
+				i, expectedPrefixCache, req.PrefixCacheScore)
+		}
+	}
+
+	// Verify that training data is properly buffered (not flushed due to long interval)
+	predictor.bufferMu.Lock()
+	bufferedCount := len(predictor.pending)
+	predictor.bufferMu.Unlock()
+
+	if bufferedCount != len(entries) {
+		t.Errorf("Expected %d buffered entries, got %d", len(entries), bufferedCount)
+	} else {
+		t.Logf("✓ Training data properly buffered: %d entries", bufferedCount)
+	}
+
+	t.Log("✅ Comprehensive prefix cache integration test completed (offline mode)")
+}
+
+// Test offline validation functionality without network dependencies
+func TestOfflineValidation(t *testing.T) {
+	t.Log("Testing offline validation functionality...")
+
+	// Create a minimal predictor for validation testing
+	predictor := &Predictor{}
+
+	// Test prediction request validation
+	t.Run("PredictionRequestValidation", func(t *testing.T) {
+		validReq := PredictionRequest{
+			KVCachePercentage:  0.7,
+			InputTokenLength:   500,
+			NumRequestWaiting:  2,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 80,
+			PrefixCacheScore:   0.85,
+		}
+
+		err := predictor.ValidatePredictionRequest(validReq)
+		if err != nil {
+			t.Errorf("Valid prediction request failed validation: %v", err)
+		}
+
+		// Test invalid requests
+		invalidTests := []struct {
+			name string
+			req  PredictionRequest
+		}{
+			{
+				name: "Negative KV cache",
+				req: PredictionRequest{
+					KVCachePercentage:  -0.1,
+					InputTokenLength:   100,
+					NumRequestWaiting:  1,
+					NumRequestRunning:  1,
+					NumTokensGenerated: 10,
+					PrefixCacheScore:   0.5,
+				},
+			},
+			{
+				name: "Invalid prefix cache",
+				req: PredictionRequest{
+					KVCachePercentage:  0.5,
+					InputTokenLength:   100,
+					NumRequestWaiting:  1,
+					NumRequestRunning:  1,
+					NumTokensGenerated: 10,
+					PrefixCacheScore:   1.5,
+				},
+			},
+		}
+
+		for _, test := range invalidTests {
+			err := predictor.ValidatePredictionRequest(test.req)
+			if err == nil {
+				t.Errorf("Invalid request '%s' should have failed validation", test.name)
+			} else {
+				t.Logf("✓ '%s' correctly rejected: %v", test.name, err)
+			}
+		}
+	})
+
+	// Test training entry validation
+	t.Run("TrainingEntryValidation", func(t *testing.T) {
+		validEntry := TrainingEntry{
+			KVCachePercentage:  0.6,
+			InputTokenLength:   300,
+			NumRequestWaiting:  1,
+			NumRequestRunning:  1,
+			NumTokensGenerated: 50,
+			ActualTTFT:         45.5,
+			ActualTPOT:         12.3,
+			PrefixCacheScore:   0.75,
+			Timestamp:          time.Now(),
+		}
+
+		err := predictor.ValidateTrainingEntry(validEntry)
+		if err != nil {
+			t.Errorf("Valid training entry failed validation: %v", err)
+		}
+
+		// Test invalid entry
+		invalidEntry := validEntry
+		invalidEntry.PrefixCacheScore = -0.5
+
+		err = predictor.ValidateTrainingEntry(invalidEntry)
+		if err == nil {
+			t.Error("Invalid training entry should have failed validation")
+		} else {
+			t.Logf("✓ Invalid training entry correctly rejected: %v", err)
+		}
+	})
+
+	// Test constructor functions
+	t.Run("ConstructorFunctions", func(t *testing.T) {
+		// Test valid constructors
+		_, err := NewPredictionRequest(0.5, 100, 1, 1, 10, 0.8)
+		if err != nil {
+			t.Errorf("Valid prediction request constructor failed: %v", err)
+		}
+
+		_, err = NewTrainingEntry(0.5, 100, 1, 1, 10, 30.0, 8.0, 0.8)
+		if err != nil {
+			t.Errorf("Valid training entry constructor failed: %v", err)
+		}
+
+		// Test invalid constructors
+		_, err = NewPredictionRequest(0.5, 100, 1, 1, 10, 1.5) // Invalid prefix cache
+		if err == nil {
+			t.Error("Invalid prediction request constructor should have failed")
+		}
+
+		_, err = NewTrainingEntry(0.5, 100, 1, 1, 10, 30.0, 8.0, -0.1) // Invalid prefix cache
+		if err == nil {
+			t.Error("Invalid training entry constructor should have failed")
+		}
+	})
+
+	t.Log("✅ Offline validation tests completed")
+}
+
+// Test configuration handling without network calls
+func TestConfigurationHandling(t *testing.T) {
+	t.Log("Testing configuration handling...")
+
+	// Test default configuration
+	defaultConfig := DefaultConfig()
+	if defaultConfig.MaxBulkSize != 100 {
+		t.Errorf("Expected default MaxBulkSize to be 100, got %d", defaultConfig.MaxBulkSize)
+	}
+
+	if defaultConfig.UseNativeXGBoost != true {
+		t.Errorf("Expected default UseNativeXGBoost to be true, got %t", defaultConfig.UseNativeXGBoost)
+	}
+
+	// Test configuration with mock URLs (no network calls)
+	config := &Config{
+		TrainingURL:            "http://mock-training.local",
+		PredictionURLs:         []string{"http://mock1.local", "http://mock2.local"},
+		MaxSampleSize:          500,
+		FlushInterval:          2 * time.Second,
+		MetricsRefreshInterval: 5 * time.Second,
+		UseNativeXGBoost:       false,
+		HTTPTimeout:            10 * time.Second,
+		MaxBulkSize:            50,
+	}
+
+	// Create logger
+	zapLog, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+	logger := zapr.NewLogger(zapLog)
+
+	// Create predictor but don't start it (to avoid network calls)
+	predictor := New(config, logger)
+
+	// Test configuration access
+	if predictor.GetTrainingURL() != config.TrainingURL {
+		t.Errorf("Training URL mismatch: expected %s, got %s",
+			config.TrainingURL, predictor.GetTrainingURL())
+	}
+
+	predictionURLs := predictor.GetPredictionURLs()
+	if len(predictionURLs) != len(config.PredictionURLs) {
+		t.Errorf("Prediction URLs length mismatch: expected %d, got %d",
+			len(config.PredictionURLs), len(predictionURLs))
+	}
+
+	// ✅ Properly cleanup
+	close(predictor.done)
+	predictor.wg.Wait()
+
+	t.Log("✅ Configuration handling tests completed")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/metrics.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictorclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+)
+
+// GetMetrics fetches & parses metrics from the training server (for Bayesian Ridge).
+func (p *Predictor) GetMetrics(ctx context.Context) (*MetricsResponse, error) {
+	url := p.config.TrainingURL + "/metrics"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics request: %w", err)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call training server /metrics endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("training server returned non-200 status: %d %s, body: %s", resp.StatusCode, resp.Status, string(body))
+	}
+
+	rawMetricsBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metrics response body: %w", err)
+	}
+	rawMetrics := string(rawMetricsBytes)
+
+	metricsResponse := &MetricsResponse{
+		RawMetrics: rawMetrics,
+		ModelType:  bayesianRidgeModelType, // Assume Bayesian Ridge when calling /metrics
+	}
+
+	coeffs, buckets, err := p.parsePrometheusMetrics(rawMetrics)
+	if err != nil {
+		p.logger.Error(err, "Failed to parse Prometheus metrics, caching raw only")
+	} else {
+		metricsResponse.Coefficients = coeffs
+		metricsResponse.BucketCounts = buckets
+	}
+
+	p.metricsMu.Lock()
+	p.cachedMetrics = metricsResponse
+	p.metricsMu.Unlock()
+
+	p.logger.V(logutil.DEBUG).Info("Successfully retrieved and cached Bayesian Ridge metrics.")
+	return metricsResponse, nil
+}
+
+// parsePrometheusMetrics parses the Prometheus-format metrics into structured data.
+func (p *Predictor) parsePrometheusMetrics(rawMetrics string) (*ModelCoefficients, *BucketCounts, error) {
+	lines := strings.Split(rawMetrics, "\n")
+
+	coefficients := &ModelCoefficients{
+		TTFTCoeffs: make(map[string]float64),
+		TPOTCoeffs: make(map[string]float64),
+	}
+	bucketCounts := &BucketCounts{
+		TTFTBuckets: make(map[int]int),
+		TPOTBuckets: make(map[int]int),
+	}
+	var firstErr error
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if err := p.parseMetricLine(line, coefficients, bucketCounts); err != nil {
+			if firstErr == nil {
+				firstErr = err // Save first error to return
+			}
+			p.logger.V(logutil.TRACE).Info("Skipping unparsable metric line", "line", line, "error", err)
+		}
+	}
+	return coefficients, bucketCounts, firstErr
+}
+
+// parseMetricLine parses a single line of Prometheus-formatted text.
+func (p *Predictor) parseMetricLine(line string, coefficients *ModelCoefficients, bucketCounts *BucketCounts) error {
+	lastSpaceIdx := strings.LastIndexAny(line, " \t")
+	if lastSpaceIdx == -1 {
+		return errors.New("invalid metric format: no space found")
+	}
+
+	metricPart := strings.TrimSpace(line[:lastSpaceIdx])
+	valueStr := strings.TrimSpace(line[lastSpaceIdx+1:])
+
+	value, err := strconv.ParseFloat(valueStr, 64)
+	if err != nil {
+		return fmt.Errorf("could not parse value '%s': %w", valueStr, err)
+	}
+
+	metricName := metricPart
+	if before, _, ok := strings.Cut(metricPart, "{"); ok {
+		metricName = before
+	}
+
+	switch metricName {
+	case "ttft_intercept":
+		coefficients.TTFTIntercept = value
+	case "tpot_intercept":
+		coefficients.TPOTIntercept = value
+	case "ttft_coef":
+		if feature := p.extractLabel(metricPart, "feature"); feature != "" {
+			coefficients.TTFTCoeffs[feature] = value
+		}
+	case "tpot_coef":
+		if feature := p.extractLabel(metricPart, "feature"); feature != "" {
+			coefficients.TPOTCoeffs[feature] = value
+		}
+	case "training_samples_count":
+		model := p.extractLabel(metricPart, "model")
+		bucketStr := p.extractLabel(metricPart, "bucket")
+		if bucket, err := strconv.Atoi(bucketStr); err == nil {
+			switch model {
+			case "ttft":
+				bucketCounts.TTFTBuckets[bucket] = int(value)
+			case "tpot":
+				bucketCounts.TPOTBuckets[bucket] = int(value)
+			}
+		}
+	}
+	return nil
+}
+
+// extractLabel extracts a label value from a Prometheus metric string.
+// Example: `metric{key="value"}`, `key` -> `"value"`
+func (p *Predictor) extractLabel(metricPart, labelName string) string {
+	searchStr := labelName + `="`
+	start := strings.Index(metricPart, searchStr)
+	if start == -1 {
+		return ""
+	}
+	start += len(searchStr)
+	end := strings.Index(metricPart[start:], `"`)
+	if end == -1 {
+		return ""
+	}
+	return metricPart[start : start+end]
+}
+
+// GetModelCoefficients fetches the latest metrics and returns the parsed coefficients.
+func (p *Predictor) GetModelCoefficients(ctx context.Context) (*ModelCoefficients, error) {
+	metrics, err := p.GetMetrics(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if metrics.Coefficients == nil {
+		return nil, errors.New("coefficients not available in fetched metrics")
+	}
+	return metrics.Coefficients, nil
+}
+
+// GetBucketCounts fetches the latest metrics and returns the parsed bucket counts.
+func (p *Predictor) GetBucketCounts(ctx context.Context) (*BucketCounts, error) {
+	metrics, err := p.GetMetrics(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if metrics.BucketCounts == nil {
+		return nil, errors.New("bucket counts not available in fetched metrics")
+	}
+	return metrics.BucketCounts, nil
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction.go
@@ -1,0 +1,334 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictorclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+)
+
+// Predict uses cached coefficients (Bayesian Ridge) or HTTP calls (XGBoost/LightGBM) for prediction.
+func (p *Predictor) Predict(ctx context.Context, req PredictionRequest) (*PredictionResponse, error) {
+	// Get current model type from server status first, fall back to model info
+	p.metricsMu.RLock()
+	modelType := ""
+	quantile := 0.9                    // default
+	objectiveType := ObjectiveQuantile // default for backward compatibility
+
+	if p.serverStatus != nil {
+		modelType = p.serverStatus.ModelType
+		quantile = p.serverStatus.Quantile
+		if p.serverStatus.ObjectiveType != "" {
+			objectiveType = p.serverStatus.ObjectiveType
+		}
+	} else if p.modelInfo != nil {
+		modelType = p.modelInfo.ModelType
+		if p.modelInfo.Quantile > 0 {
+			quantile = p.modelInfo.Quantile
+		}
+		if p.modelInfo.ObjectiveType != "" {
+			objectiveType = p.modelInfo.ObjectiveType
+		}
+	}
+
+	mr := p.cachedMetrics
+	p.metricsMu.RUnlock()
+
+	if modelType == "" {
+		return nil, errors.New("model type not yet available from server")
+	}
+
+	switch modelType {
+	case bayesianRidgeModelType:
+		return p.predictBayesianRidge(req, mr, quantile, objectiveType)
+	case xgBoostModelType, gbmModelType:
+		return p.predictHTTP(ctx, req)
+	default:
+		return nil, fmt.Errorf("unsupported or unknown model type: %s", modelType)
+	}
+}
+
+// PredictBulk makes bulk predictions with error handling (allows partial failures)
+func (p *Predictor) PredictBulk(ctx context.Context, requests []PredictionRequest) (*BulkPredictionResponse, error) {
+	if len(requests) == 0 {
+		return nil, errors.New("no prediction requests provided")
+	}
+
+	if len(requests) > p.config.MaxBulkSize {
+		return nil, fmt.Errorf("too many requests: %d (max: %d)", len(requests), p.config.MaxBulkSize)
+	}
+
+	// Validate all requests first
+	for i, req := range requests {
+		if err := p.ValidatePredictionRequest(req); err != nil {
+			return nil, fmt.Errorf("validation failed for request %d: %w", i, err)
+		}
+	}
+
+	payload := BulkPredictionRequest{Requests: requests}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bulk prediction request: %w", err)
+	}
+
+	predictionURL := p.getRandomPredictionURL()
+	url := predictionURL + "/predict/bulk"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bulk prediction request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call bulk prediction endpoint %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("bulk prediction server returned non-200 status: %d %s, body: %s", resp.StatusCode, resp.Status, string(body))
+	}
+
+	var bulkResp BulkPredictionResponseWithErrors
+	if err := json.NewDecoder(resp.Body).Decode(&bulkResp); err != nil {
+		return nil, fmt.Errorf("failed to decode bulk prediction response: %w", err)
+	}
+
+	// Convert to standard bulk response format
+	var predictions []PredictionResponse
+	for _, pred := range bulkResp.Predictions {
+		if pred != nil {
+			predictions = append(predictions, *pred)
+		}
+	}
+
+	return &BulkPredictionResponse{
+		Predictions:           predictions,
+		TotalRequests:         bulkResp.TotalRequests,
+		SuccessfulPredictions: bulkResp.SuccessfulPredictions,
+		FailedPredictions:     bulkResp.FailedPredictions,
+		ProcessingTimeMs:      bulkResp.ProcessingTimeMs,
+	}, nil
+}
+
+// PredictBulkStrict makes bulk predictions that fail if any single prediction fails.
+// When CoalesceWindow > 0, concurrent callers are coalesced into a single HTTP call.
+func (p *Predictor) PredictBulkStrict(ctx context.Context, requests []PredictionRequest) (*BulkPredictionResponse, error) {
+	if len(requests) == 0 {
+		return nil, errors.New("no prediction requests provided")
+	}
+
+	if len(requests) > p.config.MaxBulkSize {
+		return nil, fmt.Errorf("too many requests: %d (max: %d)", len(requests), p.config.MaxBulkSize)
+	}
+
+	// Validate all requests first
+	for i, req := range requests {
+		if err := p.ValidatePredictionRequest(req); err != nil {
+			return nil, fmt.Errorf("validation failed for request %d: %w", i, err)
+		}
+	}
+
+	if p.config.CoalesceWindow > 0 {
+		return p.submitCoalesced(ctx, requests)
+	}
+
+	return p.doPredictBulkStrictHTTP(ctx, requests)
+}
+
+// predictBayesianRidge uses cached coefficients for linear prediction
+func (p *Predictor) predictBayesianRidge(req PredictionRequest, mr *MetricsResponse, quantile float64, objectiveType string) (*PredictionResponse, error) {
+	if mr == nil || mr.Coefficients == nil {
+		return nil, errors.New("no cached Bayesian Ridge coefficients available for prediction")
+	}
+	c := mr.Coefficients
+
+	// Updated linear combination for TTFT to include prefix_cache_score
+	ttft := c.TTFTIntercept +
+		c.TTFTCoeffs["kv_cache_percentage"]*req.KVCachePercentage +
+		c.TTFTCoeffs["input_token_length"]*float64(req.InputTokenLength) +
+		c.TTFTCoeffs["num_request_waiting"]*float64(req.NumRequestWaiting) +
+		c.TTFTCoeffs["num_request_running"]*float64(req.NumRequestRunning) +
+		c.TTFTCoeffs["prefix_cache_score"]*req.PrefixCacheScore
+
+	// Linear combination for TPOT (remains unchanged - no prefix cache effect)
+	tpot := c.TPOTIntercept +
+		c.TPOTCoeffs["kv_cache_percentage"]*req.KVCachePercentage +
+		c.TPOTCoeffs["input_token_length"]*float64(req.InputTokenLength) +
+		c.TPOTCoeffs["num_request_waiting"]*float64(req.NumRequestWaiting) +
+		c.TPOTCoeffs["num_request_running"]*float64(req.NumRequestRunning) +
+		c.TPOTCoeffs["num_tokens_generated"]*float64(req.NumTokensGenerated)
+
+	return &PredictionResponse{
+		TTFT:          ttft,
+		TPOT:          tpot,
+		PredictedAt:   time.Now(),
+		ModelType:     bayesianRidgeModelType,
+		ObjectiveType: objectiveType,
+		Quantile:      quantile,
+	}, nil
+}
+
+// predictHTTP makes an HTTP call to a randomly selected prediction server for XGBoost/LightGBM predictions
+func (p *Predictor) predictHTTP(ctx context.Context, req PredictionRequest) (*PredictionResponse, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal prediction request: %w", err)
+	}
+
+	// Get random prediction URL for load balancing
+	predictionURL := p.getRandomPredictionURL()
+	url := predictionURL + "/predict"
+
+	p.logger.V(logutil.TRACE).Info("Making prediction request", "url", url)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call prediction endpoint %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("prediction server returned non-200 status: %d %s, body: %s", resp.StatusCode, resp.Status, string(body))
+	}
+
+	var predResp PredictionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&predResp); err != nil {
+		return nil, fmt.Errorf("failed to decode prediction response: %w", err)
+	}
+
+	return &predResp, nil
+}
+
+// ValidatePredictionRequest validates that a prediction request has all required fields
+// with valid values, including the new prefix_cache_score field.
+func (p *Predictor) ValidatePredictionRequest(req PredictionRequest) error {
+	if req.KVCachePercentage < 0.0 || req.KVCachePercentage > 1.0 {
+		return fmt.Errorf("kv_cache_percentage must be between 0.0 and 1.0, got %f", req.KVCachePercentage)
+	}
+	if req.InputTokenLength < 0 {
+		return fmt.Errorf("input_token_length must be non-negative, got %d", req.InputTokenLength)
+	}
+	if req.NumRequestWaiting < 0 {
+		return fmt.Errorf("num_request_waiting must be non-negative, got %d", req.NumRequestWaiting)
+	}
+	if req.NumRequestRunning < 0 {
+		return fmt.Errorf("num_request_running must be non-negative, got %d", req.NumRequestRunning)
+	}
+	if req.NumTokensGenerated < 0 {
+		return fmt.Errorf("num_tokens_generated must be non-negative, got %d", req.NumTokensGenerated)
+	}
+	if req.PrefixCacheScore < 0.0 || req.PrefixCacheScore > 1.0 {
+		return fmt.Errorf("prefix_cache_score must be between 0.0 and 1.0, got %f", req.PrefixCacheScore)
+	}
+	return nil
+}
+
+// NewPredictionRequest is a helper function to create a new PredictionRequest with proper validation.
+func NewPredictionRequest(
+	kvCachePercentage float64,
+	inputTokenLength int,
+	numRequestWaiting int,
+	numRequestRunning int,
+	numTokensGenerated int,
+	prefixCacheScore float64,
+) (PredictionRequest, error) {
+	req := PredictionRequest{
+		KVCachePercentage:  kvCachePercentage,
+		InputTokenLength:   inputTokenLength,
+		NumRequestWaiting:  numRequestWaiting,
+		NumRequestRunning:  numRequestRunning,
+		NumTokensGenerated: numTokensGenerated,
+		PrefixCacheScore:   prefixCacheScore,
+	}
+
+	// Create a temporary predictor for validation (could be optimized)
+	p := &Predictor{}
+	if err := p.ValidatePredictionRequest(req); err != nil {
+		return PredictionRequest{}, err
+	}
+
+	return req, nil
+}
+
+// refreshServerStatus gets current server status from a prediction server
+func (p *Predictor) refreshServerStatus(ctx context.Context) error {
+	predictionURL := p.getRandomPredictionURL()
+	url := predictionURL + "/status"
+
+	p.logger.V(logutil.DEBUG).Info("Fetching server status", "url", url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create server status request: %w", err)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call /status endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server %s returned non-200 status: %d %s, body: %s", url, resp.StatusCode, resp.Status, string(body))
+	}
+
+	var status ServerStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return fmt.Errorf("failed to decode server status response: %w", err)
+	}
+
+	p.metricsMu.Lock()
+	p.serverStatus = &status
+	p.metricsMu.Unlock()
+
+	p.logger.V(logutil.DEBUG).Info("Retrieved server status",
+		"model_type", status.ModelType,
+		"objective_type", status.ObjectiveType,
+		"quantile", status.Quantile,
+		"is_ready", status.IsReady)
+	return nil
+}
+
+// getRandomPredictionURL returns a randomly selected prediction URL for load balancing
+func (p *Predictor) getRandomPredictionURL() string {
+	if len(p.config.PredictionURLs) == 0 {
+		return p.config.TrainingURL // Fallback to training URL
+	}
+	if len(p.config.PredictionURLs) == 1 {
+		return p.config.PredictionURLs[0]
+	}
+	index := p.rng.Intn(len(p.config.PredictionURLs))
+	return p.config.PredictionURLs[index]
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/Dockerfile
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.25 AS builder
+
+WORKDIR /workspace
+
+# Copy go.mod and go.sum from the root module
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the entire source tree (needed for local module deps)
+COPY . .
+
+# Build the test binary — use package path, not file path
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -o /predictor-client-test \
+    ./sidecars/latencypredictorasync/tests/
+
+FROM alpine:3.19
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /predictor-client-test /usr/local/bin/predictor-client-test
+
+ENTRYPOINT ["/usr/local/bin/predictor-client-test"]

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/README.md
@@ -1,0 +1,125 @@
+# Latency Predictor Load Tests
+
+Load tests for the latency predictor sidecar system. These tests exercise the Go coalescer client against the prediction and training servers at various QPS levels.
+
+## Components
+
+- `main.go` — Go test client that generates prediction and training requests at a configurable QPS
+- `Dockerfile` — Builds the test client image
+- `run_qps_sweep.sh` — Runs an automated QPS sweep (1 to 10,000 QPS)
+- `manifests/predictor_warmup.yaml` — K8s Job to warm up training buckets before running load tests
+
+## Prerequisites
+
+1. A running EPP deployment with the latency predictor sidecar (training + prediction servers)
+2. The prediction server ports must be accessible from the test pod (e.g., via a K8s Service)
+
+## Building the Test Image
+
+From the repository root:
+
+```bash
+docker build -t <your-registry>/predictor-client-test:latest \
+  -f sidecars/latencypredictorasync/tests/Dockerfile .
+docker push <your-registry>/predictor-client-test:latest
+```
+
+## Running the Load Tests
+
+### Step 1: Warm Up Training Buckets
+
+The prediction servers need trained models before they can serve predictions. Run the warmup job to fill training buckets with synthetic data:
+
+```bash
+# Edit the manifest to point to your EPP service and image
+kubectl apply -f sidecars/latencypredictorasync/tests/manifests/predictor_warmup.yaml
+
+# Wait for warmup to complete (~5 minutes)
+kubectl wait --for=condition=complete job/predictor-warmup --timeout=600s
+
+# Verify training server has data
+kubectl exec <epp-pod> -c training-server-1 -- \
+  python3 -c "import urllib.request; print(urllib.request.urlopen('http://localhost:8000/metrics').read().decode())" \
+  | grep training_samples_count
+```
+
+### Step 2: Run a Single Load Test
+
+Deploy a test job with desired parameters:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: predictor-load-test
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: predictor-client-test
+        image: <your-registry>/predictor-client-test:latest
+        env:
+        - name: PREDICTION_SERVERS
+          value: "http://<epp-service>:8001"
+        - name: TRAINING_SERVER_URL
+          value: "http://<epp-service>:8000"
+        - name: TEST_QPS
+          value: "100"
+        - name: TEST_DURATION_SECONDS
+          value: "120"
+        - name: NUM_ENDPOINTS_PER_REQUEST
+          value: "10"
+        - name: MAX_CONCURRENT_DISPATCHES
+          value: "36"
+        resources:
+          requests:
+            cpu: "1000m"
+            memory: "1Gi"
+          limits:
+            cpu: "4000m"
+            memory: "8Gi"
+EOF
+```
+
+### Step 3: Run a QPS Sweep
+
+The sweep script runs tests at 1, 10, 100, 1000, 2500, and 5000 QPS (300s each):
+
+```bash
+./sidecars/latencypredictorasync/tests/run_qps_sweep.sh \
+  --pred-base-url http://<epp-service> \
+  --pred-start-port 8001 \
+  --train-url http://<epp-service>:8000
+```
+
+Results are written to `/tmp/qps_results.txt`.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PREDICTION_SERVERS` | (required) | Comma-separated prediction server URLs |
+| `TRAINING_SERVER_URL` | `http://training-service:8000` | Training server URL |
+| `TEST_QPS` | `100` | Target queries per second |
+| `TEST_DURATION_SECONDS` | `120` | Test duration in seconds |
+| `MAX_BULK_SIZE` | `200` | Max predictions per bulk request |
+| `NUM_ENDPOINTS_PER_REQUEST` | `10` | Number of endpoints per prediction request |
+| `TRAINING_BATCH_SIZE` | `100` | Training entries per batch |
+| `TRAINING_INTERVAL_MS` | `500` | Interval between training batches (ms) |
+| `MAX_CONCURRENT_DISPATCHES` | `8` | Max concurrent HTTP dispatches to prediction servers |
+| `MAX_INFLIGHT_REQUESTS` | `QPS/5+500` | Max concurrent prediction goroutines |
+| `COALESCE_WINDOW_MS` | `5` | Coalesce window for batching requests |
+| `MAX_COALESCED_CALLERS` | `50` | Max callers coalesced into a single batch |
+
+## Sizing Guide
+
+| QPS Range | Sidecars | MAX_CONCURRENT_DISPATCHES | MAX_INFLIGHT_REQUESTS |
+|-----------|----------|--------------------------|----------------------|
+| 1-2,500 | 1 | 36 | 215 |
+| 2,501-5,000 | 2 | 64 | 430 |
+| 5,001-7,500 | 3 | 92 | 640 |
+| 7,501-10,000 | 4 | 120 | 850 |

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/main.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/main.go
@@ -1,0 +1,530 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"log"
+	"math"
+	"math/rand"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/stdr"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
+	"golang.org/x/time/rate"
+)
+
+type TestMetrics struct {
+	TotalRequests         int64
+	SuccessfulRequests    int64
+	FailedRequests        int64
+	TotalLatencyMs        int64
+	MinLatency            int64 // accessed via atomic operations only
+	MaxLatency            int64 // accessed via atomic operations only
+	Latencies             []int64
+	LatenciesMutex        sync.Mutex
+	TotalPredictionsCount int64
+	SuccessfulPredictions int64
+	FailedPredictions     int64
+}
+
+type TrainingMetrics struct {
+	TotalBatches    int64
+	TotalEntries    int64
+	SuccessfulFlush int64
+	FailedFlush     int64
+}
+
+func main() {
+
+	trainingServerURL := os.Getenv("TRAINING_SERVER_URL")
+	if trainingServerURL == "" {
+		trainingServerURL = "http://training-service:8000"
+	}
+
+	predictionServersStr := os.Getenv("PREDICTION_SERVERS")
+	if predictionServersStr == "" {
+		log.Fatal("PREDICTION_SERVERS env var not set")
+	}
+	predictionServers := strings.Split(predictionServersStr, ",")
+	for i := range predictionServers {
+		predictionServers[i] = strings.TrimSpace(predictionServers[i])
+	}
+
+	testQPS := parseEnvInt("TEST_QPS", 100)
+	testDurationSeconds := parseEnvInt("TEST_DURATION_SECONDS", 120)
+	maxBulkSize := parseEnvInt("MAX_BULK_SIZE", 200)
+	numEndpointsPerRequest := parseEnvInt("NUM_ENDPOINTS_PER_REQUEST", 10)
+	trainingBatchSize := parseEnvInt("TRAINING_BATCH_SIZE", 100)
+	trainingIntervalMs := parseEnvInt("TRAINING_INTERVAL_MS", 500)
+	maxConcurrentDispatches := parseEnvInt("MAX_CONCURRENT_DISPATCHES", 8)
+	// maxInFlightRequests caps concurrent PredictBulkStrict goroutines.
+	// Without this, goroutines accumulate at (testQPS - throughput)/sec and OOM
+	// the pod when the system can't keep up with the target QPS.
+	maxInFlightRequests := parseEnvInt("MAX_INFLIGHT_REQUESTS", testQPS/5+500)
+	// coalesceWindowMs and maxCoalescedCallers together control batch size.
+	// Smaller values → smaller batches → lower Python latency but more HTTP calls.
+	// MaxCoalescedRows = numEndpointsPerRequest × maxCoalescedCallers.
+	coalesceWindowMs := parseEnvInt("COALESCE_WINDOW_MS", 5)
+	maxCoalescedCallers := parseEnvInt("MAX_COALESCED_CALLERS", 50)
+
+	if err := os.WriteFile("/tmp/test_running", []byte("running"), 0644); err != nil {
+		log.Printf("Warning: could not create test_running marker: %v", err)
+	}
+	// Removed defer — cleaned up explicitly before all exit points to satisfy gocritic.
+
+	// Create logger using stdr (standard log -> logr.Logger)
+	logger := stdr.New(log.New(os.Stdout, "[predictor-test] ", log.LstdFlags))
+
+	logger.Info("Predictor Client Test starting",
+		"prediction_servers", predictionServers,
+		"training_server", trainingServerURL,
+		"target_qps", testQPS,
+		"duration_seconds", testDurationSeconds,
+		"endpoints_per_request", numEndpointsPerRequest,
+		"training_batch_size", trainingBatchSize,
+		"training_interval_ms", trainingIntervalMs)
+
+	// Create predictor config
+	cfg := &latencypredictorclient.Config{
+		PredictionURLs:          predictionServers,
+		TrainingURL:             trainingServerURL,
+		MaxBulkSize:             maxBulkSize,
+		MetricsRefreshInterval:  30 * time.Second,
+		FlushInterval:           time.Duration(trainingIntervalMs) * time.Millisecond,
+		HTTPTimeout:             10 * time.Second,
+		MaxSampleSize:           1000,
+		UseNativeXGBoost:        false,
+		CoalesceWindow:          time.Duration(coalesceWindowMs) * time.Millisecond,
+		MaxCoalescedRows:        numEndpointsPerRequest * maxCoalescedCallers,
+		MaxConcurrentDispatches: maxConcurrentDispatches,
+	}
+
+	// Create predictor
+	predictor := latencypredictorclient.New(cfg, logger)
+
+	testCtx, cancel := context.WithTimeout(context.Background(), time.Duration(testDurationSeconds)*time.Second+30*time.Second)
+
+	if err := predictor.Start(testCtx); err != nil {
+		cancel()
+		os.Remove("/tmp/test_running")
+		logger.Error(err, "Failed to start predictor")
+		return
+	}
+
+	predMetrics := &TestMetrics{
+		MinLatency: math.MaxInt64,
+		Latencies:  make([]int64, 0, testQPS*testDurationSeconds),
+	}
+
+	trainMetrics := &TrainingMetrics{}
+
+	testStart := time.Now()
+	testEnd := testStart.Add(time.Duration(testDurationSeconds) * time.Second)
+
+	logger.Info("Starting test requests...")
+
+	// Use separate WaitGroups so generators don't block on in-flight requests
+	var generatorWg sync.WaitGroup // for generator goroutines
+	var requestWg sync.WaitGroup   // for in-flight prediction requests
+
+	// Semaphore that caps concurrent PredictBulkStrict goroutines.
+	// Without this, goroutines pile up at (testQPS - throughput)/sec and OOM
+	// the pod when the server can't keep up with the target QPS.
+	inFlightSem := make(chan struct{}, maxInFlightRequests)
+
+	// ---------------------------------------------------------------
+	// Goroutine 1: Continuously send training data in parallel
+	// ---------------------------------------------------------------
+	generatorWg.Go(func() {
+
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		trainingTicker := time.NewTicker(time.Duration(trainingIntervalMs) * time.Millisecond)
+		defer trainingTicker.Stop()
+
+		logger.Info("Training data generator started",
+			"batch_size", trainingBatchSize,
+			"interval_ms", trainingIntervalMs)
+
+		for {
+			select {
+			case <-testCtx.Done():
+				return
+			case <-trainingTicker.C:
+				if time.Now().After(testEnd) {
+					return
+				}
+
+				entries := generateTrainingBatch(rng, trainingBatchSize)
+				atomic.AddInt64(&trainMetrics.TotalBatches, 1)
+				atomic.AddInt64(&trainMetrics.TotalEntries, int64(len(entries)))
+
+				if err := predictor.AddTrainingDataBulk(entries); err != nil {
+					atomic.AddInt64(&trainMetrics.FailedFlush, 1)
+					logger.Error(err, "Failed to buffer training data")
+				} else {
+					atomic.AddInt64(&trainMetrics.SuccessfulFlush, 1)
+				}
+			}
+		}
+	})
+
+	// ---------------------------------------------------------------
+	// Goroutine 2: Generate prediction requests at target QPS.
+	//
+	// A single ticker fires at most once per ~1ms (Go timer resolution),
+	// capping it at ~1k QPS. For higher rates we use a token-bucket
+	// rate.Limiter shared across a pool of worker goroutines, each of
+	// which calls Wait() and fires one request. This accurately sustains
+	// rates well above 10k QPS.
+	// ---------------------------------------------------------------
+	// One worker per 100 QPS; min resolution per worker = 10ms.
+	numWorkers := min(max(testQPS/100, 10), 500)
+	// Burst = numWorkers so at most one token per worker fires immediately at
+	// start, giving a clean ramp-up rather than a 10% spike.
+	limiter := rate.NewLimiter(rate.Limit(testQPS), numWorkers)
+
+	logger.Info("Prediction request generator started",
+		"target_qps", testQPS,
+		"workers", numWorkers)
+
+	dispatchRequest := func() {
+		// Block the rate-limiter worker when too many requests are in flight.
+		// This applies backpressure instead of letting goroutines pile up and OOM.
+		select {
+		case inFlightSem <- struct{}{}:
+		case <-testCtx.Done():
+			return
+		}
+		requestWg.Go(func() {
+			defer func() { <-inFlightSem }()
+
+			requests := make([]latencypredictorclient.PredictionRequest, numEndpointsPerRequest)
+			for i := range numEndpointsPerRequest {
+				requests[i] = latencypredictorclient.PredictionRequest{
+					KVCachePercentage:     float64(i%10) * 0.1,
+					InputTokenLength:      512 + i*64,
+					NumRequestWaiting:     i % 5,
+					NumRequestRunning:     (i % 3) + 1,
+					NumTokensGenerated:    256,
+					PrefixCacheScore:      float64(i%10) * 0.1,
+					PodType:               "monolithic",
+					PrefillTokensInFlight: int64(i * 1500),
+					DecodeTokensInFlight:  int64(i * 500),
+				}
+			}
+
+			start := time.Now()
+			resp, err := predictor.PredictBulkStrict(testCtx, requests)
+			latency := time.Since(start).Milliseconds()
+
+			atomic.AddInt64(&predMetrics.TotalRequests, 1)
+
+			if err != nil {
+				atomic.AddInt64(&predMetrics.FailedRequests, 1)
+				return
+			}
+
+			atomic.AddInt64(&predMetrics.SuccessfulRequests, 1)
+			atomic.AddInt64(&predMetrics.TotalLatencyMs, latency)
+			atomic.AddInt64(&predMetrics.TotalPredictionsCount, int64(len(resp.Predictions)))
+			atomic.AddInt64(&predMetrics.SuccessfulPredictions, int64(resp.SuccessfulPredictions))
+			atomic.AddInt64(&predMetrics.FailedPredictions, int64(resp.FailedPredictions))
+
+			for {
+				cur := atomic.LoadInt64(&predMetrics.MinLatency)
+				if latency >= cur || atomic.CompareAndSwapInt64(&predMetrics.MinLatency, cur, latency) {
+					break
+				}
+			}
+			for {
+				cur := atomic.LoadInt64(&predMetrics.MaxLatency)
+				if latency <= cur || atomic.CompareAndSwapInt64(&predMetrics.MaxLatency, cur, latency) {
+					break
+				}
+			}
+
+			predMetrics.LatenciesMutex.Lock()
+			predMetrics.Latencies = append(predMetrics.Latencies, latency)
+			predMetrics.LatenciesMutex.Unlock()
+		})
+	}
+
+	for range numWorkers {
+		generatorWg.Go(func() {
+			for {
+				if err := limiter.Wait(testCtx); err != nil {
+					return // context cancelled or deadline exceeded
+				}
+				if time.Now().After(testEnd) {
+					return
+				}
+				dispatchRequest()
+			}
+		})
+	}
+
+	// ---------------------------------------------------------------
+	// Goroutine 3: Periodic stats printer
+	// ---------------------------------------------------------------
+	generatorWg.Go(func() {
+
+		statsTicker := time.NewTicker(10 * time.Second)
+		defer statsTicker.Stop()
+
+		for {
+			select {
+			case <-testCtx.Done():
+				return
+			case <-statsTicker.C:
+				if time.Now().After(testEnd) {
+					return
+				}
+
+				req := atomic.LoadInt64(&predMetrics.TotalRequests)
+				succ := atomic.LoadInt64(&predMetrics.SuccessfulRequests)
+				failed := atomic.LoadInt64(&predMetrics.FailedRequests)
+				totalLat := atomic.LoadInt64(&predMetrics.TotalLatencyMs)
+
+				trainBatches := atomic.LoadInt64(&trainMetrics.TotalBatches)
+				trainEntries := atomic.LoadInt64(&trainMetrics.TotalEntries)
+				trainOK := atomic.LoadInt64(&trainMetrics.SuccessfulFlush)
+				trainFail := atomic.LoadInt64(&trainMetrics.FailedFlush)
+
+				var avgLat float64
+				if succ > 0 {
+					avgLat = float64(totalLat) / float64(succ)
+				}
+
+				logger.Info("Progress",
+					"pred_requests", req,
+					"pred_ok", succ,
+					"pred_fail", failed,
+					"avg_latency_ms", avgLat,
+					"min_ms", atomic.LoadInt64(&predMetrics.MinLatency),
+					"max_ms", atomic.LoadInt64(&predMetrics.MaxLatency),
+					"train_batches", trainBatches,
+					"train_entries", trainEntries,
+					"train_ok", trainOK,
+					"train_fail", trainFail)
+			}
+		}
+	})
+
+	// Wait for generators to finish (test duration elapsed)
+	generatorWg.Wait()
+
+	// Wait for all in-flight prediction requests to complete
+	requestWg.Wait()
+
+	// ---------------------------------------------------------------
+	// Calculate percentiles
+	// ---------------------------------------------------------------
+	predMetrics.LatenciesMutex.Lock()
+	slices.Sort(predMetrics.Latencies)
+	var p50, p99, p999 int64
+	n := len(predMetrics.Latencies)
+	if n > 0 {
+		p50 = predMetrics.Latencies[n*50/100]
+		if idx := n * 99 / 100; idx < n {
+			p99 = predMetrics.Latencies[idx]
+		}
+		if idx := n * 999 / 1000; idx < n {
+			p999 = predMetrics.Latencies[idx]
+		}
+	}
+	predMetrics.LatenciesMutex.Unlock()
+
+	totalReq := atomic.LoadInt64(&predMetrics.TotalRequests)
+	successReq := atomic.LoadInt64(&predMetrics.SuccessfulRequests)
+	failedReq := atomic.LoadInt64(&predMetrics.FailedRequests)
+	totalLat := atomic.LoadInt64(&predMetrics.TotalLatencyMs)
+	totalPred := atomic.LoadInt64(&predMetrics.TotalPredictionsCount)
+	succPred := atomic.LoadInt64(&predMetrics.SuccessfulPredictions)
+	failPred := atomic.LoadInt64(&predMetrics.FailedPredictions)
+
+	trainBatches := atomic.LoadInt64(&trainMetrics.TotalBatches)
+	trainEntries := atomic.LoadInt64(&trainMetrics.TotalEntries)
+	trainOK := atomic.LoadInt64(&trainMetrics.SuccessfulFlush)
+	trainFail := atomic.LoadInt64(&trainMetrics.FailedFlush)
+
+	var avgLatency float64
+	if successReq > 0 {
+		avgLatency = float64(totalLat) / float64(successReq)
+	}
+
+	// ---------------------------------------------------------------
+	// Print final results
+	// ---------------------------------------------------------------
+	var reqSuccessRate, predSuccessRate, trainSuccessRate float64
+	if totalReq > 0 {
+		reqSuccessRate = float64(successReq) / float64(totalReq) * 100
+	}
+	if totalPred > 0 {
+		predSuccessRate = float64(succPred) / float64(totalPred) * 100
+	}
+	if trainBatches > 0 {
+		trainSuccessRate = float64(trainOK) / float64(trainBatches) * 100
+	}
+
+	logger.Info("TEST RESULTS - Predictions",
+		"total_requests", totalReq,
+		"successful", successReq,
+		"failed", failedReq,
+		"request_success_rate_pct", reqSuccessRate,
+		"total_predictions", totalPred,
+		"successful_predictions", succPred,
+		"failed_predictions", failPred,
+		"prediction_success_rate_pct", predSuccessRate,
+		"avg_latency_ms", avgLatency,
+		"min_latency_ms", atomic.LoadInt64(&predMetrics.MinLatency),
+		"max_latency_ms", atomic.LoadInt64(&predMetrics.MaxLatency),
+		"p50_ms", p50,
+		"p99_ms", p99,
+		"p999_ms", p999,
+		"achieved_qps", float64(successReq)/time.Since(testStart).Seconds())
+
+	logger.Info("TEST RESULTS - Training",
+		"batches_sent", trainBatches,
+		"batches_ok", trainOK,
+		"batches_fail", trainFail,
+		"entries_sent", trainEntries,
+		"success_rate_pct", trainSuccessRate)
+
+	// Cleanup
+	cancel()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	predictor.Stop(stopCtx)
+	stopCancel()
+
+	if failedReq > 0 {
+		logger.Info("WARNING: Test had failed prediction requests", "failed_count", failedReq)
+		os.Remove("/tmp/test_running")
+		os.Exit(1)
+	}
+
+	os.Remove("/tmp/test_running")
+	logger.Info("Test completed successfully!")
+}
+
+// generateTrainingBatch creates a batch of realistic training entries.
+func generateTrainingBatch(rng *rand.Rand, batchSize int) []latencypredictorclient.TrainingEntry {
+	entries := make([]latencypredictorclient.TrainingEntry, batchSize)
+
+	for i := range batchSize {
+		inputTokens := 128 + rng.Intn(2048)
+		// Pick queue bucket uniformly across all 5 buckets: [0], [1-2], [3-5], [6-10], [11+]
+		var numWaiting int
+		switch rng.Intn(5) {
+		case 0:
+			numWaiting = 0
+		case 1:
+			numWaiting = rng.Intn(2) + 1 // 1-2
+		case 2:
+			numWaiting = rng.Intn(3) + 3 // 3-5
+		case 3:
+			numWaiting = rng.Intn(5) + 6 // 6-10
+		default:
+			numWaiting = rng.Intn(5) + 11 // 11-15
+		}
+		numRunning := rng.Intn(8) + 1
+		kvCache := rng.Float64()
+		prefixCache := rng.Float64()
+		numTokensGenerated := 64 + rng.Intn(512)
+		prefillTIF := int64(rng.Intn(15000))
+		decodeTIF := int64(rng.Intn(5000))
+
+		// Simulate realistic TTFT
+		baseTTFT := float64(inputTokens)*0.05 +
+			float64(prefillTIF)*0.05 +
+			float64(numWaiting)*10.0 +
+			float64(numRunning)*5.0
+
+		if kvCache > 0.7 {
+			baseTTFT *= 0.3
+		} else if kvCache > 0.4 {
+			baseTTFT *= 0.6
+		}
+
+		if prefixCache > 0.5 {
+			baseTTFT *= 0.8
+		}
+
+		ttftMs := math.Max(1.0, baseTTFT+(rng.Float64()-0.5)*baseTTFT*0.2)
+
+		// Simulate realistic TPOT
+		baseTPOT := 8.0 +
+			float64(decodeTIF)*0.02 +
+			float64(numRunning-1)*2.0 +
+			(rng.Float64()-0.5)*2.0
+
+		tpotMs := math.Max(1.0, baseTPOT*float64(numTokensGenerated))
+
+		// Mix of TTFT-only, TPOT-only, and both entries
+		actualTTFT := 0.0
+		actualTPOT := 0.0
+		switch i % 3 {
+		case 0:
+			actualTTFT = math.Round(ttftMs*100) / 100
+		case 1:
+			actualTPOT = math.Round(tpotMs*100) / 100
+		case 2:
+			actualTTFT = math.Round(ttftMs*100) / 100
+			actualTPOT = math.Round(tpotMs*100) / 100
+		}
+
+		entries[i] = latencypredictorclient.TrainingEntry{
+			KVCachePercentage:     kvCache,
+			InputTokenLength:      inputTokens,
+			NumRequestWaiting:     numWaiting,
+			NumRequestRunning:     numRunning,
+			NumTokensGenerated:    numTokensGenerated,
+			ActualTTFT:            actualTTFT,
+			ActualTPOT:            actualTPOT,
+			PrefixCacheScore:      prefixCache,
+			PrefillTokensInFlight: prefillTIF,
+			DecodeTokensInFlight:  decodeTIF,
+			Timestamp:             time.Now(),
+		}
+	}
+
+	return entries
+}
+
+// parseEnvInt reads an integer environment variable, logging a warning on parse
+// failure, and returns the default value when the variable is unset or invalid.
+func parseEnvInt(key string, defaultVal int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return defaultVal
+	}
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Printf("Warning: invalid value %q for %s, using default %d", raw, key, defaultVal)
+		return defaultVal
+	}
+	if val == 0 {
+		return defaultVal
+	}
+	return val
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/manifests/predictor_warmup.yaml
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/manifests/predictor_warmup.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: predictor-warmup
+  namespace: default
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: predictor-warmup
+        image: <your-registry>/latency-predictor-load-test:latest
+        imagePullPolicy: Always
+        env:
+        - name: PREDICTION_SERVERS
+          value: "http://vllm-qwen3-32b-epp:8001"
+        - name: TRAINING_SERVER_URL
+          value: "http://vllm-qwen3-32b-epp:8000"
+        # Minimal prediction load — warmup is purely to fill training buckets
+        - name: TEST_QPS
+          value: "1"
+        - name: TEST_DURATION_SECONDS
+          value: "300"
+        - name: MAX_BULK_SIZE
+          value: "1000"
+        - name: NUM_ENDPOINTS_PER_REQUEST
+          value: "1"
+        - name: MAX_CONCURRENT_DISPATCHES
+          value: "2"
+        - name: MAX_INFLIGHT_REQUESTS
+          value: "10"
+        - name: COALESCE_WINDOW_MS
+          value: "1"
+        - name: MAX_COALESCED_CALLERS
+          value: "10"
+        # High training rate to fill buckets fast
+        - name: TRAINING_BATCH_SIZE
+          value: "1000"
+        - name: TRAINING_INTERVAL_MS
+          value: "500"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/run_qps_sweep.sh
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/run_qps_sweep.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# QPS sweep test: runs 1, 10, 100, 1000, 2500, 5000, 7500, 10000 QPS
+# Each test runs for 300s. No warmup needed (training server already full).
+# Results written to /tmp/qps_results.txt
+#
+# Usage:
+#   ./run_qps_sweep.sh [OPTIONS]
+#
+# Options:
+#   --pred-base-url    Base URL for prediction servers (port appended per sidecar)
+#                      Default: http://vllm-qwen3-32b-epp
+#   --pred-start-port  Port for the first prediction server; incremented per sidecar
+#                      Default: 8001
+#   --train-url        Full URL for the training server
+#                      Default: http://vllm-qwen3-32b-epp:8000
+#
+# Examples:
+#   # Default (EPP sidecar mode):
+#   ./run_qps_sweep.sh
+#
+#   # Standalone dual-server deployment (prediction-service serves on port 80):
+#   ./run_qps_sweep.sh \
+#     --pred-base-url http://prediction-service \
+#     --pred-start-port 80 \
+#     --train-url http://training-service:8000
+
+set -e
+
+# Defaults
+PRED_BASE_URL="http://vllm-qwen3-32b-epp"
+PRED_START_PORT=8001
+TRAIN_URL="http://vllm-qwen3-32b-epp:8000"
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pred-base-url)
+      PRED_BASE_URL="$2"; shift 2 ;;
+    --pred-start-port)
+      PRED_START_PORT="$2"; shift 2 ;;
+    --train-url)
+      TRAIN_URL="$2"; shift 2 ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--pred-base-url URL] [--pred-start-port PORT] [--train-url URL]"
+      exit 1 ;;
+  esac
+done
+
+IMAGE="${LOAD_TEST_IMAGE:-us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/latency-predictor-load-test:latest}"
+RESULTS_FILE=/tmp/qps_results.txt
+echo "QPS Sweep Results - $(date)" > $RESULTS_FILE
+echo "  pred-base-url:    ${PRED_BASE_URL}" >> $RESULTS_FILE
+echo "  pred-start-port:  ${PRED_START_PORT}" >> $RESULTS_FILE
+echo "  train-url:        ${TRAIN_URL}" >> $RESULTS_FILE
+echo "========================================" >> $RESULTS_FILE
+
+run_test() {
+  local QPS=$1 DISP=$2 INF=$3 SIDECARS=$4
+  echo ""
+  echo ">>> Running QPS=$QPS  sidecars=$SIDECARS  dispatches=$DISP  inflight=$INF"
+
+  # Build PREDICTION_SERVERS from sidecar count
+  local PRED_SERVERS=""
+  for i in $(seq 1 $SIDECARS); do
+    local PORT=$(( PRED_START_PORT + i - 1 ))
+    if [ -z "$PRED_SERVERS" ]; then
+      PRED_SERVERS="${PRED_BASE_URL}:${PORT}"
+    else
+      PRED_SERVERS="${PRED_SERVERS},${PRED_BASE_URL}:${PORT}"
+    fi
+  done
+
+  kubectl delete job predictor-client-test-sweep --ignore-not-found 2>/dev/null
+  sleep 2
+
+  cat <<YAML | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: predictor-client-test-sweep
+  namespace: default
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: predictor-client-test
+        image: ${IMAGE}
+        imagePullPolicy: Always
+        env:
+        - name: PREDICTION_SERVERS
+          value: "${PRED_SERVERS}"
+        - name: TRAINING_SERVER_URL
+          value: "${TRAIN_URL}"
+        - name: TEST_QPS
+          value: "${QPS}"
+        - name: TEST_DURATION_SECONDS
+          value: "300"
+        - name: MAX_BULK_SIZE
+          value: "1000"
+        - name: NUM_ENDPOINTS_PER_REQUEST
+          value: "100"
+        - name: MAX_CONCURRENT_DISPATCHES
+          value: "${DISP}"
+        - name: MAX_INFLIGHT_REQUESTS
+          value: "${INF}"
+        - name: COALESCE_WINDOW_MS
+          value: "1"
+        - name: MAX_COALESCED_CALLERS
+          value: "10"
+        - name: TRAINING_BATCH_SIZE
+          value: "1000"
+        - name: TRAINING_INTERVAL_MS
+          value: "500"
+        resources:
+          requests:
+            cpu: "1000m"
+            memory: "1Gi"
+          limits:
+            cpu: "4000m"
+            memory: "8Gi"
+YAML
+
+  echo "  Waiting for job to complete..."
+  kubectl wait --for=condition=complete job/predictor-client-test-sweep --timeout=480s
+
+  PRED=$(kubectl logs job/predictor-client-test-sweep 2>/dev/null | grep "TEST RESULTS - Predictions")
+  echo "QPS_TARGET=${QPS} | ${PRED}" | tee -a $RESULTS_FILE
+
+  kubectl delete job predictor-client-test-sweep --ignore-not-found 2>/dev/null
+  sleep 3
+}
+
+#       QPS    dispatches  inflight  sidecars
+run_test 1      36          5         1
+run_test 10     36          5         1
+run_test 100    36          20        1
+run_test 1000   36          85        1
+run_test 2500   36          215       1
+run_test 5000   36          430       1
+#run_test 5000   36          430       2
+#run_test 7500   92          640       3
+#run_test 10000  120         850       4
+
+echo ""
+echo "========================================" >> $RESULTS_FILE
+echo "SWEEP COMPLETE" >> $RESULTS_FILE
+echo ""
+echo "=== FINAL RESULTS ==="
+cat $RESULTS_FILE

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
@@ -1,0 +1,410 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictorclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+)
+
+// AddTrainingDataBulk buffers entries for periodic flush.
+func (p *Predictor) AddTrainingDataBulk(entries []TrainingEntry) error {
+	p.bufferMu.Lock()
+	p.pending = append(p.pending, entries...)
+	p.bufferMu.Unlock()
+	return nil
+}
+
+// randomSample returns up to maxSize entries via stratified sampling to preserve
+// the ratio of TTFT entries (ActualTTFT > 0) and TPOT entries (ActualTPOT > 0).
+func (p *Predictor) randomSample(entries []TrainingEntry, maxSize int) []TrainingEntry {
+	if len(entries) <= maxSize {
+		return entries
+	}
+
+	// Separate entries into three groups
+	var ttftEntries []TrainingEntry
+	var tpotEntries []TrainingEntry
+	var otherEntries []TrainingEntry
+
+	for _, entry := range entries {
+		hasTTFT := entry.ActualTTFT > 0
+		hasTPOT := entry.ActualTPOT > 0
+
+		switch {
+		case hasTTFT:
+			ttftEntries = append(ttftEntries, entry)
+		case hasTPOT:
+			tpotEntries = append(tpotEntries, entry)
+		default:
+			otherEntries = append(otherEntries, entry)
+		}
+	}
+
+	totalEntries := len(entries)
+	if totalEntries == 0 {
+		return entries
+	}
+
+	// Calculate proportional sample sizes
+	ttftSampleSize := int(float64(len(ttftEntries)) / float64(totalEntries) * float64(maxSize))
+	tpotSampleSize := int(float64(len(tpotEntries)) / float64(totalEntries) * float64(maxSize))
+	otherSampleSize := int(float64(len(otherEntries)) / float64(totalEntries) * float64(maxSize))
+
+	// Adjust for rounding errors to ensure we reach exactly maxSize
+	totalSampled := ttftSampleSize + tpotSampleSize + otherSampleSize
+	if totalSampled < maxSize {
+		remaining := maxSize - totalSampled
+
+		// Distribute remaining samples to the largest *original* group
+		switch {
+		case len(ttftEntries) >= len(tpotEntries) && len(ttftEntries) >= len(otherEntries):
+			ttftSampleSize += remaining
+		case len(tpotEntries) >= len(otherEntries):
+			tpotSampleSize += remaining
+		default:
+			otherSampleSize += remaining
+		}
+
+	} else if totalSampled > maxSize {
+		excess := totalSampled - maxSize
+
+		// Reduce from the largest *sampled* group
+		switch {
+		case ttftSampleSize >= tpotSampleSize && ttftSampleSize >= otherSampleSize:
+			ttftSampleSize -= excess
+		case tpotSampleSize >= otherSampleSize:
+			tpotSampleSize -= excess
+		default:
+			otherSampleSize -= excess
+		}
+	}
+
+	var result []TrainingEntry
+
+	// Sample from each group
+	if ttftSampleSize > 0 && len(ttftEntries) > 0 {
+		ttftSample := p.sampleFromSlice(ttftEntries, min(ttftSampleSize, len(ttftEntries)))
+		result = append(result, ttftSample...)
+	}
+
+	if tpotSampleSize > 0 && len(tpotEntries) > 0 {
+		tpotSample := p.sampleFromSlice(tpotEntries, min(tpotSampleSize, len(tpotEntries)))
+		result = append(result, tpotSample...)
+	}
+
+	if otherSampleSize > 0 && len(otherEntries) > 0 {
+		otherSample := p.sampleFromSlice(otherEntries, min(otherSampleSize, len(otherEntries)))
+		result = append(result, otherSample...)
+	}
+
+	return result
+}
+
+// Helper function to sample from a slice
+func (p *Predictor) sampleFromSlice(entries []TrainingEntry, sampleSize int) []TrainingEntry {
+	if len(entries) <= sampleSize {
+		return entries
+	}
+
+	// Create a copy and shuffle
+	sample := make([]TrainingEntry, len(entries))
+	copy(sample, entries)
+	p.rng.Shuffle(len(sample), func(i, j int) {
+		sample[i], sample[j] = sample[j], sample[i]
+	})
+
+	return sample[:sampleSize]
+}
+
+// flushTraining sends buffered entries to training server in one bulk POST, with error handling.
+func (p *Predictor) flushTraining(ctx context.Context) {
+	p.bufferMu.Lock()
+	if len(p.pending) == 0 {
+		p.bufferMu.Unlock()
+		return
+	}
+	batch := p.pending
+	p.pending = nil
+	p.bufferMu.Unlock()
+
+	originalSize := len(batch)
+	if originalSize > p.config.MaxSampleSize {
+		batch = p.randomSample(batch, p.config.MaxSampleSize)
+		p.logger.V(logutil.DEBUG).Info("Sampled training entries for flush",
+			"original_size", originalSize,
+			"sampled_size", len(batch))
+	}
+
+	payload := BulkTrainingRequest{Entries: batch}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		p.logger.Error(err, "Failed to marshal bulk payload")
+		return // Cannot send if marshalling fails
+	}
+
+	// Send training data to training server
+	url := p.config.TrainingURL + "/add_training_data_bulk"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(data))
+	if err != nil {
+		p.logger.Error(err, "Failed to create bulk POST request", "url", url)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		p.logger.Error(err, "Bulk POST failed", "url", url)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Ensure body is read and closed
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		p.logger.Error(err, "failed to read response body", "url", url)
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		p.logger.Error(fmt.Errorf("status %d", resp.StatusCode),
+			"Bulk POST returned non-202 status", "url", url)
+	} else {
+		p.logger.V(logutil.DEBUG).Info("Flushed training batch", "sent_count", len(batch), "original_count", originalSize)
+	}
+}
+
+// ValidateTrainingEntry validates that a training entry has all required fields
+// with valid values, including the new prefix_cache_score field.
+func (p *Predictor) ValidateTrainingEntry(entry TrainingEntry) error {
+	if entry.KVCachePercentage < 0.0 || entry.KVCachePercentage > 1.0 {
+		return fmt.Errorf("kv_cache_percentage must be between 0.0 and 1.0, got %f", entry.KVCachePercentage)
+	}
+	if entry.InputTokenLength < 0 {
+		return fmt.Errorf("input_token_length must be non-negative, got %d", entry.InputTokenLength)
+	}
+	if entry.NumRequestWaiting < 0 {
+		return fmt.Errorf("num_request_waiting must be non-negative, got %d", entry.NumRequestWaiting)
+	}
+	if entry.NumRequestRunning < 0 {
+		return fmt.Errorf("num_request_running must be non-negative, got %d", entry.NumRequestRunning)
+	}
+	if entry.NumTokensGenerated < 0 {
+		return fmt.Errorf("num_tokens_generated must be non-negative, got %d", entry.NumTokensGenerated)
+	}
+	if entry.ActualTTFT < 0.0 {
+		return fmt.Errorf("actual_ttft_ms must be non-negative, got %f", entry.ActualTTFT)
+	}
+	if entry.ActualTPOT < 0.0 {
+		return fmt.Errorf("actual_tpot_ms must be non-negative, got %f", entry.ActualTPOT)
+	}
+	if entry.PrefixCacheScore < 0.0 || entry.PrefixCacheScore > 1.0 {
+		return fmt.Errorf("prefix_cache_score must be between 0.0 and 1.0, got %f", entry.PrefixCacheScore)
+	}
+	return nil
+}
+
+// NewTrainingEntry is a helper function to create a new TrainingEntry with proper validation.
+func NewTrainingEntry(
+	kvCachePercentage float64,
+	inputTokenLength int,
+	numRequestWaiting int,
+	numRequestRunning int,
+	numTokensGenerated int,
+	actualTTFT float64,
+	actualTPOT float64,
+	prefixCacheScore float64,
+) (TrainingEntry, error) {
+	entry := TrainingEntry{
+		KVCachePercentage:  kvCachePercentage,
+		InputTokenLength:   inputTokenLength,
+		NumRequestWaiting:  numRequestWaiting,
+		NumRequestRunning:  numRequestRunning,
+		NumTokensGenerated: numTokensGenerated,
+		ActualTTFT:         actualTTFT,
+		ActualTPOT:         actualTPOT,
+		PrefixCacheScore:   prefixCacheScore,
+		Timestamp:          time.Now(),
+	}
+
+	// Create a temporary predictor for validation (could be optimized)
+	p := &Predictor{}
+	if err := p.ValidateTrainingEntry(entry); err != nil {
+		return TrainingEntry{}, err
+	}
+
+	return entry, nil
+}
+
+// refreshModelInfo gets current model type and readiness info from training server
+func (p *Predictor) refreshModelInfo(ctx context.Context) error {
+	url := p.config.TrainingURL + "/model/download/info"
+	p.logger.V(logutil.DEBUG).Info("Fetching model info", "url", url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create model info request: %w", err)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call /model/download/info endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server %s returned non-200 status: %d %s, body: %s", url, resp.StatusCode, resp.Status, string(body))
+	}
+
+	var modelInfo ModelInfo
+	if err := json.NewDecoder(resp.Body).Decode(&modelInfo); err != nil {
+		return fmt.Errorf("failed to decode model info response: %w", err)
+	}
+
+	p.metricsMu.Lock()
+	p.modelInfo = &modelInfo
+	p.metricsMu.Unlock()
+
+	p.logger.V(logutil.DEBUG).Info("Retrieved model info", "model_type", modelInfo.ModelType, "model_status", modelInfo.ModelStatus)
+	return nil
+}
+
+// refreshMetrics GETs /metrics from training server and caches parsed coefficients or fetches XGBoost trees.
+func (p *Predictor) refreshMetrics(ctx context.Context) {
+	// Refresh model info first
+	if err := p.refreshModelInfo(ctx); err != nil {
+		p.logger.Error(err, "Failed to refresh model info during periodic refresh")
+		return
+	}
+
+	p.metricsMu.RLock()
+	modelType := ""
+	if p.modelInfo != nil {
+		modelType = p.modelInfo.ModelType
+	}
+	p.metricsMu.RUnlock()
+
+	if modelType == "" {
+		p.logger.V(logutil.DEBUG).Info("Cannot refresh metrics: model type is unknown")
+		return
+	}
+
+	switch modelType {
+	case bayesianRidgeModelType:
+		if _, err := p.GetMetrics(ctx); err != nil {
+			p.logger.Error(err, "Failed to refresh Bayesian Ridge metrics")
+		}
+	case xgBoostModelType:
+		if p.config.UseNativeXGBoost {
+			// Fetch XGBoost trees for native predictions
+			trees, err := p.getXGBoostTrees(ctx)
+			if err != nil {
+				p.logger.Error(err, "Failed to fetch XGBoost trees")
+				return
+			}
+
+			p.metricsMu.Lock()
+			if p.cachedMetrics == nil {
+				p.cachedMetrics = &MetricsResponse{}
+			}
+			p.cachedMetrics.ModelType = modelType
+			p.cachedMetrics.XGBoostTrees = trees
+			p.metricsMu.Unlock()
+
+			p.logger.V(logutil.DEBUG).Info("Updated XGBoost trees for native predictions")
+		} else {
+			// Just update model type for HTTP-based predictions
+			p.metricsMu.Lock()
+			if p.cachedMetrics == nil {
+				p.cachedMetrics = &MetricsResponse{}
+			}
+			p.cachedMetrics.ModelType = modelType
+			p.metricsMu.Unlock()
+
+			p.logger.V(logutil.DEBUG).Info("Updated model type for HTTP-based predictions", "model_type", modelType)
+		}
+	case gbmModelType:
+		// LightGBM only supports HTTP calls, no native tree caching needed
+		p.metricsMu.Lock()
+		if p.cachedMetrics == nil {
+			p.cachedMetrics = &MetricsResponse{}
+		}
+		p.cachedMetrics.ModelType = modelType
+		p.metricsMu.Unlock()
+
+		p.logger.V(logutil.DEBUG).Info("Updated model type for HTTP-based predictions", "model_type", modelType)
+	default:
+		p.logger.Info("Unknown model type, cannot refresh metrics", "model_type", modelType)
+	}
+}
+
+// getXGBoostTrees fetches tree JSON from the training server
+func (p *Predictor) getXGBoostTrees(ctx context.Context) (*XGBoostTrees, error) {
+	trees := &XGBoostTrees{}
+
+	// Fetch TTFT trees from training server
+	ttftURL := p.config.TrainingURL + "/model/ttft/xgb/json"
+	ttftReq, err := http.NewRequestWithContext(ctx, http.MethodGet, ttftURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TTFT trees request: %w", err)
+	}
+
+	ttftResp, err := p.httpClient.Do(ttftReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch TTFT trees: %w", err)
+	}
+	defer ttftResp.Body.Close()
+
+	if ttftResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(ttftResp.Body)
+		return nil, fmt.Errorf("TTFT trees request failed: %d %s, body: %s", ttftResp.StatusCode, ttftResp.Status, string(body))
+	}
+
+	if err := json.NewDecoder(ttftResp.Body).Decode(&trees.TTFTTrees); err != nil {
+		return nil, fmt.Errorf("failed to decode TTFT trees: %w", err)
+	}
+
+	// Fetch TPOT trees from training server
+	tpotURL := p.config.TrainingURL + "/model/tpot/xgb/json"
+	tpotReq, err := http.NewRequestWithContext(ctx, http.MethodGet, tpotURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TPOT trees request: %w", err)
+	}
+
+	tpotResp, err := p.httpClient.Do(tpotReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch TPOT trees: %w", err)
+	}
+	defer tpotResp.Body.Close()
+
+	if tpotResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(tpotResp.Body)
+		return nil, fmt.Errorf("TPOT trees request failed: %d %s, body: %s", tpotResp.StatusCode, tpotResp.Status, string(body))
+	}
+
+	if err := json.NewDecoder(tpotResp.Body).Decode(&trees.TPOTTrees); err != nil {
+		return nil, fmt.Errorf("failed to decode TPOT trees: %w", err)
+	}
+
+	return trees, nil
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/types.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictorclient
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	gbmModelType           = "lightgbm"
+	bayesianRidgeModelType = "bayesian_ridge"
+	xgBoostModelType       = "xgboost"
+
+	// ObjectiveType constants for prediction objective.
+	ObjectiveQuantile = "quantile"
+	ObjectiveMean     = "mean"
+)
+
+// --- Configuration ---
+
+type Config struct {
+	// TrainingURL is the base URL of the Python training server.
+	TrainingURL string
+	// PredictionURLs is a list of prediction server URLs for load balancing.
+	PredictionURLs []string
+	// MaxSampleSize is the maximum number of training entries to send in each flush.
+	// If the buffer contains more entries, they will be randomly sampled.
+	MaxSampleSize int
+	// FlushInterval determines how often to flush training & refresh metrics.
+	FlushInterval time.Duration
+	// UseNativeXGBoost when true, attempts to use local XGBoost models for prediction.
+	// When false, falls back to HTTP calls to the Python server for XGBoost predictions.
+	UseNativeXGBoost bool
+	// HTTPTimeout is the timeout for HTTP requests to the Python server.
+	HTTPTimeout time.Duration
+	// MetricsRefreshInterval determines how often to refresh cached metrics.
+	MetricsRefreshInterval time.Duration
+	// MaxBulkSize is the maximum number of predictions to send in a single bulk request.
+	MaxBulkSize int
+	// CoalesceWindow is how long the coalescer waits to accumulate concurrent
+	// PredictBulkStrict callers before firing one mega-batch HTTP call.
+	// Set to 0 to disable coalescing (each caller gets its own HTTP call).
+	CoalesceWindow time.Duration
+	// MaxCoalescedRows caps the total number of rows in one coalesced mega-batch,
+	// causing an early dispatch before the window expires.
+	// This is separate from MaxBulkSize (the per-caller row limit).
+	// Default 0 means no row cap (window-only dispatch).
+	MaxCoalescedRows int
+	// MaxConcurrentDispatches limits how many coalesced HTTP calls can be
+	// in-flight to the prediction server simultaneously. Defaults to 36.
+	MaxConcurrentDispatches int
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		TrainingURL:             "http://localhost:8000",
+		PredictionURLs:          []string{"http://localhost:8001"},
+		MaxSampleSize:           1000,
+		FlushInterval:           1 * time.Second,
+		MetricsRefreshInterval:  60 * time.Second,
+		UseNativeXGBoost:        true,
+		HTTPTimeout:             10 * time.Second,
+		MaxBulkSize:             100,
+		CoalesceWindow:          1 * time.Millisecond,
+		MaxCoalescedRows:        0,
+		MaxConcurrentDispatches: 36,
+	}
+}
+
+func ConfigFromEnv() *Config {
+	cfg := DefaultConfig()
+
+	// Training URL (single URL for training data submission)
+	if url := os.Getenv("TRAINING_SERVER_URL"); url != "" {
+		cfg.TrainingURL = url
+	}
+
+	// Prediction URLs (comma-separated list for load balancing)
+	if urls := os.Getenv("PREDICTION_SERVER_URL"); urls != "" {
+		predictionURLs := strings.Split(urls, ",")
+		for i, url := range predictionURLs {
+			predictionURLs[i] = strings.TrimSpace(url)
+		}
+		cfg.PredictionURLs = predictionURLs
+	}
+
+	if sizeStr := os.Getenv("LATENCY_MAX_SAMPLE_SIZE"); sizeStr != "" {
+		if size, err := strconv.Atoi(sizeStr); err == nil && size > 0 {
+			cfg.MaxSampleSize = size
+		}
+	}
+	if intervalStr := os.Getenv("LATENCY_FLUSH_INTERVAL_SEC"); intervalStr != "" {
+		if sec, err := strconv.Atoi(intervalStr); err == nil && sec > 0 {
+			cfg.FlushInterval = time.Duration(sec) * time.Second
+		}
+	}
+	if nativeStr := os.Getenv("LATENCY_USE_NATIVE_XGBOOST"); nativeStr != "" {
+		cfg.UseNativeXGBoost = strings.ToLower(nativeStr) == "true"
+	}
+	if timeoutStr := os.Getenv("LATENCY_HTTP_TIMEOUT_SEC"); timeoutStr != "" {
+		if sec, err := strconv.Atoi(timeoutStr); err == nil && sec > 0 {
+			cfg.HTTPTimeout = time.Duration(sec) * time.Second
+		}
+	}
+	if s := os.Getenv("LATENCY_METRICS_INTERVAL_SEC"); s != "" {
+		if sec, err := strconv.Atoi(s); err == nil && sec > 0 {
+			cfg.MetricsRefreshInterval = time.Duration(sec) * time.Second
+		}
+	}
+	if bulkStr := os.Getenv("LATENCY_MAX_BULK_SIZE"); bulkStr != "" {
+		if size, err := strconv.Atoi(bulkStr); err == nil && size > 0 && size <= 100 {
+			cfg.MaxBulkSize = size
+		}
+	}
+	if msStr := os.Getenv("LATENCY_COALESCE_WINDOW_MS"); msStr != "" {
+		if ms, err := strconv.Atoi(msStr); err == nil && ms >= 0 {
+			cfg.CoalesceWindow = time.Duration(ms) * time.Millisecond
+		}
+	}
+	if s := os.Getenv("LATENCY_MAX_COALESCED_ROWS"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
+			cfg.MaxCoalescedRows = n
+		}
+	}
+	if s := os.Getenv("LATENCY_MAX_CONCURRENT_DISPATCHES"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			cfg.MaxConcurrentDispatches = n
+		} else {
+			log.Printf("WARNING: LATENCY_MAX_CONCURRENT_DISPATCHES=%q is invalid (must be > 0), using default %d", s, cfg.MaxConcurrentDispatches)
+		}
+	}
+	return cfg
+}
+
+// Predictor defines the interface for latency prediction and training.
+type PredictorInterface interface {
+	Predict(ctx context.Context, req PredictionRequest) (*PredictionResponse, error)
+	PredictBulk(ctx context.Context, requests []PredictionRequest) (*BulkPredictionResponse, error)
+	PredictBulkStrict(ctx context.Context, requests []PredictionRequest) (*BulkPredictionResponse, error)
+	AddTrainingDataBulk(entry []TrainingEntry) error
+}
+
+// --- Data Models ---
+
+type TrainingEntry struct {
+	KVCachePercentage     float64   `json:"kv_cache_percentage"`
+	InputTokenLength      int       `json:"input_token_length"`
+	NumRequestWaiting     int       `json:"num_request_waiting"`
+	NumRequestRunning     int       `json:"num_request_running"`
+	NumTokensGenerated    int       `json:"num_tokens_generated"`
+	ActualTTFT            float64   `json:"actual_ttft_ms"`
+	ActualTPOT            float64   `json:"actual_tpot_ms"`
+	PrefixCacheScore      float64   `json:"prefix_cache_score"`
+	PodType               string    `json:"pod_type,omitempty"` // "prefill", "decode", or "" for monolithic
+	PrefillTokensInFlight int64     `json:"prefill_tokens_in_flight"`
+	DecodeTokensInFlight  int64     `json:"decode_tokens_in_flight"`
+	Timestamp             time.Time `json:"timestamp"`
+}
+
+type BulkTrainingRequest struct {
+	Entries []TrainingEntry `json:"entries"`
+}
+
+type PredictionRequest struct {
+	KVCachePercentage     float64 `json:"kv_cache_percentage"`
+	InputTokenLength      int     `json:"input_token_length"`
+	NumRequestWaiting     int     `json:"num_request_waiting"`
+	NumRequestRunning     int     `json:"num_request_running"`
+	NumTokensGenerated    int     `json:"num_tokens_generated"`
+	PrefixCacheScore      float64 `json:"prefix_cache_score"`
+	PodType               string  `json:"pod_type,omitempty"` // "prefill", "decode", or "" for monolithic
+	PrefillTokensInFlight int64   `json:"prefill_tokens_in_flight"`
+	DecodeTokensInFlight  int64   `json:"decode_tokens_in_flight"`
+}
+
+type PredictionResponse struct {
+	TTFT                 float64    `json:"ttft_ms"`
+	TPOT                 float64    `json:"tpot_ms"`
+	TTFTUncertainty      float64    `json:"ttft_uncertainty,omitempty"`
+	TPOTUncertainty      float64    `json:"tpot_uncertainty,omitempty"`
+	TTFTPredictionBounds [2]float64 `json:"ttft_prediction_bounds,omitempty"`
+	TPOTPredictionBounds [2]float64 `json:"tpot_prediction_bounds,omitempty"`
+	PredictedAt          time.Time  `json:"predicted_at"`
+	ModelType            string     `json:"model_type"`
+	ObjectiveType        string     `json:"objective_type,omitempty"`
+	Quantile             float64    `json:"quantile"`
+	LastModelLoad        *time.Time `json:"last_model_load"`
+}
+
+// New data models for bulk predictions
+type BulkPredictionRequest struct {
+	Requests []PredictionRequest `json:"requests"`
+}
+
+type BulkPredictionResponse struct {
+	Predictions           []PredictionResponse `json:"predictions"`
+	TotalRequests         int                  `json:"total_requests"`
+	SuccessfulPredictions int                  `json:"successful_predictions"`
+	FailedPredictions     int                  `json:"failed_predictions"`
+	ProcessingTimeMs      float64              `json:"processing_time_ms"`
+}
+
+type BulkPredictionError struct {
+	Index   int               `json:"index"`
+	Error   string            `json:"error"`
+	Request PredictionRequest `json:"request"`
+}
+
+type BulkPredictionResponseWithErrors struct {
+	Predictions           []*PredictionResponse `json:"predictions"`
+	Errors                []BulkPredictionError `json:"errors"`
+	TotalRequests         int                   `json:"total_requests"`
+	SuccessfulPredictions int                   `json:"successful_predictions"`
+	FailedPredictions     int                   `json:"failed_predictions"`
+	ProcessingTimeMs      float64               `json:"processing_time_ms"`
+}
+
+// Server status response
+type ServerStatusResponse struct {
+	IsReady           bool            `json:"is_ready"`
+	ModelType         string          `json:"model_type"`
+	ObjectiveType     string          `json:"objective_type,omitempty"`
+	Quantile          float64         `json:"quantile"`
+	LastModelLoad     *time.Time      `json:"last_model_load"`
+	TrainingServerURL string          `json:"training_server_url"`
+	ModelsExist       map[string]bool `json:"models_exist"`
+}
+
+type ModelCoefficients struct {
+	TTFTIntercept float64            `json:"ttft_intercept"`
+	TTFTCoeffs    map[string]float64 `json:"ttft_coefficients"`
+	TPOTIntercept float64            `json:"tpot_intercept"`
+	TPOTCoeffs    map[string]float64 `json:"tpot_coefficients"`
+}
+
+type XGBoostTrees struct {
+	TTFTTrees []any `json:"ttft_trees"`
+	TPOTTrees []any `json:"tpot_trees"`
+}
+
+type BucketCounts struct {
+	TTFTBuckets map[int]int `json:"ttft_buckets"`
+	TPOTBuckets map[int]int `json:"tpot_buckets"`
+}
+
+type ModelInfo struct {
+	ModelType     string          `json:"model_type"`
+	ObjectiveType string          `json:"objective_type,omitempty"`
+	ModelStatus   map[string]bool `json:"model_status"`
+	Quantile      float64         `json:"quantile"`
+}
+
+type MetricsResponse struct {
+	ModelType    string             `json:"model_type"`
+	Coefficients *ModelCoefficients `json:"coefficients"`
+	XGBoostTrees *XGBoostTrees      `json:"xgboost_trees"`
+	BucketCounts *BucketCounts      `json:"bucket_counts"`
+	RawMetrics   string             `json:"raw_metrics"`
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -28,10 +28,10 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 
 	errcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 	"time"
 
+	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
-	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 
 	reqcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
@@ -20,8 +20,8 @@ package predictedlatency
 import (
 	"context"
 
+	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
@@ -19,9 +19,9 @@ package predictedlatency
 import (
 	"testing"
 
+	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
-	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	reqcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/request"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
+	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"testing"
 
+	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
-	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"


### PR DESCRIPTION
Copies sidecars/latencypredictorasync from
kubernetes-sigs/gateway-api-inference-extension@main as pkg/epp/.../predictedlatency/latencypredictorclient (package renamed from latencypredictorasync) and repoints the seven scheduler files that previously imported the upstream path. Adds a README describing the package as the Go client for the llm-d-latency-predictor Python service.
