### PR TITLE
refactor: align all import aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ formatters:
 
 linters:
   enable:
+    - importas
     - bodyclose
     - copyloopvar
     - dupword
@@ -48,6 +49,33 @@ linters:
       - linters: [goconst, prealloc]
         path: "_test\\.go"
   settings:
+    importas:
+      no-unaliased: false # unaliased imports are allowed; only enforce when an alias is used
+      alias:
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling
+          alias: fwksched
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol
+          alias: fwkrc
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol
+          alias: fwkfc
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks
+          alias: fwkfcmocks
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin
+          alias: fwkplugin
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix
+          alias: attrprefix
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics
+          alias: extractormetrics
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics
+          alias: sourcemetrics
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool
+          alias: poolutil
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing
+          alias: testutil
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/common/error
+          alias: errcommon
+        - pkg: github.com/llm-d/llm-d-inference-scheduler/test/utils/igw
+          alias: igwtestutils
     revive: # see https://github.com/mgechev/revive#available-rules for all options
       rules:
         - name: blank-imports

--- a/pkg/epp/backend/metrics/podmetrics_parity_test.go
+++ b/pkg/epp/backend/metrics/podmetrics_parity_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	metricextractor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
+	extractormetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
@@ -325,7 +325,7 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 		return nil, fmt.Errorf("failed to marshal datasource parameters: %w", err)
 	}
 
