### PR TITLE
refactor(datalayer): simplify Collector lifecycle, add error metrics

### DIFF
--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -41,8 +41,6 @@ const (
 	defaultCollectionTimeout = time.Second
 )
 
-var collectorLogger = log.Log.WithName("datalayer-collector")
-
 // Ticker implements a time source for periodic invocation.
 // The Ticker is passed in as parameter a Collector to allow control over time
 // progress in tests, ensuring tests are deterministic and fast.
@@ -69,15 +67,20 @@ func (t *TimeTicker) Channel() <-chan time.Time {
 }
 
 // Collector runs data collection for a single endpoint.
+//
+// Lifecycle contract: any in-flight write the collection goroutine performs
+// against the endpoint completes before Stop returns. Callers may therefore
+// mutate or release endpoint state immediately after Stop returns without
+// racing the collection goroutine.
 type Collector struct {
-	mu      sync.Mutex
-	cancel  context.CancelFunc
-	stopped bool
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 // NewCollector returns a new collector.
 func NewCollector() *Collector {
-	return &Collector{}
+	return &Collector{done: make(chan struct{})}
 }
 
 // Start launches the collection goroutine.
@@ -115,27 +118,22 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 	return nil
 }
 
-// Stop signals the collection goroutine to exit. Idempotent.
+// Stop cancels the collection goroutine and blocks until it has exited. Idempotent.
 func (c *Collector) Stop() {
-	var msg string
 	c.mu.Lock()
-	switch {
-	case c.cancel == nil:
-		msg = "Stop called before successful Start"
-	case c.stopped:
-		msg = "Stop called more than once"
-	default:
-		c.stopped = true
-		c.cancel()
-	}
+	cancel := c.cancel
 	c.mu.Unlock()
-	if msg != "" {
-		collectorLogger.Info(msg)
+	if cancel != nil {
+		cancel()
+		<-c.done
 	}
 }
 
 func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.Extractor) {
-	defer ticker.Stop()
+	defer func() {
+		close(c.done)
+		ticker.Stop()
+	}()
 	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().GetIPAddress())
 
 	for {
@@ -157,8 +155,8 @@ func (c *Collector) pollOne(ctx context.Context, src fwkdl.PollingDataSource, ep
 	tn := src.TypedName()
 
 	pollCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
+	defer cancel()
 	data, err := src.Poll(pollCtx, ep)
-	cancel()
 	if err != nil {
 		metrics.DataLayerPollErrorsTotal.WithLabelValues(tn.Type).Inc()
 		logger.V(logging.DEBUG).Info("poll failed", "source", tn, "err", err)

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
 )
 
 // TODO:
@@ -39,6 +40,8 @@ import (
 const (
 	defaultCollectionTimeout = time.Second
 )
+
+var collectorLogger = log.Log.WithName("datalayer-collector")
 
 // Ticker implements a time source for periodic invocation.
 // The Ticker is passed in as parameter a Collector to allow control over time
@@ -65,163 +68,117 @@ func (t *TimeTicker) Channel() <-chan time.Time {
 	return t.C
 }
 
-// Collector runs the data collection for a single endpoint.
+// Collector runs data collection for a single endpoint.
 type Collector struct {
-	// per-endpoint context and cancellation
-	ctx    context.Context
-	cancel context.CancelFunc
-
-	// goroutine management
-	startOnce sync.Once
-	stopOnce  sync.Once
-
-	// done is closed when the collection goroutine exits, allowing Stop to block until it is safe
-	// to inspect internal state (e.g., in tests).
-	done chan struct{}
-
-	// lastPollErrors and lastExtractErrors track the last error per source/extractor
-	// for change-only logging. Only accessed from the collection goroutine — no synchronization required.
-	lastPollErrors    map[string]error
-	lastExtractErrors map[string]error
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	stopped bool
 }
 
 // NewCollector returns a new collector.
 func NewCollector() *Collector {
-	return &Collector{
-		done:              make(chan struct{}),
-		lastPollErrors:    make(map[string]error),
-		lastExtractErrors: make(map[string]error),
-	}
+	return &Collector{}
 }
 
-// Start initiates data source collection for the endpoint.
-// All sources must implement PollingDataSource. Validation is performed by the caller.
+// Start launches the collection goroutine.
 func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.ExtractorBase) error {
-	// Validate sources slice is not empty
 	if len(pollers) == 0 {
 		return errors.New("cannot start collector with empty sources")
 	}
-
 	for _, src := range pollers {
 		if src == nil {
 			return errors.New("cannot add nil data source")
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
-	return c.startCollection(ctx, ticker, ep, pollers, extractors)
-}
-
-func (c *Collector) startCollection(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.ExtractorBase) error {
-	var ready chan struct{}
-	started := false
-
-	// Pre-compute poll-based extractors upfront to avoid repeated type assertions in the hot loop.
+	// Filter to poll-capable extractors up front so the hot loop avoids per-tick type assertions.
 	pollingExtractors := make(map[string][]fwkdl.Extractor, len(extractors))
 	for name, exts := range extractors {
 		for _, ext := range exts {
-			if poller, ok := ext.(fwkdl.Extractor); ok {
-				pollingExtractors[name] = append(pollingExtractors[name], poller)
+			if e, ok := ext.(fwkdl.Extractor); ok {
+				pollingExtractors[name] = append(pollingExtractors[name], e)
 			}
 		}
 	}
 
-	c.startOnce.Do(func() {
-		logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().GetIPAddress())
-		c.ctx, c.cancel = context.WithCancel(ctx)
-		started = true
-		ready = make(chan struct{})
-
-		go func(endpoint fwkdl.Endpoint, sources []fwkdl.PollingDataSource, exts map[string][]fwkdl.Extractor) {
-			logger.V(logging.DEFAULT).Info("starting collection")
-
-			defer func() {
-				logger.V(logging.DEFAULT).Info("terminating collection")
-				ticker.Stop()
-				close(c.done)
-			}()
-
-			close(ready) // signal ready to accept ticks
-
-			for {
-				select {
-				case <-c.ctx.Done(): // per endpoint context cancelled
-					return
-				case <-ticker.Channel():
-					for _, src := range sources {
-						tn := src.TypedName()
-						key := tn.String()
-
-						ctx, cancel := context.WithTimeout(c.ctx, defaultCollectionTimeout)
-						data, err := src.Poll(ctx, endpoint)
-						cancel()
-
-						logErrorTransition(logger, c.lastPollErrors, key, "poll", "source", err)
-						if err != nil {
-							continue
-						}
-
-						if srcExtractors, ok := exts[tn.Name]; ok && data != nil {
-							for _, ext := range srcExtractors {
-								extKey := ext.TypedName().String()
-								extErr := ext.Extract(ctx, data, endpoint)
-								logErrorTransition(logger, c.lastExtractErrors, extKey, "extract", "extractor", extErr)
-							}
-						}
-					}
-				}
-			}
-		}(ep, pollers, pollingExtractors)
-	})
-
-	if !started {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
 		return errors.New("collector start called multiple times")
 	}
-
-	// Wait for goroutine to signal readiness.
-	// The use of ready channel is mostly to make the function testable, by ensuring
-	// synchronous order of events. Ignoring test requirements, one could let the
-	// go routine start at some arbitrary point in the future, possibly after this
-	// function has returned.
-	select {
-	case <-ready:
-		return nil
-	case <-ctx.Done():
-		if c.cancel != nil {
-			c.cancel() // ensure clean up
-		}
-		return ctx.Err()
-	}
-}
-
-// Stop terminates the collector and waits for the collection goroutine to exit.
-func (c *Collector) Stop() error {
-	if c.ctx == nil || c.cancel == nil {
-		return errors.New("collector stop called before start")
-	}
-
-	stopped := false
-	c.stopOnce.Do(func() {
-		stopped = true
-		c.cancel()
-	})
-
-	if !stopped {
-		return errors.New("collector stop called multiple times")
-	}
-	<-c.done
+	ctx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+	go c.run(ctx, ticker, ep, pollers, pollingExtractors)
 	return nil
 }
 
-// logErrorTransition logs only when the error state transitions (nil→non-nil or non-nil→nil).
-// errs is updated in place. verb is the operation name ("poll"/"extract"); fieldName is the log key.
-func logErrorTransition(logger logr.Logger, errs map[string]error, key, verb, fieldName string, err error) {
-	prev, seen := errs[key]
-	if (err != nil) != (seen && prev != nil) {
-		if err != nil {
-			logger.Error(err, verb+" failed", fieldName, key)
-		} else {
-			logger.V(logging.DEFAULT).Info(verb+" recovered", fieldName, key)
+// Stop signals the collection goroutine to exit. Idempotent.
+func (c *Collector) Stop() {
+	var msg string
+	c.mu.Lock()
+	switch {
+	case c.cancel == nil:
+		msg = "Stop called before successful Start"
+	case c.stopped:
+		msg = "Stop called more than once"
+	default:
+		c.stopped = true
+		c.cancel()
+	}
+	c.mu.Unlock()
+	if msg != "" {
+		collectorLogger.Info(msg)
+	}
+}
+
+func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.Extractor) {
+	defer ticker.Stop()
+	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().GetIPAddress())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.Channel():
+			for _, src := range pollers {
+				if ctx.Err() != nil {
+					return
+				}
+				c.pollOne(ctx, src, ep, extractors, logger)
+			}
 		}
-		errs[key] = err
+	}
+}
+
+func (c *Collector) pollOne(ctx context.Context, src fwkdl.PollingDataSource, ep fwkdl.Endpoint, extractors map[string][]fwkdl.Extractor, logger logr.Logger) {
+	tn := src.TypedName()
+
+	pollCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
+	data, err := src.Poll(pollCtx, ep)
+	cancel()
+	if err != nil {
+		metrics.DataLayerPollErrorsTotal.WithLabelValues(tn.Type).Inc()
+		logger.V(logging.DEBUG).Info("poll failed", "source", tn, "err", err)
+		return
+	}
+	if data == nil {
+		return
+	}
+
+	for _, ext := range extractors[tn.Name] {
+		if ctx.Err() != nil {
+			return
+		}
+		extCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
+		err := ext.Extract(extCtx, data, ep)
+		cancel()
+		if err != nil {
+			extName := ext.TypedName()
+			metrics.DataLayerExtractErrorsTotal.WithLabelValues(tn.Type, extName.Type).Inc()
+			logger.V(logging.DEBUG).Info("extract failed", "source", tn, "extractor", extName, "err", err)
+		}
 	}
 }

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -19,42 +19,23 @@ package datalayer
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer/mocks"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	plugininterface "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	datasourcemocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
 )
-
-// errSource is a test stub that returns a configurable error from Poll.
-// The error is guarded by a mutex so it can safely be changed between ticks.
-type errSource struct {
-	datasourcemocks.MetricsDataSource
-	mu  sync.Mutex
-	err error
-}
-
-func (e *errSource) setErr(err error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.err = err
-}
-
-func (e *errSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
-	atomic.AddInt64(&e.CallCount, 1)
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return nil, e.err
-}
-
-// --- Test Stubs ---
 
 func defaultEndpoint() fwkdl.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
@@ -64,175 +45,282 @@ func defaultEndpoint() fwkdl.Endpoint {
 		},
 		Address: "1.2.3.4:5678",
 	}
-	ms := fwkdl.NewEndpoint(meta, nil)
-	return ms
+	return fwkdl.NewEndpoint(meta, nil)
 }
