### PR TITLE
refactor(datalayer): type extractor dispatch; remove reflect machinery 

### DIFF
--- a/pkg/epp/backend/metrics/podmetrics_parity_test.go
+++ b/pkg/epp/backend/metrics/podmetrics_parity_test.go
@@ -374,7 +374,7 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 		return endpoint.GetMetrics(), err
 	}
 	if data != nil {
-		err = extractor.Extract(ctx, data, endpoint)
+		err = extractor.Extract(ctx, fwkdl.NewPollingInput(data, endpoint))
 		if err != nil {
 			return endpoint.GetMetrics(), err
 		}

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -33,7 +33,6 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/config"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol"
-	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkfc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
@@ -310,22 +309,24 @@ func buildDataLayerConfig(rawDataConfig *configapi.DataLayerConfig, handle fwkpl
 	}
 
 	for _, source := range rawDataConfig.Sources {
-		if sourcePlugin, ok := handle.Plugin(source.PluginRef).(fwkdl.DataSource); ok {
-			sourceConfig := datalayer.DataSourceConfig{
-				Plugin:     sourcePlugin,
-				Extractors: []fwkdl.ExtractorBase{},
-			}
-			for _, extractor := range source.Extractors {
-				if extractorPlugin, ok := handle.Plugin(extractor.PluginRef).(fwkdl.ExtractorBase); ok {
-					sourceConfig.Extractors = append(sourceConfig.Extractors, extractorPlugin)
-				} else {
-					return nil, fmt.Errorf("the plugin %s is not a fwkdl.ExtractorBase", source.PluginRef)
-				}
-			}
-			cfg.Sources = append(cfg.Sources, sourceConfig)
-		} else {
-			return nil, fmt.Errorf("the plugin %s is not a fwkdl.DataSource", source.PluginRef)
+		src, err := datalayer.ResolveSource(handle, source.PluginRef)
+		if err != nil {
+			return nil, err
 		}
+		extractors := make([]fwkplugin.Plugin, 0, len(source.Extractors))
+		for _, e := range source.Extractors {
+			p := handle.Plugin(e.PluginRef)
+			if p == nil {
+				return nil, fmt.Errorf("extractor plugin %s not found (required by source %s)",
+					e.PluginRef, source.PluginRef)
+			}
+			extractors = append(extractors, p)
+		}
+
+		cfg.Sources = append(cfg.Sources, datalayer.DataSourceConfig{
+			Plugin:     src,
+			Extractors: extractors,
+		})
 	}
 	return &cfg, nil
 }

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -746,34 +745,16 @@ func (m *mockSaturationDetector) Saturation(ctx context.Context, endpoints []fwk
 	return 0.5
 }
 
-func (m *mockSource) AddExtractor(_ fwkdl.Extractor) error {
-	return nil
+// mockSource implements PollingDataSource for config-loader tests; Poll is
+// never exercised here, so the (nil, nil) return is intentional.
+func (m *mockSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
+	return nil, nil //nolint:nilnil // mock satisfies the interface; not invoked by these tests
 }
 
-func (m *mockSource) Collect(ctx context.Context, ep fwkdl.Endpoint) error {
-	return nil
-}
-
-func (m *mockSource) Extractors() []string {
-	return []string{}
-}
-
-func (m *mockSource) OutputType() reflect.Type {
-	return fwkdl.NotificationEventType
-}
-
-func (m *mockSource) ExtractorType() reflect.Type {
-	return fwkdl.ExtractorType
-}
-
-// Mock Extractor
+// mockExtractor satisfies PollingExtractor.
 type mockExtractor struct{ mockPlugin }
 
-func (m *mockExtractor) ExpectedInputType() reflect.Type {
-	return reflect.TypeFor[string]()
-}
-
-func (m *mockExtractor) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) error {
+func (m *mockExtractor) Extract(_ context.Context, _ fwkdl.PollingInput) error {
 	return nil
 }
 

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -30,20 +30,11 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
 )
 
-// TODO:
-// currently the data store is expected to manage the state of multiple
-// Collectors (e.g., using sync.Map mapping pod to its Collector). Alternatively,
-// this can be encapsulated in this file, providing the data store with an interface
-// to only update on endpoint addition/change and deletion. This can also be used
-// to centrally track statistics such errors, active routines, etc.
-
 const (
 	defaultCollectionTimeout = time.Second
 )
 
 // Ticker implements a time source for periodic invocation.
-// The Ticker is passed in as parameter a Collector to allow control over time
-// progress in tests, ensuring tests are deterministic and fast.
 type Ticker interface {
 	Channel() <-chan time.Time
 	Stop()
@@ -56,22 +47,16 @@ type TimeTicker struct {
 
 // NewTimeTicker returns a new time.Ticker with the configured duration.
 func NewTimeTicker(d time.Duration) Ticker {
-	return &TimeTicker{
-		Ticker: time.NewTicker(d),
-	}
+	return &TimeTicker{Ticker: time.NewTicker(d)}
 }
 
 // Channel exposes the ticker's channel.
-func (t *TimeTicker) Channel() <-chan time.Time {
-	return t.C
-}
+func (t *TimeTicker) Channel() <-chan time.Time { return t.C }
 
 // Collector runs data collection for a single endpoint.
 //
-// Lifecycle contract: any in-flight write the collection goroutine performs
-// against the endpoint completes before Stop returns. Callers may therefore
-// mutate or release endpoint state immediately after Stop returns without
-// racing the collection goroutine.
+// Lifecycle: any in-flight write the collection goroutine performs against the
+// endpoint completes before Stop returns.
 type Collector struct {
 	mu     sync.Mutex
 	cancel context.CancelFunc
@@ -84,7 +69,7 @@ func NewCollector() *Collector {
 }
 
 // Start launches the collection goroutine.
-func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.ExtractorBase) error {
+func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.PollingExtractor) error {
 	if len(pollers) == 0 {
 		return errors.New("cannot start collector with empty sources")
 	}
@@ -97,16 +82,6 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 		return err
 	}
 
-	// Filter to poll-capable extractors up front so the hot loop avoids per-tick type assertions.
-	pollingExtractors := make(map[string][]fwkdl.Extractor, len(extractors))
-	for name, exts := range extractors {
-		for _, ext := range exts {
-			if e, ok := ext.(fwkdl.Extractor); ok {
-				pollingExtractors[name] = append(pollingExtractors[name], e)
-			}
-		}
-	}
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.cancel != nil {
@@ -114,7 +89,7 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
-	go c.run(ctx, ticker, ep, pollers, pollingExtractors)
+	go c.run(ctx, ticker, ep, pollers, extractors)
 	return nil
 }
 
@@ -129,7 +104,7 @@ func (c *Collector) Stop() {
 	}
 }
 
-func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.Extractor) {
+func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.PollingExtractor) {
 	defer func() {
 		close(c.done)
 		ticker.Stop()
@@ -151,7 +126,7 @@ func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, p
 	}
 }
 
-func (c *Collector) pollOne(ctx context.Context, src fwkdl.PollingDataSource, ep fwkdl.Endpoint, extractors map[string][]fwkdl.Extractor, logger logr.Logger) {
+func (c *Collector) pollOne(ctx context.Context, src fwkdl.PollingDataSource, ep fwkdl.Endpoint, extractors map[string][]fwkdl.PollingExtractor, logger logr.Logger) {
 	tn := src.TypedName()
 
 	pollCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
@@ -166,12 +141,13 @@ func (c *Collector) pollOne(ctx context.Context, src fwkdl.PollingDataSource, ep
 		return
 	}
 
+	input := fwkdl.NewPollingInput(data, ep)
 	for _, ext := range extractors[tn.Name] {
 		if ctx.Err() != nil {
 			return
 		}
 		extCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
-		err := ext.Extract(extCtx, data, ep)
+		err := ext.Extract(extCtx, input)
 		cancel()
 		if err != nil {
 			extName := ext.TypedName()

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -19,7 +19,6 @@ package datalayer
 import (
 	"context"
 	"errors"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -90,8 +89,7 @@ type stubExtractor struct {
 func (s *stubExtractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: s.kind, Name: s.kind}
 }
-func (s *stubExtractor) ExpectedInputType() reflect.Type                          { return reflect.TypeFor[any]() }
-func (s *stubExtractor) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error { return s.err }
+func (s *stubExtractor) Extract(_ context.Context, _ fwkdl.PollingInput) error { return s.err }
 
 func TestCollectorStartInputs(t *testing.T) {
 	tests := []struct {
@@ -248,10 +246,10 @@ func TestCollectorErrorMetrics(t *testing.T) {
 				src = &dataSource{kind: tt.srcType}
 			}
 
-			var extractors map[string][]fwkdl.ExtractorBase
+			var extractors map[string][]fwkdl.PollingExtractor
 			if tt.extType != "" {
 				ext := &stubExtractor{kind: tt.extType, err: tt.extErr}
-				extractors = map[string][]fwkdl.ExtractorBase{src.TypedName().Name: {ext}}
+				extractors = map[string][]fwkdl.PollingExtractor{src.TypedName().Name: {ext}}
 			}
 
 			pollBefore := testutil.ToFloat64(metrics.DataLayerPollErrorsTotal.WithLabelValues(tt.srcType))

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -23,23 +23,19 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
-// Config defines the configuration of EPP data layer, as the set of DataSources
-// and Extractors defined on them.
+// Config holds the data layer's configured sources and their extractors.
 type Config struct {
 	Sources []DataSourceConfig
 }
 
-// DataSourceConfig defines the configuration of a specific DataSource.
-//
-// Extractors are held as plugin.Plugin and type-asserted at Configure time to
-// the variant interface matching Plugin (PollingExtractor / NotificationExtractor
-// / EndpointExtractor). Mismatches surface as config-load errors.
+// DataSourceConfig pairs a source plugin with its extractor plugins. Extractors
+// are typed at Configure time against Plugin's variant; mismatches error out.
 type DataSourceConfig struct {
 	Plugin     fwkdl.DataSource
 	Extractors []fwkplugin.Plugin
 }
 
-// ResolveSource looks up ref via handle and asserts the plugin implements DataSource.
+// ResolveSource looks up ref and asserts the plugin implements DataSource.
 func ResolveSource(handle fwkplugin.Handle, ref string) (fwkdl.DataSource, error) {
 	p := handle.Plugin(ref)
 	if p == nil {
@@ -52,9 +48,9 @@ func ResolveSource(handle fwkplugin.Handle, ref string) (fwkdl.DataSource, error
 	return src, nil
 }
 
-// assertAll type-asserts each plugin to T and returns the typed slice.
-// T is resolved at compile time at the call site; per-element conformance is
-// checked at runtime and surfaced as an error rather than a panic.
+// assertAll types each plugin to T. T is bound at compile time at the call
+// site; per-element conformance is a runtime check that returns an error
+// rather than panicking, because plugins arrive as the erased plugin.Plugin.
 func assertAll[T fwkplugin.Plugin](plugins []fwkplugin.Plugin, variant string) ([]T, error) {
 	out := make([]T, 0, len(plugins))
 	for _, p := range plugins {

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -54,6 +54,9 @@ func ResolveSource(handle fwkplugin.Handle, ref string) (fwkdl.DataSource, error
 func assertAll[T fwkplugin.Plugin](plugins []fwkplugin.Plugin, variant string) ([]T, error) {
 	out := make([]T, 0, len(plugins))
 	for _, p := range plugins {
+		if p == nil {
+			return nil, fmt.Errorf("nil plugin in %s", variant)
+		}
 		e, ok := p.(T)
 		if !ok {
 			return nil, fmt.Errorf("plugin %s is not a %s", p.TypedName(), variant)

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -17,19 +17,52 @@ limitations under the License.
 package datalayer
 
 import (
+	"fmt"
+
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
 // Config defines the configuration of EPP data layer, as the set of DataSources
-// and Extractors defined on them. Both poll-based and event-driven (notification)
-// sources are stored in Sources. Differentiation by type of source is handled during
-// the set-up phase.
+// and Extractors defined on them.
 type Config struct {
-	Sources []DataSourceConfig // the data sources configured in the data layer
+	Sources []DataSourceConfig
 }
 
-// DataSourceConfig defines the configuration of a specific DataSource
+// DataSourceConfig defines the configuration of a specific DataSource.
+//
+// Extractors are held as plugin.Plugin and type-asserted at Configure time to
+// the variant interface matching Plugin (PollingExtractor / NotificationExtractor
+// / EndpointExtractor). Mismatches surface as config-load errors.
 type DataSourceConfig struct {
-	Plugin     fwkdl.DataSource      // the data source plugin instance
-	Extractors []fwkdl.ExtractorBase // extractors defined for the data source
+	Plugin     fwkdl.DataSource
+	Extractors []fwkplugin.Plugin
+}
+
+// ResolveSource looks up ref via handle and asserts the plugin implements DataSource.
+func ResolveSource(handle fwkplugin.Handle, ref string) (fwkdl.DataSource, error) {
+	p := handle.Plugin(ref)
+	if p == nil {
+		return nil, fmt.Errorf("source plugin %q not registered", ref)
+	}
+	src, ok := p.(fwkdl.DataSource)
+	if !ok {
+		return nil, fmt.Errorf("source plugin %q does not implement DataSource", ref)
+	}
+	return src, nil
+}
+
+// assertAll type-asserts each plugin to T and returns the typed slice.
+// T is resolved at compile time at the call site; per-element conformance is
+// checked at runtime and surfaced as an error rather than a panic.
+func assertAll[T fwkplugin.Plugin](plugins []fwkplugin.Plugin, variant string) ([]T, error) {
+	out := make([]T, 0, len(plugins))
+	for _, p := range plugins {
+		e, ok := p.(T)
+		if !ok {
+			return nil, fmt.Errorf("plugin %s is not a %s", p.TypedName(), variant)
+		}
+		out = append(out, e)
+	}
+	return out, nil
 }

--- a/pkg/epp/datalayer/config_test.go
+++ b/pkg/epp/datalayer/config_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	extractormocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/mocks"
+)
+
+func TestAssertAll(t *testing.T) {
+	ext := extractormocks.NewEndpointExtractor("ext")
+
+	cases := []struct {
+		name    string
+		input   []fwkplugin.Plugin
+		wantLen int
+		wantErr string
+	}{
+		{
+			name:    "all valid",
+			input:   []fwkplugin.Plugin{ext},
+			wantLen: 1,
+		},
+		{
+			name:    "nil element",
+			input:   []fwkplugin.Plugin{ext, nil},
+			wantErr: "nil plugin",
+		},
+		{
+			name:    "wrong type",
+			input:   []fwkplugin.Plugin{&wrongPlugin{}},
+			wantErr: "is not a",
+		},
+		{
+			name:    "empty",
+			input:   nil,
+			wantLen: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := assertAll[fwkdl.EndpointExtractor](tc.input, "EndpointExtractor")
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, got, tc.wantLen)
+		})
+	}
+}
+
+type wrongPlugin struct{}
+
+func (*wrongPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "wrong", Name: "wrong"}
+}

--- a/pkg/epp/datalayer/k8s_bind.go
+++ b/pkg/epp/datalayer/k8s_bind.go
@@ -115,7 +115,7 @@ func (rn *notificationReconciler) dispatch(ctx context.Context, log logr.Logger,
 	}
 
 	for _, ext := range rn.extractors {
-		if err := ext.ExtractNotification(ctx, *processed); err != nil {
+		if err := ext.Extract(ctx, *processed); err != nil {
 			log.Error(err, "extractor failed", "extractor", ext.TypedName())
 		}
 	}

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -2,6 +2,7 @@ package datalayer
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
@@ -27,14 +28,20 @@ func newSourceManager[S fwkdl.DataSource, E fwkplugin.Plugin](name string) *sour
 	}
 }
 
-// Register installs src and (if non-empty) exts under src's name.
-func (m *sourceManager[S, E]) Register(src S, exts []E) {
+// Register installs src and (if non-empty) exts under src's name. Returns an
+// error if a source with the same name is already registered.
+func (m *sourceManager[S, E]) Register(src S, exts []E) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.sources[src.TypedName().Name] = src
-	if len(exts) > 0 {
-		m.extractors[src.TypedName().Name] = exts
+	srcName := src.TypedName().Name
+	if _, exists := m.sources[srcName]; exists {
+		return fmt.Errorf("duplicate %s source name %q", m.name, srcName)
 	}
+	m.sources[srcName] = src
+	if len(exts) > 0 {
+		m.extractors[srcName] = exts
+	}
+	return nil
 }
 
 // AppendExtractor appends ext to srcName's extractor list, deduping by type.
@@ -96,12 +103,19 @@ func (m *sourceManager[S, E]) IsEmpty() bool {
 	return len(m.sources) == 0
 }
 
-// FindByType returns the first source whose TypedName.Type matches sourceType.
+// FindByType returns the first matching source (in sorted-by-name order, so
+// behavior is stable across runs even when multiple sources share a Type).
 // match (if non-nil) is an additional filter applied to candidates.
 func (m *sourceManager[S, E]) FindByType(sourceType string, match func(S) bool) (string, S, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	for name, src := range m.sources {
+	names := make([]string, 0, len(m.sources))
+	for n := range m.sources {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		src := m.sources[name]
 		if src.TypedName().Type != sourceType {
 			continue
 		}
@@ -135,16 +149,19 @@ func newNotificationManager() *notificationManager {
 	}
 }
 
-// Register installs src after enforcing GVK uniqueness within this manager.
+// Register installs src after enforcing GVK and name uniqueness within this manager.
 func (m *notificationManager) Register(src fwkdl.NotificationSource, exts []fwkdl.NotificationExtractor) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	srcName := src.TypedName().Name
+	if _, exists := m.sources[srcName]; exists {
+		return fmt.Errorf("duplicate notification source name %q", srcName)
+	}
 	gvk := src.GVK().String()
 	if existing, exists := m.gvkToName[gvk]; exists {
 		return fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
 			gvk, existing, src.TypedName().String())
 	}
-	srcName := src.TypedName().Name
 	m.sources[srcName] = src
 	if len(exts) > 0 {
 		m.extractors[srcName] = exts

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -1,0 +1,144 @@
+package datalayer
+
+import (
+	"fmt"
+	"sync"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+)
+
+// sourceManager owns a variant's typed source + extractor maps under a single
+// RWMutex. Adding a new variant means instantiating a new sourceManager (or
+// embedding one in a variant-specific wrapper for extra fields like
+// notificationManager's gvkToName).
+type sourceManager[S fwkdl.DataSource, E fwkplugin.Plugin] struct {
+	name       string
+	mu         sync.RWMutex
+	sources    map[string]S
+	extractors map[string][]E
+}
+
+func newSourceManager[S fwkdl.DataSource, E fwkplugin.Plugin](name string) *sourceManager[S, E] {
+	return &sourceManager[S, E]{
+		name:       name,
+		sources:    make(map[string]S),
+		extractors: make(map[string][]E),
+	}
+}
+
+// Register installs src and (if non-empty) exts under src's name.
+func (m *sourceManager[S, E]) Register(src S, exts []E) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sources[src.TypedName().Name] = src
+	if len(exts) > 0 {
+		m.extractors[src.TypedName().Name] = exts
+	}
+}
+
+// AppendExtractor appends ext to srcName's extractor list, deduping by type.
+func (m *sourceManager[S, E]) AppendExtractor(srcName string, ext E) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	extType := ext.TypedName().Type
+	for _, existing := range m.extractors[srcName] {
+		if existing.TypedName().Type == extType {
+			return
+		}
+	}
+	m.extractors[srcName] = append(m.extractors[srcName], ext)
+}
+
+// Sources returns a snapshot copy of the source map.
+func (m *sourceManager[S, E]) Sources() map[string]S {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string]S, len(m.sources))
+	for k, v := range m.sources {
+		out[k] = v
+	}
+	return out
+}
+
+// Extractors returns a snapshot copy of the extractor map.
+func (m *sourceManager[S, E]) Extractors() map[string][]E {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string][]E, len(m.extractors))
+	for k, v := range m.extractors {
+		out[k] = v
+	}
+	return out
+}
+
+// ExtractorsFor returns the extractor slice for a specific source.
+func (m *sourceManager[S, E]) ExtractorsFor(srcName string) []E {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.extractors[srcName]
+}
+
+// IsEmpty reports whether any source is registered.
+func (m *sourceManager[S, E]) IsEmpty() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.sources) == 0
+}
+
+// FindByType returns the first source whose TypedName.Type matches sourceType.
+// match (if non-nil) is an additional filter applied to candidates.
+func (m *sourceManager[S, E]) FindByType(sourceType string, match func(S) bool) (string, S, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for name, src := range m.sources {
+		if src.TypedName().Type != sourceType {
+			continue
+		}
+		if match != nil && !match(src) {
+			continue
+		}
+		return name, src, true
+	}
+	var zero S
+	return "", zero, false
+}
+
+// Count returns the number of registered sources.
+func (m *sourceManager[S, E]) Count() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.sources)
+}
+
+// notificationManager extends sourceManager with GVK uniqueness tracking.
+type notificationManager struct {
+	*sourceManager[fwkdl.NotificationSource, fwkdl.NotificationExtractor]
+	// gvkToName is protected by the embedded sourceManager's mu (held during Register/Append).
+	gvkToName map[string]string
+}
+
+func newNotificationManager() *notificationManager {
+	return &notificationManager{
+		sourceManager: newSourceManager[fwkdl.NotificationSource, fwkdl.NotificationExtractor]("notification"),
+		gvkToName:     make(map[string]string),
+	}
+}
+
+// Register installs src after enforcing GVK uniqueness within this manager.
+func (m *notificationManager) Register(src fwkdl.NotificationSource, exts []fwkdl.NotificationExtractor) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	gvk := src.GVK().String()
+	if existing, exists := m.gvkToName[gvk]; exists {
+		return fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
+			gvk, existing, src.TypedName().String())
+	}
+	srcName := src.TypedName().Name
+	m.sources[srcName] = src
+	if len(exts) > 0 {
+		m.extractors[srcName] = exts
+	}
+	m.gvkToName[gvk] = srcName
+	return nil
+}

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package datalayer
 
 import (
@@ -9,20 +25,53 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
+// sourceVariant identifies one of the three DataSource integration kinds the
+// datalayer dispatches over. Each variant has its own driver lifecycle,
+// extractor signature, and manager instance:
+//
+//   - variantPolling: ticker-driven, per-endpoint scrapes (e.g. /metrics, /v1/models).
+//   - variantNotification: K8s informer-driven watches, with GVK uniqueness
+//     enforced across notification sources.
+//   - variantEndpoint: per-endpoint lifecycle events (add / update / delete)
+//     dispatched without polling.
+//
+// A new integration kind means a new constant here, a new manager field on
+// Runtime, and a new entry in Runtime.buildVariantLookups.
+type sourceVariant string
+
+const (
+	variantPolling      sourceVariant = "polling"
+	variantNotification sourceVariant = "notification"
+	variantEndpoint     sourceVariant = "endpoint"
+)
+
 // sourceManager owns a variant's typed source + extractor maps under one RWMutex.
 type sourceManager[S fwkdl.DataSource, E fwkplugin.Plugin] struct {
-	name       string
+	variant    sourceVariant
 	mu         sync.RWMutex
 	sources    map[string]S
 	extractors map[string][]E
 }
 
-func newSourceManager[S fwkdl.DataSource, E fwkplugin.Plugin](name string) *sourceManager[S, E] {
+func newSourceManager[S fwkdl.DataSource, E fwkplugin.Plugin](variant sourceVariant) *sourceManager[S, E] {
 	return &sourceManager[S, E]{
-		name:       name,
+		variant:    variant,
 		sources:    make(map[string]S),
 		extractors: make(map[string][]E),
 	}
+}
+
+type (
+	pollingManager  = sourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]
+	endpointManager = sourceManager[fwkdl.EndpointSource, fwkdl.EndpointExtractor]
+)
+
+func newPollingManager() *pollingManager {
+	return newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor](variantPolling)
+}
+
+func newEndpointManager() *endpointManager {
+	return newSourceManager[fwkdl.EndpointSource, fwkdl.EndpointExtractor](variantEndpoint)
 }
 
 // Register installs src and exts under src's name. Errors on duplicate name.
@@ -31,7 +80,7 @@ func (m *sourceManager[S, E]) Register(src S, exts []E) error {
 	defer m.mu.Unlock()
 	srcName := src.TypedName().Name
 	if _, exists := m.sources[srcName]; exists {
-		return fmt.Errorf("duplicate %s source name %q", m.name, srcName)
+		return fmt.Errorf("duplicate %s source name %q", m.variant, srcName)
 	}
 	m.sources[srcName] = src
 	if len(exts) > 0 {
@@ -138,7 +187,7 @@ type notificationManager struct {
 
 func newNotificationManager() *notificationManager {
 	return &notificationManager{
-		sourceManager: newSourceManager[fwkdl.NotificationSource, fwkdl.NotificationExtractor]("notification"),
+		sourceManager: newSourceManager[fwkdl.NotificationSource, fwkdl.NotificationExtractor](variantNotification),
 		gvkToName:     make(map[string]string),
 	}
 }

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -9,10 +9,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
-// sourceManager owns a variant's typed source + extractor maps under a single
-// RWMutex. Adding a new variant means instantiating a new sourceManager (or
-// embedding one in a variant-specific wrapper for extra fields like
-// notificationManager's gvkToName).
+// sourceManager owns a variant's typed source + extractor maps under one RWMutex.
 type sourceManager[S fwkdl.DataSource, E fwkplugin.Plugin] struct {
 	name       string
 	mu         sync.RWMutex
@@ -28,8 +25,7 @@ func newSourceManager[S fwkdl.DataSource, E fwkplugin.Plugin](name string) *sour
 	}
 }
 
-// Register installs src and (if non-empty) exts under src's name. Returns an
-// error if a source with the same name is already registered.
+// Register installs src and exts under src's name. Errors on duplicate name.
 func (m *sourceManager[S, E]) Register(src S, exts []E) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -57,7 +53,7 @@ func (m *sourceManager[S, E]) AppendExtractor(srcName string, ext E) {
 	m.extractors[srcName] = append(m.extractors[srcName], ext)
 }
 
-// Sources returns a snapshot copy of the source map.
+// Sources returns a snapshot of the source map.
 func (m *sourceManager[S, E]) Sources() map[string]S {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -68,9 +64,7 @@ func (m *sourceManager[S, E]) Sources() map[string]S {
 	return out
 }
 
-// Extractors returns a snapshot of the extractor map. Each slice value is a
-// fresh copy; mutating the returned map or its slices does not affect the
-// manager's state.
+// Extractors returns a snapshot of the extractor map; slice values are fresh copies.
 func (m *sourceManager[S, E]) Extractors() map[string][]E {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -103,9 +97,9 @@ func (m *sourceManager[S, E]) IsEmpty() bool {
 	return len(m.sources) == 0
 }
 
-// FindByType returns the first matching source (in sorted-by-name order, so
-// behavior is stable across runs even when multiple sources share a Type).
-// match (if non-nil) is an additional filter applied to candidates.
+// FindByType returns the first source whose TypedName.Type matches; iteration
+// is sorted by name so first-match is stable across runs. match (if non-nil)
+// further filters candidates.
 func (m *sourceManager[S, E]) FindByType(sourceType string, match func(S) bool) (string, S, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -135,10 +129,10 @@ func (m *sourceManager[S, E]) Count() int {
 	return len(m.sources)
 }
 
-// notificationManager extends sourceManager with GVK uniqueness tracking.
+// notificationManager adds GVK-uniqueness tracking on top of sourceManager.
+// gvkToName is guarded by the embedded sourceManager's mu.
 type notificationManager struct {
 	*sourceManager[fwkdl.NotificationSource, fwkdl.NotificationExtractor]
-	// gvkToName is protected by the embedded sourceManager's mu (held during Register/Append).
 	gvkToName map[string]string
 }
 
@@ -149,7 +143,7 @@ func newNotificationManager() *notificationManager {
 	}
 }
 
-// Register installs src after enforcing GVK and name uniqueness within this manager.
+// Register installs src after enforcing both name and GVK uniqueness.
 func (m *notificationManager) Register(src fwkdl.NotificationSource, exts []fwkdl.NotificationExtractor) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -61,22 +61,32 @@ func (m *sourceManager[S, E]) Sources() map[string]S {
 	return out
 }
 
-// Extractors returns a snapshot copy of the extractor map.
+// Extractors returns a snapshot of the extractor map. Each slice value is a
+// fresh copy; mutating the returned map or its slices does not affect the
+// manager's state.
 func (m *sourceManager[S, E]) Extractors() map[string][]E {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	out := make(map[string][]E, len(m.extractors))
 	for k, v := range m.extractors {
-		out[k] = v
+		dup := make([]E, len(v))
+		copy(dup, v)
+		out[k] = dup
 	}
 	return out
 }
 
-// ExtractorsFor returns the extractor slice for a specific source.
+// ExtractorsFor returns a copy of the extractor slice for a specific source.
 func (m *sourceManager[S, E]) ExtractorsFor(srcName string) []E {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.extractors[srcName]
+	src := m.extractors[srcName]
+	if src == nil {
+		return nil
+	}
+	dup := make([]E, len(src))
+	copy(dup, src)
+	return dup
 }
 
 // IsEmpty reports whether any source is registered.

--- a/pkg/epp/datalayer/manager_test.go
+++ b/pkg/epp/datalayer/manager_test.go
@@ -1,0 +1,265 @@
+package datalayer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	srcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
+)
+
+func TestSourceManager_Register(t *testing.T) {
+	src1 := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "src1"})
+	src2 := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "src2"})
+	srcDup := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "src1"})
+
+	tests := []struct {
+		name      string
+		ops       func(m *sourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]) error
+		wantCount int
+		wantErr   bool
+		wantInErr string
+	}{
+		{
+			name: "register one",
+			ops: func(m *sourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]) error {
+				return m.Register(src1, nil)
+			},
+			wantCount: 1,
+		},
+		{
+			name: "register two distinct",
+			ops: func(m *sourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]) error {
+				if err := m.Register(src1, nil); err != nil {
+					return err
+				}
+				return m.Register(src2, nil)
+			},
+			wantCount: 2,
+		},
+		{
+			name: "duplicate name errors",
+			ops: func(m *sourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]) error {
+				if err := m.Register(src1, nil); err != nil {
+					return err
+				}
+				return m.Register(srcDup, nil)
+			},
+			wantCount: 1,
+			wantErr:   true,
+			wantInErr: "duplicate polling source name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+			err := tc.ops(m)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantInErr != "" {
+					require.Contains(t, err.Error(), tc.wantInErr)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantCount, m.Count())
+		})
+	}
+}
+
+func TestSourceManager_AppendExtractorDedupesByType(t *testing.T) {
+	src := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "src1"})
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	require.NoError(t, m.Register(src, nil))
+
+	// Two mock extractors share the same type ("mock-extractor"); one is a
+	// different type. Manager should keep one of the same-type pair plus the
+	// distinct one.
+	first := newPollingExt(t, fwkplugin.TypedName{Type: "mock-extractor", Name: "first"})
+	second := newPollingExt(t, fwkplugin.TypedName{Type: "mock-extractor", Name: "second"})
+	other := newPollingExt(t, fwkplugin.TypedName{Type: "different-type", Name: "other"})
+
+	m.AppendExtractor("src1", first)
+	m.AppendExtractor("src1", second) // duplicate type — should be skipped
+	m.AppendExtractor("src1", other)
+
+	got := m.ExtractorsFor("src1")
+	require.Len(t, got, 2, "duplicate type should be deduped")
+	require.Equal(t, "first", got[0].TypedName().Name)
+	require.Equal(t, "other", got[1].TypedName().Name)
+}
+
+func TestSourceManager_AccessorsReturnCopies(t *testing.T) {
+	src := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "src1"})
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	ext := newPollingExt(t, fwkplugin.TypedName{Type: "mock-extractor", Name: "ext1"})
+	require.NoError(t, m.Register(src, []fwkdl.PollingExtractor{ext}))
+
+	t.Run("Sources copy", func(t *testing.T) {
+		snap := m.Sources()
+		delete(snap, "src1")
+		require.Equal(t, 1, m.Count(), "deleting from snapshot should not affect manager")
+	})
+
+	t.Run("ExtractorsFor copy", func(t *testing.T) {
+		snap := m.ExtractorsFor("src1")
+		require.Len(t, snap, 1)
+		snap[0] = nil // mutate caller copy
+		got := m.ExtractorsFor("src1")
+		require.NotNil(t, got[0], "manager's slice must be untouched by caller mutation")
+	})
+
+	t.Run("Extractors slice values are fresh", func(t *testing.T) {
+		snap := m.Extractors()
+		require.Len(t, snap["src1"], 1)
+		snap["src1"][0] = nil
+		got := m.ExtractorsFor("src1")
+		require.NotNil(t, got[0], "manager's slice must be untouched by caller mutation")
+	})
+}
+
+func TestSourceManager_FindByTypeStableSorted(t *testing.T) {
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	// Insert in order designed to produce non-deterministic Go map iteration
+	// across runs; sorted-by-name first-match must always return "aaa".
+	for _, name := range []string{"zzz", "mmm", "aaa", "bbb"} {
+		s := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: name})
+		require.NoError(t, m.Register(s, nil))
+	}
+
+	// Run several times to catch a non-stable implementation.
+	for i := 0; i < 20; i++ {
+		name, _, ok := m.FindByType("polling", nil)
+		require.True(t, ok)
+		require.Equal(t, "aaa", name, "first-match must be sort-by-name stable")
+	}
+}
+
+func TestSourceManager_FindByTypeWithFilter(t *testing.T) {
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	a := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "a"})
+	b := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "b"})
+	require.NoError(t, m.Register(a, nil))
+	require.NoError(t, m.Register(b, nil))
+
+	tests := []struct {
+		name      string
+		match     func(fwkdl.PollingDataSource) bool
+		wantFound bool
+		wantName  string
+	}{
+		{
+			name:      "no filter matches first sorted",
+			match:     nil,
+			wantFound: true,
+			wantName:  "a",
+		},
+		{
+			name:      "filter selects b",
+			match:     func(s fwkdl.PollingDataSource) bool { return s.TypedName().Name == "b" },
+			wantFound: true,
+			wantName:  "b",
+		},
+		{
+			name:      "filter rejects all",
+			match:     func(s fwkdl.PollingDataSource) bool { return false },
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, _, ok := m.FindByType("polling", tc.match)
+			require.Equal(t, tc.wantFound, ok)
+			if tc.wantFound {
+				require.Equal(t, tc.wantName, name)
+			}
+		})
+	}
+}
+
+func TestNotificationManager_Register(t *testing.T) {
+	podGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	svcGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+
+	tests := []struct {
+		name      string
+		ops       func(m *notificationManager) error
+		wantCount int
+		wantErr   bool
+		wantInErr string
+	}{
+		{
+			name: "register two distinct",
+			ops: func(m *notificationManager) error {
+				if err := m.Register(srcmocks.NewNotificationSource("notif", "a", podGVK), nil); err != nil {
+					return err
+				}
+				return m.Register(srcmocks.NewNotificationSource("notif", "b", svcGVK), nil)
+			},
+			wantCount: 2,
+		},
+		{
+			name: "duplicate GVK errors",
+			ops: func(m *notificationManager) error {
+				if err := m.Register(srcmocks.NewNotificationSource("notif", "a", podGVK), nil); err != nil {
+					return err
+				}
+				return m.Register(srcmocks.NewNotificationSource("notif", "b", podGVK), nil)
+			},
+			wantCount: 1,
+			wantErr:   true,
+			wantInErr: "duplicate notification source GVK",
+		},
+		{
+			name: "duplicate name errors",
+			ops: func(m *notificationManager) error {
+				if err := m.Register(srcmocks.NewNotificationSource("notif", "same", podGVK), nil); err != nil {
+					return err
+				}
+				return m.Register(srcmocks.NewNotificationSource("notif", "same", svcGVK), nil)
+			},
+			wantCount: 1,
+			wantErr:   true,
+			wantInErr: "duplicate notification source name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newNotificationManager()
+			err := tc.ops(m)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantInErr != "" {
+					require.Contains(t, err.Error(), tc.wantInErr)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantCount, m.Count())
+		})
+	}
+}
+
+// newPollingExt builds a mock satisfying fwkdl.PollingExtractor with the given
+// TypedName (so dedup-by-type cases can vary Type and Name independently).
+func newPollingExt(t *testing.T, tn fwkplugin.TypedName) fwkdl.PollingExtractor {
+	t.Helper()
+	return &fakePollingExtractor{t: tn}
+}
+
+type fakePollingExtractor struct {
+	t fwkplugin.TypedName
+}
+
+func (f *fakePollingExtractor) TypedName() fwkplugin.TypedName { return f.t }
+
+func (f *fakePollingExtractor) Extract(_ context.Context, _ fwkdl.PollingInput) error {
+	return nil
+}

