### PR TITLE
refactor: align eviction plugin Type names with naming conventions

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/eviction/filtering/sheddable.go
+++ b/pkg/epp/framework/plugins/flowcontrol/eviction/filtering/sheddable.go
@@ -26,7 +26,7 @@ import (
 
 // SheddableFilterType only admits sheddable requests (priority < 0) into the eviction queue.
 // This uses the project-wide definition of sheddable from requtil.IsSheddable.
-const SheddableFilterType = "eviction-sheddable-filter"
+const SheddableFilterType = "sheddable-eviction-filter"
 
 func init() {
 	plugin.Register(SheddableFilterType, SheddableFilterFactory)

--- a/pkg/epp/framework/plugins/flowcontrol/eviction/ordering/priority_time.go
+++ b/pkg/epp/framework/plugins/flowcontrol/eviction/ordering/priority_time.go
@@ -25,7 +25,7 @@ import (
 
 // PriorityThenTimeOrderingType evicts the lowest priority request first,
 // breaking ties by newest dispatch time (least KV-cache investment).
-const PriorityThenTimeOrderingType = "eviction-priority-then-time-ordering"
+const PriorityThenTimeOrderingType = "priority-then-time-eviction-order-policy"
 
 func init() {
 	plugin.Register(PriorityThenTimeOrderingType, PriorityThenTimeOrderingFactory)


### PR DESCRIPTION
Fixes #893.

Renames the two eviction plugin Type strings to match the suffix conventions @ahg-g requested in the issue:

- Eviction filters use the `-eviction-filter` suffix (distinct from endpoint filters, which use `-filter`).
- Eviction ordering plugins use the `-eviction-order-policy` suffix.

Changes:
- `eviction-sheddable-filter` → `sheddable-eviction-filter`
- `eviction-priority-then-time-ordering` → `priority-then-time-eviction-order-policy`

Only the constant string values change; the Go identifiers (`SheddableFilterType`, `PriorityThenTimeOrderingType`) and the tests are unchanged since they reference the constants by name.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./pkg/...` all pass
- Skipped: `test/e2e`, `test/sidecar/e2e`, `test/profiling/tokenizerbench` (require a live K8s cluster + running EPP)