-
-// --- Tests ---
 
 var (
 	endpoint = defaultEndpoint()
 	sources  = []fwkdl.PollingDataSource{&datasourcemocks.MetricsDataSource{}}
 )
 
+type errSource struct {
+	datasourcemocks.MetricsDataSource
+	kind string
+	err  error
+}
+
+func (e *errSource) TypedName() plugininterface.TypedName {
+	return plugininterface.TypedName{Type: e.kind, Name: e.kind}
+}
+
+func (e *errSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
+	atomic.AddInt64(&e.CallCount, 1)
+	return nil, e.err
+}
+
+type dataSource struct {
+	datasourcemocks.MetricsDataSource
+	kind string
+}
+
+func (d *dataSource) TypedName() plugininterface.TypedName {
+	return plugininterface.TypedName{Type: d.kind, Name: d.kind}
+}
+
+func (d *dataSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
+	atomic.AddInt64(&d.CallCount, 1)
+	return struct{}{}, nil
+}
+
+type stubExtractor struct {
+	kind string
+	err  error
+}
+
+func (s *stubExtractor) TypedName() plugininterface.TypedName {
+	return plugininterface.TypedName{Type: s.kind, Name: s.kind}
+}
+func (s *stubExtractor) ExpectedInputType() reflect.Type                          { return reflect.TypeFor[any]() }
+func (s *stubExtractor) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error { return s.err }
+
+func TestCollectorStartInputs(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctxCanceled bool
+		sources     []fwkdl.PollingDataSource
+		wantErr     bool
+		wantErrIs   error
+	}{
+		{name: "valid sources, live ctx", sources: sources},
+		{name: "empty sources", sources: []fwkdl.PollingDataSource{}, wantErr: true},
+		{name: "nil source", sources: []fwkdl.PollingDataSource{nil}, wantErr: true},
+		{name: "cancelled parent ctx", ctxCanceled: true, sources: sources, wantErr: true, wantErrIs: context.Canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.ctxCanceled {
+				cancel()
+			}
+
+			c := NewCollector()
+			ticker := mocks.NewTicker()
+			err := c.Start(ctx, ticker, endpoint, tt.sources, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(t, err, tt.wantErrIs)
+				}
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil),
+					"retry after failed Start should succeed")
+			} else {
+				require.NoError(t, err)
+			}
+			c.Stop()
+		})
+	}
+}
+
 func TestCollectorCanStartOnlyOnce(t *testing.T) {
 	c := NewCollector()
-	ctx := context.Background()
 	ticker := mocks.NewTicker()
-
-	err := c.Start(ctx, ticker, endpoint, sources, nil)
-	require.NoError(t, err, "first Start call should succeed")
-
-	err = c.Start(ctx, ticker, endpoint, sources, nil)
-	assert.Error(t, err, "multiple collector start should error")
-}
-
-func TestCollectorStopBeforeStartIsAnError(t *testing.T) {
-	c := NewCollector()
-	err := c.Stop()
-	assert.Error(t, err, "collector stop called before start should error")
-}
-
-func TestCollectorCanStopOnlyOnce(t *testing.T) {
-	c := NewCollector()
 	ctx := context.Background()
-	ticker := mocks.NewTicker()
 
 	require.NoError(t, c.Start(ctx, ticker, endpoint, sources, nil))
-	require.NoError(t, c.Stop(), "first Stop should succeed")
-	assert.Error(t, c.Stop(), "second Stop should fail")
+	assert.Error(t, c.Start(ctx, ticker, endpoint, sources, nil),
+		"second Start after success should error")
+	c.Stop()
 }
 