--- a/pkg/epp/datalayer/manager_test.go
+++ b/pkg/epp/datalayer/manager_test.go
@@ -57,7 +57,7 @@ func TestSourceManager_Register(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+			m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor](variantPolling)
 			err := tc.ops(m)
 			if tc.wantErr {
 				require.Error(t, err)
@@ -74,7 +74,7 @@ func TestSourceManager_Register(t *testing.T) {
 
 func TestSourceManager_AppendExtractorDedupesByType(t *testing.T) {
 	src := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "src1"})
-	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor](variantPolling)
 	require.NoError(t, m.Register(src, nil))
 
 	// Two mock extractors share the same type ("mock-extractor"); one is a
@@ -96,7 +96,7 @@ func TestSourceManager_AppendExtractorDedupesByType(t *testing.T) {
 
 func TestSourceManager_AccessorsReturnCopies(t *testing.T) {
 	src := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "src1"})
-	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor](variantPolling)
 	ext := newPollingExt(t, fwkplugin.TypedName{Type: "mock-extractor", Name: "ext1"})
 	require.NoError(t, m.Register(src, []fwkdl.PollingExtractor{ext}))
 
@@ -124,7 +124,7 @@ func TestSourceManager_AccessorsReturnCopies(t *testing.T) {
 }
 
 func TestSourceManager_FindByTypeStableSorted(t *testing.T) {
-	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor](variantPolling)
 	// Insert in order designed to produce non-deterministic Go map iteration
 	// across runs; sorted-by-name first-match must always return "aaa".
 	for _, name := range []string{"zzz", "mmm", "aaa", "bbb"} {
@@ -141,7 +141,7 @@ func TestSourceManager_FindByTypeStableSorted(t *testing.T) {
 }
 
 func TestSourceManager_FindByTypeWithFilter(t *testing.T) {
-	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling")
+	m := newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor](variantPolling)
 	a := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "a"})
 	b := srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: "b"})
 	require.NoError(t, m.Register(a, nil))

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -32,6 +32,8 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
+var ErrSourceTypeCollision = errors.New("source type registered across variants")
+
 // variantLookup pairs a sourceVariant with its FindByType adapter; r.variants
 // (built in NewRuntime) is the single source of truth for variant iteration.
 type variantLookup struct {
@@ -132,6 +134,9 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 		}
 	}
 
