### PR TITLE
Enabled more lint rules and corrected related code issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,12 +56,16 @@ linters:
         - name: error-return
         - name: error-strings
         - name: error-naming
+        - name: errorf
         - name: if-return
         - name: increment-decrement
+        - name: indent-error-flow
         - name: package-comments
         - name: range
         - name: time-naming
-        - name: errorf
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
 
 issues:
   # do not limit the number of issues, ensure even identical are reported

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -445,14 +445,13 @@ func setupDatastore(ctx context.Context, epFactory datalayer.EndpointFactory, mo
 
 	if startCrdReconcilers {
 		return datastore.NewDatastore(ctx, epFactory, modelServerMetricsPort), nil
-	} else {
-		endpointPool, err := NewEndpointPoolFromOptions(namespace, name, endpointSelector, endpointTargetPorts)
-		if err != nil {
-			setupLog.Error(err, "Failed to construct endpoint pool from options")
-			return nil, err
-		}
-		return datastore.NewDatastore(ctx, epFactory, modelServerMetricsPort).WithEndpointPool(endpointPool), nil
 	}
+	endpointPool, err := NewEndpointPoolFromOptions(namespace, name, endpointSelector, endpointTargetPorts)
+	if err != nil {
+		setupLog.Error(err, "Failed to construct endpoint pool from options")
+		return nil, err
+	}
+	return datastore.NewDatastore(ctx, epFactory, modelServerMetricsPort).WithEndpointPool(endpointPool), nil
 }
 
 // registerInTreePlugins registers the factory functions of all known plugins

--- a/pkg/common/request/headers.go
+++ b/pkg/common/request/headers.go
@@ -17,5 +17,5 @@ limitations under the License.
 package request
 
 const (
-	RequestIdHeaderKey = "x-request-id"
+	RequestIDHeaderKey = "x-request-id"
 )

--- a/pkg/epp/backend/metrics/metrics.go
+++ b/pkg/epp/backend/metrics/metrics.go
@@ -76,9 +76,9 @@ func NewPodMetricsClientImpl(logger logr.Logger, config Config) (PodMetricsClien
 	}
 	verifyMetricMapping(logger, *mapping)
 
