### PR TITLE
feat(datalayer): plugin-driven source/extractor registration via Registrant interface

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -56,6 +56,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/contracts"
 	fccontroller "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/controller"
 	fcregistry "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/flowcontrol/registry"
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
@@ -589,6 +590,15 @@ func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *conf
 		handle.AddPlugin(p.TypedName().Name, p)
 	}
 	r.requestControlConfig.AddPlugins(dataProducers...)
+
+	// Let plugins declare their datalayer source/extractor dependencies before Configure().
+	for _, p := range handle.GetAllPlugins() {
+		if registrant, ok := p.(fwkdl.Registrant); ok {
+			if err := registrant.RegisterDependencies(r.dlRuntime); err != nil {
+				return nil, fmt.Errorf("plugin %s RegisterDependencies: %w", p.TypedName(), err)
+			}
+		}
+	}
 
 	// Sort data plugins in DAG order (topological sort). Also check DAG for cycles.
 	// This must run after auto-created producers are added so they are included in the ordering.

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
@@ -39,6 +40,9 @@ type Runtime struct {
 	notifiers        sync.Map // Map of k8s notification sources (key=source name, value=NotificationSource)
 	endpointSources  sync.Map // Map of endpoint sources (key=source name, value=EndpointSource)
 	sourceExtractors sync.Map // Map sources to extractors (key=source name. value=[]Extractor)
+
+	pendingMu            sync.Mutex
+	pendingRegistrations []fwkdl.PendingRegistration // code-registered (source-type, extractor) pairs, resolved by Configure()
 
 	collectors sync.Map    // Per-endpoint poller (key=namespaced name, value=*Collector)
 	logger     logr.Logger // Set in Configure; used where no context is available (e.g. ReleaseEndpoint).
@@ -64,7 +68,8 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 // Configure is called to transform the configuration information into the Runtime's
 // internal fields.
 func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtractorType string, logger logr.Logger) error {
-	if cfg == nil || len(cfg.Sources) == 0 {
+	hasPending := len(r.pendingRegistrations) > 0
+	if (cfg == nil || len(cfg.Sources) == 0) && !hasPending {
 		if enableNewMetrics {
 			return errors.New("data layer enabled but no data sources configured")
 		}
@@ -72,54 +77,194 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 	}
 
 	r.logger = logger
-	logger.Info("Configuring datalayer runtime", "numSources", len(cfg.Sources))
+	numSources := 0
+	if cfg != nil {
+		numSources = len(cfg.Sources)
+	}
+	logger.Info("Configuring datalayer runtime", "numSources", numSources)
 
 	pollersCount := 0
 	notifiersCount := 0
 	endpointSourcesCount := 0
-	gvkToSource := make(map[string]string, len(cfg.Sources)) // track GVK uniqueness
+	gvkToSource := make(map[string]string) // track GVK uniqueness for NotificationSources
 
-	for _, srcCfg := range cfg.Sources {
-		src := srcCfg.Plugin
-		srcName := src.TypedName().Name
+	if cfg != nil {
+		for _, srcCfg := range cfg.Sources {
+			src := srcCfg.Plugin
+			srcName := src.TypedName().Name
 
-		logger.V(logging.DEFAULT).Info("Processing source", "source", srcName, "numExtractors", len(srcCfg.Extractors))
-		if err := r.validateSourceExtractors(src, srcCfg.Extractors, disallowedExtractorType); err != nil {
-			return err
-		}
-
-		if poller, ok := src.(fwkdl.PollingDataSource); ok { // Register to appropriate map based on type
-			r.pollers.Store(srcName, poller)
-			pollersCount++
-		} else if notifier, ok := src.(fwkdl.NotificationSource); ok {
-			gvk := notifier.GVK().String()
-			if existingSource, exists := gvkToSource[gvk]; exists {
-				return fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
-					gvk, existingSource, src.TypedName().String())
+			logger.V(logging.DEFAULT).Info("Processing source", "source", srcName, "numExtractors", len(srcCfg.Extractors))
+			if err := r.validateSourceExtractors(src, srcCfg.Extractors, disallowedExtractorType); err != nil {
+				return err
 			}
-			r.notifiers.Store(srcName, notifier)
-			gvkToSource[gvk] = srcName
-			notifiersCount++
-		} else if epSrc, ok := src.(fwkdl.EndpointSource); ok {
-			r.endpointSources.Store(srcName, epSrc)
-			endpointSourcesCount++
-		} else {
-			return fmt.Errorf("skipping unknown datasource plugin type %s", src.TypedName().String())
+
+			if err := r.registerSource(src, gvkToSource); err != nil {
+				return err
+			}
+			switch src.(type) {
+			case fwkdl.PollingDataSource:
+				pollersCount++
+			case fwkdl.NotificationSource:
+				notifiersCount++
+			default:
+				endpointSourcesCount++
+			}
+
+			if len(srcCfg.Extractors) > 0 { // Store extractors mapped to source
+				r.sourceExtractors.Store(srcName, srcCfg.Extractors)
+			}
+
+			extractorNames := make([]string, len(srcCfg.Extractors))
+			for i, ext := range srcCfg.Extractors {
+				extractorNames[i] = ext.TypedName().String()
+			}
+			logger.V(logging.DEFAULT).Info("Source configured", "source", srcName, "extractors", extractorNames)
+		}
+	}
+
+	// Resolve code-registered pending registrations after processing user config.
+	for _, pending := range r.pendingRegistrations {
+		var gvkFilter *schema.GroupVersionKind
+		if ns, ok := pending.DefaultSource.(fwkdl.NotificationSource); ok {
+			gvk := ns.GVK()
+			gvkFilter = &gvk
+		}
+		srcName, matchedSrc := r.findSourceByType(pending.SourceType, gvkFilter)
+
+		if matchedSrc == nil {
+			if pending.DefaultSource == nil {
+				msg := fmt.Sprintf("extractor %s requires source type %s, not configured",
+					pending.Extractor.TypedName(), pending.SourceType)
+				if pending.IfMissing == fwkdl.Warn {
+					logger.Info("datalayer: skipping unresolved dependency", "reason", msg)
+					continue
+				}
+				return errors.New(msg)
+			}
+			if regErr := r.registerSource(pending.DefaultSource, gvkToSource); regErr != nil {
+				return fmt.Errorf("auto-register default source for %s: %w",
+					pending.Extractor.TypedName(), regErr)
+			}
+			srcName = pending.DefaultSource.TypedName().Name
+			matchedSrc = pending.DefaultSource
 		}
 
-		if len(srcCfg.Extractors) > 0 { // Store extractors mapped to source
-			r.sourceExtractors.Store(srcName, srcCfg.Extractors)
+		if valErr := r.validateSourceExtractors(matchedSrc, []fwkdl.ExtractorBase{pending.Extractor}, disallowedExtractorType); valErr != nil {
+			return fmt.Errorf("code-registered extractor %s incompatible with source %s: %w",
+				pending.Extractor.TypedName(), srcName, valErr)
 		}
 
-		extractorNames := make([]string, len(srcCfg.Extractors))
-		for i, ext := range srcCfg.Extractors {
-			extractorNames[i] = ext.TypedName().String()
+		existing, _ := r.sourceExtractors.Load(srcName)
+		var exts []fwkdl.ExtractorBase
+		if existing != nil {
+			exts = existing.([]fwkdl.ExtractorBase)
 		}
-		logger.V(logging.DEFAULT).Info("Source configured", "source", srcName, "extractors", extractorNames)
+
+		// Dedup by extractor type: code registration is a no-op if already wired via config.
+		pendingType := pending.Extractor.TypedName().Type
+		alreadyWired := false
+		for _, e := range exts {
+			if e.TypedName().Type == pendingType {
+				alreadyWired = true
+				break
+			}
+		}
+		if !alreadyWired {
+			r.sourceExtractors.Store(srcName, append(exts, pending.Extractor))
+		}
 	}
 
 	logger.Info("Datalayer runtime configured", "pollers", pollersCount, "notifiers", notifiersCount, "endpointSources", endpointSourcesCount)
 	return nil
+}
+
+// Register stores a pending source/extractor dependency declared by a plugin.
+// Called by plugins implementing Registrant.RegisterDependencies() before Configure() runs.
+func (r *Runtime) Register(reg fwkdl.PendingRegistration) error {
+	if reg.Extractor == nil {
+		return fmt.Errorf("plugin %s: PendingRegistration.Extractor must not be nil", reg.Owner)
+	}
+	r.pendingMu.Lock()
+	r.pendingRegistrations = append(r.pendingRegistrations, reg)
+	r.pendingMu.Unlock()
+	return nil
+}
+
+// registerSource stores src in the appropriate typed sync.Map and enforces GVK uniqueness for NotificationSources.
+func (r *Runtime) registerSource(src fwkdl.DataSource, gvkToSource map[string]string) error {
+	srcName := src.TypedName().Name
+	if poller, ok := src.(fwkdl.PollingDataSource); ok {
+		r.pollers.Store(srcName, poller)
+	} else if notifier, ok := src.(fwkdl.NotificationSource); ok {
+		gvk := notifier.GVK().String()
+		if existingSource, exists := gvkToSource[gvk]; exists {
+			return fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
+				gvk, existingSource, src.TypedName().String())
+		}
+		r.notifiers.Store(srcName, notifier)
+		gvkToSource[gvk] = srcName
+	} else if epSrc, ok := src.(fwkdl.EndpointSource); ok {
+		r.endpointSources.Store(srcName, epSrc)
+	} else {
+		return fmt.Errorf("skipping unknown datasource plugin type %s", src.TypedName().String())
+	}
+	return nil
+}
+
+// findSourceByType searches pollers, notifiers, and endpointSources for a source whose TypedName.Type
+// matches sourceType. For NotificationSources, also filters by GVK if gvkFilter is non-nil.
+func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource) {
+	matches := func(src fwkdl.DataSource) bool {
+		if src.TypedName().Type != sourceType {
+			return false
+		}
+		if gvkFilter != nil {
+			if ns, ok := src.(fwkdl.NotificationSource); ok {
+				if ns.GVK().String() != gvkFilter.String() {
+					return false
+				}
+			}
+		}
+		return true
+	}
+
+	var foundName string
+	var foundSrc fwkdl.DataSource
+
+	r.pollers.Range(func(key, val any) bool {
+		src := val.(fwkdl.PollingDataSource)
+		if matches(src) {
+			foundName, foundSrc = key.(string), src
+			return false
+		}
+		return true
+	})
+	if foundSrc != nil {
+		return foundName, foundSrc
+	}
+
+	r.notifiers.Range(func(key, val any) bool {
+		src := val.(fwkdl.NotificationSource)
+		if matches(src) {
+			foundName, foundSrc = key.(string), src
+			return false
+		}
+		return true
+	})
+	if foundSrc != nil {
+		return foundName, foundSrc
+	}
+
+	r.endpointSources.Range(func(key, val any) bool {
+		src := val.(fwkdl.EndpointSource)
+		if matches(src) {
+			foundName, foundSrc = key.(string), src
+			return false
+		}
+		return true
+	})
+
+	return foundName, foundSrc
 }
 
 // Start is called to enable the Runtime to start processing data collection. It wires
@@ -340,3 +485,4 @@ func isEmpty(m *sync.Map) bool {
 }
 
 var _ EndpointFactory = (*Runtime)(nil)
+var _ fwkdl.Registrar = (*Runtime)(nil)

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	extractormocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/mocks"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
+)
+
+// --- Register() validation ---
+
+func TestRegister_NilExtractor(t *testing.T) {
+	r := NewRuntime(0)
+	err := r.Register(fwkdl.PendingRegistration{
+		Owner:      fwkplugin.TypedName{Type: "test", Name: "test"},
+		SourceType: notifications.EndpointNotificationSourceType,
+		Extractor:  nil,
+	})
+	require.Error(t, err, "Register should reject nil Extractor")
+}
+
+func TestRegister_ValidRegistration(t *testing.T) {
+	r := NewRuntime(0)
+	ext := extractormocks.NewEndpointExtractor("ext1")
+	err := r.Register(fwkdl.PendingRegistration{
+		Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+		SourceType: notifications.EndpointNotificationSourceType,
+		Extractor:  ext,
+	})
+	require.NoError(t, err)
+	require.Len(t, r.pendingRegistrations, 1, "registration should be stored")
+}
+
+// --- Configure() with pending registrations ---
+
+func TestConfigure_ExtractorWiredToUserConfiguredSource(t *testing.T) {
+	// (a) extractor appended to matching user-configured source
+	r := NewRuntime(0)
+	logger := newTestLogger(t)
+
+	src := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, "ep-src")
+	ext := extractormocks.NewEndpointExtractor("ext-a")
+
+	require.NoError(t, r.Register(fwkdl.PendingRegistration{
+		Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+		SourceType: notifications.EndpointNotificationSourceType,
+		Extractor:  ext,
+	}))
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{{Plugin: src}},
+	}
+	err := r.Configure(cfg, false, "", logger)
+	require.NoError(t, err)
+
+	rawExts, ok := r.sourceExtractors.Load("ep-src")
+	require.True(t, ok, "sourceExtractors should have entry for ep-src")
+	exts := rawExts.([]fwkdl.ExtractorBase)
+	require.Len(t, exts, 1)
+	assert.Equal(t, "ext-a", exts[0].TypedName().Name)
+}
+
+func TestConfigure_DefaultSourceAutoRegisteredWhenAbsent(t *testing.T) {
+	// (b) DefaultSource auto-registered when source absent
+	r := NewRuntime(0)
+	logger := newTestLogger(t)
+
+	defaultSrc := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, notifications.EndpointNotificationSourceType)
+	ext := extractormocks.NewEndpointExtractor("ext-b")
+
+	require.NoError(t, r.Register(fwkdl.PendingRegistration{
+		Owner:         fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+		SourceType:    notifications.EndpointNotificationSourceType,
+		Extractor:     ext,
+		DefaultSource: defaultSrc,
+	}))
+
+	// No user sources; default should be auto-created.
+	err := r.Configure(nil, false, "", logger)
+	require.NoError(t, err)
+
+	// Source should be in endpointSources.
+	val, ok := r.endpointSources.Load(notifications.EndpointNotificationSourceType)
+	require.True(t, ok, "auto-registered source should appear in endpointSources")
+	assert.Equal(t, notifications.EndpointNotificationSourceType, val.(fwkdl.EndpointSource).TypedName().Name)
+
+	// Extractor should be wired.
+	rawExts, ok := r.sourceExtractors.Load(notifications.EndpointNotificationSourceType)
+	require.True(t, ok, "extractor should be wired to auto-registered source")
+	exts := rawExts.([]fwkdl.ExtractorBase)
+	require.Len(t, exts, 1)
+}
+
+func TestConfigure_FailPolicyMissingSource(t *testing.T) {
+	// (c) Fail policy + nil DefaultSource + missing source → error returned
+	r := NewRuntime(0)
+	logger := newTestLogger(t)
+
+	ext := extractormocks.NewEndpointExtractor("ext-c")
+	require.NoError(t, r.Register(fwkdl.PendingRegistration{
+		Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+		SourceType: notifications.EndpointNotificationSourceType,
+		Extractor:  ext,
+		IfMissing:  fwkdl.Fail,
+	}))
+
+	err := r.Configure(nil, false, "", logger)
+	require.Error(t, err, "Fail policy should return error when source is absent")
+}
+
+func TestConfigure_WarnPolicyMissingSource(t *testing.T) {
+	// (d) Warn policy + nil DefaultSource + missing source → continues without error
+	r := NewRuntime(0)
+	logger := newTestLogger(t)
+
+	ext := extractormocks.NewEndpointExtractor("ext-d")
+	require.NoError(t, r.Register(fwkdl.PendingRegistration{
+		Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+		SourceType: notifications.EndpointNotificationSourceType,
+		Extractor:  ext,
+		IfMissing:  fwkdl.Warn,
+	}))
+
+	err := r.Configure(nil, false, "", logger)
+	require.NoError(t, err, "Warn policy should not return error when source is absent")
+}
+
+func TestConfigure_DedupByExtractorType(t *testing.T) {
+	// (g) dedup: extractor type already wired via config → code registration is a no-op
+	r := NewRuntime(0)
+	logger := newTestLogger(t)
+
+	src := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, "ep-src")
+	extFromConfig := extractormocks.NewEndpointExtractor("config-ext")
+	extFromCode := extractormocks.NewEndpointExtractor("code-ext")
+
+	// User config wires extFromConfig to src.
+	cfg := &Config{
+		Sources: []DataSourceConfig{{
+			Plugin:     src,
+			Extractors: []fwkdl.ExtractorBase{extFromConfig},
+		}},
+	}
+
+	// Code registers extFromCode — same type as extFromConfig ("mock-endpoint-extractor").
+	require.NoError(t, r.Register(fwkdl.PendingRegistration{
+		Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+		SourceType: notifications.EndpointNotificationSourceType,
+		Extractor:  extFromCode,
+	}))
+
+	err := r.Configure(cfg, false, "", logger)
+	require.NoError(t, err)
+
+	rawExts, ok := r.sourceExtractors.Load("ep-src")
+	require.True(t, ok)
+	exts := rawExts.([]fwkdl.ExtractorBase)
+	require.Len(t, exts, 1, "code registration should be deduped; only config extractor present")
+	assert.Equal(t, "config-ext", exts[0].TypedName().Name)
+}