+	// TODO: exhaustively validate cross-variant SourceType uniqueness here;
+	// today the check only fires when a pending extractor references the
+	// colliding type (via resolvePending -> findSourceByType).
 	for _, pending := range r.pendingRegistrations {
 		if err := r.resolvePending(pending, disallowedExtractorType, logger); err != nil {
 			return err
@@ -289,8 +294,8 @@ func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVer
 			continue
 		}
 		if matchedSrc != nil {
-			return "", nil, fmt.Errorf("source type %q is registered across variants: %s (%s) and %s (%s)",
-				sourceType, matchedVariant, matchedName, l.variant, name)
+			return "", nil, fmt.Errorf("%w: %q in %s (%s) and %s (%s)",
+				ErrSourceTypeCollision, sourceType, matchedVariant, matchedName, l.variant, name)
 		}
 		matchedVariant, matchedName, matchedSrc = l.variant, name, src
 	}

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -30,30 +29,29 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
 // Runtime manages data sources, extractors, their mapping, and endpoint lifecycle.
+// Per-variant state lives in dedicated managers; Runtime routes between them.
 type Runtime struct {
-	pollingInterval time.Duration // used for polling sources
+	pollingInterval time.Duration
 
-	pollers          sync.Map // Map of polling sources (key=source name, value=PollingDataSource)
-	notifiers        sync.Map // Map of k8s notification sources (key=source name, value=NotificationSource)
-	endpointSources  sync.Map // Map of endpoint sources (key=source name, value=EndpointSource)
-	sourceExtractors sync.Map // Map sources to extractors (key=source name. value=[]Extractor)
+	polling      *sourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]
+	notification *notificationManager
+	endpoint     *sourceManager[fwkdl.EndpointSource, fwkdl.EndpointExtractor]
 
 	pendingMu            sync.Mutex
-	pendingRegistrations []fwkdl.PendingRegistration // code-registered (source-type, extractor) pairs, resolved by Configure()
+	pendingRegistrations []fwkdl.PendingRegistration
 
-	collectors sync.Map    // Per-endpoint poller (key=namespaced name, value=*Collector)
-	logger     logr.Logger // Set in Configure; used where no context is available (e.g. ReleaseEndpoint).
+	collectors sync.Map    // namespaced name -> *Collector (high-churn, sync.Map is appropriate)
+	logger     logr.Logger // set in Configure
 }
 
-const (
-	defaultRefreshInterval = 50 * time.Millisecond
-)
+const defaultRefreshInterval = 50 * time.Millisecond
 
-// NewRuntime creates a new Runtime with the given polling interval.
-// If duration is <= 0, uses the defaultRefreshInterval.
+// NewRuntime returns a Runtime with the given polling interval; non-positive
+// values fall back to defaultRefreshInterval.
 func NewRuntime(pollingInterval time.Duration) *Runtime {
 	interval := defaultRefreshInterval
 	if pollingInterval > 0 {
@@ -61,12 +59,15 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 	}
 	return &Runtime{
 		pollingInterval: interval,
+		polling:         newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling"),
+		notification:    newNotificationManager(),
+		endpoint:        newSourceManager[fwkdl.EndpointSource, fwkdl.EndpointExtractor]("endpoint"),
 		logger:          logr.Discard(),
 	}
 }
 