-	var metricsHttpClient *http.Client
+	var metricsHTTPClient *http.Client
 	if config.ModelServerMetricsScheme == "https" {
-		metricsHttpClient = &http.Client{
+		metricsHTTPClient = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: config.ModelServerMetricsHTTPSInsecure,
@@ -86,13 +86,13 @@ func NewPodMetricsClientImpl(logger logr.Logger, config Config) (PodMetricsClien
 			},
 		}
 	} else {
-		metricsHttpClient = http.DefaultClient
+		metricsHTTPClient = http.DefaultClient
 	}
 	return &PodMetricsClientImpl{
 		MetricMapping:            mapping,
 		ModelServerMetricsPath:   config.ModelServerMetricsPath,
 		ModelServerMetricsScheme: config.ModelServerMetricsScheme,
-		Client:                   metricsHttpClient,
+		Client:                   metricsHTTPClient,
 	}, nil
 }
 

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -424,7 +424,7 @@ func TestInstantiateAndConfigure(t *testing.T) {
 		},
 		{
 			name:       "Error (Instantiation) - Invalid JSON Parameters",
-			configText: errorBadPluginJsonText,
+			configText: errorBadPluginJSONText,
 			wantErr:    true,
 		},
 		{

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -273,8 +273,8 @@ plugins:
   type: test-profile-handler
 `
 
-// errorBadPluginJsonText has invalid JSON in parameters (string where int expected).
-const errorBadPluginJsonText = `
+// errorBadPluginJSONText has invalid JSON in parameters (string where int expected).
+const errorBadPluginJSONText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:

--- a/pkg/epp/controller/inferencepool_reconciler_test.go
+++ b/pkg/epp/controller/inferencepool_reconciler_test.go
@@ -42,30 +42,30 @@ import (
 )
 
 var (
-	selector_v1 = map[string]string{"app": "vllm_v1"}
-	selector_v2 = map[string]string{"app": "vllm_v2"}
-	pods        = []*corev1.Pod{
+	selectorV1 = map[string]string{"app": "vllm_v1"}
+	selectorV2 = map[string]string{"app": "vllm_v2"}
+	pods       = []*corev1.Pod{
 		// Two ready pods matching pool1
 		utiltest.MakePod("pod1").
 			Namespace("pool1-ns").
-			Labels(selector_v1).ReadyCondition().ObjRef(),
+			Labels(selectorV1).ReadyCondition().ObjRef(),
 		utiltest.MakePod("pod2").
 			Namespace("pool1-ns").
-			Labels(selector_v1).
+			Labels(selectorV1).
 			ReadyCondition().ObjRef(),
 		// A not ready pod matching pool1
 		utiltest.MakePod("pod3").
 			Namespace("pool1-ns").
-			Labels(selector_v1).ObjRef(),
+			Labels(selectorV1).ObjRef(),
 		// A pod not matching pool1 namespace
 		utiltest.MakePod("pod4").
 			Namespace("pool2-ns").
-			Labels(selector_v1).
+			Labels(selectorV1).
 			ReadyCondition().ObjRef(),
 		// A ready pod matching pool1 with a new selector
 		utiltest.MakePod("pod5").
 			Namespace("pool1-ns").
-			Labels(selector_v2).
+			Labels(selectorV2).
 			ReadyCondition().ObjRef(),
 	}
 )
@@ -80,7 +80,7 @@ func TestInferencePoolReconciler(t *testing.T) {
 	}
 	pool1 := utiltest.MakeInferencePool("pool1").
 		Namespace("pool1-ns").
-		Selector(selector_v1).
+		Selector(selectorV1).
 		TargetPorts(8080).
 		EndpointPickerRef("epp-service").ObjRef()
 	pool1.SetGroupVersionKind(gvk)

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -63,6 +63,7 @@ type Datastore interface {
 	PoolGet() (*datalayer.EndpointPool, error)
 	PoolHasSynced() bool
 	PoolLabelsMatch(podLabels map[string]string) bool
+	WithEndpointPool(pool *datalayer.EndpointPool) Datastore
 
 	// InferenceObjective operations
 	ObjectiveSet(infObjective *v1alpha2.InferenceObjective)
@@ -90,7 +91,7 @@ var _ Datastore = &datastore{}
 
 // NewDatastore creates a new data store.
 // TODO: modelServerMetricsPort is being deprecated
-func NewDatastore(parentCtx context.Context, epFactory datalayer.EndpointFactory, modelServerMetricsPort int32) *datastore {
+func NewDatastore(parentCtx context.Context, epFactory datalayer.EndpointFactory, modelServerMetricsPort int32) Datastore {
 	// Initialize with defaults
 	return &datastore{
 		parentCtx:              parentCtx,
@@ -122,7 +123,7 @@ type datastore struct {
 	epf                    datalayer.EndpointFactory
 }
 
-func (ds *datastore) WithEndpointPool(pool *datalayer.EndpointPool) *datastore {
+func (ds *datastore) WithEndpointPool(pool *datalayer.EndpointPool) Datastore {
 	ds.pool = pool
 	return ds
 }

--- a/pkg/epp/flowcontrol/eviction/plugin.go
+++ b/pkg/epp/flowcontrol/eviction/plugin.go
@@ -83,7 +83,7 @@ func (p *RequestEvictor) PreRequest(
 
 	targetEndpoint := profileResult.TargetEndpoints[0]
 	metadata := targetEndpoint.GetMetadata()
-	requestID := request.Headers[reqcommon.RequestIdHeaderKey]
+	requestID := request.Headers[reqcommon.RequestIDHeaderKey]
 	if requestID == "" {
 		return
 	}
@@ -132,7 +132,7 @@ func (p *RequestEvictor) ResponseBody(
 	if request == nil {
 		return
 	}
-	requestID := request.Headers[reqcommon.RequestIdHeaderKey]
+	requestID := request.Headers[reqcommon.RequestIDHeaderKey]
 	if requestID == "" {
 		return
 	}

--- a/pkg/epp/flowcontrol/eviction/plugin_test.go
+++ b/pkg/epp/flowcontrol/eviction/plugin_test.go
@@ -51,9 +51,9 @@ func makeSchedulingResult() *scheduling.SchedulingResult {
 
 func makeInferenceRequest(requestID string, priority int) *scheduling.InferenceRequest { //nolint:unparam
 	return &scheduling.InferenceRequest{
-		RequestId: requestID,
+		RequestID: requestID,
 		Headers: map[string]string{
-			reqcommon.RequestIdHeaderKey: requestID,
+			reqcommon.RequestIDHeaderKey: requestID,
 		},
 		Objectives: scheduling.RequestObjectives{Priority: priority},
 	}

--- a/pkg/epp/framework/interface/plugin/registry.go
+++ b/pkg/epp/framework/interface/plugin/registry.go
@@ -39,7 +39,7 @@ func RegisterAsDefaultProducer(pluginType string, factory FactoryFunc, key strin
 }
 
 // Registry is a mapping from plugin type to Factory function.
-var Registry map[string]FactoryFunc = map[string]FactoryFunc{}
+var Registry = map[string]FactoryFunc{}
 
 // DefaultProducerRegistry maps a data key to the plugin type that is the default producer for it.
 // Populated via RegisterAsDefaultProducer.

--- a/pkg/epp/framework/interface/requestcontrol/types.go
+++ b/pkg/epp/framework/interface/requestcontrol/types.go
@@ -24,8 +24,8 @@ import (
 
 // Response contains information from the response received to be passed to the Response requestcontrol plugins
 type Response struct {
-	// RequestId is the Envoy generated Id for the request being processed
-	RequestId string
+	// RequestID is the Envoy generated Id for the request being processed
+	RequestID string
 	// Headers is a map of the response headers. Nil during body processing
 	Headers map[string]string
 	// StartOfStream when true indicates that this invocation contains the first chunk of the response

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -456,7 +456,7 @@ type ContentBlock struct {
 }
 
 type ImageBlock struct {
-	Url string `json:"url,omitempty"`
+	URL string `json:"url,omitempty"`
 }
 
 type AudioBlock struct {
@@ -465,7 +465,7 @@ type AudioBlock struct {
 }
 
 type VideoBlock struct {
-	Url string `json:"url,omitempty"`
+	URL string `json:"url,omitempty"`
 }
 
 // UnmarshalJSON allow use both format

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -79,7 +79,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 							Content: Content{
 								Structured: []ContentBlock{
 									{Type: "text", Text: "Describe this image:"},
-									{Type: "image_url", ImageURL: ImageBlock{Url: "http://example.com/img.png"}},
+									{Type: "image_url", ImageURL: ImageBlock{URL: "http://example.com/img.png"}},
 								},
 							},
 						},

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -42,8 +42,8 @@ type RequestObjectives struct {
 
 // InferenceRequest is a structured representation of the fields we parse out of the InferenceRequest body.
 type InferenceRequest struct {
-	// RequestId is the Envoy generated Id for the request being processed
-	RequestId string
+	// RequestID is the Envoy generated Id for the request being processed
+	RequestID string
 	// TargetModel is the final target model after traffic split.
 	TargetModel string
 	// Data contains the request-body fields that we parse out as user input.
@@ -65,7 +65,7 @@ func (r *InferenceRequest) String() string {
 	}
 
 	return fmt.Sprintf("RequestID: %s, TargetModel: %s, Body: %v, Headers: %v",
-		r.RequestId, r.TargetModel, r.Body, r.Headers)
+		r.RequestID, r.TargetModel, r.Body, r.Headers)
 }
 
 type Endpoint interface {
@@ -117,26 +117,26 @@ func NewEndpoint(meta *fwkdl.EndpointMetadata, metrics *fwkdl.Metrics, attr fwkd
 }
 
 func EndpointComparer(a, b Endpoint) bool {
-	a_ep := a.(*endpoint)
-	b_ep := b.(*endpoint)
+	aEp := a.(*endpoint)
+	bEp := b.(*endpoint)
 
-	if !reflect.DeepEqual(a_ep.EndpointMetadata, b_ep.EndpointMetadata) {
+	if !reflect.DeepEqual(aEp.EndpointMetadata, bEp.EndpointMetadata) {
 		return false
 	}
-	if !reflect.DeepEqual(a_ep.Metrics, b_ep.Metrics) {
+	if !reflect.DeepEqual(aEp.Metrics, bEp.Metrics) {
 		return false
 	}
 
 	// Compare keys and values in AttributeMap for both endpoints. DeepEqual is not used here because the order of keys may differ.
-	a_keys := a_ep.Keys()
-	b_keys := b_ep.Keys()
-	if len(a_keys) != len(b_keys) {
+	aKeys := aEp.Keys()
+	bKeys := bEp.Keys()
+	if len(aKeys) != len(bKeys) {
 		return false
 	}
 
-	for _, k := range a_keys {
-		v1, ok1 := a_ep.Get(k)
-		v2, ok2 := b_ep.Get(k)
+	for _, k := range aKeys {
+		v1, ok1 := aEp.Get(k)
+		v2, ok2 := bEp.Get(k)
 		if !ok1 || !ok2 || !reflect.DeepEqual(v1, v2) {
 			return false
 		}

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -667,7 +667,7 @@ func (f *liveSchedulingEndpoint) Clone() datalayer.AttributeMap   { return f }
 
 func makeTokenRequest(requestID, prompt string) *schedulingtypes.InferenceRequest {
 	return &schedulingtypes.InferenceRequest{
-		RequestId: requestID,
+		RequestID: requestID,
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
 		},

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -159,7 +159,7 @@ func (p *prepareData) PrepareRequestData(ctx context.Context, request *framework
 
 	// Store the state in shared plugin state for later use in PreRequest.
 	// NOTE: We use the prefix plugin's type name as part of the key so that the scorer can read it.
-	p.pluginState.Write(request.RequestId, plugin.StateKey(ApproxPrefixCachePluginType), state)
+	p.pluginState.Write(request.RequestID, plugin.StateKey(ApproxPrefixCachePluginType), state)
 
 	return nil
 }
@@ -168,7 +168,7 @@ func (p *prepareData) PrepareRequestData(ctx context.Context, request *framework
 // It updates the indexer with the prefix hashes for the selected endpoint(s).
 func (p *prepareData) PreRequest(ctx context.Context, request *framework.InferenceRequest, schedulingResult *framework.SchedulingResult) {
 	// Delete the state to avoid memory leak.
-	defer p.pluginState.Delete(request.RequestId)
+	defer p.pluginState.Delete(request.RequestID)
 	primaryProfileResult := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
 	if len(primaryProfileResult.TargetEndpoints) == 0 {
 		return
@@ -183,9 +183,9 @@ func (p *prepareData) PreRequest(ctx context.Context, request *framework.Inferen
 	}
 
 	// Read state saved during PrepareRequestData.
-	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.pluginState, request.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.pluginState, request.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to read prefix plugin state", "requestID", request.RequestId)
+		log.FromContext(ctx).Error(err, "failed to read prefix plugin state", "requestID", request.RequestID)
 		return
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -51,7 +51,7 @@ func TestPrepareRequestData(t *testing.T) {
 
 	// First request to populate cache.
 	req1 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -66,7 +66,7 @@ func TestPrepareRequestData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify state was written to PluginState
-	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	assert.NoError(t, err)
 	assert.NotNil(t, state)
 	assert.Equal(t, 2, len(state.PrefixHashes)) // "aaaabbbb" with blockSize 4 (1 token * 4 chars) -> 2 blocks
@@ -91,7 +91,7 @@ func TestPreRequest(t *testing.T) {
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 	req1 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -173,7 +173,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 
 	// First request.
 	req1 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -182,7 +182,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		},
 	}
 	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
-	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	// Input size is 6, block size is 4, so 1 body block. Total hashes = 1 (model only is not a block)
 	assert.Equal(t, 2, len(state.PrefixHashes))
 
@@ -199,7 +199,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 
 	// Third request shares partial prefix with first one.
 	req3 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -240,7 +240,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 
 	// First request with initial conversation
 	req1 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -252,7 +252,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 		},
 	}
 	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
-	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	initialHashCount := len(state1.PrefixHashes)
 	assert.Greater(t, initialHashCount, 0)
 
@@ -268,7 +268,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 
 	// Second request adds assistant response and new user message
 	req2 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -282,7 +282,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 		},
 	}
 	_ = p.PrepareRequestData(context.Background(), req2, endpoints)
-	state2, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req2.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state2, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req2.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	extendedHashCount := len(state2.PrefixHashes)
 	assert.Greater(t, extendedHashCount, initialHashCount)
 
@@ -305,7 +305,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint1}
 
 	req1 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -315,7 +315,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 						Content: fwkrh.Content{
 							Structured: []fwkrh.ContentBlock{
 								{Type: "text", Text: "Describe"},
-								{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "https://storage.googleapis.com/abc1/sample1.jpg"}},
+								{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://storage.googleapis.com/abc1/sample1.jpg"}},
 							},
 						},
 					},
@@ -324,7 +324,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 		},
 	}
 	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
-	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	initialHashCount := len(state1.PrefixHashes)
 	assert.Greater(t, initialHashCount, 0)
 
@@ -338,7 +338,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 	p.wg.Wait()
 
 	req2 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -348,7 +348,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 						Content: fwkrh.Content{
 							Structured: []fwkrh.ContentBlock{
 								{Type: "text", Text: "Describe"},
-								{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "https://storage.googleapis.com/abc1/sample1.jpg"}},
+								{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://storage.googleapis.com/abc1/sample1.jpg"}},
 							},
 						},
 					},
@@ -377,7 +377,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 	endpoints := []fwksched.Endpoint{endpoint1}
 
 	req1 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -387,7 +387,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 						Content: fwkrh.Content{
 							Structured: []fwkrh.ContentBlock{
 								{Type: "text", Text: "Describe"},
-								{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "https://storage.googleapis.com/bucket1/sample1.jpg"}},
+								{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://storage.googleapis.com/bucket1/sample1.jpg"}},
 							},
 						},
 					},
@@ -396,7 +396,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 		},
 	}
 	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
-	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	initialHashCount := len(state1.PrefixHashes)
 	assert.Greater(t, initialHashCount, 0)
 
@@ -410,7 +410,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 	p.wg.Wait()
 
 	req2 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model1",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -420,7 +420,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 						Content: fwkrh.Content{
 							Structured: []fwkrh.ContentBlock{
 								{Type: "text", Text: "Describe"},
-								{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "https://storage.googleapis.com/bucket2/sample2.jpg"}},
+								{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://storage.googleapis.com/bucket2/sample2.jpg"}},
 							},
 						},
 					},
@@ -447,7 +447,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint}
 
 	req := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -467,7 +467,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	p, _ := newPrepareData(context.Background(), config, nil)
 
 	_ = p.PrepareRequestData(context.Background(), req, endpoints)
-	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	// 128 chars / (16 tokens * 4 chars/token) = 2 blocks
 	assert.Equal(t, 2, len(state.PrefixHashes), "Should use pod block size (16 tokens) -> 2 body blocks")
 
@@ -503,7 +503,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 
 	// Prompt is 16 chars = 4 blocks at blockSize 4 chars, but should be capped to 2.
 	req := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -515,7 +515,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	err = p.PrepareRequestData(context.Background(), req, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
-	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(state.PrefixHashes), "should cap at MaxPrefixTokensToMatch/BlockSizeTokens = 2 blocks")
 
@@ -530,7 +530,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	req2 := &fwksched.InferenceRequest{
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -542,7 +542,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	err = p2.PrepareRequestData(context.Background(), req2, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
-	state2, err := plugin.ReadPluginStateKey[*SchedulingContextState](p2.PluginState(), req2.RequestId, plugin.StateKey(ApproxPrefixCachePluginType))
+	state2, err := plugin.ReadPluginStateKey[*SchedulingContextState](p2.PluginState(), req2.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(state2.PrefixHashes), "should fall back to MaxPrefixBlocksToMatch when MaxPrefixTokensToMatch is 0")
 }
@@ -566,7 +566,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 			}, nil, fwkdl.NewAttributes())
 			endpoints := []fwksched.Endpoint{endpoint}
 			req := &fwksched.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "model-stress",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -578,7 +578,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = p.PrepareRequestData(context.Background(), req, endpoints)
-				p.PluginState().Delete(req.RequestId)
+				p.PluginState().Delete(req.RequestID)
 			}
 		})
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -249,7 +249,7 @@ func (f *stubSchedulingEndpoint) Keys() []string { return f.attr.Keys() }
 
 func makeTokenRequest(requestID, prompt string) *schedulingtypes.InferenceRequest {
 	return &schedulingtypes.InferenceRequest{
-		RequestId: requestID,
+		RequestID: requestID,
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
 		},

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -51,8 +51,8 @@ const (
 	// TPOTSLOHeaderKey is the header key for the TPOT SLO.
 	TPOTSLOHeaderKey = "x-slo-tpot-ms"
 
-	// Experimental_DefaultPrefillProfile is the default profile name for prefill endpoints in disaggregated serving.
-	Experimental_DefaultPrefillProfile = "prefill"
+	// ExperimentalDefaultPrefillProfile is the default profile name for prefill endpoints in disaggregated serving.
+	ExperimentalDefaultPrefillProfile = "prefill"
 )
 
 // PredictedLatency is the latency data provider plugin. It handles:
@@ -290,7 +290,7 @@ func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedL
 }
 
 func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *framework.InferenceRequest) (*predictedLatencyCtx, error) {
-	id := request.Headers[reqcommon.RequestIdHeaderKey]
+	id := request.Headers[reqcommon.RequestIDHeaderKey]
 	if item := s.sloContextStore.Get(id); item != nil {
 		return item.Value(), nil
 	}
@@ -298,12 +298,12 @@ func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *framewo
 }
 
 func (s *PredictedLatency) setPredictedLatencyContextForRequest(request *framework.InferenceRequest, ctx *predictedLatencyCtx) {
-	id := request.Headers[reqcommon.RequestIdHeaderKey]
+	id := request.Headers[reqcommon.RequestIDHeaderKey]
 	s.sloContextStore.Set(id, ctx, ttlcache.DefaultTTL)
 }
 
 func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *framework.InferenceRequest) {
-	id := request.Headers[reqcommon.RequestIdHeaderKey]
+	id := request.Headers[reqcommon.RequestIDHeaderKey]
 	s.sloContextStore.Delete(id)
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -135,7 +135,7 @@ func createTestChatCompletionsInferenceRequest(reqID string, ttftSLO, tpotSLO fl
 
 func createTestInferenceRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *fwkrh.InferenceRequestBody) *fwksched.InferenceRequest {
 	headers := make(map[string]string)
-	headers[reqcommon.RequestIdHeaderKey] = reqID
+	headers[reqcommon.RequestIDHeaderKey] = reqID
 	if ttftSLO > 0 {
 		headers["x-ttft-slo"] = fmt.Sprintf("%f", ttftSLO)
 	}
@@ -385,7 +385,7 @@ func TestSloContextStoreEviction(t *testing.T) {
 
 	req := &fwksched.InferenceRequest{
 		Headers: map[string]string{
-			reqcommon.RequestIdHeaderKey: requestID,
+			reqcommon.RequestIDHeaderKey: requestID,
 		},
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
@@ -178,7 +178,7 @@ func TestValidatePrediction_PrefillEndpointNeutralizeTPOT(t *testing.T) {
 
 	// Simulate the fix logic from generatePredictions
 	if config.EndpointRoleLabel != "" && prefillEp.GetMetadata().Labels != nil {
-		if prefillEp.GetMetadata().Labels[config.EndpointRoleLabel] == Experimental_DefaultPrefillProfile {
+		if prefillEp.GetMetadata().Labels[config.EndpointRoleLabel] == ExperimentalDefaultPrefillProfile {
 			predResult.TPOTValid = true
 			predResult.Headroom = 0
 			predResult.IsValid = predResult.TTFTValid
@@ -198,7 +198,7 @@ func TestValidatePrediction_PrefillEndpointNeutralizeTPOT(t *testing.T) {
 		Headroom:  -969,
 	}
 	if config.EndpointRoleLabel != "" && decodeEp.GetMetadata().Labels != nil {
-		if decodeEp.GetMetadata().Labels[config.EndpointRoleLabel] == Experimental_DefaultPrefillProfile {
+		if decodeEp.GetMetadata().Labels[config.EndpointRoleLabel] == ExperimentalDefaultPrefillProfile {
 			decodeResult.TPOTValid = true
 			decodeResult.Headroom = 0
 			decodeResult.IsValid = decodeResult.TTFTValid

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -62,20 +62,20 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 		Namespace: targetMetadata.NamespacedName.Namespace,
 	}
 
-	logger.V(logutil.TRACE).Info("request ID for SLO tracking", "requestID", request.Headers[reqcommon.RequestIdHeaderKey], "endpointName", endpointName)
-	if request.Headers[reqcommon.RequestIdHeaderKey] == "" {
+	logger.V(logutil.TRACE).Info("request ID for SLO tracking", "requestID", request.Headers[reqcommon.RequestIDHeaderKey], "endpointName", endpointName)
+	if request.Headers[reqcommon.RequestIDHeaderKey] == "" {
 		logger.V(logutil.DEBUG).Error(errors.New("missing request ID"), "PredictedLatency.PreRequest: Request is missing request ID header")
 		return
 	}
 
-	id := request.Headers[reqcommon.RequestIdHeaderKey]
+	id := request.Headers[reqcommon.RequestIDHeaderKey]
 
 	actual, _ := t.runningRequestLists.LoadOrStore(endpointName, newRequestPriorityQueue())
 	endpointRequestList := actual.(*requestPriorityQueue)
 
 	predictedLatencyCtx, err := t.getPredictedLatencyContextForRequest(request)
 	if err != nil {
-		id := request.Headers[reqcommon.RequestIdHeaderKey]
+		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: Failed to get SLO context for request", "error", err, "requestID", id)
 		return
 	}
@@ -86,7 +86,7 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	}
 
 	predictedLatencyCtx.targetMetadata = targetMetadata
-	if prefillResult, exists := schedulingResult.ProfileResults[Experimental_DefaultPrefillProfile]; exists && prefillResult != nil && len(prefillResult.TargetEndpoints) > 0 {
+	if prefillResult, exists := schedulingResult.ProfileResults[ExperimentalDefaultPrefillProfile]; exists && prefillResult != nil && len(prefillResult.TargetEndpoints) > 0 {
 		prefillMetadata := prefillResult.TargetEndpoints[0].GetMetadata()
 		predictedLatencyCtx.prefillTargetMetadata = prefillMetadata
 		logger.V(logutil.DEBUG).Info("Prefill target identified for request", "requestID", id, "prefillEndpoint", prefillMetadata.NamespacedName.String())
@@ -132,7 +132,7 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 	now := time.Now()
 	predictedLatencyCtx, err := t.getPredictedLatencyContextForRequest(request)
 	if err != nil {
-		id := request.Headers[reqcommon.RequestIdHeaderKey]
+		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: Failed to get SLO context", "error", err, "requestID", id)
 		return
 	}
@@ -215,7 +215,7 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 			t.decrementEndpointCounter(&t.prefillTokensInFlight, decodePodKey, int64(predictedLatencyCtx.inputTokenCount))
 		}
 
-		id := request.Headers[reqcommon.RequestIdHeaderKey]
+		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		t.removeRequestFromQueue(id, predictedLatencyCtx)
 		t.deletePredictedLatencyContextForRequest(request)
 	}
@@ -268,7 +268,7 @@ func processFirstTokenForLatencyPrediction(
 	predictedLatencyCtx.generatedTokenCount = 1
 
 	if prefillTargetMetadata := predictedLatencyCtx.prefillTargetMetadata; prefillTargetMetadata != nil {
-		prefillMetrics, err := getLatestMetricsForProfile(predictedLatencyCtx, Experimental_DefaultPrefillProfile)
+		prefillMetrics, err := getLatestMetricsForProfile(predictedLatencyCtx, ExperimentalDefaultPrefillProfile)
 		if err == nil {
 			prefillPrefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[prefillTargetMetadata.NamespacedName.Name]
 			logger.V(logutil.DEBUG).Info("Recording prefill TTFT training data",
@@ -300,7 +300,7 @@ func processFirstTokenForLatencyPrediction(
 func initializeSampler(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, samplingMean float64, maxDecodeTokenSamplesForPrediction int) {
 	if predictedLatencyCtx.decodeTokenSampler == nil {
 		logger := log.FromContext(ctx)
-		requestID := predictedLatencyCtx.schedulingRequest.Headers[reqcommon.RequestIdHeaderKey]
+		requestID := predictedLatencyCtx.schedulingRequest.Headers[reqcommon.RequestIDHeaderKey]
 		predictedLatencyCtx.decodeTokenSampler = newDecodeTokenSampler(requestID, samplingMean, maxDecodeTokenSamplesForPrediction)
 		logger.V(logutil.DEBUG).Info("Initialized token sampler for first token", "request_id", requestID, "next_prediction_token", predictedLatencyCtx.decodeTokenSampler.getNextSampleToken())
 	}
@@ -334,7 +334,7 @@ func processTokenForLatencyPrediction(
 	logger := log.FromContext(ctx)
 
 	if predictedLatencyCtx.decodeTokenSampler == nil {
-		requestID := predictedLatencyCtx.schedulingRequest.Headers[reqcommon.RequestIdHeaderKey]
+		requestID := predictedLatencyCtx.schedulingRequest.Headers[reqcommon.RequestIDHeaderKey]
 		predictedLatencyCtx.decodeTokenSampler = newDecodeTokenSampler(requestID, samplingMean, maxDecodeTokenSamplesForPrediction)
 		logger.V(logutil.DEBUG).Info("Initialized token sampler for subsequent tokens", "request_id", requestID, "next_prediction_token", predictedLatencyCtx.decodeTokenSampler.getNextSampleToken())
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -90,7 +90,7 @@ func TestNewPredictedLatencyContext(t *testing.T) {
 
 func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
 	request := &schedulingtypes.InferenceRequest{
-		Headers: map[string]string{reqcommon.RequestIdHeaderKey: "test-nil-body"},
+		Headers: map[string]string{reqcommon.RequestIDHeaderKey: "test-nil-body"},
 		Body:    nil,
 	}
 	ctx := newPredictedLatencyContext(request)
@@ -381,7 +381,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FirstToken(t *testing.T) {
 
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
 
 	beforeTime := time.Now()
@@ -468,7 +468,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SubsequentTokens(t *testing
 
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
@@ -534,7 +534,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_Success(t *testi
 	// Create queue and add request
 	queue := newRequestPriorityQueue()
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 	predictedLatencyCtx.ttft = 80
@@ -624,7 +624,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_WithMetrics(t *t
 	// Create queue
 	queue := newRequestPriorityQueue()
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 	predictedLatencyCtx.ttft = 80
@@ -657,7 +657,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoSLOs(t *testin
 	// Create queue
 	queue := newRequestPriorityQueue()
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 0)
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 	predictedLatencyCtx.ttft = 80
@@ -696,7 +696,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken(t *testing.T) {
 
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
@@ -729,7 +729,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SingleChunk(t *testing.T) {
 
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
@@ -762,7 +762,7 @@ func TestPredictedLatency_NonStreamingMode_ResponseBody_FinalToken(t *testing.T)
 
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
@@ -842,7 +842,7 @@ func TestPredictedLatency_ResponseBody_NoOrphanDecrement_WhenPreRequestSkipped(t
 	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 
 	queue := newRequestPriorityQueue()
-	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
 
 	decodePodKey := endpoint.GetMetadata().NamespacedName.String()

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -213,7 +213,7 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 			conv.Content.Structured = append(conv.Content.Structured, tokenizerTypes.ContentBlock{
 				Type:     block.Type,
 				Text:     block.Text,
-				ImageURL: tokenizerTypes.ImageBlock{URL: block.ImageURL.Url},
+				ImageURL: tokenizerTypes.ImageBlock{URL: block.ImageURL.URL},
 			})
 		}
 		conversation = append(conversation, conv)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_scorer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_scorer_test.go
@@ -66,13 +66,13 @@ func TestTokenizerScorer_Score(t *testing.T) {
 	}{
 		{
 			name:    "skips nil body",
-			request: &scheduling.InferenceRequest{RequestId: "nil-body", Body: nil},
+			request: &scheduling.InferenceRequest{RequestID: "nil-body", Body: nil},
 			wantNil: true,
 		},
 		{
 			name: "skips unsupported request type",
 			request: &scheduling.InferenceRequest{
-				RequestId: "unsupported",
+				RequestID: "unsupported",
 				Body:      &fwkrh.InferenceRequestBody{},
 			},
 			wantNil: true,
@@ -80,7 +80,7 @@ func TestTokenizerScorer_Score(t *testing.T) {
 		{
 			name: "tokenizes completions and writes to CycleState",
 			request: &scheduling.InferenceRequest{
-				RequestId: "completions",
+				RequestID: "completions",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{Raw: "The quick brown fox"},
@@ -93,7 +93,7 @@ func TestTokenizerScorer_Score(t *testing.T) {
 		{
 			name: "tokenizes chat completions and writes to CycleState",
 			request: &scheduling.InferenceRequest{
-				RequestId: "chat",
+				RequestID: "chat",
 				Body: &fwkrh.InferenceRequestBody{
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
 						Messages: []fwkrh.Message{
@@ -108,7 +108,7 @@ func TestTokenizerScorer_Score(t *testing.T) {
 		{
 			name: "fail-open on tokenization error",
 			request: &scheduling.InferenceRequest{
-				RequestId: "fail-open",
+				RequestID: "fail-open",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "fail"}},
 				},
@@ -168,7 +168,7 @@ func TestTokenizerScorer_SkipsWhenAlreadyInCycleState(t *testing.T) {
 	p := newTestPlugin(tok)
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "already-tokenized",
+		RequestID: "already-tokenized",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "hello"}},
 		},
@@ -203,7 +203,7 @@ func TestTokenizerScorer_RenderChat_WritesMMFeaturesToCycleState(t *testing.T) {
 	cycleState := scheduling.NewCycleState()
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "mm-chat",
+		RequestID: "mm-chat",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
 				Messages: []fwkrh.Message{
@@ -242,7 +242,7 @@ func TestTokenizerScorer_RenderChat_ForwardsStructuredContent(t *testing.T) {
 	cycleState := scheduling.NewCycleState()
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "mm-structured",
+		RequestID: "mm-structured",
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
 				Messages: []fwkrh.Message{
@@ -250,7 +250,7 @@ func TestTokenizerScorer_RenderChat_ForwardsStructuredContent(t *testing.T) {
 					{Role: "user", Content: fwkrh.Content{
 						Structured: []fwkrh.ContentBlock{
 							{Type: "text", Text: "Describe this image"},
-							{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "data:image/png;base64,abc"}},
+							{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "data:image/png;base64,abc"}},
 						},
 					}},
 				},
@@ -291,7 +291,7 @@ func TestTokenizerScorer_Render_NilMMFeatures(t *testing.T) {
 	cycleState := scheduling.NewCycleState()
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "text-completions",
+		RequestID: "text-completions",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "hello"}},
 		},

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -137,7 +137,7 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 				{Role: "user", Content: fwkrh.Content{
 					Structured: []fwkrh.ContentBlock{
 						{Type: "text", Text: "Describe this image"},
-						{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "data:image/png;base64,abc123"}},
+						{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "data:image/png;base64,abc123"}},
 					},
 				}},
 			},
@@ -157,8 +157,8 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 				{Role: "user", Content: fwkrh.Content{
 					Structured: []fwkrh.ContentBlock{
 						{Type: "text", Text: "Compare these two images"},
-						{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "data:image/png;base64,img1"}},
-						{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "data:image/png;base64,img2"}},
+						{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "data:image/png;base64,img1"}},
+						{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "data:image/png;base64,img2"}},
 					},
 				}},
 			},
@@ -179,7 +179,7 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 				{Role: "user", Content: fwkrh.Content{
 					Structured: []fwkrh.ContentBlock{
 						{Type: "text", Text: "What is in this image?"},
-						{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "https://example.com/img.jpg"}},
+						{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://example.com/img.jpg"}},
 					},
 				}},
 				{Role: "assistant", Content: fwkrh.Content{Raw: "I see a dog."}},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -205,7 +205,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 							Structured: []fwkrh.ContentBlock{
 								{
 									Type:     "image_url",
-									ImageURL: fwkrh.ImageBlock{Url: "https://example.com/images/dui.jpg."},
+									ImageURL: fwkrh.ImageBlock{URL: "https://example.com/images/dui.jpg."},
 								},
 							},
 						}},
@@ -274,7 +274,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 								},
 								{
 									Type:     "video_url",
-									VideoURL: fwkrh.VideoBlock{Url: "https://example.com/video.mp4"},
+									VideoURL: fwkrh.VideoBlock{URL: "https://example.com/video.mp4"},
 								},
 							},
 						}},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -283,9 +283,9 @@ func parseGrpcPayload(data []byte) ([]byte, error) {
 func convertEmbedToInferenceRequestBody(pbReq *pb.EmbedRequest) (*fwkrh.InferenceRequestBody, error) {
 	var body *fwkrh.InferenceRequestBody
 	if pbReq.Tokenized != nil {
-		inputIds := pbReq.GetTokenized().InputIds
-		tokenIDs := make([]uint32, len(inputIds))
-		copy(tokenIDs, inputIds)
+		inputIDs := pbReq.GetTokenized().InputIds
+		tokenIDs := make([]uint32, len(inputIDs))
+		copy(tokenIDs, inputIDs)
 		body = &fwkrh.InferenceRequestBody{
 			Embeddings: &fwkrh.EmbeddingsRequest{
 				Input: fwkrh.EmbeddingsInput{

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
@@ -105,7 +105,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.Inf
 	if request.TargetModel != "" {
 		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
 	}
-	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
+	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
 
 	// Prefill header
 	delete(request.Headers, routing.PrefillEndpointHeader) // clear header, if already set

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
@@ -144,7 +144,7 @@ func TestPreRequestNilSchedulingResult(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 
@@ -173,7 +173,7 @@ func TestPrefillHeaderHandlerBackwardCompat(t *testing.T) {
 	// Verify it correctly handles a PD-only scheduling result
 	ctx := utils.NewTestContext(t)
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 	result := &scheduling.SchedulingResult{
@@ -198,7 +198,7 @@ func TestPreRequestPrefillProfileExists(t *testing.T) {
 
 	request := &scheduling.InferenceRequest{
 		TargetModel: "test-model",
-		RequestId:   "req-123",
+		RequestID:   "req-123",
 		Headers:     map[string]string{},
 	}
 
@@ -315,7 +315,7 @@ func TestPreRequestPrefillProfileNilResult(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 
@@ -338,7 +338,7 @@ func TestPreRequestPrefillEmptyTargetEndpoints(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 
@@ -388,7 +388,7 @@ func TestPreRequestEncodeProfileExists(t *testing.T) {
 
 	request := &scheduling.InferenceRequest{
 		TargetModel: "test-model",
-		RequestId:   "req-123",
+		RequestID:   "req-123",
 		Headers:     map[string]string{},
 	}
 
@@ -413,7 +413,7 @@ func TestPreRequestEncodeProfileNotExists(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 
@@ -433,7 +433,7 @@ func TestPreRequestEncodeClearsExistingHeader(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers: map[string]string{
 			routing.EncoderEndpointsHeader: "old-host:9999",
 		},
@@ -460,7 +460,7 @@ func TestPreRequestEncodeClearsHeaderWhenNoEncodeResult(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers: map[string]string{
 			routing.EncoderEndpointsHeader: "stale-host:9999",
 		},
@@ -482,7 +482,7 @@ func TestPreRequestEncodeCustomProfile(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "my-custom-encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 
@@ -507,7 +507,7 @@ func TestPreRequestEncodeIPv6Address(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 
@@ -534,7 +534,7 @@ func TestPreRequestEncodeProfileNilResult(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 
@@ -557,7 +557,7 @@ func TestPreRequestEncodeEmptyTargetEndpoints(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers: map[string]string{
 			routing.EncoderEndpointsHeader: "stale-host:9999",
 		},
@@ -582,7 +582,7 @@ func TestPreRequestEncodeMultipleEndpoints(t *testing.T) {
 	handler := NewHeadersHandler("prefill", "encode").WithName("test")
 
 	request := &scheduling.InferenceRequest{
-		RequestId: "req-123",
+		RequestID: "req-123",
 		Headers:   map[string]string{},
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -252,7 +252,7 @@ func (h *Handler) Pick(ctx context.Context, _ *scheduling.CycleState, request *s
 	if request.TargetModel != "" {
 		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
 	}
-	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
+	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
 
 	// ── Stage 1: Decode ────────────────────────────────────────────────────
 	if _, executed := profileResults[h.decodeProfile]; !executed {

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -77,7 +77,7 @@ func completionsRequest(prompt string) *scheduling.InferenceRequest {
 func chatRequest(hasImage, hasVideo, hasAudio bool) *scheduling.InferenceRequest {
 	blocks := []fwkrh.ContentBlock{{Type: "text", Text: "describe this"}}
 	if hasImage {
-		blocks = append(blocks, fwkrh.ContentBlock{Type: "image_url", ImageURL: fwkrh.ImageBlock{Url: "https://example.com/img.jpg"}})
+		blocks = append(blocks, fwkrh.ContentBlock{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://example.com/img.jpg"}})
 	}
 	if hasVideo {
 		blocks = append(blocks, fwkrh.ContentBlock{Type: "video_url"})

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -166,8 +166,8 @@ func (h *PdProfileHandler) Pick(ctx context.Context, _ *scheduling.CycleState, r
 		if request.TargetModel != "" {
 			span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
 		}
-		if request.RequestId != "" {
-			span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
+		if request.RequestID != "" {
+			span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
 		}
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
@@ -104,7 +104,7 @@ func TestPDSchedule(t *testing.T) {
 		{
 			name: "no candidate endpoints",
 			req: &fwkschd.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "any-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -118,7 +118,7 @@ func TestPDSchedule(t *testing.T) {
 		{
 			name: "one decode endpoint, long prompt",
 			req: &fwkschd.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -133,7 +133,7 @@ func TestPDSchedule(t *testing.T) {
 		{
 			name: "one prefill endpoint, long prompt",
 			req: &fwkschd.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -148,7 +148,7 @@ func TestPDSchedule(t *testing.T) {
 		{
 			name: "1P1D - long prompt",
 			req: &fwkschd.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -164,7 +164,7 @@ func TestPDSchedule(t *testing.T) {
 		{
 			name: "1P1Dshort",
 			req: &fwkschd.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -181,7 +181,7 @@ func TestPDSchedule(t *testing.T) {
 		{
 			name: "TestRolesWithNoDecode",
 			req: &fwkschd.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -213,7 +213,7 @@ func TestPDSchedule(t *testing.T) {
 		{
 			name: "1P2D - long prompt",
 			req: &fwkschd.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -251,14 +251,14 @@ func (s *ActiveRequest) PreRequest(
 		s.incrementPodCount(endpointName)
 		traceLogger.Info(
 			"Added request to cache",
-			"requestId", request.RequestId,
+			"requestId", request.RequestID,
 			"endpointName", endpointName,
 			"profileName", profileName,
 		)
 	}
 
 	// add to request cache
-	s.requestCache.Set(request.RequestId, &requestEntry{PodNames: endpointNames, RequestID: request.RequestId}, 0) // Use default TTL
+	s.requestCache.Set(request.RequestID, &requestEntry{PodNames: endpointNames, RequestID: request.RequestID}, 0) // Use default TTL
 }
 
 // ResponseBody is called after a response is sent to the client.
@@ -280,7 +280,7 @@ func (s *ActiveRequest) ResponseBody(
 		return
 	}
 
-	if item, found := s.requestCache.GetAndDelete(request.RequestId); found {
+	if item, found := s.requestCache.GetAndDelete(request.RequestID); found {
 		entry := item.Value()
 		if entry != nil {
 			for _, endpointName := range entry.PodNames {
@@ -288,10 +288,10 @@ func (s *ActiveRequest) ResponseBody(
 			}
 			traceLogger.Info("Removed request from cache", "requestEntry", entry.String())
 		} else {
-			traceLogger.Info("Request entry value is nil", "requestId", request.RequestId)
+			traceLogger.Info("Request entry value is nil", "requestId", request.RequestID)
 		}
 	} else {
-		traceLogger.Info("Request not found in cache", "requestId", request.RequestId)
+		traceLogger.Info("Request not found in cache", "requestId", request.RequestID)
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -28,7 +28,7 @@ func newTestEndpoint(name string, queueSize int) scheduling.Endpoint {
 
 func newTestRequest(id string) *scheduling.InferenceRequest {
 	return &scheduling.InferenceRequest{
-		RequestId: id,
+		RequestID: id,
 	}
 }
 
@@ -145,7 +145,7 @@ func TestActiveRequestScorer_PreRequest(t *testing.T) {
 
 		scorer.PreRequest(ctx, request, schedulingResult)
 
-		assert.True(t, scorer.requestCache.Has(request.RequestId), "Expected request to be in cache")
+		assert.True(t, scorer.requestCache.Has(request.RequestID), "Expected request to be in cache")
 		assert.Equal(t, 1, scorer.getPodCount(endpointA.GetMetadata().NamespacedName.String()))
 	})
 
@@ -158,7 +158,7 @@ func TestActiveRequestScorer_PreRequest(t *testing.T) {
 
 		scorer.PreRequest(ctx, request, schedulingResult)
 
-		assert.True(t, scorer.requestCache.Has(request.RequestId), "Expected request to be in cache")
+		assert.True(t, scorer.requestCache.Has(request.RequestID), "Expected request to be in cache")
 		assert.Equal(t, 2, scorer.getPodCount(endpointA.GetMetadata().NamespacedName.String()))
 		assert.Equal(t, 1, scorer.getPodCount(endpointB.GetMetadata().NamespacedName.String()))
 	})
@@ -204,7 +204,7 @@ func TestActiveRequestScorer_ResponseBody(t *testing.T) {
 
 			scorer.ResponseBody(ctx, request, &requestcontrol.Response{EndOfStream: tt.endOfStream}, endpointA.GetMetadata())
 
-			assert.Equal(t, tt.wantInCache, scorer.requestCache.Has(request.RequestId))
+			assert.Equal(t, tt.wantInCache, scorer.requestCache.Has(request.RequestID))
 			assert.Equal(t, tt.wantHasPodCount, scorer.hasPodCount(endpointA.GetMetadata().NamespacedName.String()))
 			if tt.wantHasPodCount {
 				assert.Equal(t, tt.wantPodCount, scorer.getPodCount(endpointA.GetMetadata().NamespacedName.String()))

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -32,7 +32,7 @@ func createEndpoint(nsn k8stypes.NamespacedName, ipaddr string, labels map[strin
 
 func createRequest() *scheduling.InferenceRequest {
 	return &scheduling.InferenceRequest{
-		RequestId: "test-request",
+		RequestID: "test-request",
 	}
 }
 
@@ -275,7 +275,7 @@ func TestContextLengthAwareWithTokenizedPromptInCycleState(t *testing.T) {
 	})
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-request",
+		RequestID:   "test-request",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -311,7 +311,7 @@ func TestContextLengthAwareFallbackWithoutTokenizedPrompt(t *testing.T) {
 	plugin := NewContextLengthAware("test-fallback", params)
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-request",
+		RequestID:   "test-request",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -263,7 +263,7 @@ func (s *NoHitLRU) Score(ctx context.Context, cycleState *scheduling.CycleState,
 
 	// Store the cold request state in plugin state for PreRequest to use
 	coldState := &coldRequestState{isCold: isCold}
-	s.pluginState.Write(request.RequestId, plugin.StateKey(s.typedName.String()), coldState)
+	s.pluginState.Write(request.RequestID, plugin.StateKey(s.typedName.String()), coldState)
 
 	if !isCold {
 		logger.Info("Cache hit detected, returning neutral scores")
@@ -285,9 +285,9 @@ func (s *NoHitLRU) PreRequest(ctx context.Context, request *scheduling.Inference
 	}
 
 	// Read the cold request state we stored in Score
-	coldState, err := plugin.ReadPluginStateKey[*coldRequestState](s.pluginState, request.RequestId, plugin.StateKey(s.typedName.String()))
+	coldState, err := plugin.ReadPluginStateKey[*coldRequestState](s.pluginState, request.RequestID, plugin.StateKey(s.typedName.String()))
 	// After fetching the cold state, drop it from the plugin state immediately (otherwise it will hang around until it becomes stale).
-	s.pluginState.Delete(request.RequestId)
+	s.pluginState.Delete(request.RequestID)
 
 	if err != nil {
 		logger.Info("No cold request state found, treating as non-cold request", "error", err)
@@ -317,5 +317,5 @@ func (s *NoHitLRU) moveTargetPodToFront(ctx context.Context, request *scheduling
 	var present struct{} // dummy value
 	s.lruCache.Add(endpointName, present)
 
-	logger.Info("Updated LRU cache for cold request", "profile", profileName, "endpoint", endpointName, "requestId", request.RequestId)
+	logger.Info("Updated LRU cache for cold request", "profile", profileName, "endpoint", endpointName, "requestId", request.RequestID)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -298,7 +298,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 
 	assertHighestScoredPod := func(expectedEndpoint scheduling.Endpoint, testName string) {
 		t.Helper()
-		coldReq := &scheduling.InferenceRequest{RequestId: testName + "-scoring-check"}
+		coldReq := &scheduling.InferenceRequest{RequestID: testName + "-scoring-check"}
 		scores := scorer.Score(ctx, &scheduling.CycleState{}, coldReq, endpoints)
 
 		highestScore := -1.0
@@ -320,14 +320,14 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	}
 
 	t.Run("initial cold request seeds cache", func(_ *testing.T) {
-		coldReqA := &scheduling.InferenceRequest{RequestId: "cold-1"}
+		coldReqA := &scheduling.InferenceRequest{RequestID: "cold-1"}
 		scorer.Score(ctx, &scheduling.CycleState{}, coldReqA, endpoints)
 		scorer.PreRequest(ctx, coldReqA, requestToEndpoint(endpointA))
 		assertHighestScoredPod(endpointB, "after-endpointA-used")
 	})
 
 	t.Run("unused endpoints rank above existing ones", func(t *testing.T) {
-		coldReqCheck := &scheduling.InferenceRequest{RequestId: "cold-check"}
+		coldReqCheck := &scheduling.InferenceRequest{RequestID: "cold-check"}
 		coldScores := scorer.Score(ctx, &scheduling.CycleState{}, coldReqCheck, endpoints)
 		if coldScores[endpointB] <= coldScores[endpointA] {
 			t.Fatalf("expected endpoint-b to outrank endpoint-a after endpoint-a handled previous cold request, scores=%+v", coldScores)
@@ -341,7 +341,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	})
 
 	t.Run("warm request leaves LRU untouched", func(t *testing.T) {
-		warmReq := &scheduling.InferenceRequest{RequestId: "warm-1"}
+		warmReq := &scheduling.InferenceRequest{RequestID: "warm-1"}
 		warmScores := scorer.Score(ctx, &scheduling.CycleState{}, warmReq, warmEndpoints())
 		for _, score := range warmScores {
 			if score != 0.5 {
@@ -349,7 +349,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 			}
 		}
 		scorer.PreRequest(ctx, warmReq, requestToEndpoint(endpointB))
-		postWarmReq := &scheduling.InferenceRequest{RequestId: "cold-after-warm"}
+		postWarmReq := &scheduling.InferenceRequest{RequestID: "cold-after-warm"}
 		postWarmScores := scorer.Score(ctx, &scheduling.CycleState{}, postWarmReq, endpoints)
 		if postWarmScores[endpointB] <= postWarmScores[endpointA] {
 			t.Fatalf("expected warm request to leave ordering unchanged, scores=%+v", postWarmScores)
@@ -357,14 +357,14 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	})
 
 	t.Run("second cold request rotates to endpointB", func(_ *testing.T) {
-		coldReqB := &scheduling.InferenceRequest{RequestId: "cold-2"}
+		coldReqB := &scheduling.InferenceRequest{RequestID: "cold-2"}
 		scorer.Score(ctx, &scheduling.CycleState{}, coldReqB, endpoints)
 		scorer.PreRequest(ctx, coldReqB, requestToEndpoint(endpointB))
 		assertHighestScoredPod(endpointC, "after-endpointB-used")
 	})
 
 	t.Run("third cold request rotates back to endpointA", func(_ *testing.T) {
-		coldReqC := &scheduling.InferenceRequest{RequestId: "cold-3"}
+		coldReqC := &scheduling.InferenceRequest{RequestID: "cold-3"}
 		scorer.Score(ctx, &scheduling.CycleState{}, coldReqC, endpoints)
 		scorer.PreRequest(ctx, coldReqC, requestToEndpoint(endpointC))
 		assertHighestScoredPod(endpointA, "after-endpointC-used")
@@ -420,7 +420,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 		scorer := nohitlru.NewNoHitLRU(ctx, nil)
 
 		// First cold request with P/D (no attributes = cold).
-		req1 := &scheduling.InferenceRequest{RequestId: "pd-request-1"}
+		req1 := &scheduling.InferenceRequest{RequestID: "pd-request-1"}
 		scorer.Score(ctx, &scheduling.CycleState{}, req1, append(prefillEndpoints, decodeEndpoints...))
 
 		pdResult := &scheduling.SchedulingResult{
@@ -436,7 +436,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 		}
 		scorer.PreRequest(ctx, req1, pdResult)
 
-		req2 := &scheduling.InferenceRequest{RequestId: "pd-request-2"}
+		req2 := &scheduling.InferenceRequest{RequestID: "pd-request-2"}
 		prefillScores := scorer.Score(ctx, &scheduling.CycleState{}, req2, prefillEndpoints)
 		decodeScores := scorer.Score(ctx, &scheduling.CycleState{}, req2, decodeEndpoints)
 
@@ -450,7 +450,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 	})
 
 	t.Run("non-P/D scenario - only primary profile exists", func(t *testing.T) {
-		req := &scheduling.InferenceRequest{RequestId: "non-pd-request"}
+		req := &scheduling.InferenceRequest{RequestID: "non-pd-request"}
 		scorer := nohitlru.NewNoHitLRU(ctx, nil)
 		scorer.Score(ctx, &scheduling.CycleState{}, req, decodeEndpoints)
 
@@ -464,7 +464,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 		}
 		scorer.PreRequest(ctx, req, result)
 
-		req2 := &scheduling.InferenceRequest{RequestId: "non-pd-request-2"}
+		req2 := &scheduling.InferenceRequest{RequestID: "non-pd-request-2"}
 		scores := scorer.Score(ctx, &scheduling.CycleState{}, req2, decodeEndpoints)
 
 		if scores[decodeEndpointB] <= scores[decodeEndpointA] {
@@ -473,14 +473,14 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 	})
 
 	t.Run("nil scheduling result - graceful handling", func(_ *testing.T) {
-		req := &scheduling.InferenceRequest{RequestId: "nil-result"}
+		req := &scheduling.InferenceRequest{RequestID: "nil-result"}
 		scorer := nohitlru.NewNoHitLRU(ctx, nil)
 		scorer.Score(ctx, &scheduling.CycleState{}, req, decodeEndpoints)
 		scorer.PreRequest(ctx, req, nil)
 	})
 
 	t.Run("empty profile results - graceful handling", func(_ *testing.T) {
-		req := &scheduling.InferenceRequest{RequestId: "empty-results"}
+		req := &scheduling.InferenceRequest{RequestID: "empty-results"}
 		scorer := nohitlru.NewNoHitLRU(ctx, nil)
 		scorer.Score(ctx, &scheduling.CycleState{}, req, decodeEndpoints)
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -395,7 +395,7 @@ func (s *Scorer) PrepareRequestData(ctx context.Context,
 	}
 
 	// 6. Save to PluginState for Score() and PreRequest()
-	s.pluginState.Write(request.RequestId, stateKey, &precisePluginState{
+	s.pluginState.Write(request.RequestID, stateKey, &precisePluginState{
 		blockKeys: blockKeys,
 		scores:    scores,
 	})
@@ -449,14 +449,14 @@ func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, r
 	if request.TargetModel != "" {
 		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
 	}
-	if request.RequestId != "" {
-		span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestId))
+	if request.RequestID != "" {
+		span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
 	}
 
 	// Try to reuse pre-computed scores from PrepareRequestData
 	var scores map[string]float64
 	if pluginStateData, err := plugin.ReadPluginStateKey[*precisePluginState](
-		s.pluginState, request.RequestId, stateKey); err == nil {
+		s.pluginState, request.RequestID, stateKey); err == nil {
 		scores = pluginStateData.scores
 		debugLogger.Info("Reusing pre-computed scores from PrepareRequestData")
 	} else {
@@ -540,13 +540,13 @@ func (s *Scorer) PreRequest(ctx context.Context,
 
 	// 1. Read block keys from PluginState
 	state, err := plugin.ReadPluginStateKey[*precisePluginState](
-		s.pluginState, request.RequestId, stateKey)
+		s.pluginState, request.RequestID, stateKey)
 	if err != nil {
 		logger.V(logging.TRACE).Info("No plugin state found for PreRequest, skipping speculative indexing",
-			"requestID", request.RequestId)
+			"requestID", request.RequestID)
 		return
 	}
-	s.pluginState.Delete(request.RequestId)
+	s.pluginState.Delete(request.RequestID)
 
 	if len(state.blockKeys) == 0 {
 		return
@@ -591,13 +591,13 @@ func (s *Scorer) PreRequest(ctx context.Context,
 	}
 
 	// 5. Register in TTL cache for automatic eviction
-	s.speculativeCache.Set(request.RequestId, &speculativeEntries{
+	s.speculativeCache.Set(request.RequestID, &speculativeEntries{
 		blockKeys:  state.blockKeys,
 		podEntries: allPodEntries,
 	}, s.speculativeTTL)
 
 	logger.V(logging.TRACE).Info("Added speculative entries",
-		"requestID", request.RequestId,
+		"requestID", request.RequestID,
 		"pod", speculativePod.PodIdentifier,
 		"blockKeys", len(state.blockKeys),
 		"ttl", s.speculativeTTL)

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_tokenized_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_tokenized_test.go
@@ -108,7 +108,7 @@ func TestScorer_UsesTokenizedPrompt(t *testing.T) {
 	})
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-tokenized",
+		RequestID:   "test-tokenized",
 		TargetModel: "test-model",
 	}
 
@@ -152,7 +152,7 @@ func TestScorer_PassesExtraFeaturesToScoreTokens(t *testing.T) {
 	})
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-mm",
+		RequestID:   "test-mm",
 		TargetModel: "test-model",
 	}
 
@@ -188,7 +188,7 @@ func TestScorer_NilExtraFeaturesForTextOnly(t *testing.T) {
 	})
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-text-only",
+		RequestID:   "test-text-only",
 		TargetModel: "test-model",
 	}
 
@@ -224,7 +224,7 @@ func TestScorer_SkipsTokenizedPromptWhenEmpty(t *testing.T) {
 	})
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-skip-empty",
+		RequestID:   "test-skip-empty",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "hello"}},

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_uds_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_uds_test.go
@@ -85,7 +85,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body:        nil,
 			},
@@ -129,7 +129,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -204,7 +204,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -314,7 +314,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -385,7 +385,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -459,7 +459,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -507,7 +507,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -834,7 +834,7 @@ func TestMMPipeline_ScoreTokensWithExtraFeatures_UDS(t *testing.T) {
 	})
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-mm-e2e",
+		RequestID:   "test-mm-e2e",
 		TargetModel: mmModelName,
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -96,7 +96,7 @@ func (s *SessionAffinity) ResponseBody(ctx context.Context, _ *scheduling.Infere
 	if response == nil || targetPod == nil {
 		reqID := "undefined"
 		if response != nil {
-			reqID = response.RequestId
+			reqID = response.RequestID
 		}
 		log.FromContext(ctx).V(logutil.DEBUG).Info("Session affinity scorer - skip post response because one of response, targetPod is nil", "req id", reqID)
 		return

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -113,25 +113,25 @@ func TestSessionAffinity_ResponseBody(t *testing.T) {
 	}{
 		{
 			name:            "standard case with existing headers map",
-			initialResponse: &requestcontrol.Response{RequestId: "req-1", Headers: make(map[string]string), EndOfStream: true},
+			initialResponse: &requestcontrol.Response{RequestID: "req-1", Headers: make(map[string]string), EndOfStream: true},
 			targetPod:       targetEndpoint,
 			wantHeaders:     map[string]string{"x-session-token": wantToken},
 		},
 		{
 			name:            "response with nil headers map",
-			initialResponse: &requestcontrol.Response{RequestId: "req-2", Headers: nil, EndOfStream: true},
+			initialResponse: &requestcontrol.Response{RequestID: "req-2", Headers: nil, EndOfStream: true},
 			targetPod:       targetEndpoint,
 			wantHeaders:     map[string]string{"x-session-token": wantToken},
 		},
 		{
 			name:            "nil targetPod should do nothing",
-			initialResponse: &requestcontrol.Response{RequestId: "req-3", Headers: make(map[string]string), EndOfStream: true},
+			initialResponse: &requestcontrol.Response{RequestID: "req-3", Headers: make(map[string]string), EndOfStream: true},
 			targetPod:       nil,
 			wantHeaders:     map[string]string{},
 		},
 		{
 			name:            "incomplete response should do nothing (EndOfStream=false)",
-			initialResponse: &requestcontrol.Response{RequestId: "req-4", Headers: make(map[string]string), EndOfStream: false},
+			initialResponse: &requestcontrol.Response{RequestID: "req-4", Headers: make(map[string]string), EndOfStream: false},
 			targetPod:       targetEndpoint,
 			wantHeaders:     map[string]string{},
 		},

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -291,15 +291,15 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
-			requestID := envoy.ExtractHeaderValue(v, reqcommon.RequestIdHeaderKey)
+			requestID := envoy.ExtractHeaderValue(v, reqcommon.RequestIDHeaderKey)
 			// request ID is a must for maintaining a state per request in plugins that hold internal state and use PluginState.
 			// if request id was not supplied as a header, we generate it ourselves.
 			if len(requestID) == 0 {
 				requestID = uuid.NewString()
 				loggerTrace.Info("RequestID header is not found in the request, generated a request id")
-				reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey] = requestID // update in headers so director can consume it
+				reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey] = requestID // update in headers so director can consume it
 			}
-			logger = logger.WithValues(reqcommon.RequestIdHeaderKey, requestID)
+			logger = logger.WithValues(reqcommon.RequestIDHeaderKey, requestID)
 			logger.V(logutil.DEFAULT).Info("EPP received request") // Request ID will be logged too as part of logger context values.
 			loggerTrace = logger.V(logutil.TRACE)
 			ctx = log.IntoContext(ctx, logger)
@@ -345,7 +345,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				// Setting evictCh from nil to a real channel dynamically enables the
 				// eviction case in the main select.
 				if s.evictionLookup != nil {
-					evictionRequestID = reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey]
+					evictionRequestID = reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey]
 					evictCh = s.evictionLookup.Get(evictionRequestID)
 				}
 
@@ -572,9 +572,8 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 		// Trailers in requests are not guaranteed
 		if err := srv.Send(r.respTrailerResp); err != nil {
 			return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
-		} else {
-			logger.V(logutil.DEBUG).Info("EPP sent trailer back to proxy")
 		}
+		logger.V(logutil.DEBUG).Info("EPP sent trailer back to proxy")
 	}
 	return nil
 }

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -627,14 +627,14 @@ func RecordRequestTPOTWithSLO(ctx context.Context, modelName, targetModelName st
 }
 
 // TPOT records duration of request.
-func RecordRequestPredictedTPOT(ctx context.Context, modelName, targetModelName string, predicted_tpot float64) bool {
-	if predicted_tpot < 0 {
+func RecordRequestPredictedTPOT(ctx context.Context, modelName, targetModelName string, predictedTpot float64) bool {
+	if predictedTpot < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "Predicted TPOT value must be non-negative",
-			"modelName", modelName, "targetModelName", targetModelName, "tpot", predicted_tpot)
+			"modelName", modelName, "targetModelName", targetModelName, "tpot", predictedTpot)
 		return false
 	}
-	requestPredictedTPOT.WithLabelValues(modelName, targetModelName).Observe(predicted_tpot)
-	inferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTPOT).Set(predicted_tpot)
+	requestPredictedTPOT.WithLabelValues(modelName, targetModelName).Observe(predictedTpot)
+	inferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTPOT).Set(predictedTpot)
 	return true
 }
 
@@ -686,14 +686,14 @@ func RecordRequestTTFTWithSLO(ctx context.Context, modelName, targetModelName st
 }
 
 // TPOT records duration of request.
-func RecordRequestPredictedTTFT(ctx context.Context, modelName, targetModelName string, predicted_ttft float64) bool {
-	if predicted_ttft < 0 {
+func RecordRequestPredictedTTFT(ctx context.Context, modelName, targetModelName string, predictedTtft float64) bool {
+	if predictedTtft < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "Predicted TTFT value must be non-negative",
-			"modelName", modelName, "targetModelName", targetModelName, "ttft", predicted_ttft)
+			"modelName", modelName, "targetModelName", targetModelName, "ttft", predictedTtft)
 		return false
 	}
-	requestPredictedTTFT.WithLabelValues(modelName, targetModelName).Observe(predicted_ttft)
-	inferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTTFT).Set(predicted_ttft)
+	requestPredictedTTFT.WithLabelValues(modelName, targetModelName).Observe(predictedTtft)
+	inferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTTFT).Set(predictedTtft)
 	return true
 }
 

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -73,7 +73,7 @@ func rejectIfSheddableAndSaturated(
 	if requtil.IsSheddable(priority) {
 		if sd.Saturation(ctx, endpointCandidates.Locate(ctx, reqCtx.Request.Metadata)) >= 1.0 {
 			logger.V(logutil.TRACE).Info("Request rejected: system saturated and request is sheddable",
-				"requestID", reqCtx.SchedulingRequest.RequestId)
+				"requestID", reqCtx.SchedulingRequest.RequestID)
 			return errcommon.Error{
 				Code: errcommon.ResourceExhausted,
 				Msg:  "system saturated, sheddable request dropped",
@@ -123,7 +123,7 @@ func (lac *LegacyAdmissionController) Admit(
 	); err != nil {
 		return err
 	}
-	logger.V(logutil.TRACE).Info("Request admitted", "requestID", reqCtx.SchedulingRequest.RequestId)
+	logger.V(logutil.TRACE).Info("Request admitted", "requestID", reqCtx.SchedulingRequest.RequestID)
 	return nil
 }
 
@@ -153,7 +153,7 @@ func (fcac *FlowControlAdmissionController) Admit(
 ) error {
 	logger := log.FromContext(ctx)
 	logger.V(logutil.TRACE).Info("Executing FlowControlAdmissionController",
-		"requestID", reqCtx.SchedulingRequest.RequestId, "priority", priority, "fairnessID", reqCtx.FairnessID)
+		"requestID", reqCtx.SchedulingRequest.RequestID, "priority", priority, "fairnessID", reqCtx.FairnessID)
 
 	fcReq := &flowControlRequest{
 		fairnessID:        reqCtx.FairnessID,
@@ -168,7 +168,7 @@ func (fcac *FlowControlAdmissionController) Admit(
 
 	outcome, err := fcac.flowController.EnqueueAndWait(ctx, fcReq)
 	logger.V(logutil.DEBUG).Info("Flow control outcome",
-		"requestID", reqCtx.SchedulingRequest.RequestId, "outcome", outcome, "error", err)
+		"requestID", reqCtx.SchedulingRequest.RequestID, "outcome", outcome, "error", err)
 	return translateFlowControlOutcome(outcome, err)
 }
 
@@ -190,7 +190,7 @@ func (r *flowControlRequest) ID() string {
 	if r.inferenceRequest == nil {
 		return ""
 	}
-	return r.inferenceRequest.RequestId
+	return r.inferenceRequest.RequestID
 }
 func (r *flowControlRequest) InitialEffectiveTTL() time.Duration { return 0 } // Use controller default.
 func (r *flowControlRequest) ByteSize() uint64                   { return r.requestByteSize }

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -69,7 +69,7 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 	t.Parallel()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	reqCtx := &handlers.RequestContext{
-		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestId: "test-req"},
+		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestID: "test-req"},
 		Request: &handlers.Request{
 			Metadata: map[string]any{},
 		},
@@ -180,7 +180,7 @@ func TestFlowControlRequestAdapter(t *testing.T) {
 				fairnessID:       tc.fairnessID,
 				priority:         tc.priority,
 				requestByteSize:  tc.requestByteSize,
-				inferenceRequest: &schedulingtypes.InferenceRequest{RequestId: tc.requestID},
+				inferenceRequest: &schedulingtypes.InferenceRequest{RequestID: tc.requestID},
 			}
 
 			assert.Equal(t, tc.requestID, fcReq.ID(), "ID() mismatch")
@@ -195,7 +195,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 	t.Parallel()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	reqCtx := &handlers.RequestContext{
-		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestId: "test-req"},
+		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestID: "test-req"},
 		Request: &handlers.Request{
 			Metadata: map[string]any{},
 		},

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -171,7 +171,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 
 	// Prepare InferenceRequest (needed for both saturation detection and Scheduler)
 	reqCtx.SchedulingRequest = &fwksched.InferenceRequest{
-		RequestId:        reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
+		RequestID:        reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
 		TargetModel:      reqCtx.TargetModelName,
 		Body:             inferenceRequestBody,
 		Headers:          reqCtx.Request.Headers,
@@ -354,7 +354,7 @@ func (d *Director) HandleResponseHeader(ctx context.Context, reqCtx *handlers.Re
 		return reqCtx
 	}
 	response := &fwk.Response{
-		RequestId:   reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
+		RequestID:   reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
 		Headers:     reqCtx.Response.Headers,
 		ReqMetadata: reqCtx.Request.Metadata,
 	}
@@ -383,18 +383,18 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 	startOfStream := !reqCtx.ResponseBodyStarted
 	reqCtx.ResponseBodyStarted = true
 	response := &fwk.Response{
-		RequestId:     reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
+		RequestID:     reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
 		Headers:       reqCtx.Response.Headers,
 		StartOfStream: startOfStream,
 		EndOfStream:   endOfStream,
 		Usage:         reqCtx.Usage,
 	}
-	requestId := reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey]
+	requestID := reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey]
 
 	if endOfStream {
 		// Drain the async queue: close the channel and wait for the goroutine to finish
 		// processing all previously queued chunks before running the final chunk synchronously.
-		if val, ok := d.responseBodyQueues.LoadAndDelete(requestId); ok {
+		if val, ok := d.responseBodyQueues.LoadAndDelete(requestID); ok {
 			q := val.(*responseBodyQueue)
 			close(q.ch)
 			<-q.done // wait for all queued chunks to be processed
@@ -410,14 +410,14 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 			response:       response,
 			targetEndpoint: reqCtx.TargetPod,
 		}
-		if val, ok := d.responseBodyQueues.Load(requestId); ok {
+		if val, ok := d.responseBodyQueues.Load(requestID); ok {
 			val.(*responseBodyQueue).ch <- work
 		} else {
 			q := &responseBodyQueue{
 				ch:   make(chan responseBodyWork, 100),
 				done: make(chan struct{}),
 			}
-			d.responseBodyQueues.Store(requestId, q)
+			d.responseBodyQueues.Store(requestID, q)
 			go d.processResponseBodyQueue(q)
 			q.ch <- work
 		}

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -771,7 +771,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				reqCtx := &handlers.RequestContext{
 					Request: &handlers.Request{
 						Headers: map[string]string{
-							reqcommon.RequestIdHeaderKey: "test-req-id-" + test.name, // Ensure a default request ID
+							reqcommon.RequestIDHeaderKey: "test-req-id-" + test.name, // Ensure a default request ID
 						},
 					},
 					ObjectiveKey:    test.inferenceObjectiveName,
@@ -1189,7 +1189,7 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 	reqCtx := &handlers.RequestContext{
 		Request: &handlers.Request{
 			Headers: map[string]string{
-				reqcommon.RequestIdHeaderKey: "test-req-id-for-response",
+				reqcommon.RequestIDHeaderKey: "test-req-id-for-response",
 			},
 		},
 		Response: &handlers.Response{ // Simulate some response headers
@@ -1201,7 +1201,7 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 
 	director.HandleResponseHeader(ctx, reqCtx)
 
-	if diff := cmp.Diff("test-req-id-for-response", pr1.lastRespOnResponse.RequestId); diff != "" {
+	if diff := cmp.Diff("test-req-id-for-response", pr1.lastRespOnResponse.RequestID); diff != "" {
 		t.Errorf("Scheduler.OnResponse RequestId mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(reqCtx.Response.Headers, pr1.lastRespOnResponse.Headers); diff != "" {
@@ -1224,7 +1224,7 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 	reqCtx := &handlers.RequestContext{
 		Request: &handlers.Request{
 			Headers: map[string]string{
-				reqcommon.RequestIdHeaderKey: "test-req-id-for-streaming",
+				reqcommon.RequestIDHeaderKey: "test-req-id-for-streaming",
 			},
 		},
 		Response: &handlers.Response{
@@ -1256,7 +1256,7 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 	assert.Equal(t, 3, len(resps), "Should have received 3 streaming calls")
 
 	for i, resp := range resps {
-		assert.Equal(t, "test-req-id-for-streaming", resp.RequestId)
+		assert.Equal(t, "test-req-id-for-streaming", resp.RequestID)
 		assert.Equal(t, reqCtx.Response.Headers, resp.Headers)
 		assert.Equal(t, "namespace1/test-pod-name", targetPods[i])
 		if i < 2 {
@@ -1287,7 +1287,7 @@ func TestDirector_HandleResponseBody_ChunkOrdering(t *testing.T) {
 			Request: &handlers.Request{
 				Headers: map[string]string{
 					// All chunks share the same request ID so they go through the same queue.
-					reqcommon.RequestIdHeaderKey: "ordering-test-request",
+					reqcommon.RequestIDHeaderKey: "ordering-test-request",
 				},
 			},
 			Response: &handlers.Response{
@@ -1303,7 +1303,7 @@ func TestDirector_HandleResponseBody_ChunkOrdering(t *testing.T) {
 	finalReqCtx := &handlers.RequestContext{
 		Request: &handlers.Request{
 			Headers: map[string]string{
-				reqcommon.RequestIdHeaderKey: "ordering-test-request",
+				reqcommon.RequestIDHeaderKey: "ordering-test-request",
 			},
 		},
 		Response: &handlers.Response{

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -88,7 +88,7 @@ func (s *Scheduler) Schedule(ctx context.Context, request *framework.InferenceRe
 	}
 
 	if len(profileRunResults) == 0 {
-		err = fmt.Errorf("failed to run any scheduler profile for request %s", request.RequestId)
+		err = fmt.Errorf("failed to run any scheduler profile for request %s", request.RequestID)
 		return nil, err
 	}
 

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -41,7 +41,7 @@ func TestSchedulePlugins(t *testing.T) {
 		ScoreRes:  0.8,
 		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
 	}
-	tp_filterAll := &testPlugin{
+	tpFilterAll := &testPlugin{
 		TypeRes:   "filter all",
 		FilterRes: []k8stypes.NamespacedName{},
 	}
@@ -95,7 +95,7 @@ func TestSchedulePlugins(t *testing.T) {
 		{
 			name: "filter all",
 			profile: NewSchedulerProfile().
-				WithFilters(tp1, tp_filterAll).
+				WithFilters(tp1, tpFilterAll).
 				WithScorers(NewWeightedScorer(tp1, 1), NewWeightedScorer(tp2, 1)).
 				WithPicker(pickerPlugin),
 			input: []fwksched.Endpoint{
@@ -122,7 +122,7 @@ func TestSchedulePlugins(t *testing.T) {
 			// Initialize the scheduling context
 			request := &fwksched.InferenceRequest{
 				TargetModel: "test-model",
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 			}
 			// Run profile cycle
 			got, err := test.profile.Run(context.Background(), request, fwksched.NewCycleState(), test.input)
@@ -398,7 +398,7 @@ func TestRunWithOutOfRangeScores(t *testing.T) {
 
 	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 	}
 
 	_, err := profile.Run(context.Background(), request, fwksched.NewCycleState(), input)
@@ -450,7 +450,7 @@ func TestFilterExecutionOrder(t *testing.T) {
 
 	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 	}
 
 	_, err := profile.Run(context.Background(), request, fwksched.NewCycleState(), input)
@@ -494,7 +494,7 @@ func TestFilterExecutionOrderViaAddPlugins(t *testing.T) {
 
 	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 	}
 
 	_, err := profile.Run(context.Background(), request, fwksched.NewCycleState(), input)
@@ -546,7 +546,7 @@ func TestFilterChainReceivesPreviousOutput(t *testing.T) {
 
 	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
-		RequestId:   uuid.NewString(),
+		RequestID:   uuid.NewString(),
 	}
 
 	_, err := profile.Run(context.Background(), request, fwksched.NewCycleState(), input)

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -66,7 +66,7 @@ func TestSchedule(t *testing.T) {
 		{
 			name: "no candidate endpoints",
 			req: &fwksched.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "any-model",
 			},
 			input:   []fwksched.Endpoint{},
@@ -76,7 +76,7 @@ func TestSchedule(t *testing.T) {
 		{
 			name: "finds optimal endpoint",
 			req: &fwksched.InferenceRequest{
-				RequestId:   uuid.NewString(),
+				RequestID:   uuid.NewString(),
 				TargetModel: "critical",
 			},
 			// pod2 will be picked because it has relatively low queue size, with the requested


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
The Inference Gateway Extension (IGW) project had a less strict configuration for linting the code using golangci-lint than was used in the llm-d-inference-scheduler. A number of the lint rules were removed to enable the migration of the code to the llm-d-inference-scheduler repo.

This PR is a step in re-enabling the golangci-lint rules that were removed. It re-enables several rules and corrected the issues in the IGW code to enable CI to pass.

Which issue(s) this PR fixes:
refs #832 and #934

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