-	mapping, err := metricextractor.NewMapping(
+	mapping, err := extractormetrics.NewMapping(
 		WaitingMetric,
 		RunningMetric,
 		KVCacheMetric,
@@ -336,12 +336,12 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 		return nil, fmt.Errorf("failed to create mapping: %w", err)
 	}
 
-	registry := metricextractor.NewMappingRegistry()
-	if err := registry.Register(metricextractor.DefaultEngineType, mapping); err != nil {
+	registry := extractormetrics.NewMappingRegistry()
+	if err := registry.Register(extractormetrics.DefaultEngineType, mapping); err != nil {
 		return nil, fmt.Errorf("failed to register mapping: %w", err)
 	}
 
-	extractor, err := metricextractor.NewCoreMetricsExtractor(registry, metricextractor.DefaultEngineTypeLabelKey)
+	extractor, err := extractormetrics.NewCoreMetricsExtractor(registry, extractormetrics.DefaultEngineTypeLabelKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create extractor: %w", err)
 	}
@@ -363,7 +363,7 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 	metadata := &fwkdl.EndpointMetadata{
 		MetricsHost: parsedURL.Host,
 		Labels: map[string]string{
-			metricextractor.DefaultEngineTypeLabelKey: metricextractor.DefaultEngineType,
+			extractormetrics.DefaultEngineTypeLabelKey: extractormetrics.DefaultEngineType,
 		},
 	}
 	endpoint := fwkdl.NewEndpoint(metadata, fwkdl.NewMetrics())

--- a/pkg/epp/config/config.go
+++ b/pkg/epp/config/config.go
@@ -19,7 +19,7 @@ package config
 import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol"
-	fwkflowcontrol "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
+	fwkfc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/scheduling"
 )
@@ -27,7 +27,7 @@ import (
 // Config is the configuration loaded from the text based configuration
 type Config struct {
 	SchedulerConfig    *scheduling.SchedulerConfig
-	SaturationDetector fwkflowcontrol.SaturationDetector
+	SaturationDetector fwkfc.SaturationDetector
 	DataConfig         *datalayer.Config
 	FlowControlConfig  *flowcontrol.Config
 	ParserConfig       *handlers.Config

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -34,10 +34,10 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	fwkflowcontrol "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
+	fwkfc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/profilehandler/single"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/scheduling"
@@ -165,9 +165,9 @@ func InstantiateAndConfigure(
 	if !ok {
 		return nil, fmt.Errorf("saturation detector plugin '%s' not found", rawConfig.SaturationDetector.PluginRef)
 	}
-	saturationDetector, ok := plugin.(fwkflowcontrol.SaturationDetector)
+	saturationDetector, ok := plugin.(fwkfc.SaturationDetector)
 	if !ok {
-		return nil, fmt.Errorf("plugin '%s' is not a fwkflowcontrol.SaturationDetector", rawConfig.SaturationDetector.PluginRef)
+		return nil, fmt.Errorf("plugin '%s' is not a fwkfc.SaturationDetector", rawConfig.SaturationDetector.PluginRef)
 	}
 
 	return &config.Config{
@@ -219,7 +219,7 @@ func buildSchedulerConfig(
 	handle fwkplugin.Handle,
 ) (*scheduling.SchedulerConfig, error) {
 
-	profiles := make(map[string]framework.SchedulerProfile)
+	profiles := make(map[string]fwksched.SchedulerProfile)
 
 	for _, cfgProfile := range configProfiles {
 		fwProfile := scheduling.NewSchedulerProfile()
@@ -233,7 +233,7 @@ func buildSchedulerConfig(
 			}
 
 			// Wrap Scorers with weights.
-			if scorer, ok := plugin.(framework.Scorer); ok {
+			if scorer, ok := plugin.(fwksched.Scorer); ok {
 				weight := DefaultScorerWeight
 				if pluginRef.Weight != nil {
 					weight = *pluginRef.Weight
@@ -248,9 +248,9 @@ func buildSchedulerConfig(
 		profiles[cfgProfile.Name] = fwProfile
 	}
 
-	var profileHandler framework.ProfileHandler
+	var profileHandler fwksched.ProfileHandler
 	for name, plugin := range handle.GetAllPluginsWithNames() {
-		if ph, ok := plugin.(framework.ProfileHandler); ok {
+		if ph, ok := plugin.(fwksched.ProfileHandler); ok {
 			if profileHandler != nil {
 				return nil, fmt.Errorf("multiple profile handlers found ('%s', '%s'); only one is allowed",
 					profileHandler.TypedName().Name, name)

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -37,10 +37,10 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/registry"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	fwkflowcontrol "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	flowcontrolmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkfc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
+	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	extractormetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
@@ -52,7 +52,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/queuedepth"
-	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 // Define constants for test plugins.
@@ -647,7 +647,7 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			}
 
 			// 2. Instantiate & Configure
-			handle := utils.NewTestHandle(context.Background())
+			handle := igwtestutils.NewTestHandle(context.Background())
 			cfg, err := InstantiateAndConfigure(rawConfig, handle, logger)
 
 			if tc.wantErr {
@@ -667,7 +667,7 @@ func TestInstantiateAndConfigure(t *testing.T) {
 // logs a warning but does not return an error.
 func TestBuildDataLayerConfigEmptySourcesWarning(t *testing.T) {
 	t.Parallel()
-	handle := utils.NewTestHandle(context.Background())
+	handle := igwtestutils.NewTestHandle(context.Background())
 	cfg, err := buildDataLayerConfig(
 		&configapi.DataLayerConfig{Sources: []configapi.DataLayerSource{}},
 		handle,
@@ -698,13 +698,13 @@ func (m *mockPlugin) TypedName() fwkplugin.TypedName { return m.t }
 type mockScorer struct{ mockPlugin }
 
 // compile-time type assertion
-var _ framework.Scorer = &mockScorer{}
+var _ fwksched.Scorer = &mockScorer{}
 
-func (m *mockScorer) Category() framework.ScorerCategory {
-	return framework.Distribution
+func (m *mockScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Distribution
 }
 
-func (m *mockScorer) Score(context.Context, *framework.CycleState, *framework.InferenceRequest, []framework.Endpoint) map[framework.Endpoint]float64 {
+func (m *mockScorer) Score(context.Context, *fwksched.CycleState, *fwksched.InferenceRequest, []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	return nil
 }
 
@@ -712,9 +712,9 @@ func (m *mockScorer) Score(context.Context, *framework.CycleState, *framework.In
 type mockPicker struct{ mockPlugin }
 
 // compile-time type assertion
-var _ framework.Picker = &mockPicker{}
+var _ fwksched.Picker = &mockPicker{}
 
-func (m *mockPicker) Pick(context.Context, *framework.CycleState, []*framework.ScoredEndpoint) *framework.ProfileRunResult {
+func (m *mockPicker) Pick(context.Context, *fwksched.CycleState, []*fwksched.ScoredEndpoint) *fwksched.ProfileRunResult {
 	return nil
 }
 
@@ -722,14 +722,14 @@ func (m *mockPicker) Pick(context.Context, *framework.CycleState, []*framework.S
 type mockHandler struct{ mockPlugin }
 
 // compile-time type assertion
-var _ framework.ProfileHandler = &mockHandler{}
+var _ fwksched.ProfileHandler = &mockHandler{}
 
-func (m *mockHandler) Pick(context.Context, *framework.CycleState, *framework.InferenceRequest, map[string]framework.SchedulerProfile,
-	map[string]*framework.ProfileRunResult) map[string]framework.SchedulerProfile {
+func (m *mockHandler) Pick(context.Context, *fwksched.CycleState, *fwksched.InferenceRequest, map[string]fwksched.SchedulerProfile,
+	map[string]*fwksched.ProfileRunResult) map[string]fwksched.SchedulerProfile {
 	return nil
 }
-func (m *mockHandler) ProcessResults(context.Context, *framework.CycleState, *framework.InferenceRequest,
-	map[string]*framework.ProfileRunResult) (*framework.SchedulingResult, error) {
+func (m *mockHandler) ProcessResults(context.Context, *fwksched.CycleState, *fwksched.InferenceRequest,
+	map[string]*fwksched.ProfileRunResult) (*fwksched.SchedulingResult, error) {
 	return nil, errors.New("sentinel error for mock handler")
 }
 
@@ -740,7 +740,7 @@ type mockSource struct{ mockPlugin }
 type mockSaturationDetector struct{ mockPlugin }
 
 // compile-time type assertion
-var _ fwkflowcontrol.SaturationDetector = &mockSaturationDetector{}
+var _ fwkfc.SaturationDetector = &mockSaturationDetector{}
 
 func (m *mockSaturationDetector) Saturation(ctx context.Context, endpoints []fwkdl.Endpoint) float64 {
 	return 0.5
@@ -828,12 +828,12 @@ func registerTestPlugins(t *testing.T) {
 	})
 
 	fwkplugin.Register(globalstrict.GlobalStrictFairnessPolicyType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
-		return &flowcontrolmocks.MockFairnessPolicy{
+		return &fwkfcmocks.MockFairnessPolicy{
 			TypedNameV: fwkplugin.TypedName{Name: name, Type: globalstrict.GlobalStrictFairnessPolicyType},
 		}, nil
 	})
 	fwkplugin.Register(fcfs.FCFSOrderingPolicyType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
-		return &flowcontrolmocks.MockOrderingPolicy{
+		return &fwkfcmocks.MockOrderingPolicy{
 			TypedNameV: fwkplugin.TypedName{Name: name, Type: fcfs.FCFSOrderingPolicyType},
 		}, nil
 	})
@@ -925,7 +925,7 @@ func TestEnsureSaturationDetector(t *testing.T) {
 				PluginRef: "existing-plugin",
 			},
 		}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 		allPlugins := map[string]fwkplugin.Plugin{
 			"existing-plugin": &mockSaturationDetector{},
 		}
@@ -941,7 +941,7 @@ func TestEnsureSaturationDetector(t *testing.T) {
 				PluginRef: "",
 			},
 		}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 		allPlugins := map[string]fwkplugin.Plugin{
 			"utilization-detector": &mockSaturationDetector{},
 		}

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -26,7 +26,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/registry"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	extractormetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization"
@@ -153,7 +153,7 @@ func ensureSchedulingLayer(
 		// Auto-populate the default profile with all Filter, Scorer, and Picker plugins found.
 		for name, p := range allPlugins {
 			switch p.(type) {
-			case framework.Filter, framework.Scorer, framework.Picker:
+			case fwksched.Filter, fwksched.Scorer, fwksched.Picker:
 				defaultProfile.Plugins = append(defaultProfile.Plugins, configapi.SchedulingPlugin{PluginRef: name})
 			}
 		}
@@ -164,7 +164,7 @@ func ensureSchedulingLayer(
 	if len(cfg.SchedulingProfiles) == 1 {
 		hasHandler := false
 		for _, p := range allPlugins {
-			if _, ok := p.(framework.ProfileHandler); ok {
+			if _, ok := p.(fwksched.ProfileHandler); ok {
 				hasHandler = true
 				break
 			}
@@ -179,7 +179,7 @@ func ensureSchedulingLayer(
 	// Find or Create a default MaxScorePicker to reuse across profiles.
 	var maxScorePickerName string
 	for name, p := range allPlugins {
-		if _, ok := p.(framework.Picker); ok {
+		if _, ok := p.(fwksched.Picker); ok {
 			maxScorePickerName = name
 			break
 		}
@@ -197,11 +197,11 @@ func ensureSchedulingLayer(
 		for j, pluginRef := range prof.Plugins {
 			p := handle.Plugin(pluginRef.PluginRef)
 
-			if _, ok := p.(framework.Scorer); ok && pluginRef.Weight == nil {
+			if _, ok := p.(fwksched.Scorer); ok && pluginRef.Weight == nil {
 				cfg.SchedulingProfiles[i].Plugins[j].Weight = &defaultScorerWeight
 			}
 
-			if _, ok := p.(framework.Picker); ok {
+			if _, ok := p.(fwksched.Picker); ok {
 				hasPicker = true
 			}
 		}

--- a/pkg/epp/config/loader/defaults_test.go
+++ b/pkg/epp/config/loader/defaults_test.go
@@ -28,7 +28,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	extractormetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
-	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 // metricsPlugins returns an allPlugins map with mock stubs for both default metrics plugins.
@@ -46,7 +46,7 @@ func TestEnsureDataLayer(t *testing.T) {
 
 	t.Run("nil DataLayer injects metrics defaults", func(t *testing.T) {
 		cfg := &configapi.EndpointPickerConfig{}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 
 		err := ensureDataLayer(cfg, handle, metricsPlugins())
 
@@ -62,7 +62,7 @@ func TestEnsureDataLayer(t *testing.T) {
 		cfg := &configapi.EndpointPickerConfig{
 			DataLayer: &configapi.DataLayerConfig{},
 		}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 
 		err := ensureDataLayer(cfg, handle, metricsPlugins())
 
@@ -79,7 +79,7 @@ func TestEnsureDataLayer(t *testing.T) {
 				},
 			},
 		}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 
 		err := ensureDataLayer(cfg, handle, metricsPlugins())
 
@@ -98,7 +98,7 @@ func TestEnsureDataLayer(t *testing.T) {
 				},
 			},
 		}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 
 		err := ensureDataLayer(cfg, handle, metricsPlugins())
 
@@ -112,7 +112,7 @@ func TestEnsureDataLayer(t *testing.T) {
 				InjectDefaults: ptr.To(false),
 			},
 		}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 
 		err := ensureDataLayer(cfg, handle, metricsPlugins())
 
@@ -124,7 +124,7 @@ func TestEnsureDataLayer(t *testing.T) {
 		cfg := &configapi.EndpointPickerConfig{
 			FeatureGates: configapi.FeatureGates{datalayer.EnableLegacyMetricsFeatureGate},
 		}
-		handle := utils.NewTestHandle(context.Background())
+		handle := igwtestutils.NewTestHandle(context.Background())
 
 		err := ensureDataLayer(cfg, handle, metricsPlugins())
 

--- a/pkg/epp/controller/inferencemodelrewrite_reconciler_test.go
+++ b/pkg/epp/controller/inferencemodelrewrite_reconciler_test.go
@@ -39,11 +39,11 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
 	poolutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
-	utiltest "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
+	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
 var (
-	poolForRewrite = utiltest.MakeInferencePool("test-pool1").Namespace("ns1").ObjRef()
+	poolForRewrite = testutil.MakeInferencePool("test-pool1").Namespace("ns1").ObjRef()
 	rewrite1       = &v1alpha2.InferenceModelRewrite{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "rewrite1",

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -38,42 +38,42 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
 	poolutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
-	utiltest "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
+	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
 var (
-	inferencePool = utiltest.MakeInferencePool("test-pool1").Namespace("ns1").ObjRef()
-	infObjective1 = utiltest.MakeInferenceObjective("model1").
+	inferencePool = testutil.MakeInferencePool("test-pool1").Namespace("ns1").ObjRef()
+	infObjective1 = testutil.MakeInferenceObjective("model1").
 			Namespace(inferencePool.Namespace).
 			Priority(1).
 			CreationTimestamp(metav1.Unix(1000, 0)).
 			PoolName(inferencePool.Name).
 			PoolGroup("inference.networking.k8s.io").ObjRef()
-	infObjective1Pool2 = utiltest.MakeInferenceObjective(infObjective1.Name).
+	infObjective1Pool2 = testutil.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
 				Priority(*infObjective1.Spec.Priority).
 				CreationTimestamp(metav1.Unix(1001, 0)).
 				PoolName("test-pool2").
 				PoolGroup("inference.networking.k8s.io").ObjRef()
-	infObjective1Critical = utiltest.MakeInferenceObjective(infObjective1.Name).
+	infObjective1Critical = testutil.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
 				Priority(2).
 				CreationTimestamp(metav1.Unix(1003, 0)).
 				PoolName(inferencePool.Name).
 				PoolGroup("inference.networking.k8s.io").ObjRef()
-	infObjective1Deleted = utiltest.MakeInferenceObjective(infObjective1.Name).
+	infObjective1Deleted = testutil.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
 				CreationTimestamp(metav1.Unix(1004, 0)).
 				DeletionTimestamp().
 				PoolName(inferencePool.Name).
 				PoolGroup("inference.networking.k8s.io").ObjRef()
-	infObjective1DiffGroup = utiltest.MakeInferenceObjective(infObjective1.Name).
+	infObjective1DiffGroup = testutil.MakeInferenceObjective(infObjective1.Name).
 				Namespace(inferencePool.Namespace).
 				Priority(1).
 				CreationTimestamp(metav1.Unix(1005, 0)).
 				PoolName(inferencePool.Name).
 				PoolGroup("inference.networking.x-k8s.io").ObjRef()
-	infObjective2 = utiltest.MakeInferenceObjective("model2").
+	infObjective2 = testutil.MakeInferenceObjective("model2").
 			Namespace(inferencePool.Namespace).
 			CreationTimestamp(metav1.Unix(1000, 0)).
 			PoolName(inferencePool.Name).

--- a/pkg/epp/controller/inferencepool_reconciler.go
+++ b/pkg/epp/controller/inferencepool_reconciler.go
@@ -28,7 +28,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
-	pooltuil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
+	poolutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
 )
 
 // InferencePoolReconciler utilizes the controller runtime to reconcile Instance Gateway resources
@@ -63,7 +63,7 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	endpointPool := pooltuil.InferencePoolToEndpointPool(pool)
+	endpointPool := poolutil.InferencePoolToEndpointPool(pool)
 	if err := c.Datastore.PoolSet(ctx, c.Reader, endpointPool); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update datastore - %w", err)
 	}

--- a/pkg/epp/controller/inferencepool_reconciler_test.go
+++ b/pkg/epp/controller/inferencepool_reconciler_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
-	utiltest "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
+	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
 var (
@@ -46,24 +46,24 @@ var (
 	selectorV2 = map[string]string{"app": "vllm_v2"}
 	pods       = []*corev1.Pod{
 		// Two ready pods matching pool1
-		utiltest.MakePod("pod1").
+		testutil.MakePod("pod1").
 			Namespace("pool1-ns").
 			Labels(selectorV1).ReadyCondition().ObjRef(),
-		utiltest.MakePod("pod2").
+		testutil.MakePod("pod2").
 			Namespace("pool1-ns").
 			Labels(selectorV1).
 			ReadyCondition().ObjRef(),
 		// A not ready pod matching pool1
-		utiltest.MakePod("pod3").
+		testutil.MakePod("pod3").
 			Namespace("pool1-ns").
 			Labels(selectorV1).ObjRef(),
 		// A pod not matching pool1 namespace
-		utiltest.MakePod("pod4").
+		testutil.MakePod("pod4").
 			Namespace("pool2-ns").
 			Labels(selectorV1).
 			ReadyCondition().ObjRef(),
 		// A ready pod matching pool1 with a new selector
-		utiltest.MakePod("pod5").
+		testutil.MakePod("pod5").
 			Namespace("pool1-ns").
 			Labels(selectorV2).
 			ReadyCondition().ObjRef(),
@@ -78,13 +78,13 @@ func TestInferencePoolReconciler(t *testing.T) {
 		Version: v1.GroupVersion.Version,
 		Kind:    "InferencePool",
 	}
-	pool1 := utiltest.MakeInferencePool("pool1").
+	pool1 := testutil.MakeInferencePool("pool1").
 		Namespace("pool1-ns").
 		Selector(selectorV1).
 		TargetPorts(8080).
 		EndpointPickerRef("epp-service").ObjRef()
 	pool1.SetGroupVersionKind(gvk)
-	pool2 := utiltest.MakeInferencePool("pool2").Namespace("pool2-ns").EndpointPickerRef("epp-service").ObjRef()
+	pool2 := testutil.MakeInferencePool("pool2").Namespace("pool2-ns").EndpointPickerRef("epp-service").ObjRef()
 	pool2.SetGroupVersionKind(gvk)
 
 	period := time.Second

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
-	utiltest "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
+	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
 var (
@@ -69,7 +69,7 @@ func TestPodReconciler(t *testing.T) {
 					},
 				},
 			},
-			incomingPod: utiltest.FromBase(basePod3).
+			incomingPod: testutil.FromBase(basePod3).
 				Labels(map[string]string{"some-key": "some-val"}).
 				ReadyCondition().ObjRef(),
 			wantPods: []*corev1.Pod{basePod1, basePod2, basePod3},
@@ -87,7 +87,7 @@ func TestPodReconciler(t *testing.T) {
 					},
 				},
 			},
-			incomingPod: utiltest.FromBase(basePod11).
+			incomingPod: testutil.FromBase(basePod11).
 				Labels(map[string]string{"some-key": "some-val"}).
 				ReadyCondition().ObjRef(),
 			wantPods: []*corev1.Pod{basePod11, basePod2},
@@ -105,7 +105,7 @@ func TestPodReconciler(t *testing.T) {
 					},
 				},
 			},
-			incomingPod: utiltest.FromBase(basePod1).
+			incomingPod: testutil.FromBase(basePod1).
 				Labels(map[string]string{"some-key": "some-val"}).
 				DeletionTimestamp().
 				ReadyCondition().ObjRef(),
@@ -140,7 +140,7 @@ func TestPodReconciler(t *testing.T) {
 					},
 				},
 			},
-			incomingPod: utiltest.FromBase(basePod3).
+			incomingPod: testutil.FromBase(basePod3).
 				Labels(map[string]string{"some-key": "some-val"}).ObjRef(),
 			wantPods: []*corev1.Pod{basePod1, basePod2},
 		},
@@ -157,7 +157,7 @@ func TestPodReconciler(t *testing.T) {
 					},
 				},
 			},
-			incomingPod: utiltest.FromBase(basePod1).
+			incomingPod: testutil.FromBase(basePod1).
 				Labels(map[string]string{"some-wrong-key": "some-val"}).
 				ReadyCondition().ObjRef(),
 			wantPods: []*corev1.Pod{basePod2},
@@ -175,7 +175,7 @@ func TestPodReconciler(t *testing.T) {
 					},
 				},
 			},
-			incomingPod: utiltest.FromBase(basePod1).
+			incomingPod: testutil.FromBase(basePod1).
 				Labels(map[string]string{"some-wrong-key": "some-val"}).
 				ReadyCondition().ObjRef(),
 			wantPods: []*corev1.Pod{basePod2},

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer/mocks"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	plugininterface "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	datasourcemocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
 )
@@ -59,8 +59,8 @@ type errSource struct {
 	err  error
 }
 
-func (e *errSource) TypedName() plugininterface.TypedName {
-	return plugininterface.TypedName{Type: e.kind, Name: e.kind}
+func (e *errSource) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: e.kind, Name: e.kind}
 }
 
 func (e *errSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
@@ -73,8 +73,8 @@ type dataSource struct {
 	kind string
 }
 
-func (d *dataSource) TypedName() plugininterface.TypedName {
-	return plugininterface.TypedName{Type: d.kind, Name: d.kind}
+func (d *dataSource) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: d.kind, Name: d.kind}
 }
 
 func (d *dataSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
@@ -87,8 +87,8 @@ type stubExtractor struct {
 	err  error
 }
 
-func (s *stubExtractor) TypedName() plugininterface.TypedName {
-	return plugininterface.TypedName{Type: s.kind, Name: s.kind}
+func (s *stubExtractor) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: s.kind, Name: s.kind}
 }
 func (s *stubExtractor) ExpectedInputType() reflect.Type                          { return reflect.TypeFor[any]() }
 func (s *stubExtractor) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error { return s.err }

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -24,8 +24,8 @@ import (
 
 	fwkfc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	fwkrq "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	fwksch "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 // ValidateAndOrderDataDependencies validates that the data dependencies among the given plugins are acyclic
@@ -155,30 +155,30 @@ func pluginToLayerExecutionOrder(plugin plugin.Plugin) int {
 	}
 
 	// Request control plugins
-	if _, ok := plugin.(fwkrq.DataProducer); ok {
+	if _, ok := plugin.(fwkrc.DataProducer); ok {
 		return RequestControlLayer
 	}
-	if _, ok := plugin.(fwkrq.Admitter); ok {
+	if _, ok := plugin.(fwkrc.Admitter); ok {
 		return RequestControlLayer
 	}
-	if _, ok := plugin.(fwkrq.PreRequest); ok {
+	if _, ok := plugin.(fwkrc.PreRequest); ok {
 		return RequestControlLayer
 	}
-	if _, ok := plugin.(fwkrq.ResponseHeaderProcessor); ok {
+	if _, ok := plugin.(fwkrc.ResponseHeaderProcessor); ok {
 		return RequestControlLayer
 	}
 
 	// Scheduling plugins
-	if _, ok := plugin.(fwksch.ProfileHandler); ok {
+	if _, ok := plugin.(fwksched.ProfileHandler); ok {
 		return SchedulingLayer
 	}
-	if _, ok := plugin.(fwksch.Filter); ok {
+	if _, ok := plugin.(fwksched.Filter); ok {
 		return SchedulingLayer
 	}
-	if _, ok := plugin.(fwksch.Scorer); ok {
+	if _, ok := plugin.(fwksched.Scorer); ok {
 		return SchedulingLayer
 	}
-	if _, ok := plugin.(fwksch.Picker); ok {
+	if _, ok := plugin.(fwksched.Picker); ok {
 		return SchedulingLayer
 	}
 

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -31,7 +31,7 @@ import (
 	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	fwksch "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const mockProducedDataKey = "mockProducedData"
@@ -62,7 +62,7 @@ func (m *mockPrepareRequestDataP) Consumes() map[string]any {
 	return m.consumes
 }
 
-func (m *mockPrepareRequestDataP) PrepareRequestData(ctx context.Context, request *fwksch.InferenceRequest, endpoints []fwksch.Endpoint) error {
+func (m *mockPrepareRequestDataP) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, &mockProducedDataType{value: 42})
 	return nil
 }
@@ -80,7 +80,7 @@ func (m *typedMockPlugin) TypedName() fwkplugin.TypedName {
 
 func (m *typedMockPlugin) Produces() map[string]any { return m.produces }
 func (m *typedMockPlugin) Consumes() map[string]any { return nil }
-func (m *typedMockPlugin) PrepareRequestData(ctx context.Context, request *fwksch.InferenceRequest, endpoints []fwksch.Endpoint) error {
+func (m *typedMockPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	return nil
 }
 
@@ -94,7 +94,7 @@ func (m *MockConsumerFairnessPolicy) Consumes() map[string]any {
 }
 
 type MockSchedulingPlugin struct {
-	fwksch.Scorer
+	fwksched.Scorer
 	consumes map[string]any
 }
 

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
-	pooltuil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
+	poolutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
 	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
@@ -129,12 +129,12 @@ func TestPool(t *testing.T) {
 					Build()
 
 				ds := NewDatastore(context.Background(), epf, 0)
-				_ = ds.PoolSet(context.Background(), fakeClient, pooltuil.InferencePoolToEndpointPool(tt.inferencePool))
+				_ = ds.PoolSet(context.Background(), fakeClient, poolutil.InferencePoolToEndpointPool(tt.inferencePool))
 				gotPool, gotErr := ds.PoolGet()
 				if diff := cmp.Diff(tt.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 					t.Errorf("Unexpected error diff (+got/-want): %s", diff)
 				}
-				if diff := cmp.Diff(pooltuil.InferencePoolToEndpointPool(tt.wantPool), gotPool); diff != "" {
+				if diff := cmp.Diff(poolutil.InferencePoolToEndpointPool(tt.wantPool), gotPool); diff != "" {
 					t.Errorf("Unexpected pool diff (+got/-want): %s", diff)
 				}
 				gotSynced := ds.PoolHasSynced()
@@ -386,7 +386,7 @@ func TestMetrics(t *testing.T) {
 					WithScheme(scheme).
 					Build()
 				ds := NewDatastore(ctx, epf, 0)
-				_ = ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(inferencePool))
+				_ = ds.PoolSet(ctx, fakeClient, poolutil.InferencePoolToEndpointPool(inferencePool))
 				for _, pod := range test.storePods {
 					ds.PodUpdateOrAddIfNotExist(ctx, pod)
 				}
@@ -461,7 +461,7 @@ func TestPods(t *testing.T) {
 				ctx := context.Background()
 				ds := NewDatastore(t.Context(), epf, 0)
 				fakeClient := fake.NewFakeClient()
-				if err := ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(inferencePool)); err != nil {
+				if err := ds.PoolSet(ctx, fakeClient, poolutil.InferencePoolToEndpointPool(inferencePool)); err != nil {
 					t.Error(err)
 				}
 				for _, pod := range test.existingPods {
@@ -556,7 +556,7 @@ func TestTargetPortsChange(t *testing.T) {
 					Selector(map[string]string{"app": "vllm"}).ObjRef()
 				initialPool.Spec.TargetPorts = test.initialTargetPorts
 
-				if err := ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(initialPool)); err != nil {
+				if err := ds.PoolSet(ctx, fakeClient, poolutil.InferencePoolToEndpointPool(initialPool)); err != nil {
 					t.Fatalf("Failed to set initial pool: %v", err)
 				}
 
@@ -572,7 +572,7 @@ func TestTargetPortsChange(t *testing.T) {
 					Selector(map[string]string{"app": "vllm"}).ObjRef()
 				updatedPool.Spec.TargetPorts = test.updatedTargetPorts
 
-				if err := ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(updatedPool)); err != nil {
+				if err := ds.PoolSet(ctx, fakeClient, poolutil.InferencePoolToEndpointPool(updatedPool)); err != nil {
 					t.Fatalf("Failed to set updated pool: %v", err)
 				}
 
@@ -764,7 +764,7 @@ func TestEndpointMetadata(t *testing.T) {
 				ctx := context.Background()
 				ds := NewDatastore(t.Context(), epf, 0)
 				fakeClient := fake.NewFakeClient()
-				if err := ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(test.pool)); err != nil {
+				if err := ds.PoolSet(ctx, fakeClient, poolutil.InferencePoolToEndpointPool(test.pool)); err != nil {
 					t.Error(err)
 				}
 				for _, pod := range test.existingPods {
@@ -920,7 +920,7 @@ func TestActivePortFiltering(t *testing.T) {
 				// Use the first pool in the test
 				if len(test.pools) > 0 {
 					pool := test.pools[0]
-					if err := ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(&pool)); err != nil {
+					if err := ds.PoolSet(ctx, fakeClient, poolutil.InferencePoolToEndpointPool(&pool)); err != nil {
 						t.Fatalf("Failed to set pool: %v", err)
 					}
 				}
@@ -1071,7 +1071,7 @@ func TestActivePortEndpointRemoval(t *testing.T) {
 				ds := NewDatastore(ctx, epf, 0)
 
 				// Set up the pool
-				if err := ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(test.pool)); err != nil {
+				if err := ds.PoolSet(ctx, fakeClient, poolutil.InferencePoolToEndpointPool(test.pool)); err != nil {
 					t.Fatalf("Failed to set pool: %v", err)
 				}
 
@@ -1125,7 +1125,7 @@ func TestPodUpdateOrAddIfNotExist_ConcurrentPoolSet(t *testing.T) {
 			ctx := context.Background()
 			ds := NewDatastore(ctx, epf, 0)
 
-			pool := pooltuil.InferencePoolToEndpointPool(
+			pool := poolutil.InferencePoolToEndpointPool(
 				testutil.MakeInferencePool("pool1").
 					Namespace("default").
 					Selector(map[string]string{"app": "vllm"}).

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -79,7 +79,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/usagelimits"
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 func init() {
@@ -241,7 +241,7 @@ func setupBenchmarkHarness(
 	customCfg *controller.Config,
 ) (*controller.FlowController, testDetector) {
 	b.Helper()
-	handle := testutils.NewTestHandle(ctx)
+	handle := igwtestutils.NewTestHandle(ctx)
 
 	fPolicy, err := globalstrict.GlobalStrictFairnessPolicyFactory(registry.DefaultFairnessPolicyRef, nil, handle)
 	if err != nil {

--- a/pkg/epp/flowcontrol/config_test.go
+++ b/pkg/epp/flowcontrol/config_test.go
@@ -26,19 +26,19 @@ import (
 	"k8s.io/utils/ptr"
 
 	configapi "github.com/llm-d/llm-d-inference-scheduler/apix/config/v1alpha1"
-	flowcontrolif "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
+	fwkfc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/usagelimits"
-	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 func TestNewConfigFromAPI(t *testing.T) {
 	t.Parallel()
 
-	handle := utils.NewTestHandle(context.Background())
+	handle := igwtestutils.NewTestHandle(context.Background())
 	handle.AddPlugin(globalstrict.GlobalStrictFairnessPolicyType, &mocks.MockFairnessPolicy{
 		TypedNameV: fwkplugin.TypedName{
 			Name: globalstrict.GlobalStrictFairnessPolicyType,
@@ -201,4 +201,4 @@ func (p *constantPointEightPolicy) ComputeLimit(_ context.Context, _ float64, pr
 }
 
 // compile-time check that constantPointEightPolicy satisfies the interface.
-var _ flowcontrolif.UsageLimitPolicy = (*constantPointEightPolicy)(nil)
+var _ fwkfc.UsageLimitPolicy = (*constantPointEightPolicy)(nil)

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/types"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	frameworkmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/usagelimits"
 )
 
@@ -295,7 +295,7 @@ type stubManagedQueue struct {
 func (s *stubManagedQueue) ByteSize() uint64 { return s.byteSizeV }
 
 func (s *stubManagedQueue) FlowQueueAccessor() flowcontrol.FlowQueueAccessor {
-	return &frameworkmocks.MockFlowQueueAccessor{ByteSizeV: s.byteSizeV}
+	return &fwkfcmocks.MockFlowQueueAccessor{ByteSizeV: s.byteSizeV}
 }
 
 // mockShardBuilder is a fixture to declaratively build mock `contracts.RegistryShard` for tests.
@@ -324,8 +324,8 @@ func (b *mockShardBuilder) build() contracts.RegistryShard {
 
 var defaultFlowKey = flowcontrol.FlowKey{ID: "test-flow", Priority: 100}
 
-func newTestRequest(key flowcontrol.FlowKey) *frameworkmocks.MockFlowControlRequest {
-	return &frameworkmocks.MockFlowControlRequest{
+func newTestRequest(key flowcontrol.FlowKey) *fwkfcmocks.MockFlowControlRequest {
+	return &fwkfcmocks.MockFlowControlRequest{
 		FlowKeyV:  key,
 		ByteSizeV: 100,
 		IDV:       "req-" + key.ID,
@@ -514,7 +514,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					}
 					h.mockProcessorFactory.processors["shard-B"] = &mockShardProcessor{
 						SubmitFunc: func(item *internal.FlowItem) error {
-							item.SetHandle(&frameworkmocks.MockQueueItemHandle{})
+							item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
 							go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
 							return nil
 						},
@@ -741,7 +741,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
 				SubmitFunc: func(item *internal.FlowItem) error {
 					// The processor accepts the item but then asynchronously finalizes it with ErrShardDraining.
-					item.SetHandle(&frameworkmocks.MockQueueItemHandle{})
+					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
 					go item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, contracts.ErrShardDraining)
 					return nil
 				},
@@ -790,7 +790,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			// Configure the processor to accept the item but never finalize it, simulating a queued request.
 			h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
 				SubmitFunc: func(item *internal.FlowItem) error {
-					item.SetHandle(&frameworkmocks.MockQueueItemHandle{})
+					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
 					itemSubmitted <- item
 					return nil
 				},
@@ -867,7 +867,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			// Configure the processor to accept the item but never finalize it.
 			h.mockProcessorFactory.processors["shard-A"] = &mockShardProcessor{
 				SubmitFunc: func(item *internal.FlowItem) error {
-					item.SetHandle(&frameworkmocks.MockQueueItemHandle{})
+					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
 					itemSubmitted <- item
 					return nil
 				},
@@ -1251,7 +1251,7 @@ func setupRegistryForConcurrency(t *testing.T, numShards int, flowKey flowcontro
 			AllOrderedPriorityLevelsFunc: func() []int { return []int{flowKey.Priority} },
 			PriorityBandAccessorFunc: func(priority int) (flowcontrol.PriorityBandAccessor, error) {
 				if priority == flowKey.Priority {
-					return &frameworkmocks.MockPriorityBandAccessor{
+					return &fwkfcmocks.MockPriorityBandAccessor{
 						PriorityV: priority,
 						IterateQueuesFunc: func(f func(flowcontrol.FlowQueueAccessor) bool) {
 							f(currentQueue.FlowQueueAccessor())
@@ -1261,7 +1261,7 @@ func setupRegistryForConcurrency(t *testing.T, numShards int, flowKey flowcontro
 				return nil, fmt.Errorf("unexpected priority %d", priority)
 			},
 			FairnessPolicyFunc: func(_ int) (flowcontrol.FairnessPolicy, error) {
-				return &frameworkmocks.MockFairnessPolicy{
+				return &fwkfcmocks.MockFairnessPolicy{
 					PickFunc: func(_ context.Context, _ flowcontrol.PriorityBandAccessor) (flowcontrol.FlowQueueAccessor, error) {
 						return currentQueue.FlowQueueAccessor(), nil
 					},

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/types"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	fwmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/usagelimits"
 )
 
@@ -192,7 +192,7 @@ func (h *testHarness) waitForFinalization(item *FlowItem) (types.QueueOutcome, e
 // newTestItem creates a new FlowItem for testing purposes.
 func (h *testHarness) newTestItem(id string, key flowcontrol.FlowKey, ttl time.Duration) *FlowItem {
 	h.t.Helper()
-	req := fwmocks.NewMockFlowControlRequest(100, id, key)
+	req := fwkfcmocks.NewMockFlowControlRequest(100, id, key)
 	return NewItem(req, ttl, h.clock.Now())
 }
 
@@ -237,7 +237,7 @@ func (h *testHarness) allOrderedPriorityLevels() []int {
 // priorityBandAccessor provides the mock implementation for the `RegistryShard` interface. It acts as a factory for a
 // fully-configured, stateless mock that is safe for concurrent use.
 func (h *testHarness) priorityBandAccessor(p int) (flowcontrol.PriorityBandAccessor, error) {
-	band := &fwmocks.MockPriorityBandAccessor{PriorityV: p}
+	band := &fwkfcmocks.MockPriorityBandAccessor{PriorityV: p}
 
 	// Safely get a snapshot of the flow IDs under a lock.
 	h.mu.Lock()
@@ -263,7 +263,7 @@ func (h *testHarness) priorityBandAccessor(p int) (flowcontrol.PriorityBandAcces
 
 // fairnessPolicy provides the mock implementation for the RegistryShard interface.
 func (h *testHarness) fairnessPolicy(p int) (flowcontrol.FairnessPolicy, error) {
-	policy := &fwmocks.MockFairnessPolicy{}
+	policy := &fwkfcmocks.MockFairnessPolicy{}
 	// If the test provided a custom implementation, use it.
 	if h.fairnessPolicyPick != nil {
 		policy.PickFunc = h.fairnessPolicyPick

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -29,37 +29,37 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/contracts"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/framework/plugins/queue"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	frameworkmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/ordering/edf"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
-	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 func newTestPluginsHandle(t *testing.T) plugin.Handle {
 	t.Helper()
-	handle := utils.NewTestHandle(t.Context())
-	handle.AddPlugin(globalstrict.GlobalStrictFairnessPolicyType, &frameworkmocks.MockFairnessPolicy{
+	handle := igwtestutils.NewTestHandle(t.Context())
+	handle.AddPlugin(globalstrict.GlobalStrictFairnessPolicyType, &fwkfcmocks.MockFairnessPolicy{
 		TypedNameV: plugin.TypedName{
 			Type: globalstrict.GlobalStrictFairnessPolicyType,
 			Name: globalstrict.GlobalStrictFairnessPolicyType,
 		},
 	})
-	handle.AddPlugin(roundrobin.RoundRobinFairnessPolicyType, &frameworkmocks.MockFairnessPolicy{
+	handle.AddPlugin(roundrobin.RoundRobinFairnessPolicyType, &fwkfcmocks.MockFairnessPolicy{
 		TypedNameV: plugin.TypedName{
 			Type: roundrobin.RoundRobinFairnessPolicyType,
 			Name: roundrobin.RoundRobinFairnessPolicyType,
 		},
 	})
-	handle.AddPlugin(fcfs.FCFSOrderingPolicyType, &frameworkmocks.MockOrderingPolicy{
+	handle.AddPlugin(fcfs.FCFSOrderingPolicyType, &fwkfcmocks.MockOrderingPolicy{
 		TypedNameV: plugin.TypedName{
 			Type: fcfs.FCFSOrderingPolicyType,
 			Name: fcfs.FCFSOrderingPolicyType,
 		},
 	})
-	handle.AddPlugin(edf.EDFOrderingPolicyType, &frameworkmocks.MockOrderingPolicy{
+	handle.AddPlugin(edf.EDFOrderingPolicyType, &fwkfcmocks.MockOrderingPolicy{
 		TypedNameV: plugin.TypedName{
 			Type: edf.EDFOrderingPolicyType,
 			Name: edf.EDFOrderingPolicyType,
@@ -262,7 +262,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name:      "ShouldError_WhenDefaultPolicyMissingFromHandle",
 			opts:      []ConfigOption{WithPriorityBand(&PriorityBandConfig{Priority: 1})},
-			handle:    utils.NewTestHandle(t.Context()), // Handle has no plugin.
+			handle:    igwtestutils.NewTestHandle(t.Context()), // Handle has no plugin.
 			expectErr: true,
 		},
 

--- a/pkg/epp/flowcontrol/registry/managedqueue_test.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/contracts/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/framework/plugins/queue"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	frameworkmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 )
 
 // --- Test Harness and Mocks ---
@@ -40,7 +40,7 @@ type mqTestHarness struct {
 	t          *testing.T
 	mq         *managedQueue
 	propagator *mockStatsPropagator
-	mockPolicy *frameworkmocks.MockOrderingPolicy
+	mockPolicy *fwkfcmocks.MockOrderingPolicy
 }
 
 // newMockedMqHarness creates a harness that uses a mocked underlying queue.
@@ -64,7 +64,7 @@ func newMqHarness(t *testing.T, queue contracts.SafeQueue, key flowcontrol.FlowK
 	t.Helper()
 
 	propagator := &mockStatsPropagator{}
-	mockPolicy := &frameworkmocks.MockOrderingPolicy{}
+	mockPolicy := &fwkfcmocks.MockOrderingPolicy{}
 
 	isDrainingFunc := func() bool { return isDraining }
 	mq := newManagedQueue(queue, mockPolicy, key, logr.Discard(), propagator.propagate, isDrainingFunc)
@@ -152,7 +152,7 @@ func TestManagedQueue_Add(t *testing.T) {
 			t.Parallel()
 			q := &mocks.MockSafeQueue{}
 			h := newMqHarness(t, q, flowKey, tc.isDraining)
-			item := frameworkmocks.NewMockQueueItemAccessor(100, "req", flowKey)
+			item := fwkfcmocks.NewMockQueueItemAccessor(100, "req", flowKey)
 			if tc.setupMock != nil {
 				tc.setupMock(q)
 			}
@@ -215,7 +215,7 @@ func TestManagedQueue_Remove(t *testing.T) {
 			t.Parallel()
 			q := &mocks.MockSafeQueue{}
 			h := newMockedMqHarness(t, q, flowKey)
-			item := frameworkmocks.NewMockQueueItemAccessor(100, "req", flowKey)
+			item := fwkfcmocks.NewMockQueueItemAccessor(100, "req", flowKey)
 			h.setupWithItems(item)
 			tc.setupMock(q, item)
 
@@ -273,8 +273,8 @@ func TestManagedQueue_Cleanup(t *testing.T) {
 			q := &mocks.MockSafeQueue{}
 			h := newMockedMqHarness(t, q, flowKey)
 			items := []flowcontrol.QueueItemAccessor{
-				frameworkmocks.NewMockQueueItemAccessor(50, "req", flowKey),
-				frameworkmocks.NewMockQueueItemAccessor(75, "req", flowKey),
+				fwkfcmocks.NewMockQueueItemAccessor(50, "req", flowKey),
+				fwkfcmocks.NewMockQueueItemAccessor(75, "req", flowKey),
 			}
 			h.setupWithItems(items...)
 			tc.setupMock(q, items)
@@ -315,8 +315,8 @@ func TestManagedQueue_Drain(t *testing.T) {
 			q := &mocks.MockSafeQueue{}
 			h := newMockedMqHarness(t, q, flowKey)
 			items := []flowcontrol.QueueItemAccessor{
-				frameworkmocks.NewMockQueueItemAccessor(50, "req", flowKey),
-				frameworkmocks.NewMockQueueItemAccessor(75, "req", flowKey),
+				fwkfcmocks.NewMockQueueItemAccessor(50, "req", flowKey),
+				fwkfcmocks.NewMockQueueItemAccessor(75, "req", flowKey),
 			}
 			h.setupWithItems(items...)
 			tc.setupMock(q, items)
@@ -338,7 +338,7 @@ func TestManagedQueue_FlowQueueAccessor(t *testing.T) {
 		flowKey := flowcontrol.FlowKey{ID: "flow", Priority: 1}
 		q := &mocks.MockSafeQueue{}
 		harness := newMockedMqHarness(t, q, flowKey)
-		item := frameworkmocks.NewMockQueueItemAccessor(100, "req-1", flowKey)
+		item := fwkfcmocks.NewMockQueueItemAccessor(100, "req-1", flowKey)
 		q.PeekHeadV = item
 		q.PeekTailV = item
 		q.NameV = "MockQueue"
@@ -398,7 +398,7 @@ func TestManagedQueue_Concurrency_StatsIntegrity(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range opsPerWorker {
-				item := frameworkmocks.NewMockQueueItemAccessor(uint64(itemByteSize), "req", flowKey)
+				item := fwkfcmocks.NewMockQueueItemAccessor(uint64(itemByteSize), "req", flowKey)
 				require.NoError(t, h.mq.Add(item), "Concurrent Add operation must succeed without errors or races")
 				// In this chaos test, `Remove` may fail if another goroutine removes the item first. This is expected.
 				_, _ = h.mq.Remove(item.Handle())
@@ -423,7 +423,7 @@ func TestManagedQueue_Concurrency_StatsIntegrity(t *testing.T) {
 func TestManagedQueue_InvariantPanics_OnUnderflow(t *testing.T) {
 	t.Parallel()
 	flowKey := flowcontrol.FlowKey{ID: "flow", Priority: 1}
-	item := frameworkmocks.NewMockQueueItemAccessor(100, "req", flowKey)
+	item := fwkfcmocks.NewMockQueueItemAccessor(100, "req", flowKey)
 	q := &mocks.MockSafeQueue{}
 	q.AddFunc = func(flowcontrol.QueueItemAccessor) {}
 	q.RemoveFunc = func(flowcontrol.QueueItemHandle) (flowcontrol.QueueItemAccessor, error) {

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	types "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 // before a request is sent to the selected model server.
 type PreRequest interface {
 	plugin.Plugin
-	PreRequest(ctx context.Context, request *types.InferenceRequest, schedulingResult *types.SchedulingResult)
+	PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult)
 }
 
 // ResponseHeaderProcessor is called by the director after the response headers are successfully received
@@ -43,7 +43,7 @@ type PreRequest interface {
 // The given pod argument is the pod that served the request.
 type ResponseHeaderProcessor interface {
 	plugin.Plugin
-	ResponseHeader(ctx context.Context, request *types.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
+	ResponseHeader(ctx context.Context, request *fwksched.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
 }
 
 // ResponseBodyProcessor is the primary hook for processing response data.
@@ -61,7 +61,7 @@ type ResponseHeaderProcessor interface {
 // between success, errors, and disconnects.
 type ResponseBodyProcessor interface {
 	plugin.Plugin
-	ResponseBody(ctx context.Context, request *types.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
+	ResponseBody(ctx context.Context, request *fwksched.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
 }
 
 // DataProducer is implemented by data producers which produce data from different sources.
@@ -69,7 +69,7 @@ type ResponseBodyProcessor interface {
 type DataProducer interface {
 	plugin.ProducerPlugin
 	plugin.ConsumerPlugin
-	PrepareRequestData(ctx context.Context, request *types.InferenceRequest, pods []types.Endpoint) error
+	PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error
 }
 
 // Admitter is called by the director after the data producer and before scheduling.
@@ -79,5 +79,5 @@ type Admitter interface {
 	plugin.Plugin
 	// AdmitRequest returns the denial reason, wrapped as error if the request is denied.
 	// If the request is allowed, it returns nil.
-	AdmitRequest(ctx context.Context, request *types.InferenceRequest, pods []types.Endpoint) error
+	AdmitRequest(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	metricsource "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
+	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
 // pipeline wraps a PollingDataSource and an Extractor, calling both in sequence.
@@ -72,7 +72,7 @@ func buildSource(t *testing.T, serverURL string) fwkdl.PollingDataSource {
 	parsedURL, err := url.Parse(serverURL)
 	require.NoError(t, err, "failed to parse server URL")
 
-	source, err := metricsource.NewHTTPMetricsDataSource(parsedURL.Scheme, parsedURL.Path, "metrics-data-source")
+	source, err := sourcemetrics.NewHTTPMetricsDataSource(parsedURL.Scheme, parsedURL.Path, "metrics-data-source")
 	require.NoError(t, err, "failed to create metrics data source")
 	return source
 }

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	frameworkmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
@@ -75,7 +75,7 @@ func runPickConformanceTests(t *testing.T, policy flowcontrol.FairnessPolicy) {
 	state := policy.NewState(ctx)
 
 	flowIDEmpty := "flow-empty"
-	mockQueueEmpty := &frameworkmocks.MockFlowQueueAccessor{
+	mockQueueEmpty := &fwkfcmocks.MockFlowQueueAccessor{
 		LenV:      0,
 		PeekHeadV: nil,
 		FlowKeyV:  flowcontrol.FlowKey{ID: flowIDEmpty},
@@ -96,7 +96,7 @@ func runPickConformanceTests(t *testing.T, policy flowcontrol.FairnessPolicy) {
 		},
 		{
 			name: "With an empty priority band accessor",
-			band: &frameworkmocks.MockPriorityBandAccessor{
+			band: &fwkfcmocks.MockPriorityBandAccessor{
 				PolicyStateV:      state,
 				FlowKeysFunc:      func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{} },
 				IterateQueuesFunc: func(callback func(flow flowcontrol.FlowQueueAccessor) bool) { /* no-op */ },
@@ -106,7 +106,7 @@ func runPickConformanceTests(t *testing.T, policy flowcontrol.FairnessPolicy) {
 		},
 		{
 			name: "With a band that has one empty queue",
-			band: &frameworkmocks.MockPriorityBandAccessor{
+			band: &fwkfcmocks.MockPriorityBandAccessor{
 				PolicyStateV: state,
 				FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{{ID: flowIDEmpty}} },
 				QueueFunc: func(fID string) flowcontrol.FlowQueueAccessor {
@@ -122,7 +122,7 @@ func runPickConformanceTests(t *testing.T, policy flowcontrol.FairnessPolicy) {
 		},
 		{
 			name: "With a band that has multiple empty queues",
-			band: &frameworkmocks.MockPriorityBandAccessor{
+			band: &fwkfcmocks.MockPriorityBandAccessor{
 				PolicyStateV: state,
 				FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{{ID: flowIDEmpty}, {ID: "flow-empty-2"}} },
 				QueueFunc:    func(fID string) flowcontrol.FlowQueueAccessor { return mockQueueEmpty },

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	frameworkmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkfcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 )
 
 var (
@@ -50,11 +50,11 @@ func TestRoundRobin_Pick_Logic(t *testing.T) {
 	state := policy.NewState(ctx)
 
 	// Setup: Three non-empty queues
-	queue1 := &frameworkmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow1Key}
-	queue2 := &frameworkmocks.MockFlowQueueAccessor{LenV: 2, FlowKeyV: flow2Key}
-	queue3 := &frameworkmocks.MockFlowQueueAccessor{LenV: 3, FlowKeyV: flow3Key}
+	queue1 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow1Key}
+	queue2 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 2, FlowKeyV: flow2Key}
+	queue3 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 3, FlowKeyV: flow3Key}
 
-	mockBand := &frameworkmocks.MockPriorityBandAccessor{
+	mockBand := &fwkfcmocks.MockPriorityBandAccessor{
 		PolicyStateV: state,
 		FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow3Key, flow1Key, flow2Key} }, // Unsorted to test sorting
 		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
@@ -100,11 +100,11 @@ func TestRoundRobin_Pick_SkipsEmptyQueues(t *testing.T) {
 
 	// Setup: Two non-empty queues and one empty queue
 	flowEmptyKey := flowcontrol.FlowKey{ID: "flowEmpty", Priority: 0}
-	queue1 := &frameworkmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow1Key}
-	queueEmpty := &frameworkmocks.MockFlowQueueAccessor{LenV: 0, FlowKeyV: flowEmptyKey}
-	queue3 := &frameworkmocks.MockFlowQueueAccessor{LenV: 3, FlowKeyV: flow3Key}
+	queue1 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow1Key}
+	queueEmpty := &fwkfcmocks.MockFlowQueueAccessor{LenV: 0, FlowKeyV: flowEmptyKey}
+	queue3 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 3, FlowKeyV: flow3Key}
 
-	mockBand := &frameworkmocks.MockPriorityBandAccessor{
+	mockBand := &fwkfcmocks.MockPriorityBandAccessor{
 		PolicyStateV: state,
 		FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flowEmptyKey, flow3Key} },
 		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
@@ -144,9 +144,9 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 	state := policy.NewState(ctx)
 
 	// Initial setup
-	queue1 := &frameworkmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow1Key}
-	queue2 := &frameworkmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow2Key}
-	mockBand := &frameworkmocks.MockPriorityBandAccessor{
+	queue1 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow1Key}
+	queue2 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow2Key}
+	mockBand := &fwkfcmocks.MockPriorityBandAccessor{
 		PolicyStateV: state,
 		FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flow2Key} },
 		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
@@ -164,7 +164,7 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 	assert.Equal(t, "flow1", selected.FlowKey().ID, "First selection should be flow1")
 
 	// --- Simulate adding a flow ---
-	queue3 := &frameworkmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow3Key}
+	queue3 := &fwkfcmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow3Key}
 	mockBand.FlowKeysFunc = func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flow2Key, flow3Key} }
 	mockBand.QueueFunc = func(id string) flowcontrol.FlowQueueAccessor {
 		switch id {
@@ -211,14 +211,14 @@ func TestRoundRobin_Pick_Concurrency(t *testing.T) {
 			state := policy.NewState(ctx) // Shared state for all goroutines
 
 			// Setup: Three non-empty queues
-			queues := []*frameworkmocks.MockFlowQueueAccessor{
+			queues := []*fwkfcmocks.MockFlowQueueAccessor{
 				{LenV: 1, FlowKeyV: flow1Key},
 				{LenV: 2, FlowKeyV: flow2Key},
 				{LenV: 3, FlowKeyV: flow3Key},
 			}
 			numQueues := int64(len(queues))
 
-			mockBand := &frameworkmocks.MockPriorityBandAccessor{
+			mockBand := &fwkfcmocks.MockPriorityBandAccessor{
 				PolicyStateV: state,
 				FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flow2Key, flow3Key} },
 				QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -32,7 +32,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 )
 
@@ -60,7 +60,7 @@ func ConcurrencyDetectorFactory(
 }
 
 var (
-	_ framework.Filter               = &detector{}
+	_ fwksched.Filter                = &detector{}
 	_ flowcontrol.SaturationDetector = &detector{}
 )
 
@@ -151,12 +151,12 @@ func (d *detector) Saturation(_ context.Context, endpoints []datalayer.Endpoint)
 // It applies a relaxed limit (MaxConcurrency * (1 + Headroom)) to allow for scheduling flexibility and burst tolerance.
 func (d *detector) Filter(
 	_ context.Context,
-	_ *framework.CycleState,
-	_ *framework.InferenceRequest,
-	endpoints []framework.Endpoint,
-) []framework.Endpoint {
+	_ *fwksched.CycleState,
+	_ *fwksched.InferenceRequest,
+	endpoints []fwksched.Endpoint,
+) []fwksched.Endpoint {
 	// Pre-allocate assuming most endpoints will pass the filter to minimize allocations.
-	filtered := make([]framework.Endpoint, 0, len(endpoints))
+	filtered := make([]fwksched.Endpoint, 0, len(endpoints))
 
 	var limit int64
 	if d.config.mode == modeTokens {

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -30,7 +30,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload"
 )
@@ -182,14 +182,14 @@ func TestDetector_Configuration(t *testing.T) {
 		endpointName := "test-endpoint"
 
 		driveLoad(ctx, reg, detector, endpointName, int(tc.effectiveHeadroomBurst-1))
-		kept := detector.Filter(ctx, nil, nil, []schedulingtypes.Endpoint{newStubSchedulingEndpoint(reg, endpointName)})
+		kept := detector.Filter(ctx, nil, nil, []fwksched.Endpoint{newStubSchedulingEndpoint(reg, endpointName)})
 		require.Len(t, kept, 1, "Endpoint should be retained when operating below burst capacity")
 
 		driveLoad(ctx, reg, detector, endpointName, 1)
 
 		t.Run("fallback to clean endpoint", func(t *testing.T) {
 			cleanEndpoint := "clean-endpoint"
-			kept = detector.Filter(ctx, nil, nil, []schedulingtypes.Endpoint{
+			kept = detector.Filter(ctx, nil, nil, []fwksched.Endpoint{
 				newStubSchedulingEndpoint(reg, endpointName),
 				newStubSchedulingEndpoint(reg, cleanEndpoint),
 			})
@@ -336,7 +336,7 @@ func TestDetector_TokenSaturation(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		requests           []*schedulingtypes.InferenceRequest
+		requests           []*fwksched.InferenceRequest
 		candidateEndpoints []string
 		wantSaturation     float64
 	}{
@@ -348,7 +348,7 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "single_endpoint_partial_tokens",
-			requests: []*schedulingtypes.InferenceRequest{
+			requests: []*fwksched.InferenceRequest{
 				makeTokenRequest("r1", "1234"), // 3 tokens with default estimator
 			},
 			candidateEndpoints: []string{"endpoint-a"},
@@ -356,10 +356,10 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "single_endpoint_half_full",
-			requests: func() []*schedulingtypes.InferenceRequest {
+			requests: func() []*fwksched.InferenceRequest {
 				// "1234567890123456" (16 chars) = 10 tokens. 5 requests = 50 tokens.
 				prompt := "1234567890123456"
-				reqs := make([]*schedulingtypes.InferenceRequest, 0, 5)
+				reqs := make([]*fwksched.InferenceRequest, 0, 5)
 				for i := range 5 {
 					reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 				}
@@ -370,10 +370,10 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "single_endpoint_full",
-			requests: func() []*schedulingtypes.InferenceRequest {
+			requests: func() []*fwksched.InferenceRequest {
 				// 10 tokens per request * 10 requests = 100 tokens.
 				prompt := "1234567890123456"
-				reqs := make([]*schedulingtypes.InferenceRequest, 0, 10)
+				reqs := make([]*fwksched.InferenceRequest, 0, 10)
 				for i := range 10 {
 					reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 				}
@@ -384,10 +384,10 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "multiple_endpoints_mixed_token_load",
-			requests: func() []*schedulingtypes.InferenceRequest {
+			requests: func() []*fwksched.InferenceRequest {
 				// endpoint-a: 50 tokens, endpoint-b: 0 (driveTokenLoad targets endpoint-a only)
 				prompt := "1234567890123456"
-				reqs := make([]*schedulingtypes.InferenceRequest, 0, 5)
+				reqs := make([]*fwksched.InferenceRequest, 0, 5)
 				for i := range 5 {
 					reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 				}
@@ -432,12 +432,12 @@ func TestDetector_TokenFilter(t *testing.T) {
 	reg := newLocalRegistry()
 	detector := newDetector("test-detector", config, logr.Discard())
 	endpointName := "token-filter-endpoint"
-	endpoints := []schedulingtypes.Endpoint{newStubSchedulingEndpoint(reg, endpointName)}
+	endpoints := []fwksched.Endpoint{newStubSchedulingEndpoint(reg, endpointName)}
 
 	// Drive 110 tokens (just below 120 burst limit) -> endpoint should pass filter
 	// "1234567890123456" = 10 tokens. 11 requests = 110 tokens.
 	prompt := "1234567890123456"
-	reqs := make([]*schedulingtypes.InferenceRequest, 0, 11)
+	reqs := make([]*fwksched.InferenceRequest, 0, 11)
 	for i := range 11 {
 		reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 	}
@@ -447,7 +447,7 @@ func TestDetector_TokenFilter(t *testing.T) {
 	require.Len(t, kept, 1, "endpoint should pass filter below burst limit")
 
 	// Add one more request to reach 120 tokens -> filtered out
-	driveTokenLoad(ctx, reg, detector, endpointName, []*schedulingtypes.InferenceRequest{
+	driveTokenLoad(ctx, reg, detector, endpointName, []*fwksched.InferenceRequest{
 		makeTokenRequest("r12", prompt),
 	})
 	kept = detector.Filter(ctx, nil, nil, endpoints)
@@ -540,7 +540,7 @@ func TestDetector_ConcurrencyStress(t *testing.T) {
 
 // --- Test Helpers & Mocks ---
 
-func simulatePreRequest(_ context.Context, reg *localRegistry, req *schedulingtypes.InferenceRequest, result *schedulingtypes.SchedulingResult) {
+func simulatePreRequest(_ context.Context, reg *localRegistry, req *fwksched.InferenceRequest, result *fwksched.SchedulingResult) {
 	endpointName := result.ProfileResults[result.PrimaryProfileName].TargetEndpoints[0].GetMetadata().NamespacedName.Name
 	id := fullEndpointName(endpointName)
 	reg.update(id, func(load *attrconcurrency.InFlightLoad) {
@@ -551,7 +551,7 @@ func simulatePreRequest(_ context.Context, reg *localRegistry, req *schedulingty
 	})
 }
 
-func simulateResponseBody(_ context.Context, reg *localRegistry, req *schedulingtypes.InferenceRequest, resp *requestcontrol.Response, metadata *datalayer.EndpointMetadata) {
+func simulateResponseBody(_ context.Context, reg *localRegistry, req *fwksched.InferenceRequest, resp *requestcontrol.Response, metadata *datalayer.EndpointMetadata) {
 	if metadata == nil || resp == nil || !resp.EndOfStream {
 		return
 	}
@@ -575,7 +575,7 @@ func driveLoad(_ context.Context, reg *localRegistry, _ *detector, endpointName 
 	})
 }
 
-func driveTokenLoad(_ context.Context, reg *localRegistry, _ *detector, endpointName string, requests []*schedulingtypes.InferenceRequest) {
+func driveTokenLoad(_ context.Context, reg *localRegistry, _ *detector, endpointName string, requests []*fwksched.InferenceRequest) {
 	id := fullEndpointName(endpointName)
 	var total int64
 	estimator := inflightload.NewSimpleTokenEstimator()
@@ -592,12 +592,12 @@ func fullEndpointName(name string) string {
 	return types.NamespacedName{Name: name, Namespace: "default"}.String()
 }
 
-func makeSchedulingResult(reg *localRegistry, endpointName string) *schedulingtypes.SchedulingResult {
-	return &schedulingtypes.SchedulingResult{
+func makeSchedulingResult(reg *localRegistry, endpointName string) *fwksched.SchedulingResult {
+	return &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
-		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"default": {
-				TargetEndpoints: []schedulingtypes.Endpoint{newStubSchedulingEndpoint(reg, endpointName)},
+				TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(reg, endpointName)},
 			},
 		},
 	}
@@ -639,7 +639,7 @@ func newFakeEndpoint(reg *localRegistry, name string) datalayer.Endpoint {
 
 // liveSchedulingEndpoint is a "live" mock for scheduling.Endpoint.
 type liveSchedulingEndpoint struct {
-	schedulingtypes.Endpoint
+	fwksched.Endpoint
 	metadata *datalayer.EndpointMetadata
 	reg      *localRegistry
 	id       string
@@ -665,8 +665,8 @@ func (f *liveSchedulingEndpoint) Keys() []string                  { return []str
 func (f *liveSchedulingEndpoint) String() string                  { return f.id }
 func (f *liveSchedulingEndpoint) Clone() datalayer.AttributeMap   { return f }
 
-func makeTokenRequest(requestID, prompt string) *schedulingtypes.InferenceRequest {
-	return &schedulingtypes.InferenceRequest{
+func makeTokenRequest(requestID, prompt string) *fwksched.InferenceRequest {
+	return &fwksched.InferenceRequest{
 		RequestID: requestID,
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
@@ -33,7 +33,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -61,7 +61,7 @@ func UtilizationDetectorFactory(
 }
 
 var (
-	_ framework.Filter               = &Detector{}
+	_ fwksched.Filter                = &Detector{}
 	_ flowcontrol.SaturationDetector = &Detector{}
 )
 
@@ -141,15 +141,15 @@ func (d *Detector) Saturation(_ context.Context, candidates []datalayer.Endpoint
 // It applies a relaxed limit (Threshold * (1 + Headroom)) to allow for scheduling flexibility and burst tolerance.
 func (d *Detector) Filter(
 	_ context.Context,
-	_ *framework.CycleState,
-	_ *framework.InferenceRequest,
-	endpoints []framework.Endpoint,
-) []framework.Endpoint {
+	_ *fwksched.CycleState,
+	_ *fwksched.InferenceRequest,
+	endpoints []fwksched.Endpoint,
+) []fwksched.Endpoint {
 	qLimit := float64(d.config.QueueDepthThreshold) * (1.0 + d.config.Headroom)
 	kvLimit := d.config.KVCacheUtilThreshold * (1.0 + d.config.Headroom)
 
 	// Pre-allocate assuming most endpoints will pass the filter to minimize allocations.
-	filtered := make([]framework.Endpoint, 0, len(endpoints))
+	filtered := make([]fwksched.Endpoint, 0, len(endpoints))
 
 	for _, endpoint := range endpoints {
 		metrics := endpoint.GetMetrics()

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -27,7 +27,7 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 func makePodMetric(name string, queueDepth int, kvUsage float64, updateTime time.Time) fwkdl.Endpoint {
@@ -46,7 +46,7 @@ func makeSchedulingEndpoint(
 	queueDepth int,
 	kvUsage float64,
 	updateTime time.Time,
-) schedulingtypes.Endpoint {
+) fwksched.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
 		NamespacedName: types.NamespacedName{Name: name, Namespace: "ns1"},
 	}
@@ -54,7 +54,7 @@ func makeSchedulingEndpoint(
 	metrics.WaitingQueueSize = queueDepth
 	metrics.KVCacheUsagePercent = kvUsage
 	metrics.UpdateTime = updateTime
-	return schedulingtypes.NewEndpoint(meta, metrics, nil)
+	return fwksched.NewEndpoint(meta, metrics, nil)
 }
 
 // TestUtilizationDetectorFactory evaluates instantiation properties and config parsing constraints.
@@ -298,12 +298,12 @@ func TestDetector_Filter(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		endpoints []schedulingtypes.Endpoint
+		endpoints []fwksched.Endpoint
 		wantLen   int
 	}{
 		{
 			name: "All pass - under thresholds",
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeSchedulingEndpoint("pod1", 1, 0.1, baseTime),
 				makeSchedulingEndpoint("pod2", 4, 0.7, baseTime),
 			},
@@ -311,14 +311,14 @@ func TestDetector_Filter(t *testing.T) {
 		},
 		{
 			name: "Pass - at threshold but under burst",
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeSchedulingEndpoint("pod1", 5, 0.8, baseTime),
 			},
 			wantLen: 1,
 		},
 		{
 			name: "Pass - in headroom burst",
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				// Q=5.5 (< 6.0). KV=0.9 (< 0.96).
 				makeSchedulingEndpoint("pod1", 5, 0.9, baseTime),
 			},
@@ -326,7 +326,7 @@ func TestDetector_Filter(t *testing.T) {
 		},
 		{
 			name: "Filtered - exceeds queue burst",
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				// Pod1 (Over): Q=10/5=2.0.
 				makeSchedulingEndpoint("pod1", 7, 0.1, baseTime),
 				// Pod2 (OK): Q=1/5=0.2.
@@ -336,7 +336,7 @@ func TestDetector_Filter(t *testing.T) {
 		},
 		{
 			name: "Filtered - exceeds KV burst",
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				// Pod1 (Over): KV=0.97/0.9=1.07...
 				makeSchedulingEndpoint("pod1", 1, 0.97, baseTime),
 				// Pod2 (OK): KV=0.5/0.9=0.55...
@@ -346,7 +346,7 @@ func TestDetector_Filter(t *testing.T) {
 		},
 		{
 			name: "Pass - all stale (Fail open at pool level)",
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeSchedulingEndpoint("pod1", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
 				makeSchedulingEndpoint("pod2", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
 			},
@@ -354,7 +354,7 @@ func TestDetector_Filter(t *testing.T) {
 		},
 		{
 			name: "Pass - all saturated (Fail open at pool level)",
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeSchedulingEndpoint("pod1", 10, 0.1, baseTime),
 				makeSchedulingEndpoint("pod2", 1, 0.99, baseTime),
 			},

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -28,7 +28,7 @@ import (
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 )
 
@@ -96,7 +96,7 @@ func (p *LatencyAdmission) Consumes() map[string]any {
 //   - No endpoint has a valid prediction (all violate SLO)
 //   - No endpoint is idle (all have running requests)
 //   - No cold pod exists (predictions are reliable)
-func (p *LatencyAdmission) AdmitRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func (p *LatencyAdmission) AdmitRequest(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		return nil

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
@@ -23,12 +23,12 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 )
 
-func makeLatencyAdmissionEndpoint(name string, kvCache float64, runningRequests int) schedulingtypes.Endpoint {
-	return schedulingtypes.NewEndpoint(
+func makeLatencyAdmissionEndpoint(name string, kvCache float64, runningRequests int) fwksched.Endpoint {
+	return fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
 		&fwkdl.Metrics{
 			KVCacheUsagePercent: kvCache,
@@ -38,23 +38,23 @@ func makeLatencyAdmissionEndpoint(name string, kvCache float64, runningRequests 
 	)
 }
 
-func makeSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.InferenceRequest {
-	return &schedulingtypes.InferenceRequest{
+func makeSheddableRequest(ttftSLO, tpotSLO string) *fwksched.InferenceRequest {
+	return &fwksched.InferenceRequest{
 		Headers: map[string]string{
 			ttftSLOHeaderKey: ttftSLO,
 			tpotSLOHeaderKey: tpotSLO,
 		},
-		Objectives: schedulingtypes.RequestObjectives{Priority: -1},
+		Objectives: fwksched.RequestObjectives{Priority: -1},
 	}
 }
 
-func makeNonSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.InferenceRequest {
-	return &schedulingtypes.InferenceRequest{
+func makeNonSheddableRequest(ttftSLO, tpotSLO string) *fwksched.InferenceRequest {
+	return &fwksched.InferenceRequest{
 		Headers: map[string]string{
 			ttftSLOHeaderKey: ttftSLO,
 			tpotSLOHeaderKey: tpotSLO,
 		},
-		Objectives: schedulingtypes.RequestObjectives{Priority: 1},
+		Objectives: fwksched.RequestObjectives{Priority: 1},
 	}
 }
 
@@ -63,9 +63,9 @@ func TestAdmitRequest(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		request   *schedulingtypes.InferenceRequest
-		endpoints []schedulingtypes.Endpoint
-		setupFn   func(endpoints []schedulingtypes.Endpoint) // set endpoint attributes
+		request   *fwksched.InferenceRequest
+		endpoints []fwksched.Endpoint
+		setupFn   func(endpoints []fwksched.Endpoint) // set endpoint attributes
 		wantErr   bool
 	}{
 		{
@@ -76,10 +76,10 @@ func TestAdmitRequest(t *testing.T) {
 		{
 			name:    "non-sheddable request — always admit",
 			request: makeNonSheddableRequest("100", "30"),
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
 			},
-			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+			setupFn: func(endpoints []fwksched.Endpoint) {
 				// All invalid predictions
 				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
 					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
@@ -89,7 +89,7 @@ func TestAdmitRequest(t *testing.T) {
 		{
 			name:    "no SLO headers — admit",
 			request: makeSheddableRequest("", ""),
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
 			},
 			wantErr: false,
@@ -97,11 +97,11 @@ func TestAdmitRequest(t *testing.T) {
 		{
 			name:    "sheddable, all invalid, all busy, no cold — reject",
 			request: makeSheddableRequest("100", "30"),
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
 				makeLatencyAdmissionEndpoint("pod2", 0.4, 3),
 			},
-			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+			setupFn: func(endpoints []fwksched.Endpoint) {
 				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
 					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
 				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
@@ -112,11 +112,11 @@ func TestAdmitRequest(t *testing.T) {
 		{
 			name:    "sheddable, all invalid, but one pod idle — admit",
 			request: makeSheddableRequest("100", "30"),
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
 				makeLatencyAdmissionEndpoint("pod2", 0.4, 0), // idle
 			},
-			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+			setupFn: func(endpoints []fwksched.Endpoint) {
 				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
 					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
 				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
@@ -127,11 +127,11 @@ func TestAdmitRequest(t *testing.T) {
 		{
 			name:    "sheddable, all invalid, but cold pod exists — admit",
 			request: makeSheddableRequest("100", "30"),
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
 				makeLatencyAdmissionEndpoint("pod2", 0.01, 3), // cold
 			},
-			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+			setupFn: func(endpoints []fwksched.Endpoint) {
 				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
 					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
 				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
@@ -142,11 +142,11 @@ func TestAdmitRequest(t *testing.T) {
 		{
 			name:    "sheddable, one valid endpoint — admit",
 			request: makeSheddableRequest("100", "30"),
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
 				makeLatencyAdmissionEndpoint("pod2", 0.4, 3),
 			},
-			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+			setupFn: func(endpoints []fwksched.Endpoint) {
 				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
 					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
 				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
@@ -157,7 +157,7 @@ func TestAdmitRequest(t *testing.T) {
 		{
 			name:    "sheddable, no prediction data on endpoints — admit (fail-open)",
 			request: makeSheddableRequest("100", "30"),
-			endpoints: []schedulingtypes.Endpoint{
+			endpoints: []fwksched.Endpoint{
 				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
 			},
 			// no setupFn — no latency attributes set

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -28,7 +28,7 @@ import (
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metrics"
 )
@@ -137,7 +137,7 @@ func (p *prepareData) PluginState() *plugin.PluginState {
 }
 
 // PrepareRequestData is called by the director before scheduling requests.
-func (p *prepareData) PrepareRequestData(ctx context.Context, request *framework.InferenceRequest, pods []framework.Endpoint) error {
+func (p *prepareData) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
 	blockSize := p.GetBlockSize(pods)
 	maxBlocks := p.config.MaxPrefixBlocksToMatch
 	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
@@ -166,7 +166,7 @@ func (p *prepareData) PrepareRequestData(ctx context.Context, request *framework
 
 // PreRequest records in the shared indexer the result of the scheduling selection.
 // It updates the indexer with the prefix hashes for the selected endpoint(s).
-func (p *prepareData) PreRequest(ctx context.Context, request *framework.InferenceRequest, schedulingResult *framework.SchedulingResult) {
+func (p *prepareData) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
 	// Delete the state to avoid memory leak.
 	defer p.pluginState.Delete(request.RequestID)
 	primaryProfileResult := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
@@ -204,7 +204,7 @@ func (p *prepareData) PreRequest(ctx context.Context, request *framework.Inferen
 	metrics.RecordPrefixCacheMatch(matchLen*blockSize*avgChars, total*blockSize*avgChars)
 }
 
-func (p *prepareData) makeserver(targetEndpoint framework.Endpoint) server {
+func (p *prepareData) makeserver(targetEndpoint fwksched.Endpoint) server {
 	gpuBlocks := defaultLRUCapacityPerServer
 	if p.config.AutoTune && targetEndpoint.GetMetrics().CacheNumBlocks > 0 {
 		gpuBlocks = targetEndpoint.GetMetrics().CacheNumBlocks
@@ -235,7 +235,7 @@ func (p *prepareData) matchLongestPrefix(ctx context.Context, hashes []blockHash
 }
 
 // GetBlockSize returns the block size in tokens, potentially auto-tuned from endpoint metrics.
-func (p *prepareData) GetBlockSize(endpoints []framework.Endpoint) int {
+func (p *prepareData) GetBlockSize(endpoints []fwksched.Endpoint) int {
 	if !p.config.AutoTune || len(endpoints) == 0 {
 		return p.config.BlockSizeTokens
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -29,7 +29,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	sourcenotifications "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
@@ -96,7 +96,7 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 	return nil
 }
 
-func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *framework.InferenceRequest, endpoints []framework.Endpoint) error {
+func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, e := range endpoints {
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(attrconcurrency.InFlightLoadKey, &attrconcurrency.InFlightLoad{
@@ -107,7 +107,7 @@ func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *framewor
 	return nil
 }
 
-func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *framework.InferenceRequest, result *framework.SchedulingResult) {
+func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.InferenceRequest, result *fwksched.SchedulingResult) {
 	if result == nil || len(result.ProfileResults) == 0 {
 		return
 	}
@@ -130,7 +130,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *framework.
 
 func (p *InFlightLoadProducer) ResponseBody(
 	ctx context.Context,
-	request *framework.InferenceRequest,
+	request *fwksched.InferenceRequest,
 	resp *requestcontrol.Response,
 	_ *datalayer.EndpointMetadata,
 ) {
@@ -167,7 +167,7 @@ func (p *InFlightLoadProducer) ResponseBody(
 	}
 }
 
-func (p *InFlightLoadProducer) release(endpoint framework.Endpoint, request *framework.InferenceRequest) {
+func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
 	if endpoint == nil || endpoint.GetMetadata() == nil {
 		return
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 )
 
@@ -47,7 +47,7 @@ func TestInFlightLoadProducer_PrepareRequestData(t *testing.T) {
 	producer.tokenTracker.add(endpointID, 500)
 
 	ctx := context.Background()
-	endpoints := []schedulingtypes.Endpoint{newStubSchedulingEndpoint(endpointName)}
+	endpoints := []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}
 
 	err := producer.PrepareRequestData(ctx, nil, endpoints)
 	require.NoError(t, err)
@@ -104,11 +104,11 @@ func TestInFlightLoadProducer_MultiPodLifecycle(t *testing.T) {
 
 	// 1. Dispatch to PodA (Prefill) and PodB (Decode)
 	req := makeTokenRequest("multi-req", "1234567890123456") // 10 tokens
-	res := &schedulingtypes.SchedulingResult{
+	res := &fwksched.SchedulingResult{
 		PrimaryProfileName: "prefill",
-		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{
-			"prefill": {TargetEndpoints: []schedulingtypes.Endpoint{newStubSchedulingEndpoint(podA)}},
-			"decode":  {TargetEndpoints: []schedulingtypes.Endpoint{newStubSchedulingEndpoint(podB)}},
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(podA)}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(podB)}},
 		},
 	}
 
@@ -193,7 +193,7 @@ func TestInFlightLoadProducer_ConcurrencyStress(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			res := makeSchedulingResult(endpointName)
-			req := &schedulingtypes.InferenceRequest{SchedulingResult: res}
+			req := &fwksched.InferenceRequest{SchedulingResult: res}
 			for range opsPerRoutine {
 				producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
 			}
@@ -211,19 +211,19 @@ func fullEndpointName(name string) string {
 	return types.NamespacedName{Name: name, Namespace: "default"}.String()
 }
 
-func makeSchedulingResult(endpointName string) *schedulingtypes.SchedulingResult {
-	return &schedulingtypes.SchedulingResult{
+func makeSchedulingResult(endpointName string) *fwksched.SchedulingResult {
+	return &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
-		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"default": {
-				TargetEndpoints: []schedulingtypes.Endpoint{newStubSchedulingEndpoint(endpointName)},
+				TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)},
 			},
 		},
 	}
 }
 
 type stubSchedulingEndpoint struct {
-	schedulingtypes.Endpoint
+	fwksched.Endpoint
 	metadata *datalayer.EndpointMetadata
 	attr     datalayer.AttributeMap
 }
@@ -247,8 +247,8 @@ func (f *stubSchedulingEndpoint) Get(key string) (datalayer.Cloneable, bool) {
 }
 func (f *stubSchedulingEndpoint) Keys() []string { return f.attr.Keys() }
 
-func makeTokenRequest(requestID, prompt string) *schedulingtypes.InferenceRequest {
-	return &schedulingtypes.InferenceRequest{
+func makeTokenRequest(requestID, prompt string) *fwksched.InferenceRequest {
+	return &fwksched.InferenceRequest{
 		RequestID: requestID,
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -19,12 +19,12 @@ package inflightload
 import (
 	"math"
 
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 // TokenEstimator estimates the number of tokens for an LLM request.
 type TokenEstimator interface {
-	Estimate(request *framework.InferenceRequest) int64
+	Estimate(request *fwksched.InferenceRequest) int64
 }
 
 // SimpleTokenEstimator estimates tokens from character count. tokens = characters / CharactersPerToken.
@@ -45,7 +45,7 @@ func NewSimpleTokenEstimator() TokenEstimator {
 // When RequestSizeBytes is set, input tokens are derived from request size (~4 bytes per token)
 // to avoid allocations. Otherwise, input tokens are estimated from prompt/message character count
 // using CharactersPerToken; output tokens are estimated as inputTokens * OutputRatio.
-func (e *SimpleTokenEstimator) Estimate(request *framework.InferenceRequest) int64 {
+func (e *SimpleTokenEstimator) Estimate(request *fwksched.InferenceRequest) int64 {
 	if request == nil {
 		return 0
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 func TestSimpleTokenEstimator_Estimate(t *testing.T) {
@@ -30,7 +30,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		request  *framework.InferenceRequest
+		request  *fwksched.InferenceRequest
 		expected int64
 	}{
 		{
@@ -40,19 +40,19 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name:     "Empty request",
-			request:  &framework.InferenceRequest{},
+			request:  &fwksched.InferenceRequest{},
 			expected: 0,
 		},
 		{
 			name: "Body nil",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: nil,
 			},
 			expected: 0,
 		},
 		{
 			name: "Less than 4 characters",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{Raw: "123"},
@@ -63,7 +63,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Completions Request",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{Raw: "Hello, world!"},
@@ -74,7 +74,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Completions with empty prompt",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{},
@@ -85,7 +85,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Completions with exactly 4 characters",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{Raw: "1234"},
@@ -96,7 +96,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions Request with Structured content",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
 						Messages: []fwkrh.Message{
@@ -119,7 +119,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions with Raw content",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
 						Messages: []fwkrh.Message{
@@ -137,7 +137,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions with multiple messages",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
 						Messages: []fwkrh.Message{
@@ -167,7 +167,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions with empty messages",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
 						Messages: []fwkrh.Message{},
@@ -178,7 +178,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Responses API with string input",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Responses: &fwkrh.ResponsesRequest{
 						Input: "Tell me a story about a brave knight.",
@@ -189,7 +189,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Responses API with structured input",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Responses: &fwkrh.ResponsesRequest{
 						Input: []any{
@@ -202,7 +202,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Conversations API",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Conversations: &fwkrh.ConversationsRequest{
 						Items: []fwkrh.ConversationItem{
@@ -231,12 +231,12 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		request  *framework.InferenceRequest
+		request  *fwksched.InferenceRequest
 		expected int64
 	}{
 		{
 			name: "Empty prompt with custom config",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{},
@@ -247,7 +247,7 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 		},
 		{
 			name: "4 chars with custom config",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{Raw: "1234"},
@@ -258,7 +258,7 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 		},
 		{
 			name: "More than 4 chars with custom config",
-			request: &framework.InferenceRequest{
+			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{Raw: "This is a longer message."},

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -38,7 +38,7 @@ import (
 	reqcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -230,7 +230,7 @@ func (pl *PredictedLatency) WithName(name string) *PredictedLatency {
 	return pl
 }
 
-func (pl *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.InferenceRequest) *predictedLatencyCtx {
+func (pl *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *fwksched.InferenceRequest) *predictedLatencyCtx {
 	sloCtx, err := pl.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		sloCtx = newPredictedLatencyContext(request)
@@ -242,10 +242,10 @@ func (pl *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *
 
 // predictedLatencyCtx holds per-request state for latency prediction and training.
 type predictedLatencyCtx struct {
-	schedulingRequest         framework.InferenceRequest
+	schedulingRequest         fwksched.InferenceRequest
 	targetMetadata            *fwkdl.EndpointMetadata
 	prefillTargetMetadata     *fwkdl.EndpointMetadata
-	schedulingResult          *framework.SchedulingResult
+	schedulingResult          *fwksched.SchedulingResult
 	lastSeenMetrics           map[string]*fwkdl.Metrics
 	lastTokenTimestamp        time.Time
 	requestReceivedTimestamp  time.Time
@@ -274,7 +274,7 @@ type predictedLatencyCtx struct {
 	decodeTokensAtDispatch           int64
 }
 
-func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedLatencyCtx {
+func newPredictedLatencyContext(request *fwksched.InferenceRequest) *predictedLatencyCtx {
 	var promptText string
 	if request.Body != nil {
 		promptText = request.Body.PromptText()
@@ -289,7 +289,7 @@ func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedL
 	}
 }
 
-func (pl *PredictedLatency) getPredictedLatencyContextForRequest(request *framework.InferenceRequest) (*predictedLatencyCtx, error) {
+func (pl *PredictedLatency) getPredictedLatencyContextForRequest(request *fwksched.InferenceRequest) (*predictedLatencyCtx, error) {
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
 	if item := pl.sloContextStore.Get(id); item != nil {
 		return item.Value(), nil
@@ -297,12 +297,12 @@ func (pl *PredictedLatency) getPredictedLatencyContextForRequest(request *framew
 	return nil, fmt.Errorf("SLO context not found for request ID: %s", id)
 }
 
-func (pl *PredictedLatency) setPredictedLatencyContextForRequest(request *framework.InferenceRequest, ctx *predictedLatencyCtx) {
+func (pl *PredictedLatency) setPredictedLatencyContextForRequest(request *fwksched.InferenceRequest, ctx *predictedLatencyCtx) {
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
 	pl.sloContextStore.Set(id, ctx, ttlcache.DefaultTTL)
 }
 
-func (pl *PredictedLatency) deletePredictedLatencyContextForRequest(request *framework.InferenceRequest) {
+func (pl *PredictedLatency) deletePredictedLatencyContextForRequest(request *fwksched.InferenceRequest) {
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
 	pl.sloContextStore.Delete(id)
 }
@@ -311,7 +311,7 @@ func (pl *PredictedLatency) deletePredictedLatencyContextForRequest(request *fra
 
 // parseFloatHeader retrieves a header by name, parses it as a float64,
 // and returns the value or an error if the header is missing or invalid.
-func parseFloatHeader(request framework.InferenceRequest, headerName string) (float64, error) {
+func parseFloatHeader(request fwksched.InferenceRequest, headerName string) (float64, error) {
 	headerValue, ok := request.Headers[headerName]
 	if !ok {
 		return 0, nil
@@ -326,7 +326,7 @@ func parseFloatHeader(request framework.InferenceRequest, headerName string) (fl
 	return parsedFloat, nil
 }
 
-func (pl *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framework.InferenceRequest, predictedLatencyCtx *predictedLatencyCtx) {
+func (pl *PredictedLatency) parseSLOHeaders(ctx context.Context, request *fwksched.InferenceRequest, predictedLatencyCtx *predictedLatencyCtx) {
 	logger := log.FromContext(ctx)
 	var err error
 
@@ -343,7 +343,7 @@ func (pl *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framew
 
 // --- Running request queue helpers ---
 
-func (pl *PredictedLatency) getEndpointMinTPOTSLO(endpoint framework.Endpoint) float64 {
+func (pl *PredictedLatency) getEndpointMinTPOTSLO(endpoint fwksched.Endpoint) float64 {
 	endpointName := endpoint.GetMetadata().NamespacedName
 	if runningReqs := pl.getRunningRequestList(endpointName); runningReqs != nil && runningReqs.GetSize() > 0 {
 		if min := runningReqs.Peek(); min != nil {
@@ -353,7 +353,7 @@ func (pl *PredictedLatency) getEndpointMinTPOTSLO(endpoint framework.Endpoint) f
 	return 0
 }
 
-func (pl *PredictedLatency) getEndpointRunningRequestCount(endpoint framework.Endpoint) int {
+func (pl *PredictedLatency) getEndpointRunningRequestCount(endpoint fwksched.Endpoint) int {
 	endpointName := endpoint.GetMetadata().NamespacedName
 	if runningReqs := pl.getRunningRequestList(endpointName); runningReqs != nil {
 		return runningReqs.GetSize()

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -31,7 +31,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 // mockPredictor implements PredictorInterface for testing
@@ -329,7 +329,7 @@ func TestPredictedLatencyFactory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handle := utils.NewTestHandle(context.Background())
+			handle := igwtestutils.NewTestHandle(context.Background())
 			rawParams := json.RawMessage(tt.jsonParams)
 			plugin, err := PredictedLatencyFactory(tt.pluginName, rawParams, handle)
 
@@ -365,7 +365,7 @@ func TestPredictedLatencyFactoryInvalidJSON(t *testing.T) {
 
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
-			handle := utils.NewTestHandle(context.Background())
+			handle := igwtestutils.NewTestHandle(context.Background())
 			rawParams := json.RawMessage(tt.jsonParams)
 			plugin, err := PredictedLatencyFactory("test", rawParams, handle)
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
@@ -25,11 +25,11 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 type endpointPredictionResult struct {
-	Endpoint         schedulingtypes.Endpoint
+	Endpoint         fwksched.Endpoint
 	TTFT             float64
 	TPOT             float64
 	TTFTValid        bool
@@ -42,7 +42,7 @@ type endpointPredictionResult struct {
 }
 
 // generatePredictions creates prediction results for all candidate pods
-func (pl *PredictedLatency) generatePredictions(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, candidateEndpoints []schedulingtypes.Endpoint) ([]endpointPredictionResult, error) {
+func (pl *PredictedLatency) generatePredictions(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, candidateEndpoints []fwksched.Endpoint) ([]endpointPredictionResult, error) {
 	logger := log.FromContext(ctx)
 	predictions := make([]endpointPredictionResult, 0, len(candidateEndpoints))
 
@@ -166,7 +166,7 @@ func (pl *PredictedLatency) validatePrediction(
 }
 
 // hasPrefillRole returns true if the endpoint has the prefill role label set.
-func hasPrefillRole(roleLabel string, endpoint schedulingtypes.Endpoint) bool {
+func hasPrefillRole(roleLabel string, endpoint fwksched.Endpoint) bool {
 	if roleLabel == "" {
 		return false
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
@@ -24,7 +24,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
@@ -33,7 +33,7 @@ var _ requestcontrol.DataProducer = &PredictedLatency{}
 
 // PrepareRequestData prepares the SLO context for the request, including
 // parsing SLO headers, gathering prefix cache scores, and generating predictions.
-func (pl *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func (pl *PredictedLatency) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	logger := log.FromContext(ctx)
 	predictedLatencyCtx := pl.getOrMakePredictedLatencyContextForRequest(request)
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -30,7 +30,7 @@ import (
 	reqcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metrics"
 )
 
@@ -40,7 +40,7 @@ var _ requestcontrol.ResponseBodyProcessor = &PredictedLatency{}
 
 // --- RequestControl Hooks ---
 
-func (pl *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, schedulingResult *schedulingtypes.SchedulingResult) {
+func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: request is nil, skipping")
@@ -110,7 +110,7 @@ func (pl *PredictedLatency) PreRequest(ctx context.Context, request *schedulingt
 	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
 }
 
-func (pl *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (pl *PredictedLatency) ResponseHeader(ctx context.Context, request *fwksched.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseReceived: request is nil, skipping")
@@ -119,7 +119,7 @@ func (pl *PredictedLatency) ResponseHeader(ctx context.Context, request *schedul
 }
 
 // ResponseBody handles both per-chunk processing and request completion logic.
-func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: request is nil, skipping")

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -32,7 +32,7 @@ import (
 	reqcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -44,15 +44,15 @@ const (
 
 // Helper functions
 
-func createTestSchedulingResult(metadata *fwkdl.EndpointMetadata) *schedulingtypes.SchedulingResult {
+func createTestSchedulingResult(metadata *fwkdl.EndpointMetadata) *fwksched.SchedulingResult {
 
 	mockPod := createTestEndpoint(metadata.NamespacedName.Name, kvUsage, runningRequests, waitingQueue)
 
-	return &schedulingtypes.SchedulingResult{
+	return &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
-		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"default": {
-				TargetEndpoints: []schedulingtypes.Endpoint{mockPod},
+				TargetEndpoints: []fwksched.Endpoint{mockPod},
 			},
 		},
 	}
@@ -89,7 +89,7 @@ func TestNewPredictedLatencyContext(t *testing.T) {
 }
 
 func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
-	request := &schedulingtypes.InferenceRequest{
+	request := &fwksched.InferenceRequest{
 		Headers: map[string]string{reqcommon.RequestIDHeaderKey: "test-nil-body"},
 		Body:    nil,
 	}
@@ -167,8 +167,8 @@ func TestPredictedLatency_PreRequest_EmptySchedulingResult(t *testing.T) {
 	ctx := context.Background()
 	request := createTestInferenceRequest("test", 100, 50)
 
-	schedulingResult := &schedulingtypes.SchedulingResult{
-		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{},
+	schedulingResult := &fwksched.SchedulingResult{
+		ProfileResults: map[string]*fwksched.ProfileRunResult{},
 	}
 
 	// Call PreRequest with empty scheduling result
@@ -1004,7 +1004,7 @@ func TestPredictedLatency_MultipleRequests_SamePod(t *testing.T) {
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set SLO contexts
-	for _, req := range []*schedulingtypes.InferenceRequest{request1, request2, request3} {
+	for _, req := range []*fwksched.InferenceRequest{request1, request2, request3} {
 		predictedLatencyCtx := newPredictedLatencyContext(req)
 		predictedLatencyCtx.avgTPOTSLO = 50
 		router.setPredictedLatencyContextForRequest(req, predictedLatencyCtx)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -28,7 +28,7 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 func TestBulkPredictWithMetrics(t *testing.T) {
@@ -127,7 +127,7 @@ func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
 	prefixCacheScores := []float64{0.0}
 
 	plCtx := &predictedLatencyCtx{
-		schedulingRequest: schedulingtypes.InferenceRequest{
+		schedulingRequest: fwksched.InferenceRequest{
 			TargetModel: "test-model",
 		},
 		incomingModelName: "incoming-model",

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
@@ -26,7 +26,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/test"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metadata"
 )
@@ -71,7 +71,7 @@ func NewDestinationEndpointServedVerifier() *DestinationEndpointServedVerifier {
 }
 
 // ResponseHeader is the handler for the ResponseHeader extension point.
-func (desv *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
+func (desv *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *fwksched.InferenceRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx).WithName(desv.TypedName().String())
 	logger.V(logging.DEBUG).Info("Verifying destination endpoint served")
 

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -31,7 +31,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
@@ -40,7 +40,7 @@ const (
 	PluginType = "prefix-cache-affinity-filter"
 )
 
-var _ framework.Filter = &Plugin{}
+var _ fwksched.Filter = &Plugin{}
 
 type Config struct {
 	// AffinityThreshold is the prefix cache score threshold. Endpoints with
@@ -102,7 +102,7 @@ func (p *Plugin) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) []framework.Endpoint {
+func (p *Plugin) Filter(ctx context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	logger := log.FromContext(ctx)
 
 	if len(endpoints) <= 1 || p.config.AffinityThreshold <= 0 {
@@ -117,7 +117,7 @@ func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framewo
 	}
 
 	// Find sticky and non-sticky endpoints.
-	var sticky, nonSticky []framework.Endpoint
+	var sticky, nonSticky []fwksched.Endpoint
 	for _, ep := range endpoints {
 		if prefixCacheScore(ep) >= p.config.AffinityThreshold {
 			sticky = append(sticky, ep)
@@ -157,7 +157,7 @@ func (p *Plugin) Consumes() map[string]any {
 	}
 }
 
-func prefixCacheScore(ep framework.Endpoint) float64 {
+func prefixCacheScore(ep fwksched.Endpoint) float64 {
 	if raw, ok := ep.Get(attrprefix.PrefixCacheMatchInfoKey); ok {
 		info := raw.(*attrprefix.PrefixCacheMatchInfo)
 		if info.TotalBlocks() > 0 {
@@ -170,7 +170,7 @@ func prefixCacheScore(ep framework.Endpoint) float64 {
 	return 0
 }
 
-func bestTTFT(endpoints []framework.Endpoint) float64 {
+func bestTTFT(endpoints []fwksched.Endpoint) float64 {
 	best := math.MaxFloat64
 	for _, ep := range endpoints {
 		if raw, ok := ep.Get(attrlatency.LatencyPredictionInfoKey); ok {

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -24,18 +24,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 // makeEndpoint creates a test endpoint with the given prefix cache match ratio
 // (prefixMatch out of 100 total blocks) and predicted TTFT.
-func makeEndpoint(name string, prefixMatch int, ttft float64) framework.Endpoint {
+func makeEndpoint(name string, prefixMatch int, ttft float64) fwksched.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
 		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
 	}
-	ep := framework.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	if prefixMatch >= 0 {
 		ep.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(prefixMatch, 100, 16))
 	}
@@ -47,7 +47,7 @@ func makeEndpoint(name string, prefixMatch int, ttft float64) framework.Endpoint
 
 func TestFilter_AffinityThresholdDisabled(t *testing.T) {
 	p := &Plugin{config: Config{AffinityThreshold: 0}}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 0, 10),
 		makeEndpoint("b", 90, 20),
 	}
@@ -57,14 +57,14 @@ func TestFilter_AffinityThresholdDisabled(t *testing.T) {
 
 func TestFilter_SingleEndpoint(t *testing.T) {
 	p := &Plugin{config: Config{AffinityThreshold: 0.80}}
-	endpoints := []framework.Endpoint{makeEndpoint("a", 90, 10)}
+	endpoints := []fwksched.Endpoint{makeEndpoint("a", 90, 10)}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 1, len(result), "single endpoint should always pass")
 }
 
 func TestFilter_NoStickyEndpoints(t *testing.T) {
 	p := &Plugin{config: Config{AffinityThreshold: 0.80, ExplorationProbability: 0}}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 10, 10),
 		makeEndpoint("b", 20, 20),
 		makeEndpoint("c", 50, 30),
@@ -75,7 +75,7 @@ func TestFilter_NoStickyEndpoints(t *testing.T) {
 
 func TestFilter_NarrowToSticky(t *testing.T) {
 	p := &Plugin{config: Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 5000}}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 100),
 		makeEndpoint("b", 85, 120),
 		makeEndpoint("c", 10, 50),
@@ -86,7 +86,7 @@ func TestFilter_NarrowToSticky(t *testing.T) {
 
 func TestFilter_TTFTPenaltyBreaksStickiness(t *testing.T) {
 	p := &Plugin{config: Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100}}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 500),
 		makeEndpoint("b", 10, 50),
 	}
@@ -96,7 +96,7 @@ func TestFilter_TTFTPenaltyBreaksStickiness(t *testing.T) {
 
 func TestFilter_ExplorationProbability(t *testing.T) {
 	p := &Plugin{config: Config{AffinityThreshold: 0.80, ExplorationProbability: 1.0}}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 100),
 		makeEndpoint("b", 10, 50),
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -30,7 +30,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 )
 
@@ -38,7 +38,7 @@ const (
 	PluginType = "slo-headroom-tier-filter"
 )
 
-var _ framework.Filter = &Plugin{}
+var _ fwksched.Filter = &Plugin{}
 
 type Config struct {
 	// EpsilonExploreNeg is the probability of selecting the negative tier
@@ -81,14 +81,14 @@ func (p *Plugin) TypedName() fwkplugin.TypedName {
 // endpoints are kept. 1% of the time, only negative-tier endpoints are kept
 // (epsilon exploration for recovery). If only one tier has endpoints, that
 // tier is returned. If no endpoints have predictions, all are kept.
-func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) []framework.Endpoint {
+func (p *Plugin) Filter(ctx context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	logger := log.FromContext(ctx)
 
 	if len(endpoints) <= 1 {
 		return endpoints
 	}
 
-	var positive, negative, noPrediction []framework.Endpoint
+	var positive, negative, noPrediction []fwksched.Endpoint
 	for _, ep := range endpoints {
 		raw, ok := ep.Get(attrlatency.LatencyPredictionInfoKey)
 		if !ok {

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
@@ -24,15 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 )
 
-func makeEndpoint(name string, ttftHeadroom, tpotHeadroom float64, hasPrediction bool) framework.Endpoint {
+func makeEndpoint(name string, ttftHeadroom, tpotHeadroom float64, hasPrediction bool) fwksched.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
 		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
 	}
-	ep := framework.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	if hasPrediction {
 		ep.Put(attrlatency.LatencyPredictionInfoKey, attrlatency.NewLatencyPredictionInfo(
 			ttftHeadroom >= 0, tpotHeadroom >= 0, ttftHeadroom, tpotHeadroom, 100, 10, 0))
@@ -42,14 +42,14 @@ func makeEndpoint(name string, ttftHeadroom, tpotHeadroom float64, hasPrediction
 
 func TestFilter_SingleEndpoint(t *testing.T) {
 	p := &Plugin{config: DefaultConfig}
-	endpoints := []framework.Endpoint{makeEndpoint("a", 10, 5, true)}
+	endpoints := []fwksched.Endpoint{makeEndpoint("a", 10, 5, true)}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 1, len(result))
 }
 
 func TestFilter_NoPredictions(t *testing.T) {
 	p := &Plugin{config: DefaultConfig}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 0, 0, false),
 		makeEndpoint("b", 0, 0, false),
 	}
@@ -59,7 +59,7 @@ func TestFilter_NoPredictions(t *testing.T) {
 
 func TestFilter_AllPositive(t *testing.T) {
 	p := &Plugin{config: Config{EpsilonExploreNeg: 0}}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 100, 50, true),
 		makeEndpoint("b", 200, 80, true),
 	}
@@ -69,7 +69,7 @@ func TestFilter_AllPositive(t *testing.T) {
 
 func TestFilter_AllNegative(t *testing.T) {
 	p := &Plugin{config: Config{EpsilonExploreNeg: 0}}
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", -100, -50, true),
 		makeEndpoint("b", -200, -80, true),
 	}
@@ -79,7 +79,7 @@ func TestFilter_AllNegative(t *testing.T) {
 
 func TestFilter_BothTiers_SelectPositive(t *testing.T) {
 	p := &Plugin{config: Config{EpsilonExploreNeg: 0}} // never explore
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("pos1", 100, 50, true),
 		makeEndpoint("pos2", 200, 80, true),
 		makeEndpoint("neg1", -100, -50, true),
@@ -91,7 +91,7 @@ func TestFilter_BothTiers_SelectPositive(t *testing.T) {
 
 func TestFilter_BothTiers_EpsilonExploreNeg(t *testing.T) {
 	p := &Plugin{config: Config{EpsilonExploreNeg: 1.0}} // always explore
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("pos1", 100, 50, true),
 		makeEndpoint("neg1", -100, -50, true),
 	}
@@ -102,7 +102,7 @@ func TestFilter_BothTiers_EpsilonExploreNeg(t *testing.T) {
 
 func TestFilter_NoPredictionGoesToNegative(t *testing.T) {
 	p := &Plugin{config: Config{EpsilonExploreNeg: 1.0}} // always explore neg
-	endpoints := []framework.Endpoint{
+	endpoints := []fwksched.Endpoint{
 		makeEndpoint("pos1", 100, 50, true),
 		makeEndpoint("nopred", 0, 0, false),
 	}

--- a/pkg/epp/framework/plugins/scheduling/picker/common.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/common.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	types "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -73,7 +73,7 @@ func (r *lockedRand) Shuffle(n int, swap func(i, j int)) {
 var PickerRand = newLockedRand()
 
 // ShuffleScoredEndpoints randomizes the order of the given scored candidates in-place.
-func ShuffleScoredEndpoints(scoredEndpoints []*types.ScoredEndpoint) {
+func ShuffleScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
 	// Shuffle in-place
 	PickerRand.Shuffle(len(scoredEndpoints), func(i, j int) {
 		scoredEndpoints[i], scoredEndpoints[j] = scoredEndpoints[j], scoredEndpoints[i]

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
@@ -30,7 +30,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/picker"
 )
 
@@ -40,7 +40,7 @@ const (
 )
 
 // compile-time type validation
-var _ framework.Picker = &MaxScorePicker{}
+var _ fwksched.Picker = &MaxScorePicker{}
 
 // MaxScorePickerFactory defines the factory function for MaxScorePicker.
 func MaxScorePickerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -84,14 +84,14 @@ func (p *MaxScorePicker) TypedName() fwkplugin.TypedName {
 }
 
 // Pick selects the endpoint(s) with the highest score calculated during the scoring phase.
-func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *framework.CycleState, scoredEndpoints []*framework.ScoredEndpoint) *framework.ProfileRunResult {
+func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *fwksched.CycleState, scoredEndpoints []*fwksched.ScoredEndpoint) *fwksched.ProfileRunResult {
 	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates sorted by max score", "max-num-of-endpoints", p.maxNumOfEndpoints,
 		"num-of-candidates", len(scoredEndpoints), "scored-endpoints", scoredEndpoints)
 
 	// Shuffle in-place - needed for random tie break when scores are equal
 	picker.ShuffleScoredEndpoints(scoredEndpoints)
 
-	slices.SortStableFunc(scoredEndpoints, func(i, j *framework.ScoredEndpoint) int { // highest score first
+	slices.SortStableFunc(scoredEndpoints, func(i, j *fwksched.ScoredEndpoint) int { // highest score first
 		if i.Score > j.Score {
 			return -1
 		}
@@ -106,10 +106,10 @@ func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *framework.CycleSt
 		scoredEndpoints = scoredEndpoints[:p.maxNumOfEndpoints]
 	}
 
-	targetEndpoints := make([]framework.Endpoint, len(scoredEndpoints))
+	targetEndpoints := make([]fwksched.Endpoint, len(scoredEndpoints))
 	for i, scoredEndpoint := range scoredEndpoints {
 		targetEndpoints[i] = scoredEndpoint
 	}
 
-	return &framework.ProfileRunResult{TargetEndpoints: targetEndpoints}
+	return &fwksched.ProfileRunResult{TargetEndpoints: targetEndpoints}
 }

--- a/pkg/epp/framework/plugins/scheduling/picker/random/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/random/picker.go
@@ -29,7 +29,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/picker"
 )
 
@@ -39,7 +39,7 @@ const (
 )
 
 // compile-time type validation
-var _ framework.Picker = &RandomPicker{}
+var _ fwksched.Picker = &RandomPicker{}
 
 // RandomPickerFactory defines the factory function for RandomPicker.
 func RandomPickerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -83,7 +83,7 @@ func (p *RandomPicker) TypedName() fwkplugin.TypedName {
 }
 
 // Pick selects random endpoint(s) from the list of candidates.
-func (p *RandomPicker) Pick(ctx context.Context, _ *framework.CycleState, scoredEndpoints []*framework.ScoredEndpoint) *framework.ProfileRunResult {
+func (p *RandomPicker) Pick(ctx context.Context, _ *fwksched.CycleState, scoredEndpoints []*fwksched.ScoredEndpoint) *fwksched.ProfileRunResult {
 	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates randomly", "max-num-of-endpoints", p.maxNumOfEndpoints,
 		"num-of-candidates", len(scoredEndpoints), "scored-endpoints", scoredEndpoints)
 
@@ -95,10 +95,10 @@ func (p *RandomPicker) Pick(ctx context.Context, _ *framework.CycleState, scored
 		scoredEndpoints = scoredEndpoints[:p.maxNumOfEndpoints]
 	}
 
-	targetEndpoints := make([]framework.Endpoint, len(scoredEndpoints))
+	targetEndpoints := make([]fwksched.Endpoint, len(scoredEndpoints))
 	for i, scoredEndpoint := range scoredEndpoints {
 		targetEndpoints[i] = scoredEndpoint
 	}
 
-	return &framework.ProfileRunResult{TargetEndpoints: targetEndpoints}
+	return &fwksched.ProfileRunResult{TargetEndpoints: targetEndpoints}
 }

--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
@@ -32,7 +32,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/picker"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/picker/random"
 )
@@ -44,12 +44,12 @@ const (
 
 // weightedScoredEndpoint represents a scored endpoint with its A-Res sampling key
 type weightedScoredEndpoint struct {
-	*framework.ScoredEndpoint
+	*fwksched.ScoredEndpoint
 	key float64
 }
 
 // compile-time type validation
-var _ framework.Picker = &WeightedRandomPicker{}
+var _ fwksched.Picker = &WeightedRandomPicker{}
 
 // WeightedRandomPickerFactory defines the factory function for WeightedRandomPicker.
 func WeightedRandomPickerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -108,9 +108,9 @@ func (p *WeightedRandomPicker) TypedName() fwkplugin.TypedName {
 
 // Pick selects the endpoint(s) randomly from the list of candidates, where the probability of the endpoint to get picked is derived
 // from its weighted score.
-func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *framework.CycleState, scoredEndpoints []*framework.ScoredEndpoint) *framework.ProfileRunResult {
+func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *fwksched.CycleState, scoredEndpoints []*fwksched.ScoredEndpoint) *fwksched.ProfileRunResult {
 	// Check if there is at least one endpoint with Score > 0, if not let random picker run
-	if slices.IndexFunc(scoredEndpoints, func(scoredEndpoint *framework.ScoredEndpoint) bool { return scoredEndpoint.Score > 0 }) == -1 {
+	if slices.IndexFunc(scoredEndpoints, func(scoredEndpoint *fwksched.ScoredEndpoint) bool { return scoredEndpoint.Score > 0 }) == -1 {
 		log.FromContext(ctx).V(logutil.DEBUG).Info("All scores are zero, delegating to RandomPicker for uniform selection")
 		return p.randomPicker.Pick(ctx, cycleState, scoredEndpoints)
 	}
@@ -146,10 +146,10 @@ func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *framework.C
 	// Select top k endpoints
 	selectedCount := min(p.maxNumOfEndpoints, len(weightedEndpoints))
 
-	targetEndpoints := make([]framework.Endpoint, selectedCount)
+	targetEndpoints := make([]fwksched.Endpoint, selectedCount)
 	for i := range selectedCount {
 		targetEndpoints[i] = weightedEndpoints[i].ScoredEndpoint
 	}
 
-	return &framework.ProfileRunResult{TargetEndpoints: targetEndpoints}
+	return &fwksched.ProfileRunResult{TargetEndpoints: targetEndpoints}
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
@@ -13,14 +13,14 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	giePlugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
 func TestMain(m *testing.M) {
-	giePlugin.Register(DisaggHeadersHandlerType, HeadersHandlerFactory)
-	giePlugin.Register(PrefillHeaderHandlerType, HeadersHandlerFactory) //nolint:staticcheck
+	fwkplugin.Register(DisaggHeadersHandlerType, HeadersHandlerFactory)
+	fwkplugin.Register(PrefillHeaderHandlerType, HeadersHandlerFactory) //nolint:staticcheck
 	os.Exit(m.Run())
 }
 
@@ -157,7 +157,7 @@ func TestPreRequestNilSchedulingResult(t *testing.T) {
 
 func TestPrefillHeaderHandlerBackwardCompat(t *testing.T) {
 	// Simulate what the config loader does when it reads type: prefill-header-handler from YAML
-	factory, ok := giePlugin.Registry[PrefillHeaderHandlerType]
+	factory, ok := fwkplugin.Registry[PrefillHeaderHandlerType]
 	require.True(t, ok, "prefill-header-handler must be in the registry")
 
 	raw := json.RawMessage(`{"prefillProfile": "prefill"}`)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -18,7 +18,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	dl_prefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 )
@@ -226,7 +226,7 @@ func (h *Handler) WithName(name string) *Handler {
 
 // Consumes defines data types consumed by this plugin (through the PD decider).
 func (*Handler) Consumes() map[string]any {
-	return map[string]any{dl_prefix.PrefixCacheMatchInfoKey: dl_prefix.PrefixCacheMatchInfo{}}
+	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
 }
 
 func newDisaggProfileHandler(handlerType, decodeProfile, prefillProfile, encodeProfile string, pdDecider, encodeDecider deciderPlugin) *Handler {

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	approxprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
@@ -109,8 +109,8 @@ func injectPrefixCache(profileResults map[string]*scheduling.ProfileRunResult, c
 		return
 	}
 	for _, ep := range res.TargetEndpoints {
-		ep.Put(approxprefix.PrefixCacheMatchInfoKey,
-			approxprefix.NewPrefixCacheMatchInfo(cachedTokens, inputTokens, 1))
+		ep.Put(attrprefix.PrefixCacheMatchInfoKey,
+			attrprefix.NewPrefixCacheMatchInfo(cachedTokens, inputTokens, 1))
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/routing"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	dl_prefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/metrics"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
@@ -130,7 +130,7 @@ type PdProfileHandler struct {
 
 // Consumes defines data types consumed by this plugin (through the PD decider).
 func (*PdProfileHandler) Consumes() map[string]any {
-	return map[string]any{dl_prefix.PrefixCacheMatchInfoKey: dl_prefix.PrefixCacheMatchInfo{}}
+	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
 }
 
 // TypedName returns the typed name of the plugin.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	approxprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
@@ -333,8 +333,8 @@ func TestPdProfileHandler_Pick(t *testing.T) {
 			for profileName, profileRes := range tt.profileResults {
 				if profileName == defaultDecodeProfile && profileRes != nil {
 					for _, pod := range profileRes.TargetEndpoints {
-						pod.Put(approxprefix.PrefixCacheMatchInfoKey,
-							approxprefix.NewPrefixCacheMatchInfo(tt.cachedTokens, inputTokens, 1))
+						pod.Put(attrprefix.PrefixCacheMatchInfoKey,
+							attrprefix.NewPrefixCacheMatchInfo(tt.cachedTokens, inputTokens, 1))
 					}
 				}
 			}
@@ -437,8 +437,8 @@ func TestPdProfileHandler_PickSeries(t *testing.T) {
 				for profileName, profileRes := range profileResults {
 					if profileName == defaultDecodeProfile && profileRes != nil {
 						for _, endpoint := range profileRes.TargetEndpoints {
-							endpoint.Put(approxprefix.PrefixCacheMatchInfoKey,
-								approxprefix.NewPrefixCacheMatchInfo(innerTest.cachedTokens, inputTokens, 1))
+							endpoint.Put(attrprefix.PrefixCacheMatchInfoKey,
+								attrprefix.NewPrefixCacheMatchInfo(innerTest.cachedTokens, inputTokens, 1))
 						}
 					}
 				}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
@@ -11,7 +11,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	approxprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 const (
@@ -120,12 +120,12 @@ func (d *PrefixBasedPDDecider) disaggregate(ctx context.Context, request *schedu
 	}
 	// inspect the decode endpoint to disaggregate if prefill should run or not.
 	// if the non-cached part is short enough - no disaggregation.
-	prefixInfoRaw, ok := endpoint.Get(approxprefix.PrefixCacheMatchInfoKey)
+	prefixInfoRaw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
 	if !ok || prefixInfoRaw == nil {
 		logger.Error(nil, "unable to read prefix cache state")
 		return false
 	}
-	prefixCacheMatchInfo, ok := prefixInfoRaw.(*approxprefix.PrefixCacheMatchInfo)
+	prefixCacheMatchInfo, ok := prefixInfoRaw.(*attrprefix.PrefixCacheMatchInfo)
 	if !ok {
 		logger.Error(nil, "wrong type of prefix cache match info")
 		return false

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -11,7 +11,7 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	prefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
 
@@ -44,8 +44,8 @@ func makeTestEndpointBase() scheduling.Endpoint {
 
 func makeTestEndpoint(cachedTokens int) scheduling.Endpoint {
 	ep := makeTestEndpointBase()
-	ep.Put(prefix.PrefixCacheMatchInfoKey,
-		prefix.NewPrefixCacheMatchInfo(cachedTokens, testTotalTokens, testBlockSize))
+	ep.Put(attrprefix.PrefixCacheMatchInfoKey,
+		attrprefix.NewPrefixCacheMatchInfo(cachedTokens, testTotalTokens, testBlockSize))
 	return ep
 }
 
@@ -291,7 +291,7 @@ func TestDisaggregateWrongPrefixInfoType(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 
 	ep := makeTestEndpointBase()
-	ep.Put(prefix.PrefixCacheMatchInfoKey, &notPrefixCacheMatchInfo{})
+	ep.Put(attrprefix.PrefixCacheMatchInfoKey, &notPrefixCacheMatchInfo{})
 
 	decider, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{NonCachedTokens: 5})
 	require.NoError(t, err)
@@ -307,7 +307,7 @@ func TestConsumes(t *testing.T) {
 	require.NoError(t, err)
 
 	consumed := handler.Consumes()
-	assert.Contains(t, consumed, prefix.PrefixCacheMatchInfoKey)
+	assert.Contains(t, consumed, attrprefix.PrefixCacheMatchInfoKey)
 }
 
 func TestWithName(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
@@ -14,8 +14,8 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
-	fwkschd "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	approxprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/picker"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/picker/maxscore"
@@ -32,7 +32,7 @@ const (
 
 // Tests the scheduler expected behavior.
 func TestPDSchedule(t *testing.T) {
-	endpoint1 := fwkschd.NewEndpoint(
+	endpoint1 := fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{
 			NamespacedName: k8stypes.NamespacedName{Name: "endpoint1"},
 			Address:        "1.2.3.4",
@@ -41,7 +41,7 @@ func TestPDSchedule(t *testing.T) {
 		&fwkdl.Metrics{WaitingQueueSize: 0},
 		fwkdl.NewAttributes(),
 	)
-	endpoint2 := fwkschd.NewEndpoint(
+	endpoint2 := fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{
 			NamespacedName: k8stypes.NamespacedName{Name: "endpoint2"},
 			Address:        "5.6.7.8",
@@ -50,7 +50,7 @@ func TestPDSchedule(t *testing.T) {
 		&fwkdl.Metrics{WaitingQueueSize: 0},
 		fwkdl.NewAttributes(),
 	)
-	noRoleEndpoint1 := fwkschd.NewEndpoint(
+	noRoleEndpoint1 := fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{
 			NamespacedName: k8stypes.NamespacedName{Name: "noRoleEndpoint1"},
 			Address:        "1.1.1.1",
@@ -59,18 +59,18 @@ func TestPDSchedule(t *testing.T) {
 		fwkdl.NewAttributes(),
 	)
 
-	prefillDecodeResult := &fwkschd.SchedulingResult{
-		ProfileResults: map[string]*fwkschd.ProfileRunResult{
+	prefillDecodeResult := &fwksched.SchedulingResult{
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			decode: {
-				TargetEndpoints: []fwkschd.Endpoint{
-					&fwkschd.ScoredEndpoint{
+				TargetEndpoints: []fwksched.Endpoint{
+					&fwksched.ScoredEndpoint{
 						Endpoint: endpoint2,
 					},
 				},
 			},
 			prefill: {
-				TargetEndpoints: []fwkschd.Endpoint{
-					&fwkschd.ScoredEndpoint{
+				TargetEndpoints: []fwksched.Endpoint{
+					&fwksched.ScoredEndpoint{
 						Endpoint: endpoint1,
 					},
 				},
@@ -80,11 +80,11 @@ func TestPDSchedule(t *testing.T) {
 		PrimaryProfileName: decode,
 	}
 
-	decodeResult := &fwkschd.SchedulingResult{
-		ProfileResults: map[string]*fwkschd.ProfileRunResult{
+	decodeResult := &fwksched.SchedulingResult{
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			decode: {
-				TargetEndpoints: []fwkschd.Endpoint{
-					&fwkschd.ScoredEndpoint{
+				TargetEndpoints: []fwksched.Endpoint{
+					&fwksched.ScoredEndpoint{
 						Endpoint: endpoint2,
 					},
 				},
@@ -95,15 +95,15 @@ func TestPDSchedule(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		req      *fwkschd.InferenceRequest
-		input    []fwkschd.Endpoint
-		wantRes  *fwkschd.SchedulingResult
-		wantRes2 *fwkschd.SchedulingResult // a subsequent call to check prefix cache and how it affects PD
+		req      *fwksched.InferenceRequest
+		input    []fwksched.Endpoint
+		wantRes  *fwksched.SchedulingResult
+		wantRes2 *fwksched.SchedulingResult // a subsequent call to check prefix cache and how it affects PD
 		err      bool
 	}{
 		{
 			name: "no candidate endpoints",
-			req: &fwkschd.InferenceRequest{
+			req: &fwksched.InferenceRequest{
 				RequestID:   uuid.NewString(),
 				TargetModel: "any-model",
 				Body: &fwkrh.InferenceRequestBody{
@@ -112,12 +112,12 @@ func TestPDSchedule(t *testing.T) {
 					},
 				},
 			},
-			input: []fwkschd.Endpoint{},
+			input: []fwksched.Endpoint{},
 			err:   true,
 		},
 		{
 			name: "one decode endpoint, long prompt",
-			req: &fwkschd.InferenceRequest{
+			req: &fwksched.InferenceRequest{
 				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
@@ -127,12 +127,12 @@ func TestPDSchedule(t *testing.T) {
 				},
 			},
 			// endpoint2 will be picked because it is the only endpoint with Decode role
-			input:   []fwkschd.Endpoint{endpoint2},
+			input:   []fwksched.Endpoint{endpoint2},
 			wantRes: decodeResult,
 		},
 		{
 			name: "one prefill endpoint, long prompt",
-			req: &fwkschd.InferenceRequest{
+			req: &fwksched.InferenceRequest{
 				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
@@ -142,12 +142,12 @@ func TestPDSchedule(t *testing.T) {
 				},
 			},
 			// no Decode endpoint
-			input: []fwkschd.Endpoint{endpoint1},
+			input: []fwksched.Endpoint{endpoint1},
 			err:   true,
 		},
 		{
 			name: "1P1D - long prompt",
-			req: &fwkschd.InferenceRequest{
+			req: &fwksched.InferenceRequest{
 				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
@@ -157,13 +157,13 @@ func TestPDSchedule(t *testing.T) {
 				},
 			},
 			// endpoint2 will be picked in the decode profile result, endpoint1 will be in the prefill profile result
-			input:    []fwkschd.Endpoint{endpoint1, endpoint2},
+			input:    []fwksched.Endpoint{endpoint1, endpoint2},
 			wantRes:  prefillDecodeResult,
 			wantRes2: decodeResult,
 		},
 		{
 			name: "1P1Dshort",
-			req: &fwkschd.InferenceRequest{
+			req: &fwksched.InferenceRequest{
 				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
@@ -174,13 +174,13 @@ func TestPDSchedule(t *testing.T) {
 			},
 			// endpoint2 will be picked because it is the decode endpoint, endpoint1 shouldn't be picked,
 			// because the prompt is too short
-			input:    []fwkschd.Endpoint{endpoint1, endpoint2},
+			input:    []fwksched.Endpoint{endpoint1, endpoint2},
 			wantRes:  decodeResult,
 			wantRes2: decodeResult,
 		},
 		{
 			name: "TestRolesWithNoDecode",
-			req: &fwkschd.InferenceRequest{
+			req: &fwksched.InferenceRequest{
 				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
@@ -189,19 +189,19 @@ func TestPDSchedule(t *testing.T) {
 					},
 				},
 			},
-			input: []fwkschd.Endpoint{endpoint1, noRoleEndpoint1},
-			wantRes: &fwkschd.SchedulingResult{
-				ProfileResults: map[string]*fwkschd.ProfileRunResult{
+			input: []fwksched.Endpoint{endpoint1, noRoleEndpoint1},
+			wantRes: &fwksched.SchedulingResult{
+				ProfileResults: map[string]*fwksched.ProfileRunResult{
 					decode: {
-						TargetEndpoints: []fwkschd.Endpoint{
-							&fwkschd.ScoredEndpoint{
+						TargetEndpoints: []fwksched.Endpoint{
+							&fwksched.ScoredEndpoint{
 								Endpoint: noRoleEndpoint1,
 							},
 						},
 					},
 					prefill: {
-						TargetEndpoints: []fwkschd.Endpoint{
-							&fwkschd.ScoredEndpoint{
+						TargetEndpoints: []fwksched.Endpoint{
+							&fwksched.ScoredEndpoint{
 								Endpoint: endpoint1,
 							},
 						},
@@ -212,7 +212,7 @@ func TestPDSchedule(t *testing.T) {
 		},
 		{
 			name: "1P2D - long prompt",
-			req: &fwkschd.InferenceRequest{
+			req: &fwksched.InferenceRequest{
 				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
@@ -223,7 +223,7 @@ func TestPDSchedule(t *testing.T) {
 			},
 			// endpoint2 will be picked in the decode profile result cause it has higher score than noRoleEndpoint1
 			// endpoint1 will be in the prefill profile result
-			input:    []fwkschd.Endpoint{endpoint1, endpoint2, noRoleEndpoint1},
+			input:    []fwksched.Endpoint{endpoint1, endpoint2, noRoleEndpoint1},
 			wantRes:  prefillDecodeResult,
 			wantRes2: decodeResult,
 		},
@@ -258,7 +258,7 @@ func TestPDSchedule(t *testing.T) {
 			profileHandle := disagg.NewDisaggProfileHandler(decode, prefill, "",
 				deciderPlugin, nil)
 
-			schedulerConfig := scheduling.NewSchedulerConfig(profileHandle, map[string]fwkschd.SchedulerProfile{
+			schedulerConfig := scheduling.NewSchedulerConfig(profileHandle, map[string]fwksched.SchedulerProfile{
 				prefill: prefillSchedulerProfile,
 				decode:  decodeSchedulerProfile,
 			})
@@ -266,7 +266,7 @@ func TestPDSchedule(t *testing.T) {
 
 			inputTokens := len(test.req.Body.Completions.Prompt.Raw) / disagg.AverageCharactersPerToken
 			for _, pod := range test.input {
-				pod.Put(approxprefix.PrefixCacheMatchInfoKey, approxprefix.NewPrefixCacheMatchInfo(0, inputTokens, 1))
+				pod.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(0, inputTokens, 1))
 			}
 			got, err := scheduler.Schedule(ctx, test.req, test.input)
 
@@ -274,13 +274,13 @@ func TestPDSchedule(t *testing.T) {
 				t.Errorf("Unexpected error, got %v, want %v", err, test.err)
 			}
 
-			if diff := cmp.Diff(test.wantRes, got, cmpopts.IgnoreUnexported(fwkdl.Attributes{}), cmpopts.IgnoreFields(fwkschd.ScoredEndpoint{}, "Score")); diff != "" {
+			if diff := cmp.Diff(test.wantRes, got, cmpopts.IgnoreUnexported(fwkdl.Attributes{}), cmpopts.IgnoreFields(fwksched.ScoredEndpoint{}, "Score")); diff != "" {
 				t.Errorf("Unexpected output (-want +got): %v", diff)
 			}
 			if test.wantRes2 != nil { // Checking the prefix match in the decode pod.
 				// update number of cached tokens for the following schedule call
 				for _, pod := range test.input {
-					pod.Put(approxprefix.PrefixCacheMatchInfoKey, approxprefix.NewPrefixCacheMatchInfo(inputTokens, inputTokens, 1))
+					pod.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(inputTokens, inputTokens, 1))
 				}
 
 				got, err = scheduler.Schedule(ctx, test.req, test.input)
@@ -288,7 +288,7 @@ func TestPDSchedule(t *testing.T) {
 					t.Errorf("Unexpected error in schedule call, got %v, want %v", err, test.err)
 				}
 
-				if diff := cmp.Diff(test.wantRes2, got, cmpopts.IgnoreUnexported(fwkdl.Attributes{}), cmpopts.IgnoreFields(fwkschd.ScoredEndpoint{}, "Score")); diff != "" {
+				if diff := cmp.Diff(test.wantRes2, got, cmpopts.IgnoreUnexported(fwkdl.Attributes{}), cmpopts.IgnoreFields(fwksched.ScoredEndpoint{}, "Score")); diff != "" {
 					t.Errorf("Unexpected output in subsequent schedule call (-want +got): %v", diff)
 				}
 			}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -31,7 +31,7 @@ const (
 )
 
 // compile-time type assertion
-var _ framework.ProfileHandler = &SingleProfileHandler{}
+var _ fwksched.ProfileHandler = &SingleProfileHandler{}
 
 // SingleProfileHandlerFactory defines the factory function for SingleProfileHandler.
 func SingleProfileHandlerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -63,10 +63,10 @@ func (h *SingleProfileHandler) WithName(name string) *SingleProfileHandler {
 
 // Pick selects the SchedulingProfiles to run from the list of candidate profiles, while taking into consideration the request properties and the
 // previously executed cycles along with their results.
-func (h *SingleProfileHandler) Pick(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest, profiles map[string]framework.SchedulerProfile,
-	profileResults map[string]*framework.ProfileRunResult) map[string]framework.SchedulerProfile {
+func (h *SingleProfileHandler) Pick(_ context.Context, _ *fwksched.CycleState, request *fwksched.InferenceRequest, profiles map[string]fwksched.SchedulerProfile,
+	profileResults map[string]*fwksched.ProfileRunResult) map[string]fwksched.SchedulerProfile {
 	if len(profiles) == len(profileResults) { // all profiles have been executed already in previous call
-		return map[string]framework.SchedulerProfile{}
+		return map[string]fwksched.SchedulerProfile{}
 	}
 	// return all profiles
 	return profiles
@@ -76,8 +76,8 @@ func (h *SingleProfileHandler) Pick(_ context.Context, _ *framework.CycleState, 
 // It may aggregate results, log test profile outputs, or apply custom logic. It specifies in the SchedulingResult the
 // key of the primary profile that should be used to get the request selected destination.
 // When a profile run fails, its result in the profileResults map is nil.
-func (h *SingleProfileHandler) ProcessResults(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest,
-	profileResults map[string]*framework.ProfileRunResult) (*framework.SchedulingResult, error) {
+func (h *SingleProfileHandler) ProcessResults(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest,
+	profileResults map[string]*fwksched.ProfileRunResult) (*fwksched.SchedulingResult, error) {
 	if len(profileResults) != 1 {
 		return nil, errors.New("single profile handler is intended to be used with a single profile, failed to process multiple profiles")
 	}
@@ -92,7 +92,7 @@ func (h *SingleProfileHandler) ProcessResults(_ context.Context, _ *framework.Cy
 		return nil, fmt.Errorf("failed to run scheduler profile '%s'", singleProfileName)
 	}
 
-	return &framework.SchedulingResult{
+	return &fwksched.SchedulingResult{
 		ProfileResults:     profileResults,
 		PrimaryProfileName: singleProfileName,
 	}, nil

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler_test.go
@@ -23,13 +23,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 type fakeSchedulerProfile struct{}
 
-func (f *fakeSchedulerProfile) Run(_ context.Context, _ *framework.InferenceRequest, _ *framework.CycleState, _ []framework.Endpoint) (*framework.ProfileRunResult, error) {
-	return &framework.ProfileRunResult{}, nil
+func (f *fakeSchedulerProfile) Run(_ context.Context, _ *fwksched.InferenceRequest, _ *fwksched.CycleState, _ []fwksched.Endpoint) (*fwksched.ProfileRunResult, error) {
+	return &fwksched.ProfileRunResult{}, nil
 }
 
 func TestNewSingleProfileHandler(t *testing.T) {
@@ -80,28 +80,28 @@ func TestPick(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		profiles       map[string]framework.SchedulerProfile
-		profileResults map[string]*framework.ProfileRunResult
+		profiles       map[string]fwksched.SchedulerProfile
+		profileResults map[string]*fwksched.ProfileRunResult
 		wantCount      int
 	}{
 		{
 			name:           "no profiles executed yet, returns all",
-			profiles:       map[string]framework.SchedulerProfile{"default": fakeProfile},
-			profileResults: map[string]*framework.ProfileRunResult{},
+			profiles:       map[string]fwksched.SchedulerProfile{"default": fakeProfile},
+			profileResults: map[string]*fwksched.ProfileRunResult{},
 			wantCount:      1,
 		},
 		{
 			name:     "all profiles already executed, returns empty",
-			profiles: map[string]framework.SchedulerProfile{"default": fakeProfile},
-			profileResults: map[string]*framework.ProfileRunResult{
+			profiles: map[string]fwksched.SchedulerProfile{"default": fakeProfile},
+			profileResults: map[string]*fwksched.ProfileRunResult{
 				"default": {TargetEndpoints: nil},
 			},
 			wantCount: 0,
 		},
 		{
 			name:           "no profiles configured, returns empty",
-			profiles:       map[string]framework.SchedulerProfile{},
-			profileResults: map[string]*framework.ProfileRunResult{},
+			profiles:       map[string]fwksched.SchedulerProfile{},
+			profileResults: map[string]*fwksched.ProfileRunResult{},
 			wantCount:      0,
 		},
 	}
@@ -109,7 +109,7 @@ func TestPick(t *testing.T) {
 	handler := NewSingleProfileHandler()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := handler.Pick(context.Background(), framework.NewCycleState(), nil, tt.profiles, tt.profileResults)
+			got := handler.Pick(context.Background(), fwksched.NewCycleState(), nil, tt.profiles, tt.profileResults)
 			if len(got) != tt.wantCount {
 				t.Errorf("Pick() returned %d profiles, want %d", len(got), tt.wantCount)
 			}
@@ -118,23 +118,23 @@ func TestPick(t *testing.T) {
 }
 
 func TestProcessResults(t *testing.T) {
-	successResult := &framework.ProfileRunResult{
+	successResult := &fwksched.ProfileRunResult{
 		TargetEndpoints: nil,
 	}
 
 	tests := []struct {
 		name           string
-		profileResults map[string]*framework.ProfileRunResult
-		wantResult     *framework.SchedulingResult
+		profileResults map[string]*fwksched.ProfileRunResult
+		wantResult     *fwksched.SchedulingResult
 		wantErr        bool
 	}{
 		{
 			name: "single successful profile",
-			profileResults: map[string]*framework.ProfileRunResult{
+			profileResults: map[string]*fwksched.ProfileRunResult{
 				"default": successResult,
 			},
-			wantResult: &framework.SchedulingResult{
-				ProfileResults: map[string]*framework.ProfileRunResult{
+			wantResult: &fwksched.SchedulingResult{
+				ProfileResults: map[string]*fwksched.ProfileRunResult{
 					"default": successResult,
 				},
 				PrimaryProfileName: "default",
@@ -142,12 +142,12 @@ func TestProcessResults(t *testing.T) {
 		},
 		{
 			name:           "no profiles returns error",
-			profileResults: map[string]*framework.ProfileRunResult{},
+			profileResults: map[string]*fwksched.ProfileRunResult{},
 			wantErr:        true,
 		},
 		{
 			name: "multiple profiles returns error",
-			profileResults: map[string]*framework.ProfileRunResult{
+			profileResults: map[string]*fwksched.ProfileRunResult{
 				"profile-a": successResult,
 				"profile-b": successResult,
 			},
@@ -155,7 +155,7 @@ func TestProcessResults(t *testing.T) {
 		},
 		{
 			name: "nil result (profile execution failure) returns error",
-			profileResults: map[string]*framework.ProfileRunResult{
+			profileResults: map[string]*fwksched.ProfileRunResult{
 				"default": nil,
 			},
 			wantErr: true,
@@ -165,7 +165,7 @@ func TestProcessResults(t *testing.T) {
 	handler := NewSingleProfileHandler()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := handler.ProcessResults(context.Background(), framework.NewCycleState(), nil, tt.profileResults)
+			got, err := handler.ProcessResults(context.Background(), fwksched.NewCycleState(), nil, tt.profileResults)
 
 			if tt.wantErr {
 				if err == nil {

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 )
 
@@ -30,7 +30,7 @@ const (
 )
 
 // compile-time type assertion
-var _ framework.Scorer = &KVCacheUtilizationScorer{}
+var _ fwksched.Scorer = &KVCacheUtilizationScorer{}
 
 // KvCacheUtilizationScorerFactory defines the factory function for KVCacheUtilizationScorer.
 func KvCacheUtilizationScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -55,8 +55,8 @@ func (s *KVCacheUtilizationScorer) TypedName() fwkplugin.TypedName {
 }
 
 // Category returns the preference the scorer applies when scoring candidate endpoints.
-func (s *KVCacheUtilizationScorer) Category() framework.ScorerCategory {
-	return framework.Distribution
+func (s *KVCacheUtilizationScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Distribution
 }
 
 // Consumes returns the list of data that is consumed by the plugin.
@@ -73,8 +73,8 @@ func (s *KVCacheUtilizationScorer) WithName(name string) *KVCacheUtilizationScor
 }
 
 // Score returns the scoring result for the given list of endpoints based on context.
-func (s *KVCacheUtilizationScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+func (s *KVCacheUtilizationScorer) Score(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
 		scores[endpoint] = 1 - endpoint.GetMetrics().KVCacheUsagePercent
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -29,7 +29,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
@@ -54,7 +54,7 @@ const (
 )
 
 // compile-time validation
-var _ framework.Scorer = &Plugin{}
+var _ fwksched.Scorer = &Plugin{}
 
 type Config struct {
 	// TTFTWeight controls the relative importance of TTFT headroom when scoring.
@@ -128,22 +128,22 @@ func (s *Plugin) TypedName() fwkplugin.TypedName {
 	return s.typedName
 }
 
-func (s *Plugin) Category() framework.ScorerCategory {
-	return framework.Balance
+func (s *Plugin) Category() fwksched.ScorerCategory {
+	return fwksched.Balance
 }
 
 // epData holds per-endpoint data gathered from attributes.
 type epData struct {
-	endpoint     framework.Endpoint
+	endpoint     fwksched.Endpoint
 	info         *attrlatency.LatencyPredictionInfo
 	ttftHeadroom float64 // cached from info.TTFTHeadroom()
 	tpotHeadroom float64 // cached from info.TPOTHeadroom()
 }
 
 // Score returns a float64 score in [0,1] for each endpoint.
-func (s *Plugin) Score(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *Plugin) Score(ctx context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	logger := log.FromContext(ctx)
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	for _, ep := range endpoints {
 		scores[ep] = 0
 	}
@@ -243,7 +243,7 @@ func (s *Plugin) Score(ctx context.Context, _ *framework.CycleState, _ *framewor
 // scoreBucket normalizes headroom within a bucket and assigns scores.
 // If forceLeast is true, the "least" strategy is used regardless of config
 // (needed for negative headroom where "most" would incorrectly prefer the most overloaded).
-func (s *Plugin) scoreBucket(ctx context.Context, data []epData, scores map[framework.Endpoint]float64, forceLeast bool) {
+func (s *Plugin) scoreBucket(ctx context.Context, data []epData, scores map[fwksched.Endpoint]float64, forceLeast bool) {
 	logger := log.FromContext(ctx)
 
 	alpha, beta := normalizedWeights(s.config.TTFTWeight, s.config.TPOTWeight)
@@ -320,8 +320,8 @@ func (s *Plugin) scoreBucket(ctx context.Context, data []epData, scores map[fram
 // compositeScores returns scores based on KV cache, queue, and prefix cache.
 // This is a fallback for when latency predictions are unavailable (sidecar down
 // or timed out).
-func (s *Plugin) compositeScores(ctx context.Context, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+func (s *Plugin) compositeScores(ctx context.Context, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 
 	wkv, wq, wpref := s.config.CompositeKVWeight, s.config.CompositeQueueWeight, s.config.CompositePrefixWeight
 	sumw := wkv + wq + wpref
@@ -381,7 +381,7 @@ func normalizedWeights(a, b float64) (float64, float64) {
 	return a / sum, b / sum
 }
 
-func prefixCacheScore(ep framework.Endpoint) float64 {
+func prefixCacheScore(ep fwksched.Endpoint) float64 {
 	if raw, ok := ep.Get(attrprefix.PrefixCacheMatchInfoKey); ok {
 		info := raw.(*attrprefix.PrefixCacheMatchInfo)
 		if info.TotalBlocks() > 0 {

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin_test.go
@@ -23,12 +23,12 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 )
 
-func makeLatencyScorerEndpoint(name string, kvCache float64, queueSize, runningReqs int) framework.Endpoint {
-	return framework.NewEndpoint(
+func makeLatencyScorerEndpoint(name string, kvCache float64, queueSize, runningReqs int) fwksched.Endpoint {
+	return fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
 		&fwkdl.Metrics{
 			KVCacheUsagePercent: kvCache,
@@ -39,7 +39,7 @@ func makeLatencyScorerEndpoint(name string, kvCache float64, queueSize, runningR
 	)
 }
 
-func setLatencyPrediction(ep framework.Endpoint, ttftValid, tpotValid bool, ttftHeadroom, tpotHeadroom, ttft, tpot float64) {
+func setLatencyPrediction(ep fwksched.Endpoint, ttftValid, tpotValid bool, ttftHeadroom, tpotHeadroom, ttft, tpot float64) {
 	ep.Put(attrlatency.LatencyPredictionInfoKey,
 		attrlatency.NewLatencyPredictionInfo(ttftValid, tpotValid, ttftHeadroom, tpotHeadroom, ttft, tpot, 0))
 }
@@ -59,8 +59,8 @@ func TestScorePositiveHeadroom(t *testing.T) {
 	setLatencyPrediction(ep1, true, true, 100, 20, 50, 10)
 	setLatencyPrediction(ep2, true, true, 30, 5, 120, 25)
 
-	endpoints := []framework.Endpoint{ep1, ep2}
-	scores := scorer.Score(context.Background(), framework.NewCycleState(), nil, endpoints)
+	endpoints := []fwksched.Endpoint{ep1, ep2}
+	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), nil, endpoints)
 
 	s1, s2 := scores[ep1], scores[ep2]
 
@@ -82,8 +82,8 @@ func TestScoreNegativeOnly(t *testing.T) {
 	setLatencyPrediction(ep1, false, false, -10, -5, 110, 35)
 	setLatencyPrediction(ep2, false, false, -100, -30, 200, 60)
 
-	endpoints := []framework.Endpoint{ep1, ep2}
-	scores := scorer.Score(context.Background(), framework.NewCycleState(), nil, endpoints)
+	endpoints := []fwksched.Endpoint{ep1, ep2}
+	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), nil, endpoints)
 
 	s1, s2 := scores[ep1], scores[ep2]
 
@@ -111,8 +111,8 @@ func TestScoreTierSplit(t *testing.T) {
 	setLatencyPrediction(ep1, true, true, 10, 2, 90, 28)
 	setLatencyPrediction(ep2, true, true, 50, 10, 50, 20)
 
-	endpoints := []framework.Endpoint{ep1, ep2}
-	scores := scorer.Score(context.Background(), framework.NewCycleState(), nil, endpoints)
+	endpoints := []fwksched.Endpoint{ep1, ep2}
+	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), nil, endpoints)
 
 	s1, s2 := scores[ep1], scores[ep2]
 
@@ -145,8 +145,8 @@ func TestScoreIdlePodPreference(t *testing.T) {
 	epIdle.Put(attrlatency.LatencyPredictionInfoKey,
 		attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
 
-	endpoints := []framework.Endpoint{epBusy, epIdle}
-	scores := scorer.Score(context.Background(), framework.NewCycleState(), nil, endpoints)
+	endpoints := []fwksched.Endpoint{epBusy, epIdle}
+	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), nil, endpoints)
 
 	sBusy, sIdle := scores[epBusy], scores[epIdle]
 
@@ -173,8 +173,8 @@ func TestScoreHierarchicalBuckets(t *testing.T) {
 	setLatencyPrediction(epTTFTNeg, false, true, -30, 5, 130, 25)    // only TTFT negative
 	setLatencyPrediction(epTPOTNeg, true, false, 10, -8, 90, 38)     // only TPOT negative
 
-	endpoints := []framework.Endpoint{epBothNeg, epTTFTNeg, epTPOTNeg}
-	scores := scorer.Score(context.Background(), framework.NewCycleState(), nil, endpoints)
+	endpoints := []fwksched.Endpoint{epBothNeg, epTTFTNeg, epTPOTNeg}
+	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), nil, endpoints)
 
 	// All should have non-zero scores (they're all in the negative tier).
 	for _, ep := range endpoints {
@@ -194,8 +194,8 @@ func TestScoreCompositeFallback(t *testing.T) {
 	ep1 := makeLatencyScorerEndpoint("pod1", 0.2, 0, 3)
 	ep2 := makeLatencyScorerEndpoint("pod2", 0.8, 5, 10)
 
-	endpoints := []framework.Endpoint{ep1, ep2}
-	scores := scorer.Score(context.Background(), framework.NewCycleState(), nil, endpoints)
+	endpoints := []fwksched.Endpoint{ep1, ep2}
+	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), nil, endpoints)
 
 	s1, s2 := scores[ep1], scores[ep2]
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 )
 
@@ -30,7 +30,7 @@ const (
 )
 
 // compile-time type assertion
-var _ framework.Scorer = &LoraAffinityScorer{}
+var _ fwksched.Scorer = &LoraAffinityScorer{}
 
 // LoraAffinityScorerFactory defines the factory function for LoraAffinityScorer.
 func LoraAffinityScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -55,8 +55,8 @@ func (s *LoraAffinityScorer) TypedName() fwkplugin.TypedName {
 }
 
 // Category returns the preference the scorer applies when scoring candidate endpoints.
-func (s *LoraAffinityScorer) Category() framework.ScorerCategory {
-	return framework.Affinity
+func (s *LoraAffinityScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Affinity
 }
 
 // Consumes returns the list of data that is consumed by the plugin.
@@ -73,8 +73,8 @@ func (s *LoraAffinityScorer) WithName(name string) *LoraAffinityScorer {
 	return s
 }
 
-func (s *LoraAffinityScorer) Score(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+func (s *LoraAffinityScorer) Score(_ context.Context, _ *fwksched.CycleState, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 
 	// Assign a score to each endpoint for loading the target adapter.
 	for _, endpoint := range endpoints {

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -12,7 +12,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	approxprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 )
 
@@ -141,11 +141,11 @@ func (s *NoHitLRU) isColdRequest(ctx context.Context, endpoints []scheduling.End
 	logger := log.FromContext(ctx).V(logging.DEBUG)
 
 	for _, ep := range endpoints {
-		attr, ok := ep.Get(approxprefix.PrefixCacheMatchInfoKey)
+		attr, ok := ep.Get(attrprefix.PrefixCacheMatchInfoKey)
 		if !ok {
 			continue
 		}
-		info, ok := attr.(*approxprefix.PrefixCacheMatchInfo)
+		info, ok := attr.(*attrprefix.PrefixCacheMatchInfo)
 		if ok && info.MatchBlocks() > 0 {
 			logger.Info("Cache hit detected on endpoint", "endpoint", ep.GetMetadata().NamespacedName)
 			return false

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -12,7 +12,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	approxprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/nohitlru"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
@@ -86,7 +86,7 @@ func newColdNS(name string) scheduling.Endpoint {
 // newWarm returns an endpoint with prefix-cache match info indicating a cache hit.
 func newWarm(name string) scheduling.Endpoint {
 	ep := newCold(name)
-	ep.Put(approxprefix.PrefixCacheMatchInfoKey, approxprefix.NewPrefixCacheMatchInfo(5, 10, 1))
+	ep.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(5, 10, 1))
 	return ep
 }
 
@@ -281,7 +281,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 			&fwkdl.Metrics{},
 			nil,
 		)
-		w.Put(approxprefix.PrefixCacheMatchInfoKey, approxprefix.NewPrefixCacheMatchInfo(5, 10, 1))
+		w.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(5, 10, 1))
 		return []scheduling.Endpoint{w, endpointB, endpointC}
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -26,7 +26,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
-	approxprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 )
@@ -333,7 +333,7 @@ func (s *Scorer) Category() scheduling.ScorerCategory {
 // Produces declares the data keys this plugin writes to endpoints.
 func (s *Scorer) Produces() map[string]any {
 	return map[string]any{
-		approxprefix.PrefixCacheMatchInfoKey: approxprefix.PrefixCacheMatchInfo{},
+		attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{},
 	}
 }
 
@@ -391,7 +391,7 @@ func (s *Scorer) PrepareRequestData(ctx context.Context,
 		}
 		addr := fmt.Sprintf("%s:%s", md.Address, md.Port)
 		matchLen := int(scores[addr])
-		ep.Put(approxprefix.PrefixCacheMatchInfoKey, approxprefix.NewPrefixCacheMatchInfo(matchLen, len(blockKeys), blockSize))
+		ep.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(matchLen, len(blockKeys), blockSize))
 	}
 
 	// 6. Save to PluginState for Score() and PreRequest()
@@ -495,7 +495,7 @@ func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, r
 				matchBlocks = 1
 			}
 		}
-		endpoint.Put(approxprefix.PrefixCacheMatchInfoKey, approxprefix.NewPrefixCacheMatchInfo(matchBlocks, 1, 1))
+		endpoint.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(matchBlocks, 1, 1))
 	}
 
 	normalizedScores := indexedScoresToNormalizedScoredPods(endpoints, endpointToKey, scores)

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -24,7 +24,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
@@ -35,7 +35,7 @@ type Plugin struct {
 
 // compile-time type assertions
 var (
-	_ framework.Scorer = &Plugin{}
+	_ fwksched.Scorer = &Plugin{}
 )
 
 const (
@@ -71,8 +71,8 @@ func (p *Plugin) TypedName() plugin.TypedName {
 }
 
 // Category returns the preference the scorer applies (Affinity).
-func (p *Plugin) Category() framework.ScorerCategory {
-	return framework.Affinity
+func (p *Plugin) Category() fwksched.ScorerCategory {
+	return fwksched.Affinity
 }
 
 // WithName sets the name of the plugin instance.
@@ -92,8 +92,8 @@ func (p *Plugin) Consumes() map[string]any {
 }
 
 // Score returns the scoring result for the given list of pods based on prefix cache match info.
-func (p *Plugin) Score(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+func (p *Plugin) Score(ctx context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	logger := log.FromContext(ctx)
 
 	for _, endpoint := range endpoints {

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
@@ -22,7 +22,7 @@ import (
 	"math"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 )
 
@@ -31,7 +31,7 @@ const (
 )
 
 // compile-time type assertion
-var _ framework.Scorer = &QueueScorer{}
+var _ fwksched.Scorer = &QueueScorer{}
 
 // QueueScorerFactory defines the factory function for QueueScorer.
 func QueueScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -57,8 +57,8 @@ func (s *QueueScorer) TypedName() fwkplugin.TypedName {
 }
 
 // Category returns the preference the scorer applies when scoring candidate endpoints.
-func (s *QueueScorer) Category() framework.ScorerCategory {
-	return framework.Distribution
+func (s *QueueScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Distribution
 }
 
 // Consumes returns the list of data that is consumed by the plugin.
@@ -75,7 +75,7 @@ func (s *QueueScorer) WithName(name string) *QueueScorer {
 }
 
 // Score returns the scoring result for the given list of endpoints based on context.
-func (s *QueueScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *QueueScorer) Score(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	minQueueSize := math.MaxInt
 	maxQueueSize := math.MinInt
 
@@ -91,7 +91,7 @@ func (s *QueueScorer) Score(_ context.Context, _ *framework.CycleState, _ *frame
 	}
 
 	// endpointScoreFunc calculates the score based on the queue size of each endpoint. Longer queue gets a lower score.
-	endpointScoreFunc := func(endpoint framework.Endpoint) float64 {
+	endpointScoreFunc := func(endpoint fwksched.Endpoint) float64 {
 		if maxQueueSize == minQueueSize {
 			// If all pods have the same queue size, return a neutral score
 			return 1.0
@@ -100,7 +100,7 @@ func (s *QueueScorer) Score(_ context.Context, _ *framework.CycleState, _ *frame
 	}
 
 	// Create a map to hold the scores for each endpoint
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
 		scores[endpoint] = endpointScoreFunc(endpoint)
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
@@ -22,7 +22,7 @@ import (
 	"math"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 )
 
@@ -31,7 +31,7 @@ const (
 )
 
 // compile-time type assertion
-var _ framework.Scorer = &RunningRequestsSizeScorer{}
+var _ fwksched.Scorer = &RunningRequestsSizeScorer{}
 
 // RunningRequestsSizeScorerFactory defines the factory function for RunningRequestsSizeScorer.
 func RunningRequestsSizeScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -57,8 +57,8 @@ func (s *RunningRequestsSizeScorer) TypedName() fwkplugin.TypedName {
 }
 
 // Category returns the preference the scorer applies when scoring candidate endpoints.
-func (s *RunningRequestsSizeScorer) Category() framework.ScorerCategory {
-	return framework.Distribution
+func (s *RunningRequestsSizeScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Distribution
 }
 
 // Consumes returns the list of data that is consumed by the plugin.
@@ -75,7 +75,7 @@ func (s *RunningRequestsSizeScorer) WithName(name string) *RunningRequestsSizeSc
 }
 
 // Score returns the scoring result for the given list of pods based on context.
-func (s *RunningRequestsSizeScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *RunningRequestsSizeScorer) Score(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	minQueueSize := math.MaxInt
 	maxQueueSize := math.MinInt
 
@@ -91,7 +91,7 @@ func (s *RunningRequestsSizeScorer) Score(_ context.Context, _ *framework.CycleS
 	}
 
 	// endpointScoreFunc calculates the score based on the queue size of each endpoint. Longer queue gets a lower score.
-	endpointScoreFunc := func(endpoint framework.Endpoint) float64 {
+	endpointScoreFunc := func(endpoint fwksched.Endpoint) float64 {
 		if maxQueueSize == minQueueSize {
 			// If all endpoints have the same queue size, return a neutral score
 			return 1.0
@@ -100,7 +100,7 @@ func (s *RunningRequestsSizeScorer) Score(_ context.Context, _ *framework.CycleS
 	}
 
 	// Create a map to hold the scores for each endpoint
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
 		scores[endpoint] = endpointScoreFunc(endpoint)
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 )
 
@@ -41,7 +41,7 @@ type Config struct {
 }
 
 // compile-time type assertion
-var _ framework.Scorer = &TokenLoadScorer{}
+var _ fwksched.Scorer = &TokenLoadScorer{}
 
 type TokenLoadScorer struct {
 	typedName            fwkplugin.TypedName
@@ -71,8 +71,8 @@ func (s *TokenLoadScorer) TypedName() fwkplugin.TypedName {
 	return s.typedName
 }
 
-func (s *TokenLoadScorer) Category() framework.ScorerCategory {
-	return framework.Distribution
+func (s *TokenLoadScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Distribution
 }
 
 func (s *TokenLoadScorer) Consumes() map[string]any {
@@ -81,8 +81,8 @@ func (s *TokenLoadScorer) Consumes() map[string]any {
 	}
 }
 
-func (s *TokenLoadScorer) Score(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
-	scores := make(map[framework.Endpoint]float64, len(endpoints))
+func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	logger := log.FromContext(ctx)
 
 	for _, endpoint := range endpoints {

--- a/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
+++ b/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/test"
 )
 
@@ -33,7 +33,7 @@ const (
 )
 
 // compile-time type assertion
-var _ framework.Filter = &HeaderBasedTestingFilter{}
+var _ fwksched.Filter = &HeaderBasedTestingFilter{}
 
 // HeaderBasedTestingFilterFactory defines the factory function for HeaderBasedTestingFilter.
 func HeaderBasedTestingFilterFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -67,10 +67,10 @@ func (f *HeaderBasedTestingFilter) WithName(name string) *HeaderBasedTestingFilt
 // Filter selects endpoints whose IP or IP:port matches any value in the
 // "test-epp-endpoint-selection" header. Values may be "IP" or "IP:port".
 // If a port is provided, only an exact IP:port match is accepted.
-func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest, endpoints []framework.Endpoint) []framework.Endpoint {
+func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *fwksched.CycleState, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	hv, ok := request.Headers[test.HeaderTestEppEndPointSelectionKey]
 	if !ok || strings.TrimSpace(hv) == "" {
-		return []framework.Endpoint{}
+		return []fwksched.Endpoint{}
 	}
 
 	normalizeIP := func(s string) string { return strings.Trim(s, "[]") }
@@ -78,8 +78,8 @@ func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *framework.CycleS
 	// Build lookup maps:
 	//   ip -> endpoint
 	//   ip:port -> endpoint (only when endpoint GetPort() is non-empty)
-	ipToEndpoint := make(map[string]framework.Endpoint, len(endpoints))
-	hpToPod := make(map[string]framework.Endpoint, len(endpoints))
+	ipToEndpoint := make(map[string]fwksched.Endpoint, len(endpoints))
+	hpToPod := make(map[string]fwksched.Endpoint, len(endpoints))
 	for _, e := range endpoints {
 		if e == nil || e.GetMetadata() == nil {
 			continue
@@ -95,7 +95,7 @@ func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *framework.CycleS
 	}
 
 	headerVals := strings.Split(hv, ",")
-	filteredEndpoints := make([]framework.Endpoint, 0, len(headerVals))
+	filteredEndpoints := make([]fwksched.Endpoint, 0, len(headerVals))
 	seen := make(map[string]struct{}, len(headerVals)) // de-dupe by endpoint IP
 
 	for _, raw := range headerVals {
@@ -113,7 +113,7 @@ func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *framework.CycleS
 		}
 		host = normalizeIP(host)
 
-		var endpoint framework.Endpoint
+		var endpoint fwksched.Endpoint
 		if port != "" {
 			// Require an exact ip:port match
 			if p, ok := hpToPod[host+":"+port]; ok {

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -42,7 +42,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metrics"
 	"github.com/llm-d/llm-d-inference-scheduler/version"
 )
@@ -112,7 +112,7 @@ type RequestContext struct {
 	RequestRunning            bool
 	Request                   *Request
 
-	SchedulingRequest *schedulingtypes.InferenceRequest
+	SchedulingRequest *fwksched.InferenceRequest
 
 	RequestState         StreamRequestState
 	modelServerStreaming bool

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -29,7 +29,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	metricsutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/metrics"
-	schedulingframework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -788,7 +788,7 @@ func RecordSchedulerE2ELatency(duration time.Duration) {
 }
 
 // RecordSchedulerAttempt records a scheduling attempt with status and endpoint information.
-func RecordSchedulerAttempt(err error, targetModelName string, result *schedulingframework.SchedulingResult) {
+func RecordSchedulerAttempt(err error, targetModelName string, result *fwksched.SchedulingResult) {
 	if err != nil {
 		schedulerAttemptsTotal.WithLabelValues(SchedulerStatusFailure, targetModelName, "", "", "").Inc()
 		return

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -33,7 +33,7 @@ import (
 	errcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	schedulingframework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 const (
@@ -839,12 +839,12 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 
 	t.Run("success with endpoint metadata", func(t *testing.T) {
 		Reset()
-		result := &schedulingframework.SchedulingResult{
+		result := &fwksched.SchedulingResult{
 			PrimaryProfileName: "primary",
-			ProfileResults: map[string]*schedulingframework.ProfileRunResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
 				"primary": {
-					TargetEndpoints: []schedulingframework.Endpoint{
-						schedulingframework.NewEndpoint(
+					TargetEndpoints: []fwksched.Endpoint{
+						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
 								PodName:        "pod-1",
@@ -863,12 +863,12 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 
 	t.Run("success with multiple endpoints uses first", func(t *testing.T) {
 		Reset()
-		result := &schedulingframework.SchedulingResult{
+		result := &fwksched.SchedulingResult{
 			PrimaryProfileName: "primary",
-			ProfileResults: map[string]*schedulingframework.ProfileRunResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
 				"primary": {
-					TargetEndpoints: []schedulingframework.Endpoint{
-						schedulingframework.NewEndpoint(
+					TargetEndpoints: []fwksched.Endpoint{
+						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
 								PodName:        "pod-1",
@@ -876,7 +876,7 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 							},
 							nil, nil,
 						),
-						schedulingframework.NewEndpoint(
+						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
 								PodName:        "pod-2",
@@ -895,12 +895,12 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 
 	t.Run("success with different models and endpoints", func(t *testing.T) {
 		Reset()
-		resultA := &schedulingframework.SchedulingResult{
+		resultA := &fwksched.SchedulingResult{
 			PrimaryProfileName: "primary",
-			ProfileResults: map[string]*schedulingframework.ProfileRunResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
 				"primary": {
-					TargetEndpoints: []schedulingframework.Endpoint{
-						schedulingframework.NewEndpoint(
+					TargetEndpoints: []fwksched.Endpoint{
+						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
 								PodName:        "pod-1",
@@ -912,12 +912,12 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 				},
 			},
 		}
-		resultB := &schedulingframework.SchedulingResult{
+		resultB := &fwksched.SchedulingResult{
 			PrimaryProfileName: "primary",
-			ProfileResults: map[string]*schedulingframework.ProfileRunResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
 				"primary": {
-					TargetEndpoints: []schedulingframework.Endpoint{
-						schedulingframework.NewEndpoint(
+					TargetEndpoints: []fwksched.Endpoint{
+						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
 								PodName:        "pod-2",

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -31,7 +31,7 @@ import (
 	fctypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/types"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/handlers"
 )
 
@@ -69,7 +69,7 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 	t.Parallel()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	reqCtx := &handlers.RequestContext{
-		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestID: "test-req"},
+		SchedulingRequest: &fwksched.InferenceRequest{RequestID: "test-req"},
 		Request: &handlers.Request{
 			Metadata: map[string]any{},
 		},
@@ -180,7 +180,7 @@ func TestFlowControlRequestAdapter(t *testing.T) {
 				fairnessID:       tc.fairnessID,
 				priority:         tc.priority,
 				requestByteSize:  tc.requestByteSize,
-				inferenceRequest: &schedulingtypes.InferenceRequest{RequestID: tc.requestID},
+				inferenceRequest: &fwksched.InferenceRequest{RequestID: tc.requestID},
 			}
 
 			assert.Equal(t, tc.requestID, fcReq.ID(), "ID() mismatch")
@@ -195,7 +195,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 	t.Parallel()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	reqCtx := &handlers.RequestContext{
-		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestID: "test-req"},
+		SchedulingRequest: &fwksched.InferenceRequest{RequestID: "test-req"},
 		Request: &handlers.Request{
 			Metadata: map[string]any{},
 		},

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -41,7 +41,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/contracts"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	fwk "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
+	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/handlers"
@@ -91,7 +91,7 @@ func NewDirectorWithConfig(
 type responseBodyWork struct {
 	ctx            context.Context
 	request        *fwksched.InferenceRequest
-	response       *fwk.Response
+	response       *fwkrc.Response
 	targetEndpoint *fwkdl.EndpointMetadata
 }
 
@@ -353,7 +353,7 @@ func (d *Director) HandleResponseHeader(ctx context.Context, reqCtx *handlers.Re
 	if len(d.requestControlPlugins.responseReceivedPlugins) == 0 {
 		return reqCtx
 	}
-	response := &fwk.Response{
+	response := &fwkrc.Response{
 		RequestID:   reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
 		Headers:     reqCtx.Response.Headers,
 		ReqMetadata: reqCtx.Request.Metadata,
@@ -382,7 +382,7 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 
 	startOfStream := !reqCtx.ResponseBodyStarted
 	reqCtx.ResponseBodyStarted = true
-	response := &fwk.Response{
+	response := &fwkrc.Response{
 		RequestID:     reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
 		Headers:       reqCtx.Response.Headers,
 		StartOfStream: startOfStream,
@@ -443,7 +443,7 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.I
 		loggerDebug.Info("Running PreRequest plugin", "plugin", plugin.TypedName())
 		before := time.Now()
 		plugin.PreRequest(ctx, request, schedulingResult)
-		metrics.RecordPluginProcessingLatency(fwk.PreRequestExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		metrics.RecordPluginProcessingLatency(fwkrc.PreRequestExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		loggerDebug.Info("Completed running PreRequest plugin successfully", "plugin", plugin.TypedName())
 	}
 }
@@ -470,24 +470,24 @@ func (d *Director) runAdmissionPlugins(ctx context.Context,
 	return true
 }
 
-func (d *Director) runResponseHeaderPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwk.Response, targetEndpoint *fwkdl.EndpointMetadata) {
+func (d *Director) runResponseHeaderPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.responseReceivedPlugins {
 		loggerDebug.Info("Running ResponseReceived plugin", "plugin", plugin.TypedName())
 		before := time.Now()
 		plugin.ResponseHeader(ctx, request, response, targetEndpoint)
-		metrics.RecordPluginProcessingLatency(fwk.ResponseReceivedExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		metrics.RecordPluginProcessingLatency(fwkrc.ResponseReceivedExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		loggerDebug.Info("Completed running ResponseReceived plugin successfully", "plugin", plugin.TypedName())
 	}
 }
 
-func (d *Director) runResponseBodyPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwk.Response, targetEndpoint *fwkdl.EndpointMetadata) {
+func (d *Director) runResponseBodyPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)
 	for _, plugin := range d.requestControlPlugins.responseStreamingPlugins {
 		loggerTrace.Info("Running ResponseStreaming plugin", "plugin", plugin.TypedName())
 		before := time.Now()
 		plugin.ResponseBody(ctx, request, response, targetEndpoint)
-		metrics.RecordPluginProcessingLatency(fwk.ResponseStreamingExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		metrics.RecordPluginProcessingLatency(fwkrc.ResponseStreamingExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		loggerTrace.Info("Completed running ResponseStreaming plugin successfully", "plugin", plugin.TypedName())
 	}
 }

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -48,7 +48,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	fwk "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
+	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requesthandling/parsers/openai"
@@ -1247,7 +1247,7 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 	director.HandleResponseBody(ctx, reqCtx, true)
 
 	ps1.mu.Lock()
-	resps := make([]*fwk.Response, len(ps1.respsOnStreaming))
+	resps := make([]*fwkrc.Response, len(ps1.respsOnStreaming))
 	copy(resps, ps1.respsOnStreaming)
 	targetPods := make([]string, len(ps1.targetPodsOnStreaming))
 	copy(targetPods, ps1.targetPodsOnStreaming)
@@ -1339,7 +1339,7 @@ func (p *orderTrackingPlugin) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *orderTrackingPlugin) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, response *fwk.Response, _ *fwkdl.EndpointMetadata) {
+func (p *orderTrackingPlugin) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, response *fwkrc.Response, _ *fwkdl.EndpointMetadata) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.observedTokenCounts = append(p.observedTokenCounts, response.Usage.CompletionTokens)
@@ -1354,18 +1354,18 @@ const (
 type testResponseReceived struct {
 	mu                      sync.Mutex
 	typedName               fwkplugin.TypedName
-	lastRespOnResponse      *fwk.Response
+	lastRespOnResponse      *fwkrc.Response
 	lastTargetPodOnResponse string
 }
 
 type testResponseStreaming struct {
 	mu                    sync.Mutex
 	typedName             fwkplugin.TypedName
-	respsOnStreaming      []*fwk.Response
+	respsOnStreaming      []*fwkrc.Response
 	targetPodsOnStreaming []string
 
 	// Legacy fields for existing tests if any, but better to update them
-	lastRespOnStreaming      *fwk.Response
+	lastRespOnStreaming      *fwkrc.Response
 	lastTargetPodOnStreaming string
 }
 
@@ -1389,14 +1389,14 @@ func (p *testResponseStreaming) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *testResponseReceived) ResponseHeader(_ context.Context, _ *fwksched.InferenceRequest, response *fwk.Response, targetPod *fwkdl.EndpointMetadata) {
+func (p *testResponseReceived) ResponseHeader(_ context.Context, _ *fwksched.InferenceRequest, response *fwkrc.Response, targetPod *fwkdl.EndpointMetadata) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.lastRespOnResponse = response
 	p.lastTargetPodOnResponse = targetPod.NamespacedName.String()
 }
 
-func (p *testResponseStreaming) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, response *fwk.Response, targetPod *fwkdl.EndpointMetadata) {
+func (p *testResponseStreaming) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, response *fwkrc.Response, targetPod *fwkdl.EndpointMetadata) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.respsOnStreaming = append(p.respsOnStreaming, response)

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -21,14 +21,14 @@ import (
 	"errors"
 	"time"
 
-	fwk "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 // executePluginsAsDAG executes PrepareData plugins as a DAG based on their dependencies asynchronously.
 // So, a plugin is executed only after all its dependencies have been executed.
 // If there is a cycle or any plugin fails with error, it returns an error.
-func executePluginsAsDAG(ctx context.Context, plugins []fwk.DataProducer, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func executePluginsAsDAG(ctx context.Context, plugins []fwkrc.DataProducer, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, plugin := range plugins {
 		if err := plugin.PrepareRequestData(ctx, request, endpoints); err != nil {
 			return errors.New("prepare data plugin " + plugin.TypedName().String() + " failed: " + err.Error())
@@ -40,8 +40,8 @@ func executePluginsAsDAG(ctx context.Context, plugins []fwk.DataProducer, reques
 // prepareDataPluginsWithTimeout executes the PrepareRequestData plugins with retries and timeout.
 // The child context is cancelled when the timeout fires so plugins can observe cancellation
 // (e.g. abort outbound HTTP calls) and avoid committing state after the director has moved on.
-func prepareDataPluginsWithTimeout(ctx context.Context, timeout time.Duration, plugins []fwk.DataProducer,
-	request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func prepareDataPluginsWithTimeout(ctx context.Context, timeout time.Duration, plugins []fwkrc.DataProducer,
+	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	fwk "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
-	schedulingtypes "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
-var _ fwk.DataProducer = &mockPrepareRequestDataPlugin{}
+var _ fwkrc.DataProducer = &mockPrepareRequestDataPlugin{}
 
 type mockPrepareRequestDataPlugin struct {
 	name      string
@@ -43,7 +43,7 @@ func (m *mockPrepareRequestDataPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock", Name: m.name}
 }
 
-func (m *mockPrepareRequestDataPlugin) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func (m *mockPrepareRequestDataPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	m.executed = true
 	if m.delay > 0 {
 		select {
@@ -76,7 +76,7 @@ func (p *ctxObservingPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock", Name: p.name}
 }
 
-func (p *ctxObservingPlugin) PrepareRequestData(ctx context.Context, _ *schedulingtypes.InferenceRequest, _ []schedulingtypes.Endpoint) error {
+func (p *ctxObservingPlugin) PrepareRequestData(ctx context.Context, _ *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
 	defer p.wg.Done()
 	select {
 	case <-time.After(p.block):
@@ -102,8 +102,8 @@ func TestPrepareDataPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
 	err := prepareDataPluginsWithTimeout(
 		context.Background(),
 		20*time.Millisecond,
-		[]fwk.DataProducer{plugin},
-		&schedulingtypes.InferenceRequest{},
+		[]fwkrc.DataProducer{plugin},
+		&fwksched.InferenceRequest{},
 		nil,
 	)
 	assert.Error(t, err)
@@ -120,30 +120,30 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 	testCases := []struct {
 		name          string
 		timeout       time.Duration
-		plugins       []fwk.DataProducer
+		plugins       []fwkrc.DataProducer
 		ctxFn         func() (context.Context, context.CancelFunc)
 		expectErrStr  string
-		checkPlugins  func(t *testing.T, plugins []fwk.DataProducer)
+		checkPlugins  func(t *testing.T, plugins []fwkrc.DataProducer)
 		expectSuccess bool
 	}{
 		{
 			name:    "success with one plugin",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.DataProducer{
+			plugins: []fwkrc.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1"},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
-			checkPlugins: func(t *testing.T, plugins []fwk.DataProducer) {
+			checkPlugins: func(t *testing.T, plugins []fwkrc.DataProducer) {
 				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
 			},
 		},
 		{
 			name:    "plugin returns error",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.DataProducer{
+			plugins: []fwkrc.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", returnErr: errors.New("plugin failed")},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
@@ -154,7 +154,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 		{
 			name:    "plugins time out",
 			timeout: 50 * time.Millisecond,
-			plugins: []fwk.DataProducer{
+			plugins: []fwkrc.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
@@ -165,7 +165,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 		{
 			name:    "context cancelled",
 			timeout: 200 * time.Millisecond,
-			plugins: []fwk.DataProducer{
+			plugins: []fwkrc.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
@@ -178,7 +178,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 		{
 			name:    "multiple plugins success",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.DataProducer{
+			plugins: []fwkrc.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1"},
 				&mockPrepareRequestDataPlugin{name: "p2"},
 			},
@@ -186,7 +186,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
-			checkPlugins: func(t *testing.T, plugins []fwk.DataProducer) {
+			checkPlugins: func(t *testing.T, plugins []fwkrc.DataProducer) {
 				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
 				assert.True(t, plugins[1].(*mockPrepareRequestDataPlugin).executed)
 			},
@@ -198,7 +198,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			ctx, cancel := tc.ctxFn()
 			defer cancel()
 
-			err := prepareDataPluginsWithTimeout(ctx, tc.timeout, tc.plugins, &schedulingtypes.InferenceRequest{}, nil)
+			err := prepareDataPluginsWithTimeout(ctx, tc.timeout, tc.plugins, &fwksched.InferenceRequest{}, nil)
 
 			if tc.expectSuccess {
 				assert.NoError(t, err)
@@ -222,7 +222,7 @@ type dagTestPlugin struct {
 	mu       sync.Mutex
 }
 
-func (p *dagTestPlugin) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func (p *dagTestPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.execTime = time.Now()
@@ -269,18 +269,18 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		plugins   []fwk.DataProducer
+		plugins   []fwkrc.DataProducer
 		expectErr bool
-		checkFunc func(t *testing.T, plugins []fwk.DataProducer)
+		checkFunc func(t *testing.T, plugins []fwkrc.DataProducer)
 	}{
 		{
 			name:    "no plugins",
-			plugins: []fwk.DataProducer{},
+			plugins: []fwkrc.DataProducer{},
 		},
 		{
 			name:    "simple linear dependency (A -> B -> C)",
-			plugins: []fwk.DataProducer{pluginA, pluginB, pluginC},
-			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
+			plugins: []fwkrc.DataProducer{pluginA, pluginB, pluginC},
+			checkFunc: func(t *testing.T, plugins []fwkrc.DataProducer) {
 				pA := plugins[0].(*dagTestPlugin)
 				pB := plugins[1].(*dagTestPlugin)
 				pC := plugins[2].(*dagTestPlugin)
@@ -295,8 +295,8 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 		},
 		{
 			name:    "DAG with multiple dependencies (A -> B, A -> D) and one independent (E)",
-			plugins: []fwk.DataProducer{pluginA, pluginB, pluginD, pluginE},
-			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
+			plugins: []fwkrc.DataProducer{pluginA, pluginB, pluginD, pluginE},
+			checkFunc: func(t *testing.T, plugins []fwkrc.DataProducer) {
 				pA := plugins[0].(*dagTestPlugin)
 				pB := plugins[1].(*dagTestPlugin)
 				pD := plugins[2].(*dagTestPlugin)
@@ -313,9 +313,9 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 		},
 		{
 			name:      "dependency fails",
-			plugins:   []fwk.DataProducer{pluginFail, pluginDependsOnFail},
+			plugins:   []fwkrc.DataProducer{pluginFail, pluginDependsOnFail},
 			expectErr: true,
-			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
+			checkFunc: func(t *testing.T, plugins []fwkrc.DataProducer) {
 				pF := plugins[0].(*dagTestPlugin)
 				pDOF := plugins[1].(*dagTestPlugin)
 
@@ -334,7 +334,7 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 				plugin.execTime = time.Time{}
 			}
 
-			err := executePluginsAsDAG(context.Background(), tc.plugins, &schedulingtypes.InferenceRequest{}, nil)
+			err := executePluginsAsDAG(context.Background(), tc.plugins, &fwksched.InferenceRequest{}, nil)
 
 			if tc.expectErr {
 				assert.Error(t, err)

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -18,58 +18,58 @@ package requestcontrol
 
 import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	fwk "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
+	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 )
 
 // NewConfig creates a new Config object and returns its pointer.
 func NewConfig() *Config {
 	return &Config{
-		admissionPlugins:         []fwk.Admitter{},
-		prepareDataPlugins:       []fwk.DataProducer{},
-		preRequestPlugins:        []fwk.PreRequest{},
-		responseReceivedPlugins:  []fwk.ResponseHeaderProcessor{},
-		responseStreamingPlugins: []fwk.ResponseBodyProcessor{},
+		admissionPlugins:         []fwkrc.Admitter{},
+		prepareDataPlugins:       []fwkrc.DataProducer{},
+		preRequestPlugins:        []fwkrc.PreRequest{},
+		responseReceivedPlugins:  []fwkrc.ResponseHeaderProcessor{},
+		responseStreamingPlugins: []fwkrc.ResponseBodyProcessor{},
 	}
 }
 
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
-	admissionPlugins         []fwk.Admitter
-	prepareDataPlugins       []fwk.DataProducer
-	preRequestPlugins        []fwk.PreRequest
-	responseReceivedPlugins  []fwk.ResponseHeaderProcessor
-	responseStreamingPlugins []fwk.ResponseBodyProcessor
+	admissionPlugins         []fwkrc.Admitter
+	prepareDataPlugins       []fwkrc.DataProducer
+	preRequestPlugins        []fwkrc.PreRequest
+	responseReceivedPlugins  []fwkrc.ResponseHeaderProcessor
+	responseStreamingPlugins []fwkrc.ResponseBodyProcessor
 }
 
 // WithPreRequestPlugins sets the given plugins as the PreRequest plugins.
 // If the Config has PreRequest plugins already, this call replaces the existing plugins with the given ones.
-func (c *Config) WithPreRequestPlugins(plugins ...fwk.PreRequest) *Config {
+func (c *Config) WithPreRequestPlugins(plugins ...fwkrc.PreRequest) *Config {
 	c.preRequestPlugins = plugins
 	return c
 }
 
 // WithResponseReceivedPlugins sets the given plugins as the ResponseReceived plugins.
 // If the Config has ResponseReceived plugins already, this call replaces the existing plugins with the given ones.
-func (c *Config) WithResponseReceivedPlugins(plugins ...fwk.ResponseHeaderProcessor) *Config {
+func (c *Config) WithResponseReceivedPlugins(plugins ...fwkrc.ResponseHeaderProcessor) *Config {
 	c.responseReceivedPlugins = plugins
 	return c
 }
 
 // WithResponseStreamingPlugins sets the given plugins as the ResponseStreaming plugins.
 // If the Config has ResponseStreaming plugins already, this call replaces the existing plugins with the given ones.
-func (c *Config) WithResponseStreamingPlugins(plugins ...fwk.ResponseBodyProcessor) *Config {
+func (c *Config) WithResponseStreamingPlugins(plugins ...fwkrc.ResponseBodyProcessor) *Config {
 	c.responseStreamingPlugins = plugins
 	return c
 }
 
 // WithPrepareDataPlugins sets the given plugins as the PrepareData plugins.
-func (c *Config) WithPrepareDataPlugins(plugins ...fwk.DataProducer) *Config {
+func (c *Config) WithPrepareDataPlugins(plugins ...fwkrc.DataProducer) *Config {
 	c.prepareDataPlugins = plugins
 	return c
 }
 
 // WithAdmissionPlugins sets the given plugins as the AdmitRequest plugins.
-func (c *Config) WithAdmissionPlugins(plugins ...fwk.Admitter) *Config {
+func (c *Config) WithAdmissionPlugins(plugins ...fwkrc.Admitter) *Config {
 	c.admissionPlugins = plugins
 	return c
 }
@@ -79,19 +79,19 @@ func (c *Config) WithAdmissionPlugins(plugins ...fwk.Admitter) *Config {
 // If a plugin implements multiple plugin interfaces, it will be added to each corresponding list.
 func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 	for _, plugin := range pluginObjects {
-		if preRequestPlugin, ok := plugin.(fwk.PreRequest); ok {
+		if preRequestPlugin, ok := plugin.(fwkrc.PreRequest); ok {
 			c.preRequestPlugins = append(c.preRequestPlugins, preRequestPlugin)
 		}
-		if responseReceivedPlugin, ok := plugin.(fwk.ResponseHeaderProcessor); ok {
+		if responseReceivedPlugin, ok := plugin.(fwkrc.ResponseHeaderProcessor); ok {
 			c.responseReceivedPlugins = append(c.responseReceivedPlugins, responseReceivedPlugin)
 		}
-		if responseStreamingPlugin, ok := plugin.(fwk.ResponseBodyProcessor); ok {
+		if responseStreamingPlugin, ok := plugin.(fwkrc.ResponseBodyProcessor); ok {
 			c.responseStreamingPlugins = append(c.responseStreamingPlugins, responseStreamingPlugin)
 		}
-		if prepareDataPlugin, ok := plugin.(fwk.DataProducer); ok {
+		if prepareDataPlugin, ok := plugin.(fwkrc.DataProducer); ok {
 			c.prepareDataPlugins = append(c.prepareDataPlugins, prepareDataPlugin)
 		}
-		if admissionPlugin, ok := plugin.(fwk.Admitter); ok {
+		if admissionPlugin, ok := plugin.(fwkrc.Admitter); ok {
 			c.admissionPlugins = append(c.admissionPlugins, admissionPlugin)
 		}
 	}
@@ -99,8 +99,8 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 
 // OrderPrepareDataPlugins reorders the prepareDataPlugins in the Config based on the given sorted plugin names.
 func (c *Config) OrderPrepareDataPlugins(sortedPluginNames []string) {
-	sortedPlugins := make([]fwk.DataProducer, 0, len(sortedPluginNames))
-	nameToPlugin := make(map[string]fwk.DataProducer)
+	sortedPlugins := make([]fwkrc.DataProducer, 0, len(sortedPluginNames))
+	nameToPlugin := make(map[string]fwkrc.DataProducer)
 	for _, plugin := range c.prepareDataPlugins {
 		nameToPlugin[plugin.TypedName().String()] = plugin
 	}

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metrics"
 )
 
@@ -46,12 +46,12 @@ func NewSchedulerWithConfig(config *SchedulerConfig) *Scheduler {
 }
 
 type Scheduler struct {
-	profileHandler framework.ProfileHandler
-	profiles       map[string]framework.SchedulerProfile
+	profileHandler fwksched.ProfileHandler
+	profiles       map[string]fwksched.SchedulerProfile
 }
 
 // Schedule finds the target pod based on metrics and the requested lora adapter.
-func (s *Scheduler) Schedule(ctx context.Context, request *framework.InferenceRequest, candidateEndpoints []framework.Endpoint) (result *framework.SchedulingResult, err error) {
+func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceRequest, candidateEndpoints []fwksched.Endpoint) (result *fwksched.SchedulingResult, err error) {
 	loggerVerbose := log.FromContext(ctx).V(logutil.VERBOSE)
 
 	scheduleStart := time.Now()
@@ -60,8 +60,8 @@ func (s *Scheduler) Schedule(ctx context.Context, request *framework.InferenceRe
 		metrics.RecordSchedulerAttempt(err, request.TargetModel, result)
 	}()
 
-	profileRunResults := map[string]*framework.ProfileRunResult{}
-	cycleState := framework.NewCycleState()
+	profileRunResults := map[string]*fwksched.ProfileRunResult{}
+	cycleState := fwksched.NewCycleState()
 
 	for { // get the next set of profiles to run iteratively based on the request and the previous execution results
 		loggerVerbose.Info("Running profile handler, Pick profiles", "plugin", s.profileHandler.TypedName())

--- a/pkg/epp/scheduling/scheduler_config.go
+++ b/pkg/epp/scheduling/scheduler_config.go
@@ -19,11 +19,11 @@ package scheduling
 import (
 	"fmt"
 
-	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
 // NewSchedulerConfig creates a new SchedulerConfig object and returns its pointer.
-func NewSchedulerConfig(profileHandler framework.ProfileHandler, profiles map[string]framework.SchedulerProfile) *SchedulerConfig {
+func NewSchedulerConfig(profileHandler fwksched.ProfileHandler, profiles map[string]fwksched.SchedulerProfile) *SchedulerConfig {
 	return &SchedulerConfig{
 		profileHandler: profileHandler,
 		profiles:       profiles,
@@ -32,8 +32,8 @@ func NewSchedulerConfig(profileHandler framework.ProfileHandler, profiles map[st
 
 // SchedulerConfig provides a configuration for the scheduler which influence routing decisions.
 type SchedulerConfig struct {
-	profileHandler framework.ProfileHandler
-	profiles       map[string]framework.SchedulerProfile
+	profileHandler fwksched.ProfileHandler
+	profiles       map[string]fwksched.SchedulerProfile
 }
 
 func (c *SchedulerConfig) String() string {

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -24,7 +24,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	errcommmon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/error"
+	errcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
@@ -117,7 +117,7 @@ func (p *SchedulerProfile) String() string {
 func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.InferenceRequest, cycleState *fwksched.CycleState, candidateEndpoints []fwksched.Endpoint) (*fwksched.ProfileRunResult, error) {
 	endpoints := p.runFilterPlugins(ctx, request, cycleState, candidateEndpoints)
 	if len(endpoints) == 0 {
-		return nil, errcommmon.Error{Code: errcommmon.Internal, Msg: "no endpoints available for the given request"}
+		return nil, errcommon.Error{Code: errcommon.Internal, Msg: "no endpoints available for the given request"}
 	}
 	// if we got here, there is at least one endpoint to score
 	weightedScorePerEndpoint := p.runScorerPlugins(ctx, request, cycleState, endpoints)

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -40,7 +40,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/controller"
 	datalayerlogger "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer/logger"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
-	fwkflowcontrol "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
+	fwkfc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/requestcontrol"
@@ -60,7 +60,7 @@ type ExtProcServerRunner struct {
 	MetricsStalenessThreshold        time.Duration
 	Director                         *requestcontrol.Director
 	Parser                           fwkrh.Parser
-	SaturationDetector               fwkflowcontrol.SaturationDetector
+	SaturationDetector               fwkfc.SaturationDetector
 	UseExperimentalDatalayerV2       bool // Pluggable data layer feature flag
 }
 

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metadata"
 	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
-	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 const (
@@ -128,16 +128,16 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 		CreationTimestamp(metav1.Unix(1000, 0)).ObjRef()
 
 	director := &testDirector{}
-	ctx, cancel, ds, _ := utils.PrepareForTestStreamingServer([]*v1alpha2.InferenceObjective{model},
+	ctx, cancel, ds, _ := igwtestutils.PrepareForTestStreamingServer([]*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
 	streamingServer := handlers.NewStreamingServer(ds, director, openai.NewOpenAIParser())
 
-	testListener, errChan := utils.SetupTestStreamingServer(ctx, t, streamingServer)
-	process, conn := utils.GetStreamingServerClient(ctx, t)
+	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
+	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
 	defer conn.Close()
 
 	// Send request headers - no response expected
-	headers := utils.BuildEnvoyGRPCHeaders(map[string]string{
+	headers := igwtestutils.BuildEnvoyGRPCHeaders(map[string]string{
 		"x-test":                   "body",
 		":method":                  "POST",
 		metadata.FlowFairnessIDKey: "a-very-interesting-fairness-id",
@@ -181,7 +181,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 			responseReqHeaders.GetRequestHeaders().Response.HeaderMutation == nil ||
 			responseReqHeaders.GetRequestHeaders().Response.HeaderMutation.SetHeaders == nil {
 			t.Error("Invalid request headers response")
-		} else if !utils.CheckEnvoyGRPCHeaders(t, responseReqHeaders.GetRequestHeaders().Response, expectedRequestHeaders) {
+		} else if !igwtestutils.CheckEnvoyGRPCHeaders(t, responseReqHeaders.GetRequestHeaders().Response, expectedRequestHeaders) {
 			t.Error("Incorrect request headers")
 		}
 	}
@@ -217,10 +217,10 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 	// Send response headers
 	if streamingResponse {
 		// If response is streaming, the header should have text/event-stream.
-		headers = utils.BuildEnvoyGRPCHeaders(map[string]string{"x-test": "body", ":method": "POST", "content-type": "text/event-stream"}, true)
+		headers = igwtestutils.BuildEnvoyGRPCHeaders(map[string]string{"x-test": "body", ":method": "POST", "content-type": "text/event-stream"}, true)
 		expectedResponseHeaders = map[string]string{"x-went-into-resp-headers": "true", ":method": "POST", "x-test": "body", "content-type": "text/event-stream"}
 	} else {
-		headers = utils.BuildEnvoyGRPCHeaders(map[string]string{"x-test": "body", ":method": "POST"}, false)
+		headers = igwtestutils.BuildEnvoyGRPCHeaders(map[string]string{"x-test": "body", ":method": "POST"}, false)
 	}
 
 	request = &pb.ProcessingRequest{
@@ -242,7 +242,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 			response.GetResponseHeaders().Response.HeaderMutation == nil ||
 			response.GetResponseHeaders().Response.HeaderMutation.SetHeaders == nil {
 			t.Error("Invalid response")
-		} else if !utils.CheckEnvoyGRPCHeaders(t, response.GetResponseHeaders().Response, expectedResponseHeaders) {
+		} else if !igwtestutils.CheckEnvoyGRPCHeaders(t, response.GetResponseHeaders().Response, expectedResponseHeaders) {
 			t.Error("Incorrect response headers")
 		}
 	}
@@ -418,16 +418,16 @@ func TestServer_Skip(t *testing.T) {
 	model := testutil.MakeInferenceObjective("v1").
 		CreationTimestamp(metav1.Unix(1000, 0)).ObjRef()
 
-	ctx, cancel, ds, _ := utils.PrepareForTestStreamingServer([]*v1alpha2.InferenceObjective{model},
+	ctx, cancel, ds, _ := igwtestutils.PrepareForTestStreamingServer([]*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
 	streamingServer := handlers.NewStreamingServer(ds, director, mockPar)
 
-	testListener, errChan := utils.SetupTestStreamingServer(ctx, t, streamingServer)
-	process, conn := utils.GetStreamingServerClient(ctx, t)
+	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
+	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
 	defer conn.Close()
 
 	// Send request headers
-	headers := utils.BuildEnvoyGRPCHeaders(map[string]string{
+	headers := igwtestutils.BuildEnvoyGRPCHeaders(map[string]string{
 		"x-request-id": "test-request-id",
 	}, false)
 	request := &pb.ProcessingRequest{

--- a/test/config/prefix_cache_mode_test.go
+++ b/test/config/prefix_cache_mode_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/config/loader"
-	giePlugins "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins"
 	preciseprefixcache "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache"
 	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils"
-	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 func TestScorer(t *testing.T) {
@@ -53,14 +53,14 @@ schedulingProfiles:
 			if err != nil {
 				t.Fatalf("unexpected error from LoadConfigPhaseOne: %v", err)
 			}
-			handle := utils.NewTestHandle(ctx)
+			handle := igwtestutils.NewTestHandle(ctx)
 			_, err = loader.InstantiateAndConfigure(rawConfig, handle, logr.Discard())
 			if err != nil {
 				t.Fatalf("unexpected error from LoadConfigPhaseTwo: %v", err)
 			}
 			fmt.Println("all plugins", handle.GetAllPluginsWithNames())
 
-			_, err = giePlugins.PluginByType[*preciseprefixcache.Scorer](handle, test.pluginName)
+			_, err = fwkplugin.PluginByType[*preciseprefixcache.Scorer](handle, test.pluginName)
 			if err != nil {
 				t.Fatalf("expected Scorer, but got error: %v", err)
 			}

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -36,7 +36,7 @@ import (
 	infextv1a2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 const (
@@ -81,7 +81,7 @@ const (
 const e2eLeaderElectionEnabledEnvVar = "E2E_LEADER_ELECTION_ENABLED"
 
 var (
-	testConfig *testutils.TestConfig
+	testConfig *igwtestutils.TestConfig
 	// Required for exec'ing in curl pod
 	e2eImage              string
 	leaderElectionEnabled bool
@@ -107,7 +107,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	if nsName == "" {
 		nsName = defaultNsName
 	}
-	testConfig = testutils.NewTestConfig(nsName, "")
+	testConfig = igwtestutils.NewTestConfig(nsName, "")
 
 	e2eImage = os.Getenv("E2E_IMAGE")
 	gomega.Expect(e2eImage).NotTo(gomega.BeEmpty(), "E2E_IMAGE environment variable is not set")
@@ -135,8 +135,8 @@ func setupInfra() {
 	if strings.Contains(modelServerManifestArray[0], "hf-token") {
 		createHfSecret(testConfig, modelServerSecretManifest)
 	}
-	testutils.ProcessKustomize(testConfig, crdKustomizePath, testutils.CreateAndVerifyObjs)
-	testutils.ValidateCRDsEstablished(testConfig, expectedCRDs)
+	igwtestutils.ProcessKustomize(testConfig, crdKustomizePath, igwtestutils.CreateAndVerifyObjs)
+	igwtestutils.ValidateCRDsEstablished(testConfig, expectedCRDs)
 
 	inferExtManifestPath := inferExtManifestDefault
 	if leaderElectionEnabled {
@@ -193,12 +193,12 @@ func cleanupResources() {
 		return // could happen if BeforeSuite had an error
 	}
 
-	gomega.Expect(testutils.DeleteClusterResources(testConfig)).To(gomega.Succeed())
-	gomega.Expect(testutils.DeleteNamespacedResources(testConfig)).To(gomega.Succeed())
+	gomega.Expect(igwtestutils.DeleteClusterResources(testConfig)).To(gomega.Succeed())
+	gomega.Expect(igwtestutils.DeleteNamespacedResources(testConfig)).To(gomega.Succeed())
 }
 
 func cleanupInferObjectiveResources() {
-	gomega.Expect(testutils.DeleteInferenceObjectiveResources(testConfig)).To(gomega.Succeed())
+	gomega.Expect(igwtestutils.DeleteInferenceObjectiveResources(testConfig)).To(gomega.Succeed())
 }
 
 var (
@@ -206,7 +206,7 @@ var (
 	curlInterval = defaultCurlInterval
 )
 
-func createNamespace(testConfig *testutils.TestConfig) {
+func createNamespace(testConfig *igwtestutils.TestConfig) {
 	ginkgo.By("Creating e2e namespace: " + testConfig.NsName)
 	obj := &corev1.Namespace{
 		ObjectMeta: v1.ObjectMeta{
@@ -218,9 +218,9 @@ func createNamespace(testConfig *testutils.TestConfig) {
 }
 
 // namespaceExists ensures that a specified namespace exists and is ready for use.
-func namespaceExists(testConfig *testutils.TestConfig) {
+func namespaceExists(testConfig *igwtestutils.TestConfig) {
 	ginkgo.By("Ensuring namespace exists: " + testConfig.NsName)
-	testutils.EventuallyExists(testConfig, func() error {
+	igwtestutils.EventuallyExists(testConfig, func() error {
 		return testConfig.K8sClient.Get(testConfig.Context,
 			types.NamespacedName{Name: testConfig.NsName}, &corev1.Namespace{})
 	})
@@ -236,20 +236,20 @@ func readModelServerManifestPath() string {
 
 func getYamlsFromModelServerManifest(modelServerManifestPath string) []string {
 	ginkgo.By("Ensuring the model server manifest points to an existing file")
-	modelServerManifestArray := testutils.ReadYaml(modelServerManifestPath)
+	modelServerManifestArray := igwtestutils.ReadYaml(modelServerManifestPath)
 	gomega.Expect(modelServerManifestArray).NotTo(gomega.BeEmpty())
 	return modelServerManifestArray
 }
 
 // createClient creates the client pod used for testing from the given filePath.
-func createClient(testConfig *testutils.TestConfig, filePath string) {
+func createClient(testConfig *igwtestutils.TestConfig, filePath string) {
 	ginkgo.By("Creating client resources from manifest: " + filePath)
-	testutils.ApplyYAMLFile(testConfig, filePath)
+	igwtestutils.ApplyYAMLFile(testConfig, filePath)
 }
 
 // createMetricsRbac creates the metrics RBAC resources from the manifest file.
-func createMetricsRbac(testConfig *testutils.TestConfig, filePath string) {
-	inManifests := testutils.ReadYaml(filePath)
+func createMetricsRbac(testConfig *igwtestutils.TestConfig, filePath string) {
+	inManifests := igwtestutils.ReadYaml(filePath)
 	ginkgo.By("Replacing placeholder namespace with E2E_NS environment variable")
 	outManifests := make([]string, 0, len(inManifests))
 	for _, m := range inManifests {
@@ -257,10 +257,10 @@ func createMetricsRbac(testConfig *testutils.TestConfig, filePath string) {
 	}
 
 	ginkgo.By("Creating RBAC resources for scraping metrics from manifest: " + filePath)
-	testutils.CreateObjsFromYaml(testConfig, outManifests)
+	igwtestutils.CreateObjsFromYaml(testConfig, outManifests)
 
 	// wait for sa token to exist
-	testutils.EventuallyExists(testConfig, func() error {
+	igwtestutils.EventuallyExists(testConfig, func() error {
 		token, err := getMetricsReaderToken(testConfig.K8sClient)
 		if err != nil {
 			return err
@@ -273,17 +273,17 @@ func createMetricsRbac(testConfig *testutils.TestConfig, filePath string) {
 }
 
 // createModelServer creates the model server resources used for testing from the given filePaths.
-func createModelServer(testConfig *testutils.TestConfig, modelServerManifestArray []string) {
-	testutils.CreateObjsFromYaml(testConfig, modelServerManifestArray)
+func createModelServer(testConfig *igwtestutils.TestConfig, modelServerManifestArray []string) {
+	igwtestutils.CreateObjsFromYaml(testConfig, modelServerManifestArray)
 }
 
 // createHfSecret read HF_TOKEN from env var and creates a secret that contains the access token.
-func createHfSecret(testConfig *testutils.TestConfig, secretPath string) {
+func createHfSecret(testConfig *igwtestutils.TestConfig, secretPath string) {
 	ginkgo.By("Ensuring the HF_TOKEN environment variable is set")
 	token := os.Getenv("HF_TOKEN")
 	gomega.Expect(token).NotTo(gomega.BeEmpty(), "HF_TOKEN is not set")
 
-	inManifests := testutils.ReadYaml(secretPath)
+	inManifests := igwtestutils.ReadYaml(secretPath)
 	ginkgo.By("Replacing placeholder secret data with HF_TOKEN environment variable")
 	outManifests := make([]string, 0, len(inManifests))
 	for _, m := range inManifests {
@@ -291,12 +291,12 @@ func createHfSecret(testConfig *testutils.TestConfig, secretPath string) {
 	}
 
 	ginkgo.By("Creating model server secret resource")
-	testutils.CreateObjsFromYaml(testConfig, outManifests)
+	igwtestutils.CreateObjsFromYaml(testConfig, outManifests)
 }
 
 // createEnvoy creates the envoy proxy resources used for testing from the given filePath.
-func createEnvoy(testConfig *testutils.TestConfig, filePath string) {
-	inManifests := testutils.ReadYaml(filePath)
+func createEnvoy(testConfig *igwtestutils.TestConfig, filePath string) {
+	inManifests := igwtestutils.ReadYaml(filePath)
 	ginkgo.By("Replacing placeholder namespace with E2E_NS environment variable")
 	outManifests := make([]string, 0, len(inManifests))
 	for _, m := range inManifests {
@@ -304,14 +304,14 @@ func createEnvoy(testConfig *testutils.TestConfig, filePath string) {
 	}
 
 	ginkgo.By("Creating envoy proxy resources from manifest: " + filePath)
-	testutils.CreateObjsFromYaml(testConfig, outManifests)
+	igwtestutils.CreateObjsFromYaml(testConfig, outManifests)
 }
 
 // createInferExt creates the inference extension resources used for testing from the given filePath.
-func createInferExt(testConfig *testutils.TestConfig, filePath string) {
+func createInferExt(testConfig *igwtestutils.TestConfig, filePath string) {
 
 	// This image needs to be updated to open multiple ports and respond.
-	inManifests := testutils.ReadYaml(filePath) // Modify inference-pool.yaml
+	inManifests := igwtestutils.ReadYaml(filePath) // Modify inference-pool.yaml
 	ginkgo.By("Replacing placeholders with environment variables")
 	outManifests := make([]string, 0, len(inManifests))
 	replacer := strings.NewReplacer(
@@ -323,7 +323,7 @@ func createInferExt(testConfig *testutils.TestConfig, filePath string) {
 	}
 
 	ginkgo.By("Creating inference extension resources from manifest: " + filePath)
-	testutils.CreateObjsFromYaml(testConfig, outManifests)
+	igwtestutils.CreateObjsFromYaml(testConfig, outManifests)
 
 	// Wait for the deployment to exist.
 	deploy := &appsv1.Deployment{
@@ -334,8 +334,8 @@ func createInferExt(testConfig *testutils.TestConfig, filePath string) {
 	}
 	if leaderElectionEnabled {
 		// With leader election enabled, only 1 replica will be "Ready" at any given time (the leader).
-		testutils.DeploymentReadyReplicas(testConfig, deploy, 1)
+		igwtestutils.DeploymentReadyReplicas(testConfig, deploy, 1)
 	} else {
-		testutils.DeploymentAvailable(testConfig, deploy)
+		igwtestutils.DeploymentAvailable(testConfig, deploy)
 	}
 }

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -32,7 +32,7 @@ import (
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 const (
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 			}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
 
 			// Wait for one replica to become ready again.
-			testutils.DeploymentReadyReplicas(testConfig, deploy, 1)
+			igwtestutils.DeploymentReadyReplicas(testConfig, deploy, 1)
 
 			// Also wait for the total number of replicas to be back to 3.
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/e2e/epp/utils_test.go
+++ b/test/e2e/epp/utils_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 
-	testutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
 const (
@@ -63,9 +63,9 @@ const (
 	statusNotFound   = "HTTP_STATUS=404"
 )
 
-// newInferenceObjective creates an InferenceObjective in the given namespace for testutils.
+// newInferenceObjective creates an InferenceObjective in the given namespace for igwtestutils.
 func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
-	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
+	return igwtestutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
 		SetPriority(2).
 		SetPoolRef(modelServerName).
 		Obj()
@@ -116,7 +116,7 @@ func verifyTrafficRouting() {
 		// Skip embeddings API if server returns 404 (not all models support embeddings).
 		if t.api == apiEmbeddings {
 			probeCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, t.api, t.promptOrMessages, false)
-			probeResp, probeErr := testutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, probeCmd)
+			probeResp, probeErr := igwtestutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, probeCmd)
 			if probeErr == nil && strings.Contains(probeResp, statusNotFound) {
 				ginkgo.Skip("Skipping " + apiEmbeddings + ": server returned 404 (embeddings may not be supported by this model)")
 			}
@@ -163,7 +163,7 @@ func verifyTrafficRouting() {
 			var err error
 			// Repeatedly send a message until we get a successful response.
 			for attempt := 0; attempt <= maxRetries; attempt++ {
-				resp, err = testutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, curlCmd)
+				resp, err = igwtestutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, curlCmd)
 				if err == nil && strings.Contains(resp, statusOK) {
 					break // Success!
 				}
@@ -217,7 +217,7 @@ func verifyMetrics() {
 
 	semaphore := make(chan struct{}, maxConcurrentRequests)
 	execFn := func(cmd []string) (string, error) {
-		return testutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, cmd)
+		return igwtestutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, cmd)
 	}
 
 	errorGood := generateTraffic(curlCmd, batches, semaphore, execFn, backoff, statusOK)
@@ -287,7 +287,7 @@ func verifyMetrics() {
 
 	gomega.Eventually(func() error {
 		// Execute the metrics scrape command inside the curl pod.
-		resp, err := testutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, metricScrapeCmd)
+		resp, err := igwtestutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, metricScrapeCmd)
 		if err != nil {
 			return err
 		}
@@ -428,7 +428,7 @@ func buildTargetPorts(start int, count int) []v1.Port {
 
 // waitForDeploymentRollout waits until the Deployment has completed its update.
 // It ensures that the new version is fully rolled out and available.
-func waitForDeploymentRollout(tc *testutils.TestConfig, deploy *appsv1.Deployment) {
+func waitForDeploymentRollout(tc *igwtestutils.TestConfig, deploy *appsv1.Deployment) {
 	ginkgo.By(fmt.Sprintf("Waiting for Deployment %s/%s to complete rollout", deploy.Namespace, deploy.Name))
 
 	key := types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}
@@ -464,7 +464,7 @@ func waitForDeploymentRollout(tc *testutils.TestConfig, deploy *appsv1.Deploymen
 }
 
 // waitForDeploymentReady waits for the Deployment to have all replicas ready.
-func waitForDeploymentReady(tc *testutils.TestConfig, deploy *appsv1.Deployment) {
+func waitForDeploymentReady(tc *igwtestutils.TestConfig, deploy *appsv1.Deployment) {
 	ginkgo.By(fmt.Sprintf("waiting for Deployment %s/%s to be ready", deploy.Namespace, deploy.Name))
 
 	key := types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -55,7 +55,7 @@ import (
 	dlmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metrics"
 	eppServer "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/server"
-	epptestutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
+	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 	integration "github.com/llm-d/llm-d-inference-scheduler/test/integration"
 )
 
@@ -402,7 +402,7 @@ func (h *TestHarness) WithPods(pods []PodState) *TestHarness {
 	for _, p := range pods {
 		name := fmt.Sprintf("pod-%d", p.index)
 
-		pod := epptestutil.MakePod(name).
+		pod := testutil.MakePod(name).
 			Namespace(h.Namespace).
 			ReadyCondition(). // Sets Status.Conditions.
 			Labels(map[string]string{"app": testPoolName}).

--- a/test/utils/igw/server.go
+++ b/test/utils/igw/server.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/backend/metrics"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datastore"
-	pooltuil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
+	poolutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/pool"
 	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
@@ -73,7 +73,7 @@ func PrepareForTestStreamingServer(objectives []*v1alpha2.InferenceObjective, po
 		Build()
 	pool := testutil.MakeInferencePool(poolName).Namespace(namespace).ObjRef()
 	pool.Spec.TargetPorts = []v1.Port{{Number: v1.PortNumber(poolPort)}}
-	_ = ds.PoolSet(context.Background(), fakeClient, pooltuil.InferencePoolToEndpointPool(pool))
+	_ = ds.PoolSet(context.Background(), fakeClient, poolutil.InferencePoolToEndpointPool(pool))
 
 	return ctx, cancel, ds, pmc
 }

--- a/test/utils/k8s_objects.go
+++ b/test/utils/k8s_objects.go
@@ -32,16 +32,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
-	gaieutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 
-type TestConfig = gaieutils.TestConfig
+type TestConfig = igwtestutils.TestConfig
 
 var (
-	NewTestConfig      = gaieutils.NewTestConfig
-	ApplyYAMLFile      = gaieutils.ApplyYAMLFile
-	CreateObjsFromYaml = gaieutils.CreateObjsFromYaml
-	ReadYaml           = gaieutils.ReadYaml
+	NewTestConfig      = igwtestutils.NewTestConfig
+	ApplyYAMLFile      = igwtestutils.ApplyYAMLFile
+	CreateObjsFromYaml = igwtestutils.CreateObjsFromYaml
+	ReadYaml           = igwtestutils.ReadYaml
 )
 
 // DeleteObjects deletes a set of Kubernetes objects in the form of kind/name.


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind cleanup


**What this PR does / why we need it**:

Cleanup of the import aliases to make them consistent according to the table in #920
(feel free to suggest alternative aliases and I'll update)

**additionally**, update .golanci.yml so that they are enforced: unaliased are allowed, otherwise the canonical aliased version should be used

| Package suffix | Candidates (count in llm-d) | Alias |
|---|---|---|
| framework/interface/scheduling | unaliased (50), framework (30), fwksched (20), schedulingtypes (15), fwksch (2), schedulingframework (2), types (2), fwkschd (1) | fwksched |
| framework/interface/requestcontrol | unaliased (22), fwk (5), fwkrc (1), fwkrq (1) | fwkrc |
| framework/interface/flowcontrol | unaliased (54), fwkflowcontrol (4), fwkfc (1), flowcontrolif (1) | fwkfc |
| framework/interface/flowcontrol/mocks | unaliased (13), frameworkmocks (5), fwmocks (1), fwkfcmocks (1), flowcontrolmocks (1) | fwkfcmocks |
| framework/interface/plugin | unaliased (61), fwkplugin (54), giePlugin (1), giePlugins (1) | fwkplugin |
| plugins/datalayer/attribute/prefix | attrprefix (10), approxprefix (7), dl_prefix (2), prefix (1) | attrprefix |
| plugins/datalayer/extractor/metrics | unaliased (4), extractormetrics (3), metricextractor (1) | extractormetrics |
| plugins/datalayer/source/metrics | sourcemetrics (9), metricsource (1) | sourcemetrics |
| util/pool | poolutil (6), pooltuil (3) | poolutil |
| util/testing | testutil (4), utiltest (4) | testutil |
| common/error | errcommon (8), errcommmon (1) | errcommon |
| test/utils/igw | utils (6), testutils (1), gaieutils (1) | igwtestutils |



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #920, related #857.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```


---

notes: I expect some rebase might be required, as we continue merging stuff, that's ok.