### PR TITLE
fix: prefill cached tokens for NIXL decode usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	cloud.google.com/go/aiplatform v1.124.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2
@@ -75,7 +76,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect

--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
@@ -39,18 +39,19 @@ type cachedTokensUsageRewriter struct {
 // See: https://platform.openai.com/docs/guides/prompt-caching
 const promptTokensDetailsField = "prompt_tokens_details"
 
-func newCachedTokensResponseWriter(w http.ResponseWriter, cachedTokens int, enabled bool) http.ResponseWriter {
-	if !enabled {
-		// Prefill did not report cached_tokens, so keep the decoder response intact.
-		return w
-	}
+func newCachedTokensResponseWriter(w http.ResponseWriter, cachedTokens int) http.ResponseWriter {
+	writer, _ := newCachedTokensResponseWriterWithFinalize(w, cachedTokens)
+	return writer
+}
+
+func newCachedTokensResponseWriterWithFinalize(w http.ResponseWriter, cachedTokens int) (http.ResponseWriter, func() error) {
 	rewriter := &cachedTokensUsageRewriter{
 		header:       w.Header(),
 		cachedTokens: cachedTokens,
 	}
 	// httpsnoop preserves optional ResponseWriter interfaces such as
 	// http.Flusher, http.Hijacker, http.Pusher, and io.ReaderFrom.
-	return httpsnoop.Wrap(w, httpsnoop.Hooks{
+	writer := httpsnoop.Wrap(w, httpsnoop.Hooks{
 		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
 			return func(statusCode int) {
 				rewriter.writeHeader(next, statusCode)
@@ -68,6 +69,9 @@ func newCachedTokensResponseWriter(w http.ResponseWriter, cachedTokens int, enab
 			}
 		},
 	})
+	return writer, func() error {
+		return rewriter.flushSSEBuffer(w.Write)
+	}
 }
 
 func (r *cachedTokensUsageRewriter) writeHeader(next httpsnoop.WriteHeaderFunc, statusCode int) {

--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/felixge/httpsnoop"
+)
+
+type cachedTokensUsageRewriter struct {
+	header       http.Header
+	cachedTokens int
+	wroteHeader  bool
+	streaming    bool
+	streamBuffer []byte
+}
+
+// OpenAI-compatible chat usage reports prompt cache hits at
+// usage.prompt_tokens_details.cached_tokens.
+// See: https://platform.openai.com/docs/guides/prompt-caching
+const promptTokensDetailsField = "prompt_tokens_details"
+
+func newCachedTokensResponseWriter(w http.ResponseWriter, cachedTokens int, enabled bool) http.ResponseWriter {
+	if !enabled {
+		// Prefill did not report cached_tokens, so keep the decoder response intact.
+		return w
+	}
+	rewriter := &cachedTokensUsageRewriter{
+		header:       w.Header(),
+		cachedTokens: cachedTokens,
+	}
+	// httpsnoop preserves optional ResponseWriter interfaces such as
+	// http.Flusher, http.Hijacker, http.Pusher, and io.ReaderFrom.
+	return httpsnoop.Wrap(w, httpsnoop.Hooks{
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(statusCode int) {
+				rewriter.writeHeader(next, statusCode)
+			}
+		},
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(body []byte) (int, error) {
+				return rewriter.write(next, body)
+			}
+		},
+		ReadFrom: func(_ httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) {
+				// ReadFrom would otherwise bypass Write and skip usage rewriting.
+				return rewriter.readFrom(w.Write, src)
+			}
+		},
+	})
+}
+
+func (r *cachedTokensUsageRewriter) writeHeader(next httpsnoop.WriteHeaderFunc, statusCode int) {
+	// Rewriting may change the body size, so any upstream Content-Length is stale.
+	r.header.Del("Content-Length")
+	r.wroteHeader = true
+	next(statusCode)
+}
+
+func (r *cachedTokensUsageRewriter) write(next httpsnoop.WriteFunc, body []byte) (int, error) {
+	updated := r.rewrite(body)
+	if !r.wroteHeader {
+		r.header.Del("Content-Length")
+	}
+	n, err := next(updated)
+	if err != nil {
+		return n, err
+	}
+	return len(body), nil
+}
+
+func (r *cachedTokensUsageRewriter) readFrom(next httpsnoop.WriteFunc, src io.Reader) (int64, error) {
+	if r.isSSE(nil) {
+		// SSE can be long-lived, so keep it streaming and rewrite complete lines.
+		n, err := io.Copy(cachedTokensStreamWriter{
+			write:   r.write,
+			forward: next,
+		}, src)
+		if err != nil {
+			return n, err
+		}
+		if err := r.flushSSEBuffer(next); err != nil {
+			return n, err
+		}
+		return n, nil
+	}
+
+	// Non-streaming JSON must be complete before we can safely rewrite usage.
+	body, err := io.ReadAll(src)
+	if err != nil {
+		return 0, err
+	}
+	_, err = r.write(next, body)
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(body)), nil
+}
+
+func (r *cachedTokensUsageRewriter) rewrite(body []byte) []byte {
+	if r.isSSE(body) {
+		return r.rewriteSSEChunk(body)
+	}
+	return replaceCachedTokens(body, r.cachedTokens)
+}
+
+type cachedTokensStreamWriter struct {
+	write   func(httpsnoop.WriteFunc, []byte) (int, error)
+	forward httpsnoop.WriteFunc
+}
+
+func (w cachedTokensStreamWriter) Write(body []byte) (int, error) {
+	return w.write(w.forward, body)
+}
+
+func (r *cachedTokensUsageRewriter) isSSE(body []byte) bool {
+	if r.streaming {
+		return true
+	}
+	contentType := r.header.Get("Content-Type")
+	// Some handlers may not set the content type before the first Write.
+	if strings.Contains(contentType, "text/event-stream") || bytes.HasPrefix(body, []byte("data:")) {
+		r.streaming = true
+		return true
+	}
+	return false
+}
+
+func (r *cachedTokensUsageRewriter) rewriteSSEChunk(body []byte) []byte {
+	r.streamBuffer = append(r.streamBuffer, body...)
+	updated := make([]byte, 0, len(r.streamBuffer))
+	for {
+		lineEnd := bytes.IndexByte(r.streamBuffer, '\n')
+		if lineEnd < 0 {
+			break
+		}
+		// Upstream may split chunks mid-event; only rewrite complete SSE lines.
+		line := r.streamBuffer[:lineEnd+1]
+		replacedLine, _ := replaceCachedTokensSSELine(line, r.cachedTokens)
+		updated = append(updated, replacedLine...)
+		r.streamBuffer = r.streamBuffer[lineEnd+1:]
+	}
+	return updated
+}
+
+func (r *cachedTokensUsageRewriter) flushSSEBuffer(next httpsnoop.WriteFunc) error {
+	if len(r.streamBuffer) == 0 {
+		return nil
+	}
+	// EOF without a final newline is malformed SSE, but forward it rather than
+	// dropping bytes. If it is a data line, still try to apply the usage rewrite.
+	replacedLine, _ := replaceCachedTokensSSELine(r.streamBuffer, r.cachedTokens)
+	r.streamBuffer = nil
+	_, err := next(replacedLine)
+	return err
+}
+
+func extractCachedTokens(response map[string]any) (int, bool) {
+	usage, ok := response["usage"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	return cachedTokensFromUsage(usage)
+}
+
+func cachedTokensFromUsage(usage map[string]any) (int, bool) {
+	// Only the documented OpenAI-compatible field is used as the source of truth.
+	details, ok := usage[promptTokensDetailsField].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	if cachedTokens, ok := intValue(details["cached_tokens"]); ok {
+		return cachedTokens, true
+	}
+	return 0, false
+}
+
+func intValue(value any) (int, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func replaceCachedTokens(body []byte, cachedTokens int) []byte {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return body
+	}
+	// Prefer full JSON first; streamed responses are handled line-by-line below.
+	if updated, ok := replaceCachedTokensJSON(body, cachedTokens); ok {
+		return updated
+	}
+	if updated, ok := replaceCachedTokensSSE(body, cachedTokens); ok {
+		return updated
+	}
+	return body
+}
+
+func replaceCachedTokensJSON(body []byte, cachedTokens int) ([]byte, bool) {
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, false
+	}
+	if !setCachedTokens(response, cachedTokens) {
+		return body, true
+	}
+	updated, err := json.Marshal(response)
+	if err != nil {
+		return body, true
+	}
+	return updated, true
+}
+
+func replaceCachedTokensSSE(body []byte, cachedTokens int) ([]byte, bool) {
+	lines := bytes.SplitAfter(body, []byte("\n"))
+	updated := make([]byte, 0, len(body))
+	changed := false
+	processed := false
+
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		replacedLine, ok := replaceCachedTokensSSELine(line, cachedTokens)
+		if !ok {
+			updated = append(updated, replacedLine...)
+			continue
+		}
+		processed = true
+		if !bytes.Equal(replacedLine, line) {
+			changed = true
+		}
+		updated = append(updated, replacedLine...)
+	}
+
+	if !processed {
+		return nil, false
+	}
+	if !changed {
+		return body, true
+	}
+	return updated, true
+}
+
+func replaceCachedTokensSSELine(line []byte, cachedTokens int) ([]byte, bool) {
+	trimmedLine := bytes.TrimRight(line, "\r\n")
+	lineEnding := line[len(trimmedLine):]
+	data, ok := bytes.CutPrefix(trimmedLine, []byte("data: "))
+	if !ok {
+		return line, false
+	}
+	if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
+		return line, true
+	}
+	// Only JSON data frames can carry usage; other SSE frames pass through.
+	replacedData, isJSON := replaceCachedTokensJSON(data, cachedTokens)
+	if !isJSON {
+		return line, true
+	}
+	updated := make([]byte, 0, len(line))
+	updated = append(updated, []byte("data: ")...)
+	updated = append(updated, replacedData...)
+	updated = append(updated, lineEnding...)
+	return updated, true
+}
+
+func setCachedTokens(response map[string]any, cachedTokens int) bool {
+	usage, ok := response["usage"].(map[string]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	details, ok := usage[promptTokensDetailsField].(map[string]any)
+	if !ok {
+		// Some decoder chunks omit details entirely; create the standard field.
+		usage[promptTokensDetailsField] = map[string]any{"cached_tokens": cachedTokens}
+		return true
+	}
+	if current, ok := intValue(details["cached_tokens"]); !ok || current != cachedTokens {
+		details["cached_tokens"] = cachedTokens
+		changed = true
+	}
+	return changed
+}

--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2" // nolint:revive
+	. "github.com/onsi/gomega"    // nolint:revive
+)
+
+type readerFromResponseWriter struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func (w *readerFromResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+	return w.header
+}
+
+func (w *readerFromResponseWriter) Write(body []byte) (int, error) {
+	return w.body.Write(body)
+}
+
+func (w *readerFromResponseWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+}
+
+func (w *readerFromResponseWriter) ReadFrom(src io.Reader) (int64, error) {
+	return io.Copy(&w.body, src)
+}
+
+var _ = Describe("Cached token usage rewriter", func() {
+	It("should replace cached tokens in JSON responses", func() {
+		body := []byte(`{"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":49}}}`)
+		Expect(replaceCachedTokens(body, 7)).To(Equal([]byte(`{"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":7}}}`)))
+	})
+
+	It("should add cached tokens when JSON usage details omit them", func() {
+		body := []byte(`{"usage":{"prompt_tokens":64,"prompt_tokens_details":{}}}`)
+		updated := replaceCachedTokens(body, 7)
+
+		var response map[string]any
+		Expect(json.Unmarshal(updated, &response)).To(Succeed())
+		usage := response["usage"].(map[string]any)
+		details := usage["prompt_tokens_details"].(map[string]any)
+		Expect(details["cached_tokens"]).To(BeNumerically("==", 7))
+	})
+
+	It("should add usage details when JSON usage omits them", func() {
+		body := []byte(`{"usage":{"prompt_tokens":64}}`)
+		updated := replaceCachedTokens(body, 7)
+
+		var response map[string]any
+		Expect(json.Unmarshal(updated, &response)).To(Succeed())
+		usage := response["usage"].(map[string]any)
+		details := usage["prompt_tokens_details"].(map[string]any)
+		Expect(details["cached_tokens"]).To(BeNumerically("==", 7))
+	})
+
+	It("should not extract cached tokens when prefill response has none", func() {
+		prefillResponse := map[string]any{
+			requestFieldKVTransferParams: map[string]any{
+				requestFieldRemoteBlockIDs: []any{float64(1), float64(2), float64(3)},
+			},
+		}
+		_, ok := extractCachedTokens(prefillResponse)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should extract zero cached tokens when prefill explicitly reports zero", func() {
+		prefillResponse := map[string]any{
+			"usage": map[string]any{
+				"prompt_tokens_details": map[string]any{
+					"cached_tokens": float64(0),
+				},
+			},
+		}
+		cachedTokens, ok := extractCachedTokens(prefillResponse)
+		Expect(ok).To(BeTrue())
+		Expect(cachedTokens).To(Equal(0))
+	})
+
+	It("should replace cached tokens in streamed usage chunks", func() {
+		body := []byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"prompt_tokens_details\":{\"cached_tokens\":49}}}\n\ndata: [DONE]\n")
+		updated := replaceCachedTokens(body, 7)
+		Expect(string(updated)).To(ContainSubstring(`"cached_tokens":7`))
+		Expect(string(updated)).To(ContainSubstring("data: [DONE]"))
+	})
+
+	It("should buffer streamed usage chunks split before the data prefix", func() {
+		recorder := httptest.NewRecorder()
+		recorder.Header().Set("Content-Type", "text/event-stream")
+		writer := newCachedTokensResponseWriter(recorder, 7, true)
+
+		n, err := writer.Write([]byte("da"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(2))
+		Expect(recorder.Body.String()).To(BeEmpty())
+
+		chunk := []byte("ta: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"prompt_tokens_details\":{\"cached_tokens\":49}}}\n\ndata: [DONE]\n")
+		n, err = writer.Write(chunk)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(chunk)))
+		Expect(recorder.Body.String()).To(ContainSubstring(`"cached_tokens":7`))
+		Expect(recorder.Body.String()).To(ContainSubstring("data: [DONE]"))
+	})
+
+	It("should buffer streamed usage chunks split inside the JSON payload", func() {
+		recorder := httptest.NewRecorder()
+		recorder.Header().Set("Content-Type", "text/event-stream")
+		writer := newCachedTokensResponseWriter(recorder, 7, true)
+
+		firstChunk := []byte(`data: {"choices":[],"usage":{"prompt_tokens":64,`)
+		n, err := writer.Write(firstChunk)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(firstChunk)))
+		Expect(recorder.Body.String()).To(BeEmpty())
+
+		secondChunk := []byte(`"prompt_tokens_details":{"cached_tokens":49}}}` + "\n\n")
+		n, err = writer.Write(secondChunk)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(secondChunk)))
+		Expect(recorder.Body.String()).To(ContainSubstring(`"cached_tokens":7`))
+	})
+
+	It("should add cached tokens in streamed usage chunks that omit them", func() {
+		body := []byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"prompt_tokens_details\":{}}}\n\ndata: [DONE]\n")
+		updated := replaceCachedTokens(body, 7)
+		Expect(string(updated)).To(ContainSubstring(`"cached_tokens":7`))
+		Expect(string(updated)).To(ContainSubstring("data: [DONE]"))
+	})
+
+	It("should preserve non-JSON streamed data lines", func() {
+		body := []byte("event: ping\ndata: not-json\n\ndata: [DONE]\n")
+		updated := replaceCachedTokens(body, 7)
+		Expect(updated).To(Equal(body))
+	})
+
+	It("should preserve ReaderFrom while rewriting cached tokens", func() {
+		base := &readerFromResponseWriter{header: http.Header{}}
+		writer := newCachedTokensResponseWriter(base, 7, true)
+		readerFrom, ok := writer.(io.ReaderFrom)
+		Expect(ok).To(BeTrue())
+
+		body := `{"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":49}}}`
+		n, err := readerFrom.ReadFrom(strings.NewReader(body))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(int64(len(body))))
+		Expect(base.body.String()).To(Equal(`{"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":7}}}`))
+	})
+
+	It("should preserve ReaderFrom for streamed responses while rewriting complete lines", func() {
+		base := &readerFromResponseWriter{header: http.Header{"Content-Type": []string{"text/event-stream"}}}
+		writer := newCachedTokensResponseWriter(base, 7, true)
+		readerFrom, ok := writer.(io.ReaderFrom)
+		Expect(ok).To(BeTrue())
+
+		body := "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"prompt_tokens_details\":{\"cached_tokens\":49}}}\n\ndata: [DONE]\n"
+		n, err := readerFrom.ReadFrom(strings.NewReader(body))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(int64(len(body))))
+		Expect(base.body.String()).To(ContainSubstring(`"cached_tokens":7`))
+		Expect(base.body.String()).To(ContainSubstring("data: [DONE]"))
+	})
+
+	It("should flush a trailing streamed data line without a final newline", func() {
+		base := &readerFromResponseWriter{header: http.Header{"Content-Type": []string{"text/event-stream"}}}
+		writer := newCachedTokensResponseWriter(base, 7, true)
+		readerFrom, ok := writer.(io.ReaderFrom)
+		Expect(ok).To(BeTrue())
+
+		body := "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"prompt_tokens_details\":{\"cached_tokens\":49}}}"
+		n, err := readerFrom.ReadFrom(strings.NewReader(body))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(int64(len(body))))
+		Expect(base.body.String()).To(ContainSubstring(`"cached_tokens":7`))
+	})
+})

