### PR TITLE
migrate: Correct some of the lint issues with the migrated IGW code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     revive: # see https://github.com/mgechev/revive#available-rules for all options
       rules:
         - name: blank-imports
+        - name: context-as-argument
         - name: context-keys-type
         - name: dot-imports
         - name: error-return

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters:
         - name: error-return
         - name: error-strings
         - name: error-naming
+        - name: if-return
         - name: package-comments
         - name: range
         - name: time-naming

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,7 @@ linters:
         - name: error-strings
         - name: error-naming
         - name: if-return
+        - name: increment-decrement
         - name: package-comments
         - name: range
         - name: time-naming

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -629,10 +629,7 @@ func (r *Runner) configureAndStartDatalayer(ctx context.Context, enableNewMetric
 		return err
 	}
 
-	if err := r.dlRuntime.Start(ctx, mgr); err != nil {
-		return err
-	}
-	return nil
+	return r.dlRuntime.Start(ctx, mgr)
 }
 
 func (r *Runner) setupMetricsCollection(enableNewMetrics bool, opts *runserver.Options, pmc backendmetrics.PodMetricsClient) datalayer.EndpointFactory {

--- a/pkg/epp/backend/metrics/podmetrics_parity_test.go
+++ b/pkg/epp/backend/metrics/podmetrics_parity_test.go
@@ -101,8 +101,8 @@ func TestMetricsParityStandard(t *testing.T) {
 			defer srv.Close()
 
 			ctx := context.Background()
-			pmMetrics, pmErr := parseWithBackendPodMetrics(t, ctx, srv.URL)
-			dlMetrics, dlErr := parseWithDatalayerMetrics(t, ctx, srv.URL)
+			pmMetrics, pmErr := parseWithBackendPodMetrics(ctx, t, srv.URL)
+			dlMetrics, dlErr := parseWithDatalayerMetrics(ctx, t, srv.URL)
 
 			assert.Equal(t, pmErr != nil, dlErr != nil,
 				"Error mismatch!\nPodMetrics err: %v\nDatalayer err: %v", pmErr, dlErr)
@@ -179,8 +179,8 @@ func TestMetricsParityMultiLoRA(t *testing.T) {
 			defer srv.Close()
 
 			ctx := context.Background()
-			pmMetrics, pmErr := parseWithBackendPodMetrics(t, ctx, srv.URL)
-			dlMetrics, dlErr := parseWithDatalayerMetrics(t, ctx, srv.URL)
+			pmMetrics, pmErr := parseWithBackendPodMetrics(ctx, t, srv.URL)
+			dlMetrics, dlErr := parseWithDatalayerMetrics(ctx, t, srv.URL)
 
 			assert.Equal(t, pmErr != nil, dlErr != nil,
 				"Error mismatch!\nPodMetrics err: %v\nDatalayer err: %v", pmErr, dlErr)
@@ -200,8 +200,8 @@ func TestMetricsParityTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	pmMetrics, pmErr := parseWithBackendPodMetrics(t, ctx, srv.URL)
-	dlMetrics, dlErr := parseWithDatalayerMetrics(t, ctx, srv.URL)
+	pmMetrics, pmErr := parseWithBackendPodMetrics(ctx, t, srv.URL)
+	dlMetrics, dlErr := parseWithDatalayerMetrics(ctx, t, srv.URL)
 
 	// Both should timeout and error
 	assert.Error(t, pmErr, "PodMetrics should have timed out")
@@ -246,8 +246,8 @@ func TestMetricsParityMalformed(t *testing.T) {
 			defer srv.Close()
 
 			ctx := context.Background()
-			pmMetrics, pmErr := parseWithBackendPodMetrics(t, ctx, srv.URL)
-			dlMetrics, dlErr := parseWithDatalayerMetrics(t, ctx, srv.URL)
+			pmMetrics, pmErr := parseWithBackendPodMetrics(ctx, t, srv.URL)
+			dlMetrics, dlErr := parseWithDatalayerMetrics(ctx, t, srv.URL)
 
 			// Both should handle errors similarly
 			if (pmErr != nil) != (dlErr != nil) {
@@ -273,7 +273,7 @@ type MetricMock struct {
 }
 
 // parseWithBackendPodMetrics uses the backend.PodMetrics implementation
-func parseWithBackendPodMetrics(t *testing.T, ctx context.Context, urlStr string) (*fwkdl.Metrics, error) {
+func parseWithBackendPodMetrics(ctx context.Context, t *testing.T, urlStr string) (*fwkdl.Metrics, error) {
 	t.Helper()
 
 	mapping, err := NewMetricMapping(
@@ -308,7 +308,7 @@ func parseWithBackendPodMetrics(t *testing.T, ctx context.Context, urlStr string
 }
 
 // parseWithDatalayerMetrics uses the datalayer source + extractor implementation
-func parseWithDatalayerMetrics(t *testing.T, ctx context.Context, urlStr string) (*fwkdl.Metrics, error) {
+func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string) (*fwkdl.Metrics, error) {
 	t.Helper()
 
 	parsedURL, err := url.Parse(urlStr)

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -192,8 +192,8 @@ func (r *benchRequest) ReceivedTimestamp() time.Time                   { return 
 
 // setupRegistry provisions the concrete FlowRegistry.
 func setupRegistry(
-	b *testing.B,
 	ctx context.Context,
+	b *testing.B,
 	handle plugin.Handle,
 	s shardCount,
 	p priorityLevels,
@@ -232,8 +232,8 @@ func setupRegistry(
 
 // setupBenchmarkHarness creates the standard SUT environment.
 func setupBenchmarkHarness(
-	b *testing.B,
 	ctx context.Context,
+	b *testing.B,
 	s shardCount,
 	p priorityLevels,
 	limit egressConcurrencyLimit,
@@ -255,7 +255,7 @@ func setupBenchmarkHarness(
 	}
 	handle.AddPlugin(registry.DefaultOrderingPolicyRef, oPolicy)
 
-	reg := setupRegistry(b, ctx, handle, s, p)
+	reg := setupRegistry(ctx, b, handle, s, p)
 
 	detector := customDetector
 	if detector == nil {

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -85,7 +85,7 @@ func BenchmarkFlowController_HighShardSort(b *testing.B) {
 func runMatrixCoordinate(b *testing.B, m benchMatrix) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	fc, detector := setupBenchmarkHarness(b, ctx, m.shards, m.priorities, m.limit, nil, nil)
+	fc, detector := setupBenchmarkHarness(ctx, b, m.shards, m.priorities, m.limit, nil, nil)
 
 	// Yield briefly to allow the background supervisor to bootstrap the data plane.
 	time.Sleep(10 * time.Millisecond)
@@ -189,7 +189,7 @@ func BenchmarkFlowController_TopologyChurn(b *testing.B) {
 		EnqueueChannelBufferSize:        100,
 	}
 
-	fc, detector := setupBenchmarkHarness(b, ctx, 4, 1, 100, nil, cfg)
+	fc, detector := setupBenchmarkHarness(ctx, b, 4, 1, 100, nil, cfg)
 
 	const numKeys = 50000
 	preAllocatedReqs := make([]*benchRequest, numKeys)
@@ -247,7 +247,7 @@ func BenchmarkFlowController_MassCancellation(b *testing.B) {
 	}
 
 	// Use the permanently saturated detector to guarantee all requests queue and definitively rot.
-	fc, _ := setupBenchmarkHarness(b, ctx, 4, 1, 100, &alwaysSaturatedDetector{}, cfg)
+	fc, _ := setupBenchmarkHarness(ctx, b, 4, 1, 100, &alwaysSaturatedDetector{}, cfg)
 
 	var timeoutCount atomic.Int64
 

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -86,8 +86,8 @@ func withHarnessClock(c clock.WithTicker) unitHarnessOption {
 // newUnitHarness creates a test environment with a mock processor factory, suitable for focused unit tests of the
 // controller's logic. It starts the controller's run loop using the provided context for lifecycle management.
 func newUnitHarness(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	cfg *Config,
 	registry *mockRegistryClient,
 	opts ...unitHarnessOption,
@@ -142,7 +142,7 @@ func newUnitHarness(
 
 // newIntegrationHarness creates a test environment that uses real `ShardProcessor`s, suitable for integration tests
 // validating the controller-processor interaction.
-func newIntegrationHarness(t *testing.T, ctx context.Context, cfg *Config, registry *mockRegistryClient) *testHarness {
+func newIntegrationHarness(ctx context.Context, t *testing.T, cfg *Config, registry *mockRegistryClient) *testHarness {
 	t.Helper()
 	mockDetector := &mockSaturationDetector{}
 	mockEndpointCandidates := &mocks.MockEndpointCandidates{}
@@ -345,7 +345,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnReqCtxExpiredBeforeDistribution", func(t *testing.T) {
 			t.Parallel()
 			// Test that if the request context provided to EnqueueAndWait is already expired, it returns immediately.
-			h := newUnitHarness(t, t.Context(), &Config{DefaultRequestTTL: 1 * time.Minute}, nil)
+			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 1 * time.Minute}, nil)
 
 			// Configure registry to return a shard.
 			shardA := newMockShard("shard-A").build()
@@ -382,7 +382,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			t.Parallel()
 			// Create a context specifically for the controller's lifecycle.
 			ctx, cancel := context.WithCancel(t.Context())
-			h := newUnitHarness(t, ctx, &Config{}, nil)
+			h := newUnitHarness(ctx, t, &Config{}, nil)
 			cancel() // Immediately stop the controller.
 
 			// Wait for the controller's run loop and all workers (none in this case) to exit.
@@ -402,7 +402,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnNoShardsAvailable", func(t *testing.T) {
 			t.Parallel()
 			// The default mockRegistryClient returns an empty list of ActiveShards.
-			h := newUnitHarness(t, t.Context(), &Config{}, nil)
+			h := newUnitHarness(t.Context(), t, &Config{}, nil)
 
 			req := newTestRequest(defaultFlowKey)
 			outcome, err := h.fc.EnqueueAndWait(context.Background(), req)
@@ -415,7 +415,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnRegistryConnectionError", func(t *testing.T) {
 			t.Parallel()
 			mockRegistry := &mockRegistryClient{}
-			h := newUnitHarness(t, t.Context(), &Config{}, mockRegistry)
+			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
 
 			expectedErr := errors.New("simulated connection failure")
 			// Configure the registry to fail when attempting to retrieve ActiveFlowConnection.
@@ -438,7 +438,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnManagedQueueError", func(t *testing.T) {
 			t.Parallel()
 			mockRegistry := &mockRegistryClient{}
-			h := newUnitHarness(t, t.Context(), &Config{}, mockRegistry)
+			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
 
 			// Create a faulty shard that successfully leases the flow but fails to return the
 			// ManagedQueue. This shard should be considered as unavailable.
@@ -615,7 +615,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				if tc.requestTTL > 0 {
 					harnessConfig.DefaultRequestTTL = tc.requestTTL
 				}
-				h := newUnitHarness(t, t.Context(), harnessConfig, mockRegistry)
+				h := newUnitHarness(t.Context(), t, harnessConfig, mockRegistry)
 
 				// Configure the registry to return the specified shards.
 				mockRegistry.WithConnectionFunc = func(
@@ -680,7 +680,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				},
 			}
 			// Use a long TTL to ensure the failure is due to cancellation, not timeout.
-			h := newUnitHarness(t, t.Context(), &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry)
+			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry)
 			h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
 				// Reject non-blocking attempt.
 				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
@@ -735,7 +735,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				},
 			}
 			// Use a long TTL to ensure retries don't time out.
-			h := newUnitHarness(t, t.Context(), &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry)
+			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry)
 
 			// Configure Shard A's processor to reject the request due to draining.
 			h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
@@ -774,7 +774,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnReqCtxCancelledAfterDistribution", func(t *testing.T) {
 			t.Parallel()
 			// Use a long TTL to ensure the failure is due to cancellation.
-			h := newUnitHarness(t, t.Context(), &Config{DefaultRequestTTL: 10 * time.Second}, nil)
+			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, nil)
 
 			shardA := newMockShard("shard-A").build()
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {
@@ -848,7 +848,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			t.Parallel()
 			// Configure a short TTL to keep the test reasonably fast.
 			const requestTTL = 50 * time.Millisecond
-			h := newUnitHarness(t, t.Context(), &Config{
+			h := newUnitHarness(t.Context(), t, &Config{
 				DefaultRequestTTL:               requestTTL,
 				ProcessorReconciliationInterval: time.Minute,
 				ExpiryCleanupInterval:           time.Minute,
@@ -949,7 +949,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				},
 			}
 
-			h := newUnitHarness(t, t.Context(), &Config{}, mockRegistry)
+			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
 
 			// 2. Setup Processor: Simulate a long wait in the queue.
 			h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
@@ -1021,7 +1021,7 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 				// The current state of the world according to the registry.
 				return []contracts.ShardStats{{ID: "shard-A"}}
 			}}
-		h := newUnitHarness(t, t.Context(), &Config{}, mockRegistry)
+		h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
 
 		// Pre-populate the controller with initial workers, simulating a previous state.
 		initialShards := []string{"shard-A", "stale-shard"}
@@ -1095,7 +1095,7 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 			return nil
 		}
 
-		h := newUnitHarness(t, t.Context(), &Config{ProcessorReconciliationInterval: reconciliationInterval}, mockRegistry)
+		h := newUnitHarness(t.Context(), t, &Config{ProcessorReconciliationInterval: reconciliationInterval}, mockRegistry)
 		// Ensure we are using the FakeClock specifically for this test, as we need Step/HasWaiters.
 		require.NotNil(t, h.mockClock, "This test requires the harness to be using FakeClock")
 
@@ -1128,7 +1128,7 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 		// Map to store the construction context for each processor instance, allowing us to verify cleanup.
 		constructionContexts := sync.Map{}
 
-		h := newUnitHarness(t, t.Context(), &Config{}, nil)
+		h := newUnitHarness(t.Context(), t, &Config{}, nil)
 
 		// Inject a custom factory to control the timing of worker creation.
 		h.fc.shardProcessorFactory = func(
@@ -1316,7 +1316,7 @@ func TestFlowController_Concurrency_Distribution(t *testing.T) {
 	mockRegistry := setupRegistryForConcurrency(t, numShards, defaultFlowKey)
 
 	// Initialize the integration harness with real ShardProcessors.
-	h := newIntegrationHarness(t, t.Context(), &Config{
+	h := newIntegrationHarness(t.Context(), t, &Config{
 		// Use a generous buffer to focus the test on distribution logic rather than backpressure.
 		EnqueueChannelBufferSize: numRequests,
 		DefaultRequestTTL:        5 * time.Second,
@@ -1385,7 +1385,7 @@ func TestFlowController_Concurrency_Backpressure(t *testing.T) {
 	mockRegistry := setupRegistryForConcurrency(t, numShards, defaultFlowKey)
 
 	// Use the integration harness with a configuration designed to induce backpressure.
-	h := newIntegrationHarness(t, t.Context(), &Config{
+	h := newIntegrationHarness(t.Context(), t, &Config{
 		// Zero buffer forces immediate use of SubmitOrBlock if the processor loop is busy.
 		EnqueueChannelBufferSize: 0,
 		// Generous TTL to ensure timeouts are not the cause of failure.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async_test.go
@@ -91,7 +91,7 @@ func TestLatencyPredictorIntegration(t *testing.T) {
 	}
 
 	t.Run("TestModelInfo", func(t *testing.T) {
-		testModelInfo(t, ctx, predictor)
+		testModelInfo(ctx, t, predictor)
 	})
 
 	t.Run("TestBulkTrainingData", func(t *testing.T) {
@@ -99,55 +99,55 @@ func TestLatencyPredictorIntegration(t *testing.T) {
 	})
 
 	t.Run("TestPrediction", func(t *testing.T) {
-		testPrediction(t, ctx, predictor)
+		testPrediction(ctx, t, predictor)
 	})
 
 	t.Run("TestBulkPredictions", func(t *testing.T) {
-		testBulkPredictions(t, ctx, predictor)
+		testBulkPredictions(ctx, t, predictor)
 	})
 
 	t.Run("TestBulkPredictionsStrict", func(t *testing.T) {
-		testBulkPredictionsStrict(t, ctx, predictor)
+		testBulkPredictionsStrict(ctx, t, predictor)
 	})
 
 	t.Run("TestPredictionWithPrefixCache", func(t *testing.T) {
-		testPredictionWithPrefixCache(t, ctx, predictor)
+		testPredictionWithPrefixCache(ctx, t, predictor)
 	})
 
 	t.Run("TestHTTPFallbackPrediction", func(t *testing.T) {
-		testHTTPFallbackPrediction(t, ctx, predictor)
+		testHTTPFallbackPrediction(ctx, t, predictor)
 	})
 
 	t.Run("TestLightGBMSupport", func(t *testing.T) {
-		testLightGBMSupport(t, ctx, predictor)
+		testLightGBMSupport(ctx, t, predictor)
 	})
 
 	t.Run("TestPredictionPerformance", func(t *testing.T) {
-		testPredictionPerformance(t, ctx, predictor)
+		testPredictionPerformance(ctx, t, predictor)
 	})
 
 	t.Run("TestBulkPredictionPerformance", func(t *testing.T) {
-		testBulkPredictionPerformance(t, ctx, predictor)
+		testBulkPredictionPerformance(ctx, t, predictor)
 	})
 
 	t.Run("TestHTTPOnlyPerformance", func(t *testing.T) {
-		testHTTPOnlyPerformance(t, ctx)
+		testHTTPOnlyPerformance(ctx, t)
 	})
 
 	t.Run("TestXGBoostJSONStructure", func(t *testing.T) {
-		testXGBoostJSONStructure(t, ctx, predictor)
+		testXGBoostJSONStructure(ctx, t, predictor)
 	})
 
 	t.Run("TestHTTPOnlyPrediction", func(t *testing.T) {
-		testHTTPOnlyPrediction(t, ctx)
+		testHTTPOnlyPrediction(ctx, t)
 	})
 
 	t.Run("TestMetricsRetrieval", func(t *testing.T) {
-		testMetricsRetrieval(t, ctx, predictor)
+		testMetricsRetrieval(ctx, t, predictor)
 	})
 
 	t.Run("TestLoadBalancing", func(t *testing.T) {
-		testLoadBalancing(t, ctx, predictor)
+		testLoadBalancing(ctx, t, predictor)
 	})
 
 	t.Run("TestPrefixCacheValidation", func(t *testing.T) {
@@ -159,7 +159,7 @@ func TestLatencyPredictorIntegration(t *testing.T) {
 	})
 }
 
-func testModelInfo(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testModelInfo(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing model info retrieval...")
 
 	modelInfo, err := predictor.GetModelInfo(ctx)
@@ -202,7 +202,7 @@ func testBulkTrainingData(t *testing.T, predictor *Predictor) {
 	t.Log("Training data should have been flushed to training server")
 }
 
-func testPrediction(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testPrediction(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing prediction functionality...")
 
 	// Log current predictor state
@@ -296,7 +296,7 @@ func testPrediction(t *testing.T, ctx context.Context, predictor *Predictor) {
 	}
 }
 
-func testBulkPredictions(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testBulkPredictions(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing bulk predictions with error tolerance...")
 
 	if !predictor.IsReady() {
@@ -365,7 +365,7 @@ func testBulkPredictions(t *testing.T, ctx context.Context, predictor *Predictor
 	}
 }
 
-func testBulkPredictionsStrict(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testBulkPredictionsStrict(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing strict bulk predictions...")
 
 	if !predictor.IsReady() {
@@ -424,7 +424,7 @@ func testBulkPredictionsStrict(t *testing.T, ctx context.Context, predictor *Pre
 	}
 }
 
-func testLightGBMSupport(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testLightGBMSupport(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing LightGBM support...")
 
 	currentModelType := predictor.GetCurrentModelType()
@@ -480,7 +480,7 @@ func testLightGBMSupport(t *testing.T, ctx context.Context, predictor *Predictor
 	}
 }
 
-func testPredictionWithPrefixCache(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testPredictionWithPrefixCache(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing prefix cache score impact on predictions...")
 
 	if !predictor.IsReady() {
@@ -550,7 +550,7 @@ func testPredictionWithPrefixCache(t *testing.T, ctx context.Context, predictor 
 	}
 }
 
-func testHTTPFallbackPrediction(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testHTTPFallbackPrediction(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing HTTP fallback prediction...")
 
 	modelType := predictor.GetCurrentModelType()
@@ -598,7 +598,7 @@ func testHTTPFallbackPrediction(t *testing.T, ctx context.Context, predictor *Pr
 	t.Logf("Successfully tested HTTP prediction with prefix cache")
 }
 
-func testPredictionPerformance(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testPredictionPerformance(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing prediction performance (target: < 300ms) with prefix cache scores...")
 
 	// Ensure predictor is ready
@@ -690,7 +690,7 @@ func testPredictionPerformance(t *testing.T, ctx context.Context, predictor *Pre
 	}
 }
 
-func testBulkPredictionPerformance(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testBulkPredictionPerformance(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing bulk prediction performance...")
 
 	if !predictor.IsReady() {
@@ -776,7 +776,7 @@ func testBulkPredictionPerformance(t *testing.T, ctx context.Context, predictor 
 	}
 }
 
-func testHTTPOnlyPerformance(t *testing.T, ctx context.Context) {
+func testHTTPOnlyPerformance(ctx context.Context, t *testing.T) {
 	t.Log("Testing HTTP-only prediction performance (no native XGBoost interference) with prefix cache...")
 
 	predictionURLs := os.Getenv("PREDICTION_SERVER_URL")
@@ -963,7 +963,7 @@ func testHTTPOnlyPerformance(t *testing.T, ctx context.Context) {
 	}
 }
 
-func testHTTPOnlyPrediction(t *testing.T, ctx context.Context) {
+func testHTTPOnlyPrediction(ctx context.Context, t *testing.T) {
 	t.Log("Testing HTTP-only prediction (bypassing native XGBoost) with prefix cache...")
 
 	// Create a predictor with native XGBoost disabled to force HTTP usage
@@ -1096,7 +1096,7 @@ func testHTTPOnlyPrediction(t *testing.T, ctx context.Context) {
 	t.Log("Successfully tested HTTP-only predictions with prefix cache")
 }
 
-func testLoadBalancing(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testLoadBalancing(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing load balancing across multiple prediction URLs with prefix cache...")
 
 	predictionURLs := predictor.GetPredictionURLs()
@@ -1288,7 +1288,7 @@ func testPredictionConstructors(t *testing.T) {
 	t.Log("✅ Constructor validation tests completed")
 }
 
-func testXGBoostJSONStructure(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testXGBoostJSONStructure(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing XGBoost JSON structure from server...")
 
 	if predictor.GetCurrentModelType() != xgBoostModelType {
@@ -1398,7 +1398,7 @@ func testConvertXGBoostJSON(t *testing.T, tree any) {
 	}
 }
 
-func testMetricsRetrieval(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testMetricsRetrieval(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing metrics retrieval...")
 
 	modelType := predictor.GetCurrentModelType()
@@ -1407,11 +1407,11 @@ func testMetricsRetrieval(t *testing.T, ctx context.Context, predictor *Predicto
 
 	switch modelType {
 	case bayesianRidgeModelType:
-		testBayesianRidgeMetrics(t, ctx, predictor)
+		testBayesianRidgeMetrics(ctx, t, predictor)
 	case xgBoostModelType:
-		testXGBoostMetrics(t, ctx, predictor)
+		testXGBoostMetrics(ctx, t, predictor)
 	case gbmModelType:
-		testLightGBMMetrics(t, ctx, predictor)
+		testLightGBMMetrics(ctx, t, predictor)
 	default:
 		t.Logf("Unknown model type %s, testing cached metrics only", modelType)
 	}
@@ -1435,7 +1435,7 @@ func testMetricsRetrieval(t *testing.T, ctx context.Context, predictor *Predicto
 	t.Logf("  Bayesian Ridge Ready: %t", predictor.IsBayesianRidgeReady())
 }
 
-func testBayesianRidgeMetrics(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testBayesianRidgeMetrics(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing Bayesian Ridge specific metrics with prefix cache support...")
 
 	metrics, err := predictor.GetMetrics(ctx)
@@ -1492,7 +1492,7 @@ func testBayesianRidgeMetrics(t *testing.T, ctx context.Context, predictor *Pred
 	}
 }
 
-func testXGBoostMetrics(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testXGBoostMetrics(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing XGBoost specific metrics...")
 
 	// Wait a bit for XGBoost models to potentially load
@@ -1523,7 +1523,7 @@ func testXGBoostMetrics(t *testing.T, ctx context.Context, predictor *Predictor)
 	}
 }
 
-func testLightGBMMetrics(t *testing.T, ctx context.Context, predictor *Predictor) {
+func testLightGBMMetrics(ctx context.Context, t *testing.T, predictor *Predictor) {
 	t.Log("Testing LightGBM specific metrics...")
 
 	// For LightGBM, we primarily use HTTP calls, so test the HTTP connectivity

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -43,10 +43,7 @@ func (s *StreamingServer) HandleRequestHeaders(ctx context.Context, reqCtx *Requ
 		// More context: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/526
 		// The above PR will address endpoint admission, but currently any request without a body will be
 		// routed to a random upstream endpoint.
-		if err := s.fallbackToRandomEndpoint(ctx, reqCtx, 0); err != nil {
-			return err
-		}
-		return nil
+		return s.fallbackToRandomEndpoint(ctx, reqCtx, 0)
 	}
 
 	for _, header := range req.RequestHeaders.Headers.Headers {

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -453,7 +453,7 @@ func (d *Director) runPrepareDataPlugins(ctx context.Context,
 	if len(d.requestControlPlugins.prepareDataPlugins) == 0 {
 		return nil
 	}
-	return prepareDataPluginsWithTimeout(prepareDataTimeout, d.requestControlPlugins.prepareDataPlugins, ctx, request, endpoints)
+	return prepareDataPluginsWithTimeout(ctx, prepareDataTimeout, d.requestControlPlugins.prepareDataPlugins, request, endpoints)
 }
 
 func (d *Director) runAdmissionPlugins(ctx context.Context,

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -28,7 +28,7 @@ import (
 // executePluginsAsDAG executes PrepareData plugins as a DAG based on their dependencies asynchronously.
 // So, a plugin is executed only after all its dependencies have been executed.
 // If there is a cycle or any plugin fails with error, it returns an error.
-func executePluginsAsDAG(plugins []fwk.DataProducer, ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func executePluginsAsDAG(ctx context.Context, plugins []fwk.DataProducer, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	for _, plugin := range plugins {
 		if err := plugin.PrepareRequestData(ctx, request, endpoints); err != nil {
 			return errors.New("prepare data plugin " + plugin.TypedName().String() + " failed: " + err.Error())
@@ -40,14 +40,14 @@ func executePluginsAsDAG(plugins []fwk.DataProducer, ctx context.Context, reques
 // prepareDataPluginsWithTimeout executes the PrepareRequestData plugins with retries and timeout.
 // The child context is cancelled when the timeout fires so plugins can observe cancellation
 // (e.g. abort outbound HTTP calls) and avoid committing state after the director has moved on.
-func prepareDataPluginsWithTimeout(timeout time.Duration, plugins []fwk.DataProducer,
-	ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func prepareDataPluginsWithTimeout(ctx context.Context, timeout time.Duration, plugins []fwk.DataProducer,
+	request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- executePluginsAsDAG(plugins, ctx, request, endpoints)
+		errCh <- executePluginsAsDAG(ctx, plugins, request, endpoints)
 	}()
 
 	select {

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -100,9 +100,9 @@ func TestPrepareDataPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
 	plugin.wg.Add(1)
 
 	err := prepareDataPluginsWithTimeout(
+		context.Background(),
 		20*time.Millisecond,
 		[]fwk.DataProducer{plugin},
-		context.Background(),
 		&schedulingtypes.InferenceRequest{},
 		nil,
 	)
@@ -198,7 +198,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			ctx, cancel := tc.ctxFn()
 			defer cancel()
 
-			err := prepareDataPluginsWithTimeout(tc.timeout, tc.plugins, ctx, &schedulingtypes.InferenceRequest{}, nil)
+			err := prepareDataPluginsWithTimeout(ctx, tc.timeout, tc.plugins, &schedulingtypes.InferenceRequest{}, nil)
 
 			if tc.expectSuccess {
 				assert.NoError(t, err)
@@ -334,7 +334,7 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 				plugin.execTime = time.Time{}
 			}
 
-			err := executePluginsAsDAG(tc.plugins, context.Background(), &schedulingtypes.InferenceRequest{}, nil)
+			err := executePluginsAsDAG(context.Background(), tc.plugins, &schedulingtypes.InferenceRequest{}, nil)
 
 			if tc.expectErr {
 				assert.Error(t, err)

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -240,11 +240,7 @@ func (opts *Options) Validate() error {
 	}
 
 	// Validate logging options.
-	if err := opts.LoggingOptions.Validate(); err != nil {
-		return err
-	}
-
-	return nil
+	return opts.LoggingOptions.Validate()
 }
 
 func removeDuplicatePorts(ports []int) []int {

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -131,7 +131,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
 	streamingServer := handlers.NewStreamingServer(ds, director, openai.NewOpenAIParser())
 
-	testListener, errChan := utils.SetupTestStreamingServer(t, ctx, streamingServer)
+	testListener, errChan := utils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := utils.GetStreamingServerClient(ctx, t)
 	defer conn.Close()
 
@@ -421,7 +421,7 @@ func TestServer_Skip(t *testing.T) {
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
 	streamingServer := handlers.NewStreamingServer(ds, director, mockPar)
 
-	testListener, errChan := utils.SetupTestStreamingServer(t, ctx, streamingServer)
+	testListener, errChan := utils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := utils.GetStreamingServerClient(ctx, t)
 	defer conn.Close()
 

--- a/test/utils/igw/server.go
+++ b/test/utils/igw/server.go
@@ -132,11 +132,7 @@ func LaunchTestGRPCServer(ctx context.Context, s pb.ExternalProcessorServer, lis
 		grpcServer.GracefulStop()
 	}()
 
-	if err := grpcServer.Serve(listener); err != nil {
-		return err
-	}
-
-	return nil
+	return grpcServer.Serve(listener)
 }
 
 func CheckEnvoyGRPCHeaders(t *testing.T, response *pb.CommonResponse, expectedHeaders map[string]string) bool {

--- a/test/utils/igw/server.go
+++ b/test/utils/igw/server.go
@@ -78,12 +78,12 @@ func PrepareForTestStreamingServer(objectives []*v1alpha2.InferenceObjective, po
 	return ctx, cancel, ds, pmc
 }
 
-func SetupTestStreamingServer(t *testing.T, ctx context.Context, streamingServer pb.ExternalProcessorServer) (*bufconn.Listener, chan error) {
+func SetupTestStreamingServer(ctx context.Context, t *testing.T, streamingServer pb.ExternalProcessorServer) (*bufconn.Listener, chan error) {
 	testListener = bufconn.Listen(bufSize)
 
 	errChan := make(chan error)
 	go func() {
-		err := LaunchTestGRPCServer(streamingServer, ctx, testListener)
+		err := LaunchTestGRPCServer(ctx, streamingServer, testListener)
 		if err != nil {
 			t.Error("Error launching listener", err)
 		}
@@ -120,7 +120,7 @@ func GetStreamingServerClient(ctx context.Context, t *testing.T) (pb.ExternalPro
 }
 
 // LaunchTestGRPCServer actually starts the server (enables testing)
-func LaunchTestGRPCServer(s pb.ExternalProcessorServer, ctx context.Context, listener net.Listener) error {
+func LaunchTestGRPCServer(ctx context.Context, s pb.ExternalProcessorServer, listener net.Listener) error {
 	grpcServer := grpc.NewServer()
 
 	pb.RegisterExternalProcessorServer(grpcServer, s)

--- a/test/utils/igw/utils.go
+++ b/test/utils/igw/utils.go
@@ -257,7 +257,7 @@ func checkPodStatus(testConfig *TestConfig, pod *corev1.Pod, conditions []corev1
 	for _, want := range conditions {
 		for _, c := range fetchedPod.Status.Conditions {
 			if c.Type == want.Type && c.Status == want.Status {
-				found += 1
+				found++
 			}
 		}
 	}
@@ -300,7 +300,7 @@ func checkDeploymentStatus(ctx context.Context, cli client.Client, deploy *appsv
 	for _, want := range conditions {
 		for _, c := range fetchedDeploy.Status.Conditions {
 			if c.Type == want.Type && c.Status == want.Status {
-				found += 1
+				found++
 			}
 		}
 	}
@@ -336,7 +336,7 @@ func checkCrdStatus(
 	for _, want := range conditions {
 		for _, c := range fetchedCrd.Status.Conditions {
 			if c.Type == want.Type && c.Status == want.Status {
-				found += 1
+				found++
 			}
 		}
 	}


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
The Inference Gateway Extension (IGW) project had a less strict configuration for linting the code using golangci-lint than was used in the llm-d-inference-scheduler. A number of the lint rules were removed to enable the migration of the code to the llm-d-inference-scheduler repo.

This PR is a step in re-enabling the golangci-lint rules that were removed. It re-enables several rules and corrected the issues in the IGW code to enable CI to pass.

Which issue(s) this PR fixes:
refs https://github.com/llm-d/llm-d-inference-scheduler/issues/832

Release note (write NONE if no user-facing change):
```release-note
NONE
```