### PR TITLE
fix make test-unit on arm64

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -11,7 +11,14 @@ ARG KUSTOMIZE_VERSION=v5.6.0
 ARG DOCKER_VERSION=29.3.0
 ARG DOCKER_BUILDX_VERSION=v0.32.1
 
-RUN dnf install -y podman && dnf clean all
+RUN dnf install -y podman gcc-toolset-12 && dnf clean all
+
+# The base image ships GCC 8 (RHEL 8 default), which lacks the ARM64 LSE
+# atomic emulation helpers (__aarch64_ldadd8_sync etc.) required by Go's
+# race detector. gcc-toolset-12 provides GCC 12 which includes them.
+# TODO: remove gcc-toolset-12 once this base image is updated to RHEL 9
+#       (GCC 11+ ships natively there and includes the helpers).
+ENV PATH=/opt/rh/gcc-toolset-12/root/usr/bin:$PATH
 
 # Install docker CLI and buildx plugin
 RUN ARCH=$(uname -m) && \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
Fixes `make test-unit` on arm64 

Install gcc-toolset-12 (GCC 12) in Dockerfile.builder and prepend it to PATH so the race detector runtime is compiled and linked with a GCC version that includes the missing helpers:
```
RUN dnf install -y podman gcc-toolset-12 && dnf clean all
ENV PATH=/opt/rh/gcc-toolset-12/root/usr/bin:$PATH
```
gcc-toolset-12 is the standard Red Hat mechanism for accessing a newer compiler on RHEL 8 without changing the base OS.

**Long-term fix**

Migrate the base image to a RHEL 9 variant (GCC 11 ships natively and includes the helpers) once quay.io/projectquay/golang or ubi9/go-toolset publishes a Go 1.25+ image built on RHEL 9. At that point, the `gcc-toolset-12` lines can be removed.

**Which issue(s) this PR fixes**:
/close #939

**Release note**:
```release-note
NONE
```