-// Configure is called to transform the configuration information into the Runtime's
-// internal fields.
+// Configure transforms cfg into the Runtime's internal state and resolves any
+// code-registered pending dependencies.
 func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtractorType string, logger logr.Logger) error {
 	hasPending := len(r.pendingRegistrations) > 0
 	if (cfg == nil || len(cfg.Sources) == 0) && !hasPending {
@@ -83,103 +84,32 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 	}
 	logger.Info("Configuring datalayer runtime", "numSources", numSources)
 
-	pollersCount := 0
-	notifiersCount := 0
-	endpointSourcesCount := 0
-	gvkToSource := make(map[string]string) // track GVK uniqueness for NotificationSources
-
 	if cfg != nil {
 		for _, srcCfg := range cfg.Sources {
-			src := srcCfg.Plugin
-			srcName := src.TypedName().Name
-
-			logger.V(logging.DEFAULT).Info("Processing source", "source", srcName, "numExtractors", len(srcCfg.Extractors))
-			if err := r.validateSourceExtractors(src, srcCfg.Extractors, disallowedExtractorType); err != nil {
+			if err := r.addSource(srcCfg.Plugin, srcCfg.Extractors, disallowedExtractorType); err != nil {
 				return err
 			}
-
-			if err := r.registerSource(src, gvkToSource); err != nil {
-				return err
-			}
-			switch src.(type) {
-			case fwkdl.PollingDataSource:
-				pollersCount++
-			case fwkdl.NotificationSource:
-				notifiersCount++
-			default:
-				endpointSourcesCount++
-			}
-
-			if len(srcCfg.Extractors) > 0 { // Store extractors mapped to source
-				r.sourceExtractors.Store(srcName, srcCfg.Extractors)
-			}
-
-			extractorNames := make([]string, len(srcCfg.Extractors))
-			for i, ext := range srcCfg.Extractors {
-				extractorNames[i] = ext.TypedName().String()
-			}
-			logger.V(logging.DEFAULT).Info("Source configured", "source", srcName, "extractors", extractorNames)
+			logger.V(logging.DEFAULT).Info("Source configured",
+				"source", srcCfg.Plugin.TypedName().Name,
+				"extractors", len(srcCfg.Extractors))
 		}
 	}
 
-	// Resolve code-registered pending registrations after processing user config.
 	for _, pending := range r.pendingRegistrations {
-		var gvkFilter *schema.GroupVersionKind
-		if ns, ok := pending.DefaultSource.(fwkdl.NotificationSource); ok {
-			gvk := ns.GVK()
-			gvkFilter = &gvk
-		}
-		srcName, matchedSrc := r.findSourceByType(pending.SourceType, gvkFilter)
-
-		if matchedSrc == nil {
-			if pending.DefaultSource == nil {
-				msg := fmt.Sprintf("extractor %s requires source type %s, not configured",
-					pending.Extractor.TypedName(), pending.SourceType)
-				if pending.IfMissing == fwkdl.Warn {
-					logger.Info("datalayer: skipping unresolved dependency", "reason", msg)
-					continue
-				}
-				return errors.New(msg)
-			}
-			if regErr := r.registerSource(pending.DefaultSource, gvkToSource); regErr != nil {
-				return fmt.Errorf("auto-register default source for %s: %w",
-					pending.Extractor.TypedName(), regErr)
-			}
-			srcName = pending.DefaultSource.TypedName().Name
-			matchedSrc = pending.DefaultSource
-		}
-
-		if valErr := r.validateSourceExtractors(matchedSrc, []fwkdl.ExtractorBase{pending.Extractor}, disallowedExtractorType); valErr != nil {
-			return fmt.Errorf("code-registered extractor %s incompatible with source %s: %w",
-				pending.Extractor.TypedName(), srcName, valErr)
-		}
-
-		existing, _ := r.sourceExtractors.Load(srcName)
-		var exts []fwkdl.ExtractorBase
-		if existing != nil {
-			exts = existing.([]fwkdl.ExtractorBase)
-		}
-
-		// Dedup by extractor type: code registration is a no-op if already wired via config.
-		pendingType := pending.Extractor.TypedName().Type
-		alreadyWired := false
-		for _, e := range exts {
-			if e.TypedName().Type == pendingType {
-				alreadyWired = true
-				break
-			}
-		}
-		if !alreadyWired {
-			r.sourceExtractors.Store(srcName, append(exts, pending.Extractor))
+		if err := r.resolvePending(pending, disallowedExtractorType, logger); err != nil {
+			return err
 		}
 	}
 
-	logger.Info("Datalayer runtime configured", "pollers", pollersCount, "notifiers", notifiersCount, "endpointSources", endpointSourcesCount)
+	logger.Info("Datalayer runtime configured",
+		"pollers", r.polling.Count(),
+		"notifiers", r.notification.Count(),
+		"endpointSources", r.endpoint.Count())
 	return nil
 }
 
 // Register stores a pending source/extractor dependency declared by a plugin.
-// Called by plugins implementing Registrant.RegisterDependencies() before Configure() runs.
+// Resolved by Configure() after user config is processed.
 func (r *Runtime) Register(reg fwkdl.PendingRegistration) error {
 	if reg.Extractor == nil {
 		return fmt.Errorf("plugin %s: PendingRegistration.Extractor must not be nil", reg.Owner)
@@ -190,144 +120,192 @@ func (r *Runtime) Register(reg fwkdl.PendingRegistration) error {
 	return nil
 }
 
-// registerSource stores src in the appropriate typed sync.Map and enforces GVK uniqueness for NotificationSources.
-func (r *Runtime) registerSource(src fwkdl.DataSource, gvkToSource map[string]string) error {
-	srcName := src.TypedName().Name
-	if poller, ok := src.(fwkdl.PollingDataSource); ok {
-		r.pollers.Store(srcName, poller)
-	} else if notifier, ok := src.(fwkdl.NotificationSource); ok {
-		gvk := notifier.GVK().String()
-		if existingSource, exists := gvkToSource[gvk]; exists {
-			return fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
-				gvk, existingSource, src.TypedName().String())
+// addSource dispatches src to the matching variant's typed handler.
+func (r *Runtime) addSource(src fwkdl.DataSource, exts []fwkplugin.Plugin, disallowedType string) error {
+	switch s := src.(type) {
+	case fwkdl.PollingDataSource:
+		return r.addPolling(s, exts, disallowedType)
+	case fwkdl.NotificationSource:
+		return r.addNotification(s, exts, disallowedType)
+	case fwkdl.EndpointSource:
+		return r.addEndpoint(s, exts, disallowedType)
+	default:
+		return fmt.Errorf("unknown datasource plugin type %s", src.TypedName().String())
+	}
+}
+
+func (r *Runtime) addPolling(src fwkdl.PollingDataSource, exts []fwkplugin.Plugin, disallowedType string) error {
+	typed, err := assertExtractors[fwkdl.PollingExtractor](src, exts, "PollingExtractor", disallowedType)
+	if err != nil {
+		return err
+	}
+	r.polling.Register(src, typed)
+	return nil
+}
+
+func (r *Runtime) addNotification(src fwkdl.NotificationSource, exts []fwkplugin.Plugin, disallowedType string) error {
+	typed, err := assertExtractors[fwkdl.NotificationExtractor](src, exts, "NotificationExtractor", disallowedType)
+	if err != nil {
+		return err
+	}
+	if err := validateNotificationGVK(src, typed); err != nil {
+		return err
+	}
+	return r.notification.Register(src, typed)
+}
+
+func (r *Runtime) addEndpoint(src fwkdl.EndpointSource, exts []fwkplugin.Plugin, disallowedType string) error {
+	typed, err := assertExtractors[fwkdl.EndpointExtractor](src, exts, "EndpointExtractor", disallowedType)
+	if err != nil {
+		return err
+	}
+	r.endpoint.Register(src, typed)
+	return nil
+}
+
+// appendPendingExtractor dispatches a single code-registered extractor to the
+// matching variant's append-with-dedup op.
+func (r *Runtime) appendPendingExtractor(srcName string, src fwkdl.DataSource, ext fwkplugin.Plugin, disallowedType string) error {
+	switch s := src.(type) {
+	case fwkdl.PollingDataSource:
+		return r.appendPendingPolling(srcName, s, ext, disallowedType)
+	case fwkdl.NotificationSource:
+		return r.appendPendingNotification(srcName, s, ext, disallowedType)
+	case fwkdl.EndpointSource:
+		return r.appendPendingEndpoint(srcName, s, ext, disallowedType)
+	default:
+		return fmt.Errorf("matched source %s has unknown variant", srcName)
+	}
+}
+
+func (r *Runtime) appendPendingPolling(srcName string, src fwkdl.PollingDataSource, ext fwkplugin.Plugin, disallowedType string) error {
+	typed, err := assertExtractors[fwkdl.PollingExtractor](src, []fwkplugin.Plugin{ext}, "PollingExtractor", disallowedType)
+	if err != nil {
+		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+	}
+	r.polling.AppendExtractor(srcName, typed[0])
+	return nil
+}
+
+func (r *Runtime) appendPendingNotification(srcName string, src fwkdl.NotificationSource, ext fwkplugin.Plugin, disallowedType string) error {
+	typed, err := assertExtractors[fwkdl.NotificationExtractor](src, []fwkplugin.Plugin{ext}, "NotificationExtractor", disallowedType)
+	if err != nil {
+		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+	}
+	if err := validateNotificationGVK(src, typed); err != nil {
+		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+	}
+	r.notification.AppendExtractor(srcName, typed[0])
+	return nil
+}
+
+func (r *Runtime) appendPendingEndpoint(srcName string, src fwkdl.EndpointSource, ext fwkplugin.Plugin, disallowedType string) error {
+	typed, err := assertExtractors[fwkdl.EndpointExtractor](src, []fwkplugin.Plugin{ext}, "EndpointExtractor", disallowedType)
+	if err != nil {
+		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+	}
+	r.endpoint.AppendExtractor(srcName, typed[0])
+	return nil
+}
+
+// resolvePending matches a pending dependency to a configured source (or
+// auto-creates from DefaultSource), then appends the extractor.
+func (r *Runtime) resolvePending(pending fwkdl.PendingRegistration, disallowedType string, logger logr.Logger) error {
+	var gvkFilter *schema.GroupVersionKind
+	if ns, ok := pending.DefaultSource.(fwkdl.NotificationSource); ok {
+		gvk := ns.GVK()
+		gvkFilter = &gvk
+	}
+	srcName, matchedSrc := r.findSourceByType(pending.SourceType, gvkFilter)
+
+	if matchedSrc == nil {
+		if pending.DefaultSource == nil {
+			msg := fmt.Sprintf("extractor %s requires source type %s, not configured",
+				pending.Extractor.TypedName(), pending.SourceType)
+			if pending.IfMissing == fwkdl.Warn {
+				logger.Info("datalayer: skipping unresolved dependency", "reason", msg)
+				return nil
+			}
+			return errors.New(msg)
 		}
-		r.notifiers.Store(srcName, notifier)
-		gvkToSource[gvk] = srcName
-	} else if epSrc, ok := src.(fwkdl.EndpointSource); ok {
-		r.endpointSources.Store(srcName, epSrc)
-	} else {
-		return fmt.Errorf("skipping unknown datasource plugin type %s", src.TypedName().String())
+		if err := r.addSource(pending.DefaultSource, nil, disallowedType); err != nil {
+			return fmt.Errorf("auto-register default source for %s: %w",
+				pending.Extractor.TypedName(), err)
+		}
+		srcName = pending.DefaultSource.TypedName().Name
+		matchedSrc = pending.DefaultSource
+	}
+
+	return r.appendPendingExtractor(srcName, matchedSrc, pending.Extractor, disallowedType)
+}
+
+// findSourceByType walks each manager looking for a source whose TypedName.Type
+// matches sourceType. For NotificationSources, also filters by GVK if non-nil.
+func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource) {
+	if name, src, ok := r.polling.FindByType(sourceType, nil); ok {
+		return name, src
+	}
+
+	var nfilter func(fwkdl.NotificationSource) bool
+	if gvkFilter != nil {
+		want := gvkFilter.String()
+		nfilter = func(s fwkdl.NotificationSource) bool { return s.GVK().String() == want }
+	}
+	if name, src, ok := r.notification.FindByType(sourceType, nfilter); ok {
+		return name, src
+	}
+
+	if name, src, ok := r.endpoint.FindByType(sourceType, nil); ok {
+		return name, src
+	}
+	return "", nil
+}
+
+// Start wires Kubernetes notifications into the manager.
+func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
+	sources := r.notification.Sources()
+	extractors := r.notification.Extractors()
+	for srcName, ns := range sources {
+		if err := BindNotificationSource(ns, extractors[srcName], mgr); err != nil {
+			return fmt.Errorf("failed to bind notification source %s: %w", ns.TypedName(), err)
+		}
+		_ = srcName
 	}
 	return nil
 }
 
-// findSourceByType searches pollers, notifiers, and endpointSources for a source whose TypedName.Type
-// matches sourceType. For NotificationSources, also filters by GVK if gvkFilter is non-nil.
-func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource) {
-	matches := func(src fwkdl.DataSource) bool {
-		if src.TypedName().Type != sourceType {
-			return false
-		}
-		if gvkFilter != nil {
-			if ns, ok := src.(fwkdl.NotificationSource); ok {
-				if ns.GVK().String() != gvkFilter.String() {
-					return false
-				}
-			}
-		}
-		return true
-	}
-
-	var foundName string
-	var foundSrc fwkdl.DataSource
-
-	r.pollers.Range(func(key, val any) bool {
-		src := val.(fwkdl.PollingDataSource)
-		if matches(src) {
-			foundName, foundSrc = key.(string), src
-			return false
+// Stop terminates data collection and stops all per-endpoint collectors.
+func (r *Runtime) Stop() error {
+	r.collectors.Range(func(_, val any) bool {
+		if c, ok := val.(*Collector); ok {
+			c.Stop()
 		}
 		return true
 	})
-	if foundSrc != nil {
-		return foundName, foundSrc
-	}
-
-	r.notifiers.Range(func(key, val any) bool {
-		src := val.(fwkdl.NotificationSource)
-		if matches(src) {
-			foundName, foundSrc = key.(string), src
-			return false
-		}
-		return true
-	})
-	if foundSrc != nil {
-		return foundName, foundSrc
-	}
-
-	r.endpointSources.Range(func(key, val any) bool {
-		src := val.(fwkdl.EndpointSource)
-		if matches(src) {
-			foundName, foundSrc = key.(string), src
-			return false
-		}
-		return true
-	})
-
-	return foundName, foundSrc
-}
-
-// Start is called to enable the Runtime to start processing data collection. It wires
-// Kubernetes notifications into the manager.
-func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
-	var err error
-
-	r.notifiers.Range(func(key, val any) bool { // bind notification sources to the manager
-		ns := val.(fwkdl.NotificationSource)
-		srcName := ns.TypedName().Name
-
-		var extractors []fwkdl.NotificationExtractor
-		if rawExts, ok := r.sourceExtractors.Load(srcName); ok {
-			raw := rawExts.([]fwkdl.ExtractorBase)
-			extractors = make([]fwkdl.NotificationExtractor, len(raw))
-			for i, e := range raw {
-				extractors[i] = e.(fwkdl.NotificationExtractor)
-			}
-		}
-
-		if bindErr := BindNotificationSource(ns, extractors, mgr); bindErr != nil {
-			err = fmt.Errorf("failed to bind notification source %s: %w", ns.TypedName(), bindErr)
-			return false
-		}
-		return true
-	})
-	return err
+	return nil
 }
 
 // NewEndpoint sets up data polling on the provided endpoint.
 func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.EndpointMetadata, _ PoolInfo) fwkdl.Endpoint {
-	// TODO: should we cache the sources and map after Configure? Or just replace with maps and Mutex?
-	// The code could be simpler and also would benefit from using RLock mutex for concurrent access
-	// (no change expected) instead of using sync.Map (avoid use of Range just to count, more idiomatic code, etc.).
 	logger, _ := logr.FromContext(ctx)
 	logger = logger.WithValues("endpoint", endpointMetadata.GetNamespacedName())
 
-	var pollers []fwkdl.PollingDataSource
-	r.pollers.Range(func(_, val any) bool {
-		if poller, ok := val.(fwkdl.PollingDataSource); ok {
-			pollers = append(pollers, poller)
-		}
-		return true
-	})
-
-	if len(pollers) == 0 {
+	pollerMap := r.polling.Sources()
+	if len(pollerMap) == 0 {
 		logger.Info("No polling sources configured, creating endpoint without collector")
 		endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
 		r.dispatchEndpointEvent(ctx, logger, fwkdl.EndpointEvent{Type: fwkdl.EventAddOrUpdate, Endpoint: endpoint})
 		return endpoint
 	}
 
-	extractors := make(map[string][]fwkdl.ExtractorBase, len(pollers))
-	r.sourceExtractors.Range(func(key, val any) bool {
-		srcName := key.(string)
-		exts := val.([]fwkdl.ExtractorBase)
-		extractors[srcName] = exts
-		return true
-	})
+	pollers := make([]fwkdl.PollingDataSource, 0, len(pollerMap))
+	for _, p := range pollerMap {
+		pollers = append(pollers, p)
+	}
+	extractors := r.polling.Extractors()
 
 	endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
 	collector := NewCollector()
-
 	key := endpointMetadata.GetNamespacedName()
 	if _, loaded := r.collectors.LoadOrStore(key, collector); loaded {
 		logger.V(logging.DEFAULT).Info("collector already running for endpoint", "endpoint", key)
@@ -345,86 +323,50 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 	return endpoint
 }
 
-// ReleaseEndpoint terminates polling for data on the given endpoint.
+// ReleaseEndpoint terminates polling for the given endpoint.
 func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 	r.dispatchEndpointEvent(context.Background(), r.logger, fwkdl.EndpointEvent{Type: fwkdl.EventDelete, Endpoint: ep})
-
 	key := ep.GetMetadata().GetNamespacedName()
 	if value, ok := r.collectors.LoadAndDelete(key); ok {
-		collector := value.(*Collector)
-		collector.Stop()
+		value.(*Collector).Stop()
 	}
 }
 
 // dispatchEndpointEvent routes an endpoint lifecycle event to all registered
 // EndpointSources and their extractors.
 func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger, event fwkdl.EndpointEvent) {
-	if isEmpty(&r.endpointSources) {
+	if r.endpoint.IsEmpty() {
 		return
 	}
-	r.endpointSources.Range(func(key, val any) bool {
-		srcName := key.(string)
-		epSrc := val.(fwkdl.EndpointSource)
-
+	sources := r.endpoint.Sources()
+	for srcName, epSrc := range sources {
 		processed, err := epSrc.NotifyEndpoint(ctx, event)
 		if err != nil {
 			logger.Error(err, "endpoint source failed to process event", "source", srcName)
-			return true
+			continue
 		}
 		if processed == nil {
-			return true
+			continue
 		}
-
-		rawExts, ok := r.sourceExtractors.Load(srcName)
-		if !ok {
-			return true
-		}
-		for _, ext := range rawExts.([]fwkdl.ExtractorBase) {
-			if epExt, ok := ext.(fwkdl.EndpointExtractor); ok {
-				if err := epExt.ExtractEndpoint(ctx, *processed); err != nil {
-					logger.Error(err, "endpoint extractor failed", "extractor", ext.TypedName())
-				}
+		for _, ext := range r.endpoint.ExtractorsFor(srcName) {
+			if err := ext.Extract(ctx, *processed); err != nil {
+				logger.Error(err, "endpoint extractor failed", "extractor", ext.TypedName())
 			}
 		}
-		return true
-	})
+	}
 }
 
-// validates the compatibility of data source and configured extractors. This includes
-// expected Extractor type, source output and extractor input type compatibility and
-// optionally source specific validation.
-func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fwkdl.ExtractorBase, disallowedExtractorType string) error {
-	for _, ext := range extractors {
-		// check if disallowed extractor type
-		if disallowedExtractorType != "" && ext.TypedName().Type == disallowedExtractorType {
+// validateExtractors enforces the disallowed-type guard and dispatches the
+// source's optional Validator over the extractors.
+func validateExtractors[E fwkplugin.Plugin](src fwkdl.DataSource, exts []E, disallowedType string) error {
+	validator, hasValidator := src.(fwkdl.Validator[E])
+	for _, ext := range exts {
+		if disallowedType != "" && ext.TypedName().Type == disallowedType {
 			return fmt.Errorf("disallowed Extractor %s is configured for source %s",
-				ext.TypedName().String(), src.TypedName().String())
+				ext.TypedName(), src.TypedName())
 		}
-
-		// validate extractor type
-		extractorType := reflect.TypeOf(ext)
-		if err := validateExtractorCompatible(extractorType, src.ExtractorType()); err != nil {
-			return fmt.Errorf("extractor %s type incompatible with datasource %s: %w",
-				ext.TypedName(), src.TypedName(), err)
-		}
-
-		// validate input/output types match
-		if err := validateInputTypeCompatible(src.OutputType(), ext.ExpectedInputType()); err != nil {
-			return fmt.Errorf("extractor %s input type incompatible with datasource %s: %w",
-				ext.TypedName(), src.TypedName(), err)
-		}
-		if notifySrc, ok := src.(fwkdl.NotificationSource); ok {
-			if notifyExt, ok := ext.(fwkdl.NotificationExtractor); ok {
-				if notifySrc.GVK().String() != notifyExt.GVK().String() {
-					return fmt.Errorf("extractor %s GVK %s does not match source %s GVK %s",
-						ext.TypedName(), notifyExt.GVK().String(), src.TypedName(), notifySrc.GVK().String())
-				}
-			}
-		}
-
-		// allow datasource custom validation
-		if validator, ok := src.(fwkdl.ValidatingDataSource); ok {
-			if err := validator.ValidateExtractor(ext); err != nil {
+		if hasValidator {
+			if err := validator.Validate(ext); err != nil {
 				return fmt.Errorf("extractor %s failed custom validation for datasource %s: %w",
 					ext.TypedName(), src.TypedName(), err)
 			}
@@ -433,43 +375,30 @@ func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fw
 	return nil
 }
 
-// validate input/output type compatibility.
-func validateInputTypeCompatible(dataSourceOutput, extractorInput reflect.Type) error {
-	if dataSourceOutput == nil || extractorInput == nil {
-		return errors.New("data source output type or extractor input type can't be nil")
-	}
-	if dataSourceOutput == extractorInput ||
-		(extractorInput.Kind() == reflect.Interface && extractorInput.NumMethod() == 0) ||
-		(extractorInput.Kind() == reflect.Interface && dataSourceOutput.Implements(extractorInput)) {
-		return nil
-	}
-	return fmt.Errorf("extractor input type %v is not compatible with data source output type %v",
-		extractorInput, dataSourceOutput)
-}
-
-// validate extractor compatibility.
-func validateExtractorCompatible(extractorType reflect.Type, expectedInterfaceType reflect.Type) error {
-	if extractorType == nil || expectedInterfaceType == nil {
-		return errors.New("extractor type or expected interface type can't be nil")
-	}
-	if expectedInterfaceType.Kind() != reflect.Interface {
-		return fmt.Errorf("expected type must be an interface, got %v", expectedInterfaceType.Kind())
-	}
-	if !extractorType.Implements(expectedInterfaceType) {
-		return fmt.Errorf("extractor type %v does not implement interface %v",
-			extractorType, expectedInterfaceType)
+// validateNotificationGVK enforces that every extractor's GVK matches the source's GVK.
+func validateNotificationGVK(src fwkdl.NotificationSource, exts []fwkdl.NotificationExtractor) error {
+	srcGVK := src.GVK().String()
+	for _, ext := range exts {
+		if ext.GVK().String() != srcGVK {
+			return fmt.Errorf("extractor %s GVK %s does not match source %s GVK %s",
+				ext.TypedName(), ext.GVK().String(), src.TypedName(), srcGVK)
+		}
 	}
 	return nil
 }
 
-// isEmpty reports whether the sync.Map has no entries.
-func isEmpty(m *sync.Map) bool {
-	empty := true
-	m.Range(func(_, _ any) bool {
-		empty = false
-		return false // stop immediately
-	})
-	return empty
+// assertExtractors types exts as []E and runs common validation.
+func assertExtractors[E fwkplugin.Plugin](
+	src fwkdl.DataSource, exts []fwkplugin.Plugin, variantName, disallowedType string,
+) ([]E, error) {
+	typed, err := assertAll[E](exts, variantName)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateExtractors[E](src, typed, disallowedType); err != nil {
+		return nil, err
+	}
+	return typed, nil
 }
 
 var _ EndpointFactory = (*Runtime)(nil)

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -32,14 +32,25 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
+// variantLookup pairs a sourceVariant with its FindByType adapter; r.variants
+// (built in NewRuntime) is the single source of truth for variant iteration.
+type variantLookup struct {
+	variant sourceVariant
+	find    func(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource, bool)
+}
+
 // Runtime routes per-variant state to the matching manager and owns
 // per-endpoint Collectors and pending dependency resolution.
 type Runtime struct {
 	pollingInterval time.Duration
 
-	polling      *sourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]
+	polling      *pollingManager
 	notification *notificationManager
-	endpoint     *sourceManager[fwkdl.EndpointSource, fwkdl.EndpointExtractor]
+	endpoint     *endpointManager
+
+	// variants enumerates every (sourceVariant, FindByType-adapter) pair.
+	// Registered in NewRuntime; consumed by findSourceByType.
+	variants []variantLookup
 
 	pendingMu            sync.Mutex
 	pendingRegistrations []fwkdl.PendingRegistration
@@ -58,12 +69,38 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 	if pollingInterval > 0 {
 		interval = pollingInterval
 	}
-	return &Runtime{
+	r := &Runtime{
 		pollingInterval: interval,
-		polling:         newSourceManager[fwkdl.PollingDataSource, fwkdl.PollingExtractor]("polling"),
+		polling:         newPollingManager(),
 		notification:    newNotificationManager(),
-		endpoint:        newSourceManager[fwkdl.EndpointSource, fwkdl.EndpointExtractor]("endpoint"),
+		endpoint:        newEndpointManager(),
 		logger:          logr.Discard(),
+	}
+	r.variants = r.buildVariantLookups()
+	return r
+}
+
+// buildVariantLookups registers every variant's FindByType adapter — adding a
+// new variant means adding one row here.
+func (r *Runtime) buildVariantLookups() []variantLookup {
+	return []variantLookup{
+		{variantPolling, func(t string, _ *schema.GroupVersionKind) (string, fwkdl.DataSource, bool) {
+			n, s, ok := r.polling.FindByType(t, nil)
+			return n, s, ok
+		}},
+		{variantNotification, func(t string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource, bool) {
+			var nfilter func(fwkdl.NotificationSource) bool
+			if gvkFilter != nil {
+				want := gvkFilter.String()
+				nfilter = func(s fwkdl.NotificationSource) bool { return s.GVK().String() == want }
+			}
+			n, s, ok := r.notification.FindByType(t, nfilter)
+			return n, s, ok
+		}},
+		{variantEndpoint, func(t string, _ *schema.GroupVersionKind) (string, fwkdl.DataSource, bool) {
+			n, s, ok := r.endpoint.FindByType(t, nil)
+			return n, s, ok
+		}},
 	}
 }
 
@@ -212,7 +249,10 @@ func (r *Runtime) resolvePending(pending fwkdl.PendingRegistration, disallowedTy
 		gvk := ns.GVK()
 		gvkFilter = &gvk
 	}
-	srcName, matchedSrc := r.findSourceByType(pending.SourceType, gvkFilter)
+	srcName, matchedSrc, err := r.findSourceByType(pending.SourceType, gvkFilter)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", pending.Extractor.TypedName(), err)
+	}
 
 	if matchedSrc == nil {
 		if pending.DefaultSource == nil {
@@ -235,25 +275,26 @@ func (r *Runtime) resolvePending(pending fwkdl.PendingRegistration, disallowedTy
 	return r.appendPendingExtractor(srcName, matchedSrc, pending.Extractor, disallowedType)
 }
 
-// findSourceByType walks all managers; gvkFilter narrows notification matches.
-func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource) {
-	if name, src, ok := r.polling.FindByType(sourceType, nil); ok {
-		return name, src
+// findSourceByType walks r.variants; gvkFilter narrows notification matches.
+// A type registered across more than one variant is a configuration error.
+func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource, error) {
+	var (
+		matchedName    string
+		matchedSrc     fwkdl.DataSource
+		matchedVariant sourceVariant
+	)
+	for _, l := range r.variants {
+		name, src, ok := l.find(sourceType, gvkFilter)
+		if !ok {
+			continue
+		}
+		if matchedSrc != nil {
+			return "", nil, fmt.Errorf("source type %q is registered across variants: %s (%s) and %s (%s)",
+				sourceType, matchedVariant, matchedName, l.variant, name)
+		}
+		matchedVariant, matchedName, matchedSrc = l.variant, name, src
 	}
-
-	var nfilter func(fwkdl.NotificationSource) bool
-	if gvkFilter != nil {
-		want := gvkFilter.String()
-		nfilter = func(s fwkdl.NotificationSource) bool { return s.GVK().String() == want }
-	}
-	if name, src, ok := r.notification.FindByType(sourceType, nfilter); ok {
-		return name, src
-	}
-
-	if name, src, ok := r.endpoint.FindByType(sourceType, nil); ok {
-		return name, src
-	}
-	return "", nil
+	return matchedName, matchedSrc, nil
 }
 
 // Start wires Kubernetes notifications into the manager.
@@ -269,14 +310,13 @@ func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
 }
 
 // Stop halts all per-endpoint collectors.
-func (r *Runtime) Stop() error {
+func (r *Runtime) Stop() {
 	r.collectors.Range(func(_, val any) bool {
 		if c, ok := val.(*Collector); ok {
 			c.Stop()
 		}
 		return true
 	})
-	return nil
 }
 
 // NewEndpoint sets up data polling on the provided endpoint.

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -32,8 +32,8 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
-// Runtime manages data sources, extractors, their mapping, and endpoint lifecycle.
-// Per-variant state lives in dedicated managers; Runtime routes between them.
+// Runtime routes per-variant state to the matching manager and owns
+// per-endpoint Collectors and pending dependency resolution.
 type Runtime struct {
 	pollingInterval time.Duration
 
@@ -44,14 +44,15 @@ type Runtime struct {
 	pendingMu            sync.Mutex
 	pendingRegistrations []fwkdl.PendingRegistration
 
-	collectors sync.Map    // namespaced name -> *Collector (high-churn, sync.Map is appropriate)
-	logger     logr.Logger // set in Configure
+	// sync.Map: per-pod reconciles write concurrently to this map; the variant
+	// maps inside the managers don't (write-once at Configure).
+	collectors sync.Map
+	logger     logr.Logger
 }
 
 const defaultRefreshInterval = 50 * time.Millisecond
 
-// NewRuntime returns a Runtime with the given polling interval; non-positive
-// values fall back to defaultRefreshInterval.
+// NewRuntime returns a Runtime; non-positive interval falls back to defaultRefreshInterval.
 func NewRuntime(pollingInterval time.Duration) *Runtime {
 	interval := defaultRefreshInterval
 	if pollingInterval > 0 {
@@ -66,8 +67,7 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 	}
 }
 
-// Configure transforms cfg into the Runtime's internal state and resolves any
-// code-registered pending dependencies.
+// Configure installs cfg's sources/extractors and resolves pending dependencies.
 func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtractorType string, logger logr.Logger) error {
 	hasPending := len(r.pendingRegistrations) > 0
 	if (cfg == nil || len(cfg.Sources) == 0) && !hasPending {
@@ -108,8 +108,7 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 	return nil
 }
 
-// Register stores a pending source/extractor dependency declared by a plugin.
-// Resolved by Configure() after user config is processed.
+// Register queues a pending dependency for Configure to resolve.
 func (r *Runtime) Register(reg fwkdl.PendingRegistration) error {
 	if reg.Extractor == nil {
 		return fmt.Errorf("plugin %s: PendingRegistration.Extractor must not be nil", reg.Owner)
@@ -120,7 +119,7 @@ func (r *Runtime) Register(reg fwkdl.PendingRegistration) error {
 	return nil
 }
 
-// addSource dispatches src to the matching variant's typed handler.
+// addSource dispatches to the matching variant's handler.
 func (r *Runtime) addSource(src fwkdl.DataSource, exts []fwkplugin.Plugin, disallowedType string) error {
 	switch s := src.(type) {
 	case fwkdl.PollingDataSource:
@@ -161,8 +160,7 @@ func (r *Runtime) addEndpoint(src fwkdl.EndpointSource, exts []fwkplugin.Plugin,
 	return r.endpoint.Register(src, typed)
 }
 
-// appendPendingExtractor dispatches a single code-registered extractor to the
-// matching variant's append-with-dedup op.
+// appendPendingExtractor dispatches one code-registered extractor to the matching variant.
 func (r *Runtime) appendPendingExtractor(srcName string, src fwkdl.DataSource, ext fwkplugin.Plugin, disallowedType string) error {
 	switch s := src.(type) {
 	case fwkdl.PollingDataSource:
@@ -206,8 +204,8 @@ func (r *Runtime) appendPendingEndpoint(srcName string, src fwkdl.EndpointSource
 	return nil
 }
 
-// resolvePending matches a pending dependency to a configured source (or
-// auto-creates from DefaultSource), then appends the extractor.
+// resolvePending matches a pending dependency to a configured source, falls
+// back to its DefaultSource, then appends the extractor.
 func (r *Runtime) resolvePending(pending fwkdl.PendingRegistration, disallowedType string, logger logr.Logger) error {
 	var gvkFilter *schema.GroupVersionKind
 	if ns, ok := pending.DefaultSource.(fwkdl.NotificationSource); ok {
@@ -237,8 +235,7 @@ func (r *Runtime) resolvePending(pending fwkdl.PendingRegistration, disallowedTy
 	return r.appendPendingExtractor(srcName, matchedSrc, pending.Extractor, disallowedType)
 }
 
-// findSourceByType walks each manager looking for a source whose TypedName.Type
-// matches sourceType. For NotificationSources, also filters by GVK if non-nil.
+// findSourceByType walks all managers; gvkFilter narrows notification matches.
 func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource) {
 	if name, src, ok := r.polling.FindByType(sourceType, nil); ok {
 		return name, src
@@ -271,7 +268,7 @@ func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
 	return nil
 }
 
-// Stop terminates data collection and stops all per-endpoint collectors.
+// Stop halts all per-endpoint collectors.
 func (r *Runtime) Stop() error {
 	r.collectors.Range(func(_, val any) bool {
 		if c, ok := val.(*Collector); ok {
@@ -329,8 +326,7 @@ func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 	}
 }
 
-// dispatchEndpointEvent routes an endpoint lifecycle event to all registered
-// EndpointSources and their extractors.
+// dispatchEndpointEvent fans event out to every EndpointSource and its extractors.
 func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger, event fwkdl.EndpointEvent) {
 	if r.endpoint.IsEmpty() {
 		return
@@ -353,8 +349,8 @@ func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger,
 	}
 }
 
-// validateExtractors enforces the disallowed-type guard and dispatches the
-// source's optional Validator over the extractors.
+// validateExtractors applies the disallowed-type guard and the source's
+// optional Validator[E] to each extractor.
 func validateExtractors[E fwkplugin.Plugin](src fwkdl.DataSource, exts []E, disallowedType string) error {
 	validator, hasValidator := src.(fwkdl.Validator[E])
 	for _, ext := range exts {
@@ -384,7 +380,7 @@ func validateNotificationGVK(src fwkdl.NotificationSource, exts []fwkdl.Notifica
 	return nil
 }
 
-// assertExtractors types exts as []E and runs common validation.
+// assertExtractors types exts to []E and runs validateExtractors on the result.
 func assertExtractors[E fwkplugin.Plugin](
 	src fwkdl.DataSource, exts []fwkplugin.Plugin, variantName, disallowedType string,
 ) ([]E, error) {

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -139,8 +139,7 @@ func (r *Runtime) addPolling(src fwkdl.PollingDataSource, exts []fwkplugin.Plugi
 	if err != nil {
 		return err
 	}
-	r.polling.Register(src, typed)
-	return nil
+	return r.polling.Register(src, typed)
 }
 
 func (r *Runtime) addNotification(src fwkdl.NotificationSource, exts []fwkplugin.Plugin, disallowedType string) error {
@@ -159,8 +158,7 @@ func (r *Runtime) addEndpoint(src fwkdl.EndpointSource, exts []fwkplugin.Plugin,
 	if err != nil {
 		return err
 	}
-	r.endpoint.Register(src, typed)
-	return nil
+	return r.endpoint.Register(src, typed)
 }
 
 // appendPendingExtractor dispatches a single code-registered extractor to the

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -322,7 +322,9 @@ func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 	r.dispatchEndpointEvent(context.Background(), r.logger, fwkdl.EndpointEvent{Type: fwkdl.EventDelete, Endpoint: ep})
 	key := ep.GetMetadata().GetNamespacedName()
 	if value, ok := r.collectors.LoadAndDelete(key); ok {
-		value.(*Collector).Stop()
+		if c, ok := value.(*Collector); ok {
+			c.Stop()
+		}
 	}
 }
 

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -181,7 +181,7 @@ func (r *Runtime) appendPendingExtractor(srcName string, src fwkdl.DataSource, e
 func (r *Runtime) appendPendingPolling(srcName string, src fwkdl.PollingDataSource, ext fwkplugin.Plugin, disallowedType string) error {
 	typed, err := assertExtractors[fwkdl.PollingExtractor](src, []fwkplugin.Plugin{ext}, "PollingExtractor", disallowedType)
 	if err != nil {
-		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+		return fmt.Errorf("code-registered for source %s: %w", srcName, err)
 	}
 	r.polling.AppendExtractor(srcName, typed[0])
 	return nil
@@ -190,10 +190,10 @@ func (r *Runtime) appendPendingPolling(srcName string, src fwkdl.PollingDataSour
 func (r *Runtime) appendPendingNotification(srcName string, src fwkdl.NotificationSource, ext fwkplugin.Plugin, disallowedType string) error {
 	typed, err := assertExtractors[fwkdl.NotificationExtractor](src, []fwkplugin.Plugin{ext}, "NotificationExtractor", disallowedType)
 	if err != nil {
-		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+		return fmt.Errorf("code-registered for source %s: %w", srcName, err)
 	}
 	if err := validateNotificationGVK(src, typed); err != nil {
-		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+		return fmt.Errorf("code-registered for source %s: %w", srcName, err)
 	}
 	r.notification.AppendExtractor(srcName, typed[0])
 	return nil
@@ -202,7 +202,7 @@ func (r *Runtime) appendPendingNotification(srcName string, src fwkdl.Notificati
 func (r *Runtime) appendPendingEndpoint(srcName string, src fwkdl.EndpointSource, ext fwkplugin.Plugin, disallowedType string) error {
 	typed, err := assertExtractors[fwkdl.EndpointExtractor](src, []fwkplugin.Plugin{ext}, "EndpointExtractor", disallowedType)
 	if err != nil {
-		return fmt.Errorf("code-registered extractor %s for source %s: %w", ext.TypedName(), srcName, err)
+		return fmt.Errorf("code-registered for source %s: %w", srcName, err)
 	}
 	r.endpoint.AppendExtractor(srcName, typed[0])
 	return nil
@@ -269,7 +269,6 @@ func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
 		if err := BindNotificationSource(ns, extractors[srcName], mgr); err != nil {
 			return fmt.Errorf("failed to bind notification source %s: %w", ns.TypedName(), err)
 		}
-		_ = srcName
 	}
 	return nil
 }

--- a/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
+++ b/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	extmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
@@ -43,7 +44,7 @@ func TestNewEndpointDispatchesEventWithNoPollers(t *testing.T) {
 		Sources: []DataSourceConfig{
 			{
 				Plugin:     epSrc,
-				Extractors: []fwkdl.ExtractorBase{extractor},
+				Extractors: []fwkplugin.Plugin{extractor},
 			},
 		},
 	}

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -22,9 +22,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	extractormocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/mocks"
+	sourcemocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
 
@@ -172,4 +175,50 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 	exts := r.endpoint.ExtractorsFor("ep-src")
 	require.Len(t, exts, 1, "code registration should be deduped; only config extractor present")
 	assert.Equal(t, "config-ext", exts[0].TypedName().Name)
+}
+
+func TestConfigure_CrossVariantSourceTypeCollisionRejected(t *testing.T) {
+	const collidingType = "colliding-source-type"
+	gvk := schema.GroupVersionKind{Group: "test.io", Version: "v1", Kind: "Probe"}
+
+	polling := func() fwkdl.DataSource {
+		return sourcemocks.NewDataSource(fwkplugin.TypedName{Type: collidingType, Name: "polling-src"})
+	}
+	notification := func() fwkdl.DataSource {
+		return sourcemocks.NewNotificationSource(collidingType, "notif-src", gvk)
+	}
+	endpoint := func() fwkdl.DataSource {
+		return notifications.NewEndpointDataSource(collidingType, "endpoint-src")
+	}
+
+	cases := []struct {
+		name    string
+		sources []fwkdl.DataSource
+	}{
+		{"polling+endpoint", []fwkdl.DataSource{polling(), endpoint()}},
+		{"polling+notification", []fwkdl.DataSource{polling(), notification()}},
+		{"notification+endpoint", []fwkdl.DataSource{notification(), endpoint()}},
+		{"all three variants", []fwkdl.DataSource{polling(), notification(), endpoint()}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRuntime(0)
+			logger := newTestLogger(t)
+
+			require.NoError(t, r.Register(fwkdl.PendingRegistration{
+				Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+				SourceType: collidingType,
+				Extractor:  extractormocks.NewEndpointExtractor("ext"),
+			}))
+
+			srcCfgs := make([]DataSourceConfig, len(tc.sources))
+			for i, s := range tc.sources {
+				srcCfgs[i] = DataSourceConfig{Plugin: s}
+			}
+
+			err := r.Configure(&Config{Sources: srcCfgs}, false, "", logger)
+			require.ErrorIs(t, err, ErrSourceTypeCollision)
+		})
+	}
 }

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -74,10 +74,8 @@ func TestConfigure_ExtractorWiredToUserConfiguredSource(t *testing.T) {
 	err := r.Configure(cfg, false, "", logger)
 	require.NoError(t, err)
 
-	rawExts, ok := r.sourceExtractors.Load("ep-src")
-	require.True(t, ok, "sourceExtractors should have entry for ep-src")
-	exts := rawExts.([]fwkdl.ExtractorBase)
-	require.Len(t, exts, 1)
+	exts := r.endpoint.ExtractorsFor("ep-src")
+	require.Len(t, exts, 1, "endpoint manager should have one extractor for ep-src")
 	assert.Equal(t, "ext-a", exts[0].TypedName().Name)
 }
 
@@ -100,16 +98,14 @@ func TestConfigure_DefaultSourceAutoRegisteredWhenAbsent(t *testing.T) {
 	err := r.Configure(nil, false, "", logger)
 	require.NoError(t, err)
 
-	// Source should be in endpointSources.
-	val, ok := r.endpointSources.Load(notifications.EndpointNotificationSourceType)
-	require.True(t, ok, "auto-registered source should appear in endpointSources")
-	assert.Equal(t, notifications.EndpointNotificationSourceType, val.(fwkdl.EndpointSource).TypedName().Name)
+	// Source should be in the endpoint manager.
+	src, ok := r.endpoint.Sources()[notifications.EndpointNotificationSourceType]
+	require.True(t, ok, "auto-registered source should appear in endpoint manager")
+	assert.Equal(t, notifications.EndpointNotificationSourceType, src.TypedName().Name)
 
 	// Extractor should be wired.
-	rawExts, ok := r.sourceExtractors.Load(notifications.EndpointNotificationSourceType)
-	require.True(t, ok, "extractor should be wired to auto-registered source")
-	exts := rawExts.([]fwkdl.ExtractorBase)
-	require.Len(t, exts, 1)
+	exts := r.endpoint.ExtractorsFor(notifications.EndpointNotificationSourceType)
+	require.Len(t, exts, 1, "extractor should be wired to auto-registered source")
 }
 
 func TestConfigure_FailPolicyMissingSource(t *testing.T) {
@@ -159,7 +155,7 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 	cfg := &Config{
 		Sources: []DataSourceConfig{{
 			Plugin:     src,
-			Extractors: []fwkdl.ExtractorBase{extFromConfig},
+			Extractors: []fwkplugin.Plugin{extFromConfig},
 		}},
 	}
 
@@ -173,9 +169,7 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 	err := r.Configure(cfg, false, "", logger)
 	require.NoError(t, err)
 
-	rawExts, ok := r.sourceExtractors.Load("ep-src")
-	require.True(t, ok)
-	exts := rawExts.([]fwkdl.ExtractorBase)
+	exts := r.endpoint.ExtractorsFor("ep-src")
 	require.Len(t, exts, 1, "code registration should be deduped; only config extractor present")
 	assert.Equal(t, "config-ext", exts[0].TypedName().Name)
 }

--- a/pkg/epp/datalayer/runtime_validate_test.go
+++ b/pkg/epp/datalayer/runtime_validate_test.go
@@ -17,115 +17,13 @@ limitations under the License.
 package datalayer
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
 )
-
-var (
-	extractorType             = reflect.TypeFor[fwkdl.Extractor]()
-	notificationextractorType = reflect.TypeFor[fwkdl.NotificationExtractor]()
-)
-
-func TestValidateInputTypeCompatible(t *testing.T) {
-	type rawStruct struct{}
-	type iface interface{ Foo() }
-
-	tests := []struct {
-		name   string
-		output reflect.Type
-		input  reflect.Type
-		valid  bool
-	}{
-		{"exact match", typeOfT(rawStruct{}), typeOfT(rawStruct{}), true},
-		{"input is interface{}", typeOfT(rawStruct{}), typeOfT((*any)(nil)), true},
-		{"nil types are not allowed", typeOfT(rawStruct{}), typeOfT(nil), false},
-		{"output does not implement input", typeOfT(rawStruct{}), typeOfT((*iface)(nil)), false},
-	}
-
-	for _, tt := range tests {
-		err := validateInputTypeCompatible(tt.output, tt.input)
-		if tt.valid {
-			assert.NoError(t, err, "%s: expected valid extractor type", tt.name)
-		} else {
-			assert.Error(t, err, "%s: expected invalid extractor type", tt.name)
-		}
-	}
-}
-
-func TestValidateExtractorCompatible(t *testing.T) {
-	type notExtractor struct{}
-
-	tests := []struct {
-		name         string
-		extType      reflect.Type
-		expectedType reflect.Type
-		valid        bool
-		errContains  string
-	}{
-		{
-			name:         "nil extractor type",
-			extType:      nil,
-			expectedType: extractorType,
-			valid:        false,
-			errContains:  "can't be nil",
-		},
-		{
-			name:         "nil expected type",
-			extType:      reflect.TypeFor[*notExtractor](),
-			expectedType: nil,
-			valid:        false,
-			errContains:  "can't be nil",
-		},
-		{
-			name:         "expected type not interface",
-			extType:      reflect.TypeFor[*notExtractor](),
-			expectedType: reflect.TypeFor[string](),
-			valid:        false,
-			errContains:  "must be an interface",
-		},
-		{
-			name:         "does not implement interface",
-			extType:      reflect.TypeFor[*notExtractor](),
-			expectedType: extractorType,
-			valid:        false,
-			errContains:  "does not implement interface",
-		},
-	}
-
-	for _, tt := range tests {
-		err := validateExtractorCompatible(tt.extType, tt.expectedType)
-		if tt.valid {
-			assert.NoError(t, err, "%s: expected valid", tt.name)
-		} else {
-			assert.Error(t, err, "%s: expected error", tt.name)
-			if tt.errContains != "" {
-				assert.Contains(t, err.Error(), tt.errContains, "%s: error should contain", tt.name)
-			}
-		}
-	}
-}
-
-func TestTypeConstants(t *testing.T) {
-	assert.True(t, extractorType.Kind() == reflect.Interface, "extractorType should be an interface")
-	assert.True(t, notificationextractorType.Kind() == reflect.Interface, "notificationextractorType should be an interface")
-}
-
-func typeOfT(v any) reflect.Type {
-	t := reflect.TypeOf(v)
-	if t == nil {
-		return nil
-	}
-	if t.Kind() == reflect.Pointer {
-		return t.Elem()
-	}
-	return t
-}
 
 func TestRuntimeConfigureWithNilExtractor(t *testing.T) {
 	logger := newTestLogger(t)
@@ -134,29 +32,28 @@ func TestRuntimeConfigureWithNilExtractor(t *testing.T) {
 	cfg := &Config{
 		Sources: []DataSourceConfig{
 			{
-				Plugin:     &mocks.MetricsDataSource{},
-				Extractors: nil, // nil extractors should be allowed
+				Plugin: &mocks.MetricsDataSource{},
+				// all extractor slices nil — allowed.
 			},
 		},
 	}
 
 	err := r.Configure(cfg, false, "", logger)
-	assert.NoError(t, err, "Configure should succeed with nil extractors")
+	assert.NoError(t, err, "Configure should succeed with no extractors")
 }
 
 func TestRuntimeConfigureDuplicateGVKFails(t *testing.T) {
 	logger := newTestLogger(t)
 	r := NewRuntime(1)
 
-	// Create two notification sources with the same GVK
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 	src1 := mocks.NewNotificationSource("test", "source1", gvk)
 	src2 := mocks.NewNotificationSource("test", "source2", gvk)
 
 	cfg := &Config{
 		Sources: []DataSourceConfig{
-			{Plugin: src1, Extractors: nil},
-			{Plugin: src2, Extractors: nil},
+			{Plugin: src1},
+			{Plugin: src2},
 		},
 	}
 

--- a/pkg/epp/datalayer/runtime_validate_test.go
+++ b/pkg/epp/datalayer/runtime_validate_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	extmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
 )
 
@@ -60,4 +62,53 @@ func TestRuntimeConfigureDuplicateGVKFails(t *testing.T) {
 	err := r.Configure(cfg, false, "", logger)
 	assert.Error(t, err, "Configure should fail with duplicate GVK")
 	assert.Contains(t, err.Error(), "duplicate", "Error should mention duplicate GVK")
+}
+
+// TestRuntimeConfigureVariantMismatch verifies that an extractor whose variant
+// interface doesn't match its source's variant is rejected at config-load.
+func TestRuntimeConfigureVariantMismatch(t *testing.T) {
+	logger := newTestLogger(t)
+	r := NewRuntime(1)
+
+	// PollingDataSource paired with an EndpointExtractor (wrong variant).
+	pollingSrc := &mocks.MetricsDataSource{}
+	endpointExt := extmocks.NewEndpointExtractor("ep-ext")
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{
+			{
+				Plugin:     pollingSrc,
+				Extractors: []fwkplugin.Plugin{endpointExt},
+			},
+		},
+	}
+
+	err := r.Configure(cfg, false, "", logger)
+	assert.Error(t, err, "Configure should reject extractor that doesn't match source variant")
+	assert.Contains(t, err.Error(), "PollingExtractor", "Error should name the expected variant")
+}
+
+// TestRuntimeConfigureNotificationGVKMismatch verifies that a NotificationExtractor
+// whose GVK doesn't match its source's GVK is rejected.
+func TestRuntimeConfigureNotificationGVKMismatch(t *testing.T) {
+	logger := newTestLogger(t)
+	r := NewRuntime(1)
+
+	srcGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	extGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+	src := mocks.NewNotificationSource("test", "source1", srcGVK)
+	ext := extmocks.NewNotificationExtractor("ext1").WithGVK(extGVK)
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{
+			{
+				Plugin:     src,
+				Extractors: []fwkplugin.Plugin{ext},
+			},
+		},
+	}
+
+	err := r.Configure(cfg, false, "", logger)
+	assert.Error(t, err, "Configure should reject extractor with mismatched GVK")
+	assert.Contains(t, err.Error(), "GVK", "Error should mention GVK mismatch")
 }

--- a/pkg/epp/datalayer/runtime_validate_test.go
+++ b/pkg/epp/datalayer/runtime_validate_test.go
@@ -19,7 +19,7 @@ package datalayer
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
@@ -27,88 +27,77 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
 )
 
-func TestRuntimeConfigureWithNilExtractor(t *testing.T) {
-	logger := newTestLogger(t)
-	r := NewRuntime(1)
+func TestRuntimeConfigure_Validation(t *testing.T) {
+	podGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	svcGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
 
-	cfg := &Config{
-		Sources: []DataSourceConfig{
-			{
-				Plugin: &mocks.MetricsDataSource{},
-				// all extractor slices nil — allowed.
-			},
+	tests := []struct {
+		name      string
+		cfg       *Config
+		wantErr   bool
+		wantInErr string
+	}{
+		{
+			name: "no extractors is allowed",
+			cfg: &Config{Sources: []DataSourceConfig{
+				{Plugin: &mocks.MetricsDataSource{}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "duplicate notification GVK across sources",
+			cfg: &Config{Sources: []DataSourceConfig{
+				{Plugin: mocks.NewNotificationSource("test", "source1", podGVK)},
+				{Plugin: mocks.NewNotificationSource("test", "source2", podGVK)},
+			}},
+			wantErr:   true,
+			wantInErr: "duplicate",
+		},
+		{
+			name: "extractor variant doesn't match source variant",
+			cfg: &Config{Sources: []DataSourceConfig{
+				{
+					Plugin:     &mocks.MetricsDataSource{},
+					Extractors: []fwkplugin.Plugin{extmocks.NewEndpointExtractor("ep-ext")},
+				},
+			}},
+			wantErr:   true,
+			wantInErr: "PollingExtractor",
+		},
+		{
+			name: "notification extractor GVK doesn't match source GVK",
+			cfg: &Config{Sources: []DataSourceConfig{
+				{
+					Plugin:     mocks.NewNotificationSource("test", "source1", podGVK),
+					Extractors: []fwkplugin.Plugin{extmocks.NewNotificationExtractor("ext1").WithGVK(svcGVK)},
+				},
+			}},
+			wantErr:   true,
+			wantInErr: "GVK",
+		},
+		{
+			name: "duplicate source name within the same variant",
+			cfg: &Config{Sources: []DataSourceConfig{
+				{Plugin: mocks.NewDataSource(fwkplugin.TypedName{Type: "metrics", Name: "same"})},
+				{Plugin: mocks.NewDataSource(fwkplugin.TypedName{Type: "metrics", Name: "same"})},
+			}},
+			wantErr:   true,
+			wantInErr: "duplicate",
 		},
 	}
 
-	err := r.Configure(cfg, false, "", logger)
-	assert.NoError(t, err, "Configure should succeed with no extractors")
-}
-
-func TestRuntimeConfigureDuplicateGVKFails(t *testing.T) {
-	logger := newTestLogger(t)
-	r := NewRuntime(1)
-
-	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-	src1 := mocks.NewNotificationSource("test", "source1", gvk)
-	src2 := mocks.NewNotificationSource("test", "source2", gvk)
-
-	cfg := &Config{
-		Sources: []DataSourceConfig{
-			{Plugin: src1},
-			{Plugin: src2},
-		},
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRuntime(1)
+			err := r.Configure(tc.cfg, false, "", newTestLogger(t))
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantInErr != "" {
+					require.Contains(t, err.Error(), tc.wantInErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
 	}
-
-	err := r.Configure(cfg, false, "", logger)
-	assert.Error(t, err, "Configure should fail with duplicate GVK")
-	assert.Contains(t, err.Error(), "duplicate", "Error should mention duplicate GVK")
-}
-
-// TestRuntimeConfigureVariantMismatch verifies that an extractor whose variant
-// interface doesn't match its source's variant is rejected at config-load.
-func TestRuntimeConfigureVariantMismatch(t *testing.T) {
-	logger := newTestLogger(t)
-	r := NewRuntime(1)
-
-	// PollingDataSource paired with an EndpointExtractor (wrong variant).
-	pollingSrc := &mocks.MetricsDataSource{}
-	endpointExt := extmocks.NewEndpointExtractor("ep-ext")
-
-	cfg := &Config{
-		Sources: []DataSourceConfig{
-			{
-				Plugin:     pollingSrc,
-				Extractors: []fwkplugin.Plugin{endpointExt},
-			},
-		},
-	}
-
-	err := r.Configure(cfg, false, "", logger)
-	assert.Error(t, err, "Configure should reject extractor that doesn't match source variant")
-	assert.Contains(t, err.Error(), "PollingExtractor", "Error should name the expected variant")
-}
-
-// TestRuntimeConfigureNotificationGVKMismatch verifies that a NotificationExtractor
-// whose GVK doesn't match its source's GVK is rejected.
-func TestRuntimeConfigureNotificationGVKMismatch(t *testing.T) {
-	logger := newTestLogger(t)
-	r := NewRuntime(1)
-
-	srcGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-	extGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
-	src := mocks.NewNotificationSource("test", "source1", srcGVK)
-	ext := extmocks.NewNotificationExtractor("ext1").WithGVK(extGVK)
-
-	cfg := &Config{
-		Sources: []DataSourceConfig{
-			{
-				Plugin:     src,
-				Extractors: []fwkplugin.Plugin{ext},
-			},
-		},
-	}
-
-	err := r.Configure(cfg, false, "", logger)
-	assert.Error(t, err, "Configure should reject extractor with mismatched GVK")
-	assert.Contains(t, err.Error(), "GVK", "Error should mention GVK mismatch")
 }

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -48,14 +48,13 @@ type Extractor[T any] interface {
 }
 
 // PollingInput pairs a poll result with the endpoint it belongs to.
-// TODO: parametrize PollingDataSource.Poll over T and drop the `any` here so
-// polling is typed end-to-end.
+// TODO: parametrize PollingDataSource.Poll over T to drop this `any`.
 type PollingInput struct {
 	Data     any
 	Endpoint Endpoint
 }
 
-// NewPollingInput pairs poll data with the endpoint it belongs to.
+// NewPollingInput builds a PollingInput from poll data and its endpoint.
 func NewPollingInput(data any, ep Endpoint) PollingInput {
 	return PollingInput{Data: data, Endpoint: ep}
 }
@@ -73,10 +72,9 @@ type NotificationExtractor interface {
 	GVK() schema.GroupVersionKind
 }
 
-// Validator is an optional interface that a DataSource can implement to
-// perform additional validation on extractors of variant T. The runtime
-// asserts to Validator[E] only when E is the source's variant, so
-// implementers receive a typed extractor without further type assertions.
+// Validator is an optional source-side hook for extra extractor validation;
+// the runtime invokes Validator[E] only when E matches the source's variant,
+// so implementers receive a typed extractor.
 type Validator[T plugin.Plugin] interface {
 	Validate(T) error
 }

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -18,7 +18,6 @@ package datalayer
 
 import (
 	"context"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,27 +25,11 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
-var (
-	ExtractorBaseType         = reflect.TypeFor[ExtractorBase]()
-	ExtractorType             = reflect.TypeFor[Extractor]()
-	NotificationExtractorType = reflect.TypeFor[NotificationExtractor]()
-	NotificationEventType     = reflect.TypeFor[NotificationEvent]()
-	EndpointExtractorType     = reflect.TypeFor[EndpointExtractor]()
-	EndpointEventReflectType  = reflect.TypeFor[EndpointEvent]()
-)
-
 // DataSource provides raw data to registered Extractors.
 // For poll-based sources, use PollingDataSource.
-// For event-driven sources, use NotificationSource.
+// For event-driven sources, use NotificationSource or EndpointSource.
 type DataSource interface {
 	plugin.Plugin
-	// OutputType returns the type of data this DataSource produces.
-	// Used for validating extractor compatibility.
-	OutputType() reflect.Type
-	// ExtractorType returns the type of Extractor this DataSource expects.
-	// For poll-based sources, this is the base Extractor interface.
-	// For notification sources, this is the NotificationExtractor interface.
-	ExtractorType() reflect.Type
 }
 
 // PollingDataSource is a poll-based DataSource that fetches data at regular intervals.
@@ -57,31 +40,45 @@ type PollingDataSource interface {
 	Poll(ctx context.Context, ep Endpoint) (any, error)
 }
 
-// ExtractorBase is the common base for all extractor variants.
-// It provides identity and type-compatibility information without
-// prescribing how extraction is triggered.
-type ExtractorBase interface {
+// Extractor transforms typed input T into endpoint attributes.
+// See PollingExtractor, EndpointExtractor, and NotificationExtractor for variants.
+type Extractor[T any] interface {
 	plugin.Plugin
-	// ExpectedInputType defines the type expected by the extractor.
-	ExpectedInputType() reflect.Type
+	Extract(ctx context.Context, input T) error
 }
 
-// Extractor transforms raw data from a PollingDataSource into structured
-// attributes. Used only with poll-based sources; the Runtime calls Extract
-// on each tick with the data returned by the source's Poll method.
-type Extractor interface {
-	ExtractorBase
-	// Extract transforms the raw data source output into a concrete structured
-	// attribute, stored on the given endpoint.
-	Extract(ctx context.Context, data any, ep Endpoint) error
+// PollingInput pairs a poll result with the endpoint it belongs to.
+// TODO: parametrize PollingDataSource.Poll over T and drop the `any` here so
+// polling is typed end-to-end.
+type PollingInput struct {
+	Data     any
+	Endpoint Endpoint
 }
 
-// ValidatingDataSource is an optional interface that DataSources can implement
-// to perform additional custom validation when adding extractors.
-type ValidatingDataSource interface {
-	// ValidateExtractor allows the DataSource to perform additional validation
-	// beyond the standard type compatibility checks. Return an error if validation fails.
-	ValidateExtractor(extractor ExtractorBase) error
+// NewPollingInput pairs poll data with the endpoint it belongs to.
+func NewPollingInput(data any, ep Endpoint) PollingInput {
+	return PollingInput{Data: data, Endpoint: ep}
+}
+
+// PollingExtractor is an Extractor paired with a PollingDataSource.
+type PollingExtractor = Extractor[PollingInput]
+
+// EndpointExtractor processes endpoint lifecycle events.
+type EndpointExtractor = Extractor[EndpointEvent]
+
+// NotificationExtractor processes k8s object events pushed from a NotificationSource.
+type NotificationExtractor interface {
+	Extractor[NotificationEvent]
+	// GVK returns the GroupVersionKind this extractor handles.
+	GVK() schema.GroupVersionKind
+}
+
+// Validator is an optional interface that a DataSource can implement to
+// perform additional validation on extractors of variant T. The runtime
+// asserts to Validator[E] only when E is the source's variant, so
+// implementers receive a typed extractor without further type assertions.
+type Validator[T plugin.Plugin] interface {
+	Validate(T) error
 }
 
 // EventType identifies the type of mutation that triggered the notification.
@@ -120,18 +117,6 @@ type NotificationSource interface {
 	Notify(ctx context.Context, event NotificationEvent) (*NotificationEvent, error)
 }
 
-// NotificationExtractor processes k8s object events pushed from a
-// NotificationSource. The Runtime calls ExtractNotification directly;
-// Extract from the base Extractor interface is never invoked on this type.
-type NotificationExtractor interface {
-	ExtractorBase
-	// GVK returns the GroupVersionKind this extractor handles.
-	GVK() schema.GroupVersionKind
-	// ExtractNotification processes a notification event. Called synchronously
-	// by the source in event order.
-	ExtractNotification(ctx context.Context, event NotificationEvent) error
-}
-
 // EndpointEvent carries an endpoint lifecycle event.
 // Reuses EventType: EventAddOrUpdate signals an endpoint was added to the
 // datastore; EventDelete signals an endpoint was removed.
@@ -150,13 +135,4 @@ type EndpointSource interface {
 	// Returns the event (possibly modified) for the Runtime to dispatch to extractors.
 	// Returns nil event to signal Runtime to skip extractor dispatch.
 	NotifyEndpoint(ctx context.Context, event EndpointEvent) (*EndpointEvent, error)
-}
-
-// EndpointExtractor processes endpoint lifecycle events pushed from an
-// EndpointSource. The Runtime calls ExtractEndpoint directly;
-// Extract from the base Extractor interface is never invoked on this type.
-type EndpointExtractor interface {
-	ExtractorBase
-	// ExtractEndpoint processes an endpoint lifecycle event.
-	ExtractEndpoint(ctx context.Context, event EndpointEvent) error
 }

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -37,6 +37,7 @@ type PollingDataSource interface {
 	DataSource
 	// Poll fetches data for an endpoint and returns it.
 	// The Runtime handles calling extractors with the returned data.
+	// TODO: make PollingDataSource generic on T to drop this `any`.
 	Poll(ctx context.Context, ep Endpoint) (any, error)
 }
 
@@ -48,7 +49,6 @@ type Extractor[T any] interface {
 }
 
 // PollingInput pairs a poll result with the endpoint it belongs to.
-// TODO: parametrize PollingDataSource.Poll over T to drop this `any`.
 type PollingInput struct {
 	Data     any
 	Endpoint Endpoint

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -113,7 +113,7 @@ type NotificationSource interface {
 	// The event object is already deep-copied.
 	// Returns the event (possibly modified) for Runtime to dispatch to extractors.
 	// Returns nil event to signal Runtime to skip extractor dispatch.
-	// TODO: ahy accept event but return *event?
+	// TODO: accept event by value but return *event — should the input be a pointer too?
 	Notify(ctx context.Context, event NotificationEvent) (*NotificationEvent, error)
 }
 

--- a/pkg/epp/framework/interface/datalayer/registrar.go
+++ b/pkg/epp/framework/interface/datalayer/registrar.go
@@ -34,13 +34,16 @@ type Registrant interface {
 
 // PendingRegistration describes a (source-type, extractor) dependency.
 // Extractor must be non-nil; registering a DataSource without an Extractor is not supported.
+// Extractor is held as plugin.Plugin and type-asserted at resolution time to the
+// variant interface matching the resolved source (PollingExtractor /
+// NotificationExtractor / EndpointExtractor); a mismatch errors at config load.
 // If DefaultSource is nil, IfMissing governs behavior when no matching source exists.
 // If DefaultSource is non-nil, it is registered as a new source when no match is found;
 // for NotificationSources its GVK() narrows the match.
 type PendingRegistration struct {
 	Owner         plugin.TypedName // registering plugin; used as map key + error context
 	SourceType    string           // TypedName.Type to match, e.g. "endpoint-notification-source"
-	Extractor     ExtractorBase    // required; extractor to wire to the matched source
+	Extractor     plugin.Plugin    // required; type-asserted to the matched source's variant at resolution
 	DefaultSource DataSource       // nil → no auto-create; non-nil → create if absent
 	IfMissing     MissingPolicy    // applies only when DefaultSource is nil
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -86,18 +85,17 @@ func (ext *Extractor) TypedName() fwkplugin.TypedName {
 	return ext.typedName
 }
 
-// ExpectedType defines the type expected by the metrics.Extractor - a
-// parsed output from a Prometheus metrics endpoint.
-func (ext *Extractor) ExpectedInputType() reflect.Type {
-	return sourcemetrics.PrometheusMetricType
-}
-
-// Extract transforms the data source output into a concrete attribute that
-// is stored on the given endpoint.
-func (ext *Extractor) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) error {
-	families, ok := data.(sourcemetrics.PrometheusMetricMap)
+// Extract transforms the data source output into a concrete attribute stored
+// on the input's endpoint.
+func (ext *Extractor) Extract(ctx context.Context, input fwkdl.PollingInput) error {
+	families, ok := input.Data.(sourcemetrics.PrometheusMetricMap)
 	if !ok {
-		return fmt.Errorf("unexpected input in Extract: %T", data)
+		return fmt.Errorf("unexpected input in Extract: %T", input.Data)
+	}
+
+	ep := input.Endpoint
+	if ep == nil {
+		return errors.New("Extract called without an endpoint")
 	}
 
 	engineType := getEngineTypeFromEndpoint(ep, ext.engineLabelKey)

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -70,10 +70,6 @@ func TestExtractorExtract(t *testing.T) {
 		t.Error("empty extractor name")
 	}
 
-	if inputType := extractor.ExpectedInputType(); inputType != sourcemetrics.PrometheusMetricType {
-		t.Errorf("incorrect expected input type: %v", inputType)
-	}
-
 	ep := fwkdl.NewEndpoint(nil, nil)
 	if ep == nil {
 		t.Fatal("expected non-nil endpoint")
@@ -193,7 +189,7 @@ func TestExtractorExtract(t *testing.T) {
 			}()
 
 			before := ep.GetMetrics().Clone()
-			err := extractor.Extract(ctx, tt.data, ep)
+			err := extractor.Extract(ctx, fwkdl.NewPollingInput(tt.data, ep))
 			after := ep.GetMetrics()
 
 			if tt.wantErr && err == nil {
@@ -253,7 +249,7 @@ func TestExtractorMultiEngine(t *testing.T) {
 	epVllm := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		Labels: map[string]string{DefaultEngineTypeLabelKey: "vllm"},
 	}, nil)
-	_ = extractor.Extract(ctx, data, epVllm)
+	_ = extractor.Extract(ctx, fwkdl.NewPollingInput(data, epVllm))
 	if epVllm.GetMetrics().WaitingQueueSize != 10 {
 		t.Errorf("vllm: expected queue size 10, got %v", epVllm.GetMetrics().WaitingQueueSize)
 	}
@@ -262,7 +258,7 @@ func TestExtractorMultiEngine(t *testing.T) {
 	epSgl := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		Labels: map[string]string{DefaultEngineTypeLabelKey: "sglang"},
 	}, nil)
-	_ = extractor.Extract(ctx, data, epSgl)
+	_ = extractor.Extract(ctx, fwkdl.NewPollingInput(data, epSgl))
 	if epSgl.GetMetrics().WaitingQueueSize != 20 {
 		t.Errorf("sglang: expected queue size 20, got %v", epSgl.GetMetrics().WaitingQueueSize)
 	}
@@ -291,7 +287,7 @@ func TestBackwardCompatibility(t *testing.T) {
 
 	// Case 1: No labels at all
 	epNone := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{Labels: nil}, nil)
-	_ = extractor.Extract(ctx, data, epNone)
+	_ = extractor.Extract(ctx, fwkdl.NewPollingInput(data, epNone))
 	if epNone.GetMetrics().WaitingQueueSize != 100 {
 		t.Errorf("no labels: expected 100, got %v", epNone.GetMetrics().WaitingQueueSize)
 	}
@@ -300,7 +296,7 @@ func TestBackwardCompatibility(t *testing.T) {
 	epUnknown := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		Labels: map[string]string{DefaultEngineTypeLabelKey: "unknown-engine"},
 	}, nil)
-	_ = extractor.Extract(ctx, data, epUnknown)
+	_ = extractor.Extract(ctx, fwkdl.NewPollingInput(data, epUnknown))
 	if epUnknown.GetMetrics().WaitingQueueSize != 100 {
 		t.Errorf("unknown label: expected 100, got %v", epUnknown.GetMetrics().WaitingQueueSize)
 	}
@@ -350,7 +346,7 @@ func TestCacheInfoLabelAliasing(t *testing.T) {
 	}
 
 	ep := fwkdl.NewEndpoint(nil, nil)
-	_ = extractor.Extract(ctx, data, ep)
+	_ = extractor.Extract(ctx, fwkdl.NewPollingInput(data, ep))
 
 	if ep.GetMetrics().CacheBlockSize != 64 {
 		t.Errorf("expected CacheBlockSize 64, got %d", ep.GetMetrics().CacheBlockSize)
@@ -417,7 +413,7 @@ func TestDirectGaugeSpecExtraction(t *testing.T) {
 	}
 
 	ep := fwkdl.NewEndpoint(nil, nil)
-	_ = extractor.Extract(ctx, data, ep)
+	_ = extractor.Extract(ctx, fwkdl.NewPollingInput(data, ep))
 
 	if ep.GetMetrics().CacheBlockSize != 64 {
 		t.Errorf("expected CacheBlockSize 64, got %d", ep.GetMetrics().CacheBlockSize)

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -50,7 +50,7 @@ import (
 // the full fetch→extract path without a running Collector.
 type pipeline struct {
 	source    fwkdl.PollingDataSource
-	extractor fwkdl.Extractor
+	extractor fwkdl.PollingExtractor
 }
 
 // Poll fetches raw data from the source then passes it to the extractor.
@@ -62,7 +62,7 @@ func (p *pipeline) Poll(ctx context.Context, ep fwkdl.Endpoint) error {
 	if data == nil {
 		return nil
 	}
-	return p.extractor.Extract(ctx, data, ep)
+	return p.extractor.Extract(ctx, fwkdl.NewPollingInput(data, ep))
 }
 
 // buildSource creates a MetricsDataSource pointing at the given server URL.

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
@@ -18,7 +18,6 @@ package mocks
 
 import (
 	"context"
-	"reflect"
 	"sync"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
@@ -41,7 +40,7 @@ func NewEndpointExtractor(name string) *EndpointExtractor {
 	return &EndpointExtractor{name: name}
 }
 
-// WithExtractError configures the extractor to return an error on ExtractEndpoint.
+// WithExtractError configures the extractor to return an error on Extract.
 func (m *EndpointExtractor) WithExtractError(err error) *EndpointExtractor {
 	m.extractErr = err
 	return m
@@ -51,12 +50,8 @@ func (m *EndpointExtractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock-endpoint-extractor", Name: m.name}
 }
 
-func (m *EndpointExtractor) ExpectedInputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractEndpoint records the event and returns any configured error.
-func (m *EndpointExtractor) ExtractEndpoint(_ context.Context, event fwkdl.EndpointEvent) error {
+// Extract records the event and returns any configured error.
+func (m *EndpointExtractor) Extract(_ context.Context, event fwkdl.EndpointEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.events = append(m.events, event)

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
@@ -18,7 +18,6 @@ package mocks
 
 import (
 	"context"
-	"reflect"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,7 +26,9 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
-// NotificationExtractor implements both Extractor and NotificationExtractor for testing.
+var _ fwkdl.NotificationExtractor = (*NotificationExtractor)(nil)
+
+// NotificationExtractor is a mock NotificationExtractor for testing.
 // It records all events it receives and provides helper methods for test assertions.
 type NotificationExtractor struct {
 	name       string
@@ -51,7 +52,7 @@ func (m *NotificationExtractor) WithGVK(gvk schema.GroupVersionKind) *Notificati
 	return m
 }
 
-// WithExtractError configures the extractor to return an error on ExtractNotification.
+// WithExtractError configures the extractor to return an error on Extract.
 func (m *NotificationExtractor) WithExtractError(err error) *NotificationExtractor {
 	m.extractErr = err
 	return m
@@ -61,16 +62,12 @@ func (m *NotificationExtractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock-extractor", Name: m.name}
 }
 
-func (m *NotificationExtractor) ExpectedInputType() reflect.Type {
-	return reflect.TypeFor[fwkdl.NotificationEvent]()
-}
-
 func (m *NotificationExtractor) GVK() schema.GroupVersionKind {
 	return m.gvk
 }
 
-// ExtractNotification is the NotificationExtractor method — records the event.
-func (m *NotificationExtractor) ExtractNotification(_ context.Context, event fwkdl.NotificationEvent) error {
+// Extract records the event and returns any configured error.
+func (m *NotificationExtractor) Extract(_ context.Context, event fwkdl.NotificationEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.events = append(m.events, event)
@@ -93,11 +90,10 @@ func (m *NotificationExtractor) Reset() {
 	m.events = nil
 }
 
-// Extractor is a generic mock for Extractor interface.
+// Extractor is a generic mock for the polling Extractor interface.
 // It records call counts and optionally updates endpoint metrics.
 type Extractor struct {
 	name            string
-	inputType       reflect.Type
 	callCount       int
 	mu              sync.Mutex
 	extractErr      error
@@ -105,17 +101,14 @@ type Extractor struct {
 	metricsToUpdate *fwkdl.Metrics
 }
 
-// NewExtractor creates a new mock extractor with the given name and input type.
-func NewExtractor(name string, inputType reflect.Type) *Extractor {
-	return &Extractor{
-		name:      name,
-		inputType: inputType,
-	}
+// NewExtractor creates a new mock polling extractor with the given name.
+func NewExtractor(name string) *Extractor {
+	return &Extractor{name: name}
 }
 
-// NewPollingExtractor creates a mock extractor for polling data sources (Metrics type).
+// NewPollingExtractor is an alias kept for test-callsite stability.
 func NewPollingExtractor(name string) *Extractor {
-	return NewExtractor(name, reflect.TypeFor[fwkdl.Metrics]())
+	return NewExtractor(name)
 }
 
 // WithExtractError configures the extractor to return an error.
@@ -135,17 +128,13 @@ func (m *Extractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock-extractor", Name: m.name}
 }
 
-func (m *Extractor) ExpectedInputType() reflect.Type {
-	return m.inputType
-}
-
-func (m *Extractor) Extract(_ context.Context, data any, ep fwkdl.Endpoint) error {
+func (m *Extractor) Extract(_ context.Context, input fwkdl.PollingInput) error {
 	m.mu.Lock()
 	m.callCount++
 	m.mu.Unlock()
 
-	if m.updateMetrics && m.metricsToUpdate != nil {
-		ep.UpdateMetrics(m.metricsToUpdate)
+	if m.updateMetrics && m.metricsToUpdate != nil && input.Endpoint != nil {
+		input.Endpoint.UpdateMetrics(m.metricsToUpdate)
 	}
 
 	return m.extractErr

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -82,27 +83,23 @@ func (me *ModelExtractor) TypedName() fwkplugin.TypedName {
 	return me.typedName
 }
 
-// ExpectedInputType defines the type expected by ModelExtractor.
-func (me *ModelExtractor) ExpectedInputType() reflect.Type {
-	return ModelsResponseType
-}
-
-// ModelServerExtractorFactory is a factory function used to instantiate data layer's
-// models extractor plugins specified in a configuration.
+// ModelServerExtractorFactory instantiates the models extractor plugin.
 func ModelServerExtractorFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	extractor := NewModelExtractor()
 	extractor.typedName.Name = name
 	return extractor, nil
 }
 
-// Extract transforms the data source output into a concrete attribute that
-// is stored on the given endpoint.
-func (me *ModelExtractor) Extract(_ context.Context, data any, ep fwkdl.Endpoint) error {
-	models, ok := data.(*ModelResponse)
+// Extract transforms the data source output into a concrete attribute stored
+// on the input's endpoint.
+func (me *ModelExtractor) Extract(_ context.Context, input fwkdl.PollingInput) error {
+	models, ok := input.Data.(*ModelResponse)
 	if !ok {
-		return fmt.Errorf("unexpected input in Extract: %T", data)
+		return fmt.Errorf("unexpected input in Extract: %T", input.Data)
 	}
-
-	ep.GetAttributes().Put(ModelsAttributeKey, ModelDataCollection(models.Data))
+	if input.Endpoint == nil {
+		return errors.New("Extract called without an endpoint")
+	}
+	input.Endpoint.GetAttributes().Put(ModelsAttributeKey, ModelDataCollection(models.Data))
 	return nil
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
@@ -57,11 +56,6 @@ type ModelResponse struct {
 	Object string      `json:"object"`
 	Data   []ModelData `json:"data"`
 }
-
-// ModelsResponseType is the type of models response
-var (
-	ModelsResponseType = reflect.TypeOf(ModelResponse{})
-)
 
 // ModelExtractor implements the models extraction.
 type ModelExtractor struct {

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor_test.go
@@ -16,7 +16,7 @@ func TestExtractorExtract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create extractor: %v", err)
 	}
-	extractor := extPlugin.(fwkdl.Extractor)
+	extractor := extPlugin.(fwkdl.PollingExtractor)
 
 	if exType := extPlugin.TypedName().Type; exType == "" {
 		t.Error("empty extractor type")
@@ -24,10 +24,6 @@ func TestExtractorExtract(t *testing.T) {
 
 	if exName := extPlugin.TypedName().Name; exName == "" {
 		t.Error("empty extractor name")
-	}
-
-	if inputType := extractor.ExpectedInputType(); inputType != ModelsResponseType {
-		t.Errorf("incorrect expected input type: %v", inputType)
 	}
 
 	ep := fwkdl.NewEndpoint(nil, nil)
@@ -87,7 +83,7 @@ func TestExtractorExtract(t *testing.T) {
 			if ok && before != nil {
 				t.Error("expected empty attributes")
 			}
-			err := extractor.Extract(ctx, tt.data, ep)
+			err := extractor.Extract(ctx, fwkdl.NewPollingInput(tt.data, ep))
 			after, ok := attr.Get(ModelsAttributeKey)
 			if !ok && tt.updated {
 				t.Error("expected updated attributes")

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -73,16 +73,6 @@ func (dataSrc *HTTPDataSource) TypedName() fwkplugin.TypedName {
 	return dataSrc.typedName
 }
 
-// OutputType returns the type of data this DataSource produces.
-func (dataSrc *HTTPDataSource) OutputType() reflect.Type {
-	return dataSrc.outputType
-}
-
-// ExtractorType returns the type of Extractor this DataSource expects.
-func (dataSrc *HTTPDataSource) ExtractorType() reflect.Type {
-	return fwkdl.ExtractorType
-}
-
 // Poll fetches data for an endpoint and returns it.
 func (dataSrc *HTTPDataSource) Poll(ctx context.Context, ep fwkdl.Endpoint) (any, error) {
 	target := dataSrc.getEndpoint(ep.GetMetadata())

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"reflect"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
@@ -34,15 +33,14 @@ type HTTPDataSource struct {
 	scheme    string // scheme to use
 	path      string // path to use
 
-	client     Client // client (e.g. a wrapped http.Client) used to get data
-	parser     func(io.Reader) (any, error)
-	outputType reflect.Type
+	client Client // client (e.g. a wrapped http.Client) used to get data
+	parser func(io.Reader) (any, error)
 }
 
 // NewHTTPDataSource returns a new data source, configured with
 // the provided scheme, path and certificate verification parameters.
 func NewHTTPDataSource(scheme string, path string, skipCertVerification bool, pluginType string,
-	pluginName string, parser func(io.Reader) (any, error), outputType reflect.Type) (*HTTPDataSource, error) {
+	pluginName string, parser func(io.Reader) (any, error)) (*HTTPDataSource, error) {
 	if scheme != "http" && scheme != "https" {
 		return nil, fmt.Errorf("unsupported scheme: %s", scheme)
 	}
@@ -59,11 +57,10 @@ func NewHTTPDataSource(scheme string, path string, skipCertVerification bool, pl
 			Type: pluginType,
 			Name: pluginName,
 		},
-		scheme:     scheme,
-		path:       path,
-		client:     defaultClient,
-		parser:     parser,
-		outputType: outputType,
+		scheme: scheme,
+		path:   path,
+		client: defaultClient,
+		parser: parser,
 	}
 	return dataSrc, nil
 }

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -55,7 +55,7 @@ type metricsDatasourceParams struct {
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource, error) {
 	return http.NewHTTPDataSource(scheme, path, defaultMetricsInsecureSkipVerify,
-		MetricsDataSourceType, name, parseMetrics, PrometheusMetricType)
+		MetricsDataSourceType, name, parseMetrics)
 }
 
 // MetricsDataSourceFactory is a factory function used to instantiate data layer's
@@ -73,7 +73,7 @@ func MetricsDataSourceFactory(name string, parameters json.RawMessage, handle fw
 	}
 
 	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify, MetricsDataSourceType,
-		name, parseMetrics, PrometheusMetricType)
+		name, parseMetrics)
 }
 
 // These flags are registered in options.go (server package) and marked as deprecated there.

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -29,11 +29,11 @@ import (
 
 func TestDatasource(t *testing.T) {
 	_, err := http.NewHTTPDataSource("invalid", "/metrics", true, MetricsDataSourceType,
-		"metrics-data-source", parseMetrics, PrometheusMetricType)
+		"metrics-data-source", parseMetrics)
 	assert.NotNil(t, err, "expected to fail with invalid scheme")
 
 	source, err := http.NewHTTPDataSource("https", "/metrics", true, MetricsDataSourceType,
-		"metrics-data-source", parseMetrics, PrometheusMetricType)
+		"metrics-data-source", parseMetrics)
 	assert.Nil(t, err, "failed to create HTTP datasource")
 
 	dsType := source.TypedName().Type

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/types.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/types.go
@@ -17,13 +17,7 @@ limitations under the License.
 package metrics
 
 import (
-	"reflect"
-
 	dto "github.com/prometheus/client_model/go"
 )
 
 type PrometheusMetricMap = map[string]*dto.MetricFamily
-
-var (
-	PrometheusMetricType = reflect.TypeFor[PrometheusMetricMap]()
-)

--- a/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
+++ b/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
@@ -19,7 +19,6 @@ package mocks
 import (
 	"context"
 	"errors"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -48,14 +47,6 @@ func NewDataSource(typedName plugin.TypedName) *MetricsDataSource {
 
 func (fds *MetricsDataSource) TypedName() plugin.TypedName {
 	return fds.typedName
-}
-
-func (fds *MetricsDataSource) OutputType() reflect.Type {
-	return reflect.TypeFor[fwkdl.Metrics]()
-}
-
-func (fds *MetricsDataSource) ExtractorType() reflect.Type {
-	return reflect.TypeFor[fwkdl.Extractor]()
 }
 
 // SetMetrics replaces the metrics map in a thread-safe manner.
@@ -104,30 +95,10 @@ func (m *NotificationSource) TypedName() plugin.TypedName {
 	return m.typedName
 }
 
-func (m *NotificationSource) OutputType() reflect.Type {
-	return reflect.TypeFor[fwkdl.NotificationEvent]()
-}
-
-func (m *NotificationSource) ExtractorType() reflect.Type {
-	return reflect.TypeFor[fwkdl.NotificationExtractor]()
-}
-
 func (m *NotificationSource) GVK() schema.GroupVersionKind {
 	return m.gvk
 }
 
 func (m *NotificationSource) Notify(_ context.Context, event fwkdl.NotificationEvent) (*fwkdl.NotificationEvent, error) {
 	return &event, nil
-}
-
-func (m *NotificationSource) Extractors() []string {
-	return []string{}
-}
-
-func (m *NotificationSource) AddExtractor(_ fwkdl.Extractor) error {
-	return nil
-}
-
-func (m *NotificationSource) Collect(_ context.Context, _ fwkdl.Endpoint) error {
-	return nil
 }

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
@@ -35,7 +35,7 @@ type modelsDatasourceParams struct {
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPModelsDataSource(scheme, path, name string) (*http.HTTPDataSource, error) {
 	return http.NewHTTPDataSource(scheme, path, defaultModelsInsecureSkipVerify,
-		ModelsDataSourceType, name, parseModels, extmodels.ModelsResponseType)
+		ModelsDataSourceType, name, parseModels)
 }
 
 // ModelDataSourceFactory is a factory function used to instantiate data layer's
@@ -52,7 +52,7 @@ func ModelDataSourceFactory(name string, parameters json.RawMessage, _ plugin.Ha
 	}
 
 	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify, ModelsDataSourceType,
-		name, parseModels, extmodels.ModelsResponseType)
+		name, parseModels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP data source: %w", err)
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	extmodels "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/models"
 )
 
@@ -24,13 +25,13 @@ func TestDatasource(t *testing.T) {
 
 	extPlugin, err := extmodels.ModelServerExtractorFactory("models-data-extractor", nil, nil)
 	assert.Nil(t, err, "failed to create extractor")
-	extractor := extPlugin.(fwkdl.Extractor)
+	extractor := extPlugin.(fwkdl.PollingExtractor)
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
 			{
 				Plugin:     source,
-				Extractors: []fwkdl.ExtractorBase{extractor},
+				Extractors: []fwkplugin.Plugin{extractor},
 			},
 		},
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource.go
@@ -18,7 +18,6 @@ package notifications
 
 import (
 	"context"
-	"reflect"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
@@ -48,16 +47,6 @@ func NewEndpointDataSource(pluginType, pluginName string) *EndpointDataSource {
 // TypedName returns the plugin type and name.
 func (s *EndpointDataSource) TypedName() fwkplugin.TypedName {
 	return s.typedName
-}
-
-// OutputType returns the type of data this DataSource produces (EndpointEvent).
-func (s *EndpointDataSource) OutputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractorType returns the type of Extractor this DataSource expects (EndpointExtractor).
-func (s *EndpointDataSource) ExtractorType() reflect.Type {
-	return fwkdl.EndpointExtractorType
 }
 
 // NotifyEndpoint passes the event through unchanged for the Runtime to dispatch to extractors.

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource_test.go
@@ -43,8 +43,6 @@ func TestNewEndpointDataSource(t *testing.T) {
 	src := NewEndpointDataSource("test-type", "test-name")
 	assert.Equal(t, "test-type", src.TypedName().Type)
 	assert.Equal(t, "test-name", src.TypedName().Name)
-	assert.Equal(t, fwkdl.EndpointEventReflectType, src.OutputType())
-	assert.Equal(t, fwkdl.EndpointExtractorType, src.ExtractorType())
 }
 
 func TestEndpointNotifyReturnsEvent(t *testing.T) {

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource.go
@@ -18,7 +18,6 @@ package notifications
 
 import (
 	"context"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -55,16 +54,6 @@ func (s *K8sNotificationSource) TypedName() fwkplugin.TypedName {
 // GVK returns the GroupVersionKind this source watches.
 func (s *K8sNotificationSource) GVK() schema.GroupVersionKind {
 	return s.gvk
-}
-
-// OutputType returns the type of data this DataSource produces (NotificationEvent).
-func (s *K8sNotificationSource) OutputType() reflect.Type {
-	return fwkdl.NotificationEventType
-}
-
-// ExtractorType returns the type of Extractor this DataSource expects (NotificationExtractor).
-func (s *K8sNotificationSource) ExtractorType() reflect.Type {
-	return fwkdl.NotificationExtractorType
 }
 
 // Notify processes a notification event and returns it for Runtime to dispatch.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -19,7 +19,6 @@ package inflightload
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 	"sync"
 	"sync/atomic"
 
@@ -67,8 +66,8 @@ func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-// RegisterDependencies declares that this plugin needs an endpoint-notification-source to track
-// endpoint lifecycle events. The source is auto-created if not already in the config.
+// RegisterDependencies declares that this plugin needs an endpoint-notification-source.
+// The source is auto-created if not already in the config.
 func (p *InFlightLoadProducer) RegisterDependencies(r datalayer.Registrar) error {
 	return r.Register(datalayer.PendingRegistration{
 		Owner:         p.TypedName(),
@@ -78,13 +77,8 @@ func (p *InFlightLoadProducer) RegisterDependencies(r datalayer.Registrar) error
 	})
 }
 
-// ExpectedInputType defines the type expected by the extractor.
-func (p *InFlightLoadProducer) ExpectedInputType() reflect.Type {
-	return datalayer.EndpointEventReflectType
-}
-
-// ExtractEndpoint handles endpoint deletion events to prune stateful trackers.
-func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datalayer.EndpointEvent) error {
+// Extract handles endpoint deletion events to prune stateful trackers.
+func (p *InFlightLoadProducer) Extract(ctx context.Context, event datalayer.EndpointEvent) error {
 	if event.Type != datalayer.EventDelete || event.Endpoint == nil {
 		return nil
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -149,7 +149,7 @@ func TestInFlightLoadProducer_NotificationCleanup(t *testing.T) {
 		Endpoint: newStubSchedulingEndpoint(endpointName),
 	}
 
-	err := producer.ExtractEndpoint(ctx, eventEndpoint)
+	err := producer.Extract(ctx, eventEndpoint)
 	require.NoError(t, err)
 
 	// Verify Cleanup

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync/atomic"
 	"time"
 
@@ -600,23 +599,19 @@ func (s *Scorer) PreRequest(ctx context.Context,
 
 // --- EndpointExtractor implementation ---
 
-// ExpectedInputType declares the data type this extractor consumes.
-// Required by the data layer's source/extractor type-compatibility check.
-func (s *Scorer) ExpectedInputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractEndpoint reacts to endpoint lifecycle events from the data layer's
+// Extract reacts to endpoint lifecycle events from the data layer's
 // endpoint-notification-source: an add/update installs a per-pod ZMQ
 // subscriber so KV-cache events flow into the index; a delete tears it down.
 // No-op when DiscoverPods is disabled or the namespaced name is unavailable.
 //
 // Being called at all is also the signal that the data layer is wired for
-// this scorer; the legacy in-Score discovery path turns itself off from
-// here on.
-func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
+// this scorer; the legacy in-Score discovery path turns itself off from here on.
+func (s *Scorer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error {
 	s.extractorActive.Store(true)
 	if !s.kvEventsConfig.DiscoverPods || s.kvEventsConfig.PodDiscoveryConfig == nil {
+		return nil
+	}
+	if event.Endpoint == nil {
 		return nil
 	}
 	meta := event.Endpoint.GetMetadata()

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -58,11 +58,11 @@ func TestScorer_EndpointExtractor_InterfaceContract(t *testing.T) {
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	assert.Equal(t, fwkdl.EndpointEventReflectType, s.ExpectedInputType(),
-		"ExpectedInputType must report EndpointEvent for data-layer compatibility checks")
-
 	var _ fwkdl.EndpointExtractor = s
 	assert.True(t, reflect.TypeOf(s).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
+
+	// Extract on an event with nil endpoint is a no-op (guarded early).
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{}))
 }
 
 func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
@@ -74,7 +74,7 @@ func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 	wantKey := "ns/pod-a"
 	wantEndpoint := "tcp://10.0.0.1:5557"
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
@@ -84,14 +84,14 @@ func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 	require.Equal(t, []string{wantEndpoint}, endpoints, "ZMQ endpoint must derive from address + SocketPort")
 
 	// Re-add is idempotent (EnsureSubscriber dedups on identical endpoint).
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
 	ids, _ = s.subscribersManager.GetActiveSubscribers()
 	assert.Len(t, ids, 1, "duplicate add must not create a second subscriber")
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: ep,
 	}))
@@ -106,7 +106,7 @@ func TestScorer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
 	s := newExtractorScorer(false)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
@@ -125,7 +125,7 @@ func TestScorer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
 		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
@@ -195,7 +195,7 @@ func TestScorer_LegacyInScoreDiscovery_DisabledOnceExtractorObserved(t *testing.
 
 	// Simulate the data layer dispatching even an unrelated event — the call
 	// itself proves the source is wired.
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: newEndpoint("pod-x", "10.0.0.99"),
 	}))
@@ -241,7 +241,7 @@ func TestScorer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscribe
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
@@ -253,7 +253,7 @@ func TestScorer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscribe
 		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: deleteEndpoint,
 	}))

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -2,7 +2,6 @@ package preciseprefixcache
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -59,7 +58,6 @@ func TestScorer_EndpointExtractor_InterfaceContract(t *testing.T) {
 	defer s.subscribersManager.Shutdown(ctx)
 
 	var _ fwkdl.EndpointExtractor = s
-	assert.True(t, reflect.TypeOf(s).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
 
 	// Extract on an event with nil endpoint is a no-op (guarded early).
 	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{}))

--- a/test/integration/epp/runtime_notification_test.go
+++ b/test/integration/epp/runtime_notification_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
@@ -45,7 +46,7 @@ func setupRuntimeWithExtractor(r *datalayer.Runtime, extractorName string) (*moc
 	ext := mocks.NewNotificationExtractor(extractorName)
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: src, Extractors: []fwkdl.ExtractorBase{ext}},
+			{Plugin: src, Extractors: []fwkplugin.Plugin{ext}},
 		},
 	}
 	return ext, r.Configure(cfg, false, "", logger)
@@ -141,7 +142,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 				ext2 := mocks.NewNotificationExtractor("extractor-2")
 				cfg := &datalayer.Config{
 					Sources: []datalayer.DataSourceConfig{
-						{Plugin: src, Extractors: []fwkdl.ExtractorBase{ext1, ext2}},
+						{Plugin: src, Extractors: []fwkplugin.Plugin{ext1, ext2}},
 					},
 				}
 				return ext1, r.Configure(cfg, false, "", logger)
@@ -164,7 +165,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 				workingExtractor := mocks.NewNotificationExtractor("working-extractor")
 				cfg := &datalayer.Config{
 					Sources: []datalayer.DataSourceConfig{
-						{Plugin: src, Extractors: []fwkdl.ExtractorBase{errExtractor, workingExtractor}},
+						{Plugin: src, Extractors: []fwkplugin.Plugin{errExtractor, workingExtractor}},
 					},
 				}
 				return workingExtractor, r.Configure(cfg, false, "", logger)
@@ -216,7 +217,7 @@ func TestRuntimeNotificationWithRuntime(t *testing.T) {
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: src, Extractors: []fwkdl.ExtractorBase{extractor}},
+			{Plugin: src, Extractors: []fwkplugin.Plugin{extractor}},
 		},
 	}
 	require.NoError(t, r.Configure(cfg, false, "", logger))
@@ -243,8 +244,8 @@ func TestRuntimeNotificationDifferentGVKs(t *testing.T) {
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: podSrc, Extractors: []fwkdl.ExtractorBase{podExtractor}},
-			{Plugin: svcSrc, Extractors: []fwkdl.ExtractorBase{svcExtractor}},
+			{Plugin: podSrc, Extractors: []fwkplugin.Plugin{podExtractor}},
+			{Plugin: svcSrc, Extractors: []fwkplugin.Plugin{svcExtractor}},
 		},
 	}
 

--- a/test/integration/epp/runtime_polling_test.go
+++ b/test/integration/epp/runtime_polling_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 	"time"
 
@@ -88,7 +87,7 @@ func TestRuntimePollingDispatch(t *testing.T) {
 			ext := mocks.NewPollingExtractor("test-extractor")
 
 			httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-				parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+				parsePrometheusMetrics)
 			require.NoError(t, err)
 
 			cfg := &datalayer.Config{
@@ -140,7 +139,7 @@ func TestRuntimePollingMultipleExtractors(t *testing.T) {
 	ext2 := mocks.NewPollingExtractor("extractor-2")
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{
@@ -189,7 +188,7 @@ func TestRuntimePollingEndpointLifecycle(t *testing.T) {
 	ext := mocks.NewPollingExtractor("lifecycle-extractor")
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{
@@ -243,7 +242,7 @@ func TestRuntimePollingWithoutExtractors(t *testing.T) {
 	r := datalayer.NewRuntime(50 * time.Millisecond)
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{
@@ -282,7 +281,7 @@ func TestRuntimePollingHTTPError(t *testing.T) {
 	ext := mocks.NewPollingExtractor("error-extractor")
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{

--- a/test/integration/epp/runtime_polling_test.go
+++ b/test/integration/epp/runtime_polling_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	httpds "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/http"
 )
@@ -92,7 +93,7 @@ func TestRuntimePollingDispatch(t *testing.T) {
 
 			cfg := &datalayer.Config{
 				Sources: []datalayer.DataSourceConfig{
-					{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext}},
+					{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext}},
 				},
 			}
 
@@ -144,7 +145,7 @@ func TestRuntimePollingMultipleExtractors(t *testing.T) {
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext1, ext2}},
+			{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext1, ext2}},
 		},
 	}
 
@@ -193,7 +194,7 @@ func TestRuntimePollingEndpointLifecycle(t *testing.T) {
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext}},
+			{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext}},
 		},
 	}
 
@@ -286,7 +287,7 @@ func TestRuntimePollingHTTPError(t *testing.T) {
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext}},
+			{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext}},
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Reshapes the data-layer extractor surface and runtime around typed generics, dropping the reflect-based validation it replaced.                                              
                                                                   
- Extractor[T any] with typed per-variant storage on `Runtime`: `*pollingManager` /  `*notificationManager` / `*endpointManager` (generic `sourceManager[S, E]`, plus a small notification wrapper for GVK uniqueness).                                        
- Removes reflect-based validation (`OutputType`, `ExpectedInputType`, `validateInputTypeCompatible`) and per-tick type assertions.
- Unifies the extractor method to `Extract` (was `ExtractNotification` / `ExtractEndpoint`).                                              
- A typed `sourceVariant` enum drives variant dispatch; `findSourceByType` walks one `Runtime.variants` lookup table built once in `NewRuntime` (single source of truth no parallel hard-coded list to drift).                                                   
- Cross-variant SourceType collisions now surface as configuration errors when a pending extractor references the colliding type. (Exhaustive startup-time validation for consumer-less collisions is tracked as a TODO in Configure.)                                              
- Drops the dead `outputType reflect.Type` plumbing from `HTTPDataSource` and the orphaned `PrometheusMetricType` / `ModelsResponseType` values. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/llm-d/llm-d-inference-scheduler/issues/1053

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