--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 	It("should buffer streamed usage chunks split before the data prefix", func() {
 		recorder := httptest.NewRecorder()
 		recorder.Header().Set("Content-Type", "text/event-stream")
-		writer := newCachedTokensResponseWriter(recorder, 7, true)
+		writer := newCachedTokensResponseWriter(recorder, 8)
 
 		n, err := writer.Write([]byte("da"))
 		Expect(err).ToNot(HaveOccurred())
@@ -125,14 +125,14 @@ var _ = Describe("Cached token usage rewriter", func() {
 		n, err = writer.Write(chunk)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(n).To(Equal(len(chunk)))
-		Expect(recorder.Body.String()).To(ContainSubstring(`"cached_tokens":7`))
+		Expect(recorder.Body.String()).To(ContainSubstring(`"cached_tokens":8`))
 		Expect(recorder.Body.String()).To(ContainSubstring("data: [DONE]"))
 	})
 
 	It("should buffer streamed usage chunks split inside the JSON payload", func() {
 		recorder := httptest.NewRecorder()
 		recorder.Header().Set("Content-Type", "text/event-stream")
-		writer := newCachedTokensResponseWriter(recorder, 7, true)
+		writer := newCachedTokensResponseWriter(recorder, 7)
 
 		firstChunk := []byte(`data: {"choices":[],"usage":{"prompt_tokens":64,`)
 		n, err := writer.Write(firstChunk)
@@ -162,7 +162,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 
 	It("should preserve ReaderFrom while rewriting cached tokens", func() {
 		base := &readerFromResponseWriter{header: http.Header{}}
-		writer := newCachedTokensResponseWriter(base, 7, true)
+		writer := newCachedTokensResponseWriter(base, 7)
 		readerFrom, ok := writer.(io.ReaderFrom)
 		Expect(ok).To(BeTrue())
 
@@ -175,7 +175,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 
 	It("should preserve ReaderFrom for streamed responses while rewriting complete lines", func() {
 		base := &readerFromResponseWriter{header: http.Header{"Content-Type": []string{"text/event-stream"}}}
-		writer := newCachedTokensResponseWriter(base, 7, true)
+		writer := newCachedTokensResponseWriter(base, 7)
 		readerFrom, ok := writer.(io.ReaderFrom)
 		Expect(ok).To(BeTrue())
 
@@ -189,7 +189,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 
 	It("should flush a trailing streamed data line without a final newline", func() {
 		base := &readerFromResponseWriter{header: http.Header{"Content-Type": []string{"text/event-stream"}}}
-		writer := newCachedTokensResponseWriter(base, 7, true)
+		writer := newCachedTokensResponseWriter(base, 7)
 		readerFrom, ok := writer.(io.ReaderFrom)
 		Expect(ok).To(BeTrue())
 
@@ -198,5 +198,20 @@ var _ = Describe("Cached token usage rewriter", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(n).To(Equal(int64(len(body))))
 		Expect(base.body.String()).To(ContainSubstring(`"cached_tokens":7`))
+	})
+
+	It("should finalize a trailing streamed data line written without a final newline", func() {
+		recorder := httptest.NewRecorder()
+		recorder.Header().Set("Content-Type", "text/event-stream")
+		writer, finalize := newCachedTokensResponseWriterWithFinalize(recorder, 7)
+
+		body := []byte(`data: {"choices":[],"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":49}}}`)
+		n, err := writer.Write(body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(body)))
+		Expect(recorder.Body.String()).To(BeEmpty())
+
+		Expect(finalize()).To(Succeed())
+		Expect(recorder.Body.String()).To(ContainSubstring(`"cached_tokens":7`))
 	})
 })

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -188,6 +188,11 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 		s.logger.Info("warning: missing 'kv_transfer_params' field in prefiller response")
 	}
 	pCachedTokens, hasPCachedTokens := extractCachedTokens(prefillerResponse)
+	if !hasPCachedTokens {
+		// vLLM returns prompt_tokens_details as null when cached_tokens is 0,
+		// so treat a missing prefiller cached_tokens value as zero.
+		pCachedTokens = 0
+	}
 
 	s.logger.V(5).Info("received prefiller response", requestFieldKVTransferParams, pKVTransferParams)
 
@@ -245,7 +250,7 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	// 2. Forward to local decoder.
 
 	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
-	decodeWriter := newCachedTokensResponseWriter(w, pCachedTokens, hasPCachedTokens)
+	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens)
 	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeWriter, dreq)
 	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
 
@@ -253,6 +258,11 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 		s.logger.V(4).Info("sending request to decoder", "to", s.config.DecoderURL.Host)
 		decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host))
 		s.decoderProxy.ServeHTTP(decodeWriter, dreq)
+	}
+	if err := finalizeDecodeWriter(); err != nil {
+		s.logger.Error(err, "failed to flush cached token response writer")
+		decodeSpan.SetStatus(codes.Error, "failed to flush cached token response writer")
+		return
 	}
 
 	decodeDuration := time.Since(decodeStart)

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -187,6 +187,7 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	if !ok {
 		s.logger.Info("warning: missing 'kv_transfer_params' field in prefiller response")
 	}
