### PR TITLE
refactor(disagg): add PreRequest to disagg-profile-handler, deprecate disagg-headers-handler

### DIFF
--- a/deploy/config/pd-epp-config.yaml
+++ b/deploy/config/pd-epp-config.yaml
@@ -4,7 +4,6 @@ kind: EndpointPickerConfig
 featureGates:
 - prepareDataPlugins
 plugins:
-- type: disagg-headers-handler
 - type: prefix-cache-scorer
   parameters:
     maxPrefixBlocksToMatch: 256

--- a/deploy/config/sim-e-p-d-epp-config.yaml
+++ b/deploy/config/sim-e-p-d-epp-config.yaml
@@ -4,7 +4,6 @@ kind: EndpointPickerConfig
 featureGates:
 - prepareDataPlugins
 plugins:
-- type: disagg-headers-handler
 - type: queue-scorer
 - type: encode-filter
 - type: prefill-filter

--- a/deploy/config/sim-e-pd-epp-config.yaml
+++ b/deploy/config/sim-e-pd-epp-config.yaml
@@ -3,7 +3,6 @@
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: encode-filter
 - type: decode-filter
 - type: max-score-picker

--- a/deploy/config/sim-pd-epp-config.yaml
+++ b/deploy/config/sim-pd-epp-config.yaml
@@ -5,7 +5,6 @@ kind: EndpointPickerConfig
 featureGates:
 - prepareDataPlugins
 plugins:
-- type: disagg-headers-handler
 - type: prefix-cache-scorer
   parameters:
     blockSizeTokens: 16

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -277,7 +277,6 @@ plugins:
       maxPrefixBlocksToMatch: 256
       lruCapacityPerServer: 31250
   - type: max-score-picker
-  - type: disagg-headers-handler
   - type: prefix-based-pd-decider
     parameters:
       nonCachedTokens: 8
@@ -336,7 +335,6 @@ plugins:
       maxPrefixBlocksToMatch: 256
       lruCapacityPerServer: 31250
   - type: max-score-picker
-  - type: disagg-headers-handler
   - type: always-disagg-multimodal-decider
   - type: prefix-based-pd-decider
     parameters:

