### PR TITLE
Align GIE CRDs with v1.5.0

### DIFF
--- a/deploy/components/crds-gie/kustomization.yaml
+++ b/deploy/components/crds-gie/kustomization.yaml
@@ -8,4 +8,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=v1.4.0
+- https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=v1.5.0

--- a/test/config/prefix_cache_mode_test.go
+++ b/test/config/prefix_cache_mode_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestScorer(t *testing.T) {
+	if _, err := os.Stat("/tmp/tokenizer/tokenizer-uds.socket"); err != nil {
+		t.Skipf("tokenizer UDS socket unavailable: %v", err)
+	}
+
 	tests := []struct {
 		name       string
 		pluginName string
@@ -31,6 +35,9 @@ plugins:
 - name: precisePrefixCache
   type: precise-prefix-cache-scorer
   parameters:
+    indexerConfig:
+      tokenizersPoolConfig:
+        modelName: "test-model"
     kvEventsConfig:
       zmqEndpoint: "tcp://localhost:5557"
 - name: profileHandler


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates the Gateway API Inference Extension CRD kustomization reference to v1.5.0 so deployed CRDs match the GIE dependency version.

Also updates the precise prefix cache config test fixture with the required tokenizer model config and skips it when the local tokenizer socket is unavailable.

**Which issue(s) this PR fixes**:
Fixes: #949 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```