+	pCachedTokens, hasPCachedTokens := extractCachedTokens(prefillerResponse)
 
 	s.logger.V(5).Info("received prefiller response", requestFieldKVTransferParams, pKVTransferParams)
 
@@ -244,13 +245,14 @@ func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefi
 	// 2. Forward to local decoder.
 
 	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
-	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(w, dreq)
+	decodeWriter := newCachedTokensResponseWriter(w, pCachedTokens, hasPCachedTokens)
+	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeWriter, dreq)
 	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
 
 	if !dataParallelUsed {
 		s.logger.V(4).Info("sending request to decoder", "to", s.config.DecoderURL.Host)
 		decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host))
-		s.decoderProxy.ServeHTTP(w, dreq)
+		s.decoderProxy.ServeHTTP(decodeWriter, dreq)
 	}
 
 	decodeDuration := time.Since(decodeStart)

--- a/pkg/sidecar/proxy/connector_nixlv2_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_test.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -28,6 +29,17 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 )
 
+const (
+	chatCompletionsRequestBody = `{
+				"model": "Qwen/Qwen2-0.5B",
+				"messages": [
+				  {"role": "user", "content": "Hello"}
+				],
+				"max_tokens": 50
+			}`
+	eventStreamContentType = "text/event-stream"
+)
+
 var _ = Describe("NIXL Connector (v2)", func() {
 
 	var testInfo *sidecarTestInfo
@@ -36,8 +48,7 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		testInfo = sidecarConnectionTestSetup(KVConnectorNIXLV2)
 	})
 
