### PR TITLE
refactor: migrate GAIE runtime strings to llm-d.ai

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -186,7 +186,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	logutil.InitLogging(&opts.ZapOptions)
 
 	if opts.Tracing {
-		err := tracing.InitTracing(ctx, setupLog, "gateway-api-inference-extension/epp")
+		err := tracing.InitTracing(ctx, setupLog, "llm-d-inference-scheduler/epp")
 		if err != nil {
 			return fmt.Errorf("failed to init tracing %w", err)
 		}

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -50,7 +50,7 @@ const (
 	// activePortsAnnotation is used to specify which ports on a pod should be considered
 	// as active for inference traffic. The value should be a comma-separated list of port numbers.
 	// Example: "8000,8001,8002"
-	activePortsAnnotation = "inference.networking.k8s.io/active-ports"
+	activePortsAnnotation = "llm-d.ai/active-ports"
 )
 
 // The datastore is a local cache of relevant data for the given InferencePool (currently all pulled from k8s-api)

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -51,7 +51,9 @@ const (
 	// as active for inference traffic. The value should be a comma-separated list of port numbers.
 	// Example: "8000,8001,8002"
 	activePortsAnnotation = "llm-d.ai/active-ports"
+
 	// legacyGAIEActivePortsAnnotation is the legacy GAIE active ports annotation key, kept for backward compatibility.
+	//
 	// Deprecated: use activePortsAnnotation instead; this may be removed in a future release.
 	legacyGAIEActivePortsAnnotation = "inference.networking.k8s.io/active-ports"
 )

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -51,6 +51,9 @@ const (
 	// as active for inference traffic. The value should be a comma-separated list of port numbers.
 	// Example: "8000,8001,8002"
 	activePortsAnnotation = "llm-d.ai/active-ports"
+	// legacyGAIEActivePortsAnnotation is the legacy GAIE active ports annotation key, kept for backward compatibility.
+	// Deprecated: use activePortsAnnotation instead; this may be removed in a future release.
+	legacyGAIEActivePortsAnnotation = "inference.networking.k8s.io/active-ports"
 )
 
 // The datastore is a local cache of relevant data for the given InferencePool (currently all pulled from k8s-api)
@@ -424,7 +427,10 @@ func extractActivePorts(pod *corev1.Pod, targetPorts []int) sets.Set[int] {
 	annotations := pod.GetAnnotations()
 	portsAnnotation, ok := annotations[activePortsAnnotation]
 	if !ok {
-		return allPorts
+		portsAnnotation, ok = annotations[legacyGAIEActivePortsAnnotation]
+		if !ok {
+			return allPorts
+		}
 	}
 
 	activePorts := sets.New[int]()

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -1288,6 +1288,33 @@ func TestExtractActivePorts(t *testing.T) {
 			validPorts:    []int{8000, 8001, 8002},
 			expectedPorts: sets.New(8000),
 		},
+		{
+			name: "Pod with legacy GAIE annotation key",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pod",
+					Namespace:   "default",
+					Annotations: map[string]string{legacyGAIEActivePortsAnnotation: "8000,8001"},
+				},
+			},
+			validPorts:    []int{8000, 8001, 8002},
+			expectedPorts: sets.New(8000, 8001),
+		},
+		{
+			name: "New annotation key takes precedence over legacy GAIE key",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						activePortsAnnotation:           "8000",
+						legacyGAIEActivePortsAnnotation: "8001",
+					},
+				},
+			},
+			validPorts:    []int{8000, 8001, 8002},
+			expectedPorts: sets.New(8000),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -792,7 +792,7 @@ func TestActivePortFiltering(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"app": "vllm"},
 			Annotations: map[string]string{
-				"inference.networking.k8s.io/active-ports": "8000,8002",
+				activePortsAnnotation: "8000,8002",
 			},
 		},
 		Status: corev1.PodStatus{
@@ -827,7 +827,7 @@ func TestActivePortFiltering(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"app": "vllm"},
 			Annotations: map[string]string{
-				"inference.networking.k8s.io/active-ports": "",
+				activePortsAnnotation: "",
 			},
 		},
 		Status: corev1.PodStatus{
@@ -959,7 +959,7 @@ func TestActivePortEndpointRemoval(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"app": "vllm"},
 			Annotations: map[string]string{
-				"inference.networking.k8s.io/active-ports": "8000,8001,8002",
+				activePortsAnnotation: "8000,8001,8002",
 			},
 		},
 		Status: corev1.PodStatus{
@@ -978,7 +978,7 @@ func TestActivePortEndpointRemoval(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"app": "vllm"},
 			Annotations: map[string]string{
-				"inference.networking.k8s.io/active-ports": "8000",
+				activePortsAnnotation: "8000",
 			},
 		},
 		Status: corev1.PodStatus{
@@ -997,7 +997,7 @@ func TestActivePortEndpointRemoval(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"app": "vllm"},
 			Annotations: map[string]string{
-				"inference.networking.k8s.io/active-ports": "",
+				activePortsAnnotation: "",
 			},
 		},
 		Status: corev1.PodStatus{

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
@@ -37,7 +37,9 @@ The plugin populates several standard keys on the endpoint:
 
 The plugin config supports:
 
--   `engineLabelKey`: The Pod label key used to identify the engine type. Defaults to `inference.networking.k8s.io/engine-type`.
+-   `engineLabelKey`: The Pod label key used to identify the engine type. Defaults to `llm-d.ai/engine-type`. 
+    The deprecated GAIE key `inference.networking.k8s.io/engine-type` is also supported as a fallback, 
+    but will be removed in a future release.
 -   `defaultEngine`: The engine type to use if the label is missing. Defaults to `vllm`.
 -   `engineConfigs`: A list of engine-specific metric specifications.
 
@@ -54,7 +56,7 @@ To correctly establish the mapping, model server Pods should be labeled using th
 ```yaml
 metadata:
   labels:
-    inference.networking.k8s.io/engine-type: vllm # other options: sglang, trtllm-serve, triton-tensorrt-llm 
+    llm-d.ai/engine-type: vllm # other options: sglang, trtllm-serve, triton-tensorrt-llm 
 
 ```
 
@@ -76,7 +78,7 @@ and the model server deployment Pods should have the label:
 ```yaml
 metadata:
   labels:
-    inference.networking.k8s.io/engine-type: my-custom-engine
+    llm-d.ai/engine-type: my-custom-engine
 
 ```
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -206,7 +206,10 @@ func getEngineTypeFromEndpoint(ep fwkdl.Endpoint, labelKey string) string {
 
 	engineType, ok := meta.Labels[labelKey]
 	if !ok || engineType == "" {
-		return DefaultEngineType
+		engineType, ok = meta.Labels[LegacyGAIEEngineTypeLabelKey]
+		if !ok || engineType == "" {
+			return DefaultEngineType
+		}
 	}
 
 	return engineType

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -206,7 +206,7 @@ func getEngineTypeFromEndpoint(ep fwkdl.Endpoint, labelKey string) string {
 
 	engineType, ok := meta.Labels[labelKey]
 	if !ok || engineType == "" {
-		engineType, ok = meta.Labels[LegacyGAIEEngineTypeLabelKey]
+		engineType, ok = meta.Labels[legacyGAIEEngineTypeLabelKey]
 		if !ok || engineType == "" {
 			return DefaultEngineType
 		}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -665,3 +665,56 @@ func TestCoreMetricsExtractorFactoryDefaultEngine(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEngineTypeFromEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		labelKey string
+		want     string
+	}{
+		{
+			name:     "new label key",
+			labels:   map[string]string{DefaultEngineTypeLabelKey: "vllm"},
+			labelKey: DefaultEngineTypeLabelKey,
+			want:     "vllm",
+		},
+		{
+			name:     "legacy GAIE label key fallback",
+			labels:   map[string]string{LegacyGAIEEngineTypeLabelKey: "sglang"},
+			labelKey: DefaultEngineTypeLabelKey,
+			want:     "sglang",
+		},
+		{
+			name: "new label key takes precedence over legacy GAIE key",
+			labels: map[string]string{
+				DefaultEngineTypeLabelKey:    "vllm",
+				LegacyGAIEEngineTypeLabelKey: "sglang",
+			},
+			labelKey: DefaultEngineTypeLabelKey,
+			want:     "vllm",
+		},
+		{
+			name:     "no labels returns default",
+			labels:   map[string]string{},
+			labelKey: DefaultEngineTypeLabelKey,
+			want:     DefaultEngineType,
+		},
+		{
+			name:     "nil labels returns default",
+			labels:   nil,
+			labelKey: DefaultEngineTypeLabelKey,
+			want:     DefaultEngineType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{Labels: tt.labels}, nil)
+			got := getEngineTypeFromEndpoint(ep, tt.labelKey)
+			if got != tt.want {
+				t.Errorf("getEngineTypeFromEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -681,7 +681,7 @@ func TestGetEngineTypeFromEndpoint(t *testing.T) {
 		},
 		{
 			name:     "legacy GAIE label key fallback",
-			labels:   map[string]string{LegacyGAIEEngineTypeLabelKey: "sglang"},
+			labels:   map[string]string{legacyGAIEEngineTypeLabelKey: "sglang"},
 			labelKey: DefaultEngineTypeLabelKey,
 			want:     "sglang",
 		},
@@ -689,7 +689,7 @@ func TestGetEngineTypeFromEndpoint(t *testing.T) {
 			name: "new label key takes precedence over legacy GAIE key",
 			labels: map[string]string{
 				DefaultEngineTypeLabelKey:    "vllm",
-				LegacyGAIEEngineTypeLabelKey: "sglang",
+				legacyGAIEEngineTypeLabelKey: "sglang",
 			},
 			labelKey: DefaultEngineTypeLabelKey,
 			want:     "vllm",

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -65,7 +65,7 @@ type (
 	// modelServerExtractorParams holds the configuration parameters for the core metrics extractor plugin.
 	modelServerExtractorParams struct {
 		// EngineLabelKey is the Pod label key used to identify the engine type.
-		// Defaults to "inference.networking.k8s.io/engine-type".
+		// Defaults to "llm-d.ai/engine-type".
 		EngineLabelKey string `json:"engineLabelKey"`
 		// DefaultEngine specifies which engine to use as the default for unlabeled Pods.
 		// Can be any engine name from EngineConfigs. Defaults to "vllm".

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
@@ -29,6 +29,7 @@ const (
 	DefaultEngineTypeLabelKey = "llm-d.ai/engine-type"
 
 	// legacyGAIEEngineTypeLabelKey is the legacy GAIE label key, kept for backward compatibility.
+	//
 	// Deprecated: use DefaultEngineTypeLabelKey instead; this may be removed in a future release.
 	legacyGAIEEngineTypeLabelKey = "inference.networking.k8s.io/engine-type"
 )

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
@@ -26,7 +26,7 @@ const (
 	DefaultEngineType = "default"
 
 	// DefaultEngineTypeLabelKey is the default label on Pods that indicates the inference engine type.
-	DefaultEngineTypeLabelKey = "inference.networking.k8s.io/engine-type"
+	DefaultEngineTypeLabelKey = "llm-d.ai/engine-type"
 )
 
 // MappingRegistry holds multiple metric mappings for different inference engines.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
@@ -28,9 +28,9 @@ const (
 	// DefaultEngineTypeLabelKey is the default label on Pods that indicates the inference engine type.
 	DefaultEngineTypeLabelKey = "llm-d.ai/engine-type"
 
-	// LegacyGAIEEngineTypeLabelKey is the legacy GAIE label key, kept for backward compatibility.
+	// legacyGAIEEngineTypeLabelKey is the legacy GAIE label key, kept for backward compatibility.
 	// Deprecated: use DefaultEngineTypeLabelKey instead; this may be removed in a future release.
-	LegacyGAIEEngineTypeLabelKey = "inference.networking.k8s.io/engine-type"
+	legacyGAIEEngineTypeLabelKey = "inference.networking.k8s.io/engine-type"
 )
 
 // MappingRegistry holds multiple metric mappings for different inference engines.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
@@ -27,6 +27,10 @@ const (
 
 	// DefaultEngineTypeLabelKey is the default label on Pods that indicates the inference engine type.
 	DefaultEngineTypeLabelKey = "llm-d.ai/engine-type"
+
+	// LegacyGAIEEngineTypeLabelKey is the legacy GAIE label key, kept for backward compatibility.
+	// Deprecated: use DefaultEngineTypeLabelKey instead; this may be removed in a future release.
+	LegacyGAIEEngineTypeLabelKey = "inference.networking.k8s.io/engine-type"
 )
 
 // MappingRegistry holds multiple metric mappings for different inference engines.

--- a/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/README.md
@@ -22,7 +22,7 @@ The primary purpose of this plugin is to provide visibility into resource consum
 The plugin is configured within the EPP server's configuration file (provided via `--config-file` or `--config-text`). It uses the `request-attribute-reporter` type.
 
 ```yaml
-apiVersion: config.apix.gateway-api-inference-extension.sigs.k8s.io/v1alpha1
+apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
   - name: total-tokens-cost-reporter

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/proto/vllm_engine.proto
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/proto/vllm_engine.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package vllm.grpc.engine;
 
-option go_package = "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen";
+option go_package = "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen";
 
 // Service definition for vLLM engine communication
 // This protocol is designed for efficient binary communication between

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -167,7 +167,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 	// Start tracing span for the request
 	tracer := otel.Tracer(
-		"gateway-api-inference-extension/epp/extproc",
+		"llm-d-inference-scheduler/epp/extproc",
 		trace.WithInstrumentationVersion(version.BuildRef),
 		trace.WithInstrumentationAttributes(
 			attribute.String("commit-sha", version.CommitSHA),

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -149,7 +149,7 @@ func (d *Director) getInferenceObjective(ctx context.Context, reqCtx *handlers.R
 // HandleRequest orchestrates the request lifecycle.
 // It always returns the requestContext even in the error case, as the request context is used in error handling.
 func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (*handlers.RequestContext, error) {
-	tracer := otel.Tracer("gateway-api-inference-extension")
+	tracer := otel.Tracer("llm-d-inference-scheduler")
 	ctx, span := tracer.Start(ctx, "gateway.request_orchestration", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 

--- a/pkg/epp/server/controller_manager.go
+++ b/pkg/epp/server/controller_manager.go
@@ -87,7 +87,7 @@ func NewDefaultManager(controllerCfg ControllerConfig, gknn common.GKNN, restCon
 		opt.LeaderElection = true
 		opt.LeaderElectionResourceLock = "leases"
 		// The lease name needs to be unique per EPP deployment.
-		opt.LeaderElectionID = fmt.Sprintf("epp-%s-%s.gateway-api-inference-extension.sigs.k8s.io", gknn.Namespace, gknn.Name)
+		opt.LeaderElectionID = fmt.Sprintf("epp-%s-%s.llm-d.ai", gknn.Namespace, gknn.Name)
 		opt.LeaderElectionNamespace = gknn.Namespace
 		opt.LeaderElectionReleaseOnCancel = true
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/cleanup

**What this PR does / why we need it**:

addresses hardcoded GAIE keys/labels/references and migrate them to llm-d.ai prefix

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #873, _does not_ address #872

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The following Kubernetes label/annotation keys have been migrated from the GAIE prefix to `llm-d.ai`:

- Pod annotation: `inference.networking.k8s.io/active-ports` is now `llm-d.ai/active-ports`
- Pod label: `inference.networking.k8s.io/engine-type` is now `llm-d.ai/engine-type`

Both legacy GAIE keys are still checked as fallbacks during the transition period
but are deprecated and will be removed in a future release.
```

note: rebasing might be needed as merging continues, will do if required