--- a/pkg/epp/framework/interface/datalayer/registrar.go
+++ b/pkg/epp/framework/interface/datalayer/registrar.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+
+// Registrar accepts pending source/extractor dependency declarations from plugins.
+// Runtime.Configure() resolves them after processing user config.
+// Register returns an error if the registration is invalid (e.g. nil Extractor).
+type Registrar interface {
+	Register(PendingRegistration) error
+}
+
+// Registrant is an optional interface any Plugin may implement to declare its
+// datalayer dependencies. The runner calls RegisterDependencies on all eligible
+// plugins after instantiation, before Runtime.Configure().
+type Registrant interface {
+	RegisterDependencies(Registrar) error
+}
+
+// PendingRegistration describes a (source-type, extractor) dependency.
+// Extractor must be non-nil; registering a DataSource without an Extractor is not supported.
+// If DefaultSource is nil, IfMissing governs behavior when no matching source exists.
+// If DefaultSource is non-nil, it is registered as a new source when no match is found;
+// for NotificationSources its GVK() narrows the match.
+type PendingRegistration struct {
+	Owner         plugin.TypedName // registering plugin; used as map key + error context
+	SourceType    string           // TypedName.Type to match, e.g. "endpoint-notification-source"
+	Extractor     ExtractorBase    // required; extractor to wire to the matched source
+	DefaultSource DataSource       // nil → no auto-create; non-nil → create if absent
+	IfMissing     MissingPolicy    // applies only when DefaultSource is nil
+}
+
+// MissingPolicy controls behavior when a required source type is absent from the config.
+type MissingPolicy int
+
+const (
+	// Fail returns an error if the required source type is not configured (default).
+	Fail MissingPolicy = iota
+	// Warn logs a warning and skips wiring; the plugin degrades gracefully.
+	Warn
+)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	framework "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	sourcenotifications "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
 
 const (
@@ -52,6 +53,7 @@ var (
 	_ requestcontrol.ResponseBodyProcessor = &InFlightLoadProducer{}
 	_ requestcontrol.DataProducer          = &InFlightLoadProducer{}
 	_ datalayer.EndpointExtractor          = &InFlightLoadProducer{}
+	_ datalayer.Registrant                 = &InFlightLoadProducer{}
 )
 
 type InFlightLoadProducer struct {
@@ -63,6 +65,17 @@ type InFlightLoadProducer struct {
 
 func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
 	return p.typedName
+}
+
+// RegisterDependencies declares that this plugin needs an endpoint-notification-source to track
+// endpoint lifecycle events. The source is auto-created if not already in the config.
+func (p *InFlightLoadProducer) RegisterDependencies(r datalayer.Registrar) error {
+	return r.Register(datalayer.PendingRegistration{
+		Owner:         p.TypedName(),
+		SourceType:    sourcenotifications.EndpointNotificationSourceType,
+		Extractor:     p,
+		DefaultSource: sourcenotifications.NewEndpointDataSource(sourcenotifications.EndpointNotificationSourceType, sourcenotifications.EndpointNotificationSourceType),
+	})
 }
 
 // ExpectedInputType defines the type expected by the extractor.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Introduce the `Registrar`/`Registrant` interfaces so plugins can declare their datalayer dependencies at init time rather than hard-coding them in configuration.

- `fwkdl.Registrar` / `fwkdl.Registrant` / `PendingRegistration` live in `pkg/epp/framework/interface/datalayer/registrar.go`
- `Runtime` implements `Registrar`; `Configure()` resolves pending registrations after processing user-config sources: wires extractors to matching sources, auto-registers a `DefaultSource` when absent, respects Fail/Warn policy, and deduplicates by extractor type
- Runner iterates all plugins and calls `RegisterDependencies` on any that implement `Registrant`, immediately before `Runtime.Configure()`
- `InFlightLoadProducer` is the first adopter: it registers itself as an `EndpointExtractor` against the endpoint-notification source (auto-creating the source when absent from user config) so endpoint-deletion events deterministically clean up its concurrency trackers

**Depends on**: #941 — the auto-created endpoint source is only useful when `ensureDataLayer()` is additive (so the metrics source is not silently dropped). Please merge #941 first.

**Which issue(s) this PR fixes**:
Fixes #963 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
Deferred registrations are only allowed in code and are not a user exposed feature.