-	It("should successfully send request to 1. prefill 2. decode with the correct fields", func() {
-		By("starting the proxy")
+	startProxy := func() string {
 		go func() {
 			defer GinkgoRecover()
 
@@ -49,19 +60,73 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		}()
 
 		<-testInfo.proxy.readyCh
-		proxyBaseAddr := "http://" + testInfo.proxy.addr.String()
+		DeferCleanup(func() {
+			testInfo.cancelFn()
+			<-testInfo.stoppedCh
+		})
 
-		By("sending a /v1/chat/completions request with prefill header")
-		//nolint:goconst
+		return "http://" + testInfo.proxy.addr.String()
+	}
+
+	sendChatCompletionsRequest := func(proxyBaseAddr string) map[string]any {
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(chatCompletionsRequestBody)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+
+		responseBody, err := io.ReadAll(rp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rp.StatusCode).To(Equal(http.StatusOK), string(responseBody))
+
+		var response map[string]any
+		Expect(json.Unmarshal(responseBody, &response)).To(Succeed())
+		return response
+	}
+
+	sendStreamingChatCompletionsRequest := func(proxyBaseAddr string) string {
 		body := `{
 				"model": "Qwen/Qwen2-0.5B",
 				"messages": [
 				  {"role": "user", "content": "Hello"}
 				],
-				"max_tokens": 50
+				"max_tokens": 50,
+				"stream": true,
+				"stream_options": {"include_usage": true}
 			}`
 
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+
+		responseBody, err := io.ReadAll(rp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rp.StatusCode).To(Equal(http.StatusOK), string(responseBody))
+		Expect(rp.Header.Get("Content-Type")).To(ContainSubstring(eventStreamContentType))
+		return string(responseBody)
+	}
+
+	cachedTokensFromResponse := func(response map[string]any) float64 {
+		usage, ok := response["usage"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		details, ok := usage["prompt_tokens_details"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		cachedTokens, ok := details["cached_tokens"].(float64)
+		Expect(ok).To(BeTrue())
+		return cachedTokens
+	}
+
+	It("should successfully send request to 1. prefill 2. decode with the correct fields", func() {
+		proxyBaseAddr := startProxy()
+
+		By("sending a /v1/chat/completions request with prefill header")
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(chatCompletionsRequestBody)))
 		Expect(err).ToNot(HaveOccurred())
 		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
 
@@ -100,8 +165,90 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
 		Expect(testInfo.decodeHandler.CompletionRequests).To(HaveLen(1))
 
-		testInfo.cancelFn()
-		<-testInfo.stoppedCh
+		responseBody, err := io.ReadAll(rp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		var response map[string]any
+		Expect(json.Unmarshal(responseBody, &response)).To(Succeed())
+		usage := response["usage"].(map[string]any)
+		details := usage["prompt_tokens_details"].(map[string]any)
+		Expect(details["cached_tokens"]).To(BeNumerically("==", 7))
+
+	})
+
+	It("should add prefiller cached tokens when decoder usage details omit cached_tokens", func() {
+		testInfo.decodeHandler.RawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{}}}`
+		proxyBaseAddr := startProxy()
+
+		response := sendChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 7))
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+	})
+
+	It("should create prompt token details when decoder usage omits them", func() {
+		testInfo.decodeHandler.RawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65}}`
+		proxyBaseAddr := startProxy()
+
+		response := sendChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 7))
+	})
+
+	It("should keep decoder cached tokens when prefiller does not report cached tokens", func() {
+		testInfo.prefillHandler.RawResponse = `{"kv_transfer_params":{"remote_block_ids":[1,2,3],"remote_engine_id":"5b5fb28f-3f30-4bdd-9a36-958d52459200","remote_host":"ahost","remote_port":4032},"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{}}}`
+		testInfo.decodeHandler.RawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":49}}}`
+		proxyBaseAddr := startProxy()
+
+		response := sendChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 49))
+	})
+
+	It("should overwrite decoder cached tokens when prefiller reports zero cached tokens", func() {
+		testInfo.prefillHandler.RawResponse = `{"kv_transfer_params":{"remote_block_ids":[1,2,3],"remote_engine_id":"5b5fb28f-3f30-4bdd-9a36-958d52459200","remote_host":"ahost","remote_port":4032},"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":0}}}`
+		testInfo.decodeHandler.RawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":49}}}`
+		proxyBaseAddr := startProxy()
+
+		response := sendChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 0))
+	})
+
+	It("should replace cached tokens in streamed usage chunks", func() {
+		testInfo.decodeHandler.RawResponseType = eventStreamContentType
+		testInfo.decodeHandler.RawResponse = "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"completion_tokens\":1,\"total_tokens\":65,\"prompt_tokens_details\":{\"cached_tokens\":49}}}\n\ndata: [DONE]\n"
+		proxyBaseAddr := startProxy()
+
+		responseBody := sendStreamingChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(responseBody).To(ContainSubstring(`"content":"hello"`))
+		Expect(responseBody).To(ContainSubstring(`"cached_tokens":7`))
+		Expect(responseBody).ToNot(ContainSubstring(`"cached_tokens":49`))
+		Expect(responseBody).To(ContainSubstring("data: [DONE]"))
+	})
+
+	It("should create cached token details in streamed usage chunks that omit them", func() {
+		testInfo.decodeHandler.RawResponseType = eventStreamContentType
+		testInfo.decodeHandler.RawResponse = "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"completion_tokens\":1,\"total_tokens\":65}}\n\ndata: [DONE]\n"
+		proxyBaseAddr := startProxy()
+
+		responseBody := sendStreamingChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(responseBody).To(ContainSubstring(`"prompt_tokens_details":{"cached_tokens":7}`))
+		Expect(responseBody).To(ContainSubstring("data: [DONE]"))
+	})
+
+	It("should keep decoder cached tokens in streamed usage when prefiller does not report cached tokens", func() {
+		testInfo.prefillHandler.RawResponse = `{"kv_transfer_params":{"remote_block_ids":[1,2,3],"remote_engine_id":"5b5fb28f-3f30-4bdd-9a36-958d52459200","remote_host":"ahost","remote_port":4032},"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{}}}`
+		testInfo.decodeHandler.RawResponseType = eventStreamContentType
+		testInfo.decodeHandler.RawResponse = "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"completion_tokens\":1,\"total_tokens\":65,\"prompt_tokens_details\":{\"cached_tokens\":49}}}\n\ndata: [DONE]\n"
+		proxyBaseAddr := startProxy()
+
+		responseBody := sendStreamingChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(responseBody).To(ContainSubstring(`"cached_tokens":49`))
+		Expect(responseBody).To(ContainSubstring("data: [DONE]"))
 	})
 
 	// Responses API tests — exercise the same NIXL v2 connector with

