### PR TITLE
fix(scorer): treat unset maxBusyScore as default 1.0 in active-reques…

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -34,9 +34,10 @@ type Parameters struct {
 	// (pods with request count > idleThreshold). This creates a scoring gap
 	// between idle and busy pods.
 	// Range: 0.0 to 1.0
-	// Default: 1.0 (no gap, current behavior)
+	// Default: 1.0 (no gap, current behavior). Pointer so an unset value is
+	// distinguishable from an explicit 0.0.
 	// Example: 0.5 means idle pods get 1.0, busiest pod gets 0.0, least busy gets 0.5
-	MaxBusyScore float64 `json:"maxBusyScore"`
+	MaxBusyScore *float64 `json:"maxBusyScore,omitempty"`
 
 	InFlightLoadProducerName string `json:"inFlightLoadProducerName,omitempty"`
 }
@@ -86,8 +87,12 @@ func NewActiveRequest(ctx context.Context, params *Parameters) *ActiveRequest {
 
 	// Set max busy score (default: 1.0)
 	maxBusyScore := 1.0
-	if params != nil && params.MaxBusyScore >= 0 && params.MaxBusyScore <= 1.0 {
-		maxBusyScore = params.MaxBusyScore
+	if params != nil && params.MaxBusyScore != nil {
+		if *params.MaxBusyScore >= 0 && *params.MaxBusyScore <= 1.0 {
+			maxBusyScore = *params.MaxBusyScore
+		} else {
+			logger.Info("Ignoring out-of-range maxBusyScore; using default 1.0", "provided", *params.MaxBusyScore)
+		}
 	}
 
 	if idleThreshold != 0 || maxBusyScore != 1.0 {

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -18,6 +18,8 @@ import (
 
 // Test helper functions
 
+func float64Ptr(v float64) *float64 { return &v }
+
 func newTestEndpoint(name string, queueSize int) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
@@ -176,7 +178,7 @@ func TestActiveRequest_IdleThresholdAndMaxBusyScore(t *testing.T) {
 	t.Run("binary mode: idleThreshold=0, maxBusyScore=0", func(t *testing.T) {
 		params := &Parameters{
 			IdleThreshold: 0,
-			MaxBusyScore:  0.0,
+			MaxBusyScore:  float64Ptr(0.0),
 		}
 		scorer := NewActiveRequest(ctx, params)
 
@@ -198,7 +200,7 @@ func TestActiveRequest_IdleThresholdAndMaxBusyScore(t *testing.T) {
 	t.Run("hybrid mode: idleThreshold=1, maxBusyScore=0.5", func(t *testing.T) {
 		params := &Parameters{
 			IdleThreshold: 1,
-			MaxBusyScore:  0.5,
+			MaxBusyScore:  float64Ptr(0.5),
 		}
 		scorer := NewActiveRequest(ctx, params)
 
@@ -211,6 +213,23 @@ func TestActiveRequest_IdleThresholdAndMaxBusyScore(t *testing.T) {
 		assert.Equal(t, 0.0, scores[podB], "Pod with 2 requests (busiest) scores 0.0")
 		assert.Equal(t, 1.0, scores[podC], "Pod with 0 requests is idle")
 	})
+}
+
+// TestActiveRequest_DefaultParamsProduceContinuousScores guards against the
+// regression where an unset MaxBusyScore (Go zero-value 0.0) silently put the
+// scorer into binary mode, returning 0.0 for every non-idle pod.
+func TestActiveRequest_DefaultParamsProduceContinuousScores(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := NewActiveRequest(ctx, &Parameters{})
+
+	podLight := newTestEndpointWithLoad("pod-light", 3)
+	podHeavy := newTestEndpointWithLoad("pod-heavy", 11)
+
+	scores := scorer.Score(ctx, nil, []scheduling.Endpoint{podLight, podHeavy})
+
+	assert.InDelta(t, 0.7272, scores[podLight], 0.001,
+		"light pod must get a non-zero score when no parameters are configured")
+	assert.Equal(t, 0.0, scores[podHeavy])
 }
 
 func inFlightRequests(t *testing.T, endpoint scheduling.Endpoint) int64 {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`active-request-scorer` is documented to return a continuous score in `[0, 1]` inversely proportional to pod load. In practice, when the YAML does not specify `maxBusyScore`, the scorer returns `0.0` for every non-idle pod, providing no load-balancing signal. Every known deployment in the `llm-d` org (including the official `wide-ep-lws` guide) is affected because no one sets `maxBusyScore` in config.

**Root cause:** Go's zero-value for `float64` is `0.0`, which collides with a valid configuration value. The constructor cannot tell "user omitted the key" from "user explicitly set it to 0", and treats both as `0.0` — clobbering the documented default of `1.0`.

**Fix:** Change `Parameters.MaxBusyScore` from `float64` to `*float64` so `nil` unambiguously means "unset, use default". Out-of-range explicit values now log a warning and fall back to `1.0` instead of being silently dropped.

**Behavior after fix:**

| YAML                                | `params.MaxBusyScore` | resulting `maxBusyScore` |
|-------------------------------------|-----------------------|--------------------------|
| *(no `parameters:` block)*          | `nil`                 | **`1.0`** (fix)          |
| `parameters: { maxBusyScore: 0.0 }` | `*0.0`                | `0.0` (binary)           |
| `parameters: { maxBusyScore: 0.5 }` | `*0.5`                | `0.5` (hybrid)           |
| `parameters: { maxBusyScore: 2.0 }` | `*2.0`                | `1.0` (rejected, logged) |

**Evidence from production:**

In a 7-pod Qwen3-30B-A3B, the scorer's count tracking matched ground truth (e.g. 11 active requests on the busiest pod, 3 on the lightest), but every `"Scored endpoints"` log line reported `0.0` for every pod. With the documented default `maxBusyScore=1.0` the lightest pods should have scored `~0.727`. At weight `3.8` this scorer was expected to be a dominant routing signal; with the bug it contributed nothing and load drifted into a 4× imbalance (3 vs 11 active requests).

**Changes:**

- `pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go`: `MaxBusyScore` is now `*float64`; nil → default `1.0`; out-of-range values log and fall back.
- `pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go`: existing tests updated to use a `float64Ptr` helper. Added regression test `TestActiveRequest_DefaultParamsProduceContinuousScores` that constructs the scorer with empty `Parameters` and asserts continuous (non-binary) scoring.

**Backward compatibility:**

- JSON tag `"maxBusyScore"` unchanged — existing YAML configs that explicitly set the value behave identically.
- The only in-tree caller building `Parameters` directly (apart from tests) is the factory, which uses `json.Unmarshal` — pointer types are handled natively.

**Which issue(s) this PR fixes**:

N/A — bug discovered via internal experiment logs 

**Release note**:
```release-note
fix(scorer): `active-request-scorer` now correctly applies its documented default `maxBusyScore=1.0` when the parameter is omitted from configuration. Previously, an unset value silently collapsed the scorer into binary mode (0.0 for any non-idle pod), eliminating its load-balancing signal in every deployment that relied on default parameters.