-func TestCollectorCollectsOnTicks(t *testing.T) {
-	source := &datasourcemocks.MetricsDataSource{}
-	c := NewCollector()
-	ticker := mocks.NewTicker()
-	ctx := context.Background()
-
-	require.NoError(t, c.Start(ctx, ticker, endpoint, []fwkdl.PollingDataSource{source}, nil))
-	ticker.Tick()
-	ticker.Tick()
-
-	// use Eventually for async processing
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt64(&source.CallCount) == 2
-	}, 1*time.Second, 2*time.Millisecond, "expected 2 collections")
-
-	require.NoError(t, c.Stop())
-}
-
-func TestCollectorStopCancelsContext(t *testing.T) {
-	source := &datasourcemocks.MetricsDataSource{}
-	c := NewCollector()
-	ticker := mocks.NewTicker()
-	ctx := context.Background()
-
-	require.NoError(t, c.Start(ctx, ticker, endpoint, []fwkdl.PollingDataSource{source}, nil))
-	ticker.Tick() // should be processed
-	time.Sleep(20 * time.Millisecond)
-
-	require.NoError(t, c.Stop())
-	before := atomic.LoadInt64(&source.CallCount)
-
-	ticker.Tick()
-	time.Sleep(20 * time.Millisecond) // let collector run again
-	after := atomic.LoadInt64(&source.CallCount)
-	assert.Equal(t, before, after, "call count changed after stop")
-}
-
-func TestCollectorStartSourceValidation(t *testing.T) {
+func TestCollectorStop(t *testing.T) {
 	tests := []struct {
-		name    string
-		sources []fwkdl.PollingDataSource
-		wantErr bool
+		name  string
+		setup func(t *testing.T) *Collector
 	}{
 		{
-			name:    "empty sources returns error",
-			sources: []fwkdl.PollingDataSource{},
-			wantErr: true,
+			name:  "before any Start",
+			setup: func(t *testing.T) *Collector { return NewCollector() },
 		},
 		{
-			name:    "nil source returns error",
-			sources: []fwkdl.PollingDataSource{nil},
-			wantErr: true,
+			name: "after failed Start",
+			setup: func(t *testing.T) *Collector {
+				c := NewCollector()
+				ticker := mocks.NewTicker()
+				_ = c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{}, nil)
+				return c
+			},
 		},
 		{
-			name:    "valid polling source succeeds",
-			sources: []fwkdl.PollingDataSource{&datasourcemocks.MetricsDataSource{}},
+			name: "after successful Start",
+			setup: func(t *testing.T) *Collector {
+				c := NewCollector()
+				ticker := mocks.NewTicker()
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil))
+				return c
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewCollector()
-			ticker := mocks.NewTicker()
-			ctx := context.Background()
-
-			err := c.Start(ctx, ticker, endpoint, tt.sources, nil)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				require.NoError(t, c.Stop())
-			}
+			c := tt.setup(t)
+			c.Stop()
+			c.Stop()
+			c.Stop()
 		})
 	}
 }
 