--- a/pkg/sidecar/proxy/connector_nixlv2_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_test.go
@@ -195,14 +195,14 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 7))
 	})
 
-	It("should keep decoder cached tokens when prefiller does not report cached tokens", func() {
+	It("should return zero cached tokens when prefiller does not report cached tokens", func() {
 		testInfo.prefillHandler.RawResponse = `{"kv_transfer_params":{"remote_block_ids":[1,2,3],"remote_engine_id":"5b5fb28f-3f30-4bdd-9a36-958d52459200","remote_host":"ahost","remote_port":4032},"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{}}}`
 		testInfo.decodeHandler.RawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":49}}}`
 		proxyBaseAddr := startProxy()
 
 		response := sendChatCompletionsRequest(proxyBaseAddr)
 
-		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 49))
+		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 0))
 	})
 
 	It("should overwrite decoder cached tokens when prefiller reports zero cached tokens", func() {
@@ -239,7 +239,7 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		Expect(responseBody).To(ContainSubstring("data: [DONE]"))
 	})
 
-	It("should keep decoder cached tokens in streamed usage when prefiller does not report cached tokens", func() {
+	It("should return zero cached tokens in streamed usage when prefiller does not report cached tokens", func() {
 		testInfo.prefillHandler.RawResponse = `{"kv_transfer_params":{"remote_block_ids":[1,2,3],"remote_engine_id":"5b5fb28f-3f30-4bdd-9a36-958d52459200","remote_host":"ahost","remote_port":4032},"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{}}}`
 		testInfo.decodeHandler.RawResponseType = eventStreamContentType
 		testInfo.decodeHandler.RawResponse = "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"completion_tokens\":1,\"total_tokens\":65,\"prompt_tokens_details\":{\"cached_tokens\":49}}}\n\ndata: [DONE]\n"
@@ -247,7 +247,8 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 		responseBody := sendStreamingChatCompletionsRequest(proxyBaseAddr)
 
-		Expect(responseBody).To(ContainSubstring(`"cached_tokens":49`))
+		Expect(responseBody).To(ContainSubstring(`"cached_tokens":0`))
+		Expect(responseBody).ToNot(ContainSubstring(`"cached_tokens":49`))
 		Expect(responseBody).To(ContainSubstring("data: [DONE]"))
 	})
 

--- a/test/sidecar/mock/chat_completions_handler.go
+++ b/test/sidecar/mock/chat_completions_handler.go
@@ -34,12 +34,16 @@ const (
 
 	// RolePrefill indicates the handler is a prefiller
 	RolePrefill Role = "prefill"
+
+	contentTypeEventStream = "text/event-stream"
 )
 
 // ChatCompletionHandler is a simple chat completion mock handler
 type ChatCompletionHandler struct {
 	Connector           string
 	Role                Role
+	RawResponse         string
+	RawResponseType     string
 	RequestCount        atomic.Int32
 	CompletionRequests  []map[string]any
 	CompletionResponses []map[string]any
@@ -84,7 +88,7 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	case "nixlv2":
 		switch cc.Role {
 		case RoleDecode:
-			rawResponse = `{}`
+			rawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":49}}}`
 		case RolePrefill:
 
 			// 1. Verify Prefill Request
@@ -135,7 +139,7 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 			// 2. Produce Response
 
-			rawResponse = `{"kv_transfer_params":{"remote_block_ids":[1, 2, 3], "remote_engine_id": "5b5fb28f-3f30-4bdd-9a36-958d52459200", "remote_host":"ahost", "remote_port":4032}}`
+			rawResponse = `{"kv_transfer_params":{"remote_block_ids":[1, 2, 3], "remote_engine_id": "5b5fb28f-3f30-4bdd-9a36-958d52459200", "remote_host":"ahost", "remote_port":4032},"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":7}}}`
 
 		}
 
@@ -148,16 +152,24 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		rawResponse = `{}`
 	}
 
-	var completionResponse map[string]any
-	if err := json.Unmarshal([]byte(rawResponse), &completionResponse); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error())) //nolint:all
-		return
+	if cc.RawResponse != "" {
+		rawResponse = cc.RawResponse
+	}
+	if cc.RawResponseType != "" {
+		w.Header().Set("Content-Type", cc.RawResponseType)
 	}
 
