### PR TITLE
feat(datalayer): additive ensureDataLayer with InjectDefaults opt-out

### DIFF
--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -213,10 +213,13 @@ func (sdc *SaturationDetectorConfig) String() string {
 
 // DataLayerConfig contains the configuration of the DataLayer feature
 type DataLayerConfig struct {
-	// +required
-	// +kubebuilder:validation:Required
+	// +optional
+	// InjectDefaults controls automatic injection of the default metrics source and extractor.
+	// Defaults to true when omitted. Set to false to disable all default source injection.
+	InjectDefaults *bool `json:"injectDefaults,omitempty"`
+	// +optional
 	// Sources is the list of sources to define to the DataLayer
-	Sources []DataLayerSource `json:"sources"`
+	Sources []DataLayerSource `json:"sources,omitempty"`
 }
 
 func (dlc *DataLayerConfig) String() string {

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -504,27 +504,42 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			},
 		},
 		{
-			name:       "Success (DataLayer) - Empty dataLayer section disables default metrics",
+			name:       "Success (DataLayer) - Empty dataLayer section injects defaults (additive)",
 			configText: successDataLayerNoSourcesText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, rawCfg.DataLayer, "DataLayer section should be present (user provided it)")
-				require.Empty(t, rawCfg.DataLayer.Sources, "No sources should be present")
-				require.Nil(t, handle.Plugin(sourcemetrics.MetricsDataSourceType), "MetricsDataSource should not be instantiated")
-				require.Nil(t, handle.Plugin(extractormetrics.MetricsExtractorType), "MetricsExtractor should not be instantiated")
-				require.NotNil(t, cfg.DataConfig, "DataConfig should still be built (just empty)")
-				require.Empty(t, cfg.DataConfig.Sources, "DataConfig should have no sources")
+				require.NotNil(t, rawCfg.DataLayer, "DataLayer section should be present")
+				require.Len(t, rawCfg.DataLayer.Sources, 1, "Default metrics source should be injected")
+				require.Equal(t, sourcemetrics.MetricsDataSourceType, rawCfg.DataLayer.Sources[0].PluginRef)
+				require.NotNil(t, handle.Plugin(sourcemetrics.MetricsDataSourceType), "MetricsDataSource should be instantiated")
+				require.NotNil(t, handle.Plugin(extractormetrics.MetricsExtractorType), "MetricsExtractor should be instantiated")
+				require.NotNil(t, cfg.DataConfig)
+				require.Len(t, cfg.DataConfig.Sources, 1)
 			},
 		},
 		{
-			name:       "Success (DataLayer) - Explicit data config preserved",
+			name:       "Success (DataLayer) - injectDefaults: false suppresses injection",
+			configText: successDataLayerOptOutText,
+			wantErr:    false,
+			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
+				require.NotNil(t, rawCfg.DataLayer)
+				require.Empty(t, rawCfg.DataLayer.Sources, "No sources should be present when InjectDefaults is false")
+				require.Nil(t, handle.Plugin(sourcemetrics.MetricsDataSourceType), "MetricsDataSource should not be instantiated")
+				require.Nil(t, handle.Plugin(extractormetrics.MetricsExtractorType), "MetricsExtractor should not be instantiated")
+				require.NotNil(t, cfg.DataConfig, "DataConfig is built but empty")
+				require.Empty(t, cfg.DataConfig.Sources)
+			},
+		},
+		{
+			name:       "Success (DataLayer) - Explicit non-metrics source gets defaults injected too",
 			configText: successDataLayerExplicitConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
 				require.NotNil(t, rawCfg.DataLayer, "Data config should be present")
-				require.Len(t, rawCfg.DataLayer.Sources, 1)
-				require.Equal(t, "testSource", rawCfg.DataLayer.Sources[0].PluginRef,
-					"Explicit source should be preserved, not overwritten by defaults")
+				require.Len(t, rawCfg.DataLayer.Sources, 2, "User source + injected metrics source")
+				pluginRefs := []string{rawCfg.DataLayer.Sources[0].PluginRef, rawCfg.DataLayer.Sources[1].PluginRef}
+				require.Contains(t, pluginRefs, "testSource", "User source should be preserved")
+				require.Contains(t, pluginRefs, sourcemetrics.MetricsDataSourceType, "Default metrics source should be injected")
 			},
 		},
 		{

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -288,16 +288,17 @@ func ensureSaturationDetector(
 	return nil
 }
 
-// ensureDataLayer guarantees that the data layer is configured unless explicitly disabled.
-// If no data section is provided, the default plugins are added.
-// If a data section is explicitly provided (even empty), it is left unchanged — an empty section
-// disables metrics collection without falling back to legacy.
+// ensureDataLayer additively injects the default metrics source and extractor unless opted out.
+// Unlike other ensureXxx functions, it checks for explicit opt-out via InjectDefaults and avoids
+// double-injection when the metrics source is already present in a user-supplied config.
 func ensureDataLayer(cfg *configapi.EndpointPickerConfig, handle fwkplugin.Handle, allPlugins map[string]fwkplugin.Plugin) error {
 	if slices.Contains(cfg.FeatureGates, datalayer.EnableLegacyMetricsFeatureGate) {
 		return nil
 	}
-
-	if cfg.DataLayer != nil {
+	if cfg.DataLayer != nil && cfg.DataLayer.InjectDefaults != nil && !*cfg.DataLayer.InjectDefaults {
+		return nil
+	}
+	if cfg.DataLayer != nil && hasSourceOfType(cfg.DataLayer, sourcemetrics.MetricsDataSourceType) {
 		return nil
 	}
 
@@ -312,16 +313,26 @@ func ensureDataLayer(cfg *configapi.EndpointPickerConfig, handle fwkplugin.Handl
 		}
 	}
 
-	cfg.DataLayer = &configapi.DataLayerConfig{
-		Sources: []configapi.DataLayerSource{{
-			PluginRef: sourcemetrics.MetricsDataSourceType,
-			Extractors: []configapi.DataLayerExtractor{{
-				PluginRef: extractormetrics.MetricsExtractorType,
-			}},
-		}},
+	if cfg.DataLayer == nil {
+		cfg.DataLayer = &configapi.DataLayerConfig{}
 	}
+	cfg.DataLayer.Sources = append(cfg.DataLayer.Sources, configapi.DataLayerSource{
+		PluginRef: sourcemetrics.MetricsDataSourceType,
+		Extractors: []configapi.DataLayerExtractor{{
+			PluginRef: extractormetrics.MetricsExtractorType,
+		}},
+	})
 
 	return nil
+}
+
+func hasSourceOfType(dl *configapi.DataLayerConfig, pluginType string) bool {
+	for _, s := range dl.Sources {
+		if s.PluginRef == pluginType {
+			return true
+		}
+	}
+	return false
 }
 
 // registerDefaultPlugin instantiates a plugin with empty configuration (defaults) and adds it to both the handle and

--- a/pkg/epp/config/loader/defaults_test.go
+++ b/pkg/epp/config/loader/defaults_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	configapi "github.com/llm-d/llm-d-inference-scheduler/apix/config/v1alpha1"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	extractormetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
+	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
+	utils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
+)
+
+// metricsPlugins returns an allPlugins map with mock stubs for both default metrics plugins.
+// Providing them prevents ensureDataLayer from calling registerDefaultPlugin (which needs the
+// global factory registry). The function still injects the DataLayer.Sources entries.
+func metricsPlugins() map[string]fwkplugin.Plugin {
+	return map[string]fwkplugin.Plugin{
+		sourcemetrics.MetricsDataSourceType:   &mockPlugin{t: fwkplugin.TypedName{Type: sourcemetrics.MetricsDataSourceType, Name: sourcemetrics.MetricsDataSourceType}},
+		extractormetrics.MetricsExtractorType: &mockPlugin{t: fwkplugin.TypedName{Type: extractormetrics.MetricsExtractorType, Name: extractormetrics.MetricsExtractorType}},
+	}
+}
+
+func TestEnsureDataLayer(t *testing.T) {
+	// Not parallel: shares helpers with configloader_test.go that depend on global state.
+
+	t.Run("nil DataLayer injects metrics defaults", func(t *testing.T) {
+		cfg := &configapi.EndpointPickerConfig{}
+		handle := utils.NewTestHandle(context.Background())
+
+		err := ensureDataLayer(cfg, handle, metricsPlugins())
+
+		require.NoError(t, err)
+		require.NotNil(t, cfg.DataLayer)
+		require.Len(t, cfg.DataLayer.Sources, 1)
+		require.Equal(t, sourcemetrics.MetricsDataSourceType, cfg.DataLayer.Sources[0].PluginRef)
+		require.Len(t, cfg.DataLayer.Sources[0].Extractors, 1)
+		require.Equal(t, extractormetrics.MetricsExtractorType, cfg.DataLayer.Sources[0].Extractors[0].PluginRef)
+	})
+
+	t.Run("empty DataLayer {} injects metrics defaults (regression: was no-op)", func(t *testing.T) {
+		cfg := &configapi.EndpointPickerConfig{
+			DataLayer: &configapi.DataLayerConfig{},
+		}
+		handle := utils.NewTestHandle(context.Background())
+
+		err := ensureDataLayer(cfg, handle, metricsPlugins())
+
+		require.NoError(t, err)
+		require.Len(t, cfg.DataLayer.Sources, 1)
+		require.Equal(t, sourcemetrics.MetricsDataSourceType, cfg.DataLayer.Sources[0].PluginRef)
+	})
+
+	t.Run("non-metrics source gets metrics injected too (additive)", func(t *testing.T) {
+		cfg := &configapi.EndpointPickerConfig{
+			DataLayer: &configapi.DataLayerConfig{
+				Sources: []configapi.DataLayerSource{
+					{PluginRef: "k8s-notification-source"},
+				},
+			},
+		}
+		handle := utils.NewTestHandle(context.Background())
+
+		err := ensureDataLayer(cfg, handle, metricsPlugins())
+
+		require.NoError(t, err)
+		require.Len(t, cfg.DataLayer.Sources, 2)
+		refs := []string{cfg.DataLayer.Sources[0].PluginRef, cfg.DataLayer.Sources[1].PluginRef}
+		require.Contains(t, refs, "k8s-notification-source")
+		require.Contains(t, refs, sourcemetrics.MetricsDataSourceType)
+	})
+
+	t.Run("existing metrics-data-source is not double-injected", func(t *testing.T) {
+		cfg := &configapi.EndpointPickerConfig{
+			DataLayer: &configapi.DataLayerConfig{
+				Sources: []configapi.DataLayerSource{
+					{PluginRef: sourcemetrics.MetricsDataSourceType},
+				},
+			},
+		}
+		handle := utils.NewTestHandle(context.Background())
+
+		err := ensureDataLayer(cfg, handle, metricsPlugins())
+
+		require.NoError(t, err)
+		require.Len(t, cfg.DataLayer.Sources, 1, "no duplicate metrics source")
+	})
+
+	t.Run("injectDefaults: false suppresses injection", func(t *testing.T) {
+		cfg := &configapi.EndpointPickerConfig{
+			DataLayer: &configapi.DataLayerConfig{
+				InjectDefaults: ptr.To(false),
+			},
+		}
+		handle := utils.NewTestHandle(context.Background())
+
+		err := ensureDataLayer(cfg, handle, metricsPlugins())
+
+		require.NoError(t, err)
+		require.Empty(t, cfg.DataLayer.Sources)
+	})
+
+	t.Run("enableLegacyMetrics feature gate suppresses injection", func(t *testing.T) {
+		cfg := &configapi.EndpointPickerConfig{
+			FeatureGates: configapi.FeatureGates{datalayer.EnableLegacyMetricsFeatureGate},
+		}
+		handle := utils.NewTestHandle(context.Background())
+
+		err := ensureDataLayer(cfg, handle, metricsPlugins())
+
+		require.NoError(t, err)
+		require.Nil(t, cfg.DataLayer)
+	})
+}

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -504,7 +504,7 @@ featureGates:
 `
 
 // successDataLayerNoSourcesText has an explicit empty dataLayer section with no sources.
-// The loader should NOT inject defaults — the empty section signals "no metrics collection".
+// The loader should additively inject the default metrics source because InjectDefaults is unset (default: true).
 const successDataLayerNoSourcesText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
@@ -518,8 +518,23 @@ schedulingProfiles:
 dataLayer: {}
 `
 
-// successDataLayerExplicitConfigText has the datalayer enabled with explicit data config.
-// The loader should preserve the user's config and NOT overwrite with defaults.
+// successDataLayerOptOutText has dataLayer with injectDefaults: false, disabling automatic injection.
+const successDataLayerOptOutText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+dataLayer:
+  injectDefaults: false
+`
+
+// successDataLayerExplicitConfigText has the datalayer enabled with an explicit non-metrics source.
+// The loader should inject the default metrics source in addition to the user's source (additive).
 const successDataLayerExplicitConfigText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Previously, any non-nil DataLayer config (even `dataLayer: {}` or a user-supplied source) caused ensureDataLayer() to skip default injection entirely. This silently broke metrics collection for users who added e.g. a k8s-notification-source without also repeating the metrics source.

- Add InjectDefaults *bool field to DataLayerConfig (nil = true, opt-in to defaults)
- Rewrite ensureDataLayer() to be additive like all other ensureXxx() functions: skip injection only when a metrics source is already present, or InjectDefaults is explicitly false
- Add hasSourceOfType() helper used by ensureDataLayer
- Add TestEnsureDataLayer unit tests covering all five behaviour matrix rows
- Update TestInstantiateAndConfigure integration tests to match new semantics

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
New configuration parameter in `Data` section - `InjectDefaults` controls automatic injection of the default metrics source and extractor. Defaults to true when omitted. Set to false to disable all default source injection.
```