-func TestCollectorLogsFirstPollError(t *testing.T) {
-	pollErr := errors.New("metric family not found")
-	src := &errSource{err: pollErr}
+// TestCollectorCollectsOnTicks confirms ticks drive Poll calls.
+func TestCollectorCollectsOnTicks(t *testing.T) {
+	source := &datasourcemocks.MetricsDataSource{}
 	c := NewCollector()
 	ticker := mocks.NewTicker()
-	ctx := context.Background()
 
-	require.NoError(t, c.Start(ctx, ticker, endpoint, []fwkdl.PollingDataSource{src}, nil))
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{source}, nil))
+	defer c.Stop()
 
-	ticker.Tick()
 	ticker.Tick()
 	ticker.Tick()
 
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt64(&src.CallCount) == 3
-	}, 1*time.Second, 2*time.Millisecond, "expected 3 poll calls")
-
-	require.NoError(t, c.Stop()) // Stop waits for the goroutine to exit
-
-	// Error is recorded exactly once regardless of how many ticks delivered it.
-	key := src.TypedName().String()
-	require.Len(t, c.lastPollErrors, 1, "expected exactly one error state entry")
-	assert.Equal(t, pollErr, c.lastPollErrors[key])
+		return atomic.LoadInt64(&source.CallCount) == 2
+	}, 1*time.Second, 2*time.Millisecond, "expected 2 collections")
 }
 
