### PR TITLE
feat(sidecar): allow injecting custom proxy handlers

### DIFF
--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -174,7 +174,7 @@ type Config struct {
 	InferencePoolName string
 	// PoolGroup is the API group of the InferencePool resource.
 	PoolGroup string
-	
+
 	// DecoderHandlerFactory is an optional custom handler factory for the decoder proxy.
 	// If set, it replaces the default reverse proxy handler.
 	DecoderHandlerFactory ProxyHandlerFactory
@@ -188,19 +188,52 @@ type Config struct {
 
 // MarshalJSON implements json.Marshaler for Config.
 // It overrides the default marshaling of DecoderURL (*url.URL) to serialize it as a string.
+// It also excludes function type fields (ProxyHandlerFactory) which cannot be marshaled.
 func (c Config) MarshalJSON() ([]byte, error) {
-	// alias avoids infinite recursion when calling json.Marshal below
-	type alias Config
 	decoderURL := ""
 	if c.DecoderURL != nil {
 		decoderURL = c.DecoderURL.String()
 	}
 	return json.Marshal(struct {
-		alias
-		DecoderURL string
+		Port                           string `json:"Port"`
+		DecoderURL                     string `json:"DecoderURL"`
+		KVConnector                    string `json:"KVConnector"`
+		ECConnector                    string `json:"ECConnector"`
+		DataParallelSize               int    `json:"DataParallelSize"`
+		MaxIdleConnsPerHost            int    `json:"MaxIdleConnsPerHost"`
+		EnablePrefillerSampling        bool   `json:"EnablePrefillerSampling"`
+		UseTLSForPrefiller             bool   `json:"UseTLSForPrefiller"`
+		UseTLSForDecoder               bool   `json:"UseTLSForDecoder"`
+		UseTLSForEncoder               bool   `json:"UseTLSForEncoder"`
+		InsecureSkipVerifyForPrefiller bool   `json:"InsecureSkipVerifyForPrefiller"`
+		InsecureSkipVerifyForEncoder   bool   `json:"InsecureSkipVerifyForEncoder"`
+		InsecureSkipVerifyForDecoder   bool   `json:"InsecureSkipVerifyForDecoder"`
+		SecureServing                  bool   `json:"SecureServing"`
+		CertPath                       string `json:"CertPath"`
+		EnableSSRFProtection           bool   `json:"EnableSSRFProtection"`
+		InferencePoolNamespace         string `json:"InferencePoolNamespace"`
+		InferencePoolName              string `json:"InferencePoolName"`
+		PoolGroup                      string `json:"PoolGroup"`
 	}{
-		alias:      alias(c),
-		DecoderURL: decoderURL,
+		Port:                           c.Port,
+		DecoderURL:                     decoderURL,
+		KVConnector:                    c.KVConnector,
+		ECConnector:                    c.ECConnector,
+		DataParallelSize:               c.DataParallelSize,
+		MaxIdleConnsPerHost:            c.MaxIdleConnsPerHost,
+		EnablePrefillerSampling:        c.EnablePrefillerSampling,
+		UseTLSForPrefiller:             c.UseTLSForPrefiller,
+		UseTLSForDecoder:               c.UseTLSForDecoder,
+		UseTLSForEncoder:               c.UseTLSForEncoder,
+		InsecureSkipVerifyForPrefiller: c.InsecureSkipVerifyForPrefiller,
+		InsecureSkipVerifyForEncoder:   c.InsecureSkipVerifyForEncoder,
+		InsecureSkipVerifyForDecoder:   c.InsecureSkipVerifyForDecoder,
+		SecureServing:                  c.SecureServing,
+		CertPath:                       c.CertPath,
+		EnableSSRFProtection:           c.EnableSSRFProtection,
+		InferencePoolNamespace:         c.InferencePoolNamespace,
+		InferencePoolName:              c.InferencePoolName,
+		PoolGroup:                      c.PoolGroup,
 	})
 }
 

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -174,6 +174,16 @@ type Config struct {
 	InferencePoolName string
 	// PoolGroup is the API group of the InferencePool resource.
 	PoolGroup string
+	
+	// DecoderHandlerFactory is an optional custom handler factory for the decoder proxy.
+	// If set, it replaces the default reverse proxy handler.
+	DecoderHandlerFactory ProxyHandlerFactory
+	// PrefillerHandlerFactory is an optional custom handler factory for the prefiller proxy.
+	// If set, it replaces the default reverse proxy handler.
+	PrefillerHandlerFactory ProxyHandlerFactory
+	// EncoderHandlerFactory is an optional custom handler factory for the encoder proxy.
+	// If set, it replaces the default reverse proxy handler.
+	EncoderHandlerFactory ProxyHandlerFactory
 }
 
 // MarshalJSON implements json.Marshaler for Config.
@@ -206,6 +216,10 @@ func (c Config) String() string {
 type pdConnectorRunner func(http.ResponseWriter, *http.Request, string, APIType)
 
 type epdProtocolRunner func(http.ResponseWriter, *http.Request, string, []string)
+
+// ProxyHandlerFactory creates an http.Handler for the given target URL.
+// If provided, it replaces the default reverse proxy handler.
+type ProxyHandlerFactory func(targetURL *url.URL) http.Handler
 
 // Server is the reverse proxy server
 type Server struct {
@@ -402,12 +416,15 @@ func (s *Server) createRoutes() *http.ServeMux {
 }
 
 // createProxyHandler creates a reverse proxy handler for the given host:port.
-// It uses the provided cache, URL prefix, and TLS settings.
+// It uses the provided cache, URL prefix, TLS settings, and optional handler factory.
+// If proxyFactory is provided, it is used to create the handler; otherwise, a default
+// reverse proxy is created.
 func (s *Server) createProxyHandler(
 	hostPort string,
 	cache *lru.Cache[string, http.Handler],
 	urlPrefix string,
 	insecureSkipVerify bool,
+	proxyFactory ProxyHandlerFactory,
 ) (http.Handler, error) {
 	// Check cache first
 	proxy, exists := cache.Get(hostPort)
@@ -424,8 +441,14 @@ func (s *Server) createProxyHandler(
 		return nil, err
 	}
 
-	newProxy := httputil.NewSingleHostReverseProxy(u)
-	newProxy.Transport = s.newProxyTransport(u.Scheme, insecureSkipVerify)
+	var newProxy http.Handler
+	if proxyFactory != nil {
+		newProxy = proxyFactory(u)
+	} else {
+		rp := httputil.NewSingleHostReverseProxy(u)
+		rp.Transport = s.newProxyTransport(u.Scheme, insecureSkipVerify)
+		newProxy = rp
+	}
 	cache.Add(hostPort, newProxy)
 
 	return newProxy, nil
@@ -437,6 +460,7 @@ func (s *Server) prefillerProxyHandler(hostPort string) (http.Handler, error) {
 		s.prefillerProxies,
 		s.prefillerURLPrefix,
 		s.config.InsecureSkipVerifyForPrefiller,
+		s.config.PrefillerHandlerFactory,
 	)
 }
 
@@ -446,5 +470,6 @@ func (s *Server) encoderProxyHandler(hostPort string) (http.Handler, error) {
 		s.encoderProxies,
 		s.encoderURLPrefix,
 		s.config.InsecureSkipVerifyForEncoder,
+		s.config.EncoderHandlerFactory,
 	)
 }

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -132,7 +132,13 @@ func (s *Server) startHTTP(ctx context.Context) error {
 }
 
 // Passthrough decoder handler
-func (s *Server) createDecoderProxyHandler(decoderURL *url.URL, decoderInsecureSkipVerify bool) *httputil.ReverseProxy {
+// If Config.DecoderHandlerFactory is set, it is used to create the handler;
+// otherwise, a default reverse proxy is created.
+func (s *Server) createDecoderProxyHandler(decoderURL *url.URL, decoderInsecureSkipVerify bool) http.Handler {
+	if s.config.DecoderHandlerFactory != nil {
+		return s.config.DecoderHandlerFactory(decoderURL)
+	}
+
 	decoderProxy := httputil.NewSingleHostReverseProxy(decoderURL)
 	decoderProxy.Transport = s.newProxyTransport(decoderURL.Scheme, decoderInsecureSkipVerify)
 	decoderProxy.ErrorHandler = func(res http.ResponseWriter, _ *http.Request, err error) {

--- a/pkg/sidecar/proxy/proxy_test.go
+++ b/pkg/sidecar/proxy/proxy_test.go
@@ -333,8 +333,8 @@ var _ = Describe("Custom ProxyHandlerFactory", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			cfg := Config{
-				Port:                 "0",
-				DecoderURL:           targetURL,
+				Port:                  "0",
+				DecoderURL:            targetURL,
 				DecoderHandlerFactory: customFactory,
 			}
 			proxy := NewProxy(cfg)

--- a/pkg/sidecar/proxy/proxy_test.go
+++ b/pkg/sidecar/proxy/proxy_test.go
@@ -316,3 +316,143 @@ var _ = Describe("Reverse Proxy", func() {
 		})
 	})
 })
+
+var _ = Describe("Custom ProxyHandlerFactory", func() {
+	When("a custom handler factory is provided", func() {
+		It("should use the custom factory for decoder proxy", func() {
+			customHandlerCalled := false
+			customFactory := func(targetURL *url.URL) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					customHandlerCalled = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("custom handler response"))
+				})
+			}
+
+			targetURL, err := url.Parse("http://localhost:8001")
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg := Config{
+				Port:                 "0",
+				DecoderURL:           targetURL,
+				DecoderHandlerFactory: customFactory,
+			}
+			proxy := NewProxy(cfg)
+
+			proxy.allowlistValidator = &AllowlistValidator{enabled: false}
+			handler := proxy.createDecoderProxyHandler(targetURL, false)
+			Expect(handler).ToNot(BeNil())
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			Expect(customHandlerCalled).To(BeTrue())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(Equal("custom handler response"))
+		})
+
+		It("should use the custom factory for prefiller proxy", func() {
+			customHandlerCalled := false
+			customFactory := func(targetURL *url.URL) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					customHandlerCalled = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("custom prefiller response"))
+				})
+			}
+
+			targetURL, err := url.Parse("http://localhost:8001")
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg := Config{
+				Port:                    "0",
+				DecoderURL:              targetURL,
+				PrefillerHandlerFactory: customFactory,
+			}
+			proxy := NewProxy(cfg)
+
+			handler, err := proxy.prefillerProxyHandler("localhost:9000")
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			Expect(customHandlerCalled).To(BeTrue())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(Equal("custom prefiller response"))
+		})
+
+		It("should use the custom factory for encoder proxy", func() {
+			customHandlerCalled := false
+			customFactory := func(targetURL *url.URL) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					customHandlerCalled = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("custom encoder response"))
+				})
+			}
+
+			targetURL, err := url.Parse("http://localhost:8001")
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg := Config{
+				Port:                  "0",
+				DecoderURL:            targetURL,
+				EncoderHandlerFactory: customFactory,
+			}
+			proxy := NewProxy(cfg)
+
+			handler, err := proxy.encoderProxyHandler("localhost:9000")
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			Expect(customHandlerCalled).To(BeTrue())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(Equal("custom encoder response"))
+		})
+
+		It("should fall back to default reverse proxy when factory is nil", func() {
+			targetURL, err := url.Parse("http://localhost:8001")
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg := Config{
+				Port:       "0",
+				DecoderURL: targetURL,
+			}
+			proxy := NewProxy(cfg)
+
+			proxy.allowlistValidator = &AllowlistValidator{enabled: false}
+			handler := proxy.createDecoderProxyHandler(targetURL, false)
+			Expect(handler).ToNot(BeNil())
+		})
+
+		It("should preserve handler factories in Clone via config", func() {
+			customFactory := func(targetURL *url.URL) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+			}
+
+			targetURL, err := url.Parse("http://localhost:8001")
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg := Config{
+				Port:                    "0",
+				DecoderURL:              targetURL,
+				DecoderHandlerFactory:   customFactory,
+				PrefillerHandlerFactory: customFactory,
+				EncoderHandlerFactory:   customFactory,
+			}
+			proxy := NewProxy(cfg)
+
+			clone := proxy.Clone()
+
+			Expect(clone.config.DecoderHandlerFactory).ToNot(BeNil())
+			Expect(clone.config.PrefillerHandlerFactory).ToNot(BeNil())
+			Expect(clone.config.EncoderHandlerFactory).ToNot(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Add ProxyHandlerFactory type to Config for decoder, prefiller, and encoder proxies. Falls back to default reverse proxy when not set.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind feature

**What this PR does / why we need it**:

Add ProxyHandlerFactory type to Config for decoder, prefiller, and encoder proxies. This allows users to inject custom http.Handler for use cases like:
- **Token usage tracking**: During prefill/decode disaggregation, the prefill stage has access to exact prompt tokens and cached tokens values (decode processes as 100% cached tokens). Custom handlers can capture this information for accurate per-project/user token accounting (e.g., Redis-based tracking).
- Request/response transformation and content filtering.
Falls back to default reverse proxy when not set.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #896 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