-	cc.mu.Lock()
-	cc.CompletionResponses = append(cc.CompletionResponses, completionResponse)
-	cc.mu.Unlock()
+	var completionResponse map[string]any
+	if cc.RawResponseType != contentTypeEventStream {
+		if err := json.Unmarshal([]byte(rawResponse), &completionResponse); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(err.Error())) //nolint:all
+			return
+		}
+		cc.mu.Lock()
+		cc.CompletionResponses = append(cc.CompletionResponses, completionResponse)
+		cc.mu.Unlock()
+	}
 
 	w.Write([]byte(rawResponse)) //nolint:all
 }


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind bug


**What this PR does / why we need it**:

In NIXL P/D mode, the sidecar currently returns the decoder's usage response directly. When the decoder consumes KV blocks transferred from the prefiller, vLLM may report nearly all prompt tokens as cached from the decoder perspective.

This updates the NIXL v2 sidecar flow to cached token usage reported by the prefiller. If the prefiller response includes `usage.prompt_tokens_details.cached_tokens`, the sidecar rewrites the decoder response usage with that value. If the prefiller does not report cached tokens, set to 0.

The rewrite supports both JSON responses and streamed SSE usage chunks.

Related to #896 and #906.

This PR implements the built-in NIXL v2 sidecar response usage correction for the default path, while #906 adds custom proxy handler extension points for similar accounting needs.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1012

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Use prefiller cached token usage for NIXL P/D responses.
```
