### PR TITLE
fix(test): eliminate data race in SGLang connector test

### DIFF
--- a/pkg/sidecar/proxy/connector_sglang_test.go
+++ b/pkg/sidecar/proxy/connector_sglang_test.go
@@ -80,18 +80,19 @@ var _ = Describe("SGLang Connector", func() {
 		}
 
 		// Because SGLang connector sends requests concurrently (prefill in goroutine),
-		// we sleep a tiny bit to ensure the prefill handler has time to finish processing.
-		time.Sleep(100 * time.Millisecond)
+		// wait until the prefill handler has finished processing before reading its state.
+		Eventually(testInfo.prefillHandler.RequestCount.Load).Should(Equal(int32(1)))
 
 		// Validate prefill request
-		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 1))
-		Expect(testInfo.prefillHandler.CompletionRequests).To(HaveLen(1))
-		prq1 := testInfo.prefillHandler.CompletionRequests[0]
+		prefillReqs := testInfo.prefillHandler.GetCompletionRequests()
+		Expect(prefillReqs).To(HaveLen(1))
+		prq1 := prefillReqs[0]
 
 		// Validate decode request
 		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
-		Expect(testInfo.decodeHandler.CompletionRequests).To(HaveLen(1))
-		drq1 := testInfo.decodeHandler.CompletionRequests[0]
+		decodeReqs := testInfo.decodeHandler.GetCompletionRequests()
+		Expect(decodeReqs).To(HaveLen(1))
+		drq1 := decodeReqs[0]
 
 		// Bootstrap validations for prefill
 		Expect(prq1).To(HaveKey(requestFieldBootstrapHost))

--- a/test/sidecar/mock/chat_completions_handler.go
+++ b/test/sidecar/mock/chat_completions_handler.go
@@ -46,6 +46,13 @@ type ChatCompletionHandler struct {
 	mu                  sync.Mutex
 }
 
+// GetCompletionRequests returns a snapshot of the received requests, safe for concurrent access.
+func (cc *ChatCompletionHandler) GetCompletionRequests() []map[string]any {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	return append([]map[string]any(nil), cc.CompletionRequests...)
+}
+
 func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cc.RequestCount.Add(1)
 


### PR DESCRIPTION
/kind bug

- Replace `time.Sleep(100ms)` with `Eventually` on the atomic `RequestCount` so the test properly waits for the async prefill handler to complete before reading its state.
- Add `GetCompletionRequests()` accessor to `ChatCompletionHandler` that returns a locked copy of the slice, eliminating the lock-vs-no-lock race on both the slice and the map contents.
- Switch all direct `CompletionRequests` field accesses in the test to `GetCompletionRequests()`.


Fixes #885 