### PR TITLE
Centralize token count estimation and remove raw prompt passing in latency predictor

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -25,13 +25,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const nilStr = "<nil>"
+const (
+	nilStr = "<nil>"
+	// ModalityImage is the only currently supported modality.
+	ModalityImage Modality = "image"
+	// This is an estimation of character per token used to generate token hint for InferenceRequestBody.
+	AverageCharactersPerToken = 4
+)
 
 // Modality identifies the type of multimodal content in a prompt.
 type Modality string
-
-// ModalityImage is the only currently supported modality.
-const ModalityImage Modality = "image"
 
 // RequestPayload represents a strongly-typed unmarshaled request payload or raw bytes.
 type RequestPayload interface {
@@ -143,17 +146,20 @@ func (r *InferenceRequestBody) PromptText() string {
 	}
 }
 
-// InputTokenCountHint returns a best-effort input token count when the
-// caller knows it exactly (token-ID inputs), or -1 when the count has
-// to be estimated from text.
+// InputTokenCountHint returns a best-effort input token count.
+// If the input is token based, the return value is the number of token as is.
+// If the input is character based, it is using (length_of_the_prompt / AverageCharactersPerToken) to estimate the token count.
 func (r *InferenceRequestBody) InputTokenCountHint() int {
-	if r.Completions != nil {
-		return r.Completions.Prompt.TokenCountHint()
+	if r.Completions != nil && len(r.Completions.Prompt.TokenIDs) > 0 {
+		return len(r.Completions.Prompt.TokenIDs)
 	}
-	if r.Embeddings != nil {
-		return r.Embeddings.Input.TokenCountHint()
+	if r.Embeddings != nil && len(r.Embeddings.Input.TokenIDs) > 0 {
+		return len(r.Embeddings.Input.TokenIDs)
 	}
-	return -1
+	if len(r.PromptText()) == 0 {
+		return 0
+	}
+	return max(1, len(r.PromptText())/AverageCharactersPerToken) // Make sure the tokenCountHint is at least 1 when prompt is not zero.
 }
 
 func (r *InferenceRequestBody) CacheSalt() string {
@@ -243,13 +249,6 @@ func (p *Prompt) UnmarshalJSON(data []byte) error {
 	default:
 		return errors.New("prompt: must be a string or an array")
 	}
-}
-
-func (p Prompt) TokenCountHint() int {
-	if len(p.TokenIDs) > 0 {
-		return len(p.TokenIDs)
-	}
-	return -1
 }
 
 func (p Prompt) MarshalJSON() ([]byte, error) {
@@ -388,13 +387,6 @@ func (e *EmbeddingsInput) UnmarshalJSON(data []byte) error {
 	default:
 		return errors.New("embeddings input: must be a string or an array")
 	}
-}
-
-func (e EmbeddingsInput) TokenCountHint() int {
-	if len(e.TokenIDs) > 0 {
-		return len(e.TokenIDs)
-	}
-	return -1
 }
 
 func (e EmbeddingsInput) PlainText() string {

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -295,13 +295,22 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 			wantHint: 3,
 		},
 		{
-			name: "completions with text returns -1",
+			name: "completions with text returns estimated count",
 			body: &InferenceRequestBody{
 				Completions: &CompletionsRequest{
 					Prompt: Prompt{Raw: "hello"},
 				},
 			},
-			wantHint: -1,
+			wantHint: 1, // len("hello") / 4 = 5 / 4 = 1
+		},
+		{
+			name: "completions with text length < 4 returns estimated count",
+			body: &InferenceRequestBody{
+				Completions: &CompletionsRequest{
+					Prompt: Prompt{Raw: "hel"},
+				},
+			},
+			wantHint: 1, // max(1, len("hel") / 4) = 1
 		},
 		{
 			name: "embeddings with token IDs returns count",
@@ -313,18 +322,36 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 			wantHint: 4,
 		},
 		{
-			name: "embeddings with text returns -1",
+			name: "embeddings with text returns estimated count",
 			body: &InferenceRequestBody{
 				Embeddings: &EmbeddingsRequest{
 					Input: EmbeddingsInput{Raw: "hello"},
 				},
 			},
-			wantHint: -1,
+			wantHint: 1, // len("hello") / 4 = 5 / 4 = 1
 		},
 		{
-			name:     "empty body returns -1",
+			name:     "empty body returns 0",
 			body:     &InferenceRequestBody{},
-			wantHint: -1,
+			wantHint: 0, // len("") / 4 = 0
+		},
+		{
+			name: "completions with long text returns estimated count",
+			body: &InferenceRequestBody{
+				Completions: &CompletionsRequest{
+					Prompt: Prompt{Raw: "This is a longer prompt with more characters."},
+				},
+			},
+			wantHint: 11, // len("This is a longer prompt with more characters.") = 45. 45 / 4 = 11
+		},
+		{
+			name: "completions with short text returns at least 1",
+			body: &InferenceRequestBody{
+				Completions: &CompletionsRequest{
+					Prompt: Prompt{Raw: "123"},
+				},
+			},
+			wantHint: 1, // len("123") = 3. max(1, 3/4) = 1
 		},
 	}
 

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -52,9 +52,6 @@ type InferenceRequest struct {
 	Headers map[string]string
 	// Request Objective
 	Objectives RequestObjectives
-	// RequestSizeBytes is the size of the raw request body in bytes when available.
-	// Used for token estimation (e.g. inputTokens ≈ RequestSizeBytes/4) without parsing body or calling PlainText().
-	RequestSizeBytes int
 	// SchedulingResult captures the scheduling decisions made during the cycle.
 	SchedulingResult *SchedulingResult
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -29,15 +29,13 @@ type TokenEstimator interface {
 
 // SimpleTokenEstimator estimates tokens from character count. tokens = characters / CharactersPerToken.
 type SimpleTokenEstimator struct {
-	CharactersPerToken float64
-	OutputRatio        float64
+	outputRatio float64
 }
 
 // NewSimpleTokenEstimator returns a SimpleTokenEstimator with default 4.0 chars per token.
 func NewSimpleTokenEstimator() TokenEstimator {
 	return &SimpleTokenEstimator{
-		CharactersPerToken: 4.0,
-		OutputRatio:        1.5,
+		outputRatio: 1.5,
 	}
 }
 
@@ -46,27 +44,10 @@ func NewSimpleTokenEstimator() TokenEstimator {
 // to avoid allocations. Otherwise, input tokens are estimated from prompt/message character count
 // using CharactersPerToken; output tokens are estimated as inputTokens * OutputRatio.
 func (e *SimpleTokenEstimator) Estimate(request *framework.InferenceRequest) int64 {
-	if request == nil {
+	if request == nil || request.Body == nil {
 		return 0
 	}
-	// Prefer request body size when available: avoids PlainText() and reduces GC pressure.
-	var inputTokens int64
-	switch {
-	case request.RequestSizeBytes > 0:
-		inputTokens = max(int64(request.RequestSizeBytes)/4, 1)
-	case request.Body != nil:
-		hint := request.Body.InputTokenCountHint()
-		if hint >= 0 {
-			inputTokens = int64(hint)
-		} else {
-			// Fallback: character count from prompt text across all API types
-			// (completions, chat/completions, responses, conversations).
-			chars := len(request.Body.PromptText())
-			inputTokens = int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
-		}
-	default:
-		return 0
-	}
-	outputTokens := int64(math.Round(float64(inputTokens) * e.OutputRatio))
-	return inputTokens + outputTokens
+	inputToken := int64(request.Body.InputTokenCountHint())
+	outputTokens := int64(math.Round(float64(inputToken) * e.outputRatio))
+	return inputToken + outputTokens
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
@@ -59,7 +59,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 3, // 3/4 (input tokens) + 3/4*1.5 (output tokens) = 3
+			expected: 3, // 3 chars -> 1 input token. 1 + round(1 * 1.5) = 3
 		},
 		{
 			name: "Completions Request",
@@ -70,7 +70,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 8, // 8/4 (input tokens) + 8/4*1.5 (output tokens) = 8
+			expected: 8, // 13 / 4 = 3. output = round(3 * 1.5) = 5. total = 8
 		},
 		{
 			name: "Completions with empty prompt",
@@ -81,7 +81,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 3,
+			expected: 0, // 0 / 4 = 0
 		},
 		{
 			name: "Completions with exactly 4 characters",
@@ -92,7 +92,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 3,
+			expected: 3, // 4 / 4 = 1. output = round(1 * 1.5) = 2. total = 3
 		},
 		{
 			name: "Chat Completions Request with Structured content",
@@ -115,7 +115,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 18,
+			expected: 15, // len is 27. 27 / 4 = 6. output = round(6 * 1.5) = 9. total = 15
 		},
 		{
 			name: "Chat Completions with Raw content",
@@ -133,7 +133,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 13,
+			expected: 13, // len is 21. 21 / 4 = 5. output = round(5 * 1.5) = 8. total = 13
 		},
 		{
 			name: "Chat Completions with multiple messages",
@@ -161,9 +161,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			// PromptText() joins messages with a trailing space separator ("Hi Hello " = 9 chars),
-			// so the estimate is higher than summing per-message lengths individually (7 chars).
-			expected: 8,
+			expected: 5, // len is 11. 11 / 4 = 2. output = round(2 * 1.5) = 3. total = 5
 		},
 		{
 			name: "Chat Completions with empty messages",
@@ -174,7 +172,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 3,
+			expected: 0, // 0 / 4 = 0
 		},
 		{
 			name: "Responses API with string input",
@@ -185,7 +183,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 23,
+			expected: 23, // len is 37. 37 / 4 = 9. output = round(9 * 1.5) = 14. total = 23
 		},
 		{
 			name: "Responses API with structured input",
@@ -198,7 +196,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 23,
+			expected: 20, // len is 35. 35 / 4 = 8. output = round(8 * 1.5) = 12. total = 20
 		},
 		{
 			name: "Conversations API",
@@ -211,7 +209,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 35,
+			expected: 33, // len is 55. 55 / 4 = 13. output = round(13 * 1.5) = 20. total = 33
 		},
 	}
 
@@ -225,8 +223,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 
 func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 	estimator := &SimpleTokenEstimator{
-		CharactersPerToken: 2.0,
-		OutputRatio:        2.0,
+		outputRatio: 2.0,
 	}
 
 	testCases := []struct {
@@ -243,7 +240,7 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: 3,
+			expected: 0, // 0 / 4 = 0
 		},
 		{
 			name: "4 chars with custom config",
@@ -254,7 +251,7 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: 6,
+			expected: 3, // 4 / 4 = 1. output = round(1 * 2.0) = 2. total = 3
 		},
 		{
 			name: "More than 4 chars with custom config",
@@ -265,7 +262,7 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: 39,
+			expected: 18, // len is 25. 25 / 4 = 6. output = round(6 * 2.0) = 12. total = 18
 		},
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -259,7 +258,6 @@ type predictedLatencyCtx struct {
 	tpotObservations          []float64
 	predictedTPOTObservations []float64
 
-	promptText      string
 	inputTokenCount int
 
 	prefixCacheScoresForEndpoints map[string]float64
@@ -275,14 +273,13 @@ type predictedLatencyCtx struct {
 }
 
 func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedLatencyCtx {
-	var promptText string
+	var inputTokenHint int
 	if request.Body != nil {
-		promptText = request.Body.PromptText()
+		inputTokenHint = request.Body.InputTokenCountHint()
 	}
 	return &predictedLatencyCtx{
 		schedulingRequest:             *request,
-		promptText:                    promptText,
-		inputTokenCount:               len(strings.Fields(promptText)),
+		inputTokenCount:               inputTokenHint,
 		lastSeenMetrics:               make(map[string]*fwkdl.Metrics),
 		prefixCacheScoresForEndpoints: make(map[string]float64),
 		predictionsForScheduling:      make(map[string]endpointPredictionResult),

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
@@ -49,7 +49,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 	// Prepare inputs for bulk prediction
 	metricsStates := make([]*fwkdl.Metrics, len(candidateEndpoints))
 	targetEndpointsMetadatas := make([]*fwkdl.EndpointMetadata, len(candidateEndpoints))
-	prompts := make([]string, len(candidateEndpoints))
+	inputTokenCounts := make([]int, len(candidateEndpoints))
 	generatedTokenCounts := make([]int, len(candidateEndpoints))
 	prefixCacheScores := make([]float64, len(candidateEndpoints))
 	prefillTokensInFlights := make([]int64, len(candidateEndpoints))
@@ -64,7 +64,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 
 		metricsStates[i] = endpoint.GetMetrics()
 		targetEndpointsMetadatas[i] = endpoint.GetMetadata()
-		prompts[i] = predictedLatencyCtx.promptText
+		inputTokenCounts[i] = predictedLatencyCtx.inputTokenCount
 		generatedTokenCounts[i] = 1
 		prefixCacheScores[i] = prefixCacheScore
 
@@ -73,7 +73,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 	}
 
 	// Bulk predict
-	bulkPredictions, err := bulkPredictWithMetrics(ctx, predictedLatencyCtx, s.latencypredictor, metricsStates, s.config.EndpointRoleLabel, targetEndpointsMetadatas, prompts, generatedTokenCounts, prefixCacheScores, prefillTokensInFlights)
+	bulkPredictions, err := bulkPredictWithMetrics(ctx, predictedLatencyCtx, s.latencypredictor, metricsStates, s.config.EndpointRoleLabel, targetEndpointsMetadatas, inputTokenCounts, generatedTokenCounts, prefixCacheScores, prefillTokensInFlights)
 	if err != nil {
 		logger.V(logutil.DEBUG).Error(err, "Bulk prediction failed")
 		return nil, err

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
@@ -149,7 +149,7 @@ func TestValidatePrediction_PrefillEndpointNeutralizeTPOT(t *testing.T) {
 	plCtx := &predictedLatencyCtx{
 		ttftSLO:                       100,
 		avgTPOTSLO:                    30,
-		promptText:                    "test",
+		inputTokenCount:               1,
 		prefixCacheScoresForEndpoints: map[string]float64{"prefill-pod": 0, "decode-pod": 0, "unlabeled-pod": 0},
 		predictionsForScheduling:      make(map[string]endpointPredictionResult),
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -187,7 +187,7 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 					t.config.EndpointRoleLabel,
 					targetMetadata,
 					m,
-					predictedLatencyCtx.promptText,
+					predictedLatencyCtx.inputTokenCount,
 					0,
 					predictedLatencyCtx.avgTPOT,
 					now,
@@ -362,7 +362,7 @@ func processTokenForLatencyPrediction(
 			endpointRoleLabel,
 			targetEndpointMetadata,
 			m,
-			predictedLatencyCtx.promptText,
+			predictedLatencyCtx.inputTokenCount,
 			predictedLatencyCtx.generatedTokenCount,
 			0,
 		)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -80,7 +80,7 @@ func TestNewPredictedLatencyContext(t *testing.T) {
 
 	assert.NotNil(t, ctx)
 	assert.Equal(t, *request, ctx.schedulingRequest)
-	assert.Equal(t, "test prompt", ctx.promptText)
+	assert.Equal(t, request.Body.InputTokenCountHint(), ctx.inputTokenCount)
 	assert.NotNil(t, ctx.lastSeenMetrics)
 	assert.NotNil(t, ctx.prefixCacheScoresForEndpoints)
 	assert.NotNil(t, ctx.predictionsForScheduling)
@@ -96,7 +96,7 @@ func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
 	ctx := newPredictedLatencyContext(request)
 
 	assert.NotNil(t, ctx)
-	assert.Empty(t, ctx.promptText)
+	assert.Zero(t, ctx.inputTokenCount)
 }
 
 func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
@@ -104,7 +104,7 @@ func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
 	ctx := newPredictedLatencyContext(request)
 
 	assert.NotNil(t, ctx)
-	assert.Equal(t, "You are a helpful assistant. Tell me a joke. ", ctx.promptText)
+	assert.Equal(t, request.Body.InputTokenCountHint(), ctx.inputTokenCount)
 }
 
 func TestPredictedLatency_SetAndGetSLOContext(t *testing.T) {
@@ -911,7 +911,7 @@ func TestPredictedLatencyContext_Fields(t *testing.T) {
 	assert.Nil(t, ctx.targetMetadata)
 	assert.Nil(t, ctx.schedulingResult)
 	assert.Nil(t, ctx.decodeTokenSampler)
-	assert.Equal(t, "test prompt", ctx.promptText)
+	assert.Equal(t, request.Body.InputTokenCountHint(), ctx.inputTokenCount)
 }
 
 func TestPredictedLatencyContext_UpdateMetrics(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	latencypredictor "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
@@ -36,7 +35,7 @@ func buildPredictionRequest(
 	endpointRoleLabel string,
 	targetEndpointMetadata *fwkdl.EndpointMetadata,
 	metrics *fwkdl.Metrics,
-	prompt string,
+	inputTokenCount int,
 	generatedTokens int,
 	prefixCacheScore float64,
 ) latencypredictor.PredictionRequest {
@@ -47,7 +46,7 @@ func buildPredictionRequest(
 
 	return latencypredictor.PredictionRequest{
 		KVCachePercentage:  metrics.KVCacheUsagePercent,
-		InputTokenLength:   len(strings.Fields(prompt)),
+		InputTokenLength:   inputTokenCount,
 		NumRequestWaiting:  metrics.WaitingQueueSize,
 		NumRequestRunning:  metrics.RunningRequestsSize,
 		NumTokensGenerated: generatedTokens,
@@ -61,7 +60,7 @@ func buildTrainingEntry(
 	endpointRoleLabel string,
 	targetEndpointMetadata *fwkdl.EndpointMetadata,
 	m *fwkdl.Metrics,
-	prompt string,
+	inputTokenCount int,
 	actualTTFT float64,
 	actualTPOT float64,
 	timestamp time.Time,
@@ -75,7 +74,7 @@ func buildTrainingEntry(
 
 	return latencypredictor.TrainingEntry{
 		KVCachePercentage:  m.KVCacheUsagePercent,
-		InputTokenLength:   len(strings.Fields(prompt)),
+		InputTokenLength:   inputTokenCount,
 		ActualTTFT:         actualTTFT,
 		ActualTPOT:         actualTPOT,
 		Timestamp:          timestamp,
@@ -103,7 +102,7 @@ func recordTTFTTrainingData(
 		endpointRoleLabel,
 		targetEndpointMetadata,
 		m,
-		predictedLatencyCtx.promptText,
+		predictedLatencyCtx.inputTokenCount,
 		predictedLatencyCtx.ttft,
 		0,
 		now,
@@ -159,16 +158,16 @@ func bulkPredictWithMetrics(
 	metricsStates []*fwkdl.Metrics,
 	endpointRoleLabel string,
 	targetEndpointsMetadatas []*fwkdl.EndpointMetadata,
-	prompts []string,
+	inputTokenCounts []int,
 	generatedTokenCounts []int,
 	prefixCacheScores []float64,
 	prefillTokensInFlights []int64,
 ) ([]*latencypredictor.PredictionResponse, error) {
 	logger := log.FromContext(ctx)
 
-	if len(targetEndpointsMetadatas) != len(metricsStates) || len(metricsStates) != len(prompts) || len(prompts) != len(generatedTokenCounts) || len(generatedTokenCounts) != len(prefixCacheScores) {
-		return nil, fmt.Errorf("input slice lengths must match: endpoints=%d, metrics=%d, prompts=%d, tokenCounts=%d, prefixScores=%d",
-			len(targetEndpointsMetadatas), len(metricsStates), len(prompts), len(generatedTokenCounts), len(prefixCacheScores))
+	if len(targetEndpointsMetadatas) != len(metricsStates) || len(metricsStates) != len(inputTokenCounts) || len(inputTokenCounts) != len(generatedTokenCounts) || len(generatedTokenCounts) != len(prefixCacheScores) {
+		return nil, fmt.Errorf("input slice lengths must match: endpoints=%d, metrics=%d, inputTokenCounts=%d, tokenCounts=%d, prefixScores=%d",
+			len(targetEndpointsMetadatas), len(metricsStates), len(inputTokenCounts), len(generatedTokenCounts), len(prefixCacheScores))
 	}
 
 	if len(metricsStates) == 0 {
@@ -193,7 +192,7 @@ func bulkPredictWithMetrics(
 			endpointRoleLabel,
 			targetEndpointsMetadatas[i],
 			metricsStates[i],
-			prompts[i],
+			inputTokenCounts[i],
 			generatedTokenCounts[i],
 			prefixCacheScores[i],
 		)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -51,11 +51,11 @@ func TestBulkPredictWithMetrics(t *testing.T) {
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod2"},
 		},
 	}
-	prompts := []string{"prompt1", "prompt2"}
+	inputTokenCounts := []int{1, 1}
 	generatedTokenCounts := []int{1, 1}
 	prefixCacheScores := []float64{0.0, 0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, inputTokenCounts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
@@ -78,11 +78,11 @@ func TestBulkPredictWithMetrics_Error(t *testing.T) {
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
-	prompts := []string{"prompt1"}
+	inputTokenCounts := []int{1}
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, inputTokenCounts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, results)
@@ -96,11 +96,11 @@ func TestBulkPredictWithMetrics_InputMismatch(t *testing.T) {
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
-	prompts := []string{"prompt1", "prompt2"} // Mismatch length
+	inputTokenCounts := []int{1, 1} // Mismatch length
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, inputTokenCounts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, results)
@@ -122,7 +122,7 @@ func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
-	prompts := []string{"prompt1"}
+	inputTokenCounts := []int{1}
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
@@ -133,7 +133,7 @@ func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
 		incomingModelName: "incoming-model",
 	}
 
-	results, err := bulkPredictWithMetrics(context.Background(), plCtx, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), plCtx, mockPredictor, metricsStates, "", pods, inputTokenCounts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -160,11 +160,11 @@ func TestBulkPredictWithMetrics_ChatCompletionsPrompt(t *testing.T) {
 			},
 		},
 	}
-	prompts := []string{chatBody.PromptText()}
+	inputTokenCounts := []int{chatBody.InputTokenCountHint()}
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mp, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, []int64{0})
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mp, metricsStates, "", pods, inputTokenCounts, generatedTokenCounts, prefixCacheScores, []int64{0})
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -179,11 +179,11 @@ func TestBulkPredictWithMetrics_NilMetricsState(t *testing.T) {
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
-	prompts := []string{"prompt1"}
+	inputTokenCounts := []int{1}
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, inputTokenCounts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, results)

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -171,12 +171,11 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 
 	// Prepare InferenceRequest (needed for both saturation detection and Scheduler)
 	reqCtx.SchedulingRequest = &fwksched.InferenceRequest{
-		RequestId:        reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
-		TargetModel:      reqCtx.TargetModelName,
-		Body:             inferenceRequestBody,
-		Headers:          reqCtx.Request.Headers,
-		Objectives:       requestObjectives,
-		RequestSizeBytes: reqCtx.RequestSize,
+		RequestId:   reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
+		TargetModel: reqCtx.TargetModelName,
+		Body:        inferenceRequestBody,
+		Headers:     reqCtx.Request.Headers,
+		Objectives:  requestObjectives,
 	}
 
 	logger = logger.WithValues("objectiveKey", reqCtx.ObjectiveKey, "incomingModelName", reqCtx.IncomingModelName, "targetModelName", reqCtx.TargetModelName, "priority", infObjective.Spec.Priority)


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind cleanup

**What this PR does / why we need it**:

This PR centralizes token count estimation in `InferenceRequestBody.InputTokenCountHint()` and updates all related components(latencyPredictor and tokenEstimator) to use it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #840

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