-func TestCollectorLogsRecoveryAfterError(t *testing.T) {
-	pollErr := errors.New("transient error")
-	src := &errSource{err: pollErr}
+// TestCollectorErrorMetrics confirms Poll/Extract errors increment per-event
+// counters (no transition dedup) and successes do not.
+func TestCollectorErrorMetrics(t *testing.T) {
+	pollErr := errors.New("poll boom")
+	extErr := errors.New("extract boom")
+
+	tests := []struct {
+		name          string
+		srcType       string
+		srcErr        error // if non-nil, source.Poll returns it
+		extType       string
+		extErr        error // if extType set and this non-nil, extractor.Extract returns it
+		ticks         int
+		wantPollDelta float64
+		wantExtDelta  float64
+	}{
+		{
+			name:          "poll errors increment per tick",
+			srcType:       "table-poll-err",
+			srcErr:        pollErr,
+			ticks:         3,
+			wantPollDelta: 3,
+		},
+		{
+			name:         "extract errors increment per tick",
+			srcType:      "table-ext-src",
+			extType:      "table-ext-err",
+			extErr:       extErr,
+			ticks:        2,
+			wantExtDelta: 2,
+		},
+		{
+			name:    "success records nothing",
+			srcType: "table-success-src",
+			extType: "table-success-ext",
+			ticks:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var src fwkdl.PollingDataSource
+			if tt.srcErr != nil {
+				src = &errSource{kind: tt.srcType, err: tt.srcErr}
+			} else {
+				src = &dataSource{kind: tt.srcType}
+			}
+
+			var extractors map[string][]fwkdl.ExtractorBase
+			if tt.extType != "" {
+				ext := &stubExtractor{kind: tt.extType, err: tt.extErr}
+				extractors = map[string][]fwkdl.ExtractorBase{src.TypedName().Name: {ext}}
+			}
+
+			pollBefore := testutil.ToFloat64(metrics.DataLayerPollErrorsTotal.WithLabelValues(tt.srcType))
+			var extBefore float64
+			if tt.extType != "" {
+				extBefore = testutil.ToFloat64(metrics.DataLayerExtractErrorsTotal.WithLabelValues(tt.srcType, tt.extType))
+			}
+
+			c := NewCollector()
+			ticker := mocks.NewTicker()
+			require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{src}, extractors))
+			defer c.Stop()
+
+			for i := 0; i < tt.ticks; i++ {
+				ticker.Tick()
+			}
+
+			require.Eventually(t, func() bool {
+				gotPoll := testutil.ToFloat64(metrics.DataLayerPollErrorsTotal.WithLabelValues(tt.srcType)) - pollBefore
+				if gotPoll != tt.wantPollDelta {
+					return false
+				}
+				if tt.extType != "" {
+					gotExt := testutil.ToFloat64(metrics.DataLayerExtractErrorsTotal.WithLabelValues(tt.srcType, tt.extType)) - extBefore
+					if gotExt != tt.wantExtDelta {
+						return false
+					}
+				}
+				// For success case, also verify polls actually happened (otherwise
+				// the deltas being zero is trivially satisfied).
+				if d, ok := src.(*dataSource); ok && atomic.LoadInt64(&d.CallCount) < int64(tt.ticks) {
+					return false
+				}
+				return true
+			}, 1*time.Second, 5*time.Millisecond, "expected counter deltas to settle")
+		})
+	}
+}
+
+// TestCollectorRapidStartStopRaceFree simulates the Runtime's pattern of
+// ReleaseEndpoint immediately followed by NewEndpoint for the same key.
+// Stop returns asynchronously, so a fresh Collector's goroutine may briefly
+// coexist with a prior Collector's goroutine still exiting. -race surfaces
+// any data race in the lifecycle.
+func TestCollectorRapidStartStopRaceFree(t *testing.T) {
+	src := &datasourcemocks.MetricsDataSource{}
+	for i := 0; i < 100; i++ {
+		c := NewCollector()
+		ticker := mocks.NewTicker()
+		require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{src}, nil))
+		ticker.Tick()
+		c.Stop()
+	}
+}
+
+// TestCollectorConcurrentStopRaceFree drives multiple Stop calls in parallel
+// to verify the cancel field's mutex serializes them.
+func TestCollectorConcurrentStopRaceFree(t *testing.T) {
 	c := NewCollector()
 	ticker := mocks.NewTicker()
-	ctx := context.Background()
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil))
 
