### PR TITLE
docs: add README for undocumented scheduler plugins

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/README.md
@@ -1,0 +1,90 @@
+# Label-Based Filter Plugins
+
+Filters inference requests to pods based on Kubernetes labels. This
+package provides five filter plugins: three role-based filters for
+disaggregated serving, and two generic label filters.
+
+## Role-based filters
+
+### `decode-filter`
+
+Passes only pods designated as decode workers.
+
+**Type:** `decode-filter`
+
+**Accepted `llm-d.ai/role` values:** `decode`, `prefill-decode`, `both`, `encode-prefill-decode`
+
+**Pods with no role label:** excluded
+
+```yaml
+- type: decode-filter
+```
+
+### `prefill-filter`
+
+Passes only pods designated as prefill workers.
+
+**Type:** `prefill-filter`
+
+**Accepted `llm-d.ai/role` values:** `prefill`, `encode-prefill`, `prefill-decode`, `both`, `encode-prefill-decode`
+
+**Pods with no role label:** excluded
+
+```yaml
+- type: prefill-filter
+```
+
+### `encode-filter`
+
+Passes only pods designated as encode workers (first stage in E/P/D pipeline).
+
+**Type:** `encode-filter`
+
+**Accepted `llm-d.ai/role` values:** `encode`, `encode-prefill`, `encode-prefill-decode`
+
+**Pods with no role label:** excluded
+
+```yaml
+- type: encode-filter
+```
+
+## Generic label filters
+
+### `by-label`
+
+Passes pods whose label value matches one of a configured set of values.
+
+**Type:** `by-label`
+
+```yaml
+- type: by-label
+  parameters:
+    label: "my-label"
+    validValues: ["value1", "value2"]
+    allowsNoLabel: false   # if true, pods without the label are also passed
+```
+
+### `by-label-selector`
+
+Passes pods matching a Kubernetes label selector expression (supports
+`matchLabels` and `matchExpressions` with AND logic).
+
+**Type:** `by-label-selector`
+
+```yaml
+- type: by-label-selector
+  parameters:
+    matchLabels:
+      app: my-app
+    matchExpressions:
+      - key: tier
+        operator: In
+        values: ["fast", "medium"]
+```
+
+## When to use
+
+Use `decode-filter` and `prefill-filter` together in P/D disaggregated
+scheduling profiles. Use `encode-filter` for E/P/D multimodal pipelines.
+Use `by-label` or `by-label-selector` for custom routing requirements
+beyond the built-in role system.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/README.md
@@ -1,0 +1,23 @@
+# data-parallel-profile-handler
+
+> **Deprecated:** Use `simple-profile-handler` with Istio >= 1.28.1.
+
+Handles scheduler profile selection for data-parallel (DP) serving
+topologies where multiple identical pods share the same model.
+
+## Type
+
+`data-parallel-profile-handler`
+
+## Configuration
+
+```yaml
+- type: data-parallel-profile-handler
+  parameters:
+    primaryPort: 8000   # base port for data-parallel communication (default: 8000)
+```
+
+## When to use
+
+Only use this handler if you are running Istio < 1.28.1. For all new
+deployments, use `simple-profile-handler` instead.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
@@ -1,0 +1,76 @@
+# Disaggregated Profile Handler Plugins
+
+Profile handler plugins that orchestrate prefill/decode (P/D) and
+encode/prefill/decode (E/P/D) disaggregated serving by selecting which
+scheduling profiles to run for each request.
+
+## Plugins
+
+### `disagg-profile-handler`
+
+Selects prefill, encode, and decode scheduling profiles based on a
+configurable decider plugin. The decider determines whether a request
+should be disaggregated or served entirely on decode pods.
+
+**Type:** `disagg-profile-handler`
+
+```yaml
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      prefill: prefix-based-pd-decider      # decider for P/D disaggregation
+      encode: always-disagg-multimodal-decider  # decider for E/P/D
+    decodeProfile: "decode"    # name of the decode scheduling profile (default: "decode")
+    prefillProfile: "prefill"  # name of the prefill scheduling profile (default: "prefill")
+    encodeProfile: "encode"    # name of the encode scheduling profile (default: "encode")
+```
+
+### `disagg-headers-handler`
+
+PreRequest plugin that wires prefill and encode scheduling profile
+results into HTTP headers, telling the decode worker which prefill
+and encode pods to contact for KV-cache transfer.
+
+Sets `x-prefiller-url` (prefill pod address) and encoder endpoint
+headers based on the scheduling result.
+
+**Type:** `disagg-headers-handler`
+
+```yaml
+- type: disagg-headers-handler
+  parameters:
+    prefillProfile: "prefill"  # scheduling profile name for prefill (default: "prefill")
+    encodeProfile: "encode"    # scheduling profile name for encode (default: "encode")
+```
+
+### `prefix-based-pd-decider`
+
+Decides whether to disaggregate a request into prefill and decode phases
+based on the number of non-cached tokens. Requests below the threshold
+are served on decode pods only (avoiding disaggregation overhead).
+
+**Type:** `prefix-based-pd-decider`
+
+```yaml
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 100   # minimum uncached tokens to trigger P/D disaggregation
+```
+
+### `always-disagg-multimodal-decider`
+
+Always triggers encode disaggregation for multimodal requests
+(those containing image, video, or audio inputs).
+
+**Type:** `always-disagg-multimodal-decider`
+
+```yaml
+- type: always-disagg-multimodal-decider
+```
+
+## When to use
+
+Use `disagg-profile-handler` + `disagg-headers-handler` together when
+running P/D or E/P/D disaggregated deployments. Pair with
+`prefix-based-pd-decider` to skip disaggregation for short or
+fully-cached prompts where the overhead outweighs the benefit.

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/README.md
@@ -1,0 +1,25 @@
+# active-request-scorer
+
+Scores pods based on the number of actively in-flight requests being served.
+Each request is tracked individually with a configurable TTL to handle stale
+entries from timed-out requests.
+
+## Type
+
+`active-request-scorer`
+
+## How it works
+
+Pods with active request count at or below `idleThreshold` receive a score
+of `1.0`. Busier pods receive lower scores proportional to their load,
+down to `0.0` for the most loaded pod. A `maxBusyScore` parameter creates
+a scoring gap between idle and busy pods to strongly prefer idle pods.
+
+## Configuration
+
+```yaml
+## When to use
+
+Use when you want to route away from pods that are actively serving many
+requests. Pairs well with `queue-depth-scorer` for comprehensive load
+awareness.

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
@@ -1,0 +1,45 @@
+# context-length-aware
+
+Scores (and optionally filters) pods based on their supported context
+length range, routing requests to pods optimized for the input length.
+
+## Type
+
+`context-length-aware`
+
+## How it works
+
+Reads a pod label (default: `llm-d.ai/context-length-range`) that
+specifies the context length range the pod is optimized for, in the
+format `min-max` (e.g., `0-2048` or `2048-131072`).
+
+Scores pods higher when the incoming request's token count falls within
+their declared range. When `enableFiltering` is true, pods whose range
+does not cover the request length are filtered out entirely.
+
+Token count is estimated from prompt length using a character-to-token
+multiplier (0.25) when no tokenizer is configured.
+
+## Configuration
+
+```yaml
+- type: context-length-aware
+  parameters:
+    label: "llm-d.ai/context-length-range"   # pod label to read (default)
+    enableFiltering: false                    # also filter non-matching pods (default: false)
+```
+
+## Pod labeling
+
+```yaml
+metadata:
+  labels:
+    llm-d.ai/context-length-range: "0-8192"
+```
+
+## When to use
+
+Use when serving heterogeneous hardware where some pods have larger KV
+cache capacity (optimized for long contexts) and others are optimized for
+short contexts. Improves GPU memory utilization by matching request length
+to pod capability.

--- a/pkg/epp/framework/plugins/scheduling/scorer/loadaware/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loadaware/README.md
@@ -1,0 +1,26 @@
+# load-aware-scorer
+
+Scores pods based on their combined queue depth and active request load,
+normalized against a configurable threshold.
+
+## Type
+
+`load-aware-scorer`
+
+## How it works
+
+Computes a load score for each pod using its waiting queue size and
+active request count. Pods with load below the threshold receive higher
+scores. Once load exceeds the threshold, the score approaches zero.
+
+## Configuration
+
+```yaml
+## When to use
+
+Use as a general-purpose load balancer when you want to spread requests
+evenly across pods. Can be combined with prefix cache scorers to balance
+load against cache affinity.
+
+> **Note:** This scorer is deprecated in favor of `queue-depth-scorer`
+> and `active-request-scorer` which provide more granular control.

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/README.md
@@ -1,0 +1,34 @@
+# no-hit-lru-scorer
+
+Penalizes pods that recently caused KV-cache misses, steering cold
+requests away from pods that are unlikely to have cached prefixes.
+
+## Type
+
+`no-hit-lru-scorer`
+
+## How it works
+
+Tracks which pods served requests that resulted in a KV-cache miss using
+an LRU cache. When a new request arrives, pods that recently had misses
+receive a lower score. The plugin reads prefix cache hit/miss state from
+a companion prefix cache scorer plugin.
+
+Also implements `PreRequest` to record routing decisions for future
+scoring rounds.
+
+## Configuration
+
+```yaml
+- type: no-hit-lru-scorer
+  parameters:
+    prefixPluginType: "prefix-cache-scorer"   # type of the prefix cache plugin to read from
+    prefixPluginName: "prefix-cache-scorer"   # name of the prefix cache plugin instance
+    lruSize: 1024                             # max number of endpoints tracked (default: 1024)
+```
+
+## When to use
+
+Use alongside a prefix cache scorer in P/D disaggregated deployments to
+avoid routing cold requests to pods that have recently experienced cache
+misses.

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
@@ -1,0 +1,46 @@
+# precise-prefix-cache-scorer
+
+Scores pods based on real-time KV-cache block locality, providing more
+accurate prefix cache affinity than estimation-based scorers.
+
+## Type
+
+`precise-prefix-cache-scorer`
+
+## How it works
+
+Unlike the approximate prefix cache scorer (which estimates cache state
+from scheduling history), this plugin subscribes to KV-cache events
+directly from vLLM instances and maintains a real-time index of which
+KV blocks are present on each pod.
+
+When scoring, it computes the overlap between the incoming request's
+token blocks and each pod's cached blocks, giving higher scores to pods
+with more matching blocks.
+
+Supports speculative indexing: after a routing decision, the plugin
+proactively adds predicted cache entries to close the blind spot between
+routing and KV event arrival.
+
+## Configuration
+
+```yaml
+- type: precise-prefix-cache-scorer
+  parameters:
+    tokenProcessorConfig:
+      blockSize: 16          # must match vLLM block size
+      modelName: "my-model"  # model name for tokenizer lookup
+    indexerConfig:
+      maxPrefixBlocksToMatch: 256
+    kvEventsConfig: {}
+    speculativeIndexing: true
+```
+
+> **Important:** `blockSize` and `hashSeed` in `tokenProcessorConfig`
+> must match the values used in your vLLM deployment.
+
+## When to use
+
+Use instead of `prefix-cache-scorer` when you need accurate, real-time
+KV-cache locality scoring. Requires vLLM instances to emit KV-cache
+events. Recommended for production P/D disaggregated deployments.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/README.md
@@ -1,0 +1,29 @@
+# session-affinity-scorer
+
+Routes subsequent requests in a session to the same pod as the first
+request, maximizing KV-cache reuse for multi-turn conversations.
+
+## Type
+
+`session-affinity-scorer`
+
+## How it works
+
+The scorer reads the `x-session-token` header from incoming requests.
+On the first request in a session, a pod is selected normally. On
+subsequent requests with the same session token, that pod receives the
+highest score and all other pods receive zero, pinning the session.
+
+The scorer also implements `ResponseBodyProcessor` to extract and persist
+session state from responses.
+
+## Configuration
+
+No parameters. The plugin is stateless per-instance.
+
+```yaml
+## When to use
+
+Use for multi-turn chat applications or agentic workflows where the same
+context prefix is reused across turns. Avoids KV-cache misses caused by
+routing the same session to different pods.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Adds README.md files for 9 scheduler plugins that were missing documentation. Each README covers the plugin type name, how it works, configuration parameters with defaults, and when to use it.

Plugins documented:
- `active-request-scorer`
- `session-affinity-scorer`
- `load-aware-scorer`
- `no-hit-lru-scorer`
- `precise-prefix-cache-scorer`
- `context-length-aware`
- `bylabel` filters (`decode-filter`, `prefill-filter`, `encode-filter`, `by-label`, `by-label-selector`)
- `data-parallel-profile-handler`
- `disagg` profile handlers (`disagg-profile-handler`, `disagg-headers-handler`, `prefix-based-pd-decider`, `always-disagg-multimodal-decider`)

**Which issue(s) this PR fixes**:
Relates to #846

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```