### PR TITLE
Second step in refactoring the FlowControl component

### DIFF
--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -90,9 +90,6 @@ func init() {
 // egressConcurrencyLimit (L) defines the maximum capacity of the simulated pool.
 type egressConcurrencyLimit int64
 
-// shardCount (S) dictates the data parallelism of the Flow Control layer.
-type shardCount int
-
 // priorityLevels (P) dictates the number of priority bands.
 type priorityLevels int
 
@@ -107,7 +104,6 @@ type ingressConcurrency int
 // benchMatrix defines a single coordinate in the performance hypercube.
 type benchMatrix struct {
 	limit       egressConcurrencyLimit
-	shards      shardCount
 	priorities  priorityLevels
 	flows       flowCount
 	concurrency ingressConcurrency
@@ -115,8 +111,8 @@ type benchMatrix struct {
 
 // name returns a human-readable string representation of the matrix coordinate.
 func (m benchMatrix) name() string {
-	return fmt.Sprintf("L=%03d/S=%03d/P=%03d/F=%06d/W=%05d",
-		m.limit, m.shards, m.priorities, m.flows, m.concurrency)
+	return fmt.Sprintf("L=%03d/P=%03d/F=%06d/W=%05d",
+		m.limit, m.priorities, m.flows, m.concurrency)
 }
 
 // testDetector exposes an API to manually release downstream capacity during a test run.
@@ -195,13 +191,11 @@ func setupRegistry(
 	ctx context.Context,
 	b *testing.B,
 	handle plugin.Handle,
-	s shardCount,
 	p priorityLevels,
 ) contracts.FlowRegistry {
 	b.Helper()
 
 	cfgOpts := []registry.ConfigOption{
-		registry.WithInitialShardCount(int(s)),
 		registry.WithMaxBytes(0), // Capacity restricted strictly via concurrency (L).
 	}
 
@@ -234,7 +228,6 @@ func setupRegistry(
 func setupBenchmarkHarness(
 	ctx context.Context,
 	b *testing.B,
-	s shardCount,
 	p priorityLevels,
 	limit egressConcurrencyLimit,
 	customDetector testDetector,
@@ -255,7 +248,7 @@ func setupBenchmarkHarness(
 	}
 	handle.AddPlugin(registry.DefaultOrderingPolicyRef, oPolicy)
 
-	reg := setupRegistry(ctx, b, handle, s, p)
+	reg := setupRegistry(ctx, b, handle, p)
 
 	detector := customDetector
 	if detector == nil {
@@ -266,8 +259,7 @@ func setupBenchmarkHarness(
 
 	cfg := customCfg
 	if cfg == nil {
-		// Buffer size dynamically scales down with parallel shards to isolate queue sorting overhead.
-		bufferSize := max(2000/int(s), 10)
+		bufferSize := max(2000, 10)
 		cfg = &controller.Config{
 			DefaultRequestTTL:               5 * time.Minute,
 			ProcessorReconciliationInterval: 1 * time.Hour, // Effectively disabled

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -259,12 +259,11 @@ func setupBenchmarkHarness(
 
 	cfg := customCfg
 	if cfg == nil {
-		bufferSize := max(2000, 10)
 		cfg = &controller.Config{
 			DefaultRequestTTL:               5 * time.Minute,
 			ProcessorReconciliationInterval: 1 * time.Hour, // Effectively disabled
 			ExpiryCleanupInterval:           1 * time.Hour, // Effectively disabled
-			EnqueueChannelBufferSize:        bufferSize,
+			EnqueueChannelBufferSize:        2000,
 		}
 	}
 

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -125,8 +125,8 @@ func runMatrixCoordinate(b *testing.B, m benchMatrix) {
 
 		// Offset the starting index per thread to prevent identical striding over the array.
 		// Multiply by a prime to guarantee threads start at different offsets.
-		threadId := globalThreadID.Add(1)
-		localIdx := int(threadId) * 9973
+		threadID := globalThreadID.Add(1)
+		localIdx := int(threadID) * 9973
 
 		for pb.Next() {
 			localIdx++

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -40,44 +40,29 @@ func BenchmarkFlowController_PerformanceMatrix(b *testing.B) {
 		b.Skip("skipping PerformanceMatrix in short mode")
 	}
 	limits := []egressConcurrencyLimit{0, 1, 100}
-	shards := []shardCount{1, 8}
 	priorities := []priorityLevels{1, 8}
-	flows := []flowCount{10, 50000}
-	concurrencies := []ingressConcurrency{10, 5000, 50000}
+	flows := []flowCount{10, 5000}
+	concurrencies := []ingressConcurrency{10, 5000}
 
 	for _, L := range limits {
-		for _, S := range shards {
-			for _, P := range priorities {
-				for _, F := range flows {
-					for _, W := range concurrencies {
-						// Skip illogical boundaries.
-						if L == 0 && W > 100 {
-							continue // High concurrency is redundant for free-flow.
-						}
-						if L > 0 && int64(W) <= int64(L) {
-							continue // Requires W > L to generate backpressure.
-						}
-
-						matrix := benchMatrix{limit: L, shards: S, priorities: P, flows: F, concurrency: W}
-						b.Run(matrix.name(), func(b *testing.B) {
-							runMatrixCoordinate(b, matrix)
-						})
+		for _, P := range priorities {
+			for _, F := range flows {
+				for _, W := range concurrencies {
+					// Skip illogical boundaries.
+					if L == 0 && W > 100 {
+						continue // High concurrency is redundant for free-flow.
 					}
+					if L > 0 && int64(W) <= int64(L) {
+						continue // Requires W > L to generate backpressure.
+					}
+
+					matrix := benchMatrix{limit: L, priorities: P, flows: F, concurrency: W}
+					b.Run(matrix.name(), func(b *testing.B) {
+						runMatrixCoordinate(b, matrix)
+					})
 				}
 			}
 		}
-	}
-}
-
-// BenchmarkFlowController_HighShardSort isolates the O(S log S) sorting overhead of shortest-queue
-// load balancing by evaluating highly sharded configurations.
-func BenchmarkFlowController_HighShardSort(b *testing.B) {
-	shards := []shardCount{16, 64, 128, 256}
-	for _, S := range shards {
-		matrix := benchMatrix{limit: 50, shards: S, priorities: 1, flows: 100, concurrency: 100}
-		b.Run(matrix.name(), func(b *testing.B) {
-			runMatrixCoordinate(b, matrix)
-		})
 	}
 }
 
@@ -85,7 +70,7 @@ func BenchmarkFlowController_HighShardSort(b *testing.B) {
 func runMatrixCoordinate(b *testing.B, m benchMatrix) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	fc, detector := setupBenchmarkHarness(ctx, b, m.shards, m.priorities, m.limit, nil, nil)
+	fc, detector := setupBenchmarkHarness(ctx, b, m.priorities, m.limit, nil, nil)
 
 	// Yield briefly to allow the background supervisor to bootstrap the data plane.
 	time.Sleep(10 * time.Millisecond)
@@ -140,7 +125,8 @@ func runMatrixCoordinate(b *testing.B, m benchMatrix) {
 
 		// Offset the starting index per thread to prevent identical striding over the array.
 		// Multiply by a prime to guarantee threads start at different offsets.
-		localIdx := int(globalThreadID.Add(1)) * 9973
+		threadId := globalThreadID.Add(1)
+		localIdx := int(threadId) * 9973
 
 		for pb.Next() {
 			localIdx++
@@ -189,9 +175,9 @@ func BenchmarkFlowController_TopologyChurn(b *testing.B) {
 		EnqueueChannelBufferSize:        100,
 	}
 
-	fc, detector := setupBenchmarkHarness(ctx, b, 4, 1, 100, nil, cfg)
+	fc, detector := setupBenchmarkHarness(ctx, b, 1, 100, nil, cfg)
 
-	const numKeys = 50000
+	const numKeys = 5000
 	preAllocatedReqs := make([]*benchRequest, numKeys)
 	for i := range numKeys {
 		preAllocatedReqs[i] = &benchRequest{
@@ -247,7 +233,7 @@ func BenchmarkFlowController_MassCancellation(b *testing.B) {
 	}
 
 	// Use the permanently saturated detector to guarantee all requests queue and definitively rot.
-	fc, _ := setupBenchmarkHarness(ctx, b, 4, 1, 100, &alwaysSaturatedDetector{}, cfg)
+	fc, _ := setupBenchmarkHarness(ctx, b, 1, 100, &alwaysSaturatedDetector{}, cfg)
 
 	var timeoutCount atomic.Int64
 

--- a/pkg/epp/flowcontrol/config_test.go
+++ b/pkg/epp/flowcontrol/config_test.go
@@ -82,8 +82,6 @@ func TestNewConfigFromAPI(t *testing.T) {
 				assert.NotNil(t, cfg.Registry, "Registry config sub-struct should be initialized even when API config is nil")
 				assert.NotNil(t, cfg.Controller,
 					"Controller config sub-struct should be initialized even when API config is nil")
-				assert.NotZero(t, cfg.Registry.InitialShardCount,
-					"Registry should contain default values (InitialShardCount) when API config is nil")
 				assert.NotZero(t, cfg.Controller.EnqueueChannelBufferSize,
 					"Controller should contain default values (EnqueueChannelBufferSize) when API config is nil")
 			},

--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -53,7 +53,7 @@ type MockRegistryShard struct {
 	FairnessPolicyFunc           func(priority int) (flowcontrol.FairnessPolicy, error)
 	PriorityBandAccessorFunc     func(priority int) (flowcontrol.PriorityBandAccessor, error)
 	AllOrderedPriorityLevelsFunc func() []int
-	StatsFunc                    func() contracts.ShardStats
+	StatsFunc                    func() *contracts.ShardStats
 }
 
 func (m *MockRegistryShard) ID() string {
@@ -98,11 +98,11 @@ func (m *MockRegistryShard) AllOrderedPriorityLevels() []int {
 	return nil
 }
 
-func (m *MockRegistryShard) Stats() contracts.ShardStats {
+func (m *MockRegistryShard) Stats() *contracts.ShardStats {
 	if m.StatsFunc != nil {
 		return m.StatsFunc()
 	}
-	return contracts.ShardStats{}
+	return &contracts.ShardStats{}
 }
 
 var _ contracts.RegistryShard = &MockRegistryShard{}

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -56,8 +56,8 @@ type FlowRegistryObserver interface {
 	// Stats returns a near-consistent snapshot globally aggregated statistics for the entire `FlowRegistry`.
 	Stats() AggregateStats
 
-	// ShardStats returns a near-consistent slice of statistics snapshots, one for each `RegistryShard`.
-	ShardStats() []ShardStats
+	// ShardStats returns a near-consistent statistics snapshot for the `RegistryShard`.
+	ShardStats() *ShardStats
 }
 
 // FlowRegistryDataPlane defines the high-throughput, request-path interface for the registry.
@@ -90,8 +90,8 @@ type FlowRegistryDataPlane interface {
 // This interface represents an active "Lease" on the flow. As long as this object is valid (within the callback), the
 // Flow Registry guarantees that the underlying Flow State is "Pinned" and protected from Garbage Collection.
 type ActiveFlowConnection interface {
-	// ActiveShards returns a current snapshot of accessors for all Active internal state shards.
-	ActiveShards() []RegistryShard
+	// GetShard returns the shard this connection is pinned to.
+	GetShard() RegistryShard
 
 	// FlowKey returns the immutable identity of the flow this connection is pinned to.
 	FlowKey() flowcontrol.FlowKey
@@ -140,7 +140,7 @@ type RegistryShard interface {
 	AllOrderedPriorityLevels() []int
 
 	// Stats returns a near consistent snapshot of the shard's state.
-	Stats() ShardStats
+	Stats() *ShardStats
 }
 
 // ManagedQueue defines the interface for a flow's queue on a specific shard.

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -22,11 +22,9 @@ limitations under the License.
 package controller
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -326,7 +324,7 @@ func (fc *FlowController) tryDistribution(
 	// We must create a fresh FlowItem on each attempt as finalization is per-lifecycle.
 	item := internal.NewItem(req, effectiveTTL, enqueueTime)
 
-	candidates, err := fc.selectDistributionCandidates(conn)
+	candidate, err := fc.selectDistributionCandidate(conn)
 	if err != nil {
 		outcome := types.QueueOutcomeRejectedOther
 		if errors.Is(err, errNoShards) {
@@ -337,7 +335,7 @@ func (fc *FlowController) tryDistribution(
 		return item, finalErr
 	}
 
-	outcome, err := fc.distributeRequest(reqCtx, item, candidates)
+	outcome, err := fc.distributeRequest(reqCtx, item, candidate)
 	if err == nil {
 		// Success: Ownership of the item has been transferred to the processor.
 		return item, nil
@@ -406,36 +404,23 @@ type candidate struct {
 	byteSize  uint64
 }
 
-// selectDistributionCandidates identifies all Active shards for the leased flow and ranks them by the current byte size
+// selectDistributionCandidate identifies all Active shards for the leased flow and ranks them by the current byte size
 // of that flow's queue, from least to most loaded.
-func (fc *FlowController) selectDistributionCandidates(conn contracts.ActiveFlowConnection) ([]candidate, error) {
-	shards := conn.ActiveShards()
-	if len(shards) == 0 {
+func (fc *FlowController) selectDistributionCandidate(conn contracts.ActiveFlowConnection) (*candidate, error) {
+	shard := conn.GetShard()
+	if shard == nil {
 		return nil, fmt.Errorf("%w for flow %s", errNoShards, conn.FlowKey())
 	}
 
-	candidates := make([]candidate, 0, len(shards))
-	for _, shard := range shards {
-		worker := fc.getOrStartWorker(shard)
-		mq, err := shard.ManagedQueue(conn.FlowKey())
-		if err != nil {
-			fc.logger.Error(err,
-				"Invariant violation. Failed to get ManagedQueue for a leased flow on an Active shard. Skipping shard.",
-				"flowKey", conn.FlowKey(), "shardID", shard.ID())
-			continue
-		}
-		candidates = append(candidates, candidate{worker.processor, shard.ID(), mq.FlowQueueAccessor().ByteSize()})
-	}
-
-	if len(candidates) == 0 {
+	worker := fc.getOrStartWorker(shard)
+	mq, err := shard.ManagedQueue(conn.FlowKey())
+	if err != nil {
+		fc.logger.Error(err,
+			"Invariant violation. Failed to get ManagedQueue for a leased flow on an Active shard. Skipping shard.",
+			"flowKey", conn.FlowKey(), "shardID", shard.ID())
 		return nil, fmt.Errorf("%w for flow %s", errNoShards, conn.FlowKey())
 	}
-
-	slices.SortFunc(candidates, func(a, b candidate) int {
-		return cmp.Compare(a.byteSize, b.byteSize)
-	})
-
-	return candidates, nil
+	return &candidate{worker.processor, shard.ID(), mq.FlowQueueAccessor().ByteSize()}, nil
 }
 
 // distributeRequest implements a flow-aware, two-phase "Join-Shortest-Queue-by-Bytes" (JSQ-Bytes) distribution strategy
@@ -456,22 +441,19 @@ func (fc *FlowController) selectDistributionCandidates(conn contracts.ActiveFlow
 func (fc *FlowController) distributeRequest(
 	ctx context.Context,
 	item *internal.FlowItem,
-	candidates []candidate,
+	candidate *candidate,
 ) (types.QueueOutcome, error) {
 	reqID := item.OriginalRequest().ID()
-	for _, c := range candidates {
-		if err := c.processor.Submit(item); err == nil {
-			return types.QueueOutcomeNotYetFinalized, nil
-		}
-		fc.logger.V(logutil.TRACE).Info("Processor busy during fast failover, trying next candidate",
-			"shardID", c.shardID, "requestID", reqID)
+	if err := candidate.processor.Submit(item); err == nil {
+		return types.QueueOutcomeNotYetFinalized, nil
 	}
+	fc.logger.V(logutil.TRACE).Info("Processor busy during fast failover, trying next candidate",
+		"shardID", candidate.shardID, "requestID", reqID)
 
-	// All processors are busy. Attempt a single blocking submission to the least-loaded candidate.
-	bestCandidate := candidates[0]
+	// processor are busy. Attempt a single blocking submission to the candidate.
 	fc.logger.V(logutil.TRACE).Info("All processors busy, attempting blocking submit to best candidate",
-		"shardID", bestCandidate.shardID, "requestID", reqID)
-	err := bestCandidate.processor.SubmitOrBlock(ctx, item)
+		"shardID", candidate.shardID, "requestID", reqID)
+	err := candidate.processor.SubmitOrBlock(ctx, item)
 	if err != nil {
 		return types.QueueOutcomeRejectedOther, fmt.Errorf("%w: request not accepted: %w", types.ErrRejected, err)
 	}
@@ -528,8 +510,8 @@ func (fc *FlowController) getOrStartWorker(shard contracts.RegistryShard) *manag
 func (fc *FlowController) reconcileProcessors() {
 	stats := fc.registry.ShardStats()
 	activeShards := sets.New[string]()
-	for _, s := range stats {
-		activeShards.Insert(s.ID)
+	if stats != nil {
+		activeShards.Insert(stats.ID)
 	}
 
 	fc.workers.Range(func(key, value any) bool {

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	k8srand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -249,47 +248,32 @@ func (fc *FlowController) EnqueueAndWait(
 	// 2. Acquire a lease for the Flow.
 	// We hold this lease for the entire duration of the request (Distribution + Queueing).
 	err := fc.registry.WithConnection(flowKey, func(conn contracts.ActiveFlowConnection) error {
-		// 3. Enter the distribution loop to find a home for the request.
-		// This loop is responsible for retrying on ErrShardDraining.
-		// We can safely retry within this loop using the same 'conn' object because conn.ActiveShards() provides a live
-		// view of the topology.
-		for {
-			select { // Non-blocking check on controller lifecycle.
-			case <-fc.parentCtx.Done():
-				finalOutcome = types.QueueOutcomeRejectedOther
-				return fmt.Errorf("%w: %w", types.ErrRejected, types.ErrFlowControllerNotRunning)
-			default:
-			}
 
-			// Attempt to distribute the request once, passing the active connection.
-			item, err := fc.tryDistribution(reqCtx, req, enqueueTime, conn)
-			if err != nil {
-				// Distribution failed terminally (e.g., no shards, context cancelled during blocking submit).
-				// The item has already been finalized by tryDistribution.
-				finalState := item.FinalState()
-				finalOutcome = finalState.Outcome
-				return finalState.Err
-			}
-
-			// Distribution was successful; ownership of the item has been transferred to a processor.
-			// Now, we block here in awaitFinalization until the request is finalized by either the processor (e.g., dispatched,
-			// rejected) or the controller itself (e.g., caller's context cancelled/TTL expired).
-			outcome, err := fc.awaitFinalization(reqCtx, item)
-			if errors.Is(err, contracts.ErrShardDraining) {
-				// This is a benign race condition where the chosen shard started draining after acceptance.
-				fc.logger.V(logutil.DEBUG).Info("Selected shard is Draining, retrying request distribution",
-					"flowKey", req.FlowKey(), "requestID", req.ID())
-				// Introduce a small, randomized delay (1-10ms) to prevent tight spinning loops and thundering herds during retry
-				// scenarios (e.g., shard draining)
-				jitterMs := k8srand.Intn(10) + 1
-				fc.clock.Sleep(time.Duration(jitterMs) * time.Millisecond)
-				continue
-			}
-
-			// The outcome is terminal (Dispatched, Evicted, or a non-retriable rejection).
-			finalOutcome = outcome
-			return err
+		select { // Non-blocking check on controller lifecycle.
+		case <-fc.parentCtx.Done():
+			finalOutcome = types.QueueOutcomeRejectedOther
+			return fmt.Errorf("%w: %w", types.ErrRejected, types.ErrFlowControllerNotRunning)
+		default:
 		}
+
+		// Attempt to distribute the request once, passing the active connection.
+		item, err := fc.tryDistribution(reqCtx, req, enqueueTime, conn)
+		if err != nil {
+			// Distribution failed terminally (e.g., context cancelled during blocking submit).
+			// The item has already been finalized by tryDistribution.
+			finalState := item.FinalState()
+			finalOutcome = finalState.Outcome
+			return finalState.Err
+		}
+
+		// Distribution was successful; ownership of the item has been transferred to a processor.
+		// Now, we block here in awaitFinalization until the request is finalized by either the processor (e.g., dispatched,
+		// rejected) or the controller itself (e.g., caller's context cancelled/TTL expired).
+		outcome, err := fc.awaitFinalization(reqCtx, item)
+
+		// The outcome is terminal (Dispatched, Evicted, or another rejection).
+		finalOutcome = outcome
+		return err
 	})
 
 	// If WithConnection returned an error (e.g. connection failure, context cancelled before lease), we must ensure we
@@ -447,12 +431,9 @@ func (fc *FlowController) distributeRequest(
 	if err := candidate.processor.Submit(item); err == nil {
 		return types.QueueOutcomeNotYetFinalized, nil
 	}
-	fc.logger.V(logutil.TRACE).Info("Processor busy during fast failover, trying next candidate",
-		"shardID", candidate.shardID, "requestID", reqID)
 
-	// processor are busy. Attempt a single blocking submission to the candidate.
-	fc.logger.V(logutil.TRACE).Info("All processors busy, attempting blocking submit to best candidate",
-		"shardID", candidate.shardID, "requestID", reqID)
+	// processor is busy. Attempt a single blocking submission to the candidate.
+	fc.logger.V(logutil.TRACE).Info("Processor is busy, attempting blocking submit", "requestID", reqID)
 	err := candidate.processor.SubmitOrBlock(ctx, item)
 	if err != nil {
 		return types.QueueOutcomeRejectedOther, fmt.Errorf("%w: request not accepted: %w", types.ErrRejected, err)

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -1129,7 +1129,7 @@ func setupRegistryForConcurrency(t *testing.T, flowKey flowcontrol.FlowKey) *moc
 		AllOrderedPriorityLevelsFunc: func() []int { return []int{flowKey.Priority} },
 		PriorityBandAccessorFunc: func(priority int) (flowcontrol.PriorityBandAccessor, error) {
 			if priority == flowKey.Priority {
-				return &frameworkmocks.MockPriorityBandAccessor{
+				return &fwkfcmocks.MockPriorityBandAccessor{
 					PriorityV: priority,
 					IterateQueuesFunc: func(f func(flowcontrol.FlowQueueAccessor) bool) {
 						f(currentQueue.FlowQueueAccessor())
@@ -1139,7 +1139,7 @@ func setupRegistryForConcurrency(t *testing.T, flowKey flowcontrol.FlowKey) *moc
 			return nil, fmt.Errorf("unexpected priority %d", priority)
 		},
 		FairnessPolicyFunc: func(_ int) (flowcontrol.FairnessPolicy, error) {
-			return &frameworkmocks.MockFairnessPolicy{
+			return &fwkfcmocks.MockFairnessPolicy{
 				PickFunc: func(_ context.Context, _ flowcontrol.PriorityBandAccessor) (flowcontrol.FlowQueueAccessor, error) {
 					return currentQueue.FlowQueueAccessor(), nil
 				},

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -175,16 +175,16 @@ func newIntegrationHarness(ctx context.Context, t *testing.T, cfg *Config, regis
 
 // mockActiveFlowConnection is a local mock for the `contracts.ActiveFlowConnection` interface.
 type mockActiveFlowConnection struct {
-	ActiveShardsV    []contracts.RegistryShard
-	ActiveShardsFunc func() []contracts.RegistryShard
-	FlowKeyV         flowcontrol.FlowKey
+	ShardV    contracts.RegistryShard
+	ShardFunc func() contracts.RegistryShard
+	FlowKeyV  flowcontrol.FlowKey
 }
 
-func (m *mockActiveFlowConnection) ActiveShards() []contracts.RegistryShard {
-	if m.ActiveShardsFunc != nil {
-		return m.ActiveShardsFunc()
+func (m *mockActiveFlowConnection) GetShard() contracts.RegistryShard {
+	if m.ShardFunc != nil {
+		return m.ShardFunc()
 	}
-	return m.ActiveShardsV
+	return m.ShardV
 }
 
 func (m *mockActiveFlowConnection) FlowKey() flowcontrol.FlowKey {
@@ -196,7 +196,7 @@ type mockRegistryClient struct {
 	contracts.FlowRegistryObserver
 	contracts.FlowRegistryDataPlane
 	WithConnectionFunc func(key flowcontrol.FlowKey, fn func(conn contracts.ActiveFlowConnection) error) error
-	ShardStatsFunc     func() []contracts.ShardStats
+	ShardStatsFunc     func() *contracts.ShardStats
 }
 
 func (m *mockRegistryClient) WithConnection(
@@ -209,7 +209,7 @@ func (m *mockRegistryClient) WithConnection(
 	return fn(&mockActiveFlowConnection{})
 }
 
-func (m *mockRegistryClient) ShardStats() []contracts.ShardStats {
+func (m *mockRegistryClient) ShardStats() *contracts.ShardStats {
 	if m.ShardStatsFunc != nil {
 		return m.ShardStatsFunc()
 	}
@@ -308,11 +308,6 @@ func newMockShard(id string) *mockShardBuilder {
 	return &mockShardBuilder{id: id}
 }
 
-func (b *mockShardBuilder) withByteSize(size uint64) *mockShardBuilder {
-	b.byteSize = size
-	return b
-}
-
 func (b *mockShardBuilder) build() contracts.RegistryShard {
 	return &mocks.MockRegistryShard{
 		IDFunc: func() string { return b.id },
@@ -351,8 +346,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			shardA := newMockShard("shard-A").build()
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {
 				return fn(&mockActiveFlowConnection{
-					ActiveShardsV: []contracts.RegistryShard{shardA},
-					FlowKeyV:      key,
+					ShardV:   shardA,
+					FlowKeyV: key,
 				})
 			}
 			// Configure processor to block until context expiry.
@@ -453,8 +448,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				fn func(conn contracts.ActiveFlowConnection) error,
 			) error {
 				return fn(&mockActiveFlowConnection{
-					ActiveShardsV: []contracts.RegistryShard{faultyShard},
-					FlowKeyV:      key,
+					ShardV:   faultyShard,
+					FlowKeyV: key,
 				})
 			}
 
@@ -477,7 +472,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 
 		testCases := []struct {
 			name            string
-			shards          []contracts.RegistryShard
+			shard           contracts.RegistryShard
 			setupProcessors func(t *testing.T, h *testHarness)
 			// requestTTL overrides the default TTL for time-sensitive tests.
 			requestTTL      time.Duration
@@ -486,8 +481,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			expectErrIs     error
 		}{
 			{
-				name:   "SubmitSucceeds_NonBlocking_WithSingleActiveShard",
-				shards: []contracts.RegistryShard{newMockShard("shard-A").build()},
+				name:  "SubmitSucceeds_NonBlocking_WithSingleShard",
+				shard: newMockShard("shard-A").build(),
 				setupProcessors: func(t *testing.T, h *testHarness) {
 					h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
 						SubmitFunc: func(item *internal.FlowItem) error {
@@ -500,56 +495,10 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				expectedOutcome: types.QueueOutcomeDispatched,
 			},
 			{
-				name: "DistributesToLeastLoadedShard_WithMultipleActiveShards",
-				shards: []contracts.RegistryShard{
-					newMockShard("shard-A").withByteSize(1000).build(), // More loaded
-					newMockShard("shard-B").withByteSize(100).build(),  // Least loaded
-				},
-				setupProcessors: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
-						SubmitFunc: func(_ *internal.FlowItem) error {
-							t.Error("Submit was called on the more loaded shard (shard-A); JSQ-Bytes algorithm failed")
-							return internal.ErrProcessorBusy
-						},
-					}
-					h.mockProcessorFactory.processors["shard-B"] = &mockShardProcessor{
-						SubmitFunc: func(item *internal.FlowItem) error {
-							item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
-							go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
-							return nil
-						},
-					}
-				},
-				expectedOutcome: types.QueueOutcomeDispatched,
-			},
-			{
-				name: "SubmitSucceeds_AfterBlocking_WithAllProcessorsBusy",
-				shards: []contracts.RegistryShard{
-					newMockShard("shard-A").withByteSize(1000).build(),
-					newMockShard("shard-B").withByteSize(100).build(),
-				},
-				setupProcessors: func(t *testing.T, h *testHarness) {
-					// Both processors reject the initial non-blocking Submit.
-					h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
-						SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
-					}
-					// Shard-B is the least loaded, so it should receive the blocking fallback (SubmitOrBlock).
-					h.mockProcessorFactory.processors["shard-B"] = &mockShardProcessor{
-						SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
-						SubmitOrBlockFunc: func(_ context.Context, item *internal.FlowItem) error {
-							// The blocking call succeeds.
-							go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
-							return nil
-						},
-					}
-				},
-				expectedOutcome: types.QueueOutcomeDispatched,
-			},
-			{
 				// Validates the scenario where the request's TTL expires while the controller is blocked waiting for capacity.
 				// NOTE: This relies on real time passing, as context.WithDeadline timers cannot be controlled by FakeClock.
 				name:       "Rejects_AfterBlocking_WhenTTL_Expires",
-				shards:     []contracts.RegistryShard{newMockShard("shard-A").build()},
+				shard:      newMockShard("shard-A").build(),
 				requestTTL: 50 * time.Millisecond, // Short TTL to keep the test fast.
 				setupProcessors: func(t *testing.T, h *testHarness) {
 					h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
@@ -570,8 +519,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				expectErrIs: types.ErrTTLExpired,
 			},
 			{
-				name:   "Rejects_OnProcessorShutdownDuringSubmit",
-				shards: []contracts.RegistryShard{newMockShard("shard-A").build()},
+				name:  "Rejects_OnProcessorShutdownDuringSubmit",
+				shard: newMockShard("shard-A").build(),
 				setupProcessors: func(t *testing.T, h *testHarness) {
 					h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
 						// Simulate the processor shutting down during the non-blocking handoff.
@@ -586,8 +535,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				expectErrIs:     types.ErrFlowControllerNotRunning,
 			},
 			{
-				name:   "Rejects_OnProcessorShutdownDuringSubmitOrBlock",
-				shards: []contracts.RegistryShard{newMockShard("shard-A").build()},
+				name:  "Rejects_OnProcessorShutdownDuringSubmitOrBlock",
+				shard: newMockShard("shard-A").build(),
 				setupProcessors: func(t *testing.T, h *testHarness) {
 					h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
 						SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
@@ -623,8 +572,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					fn func(conn contracts.ActiveFlowConnection) error,
 				) error {
 					return fn(&mockActiveFlowConnection{
-						ActiveShardsV: tc.shards,
-						FlowKeyV:      key,
+						ShardV:   tc.shard,
+						FlowKeyV: key,
 					})
 				}
 				tc.setupProcessors(t, h)
@@ -674,8 +623,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					fn func(conn contracts.ActiveFlowConnection,
 					) error) error {
 					return fn(&mockActiveFlowConnection{
-						ActiveShardsV: []contracts.RegistryShard{newMockShard("shard-A").build()},
-						FlowKeyV:      key,
+						ShardV:   newMockShard("shard-A").build(),
+						FlowKeyV: key,
 					})
 				},
 			}
@@ -705,63 +654,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			assert.Equal(t, types.QueueOutcomeRejectedOther, outcome,
 				"outcome should be QueueOutcomeRejectedOther when cancelled during distribution")
 		})
-
-		// This test validates the retry mechanism when a processor reports that its shard is draining.
-		t.Run("RetriesAndSucceeds_OnProcessorReportsShardDraining", func(t *testing.T) {
-			t.Parallel()
-			var callCount atomic.Int32
-			mockRegistry := &mockRegistryClient{
-				WithConnectionFunc: func(
-					key flowcontrol.FlowKey,
-					fn func(conn contracts.ActiveFlowConnection) error,
-				) error {
-					shardA := newMockShard("shard-A").withByteSize(100).build()
-					shardB := newMockShard("shard-B").withByteSize(1000).build()
-
-					// We construct the connection once, using a hook for dynamic topology.
-					conn := &mockActiveFlowConnection{
-						FlowKeyV: key,
-						ActiveShardsFunc: func() []contracts.RegistryShard {
-							attempt := callCount.Add(1)
-							if attempt == 1 {
-								// Attempt 1: Shard A is present and will be selected (least loaded).
-								return []contracts.RegistryShard{shardA, shardB}
-							}
-							// Attempt 2 (Retry): Assume Shard A is now draining and removed from the active set by the registry.
-							return []contracts.RegistryShard{shardB}
-						},
-					}
-					return fn(conn)
-				},
-			}
-			// Use a long TTL to ensure retries don't time out.
-			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry)
-
-			// Configure Shard A's processor to reject the request due to draining.
-			h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
-				SubmitFunc: func(item *internal.FlowItem) error {
-					// The processor accepts the item but then asynchronously finalizes it with ErrShardDraining.
-					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
-					go item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, contracts.ErrShardDraining)
-					return nil
-				},
-			}
-			// Configure Shard B's processor to successfully dispatch the request on the retry.
-			h.mockProcessorFactory.processors["shard-B"] = &mockShardProcessor{
-				SubmitFunc: func(item *internal.FlowItem) error {
-					go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
-					return nil
-				},
-			}
-
-			// Act
-			outcome, err := h.fc.EnqueueAndWait(context.Background(), newTestRequest(defaultFlowKey))
-
-			// Assert
-			require.NoError(t, err, "EnqueueAndWait must succeed after retrying on a healthy shard")
-			assert.Equal(t, types.QueueOutcomeDispatched, outcome, "outcome should be QueueOutcomeDispatched")
-			assert.Equal(t, int32(2), callCount.Load(), "registry must be consulted for Active shards on each retry attempt")
-		})
 	})
 
 	// Lifecycle covers the post-distribution phase, focusing on how the controller handles context cancellation and TTL
@@ -779,8 +671,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			shardA := newMockShard("shard-A").build()
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {
 				return fn(&mockActiveFlowConnection{
-					ActiveShardsV: []contracts.RegistryShard{shardA},
-					FlowKeyV:      key,
+					ShardV:   shardA,
+					FlowKeyV: key,
 				})
 			}
 
@@ -857,8 +749,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			shardA := newMockShard("shard-A").build()
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {
 				return fn(&mockActiveFlowConnection{
-					ActiveShardsV: []contracts.RegistryShard{shardA},
-					FlowKeyV:      key,
+					ShardV:   shardA,
+					FlowKeyV: key,
 				})
 			}
 
@@ -940,8 +832,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				) error {
 					// Execute the controller's logic.
 					err := fn(&mockActiveFlowConnection{
-						ActiveShardsV: []contracts.RegistryShard{newMockShard("shard-A").build()},
-						FlowKeyV:      key,
+						ShardV:   newMockShard("shard-A").build(),
+						FlowKeyV: key,
 					})
 					// Signal that the closure has finished and the lease is about to be released.
 					close(leaseReleased)
@@ -1017,14 +909,14 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 
 		// Setup: A registry that initially knows about "shard-A" and "stale-shard", but later only reports "shard-A".
 		mockRegistry := &mockRegistryClient{
-			ShardStatsFunc: func() []contracts.ShardStats {
+			ShardStatsFunc: func() *contracts.ShardStats {
 				// The current state of the world according to the registry.
-				return []contracts.ShardStats{{ID: "shard-A"}}
+				return &contracts.ShardStats{ID: "shard-A"}
 			}}
 		h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
 
 		// Pre-populate the controller with initial workers, simulating a previous state.
-		initialShards := []string{"shard-A", "stale-shard"}
+		initialShards := []string{"shard-A"}
 		for _, shardID := range initialShards {
 			currentShardID := shardID
 			// Initialize the processor mocks with the channel needed to synchronize startup.
@@ -1033,7 +925,7 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 			// Start the worker using the internal mechanism.
 			h.fc.getOrStartWorker(shard)
 		}
-		require.Len(t, h.mockProcessorFactory.processors, 2, "pre-condition: initial workers not set up correctly")
+		require.Len(t, h.mockProcessorFactory.processors, 1, "pre-condition: initial workers not set up correctly")
 
 		// Wait for all worker goroutines to have started and captured their contexts.
 		for id, p := range h.mockProcessorFactory.processors {
@@ -1048,18 +940,6 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 
 		// Act: Manually trigger the reconciliation logic.
 		h.fc.reconcileProcessors()
-
-		t.Run("StaleWorkerIsCancelled", func(t *testing.T) {
-			staleProc := h.mockProcessorFactory.processors["stale-shard"]
-			require.NotNil(t, staleProc.Context(), "precondition: stale processor context should have been captured")
-			// The context of the removed worker must be cancelled to signal shutdown.
-			select {
-			case <-staleProc.Context().Done():
-				// Success: Context was cancelled.
-			case <-time.After(100 * time.Millisecond):
-				t.Error("context of the stale worker was not cancelled during reconciliation")
-			}
-		})
 
 		t.Run("ActiveWorkerIsNotCancelled", func(t *testing.T) {
 			activeProc := h.mockProcessorFactory.processors["shard-A"]
@@ -1090,7 +970,7 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 
 		// Count the number of times the reconciliation logic (which calls ShardStats) runs.
 		var reconcileCount atomic.Int32
-		mockRegistry.ShardStatsFunc = func() []contracts.ShardStats {
+		mockRegistry.ShardStatsFunc = func() *contracts.ShardStats {
 			reconcileCount.Add(1)
 			return nil
 		}
@@ -1230,74 +1110,67 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 }
 
 // Helper function to create a realistic mock registry environment for integration/concurrency tests.
-func setupRegistryForConcurrency(t *testing.T, numShards int, flowKey flowcontrol.FlowKey) *mockRegistryClient {
+func setupRegistryForConcurrency(t *testing.T, flowKey flowcontrol.FlowKey) *mockRegistryClient {
 	t.Helper()
 	mockRegistry := &mockRegistryClient{}
-	shards := make([]contracts.RegistryShard, numShards)
 
-	// Configure the shards and their dependencies required by the real ShardProcessor implementation.
-	for i := range numShards {
-		// Capture loop variables for closures.
-		shardID := fmt.Sprintf("shard-%d", i)
-		// Use high-fidelity mock queues (MockManagedQueue) that implement the necessary interfaces and synchronization.
-		currentQueue := &mocks.MockManagedQueue{FlowKeyV: flowKey}
+	// Configure the shard and its dependencies required by the real ShardProcessor implementation.
 
-		shards[i] = &mocks.MockRegistryShard{
-			IDFunc: func() string { return shardID },
-			ManagedQueueFunc: func(_ flowcontrol.FlowKey) (contracts.ManagedQueue, error) {
-				return currentQueue, nil
-			},
-			// Configuration required for ShardProcessor initialization and dispatch logic.
-			AllOrderedPriorityLevelsFunc: func() []int { return []int{flowKey.Priority} },
-			PriorityBandAccessorFunc: func(priority int) (flowcontrol.PriorityBandAccessor, error) {
-				if priority == flowKey.Priority {
-					return &fwkfcmocks.MockPriorityBandAccessor{
-						PriorityV: priority,
-						IterateQueuesFunc: func(f func(flowcontrol.FlowQueueAccessor) bool) {
-							f(currentQueue.FlowQueueAccessor())
-						},
-					}, nil
-				}
-				return nil, fmt.Errorf("unexpected priority %d", priority)
-			},
-			FairnessPolicyFunc: func(_ int) (flowcontrol.FairnessPolicy, error) {
-				return &fwkfcmocks.MockFairnessPolicy{
-					PickFunc: func(_ context.Context, _ flowcontrol.PriorityBandAccessor) (flowcontrol.FlowQueueAccessor, error) {
-						return currentQueue.FlowQueueAccessor(), nil
+	shardID := "shard-0"
+	// Use high-fidelity mock queues (MockManagedQueue) that implement the necessary interfaces and synchronization.
+	currentQueue := &mocks.MockManagedQueue{FlowKeyV: flowKey}
+
+	shard := &mocks.MockRegistryShard{
+		IDFunc: func() string { return shardID },
+		ManagedQueueFunc: func(_ flowcontrol.FlowKey) (contracts.ManagedQueue, error) {
+			return currentQueue, nil
+		},
+		// Configuration required for ShardProcessor initialization and dispatch logic.
+		AllOrderedPriorityLevelsFunc: func() []int { return []int{flowKey.Priority} },
+		PriorityBandAccessorFunc: func(priority int) (flowcontrol.PriorityBandAccessor, error) {
+			if priority == flowKey.Priority {
+				return &frameworkmocks.MockPriorityBandAccessor{
+					PriorityV: priority,
+					IterateQueuesFunc: func(f func(flowcontrol.FlowQueueAccessor) bool) {
+						f(currentQueue.FlowQueueAccessor())
 					},
 				}, nil
-			},
-			// Configure stats reporting based on the live state of the mock queues.
-			StatsFunc: func() contracts.ShardStats {
-				return contracts.ShardStats{
-					ID:            shardID,
-					TotalLen:      uint64(currentQueue.Len()),
-					TotalByteSize: currentQueue.ByteSize(),
-					PerPriorityBandStats: map[int]contracts.PriorityBandStats{
-						flowKey.Priority: {
-							Len:           uint64(currentQueue.Len()),
-							ByteSize:      currentQueue.ByteSize(),
-							CapacityBytes: 1e9, // Effectively unlimited capacity to ensure dispatch success.
-						},
+			}
+			return nil, fmt.Errorf("unexpected priority %d", priority)
+		},
+		FairnessPolicyFunc: func(_ int) (flowcontrol.FairnessPolicy, error) {
+			return &frameworkmocks.MockFairnessPolicy{
+				PickFunc: func(_ context.Context, _ flowcontrol.PriorityBandAccessor) (flowcontrol.FlowQueueAccessor, error) {
+					return currentQueue.FlowQueueAccessor(), nil
+				},
+			}, nil
+		},
+		// Configure stats reporting based on the live state of the mock queues.
+		StatsFunc: func() *contracts.ShardStats {
+			return &contracts.ShardStats{
+				ID:            shardID,
+				TotalLen:      uint64(currentQueue.Len()),
+				TotalByteSize: currentQueue.ByteSize(),
+				PerPriorityBandStats: map[int]contracts.PriorityBandStats{
+					flowKey.Priority: {
+						Len:           uint64(currentQueue.Len()),
+						ByteSize:      currentQueue.ByteSize(),
+						CapacityBytes: 1e9, // Effectively unlimited capacity to ensure dispatch success.
 					},
-				}
-			},
-		}
+				},
+			}
+		},
 	}
 
 	// Configure the registry connection.
 	mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(conn contracts.ActiveFlowConnection) error) error {
 		return fn(&mockActiveFlowConnection{
-			ActiveShardsV: shards,
-			FlowKeyV:      key,
+			ShardV:   shard,
+			FlowKeyV: key,
 		})
 	}
-	mockRegistry.ShardStatsFunc = func() []contracts.ShardStats {
-		stats := make([]contracts.ShardStats, len(shards))
-		for i, shard := range shards {
-			stats[i] = shard.Stats()
-		}
-		return stats
+	mockRegistry.ShardStatsFunc = func() *contracts.ShardStats {
+		return shard.Stats()
 	}
 	return mockRegistry
 }
@@ -1307,13 +1180,12 @@ func setupRegistryForConcurrency(t *testing.T, numShards int, flowKey flowcontro
 // It validates the thread-safety of the distribution logic and the overall system throughput.
 func TestFlowController_Concurrency_Distribution(t *testing.T) {
 	const (
-		numShards     = 4
 		numGoroutines = 50
 		numRequests   = 200
 	)
 
 	// Arrange
-	mockRegistry := setupRegistryForConcurrency(t, numShards, defaultFlowKey)
+	mockRegistry := setupRegistryForConcurrency(t, defaultFlowKey)
 
 	// Initialize the integration harness with real ShardProcessors.
 	h := newIntegrationHarness(t.Context(), t, &Config{
@@ -1375,14 +1247,13 @@ func TestFlowController_Concurrency_Backpressure(t *testing.T) {
 	t.Parallel()
 
 	const (
-		numShards     = 2
 		numGoroutines = 20
 		// Fewer requests than the distribution test, as the blocking path is inherently slower.
 		numRequests = 40
 	)
 
 	// Arrange: Set up the registry environment.
-	mockRegistry := setupRegistryForConcurrency(t, numShards, defaultFlowKey)
+	mockRegistry := setupRegistryForConcurrency(t, defaultFlowKey)
 
 	// Use the integration harness with a configuration designed to induce backpressure.
 	h := newIntegrationHarness(t.Context(), t, &Config{

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -123,8 +123,8 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 	h.FairnessPolicyFunc = h.fairnessPolicy
 
 	// Provide a default stats implementation that is effectively infinite.
-	h.StatsFunc = func() contracts.ShardStats {
-		return contracts.ShardStats{
+	h.StatsFunc = func() *contracts.ShardStats {
+		return &contracts.ShardStats{
 			TotalCapacityBytes: 1e9,
 			PerPriorityBandStats: map[int]contracts.PriorityBandStats{
 				testFlow.Priority: {CapacityBytes: 1e9},
@@ -321,8 +321,8 @@ func TestShardProcessor(t *testing.T) {
 			h := newTestHarness(t, testCleanupTick)
 			item := h.newTestItem("req-capacity-reject", testFlow, testTTL)
 			h.addQueue(testFlow)
-			h.StatsFunc = func() contracts.ShardStats {
-				return contracts.ShardStats{PerPriorityBandStats: map[int]contracts.PriorityBandStats{
+			h.StatsFunc = func() *contracts.ShardStats {
+				return &contracts.ShardStats{PerPriorityBandStats: map[int]contracts.PriorityBandStats{
 					testFlow.Priority: {CapacityBytes: 50}, // 50 is less than item size of 100
 				}}
 			}
@@ -878,7 +878,7 @@ func TestShardProcessor(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					t.Parallel()
 					h := newTestHarness(t, testCleanupTick)
-					h.StatsFunc = func() contracts.ShardStats { return tc.stats }
+					h.StatsFunc = func() *contracts.ShardStats { return &tc.stats }
 					hasCap := h.processor.hasCapacity(testFlow.Priority, tc.itemByteSize)
 					assert.Equal(t, tc.expectHasCap, hasCap, "Capacity check result should match expected value")
 				})

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -51,8 +51,6 @@ const (
 	defaultPriorityBandMaxBytes uint64 = 1_000_000_000
 	// defaultQueue is the default queue implementation for flows.
 	defaultQueue queue.RegisteredQueueName = queue.ListQueueName
-	// defaultInitialShardCount is the default number of parallel shards to create when the registry is initialized.
-	defaultInitialShardCount int = 1
 	// defaultFlowGCTimeout is the default duration of inactivity after which an idle flow is garbage collected.
 	// This also serves as the interval for the periodic garbage collection scan.
 	defaultFlowGCTimeout time.Duration = 5 * time.Minute
@@ -131,11 +129,6 @@ type Config struct {
 	// If nil, it is automatically populated with system defaults during NewConfig.
 	DefaultPriorityBand *PriorityBandConfig
 
-	// InitialShardCount specifies the number of parallel shards to create when the registry is initialized.
-	// This value must be greater than zero.
-	// Optional: Defaults to `defaultInitialShardCount` (1).
-	InitialShardCount int
-
 	// FlowGCTimeout defines the interval at which the registry scans for and garbage collects idle flows.
 	// A flow is collected if it has been observed to be Idle for at least one full scan interval.
 	// Optional: Defaults to `defaultFlowGCTimeout` (1 hour).
@@ -208,17 +201,6 @@ func WithMaxBytes(maxBytes uint64) ConfigOption {
 func WithMaxRequests(maxRequests uint64) ConfigOption {
 	return func(b *configBuilder) error {
 		b.config.MaxRequests = maxRequests
-		return nil
-	}
-}
-
-// WithInitialShardCount sets the number of shards to create on startup.
-func WithInitialShardCount(count int) ConfigOption {
-	return func(b *configBuilder) error {
-		if count <= 0 {
-			return errors.New("initialShardCount must be greater than 0")
-		}
-		b.config.InitialShardCount = count
 		return nil
 	}
 }
@@ -501,7 +483,6 @@ func NewConfig(handle plugin.Handle, opts ...ConfigOption) (*Config, error) {
 		config: &Config{
 			MaxBytes:              0, // no limit enforced
 			MaxRequests:           0, // no limit enforced
-			InitialShardCount:     defaultInitialShardCount,
 			FlowGCTimeout:         defaultFlowGCTimeout,
 			PriorityBandGCTimeout: defaultPriorityBandGCTimeout,
 			PriorityBands:         make(map[int]*PriorityBandConfig),
@@ -619,9 +600,6 @@ func (p *PriorityBandConfig) validate(checker capabilityChecker) error {
 
 // validate checks global constraints and delegates band validation.
 func (c *Config) validate(checker capabilityChecker) error {
-	if c.InitialShardCount <= 0 {
-		return errors.New("initialShardCount must be greater than 0")
-	}
 	if c.FlowGCTimeout <= 0 {
 		return errors.New("flowGCTimeout must be positive")
 	}

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -109,7 +109,6 @@ func TestNewConfig(t *testing.T) {
 			},
 			handle: newTestPluginsHandle(t),
 			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, defaultInitialShardCount, cfg.InitialShardCount, "InitialShardCount should be defaulted")
 				assert.Equal(t, defaultFlowGCTimeout, cfg.FlowGCTimeout, "FlowGCTimeout should be defaulted")
 				assert.Equal(t, defaultPriorityBandGCTimeout, cfg.PriorityBandGCTimeout, "PriorityBandGCTimeout should be defaulted")
 
@@ -126,7 +125,6 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "ShouldRespectGlobalOverrides",
 			opts: []ConfigOption{
-				WithInitialShardCount(10),
 				WithMaxBytes(5000),
 				WithFlowGCTimeout(1 * time.Hour),
 				WithPriorityBandGCTimeout(2 * time.Hour),
@@ -134,7 +132,6 @@ func TestNewConfig(t *testing.T) {
 			},
 			handle: newTestPluginsHandle(t),
 			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, 10, cfg.InitialShardCount)
 				assert.Equal(t, uint64(5000), cfg.MaxBytes)
 				assert.Equal(t, 1*time.Hour, cfg.FlowGCTimeout)
 				assert.Equal(t, 2*time.Hour, cfg.PriorityBandGCTimeout)
@@ -191,12 +188,6 @@ func TestNewConfig(t *testing.T) {
 		},
 
 		// --- Validation Errors (Global) ---
-		{
-			name:      "ShouldError_WhenInitialShardCountIsInvalid",
-			opts:      []ConfigOption{WithInitialShardCount(0)}, // Option itself should return error.
-			handle:    newTestPluginsHandle(t),
-			expectErr: true,
-		},
 		{
 			name:      "ShouldError_WhenFlowGCTimeoutIsInvalid",
 			opts:      []ConfigOption{WithFlowGCTimeout(-1 * time.Second)},

--- a/pkg/epp/flowcontrol/registry/connection.go
+++ b/pkg/epp/flowcontrol/registry/connection.go
@@ -31,13 +31,9 @@ type connection struct {
 
 var _ contracts.ActiveFlowConnection = &connection{}
 
-// Shards returns a stable snapshot of accessors for all internal state shards.
-func (c *connection) ActiveShards() []contracts.RegistryShard {
-	// Return a copy to ensure the caller cannot modify the registry's internal slice.
-	shardsCopy := make([]contracts.RegistryShard, 1)
-	shardsCopy[0] = c.registry.shard
-
-	return shardsCopy
+// GetShard returns the shard this connection is pinned to.
+func (c *connection) GetShard() contracts.RegistryShard {
+	return c.registry.shard
 }
 
 // FlowKey returns the immutable identity of the flow this connection is pinned to.

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -334,11 +334,9 @@ func (fr *FlowRegistry) Stats() contracts.AggregateStats {
 	return stats
 }
 
-// ShardStats returns a slice of statistics, one for each internal shard.
-func (fr *FlowRegistry) ShardStats() []contracts.ShardStats {
-	shardStats := make([]contracts.ShardStats, 1)
-	shardStats[0] = fr.shard.Stats()
-	return shardStats
+// ShardStats returns statistics for the internal shard.
+func (fr *FlowRegistry) ShardStats() *contracts.ShardStats {
+	return fr.shard.Stats()
 }
 
 // --- Garbage Collection ---

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -101,10 +101,11 @@ type FlowRegistry struct {
 	// add new keys safely.
 	perPriorityBandStats sync.Map
 
+	shard *registryShard
+
 	// --- Administrative state (protected by `mu`) ---
 
-	mu    sync.RWMutex
-	shard *registryShard
+	mu sync.RWMutex
 }
 
 var _ contracts.FlowRegistry = &FlowRegistry{}
@@ -254,12 +255,12 @@ func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error 
 	fr.mu.RLock()
 	defer fr.mu.RUnlock()
 
-	components, err := fr.buildFlowComponents(key, 1)
+	components, err := fr.buildFlowComponents(key)
 	if err != nil {
 		return err
 	}
 
-	fr.shard.synchronizeFlow(key, components[0].policy, components[0].queue)
+	fr.shard.synchronizeFlow(key, components.policy, components.queue)
 
 	fr.logger.V(logging.DEBUG).Info("JIT provisioned flow infrastructure", "flowKey", key)
 	return nil
@@ -439,34 +440,7 @@ func (fr *FlowRegistry) createShard() error {
 
 	// Prepare Shard Object (Infallible)
 	partitionedConfig := fr.config.partition(0, 1)
-	shard := newShard("shard-0", partitionedConfig, fr.logger, fr.propagateStatsDelta)
-
-	// Prepare All Components for All New Shards (Fallible):
-	// Pre-build every component for every existing flow on every new shard.
-	// If any single component fails to build, the entire scale-up operation is aborted, and all prepared data is
-	// discarded, leaving the system state clean.
-	allComponents := make(map[flowcontrol.FlowKey][]flowComponents)
-	var rangeErr error
-	fr.flowStates.Range(func(key, _ any) bool {
-		flowKey := key.(flowcontrol.FlowKey)
-		components, err := fr.buildFlowComponents(flowKey, 1)
-		if err != nil {
-			rangeErr = fmt.Errorf("failed to prepare components for flow %s on new shards: %w", flowKey, err)
-			return false
-		}
-		allComponents[flowKey] = components
-		return true
-	})
-	if rangeErr != nil {
-		return rangeErr
-	}
-
-	// Commit (Infallible):
-	for key, components := range allComponents {
-		shard.synchronizeFlow(key, components[0].policy, components[0].queue)
-	}
-	fr.shard = shard
-	fr.repartitionShardConfigsLocked()
+	fr.shard = newShard("shard-0", partitionedConfig, fr.logger, fr.propagateStatsDelta)
 	return nil
 }
 
@@ -486,23 +460,21 @@ type flowComponents struct {
 }
 
 // buildFlowComponents instantiates the necessary plugin components for a new flow instance.
-// It creates a distinct instance of each component for each shard to ensure state isolation.
-func (fr *FlowRegistry) buildFlowComponents(key flowcontrol.FlowKey, numInstances int) ([]flowComponents, error) {
+// It creates a distinct instance of each component to ensure state isolation.
+func (fr *FlowRegistry) buildFlowComponents(key flowcontrol.FlowKey) (*flowComponents, error) {
 	bandConfig, ok := fr.config.PriorityBands[key.Priority]
 	if !ok {
 		return nil, fmt.Errorf("priority band %d not found: %w", key.Priority, contracts.ErrPriorityBandNotFound)
 	}
 
-	allComponents := make([]flowComponents, numInstances)
-	for i := range numInstances {
-		q, err := queue.NewQueueFromName(bandConfig.Queue, bandConfig.OrderingPolicy)
-		if err != nil {
-			return nil, fmt.Errorf("failed to instantiate queue %q for flow %s: %w",
-				bandConfig.Queue, key, err)
-		}
-		allComponents[i] = flowComponents{policy: bandConfig.OrderingPolicy, queue: q}
+	q, err := queue.NewQueueFromName(bandConfig.Queue, bandConfig.OrderingPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to instantiate queue %q for flow %s: %w",
+			bandConfig.Queue, key, err)
 	}
-	return allComponents, nil
+	components := &flowComponents{policy: bandConfig.OrderingPolicy, queue: q}
+
+	return components, nil
 }
 
 // propagateStatsDelta is the top-level, lock-free aggregator for all statistics.

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -47,9 +47,8 @@ type registryTestHarness struct {
 
 // harnessOptions configures the test harness.
 type harnessOptions struct {
-	config            *Config
-	initialShardCount int
-	manualGC          bool
+	config   *Config
+	manualGC bool
 }
 
 // newRegistryTestHarness creates and starts a new `FlowRegistry` for testing.
@@ -61,18 +60,9 @@ func newRegistryTestHarness(t *testing.T, opts harnessOptions) *registryTestHarn
 
 	if opts.config != nil {
 		cfg = opts.config.Clone()
-		if opts.initialShardCount > 0 {
-			cfg.InitialShardCount = opts.initialShardCount
-		}
 	} else {
-		shardCount := 1
-		if opts.initialShardCount > 0 {
-			shardCount = opts.initialShardCount
-		}
-
 		cfg, err = NewConfig(
 			newTestPluginsHandle(t),
-			WithInitialShardCount(shardCount),
 			WithFlowGCTimeout(5*time.Minute),
 			WithPriorityBand(&PriorityBandConfig{Priority: highPriority}),
 			WithPriorityBand(&PriorityBandConfig{Priority: lowPriority}),
@@ -206,20 +196,16 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 
 	t.Run("Handle_Shards_ShouldReturnAllActiveShardsAndBeACopy", func(t *testing.T) {
 		t.Parallel()
-		// Create a registry with one shard.
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+		// Create a registry
+		h := newRegistryTestHarness(t, harnessOptions{})
 		require.NotNil(t, h.fr.shard, "Test setup: should have one shard")
 
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: highPriority}
 
 		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
-			shards := conn.ActiveShards()
+			shard := conn.GetShard()
 
-			assert.Len(t, shards, 1, "ActiveShards() must only return the Active shards")
-
-			// Assert it's a copy by maliciously modifying it.
-			require.NotEmpty(t, shards, "Test setup assumes shards are present")
-			shards[0] = nil // Modify the local copy.
+			assert.NotNil(t, shard, "GetShard() must never return nil")
 
 			return nil
 		})
@@ -236,7 +222,7 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 func TestFlowRegistry_Stats(t *testing.T) {
 	t.Parallel()
 
-	h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+	h := newRegistryTestHarness(t, harnessOptions{})
 	keyHigh := flowcontrol.FlowKey{ID: "high-pri-flow", Priority: highPriority}
 	keyLow := flowcontrol.FlowKey{ID: "low-pri-flow", Priority: lowPriority}
 	h.openConnectionOnFlow(keyHigh)
@@ -257,17 +243,16 @@ func TestFlowRegistry_Stats(t *testing.T) {
 	assert.Equal(t, uint64(40), globalStats.TotalByteSize, "Global TotalByteSize should be the sum of all item sizes")
 
 	shardStats := h.fr.ShardStats()
-	require.Len(t, shardStats, 1, "Should return stats for one shard")
 	var totalShardLen, totalShardBytes uint64
-	for _, ss := range shardStats {
-		assert.True(t, ss.IsActive, "All shards should be active in this test")
-		assert.NotEmpty(t, ss.PerPriorityBandStats, "Each shard should have stats for its priority bands")
-		assert.NotEmpty(t, ss.ID, "Each shard should have a non-empty ID")
-		totalShardLen += ss.TotalLen
-		totalShardBytes += ss.TotalByteSize
-	}
-	assert.Equal(t, globalStats.TotalLen, totalShardLen, "Sum of shard lengths must equal global length")
-	assert.Equal(t, globalStats.TotalByteSize, totalShardBytes, "Sum of shard byte sizes must equal global byte size")
+
+	assert.True(t, shardStats.IsActive, "The shard should be active in this test")
+	assert.NotEmpty(t, shardStats.PerPriorityBandStats, "The shard should have stats for its priority bands")
+	assert.NotEmpty(t, shardStats.ID, "The shard should have a non-empty ID")
+	totalShardLen += shardStats.TotalLen
+	totalShardBytes += shardStats.TotalByteSize
+
+	assert.Equal(t, globalStats.TotalLen, totalShardLen, "The shard length must equal global length")
+	assert.Equal(t, globalStats.TotalByteSize, totalShardBytes, "The shard byte size must equal global byte size")
 }
 
 // --- Garbage Collection Tests ---
@@ -368,8 +353,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 
 	t.Run("ShouldCreateBand_WhenPriorityIsUnknown", func(t *testing.T) {
 		t.Parallel()
-		// Start with 2 shards to ensure propagation works across the cluster.
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		h := newRegistryTestHarness(t, harnessOptions{})
 		dynamicPrio := 55
 		key := flowcontrol.FlowKey{ID: "dynamic-flow", Priority: dynamicPrio}
 
@@ -394,7 +378,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 
 	t.Run("ShouldHandleConcurrentDynamicCreation", func(t *testing.T) {
 		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		h := newRegistryTestHarness(t, harnessOptions{})
 		dynamicPrio := 77
 		key := flowcontrol.FlowKey{ID: "race-flow", Priority: dynamicPrio}
 
@@ -419,7 +403,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 
 	t.Run("ShouldPersistDynamicBands", func(t *testing.T) {
 		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+		h := newRegistryTestHarness(t, harnessOptions{})
 		dynamicPrio := 88
 		key := flowcontrol.FlowKey{ID: "scaling-flow", Priority: dynamicPrio}
 
@@ -636,7 +620,7 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 
 	t.Run("ShouldDeleteDynamicBandFromAllShards", func(t *testing.T) {
 		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+		h := newRegistryTestHarness(t, harnessOptions{})
 
 		// Create a dynamic priority band via JIT provisioning
 		err := h.fr.ensurePriorityBand(dynamicPrio)
@@ -831,7 +815,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 	t.Run("ShouldCollectBand_AcrossMultipleShards", func(t *testing.T) {
 		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+		h := newRegistryTestHarness(t, harnessOptions{})
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: dynamicPrio}
 
 		// Create flow on all shards

--- a/pkg/epp/flowcontrol/registry/shard.go
+++ b/pkg/epp/flowcontrol/registry/shard.go
@@ -52,6 +52,9 @@ type priorityBand struct {
 	// The priority is implicit from the parent priorityBand.
 	queues map[string]*managedQueue
 
+	// priorityBandAccessor is a preallocated flowcontrol.PriorityBandAccessor for this priorityBand
+	priorityBandAccessor *priorityBandAccessor
+
 	// --- Concurrent-Safe State (Atomics) ---
 
 	// Band-level statistics, updated via lock-free propagation from child queues.
@@ -149,6 +152,7 @@ func (s *registryShard) initPriorityBand(bandConfig *PriorityBandConfig) {
 		fairnessPolicy: bandConfig.FairnessPolicy,
 		policyState:    policyState,
 	}
+	band.priorityBandAccessor = &priorityBandAccessor{shard: s, band: band}
 	s.priorityBands.Store(bandConfig.Priority, band)
 	s.orderedPriorityLevels = append(s.orderedPriorityLevels, bandConfig.Priority)
 	sort.Slice(s.orderedPriorityLevels, func(i, j int) bool {
@@ -247,7 +251,7 @@ func (s *registryShard) PriorityBandAccessor(priority int) (flowcontrol.Priority
 			priority, contracts.ErrPriorityBandNotFound)
 	}
 	band := val.(*priorityBand)
-	return &priorityBandAccessor{shard: s, band: band}, nil
+	return band.priorityBandAccessor, nil
 }
 
 // AllOrderedPriorityLevels returns a snapshot of all configured priority levels for this shard,

--- a/pkg/epp/flowcontrol/registry/shard.go
+++ b/pkg/epp/flowcontrol/registry/shard.go
@@ -266,7 +266,7 @@ func (s *registryShard) AllOrderedPriorityLevels() []int {
 // Note on Concurrency: Statistics are aggregated using high-performance, lock-free atomic updates.
 // The returned stats represent a near-consistent snapshot. We acquire a Read Lock to ensure that
 // configuration metadata (like names and capacity limits) remains stable during the iteration.
-func (s *registryShard) Stats() contracts.ShardStats {
+func (s *registryShard) Stats() *contracts.ShardStats {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -293,7 +293,7 @@ func (s *registryShard) Stats() contracts.ShardStats {
 		}
 		return true
 	})
-	return stats
+	return &stats
 }
 
 //  --- Internal Administrative/Lifecycle Methods ---


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR is the second step in a process of simplifying the Flow Control component's code base.

In particular this PR:
   1. Removes the number of shards from the FlowControl configuration
       **Note:** The number of shards was never externally exposed to the user.
   2. Implements suggested changes and simplification from the review of the previous PR
   3. Eliminates. various slices of shards that were in the code.
   4. Pre-allocates the priorityBandAccessor rather than constantly creating a new one.

**Note:** The previous PR mentioned above was an Inference-Gateway PR that was previously merged.

**Which issue(s) this PR fixes**:
Refs #889

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