--- a/pkg/epp/framework/plugins/register.go
+++ b/pkg/epp/framework/plugins/register.go
@@ -24,9 +24,9 @@ func RegisterAllPlugins() {
 	plugin.Register(bylabel.EncodeRoleType, bylabel.EncodeRoleFactory)
 	plugin.Register(bylabel.DecodeRoleType, bylabel.DecodeRoleFactory)
 	plugin.Register(bylabel.PrefillRoleType, bylabel.PrefillRoleFactory)
-	plugin.Register(disagg.DisaggHeadersHandlerType, disagg.HeadersHandlerFactory)
-	// Legacy alias - existing YAML configs using prefill-header-handler continue to work.
-	plugin.Register(disagg.PrefillHeaderHandlerType, disagg.HeadersHandlerFactory) //nolint:staticcheck // intentional: keep backward compatibility (SA1019)
+	// Deprecated aliases — disagg-profile-handler now handles PreRequest natively.
+	plugin.Register(disagg.DisaggHeadersHandlerType, disagg.HeadersHandlerFactory) //nolint:staticcheck // intentional: keep backward compatibility
+	plugin.Register(disagg.PrefillHeaderHandlerType, disagg.HeadersHandlerFactory) //nolint:staticcheck // intentional: keep backward compatibility
 	plugin.Register(dataparallel.DataParallelProfileHandlerType, dataparallel.ProfileHandlerFactory)
 	plugin.Register(disagg.DisaggProfileHandlerType, disagg.HandlerFactory)
 	// Legacy aliases - existing YAML configs continue to work.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
@@ -1,6 +1,6 @@
 # Disaggregated Profile Handler, PreRequest, and Decider Plugins
 
-Plugins for disaggregated inference scheduling: a profile handler that selects the active stages: EPD (no disaggregation), P/D (Prefill/Decode), E/P/D (Encode/Prefill/Decode), or E/PD (Encode/Prefill-Decode), a headers handler that routes pods across stages, and decider plugins that control whether each disaggregation stage runs per request.
+Plugins for disaggregated inference scheduling: a profile handler that selects the active stages: EPD (no disaggregation), P/D (Prefill/Decode), E/P/D (Encode/Prefill/Decode), or E/PD (Encode/Prefill-Decode), legacy headers handlers (deprecated) kept for backward compatibility, and decider plugins that control whether each disaggregation stage runs per request.
 
 ## Contents
 
@@ -8,7 +8,7 @@ Plugins for disaggregated inference scheduling: a profile handler that selects t
   - [DisaggProfileHandler](#disaggprofilehandler)
   - [PdProfileHandler (Deprecated)](#pdprofilehandler-deprecated)
 - [PreRequest Plugins](#prerequest-plugins)
-  - [DisaggHeadersHandler](#disaggheadershandler)
+  - [DisaggHeadersHandler (Deprecated)](#disaggheadershandler-deprecated)
   - [PrefillHeaderHandler (Deprecated)](#prefillheaderhandler-deprecated)
 - [Decider Plugins](#decider-plugins)
   - [PrefixBasedPDDecider](#prefixbasedpddecider)
@@ -100,10 +100,16 @@ plugins:
 
 ## PreRequest Plugins
 
-### DisaggHeadersHandler
+### DisaggHeadersHandler (Deprecated)
 
 **Type:** `disagg-headers-handler`
 **Interfaces**: `requestcontrol.PreRequest`
+
+> **Deprecated:** Use `disagg-profile-handler` instead.
+>
+> `disagg-profile-handler` now implements `requestcontrol.PreRequest` natively.
+>
+> Planned removal: `v0.11`.
 
 Sets HTTP routing headers on the outgoing request so the inference proxy can forward prefill and encode work to the selected disaggregated pods.
 
@@ -152,7 +158,9 @@ plugins:
 **Type:** `prefill-header-handler`
 **Interfaces**: `requestcontrol.PreRequest`
 
-> **Deprecated:** Use `disagg-headers-handler` instead.
+> **Deprecated:** Use `disagg-profile-handler` instead.
+>
+> Planned removal: `v0.11`.
 
 ---
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
@@ -19,12 +19,14 @@ import (
 )
 
 const (
-	// DisaggHeadersHandlerType is the type of the HeadersHandler
+	// DisaggHeadersHandlerType is the type of the HeadersHandler.
+	//
+	// Deprecated: Use DisaggProfileHandlerType instead, disagg-profile-handler now implements PreRequest natively.
 	DisaggHeadersHandlerType = "disagg-headers-handler"
 
 	// PrefillHeaderHandlerType is a deprecated alias for DisaggHeadersHandlerType.
 	//
-	// Deprecated: use DisaggHeadersHandlerType instead.
+	// Deprecated: Use DisaggProfileHandlerType instead, disagg-profile-handler now implements PreRequest natively.
 	PrefillHeaderHandlerType = "prefill-header-handler"
 )
 
@@ -36,7 +38,9 @@ type disaggHeadersHandlerParameters struct {
 	EncodeProfile  string `json:"encodeProfile"`
 }
 
-// HeadersHandlerFactory defines the factory function for the HeadersHandler
+// HeadersHandlerFactory defines the factory function for the HeadersHandler.
+//
+// Deprecated: Use HandlerFactory instead, disagg-profile-handler now implements PreRequest natively.
 func HeadersHandlerFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	parameters := disaggHeadersHandlerParameters{
 		PrefillProfile: defaultPrefillProfile,
@@ -51,6 +55,8 @@ func HeadersHandlerFactory(name string, rawParameters json.RawMessage, _ plugin.
 }
 
 // NewHeadersHandler initializes a new HeadersHandler and returns its pointer.
+//
+// Deprecated: Use NewDisaggProfileHandler instead, disagg-profile-handler now implements PreRequest natively.
 func NewHeadersHandler(prefillProfile, encodeProfile string) *HeadersHandler {
 	return &HeadersHandler{
 		typedName:      plugin.TypedName{Type: DisaggHeadersHandlerType},
@@ -60,6 +66,8 @@ func NewHeadersHandler(prefillProfile, encodeProfile string) *HeadersHandler {
 }
 
 // HeadersHandler PreRequest plugin that sets both prefill and encode disaggregation headers.
+//
+// Deprecated: Use Handler instead, disagg-profile-handler now implements PreRequest natively.
 type HeadersHandler struct {
 	typedName      plugin.TypedName
 	prefillProfile string

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -6,13 +6,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	dl_prefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
@@ -187,8 +191,11 @@ func NewDisaggProfileHandler(decodeProfile, prefillProfile, encodeProfile string
 
 // ── Shared implementation ───────────────────────────────────────────────────
 
-// compile-time assertion
-var _ scheduling.ProfileHandler = &Handler{}
+// compile-time assertions
+var (
+	_ scheduling.ProfileHandler = &Handler{}
+	_ requestcontrol.PreRequest = &Handler{}
+)
 
 // Handler is the unified disaggregation profile handler.
 // It drives one or more of the following stages, each optional except decode:
@@ -344,4 +351,94 @@ func (h *Handler) ProcessResults(
 		PrimaryProfileName: h.decodeProfile,
 		ProfileResults:     updatedResults,
 	}, nil
+}
+
+// ── PreRequest ──────────────────────────────────────────────────────────────
+
+// PreRequest wires prefill and encode SchedulerProfile results into headers
+// so the sidecar knows which pods to contact for disaggregated work.
+func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+	tracer := telemetry.Tracer()
+	_, span := tracer.Start(ctx, "llm_d.epp.prerequest.disaggregation",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	if request == nil {
+		span.SetAttributes(
+			attribute.Bool("llm_d.epp.pd.disaggregation_used", false),
+			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
+			attribute.String("llm_d.epp.disagg.reason", "request_is_nil"),
+		)
+		return
+	}
+	if schedulingResult == nil {
+		span.SetAttributes(
+			attribute.Bool("llm_d.epp.pd.disaggregation_used", false),
+			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
+			attribute.String("llm_d.epp.disagg.reason", "scheduling_result_is_nil"),
+		)
+		return
+	}
+
+	if request.TargetModel != "" {
+		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
+	}
+	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
+
+	// Prefill header
+	delete(request.Headers, routing.PrefillEndpointHeader)
+	prefillProfileRunResult := schedulingResult.ProfileResults[h.prefillProfile]
+	switch {
+	case prefillProfileRunResult == nil:
+		span.SetAttributes(
+			attribute.Bool("llm_d.epp.pd.disaggregation_used", false),
+			attribute.String("llm_d.epp.pd.reason", "no_prefill_profile_result"),
+		)
+	case len(prefillProfileRunResult.TargetEndpoints) == 0:
+		span.SetAttributes(
+			attribute.Bool("llm_d.epp.pd.disaggregation_used", false),
+			attribute.String("llm_d.epp.pd.reason", "no_prefill_profile_target_endpoints"),
+		)
+	default:
+		targetPod := prefillProfileRunResult.TargetEndpoints[0].GetMetadata()
+		prefillHostPort := net.JoinHostPort(targetPod.Address, targetPod.Port)
+		request.Headers[routing.PrefillEndpointHeader] = prefillHostPort
+		span.SetAttributes(
+			attribute.Bool("llm_d.epp.pd.disaggregation_used", true),
+			attribute.String("llm_d.epp.pd.prefill_pod_address", targetPod.Address),
+			attribute.String("llm_d.epp.pd.prefill_pod_port", targetPod.Port),
+		)
+	}
+
+	// Encode header
+	delete(request.Headers, routing.EncoderEndpointsHeader)
+	encodeProfileRunResult := schedulingResult.ProfileResults[h.encodeProfile]
+	if encodeProfileRunResult == nil {
+		span.SetAttributes(
+			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
+			attribute.String("llm_d.epp.encode.reason", "no_encode_profile_result"),
+		)
+		return
+	}
+
+	var encodeHostPorts []string
+	for _, endpoint := range encodeProfileRunResult.TargetEndpoints {
+		targetEndpoint := endpoint.GetMetadata()
+		encodeHostPort := net.JoinHostPort(targetEndpoint.Address, targetEndpoint.Port)
+		encodeHostPorts = append(encodeHostPorts, encodeHostPort)
+	}
+	if len(encodeHostPorts) == 0 {
+		span.SetAttributes(
+			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
+			attribute.String("llm_d.epp.encode.reason", "no_encode_profile_target_endpoints"),
+		)
+		return
+	}
+
+	request.Headers[routing.EncoderEndpointsHeader] = strings.Join(encodeHostPorts, ",")
+	span.SetAttributes(
+		attribute.Bool("llm_d.epp.encode.disaggregation_used", true),
+		attribute.String("llm_d.epp.encode.endpoints", strings.Join(encodeHostPorts, ",")),
+	)
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
@@ -1289,4 +1291,45 @@ func TestHandler_Factory_NilDeciders(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBothProfileAndHeadersHandlerPreRequest verifies that when both
+// disagg-profile-handler and the deprecated disagg-headers-handler are
+// active, both PreRequest hooks run without error. The result is redundant
+// (same header written twice) but not conflicting.
+func TestBothProfileAndHeadersHandlerPreRequest(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	profileHandler := NewDisaggProfileHandler("decode", "prefill", "encode", nil, nil).WithName("profile")
+	headersHandler := NewHeadersHandler("prefill", "encode").WithName("headers") //nolint:staticcheck // intentional: testing deprecated path
+
+	podAddr := "10.0.0.5"
+	podPort := "8080"
+	ep := scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"},
+			Address:        podAddr,
+			Port:           podPort,
+		},
+		&fwkdl.Metrics{},
+		nil,
+	)
+
+	request := &scheduling.InferenceRequest{
+		RequestID: "req-both",
+		Headers:   map[string]string{},
+	}
+	result := &scheduling.SchedulingResult{
+		PrimaryProfileName: "decode",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"prefill": {TargetEndpoints: []scheduling.Endpoint{ep}},
+		},
+	}
+
+	profileHandler.PreRequest(ctx, request, result)
+	headersHandler.PreRequest(ctx, request, result)
+
+	expected := net.JoinHostPort(podAddr, podPort)
+	assert.Equal(t, expected, request.Headers[routing.PrefillEndpointHeader],
+		"both handlers set the same prefill header — redundant but no conflict")
 }

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -60,7 +60,6 @@ schedulingProfiles:
 const epdEncodeDecodeConfig = `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: encode-filter
 - type: decode-filter
 - type: max-score-picker
@@ -83,7 +82,6 @@ schedulingProfiles:
 const epdConfig = `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefill-header-handler
 - type: encode-filter
 - type: prefill-filter
 - type: decode-filter
@@ -124,7 +122,6 @@ schedulingProfiles:
 const pdConfig = `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: prefix-cache-scorer
   parameters:
     blockSizeTokens: 16


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind deprecation

**What this PR does / why we need it:**

`disagg-profile-handler` (`Handler`) now implements both `ProfileHandler` and `PreRequest`, so configs no longer need a separate `disagg-headers-handler` entry.

`disagg_headers_handler.go` and its tests are preserved with all exported symbols marked `// Deprecated:` — existing configs that reference `disagg-headers-handler` or `prefill-header-handler` continue to work without changes. 
This introduces temporary code duplication that can be cleaned up once the deprecated plugin is removed in a future release.

**Key changes:**
- Add `PreRequest` method to `Handler` in `disagg_profile_handler.go`
- Mark `disagg_headers_handler.go` and all its exported symbols as `Deprecated`
- Remove `disagg-headers-handler` entries from deploy configs, e2e test configs, and documentation examples
- Add `TestBothProfileAndHeadersHandlerPreRequest` to verify both handlers can coexist safely (redundant but not conflicting)

**Backward compatibility:**
When both `disagg-profile-handler` and `disagg-headers-handler` appear in the same config, `HeadersHandler` implements only `PreRequest` (not `ProfileHandler`), so the "multiple profile handlers" validation does not trigger. The prefill/encode headers are written redundantly by both handlers — safe and idempotent.

**Which issue(s) this PR fixes:**

Fixes #833

**Release note (write NONE if no user-facing change):**
```release-note
disagg-headers-handler and prefill-header-handler plugins are now deprecated.
their PreRequest functionality is built into disagg-profile-handler.
existing configs continue to work; the deprecated plugin will be removed in a future release