-	require.NoError(t, c.Start(ctx, ticker, endpoint, []fwkdl.PollingDataSource{src}, nil))
-
-	// Two ticks with an error.
-	ticker.Tick()
-	ticker.Tick()
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt64(&src.CallCount) == 2
-	}, 1*time.Second, 2*time.Millisecond, "expected 2 poll calls with error")
-
-	// Clear the error, then send more ticks.
-	src.setErr(nil)
-	ticker.Tick()
-	ticker.Tick()
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt64(&src.CallCount) == 4
-	}, 1*time.Second, 2*time.Millisecond, "expected 4 total poll calls after recovery")
-
-	require.NoError(t, c.Stop()) // Stop waits for the goroutine to exit
-
-	// After recovery the entry exists but holds nil.
-	key := src.TypedName().String()
-	entry, seen := c.lastPollErrors[key]
-	require.True(t, seen, "recovery should leave a nil entry in lastPollErrors")
-	assert.Nil(t, entry)
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Stop()
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -294,18 +294,6 @@ func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
 	return err
 }
 
-// Stop is called to terminate the Runtime's data collection. It terminates all
-// go routines used for polling data sources.
-func (r *Runtime) Stop() error {
-	r.collectors.Range(func(_, val any) bool {
-		if c, ok := val.(*Collector); ok {
-			_ = c.Stop()
-		}
-		return true
-	})
-	return nil
-}
-
 // NewEndpoint sets up data polling on the provided endpoint.
 func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.EndpointMetadata, _ PoolInfo) fwkdl.Endpoint {
 	// TODO: should we cache the sources and map after Configure? Or just replace with maps and Mutex?
@@ -364,7 +352,7 @@ func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 	key := ep.GetMetadata().GetNamespacedName()
 	if value, ok := r.collectors.LoadAndDelete(key); ok {
 		collector := value.(*Collector)
-		_ = collector.Stop()
+		collector.Stop()
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -45,11 +45,37 @@ var (
 		},
 		[]string{"model_name", "decision_type"},
 	)
+
+	// Data-layer counters: label values must be plugin TypedName.Type only —
+	// never per-instance or runtime-variable strings (cardinality).
+
+	DataLayerPollErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      "datalayer_poll_errors_total",
+			Help:      metrics.HelpMsgWithStability("Data-source poll errors per source type.", compbasemetrics.ALPHA),
+		},
+		[]string{"source_type"},
+	)
+
+	DataLayerExtractErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      "datalayer_extract_errors_total",
+			Help:      metrics.HelpMsgWithStability("Extract errors per source/extractor type.", compbasemetrics.ALPHA),
+		},
+		[]string{"source_type", "extractor_type"},
+	)
 )
 
 // GetCollectors returns all custom collectors for the llm-d-inference-scheduler.
 func GetCollectors() []prometheus.Collector {
-	return []prometheus.Collector{SchedulerPDDecisionCount, SchedulerDisaggDecisionCount}
+	return []prometheus.Collector{
+		SchedulerPDDecisionCount,
+		SchedulerDisaggDecisionCount,
+		DataLayerPollErrorsTotal,
+		DataLayerExtractErrorsTotal,
+	}
 }
 
 // RecordPDDecision increments the counter for a specific P/D routing decision.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind bug

**What this PR does / why we need it**:

Simplifies `datalayer.Collector` lifecycle and replaces in-binary error tracking with Prometheus counters.

- Drop stored `ctx`; goroutine captures it via closure. Mutex + cancel func replace `startOnce`/`stopOnce`/`done`.
- `Stop()` is fire-and-forget and idempotent; misuse logged. Shutdown flows through parent ctx cancellation.
- Per-call timeouts for both Poll and each Extract. Fixes a latent bug where Extract received an already-cancelled ctx.
- Bail on `ctx.Err()` between iterations.
- Remove `Runtime.Stop()`: unused.
- Replace error-state maps + transition log with `datalayer_poll_errors_total{source_type}` and `datalayer_extract_errors_total{source_type, extractor_type}`. Cardinality bounded by plugin Type.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
  
```release-note
  Add `datalayer_poll_errors_total` and `datalayer_extract_errors_total`
  Prometheus counters; remove transition-only error logging.
```