### PR TITLE
migrate: e2e tests from sigs.k8s.io/gateway-api-inference-extension 

### DIFF
--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -10,7 +10,7 @@ The end-to-end tests are designed to validate end-to-end Gateway API Inference E
 
 - [Go](https://golang.org/doc/install) installed on your machine.
 - [Make](https://www.gnu.org/software/make/manual/make.html) installed to run the end-to-end test target.
-- A Hugging Face Hub token with access to the [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf) model.
+- A Hugging Face Hub token with access to the [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct) model.
 
 ## Running the End-to-End Tests
 
@@ -34,5 +34,5 @@ Follow these steps to run the end-to-end tests:
    make test-e2e
    ```
 
-   The test suite prints details for each step. Note that the `vllm-llama2-7b-pool` model server deployment
+   The test suite prints details for each step. Note that the `vllm-llama3-8b-instruct-pool` model server deployment
    may take several minutes to report an `Available=True` status due to the time required for bootstraping.

--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -28,6 +28,13 @@ Follow these steps to run the end-to-end tests:
    export HF_TOKEN=<MY_HF_TOKEN>
    ```
 
+1. **(Optional): Set the test namespace**: By default, the e2e test creates resources in the `inf-ext-e2e` namespace.
+   If you would like to change this namespace, set the following environment variable:
+
+   ```sh
+   export E2E_NS=<MY_NS>
+   ```
+
 1. **Run the Tests**: Run the `test-e2e` target:
 
    ```sh

--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -1,0 +1,38 @@
+# End-to-End Tests
+
+This document provides instructions on how to run the end-to-end tests.
+
+## Overview
+
+The end-to-end tests are designed to validate end-to-end Gateway API Inference Extension functionality. These tests are executed against a Kubernetes cluster and use the Ginkgo testing framework to ensure the extension behaves as expected.
+
+## Prerequisites
+
+- [Go](https://golang.org/doc/install) installed on your machine.
+- [Make](https://www.gnu.org/software/make/manual/make.html) installed to run the end-to-end test target.
+- A Hugging Face Hub token with access to the [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf) model.
+
+## Running the End-to-End Tests
+
+Follow these steps to run the end-to-end tests:
+
+1. **Clone the Repository**: Clone the `gateway-api-inference-extension` repository:
+
+   ```sh
+   git clone https://github.com/kubernetes-sigs/gateway-api-inference-extension.git && cd gateway-api-inference-extension
+   ```
+
+1. **Export Your Hugging Face Hub Token**: The token is required to run the test model server:
+
+   ```sh
+   export HF_TOKEN=<MY_HF_TOKEN>
+   ```
+
+1. **Run the Tests**: Run the `test-e2e` target:
+
+   ```sh
+   make test-e2e
+   ```
+
+   The test suite prints details for each step. Note that the `vllm-llama2-7b-pool` model server deployment
+   may take several minutes to report an `Available=True` status due to the time required for bootstraping.

--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -10,7 +10,13 @@ The end-to-end tests are designed to validate end-to-end Gateway API Inference E
 
 - [Go](https://golang.org/doc/install) installed on your machine.
 - [Make](https://www.gnu.org/software/make/manual/make.html) installed to run the end-to-end test target.
-- A Hugging Face Hub token with access to the [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct) model.
+- (Optional) When using the GPU-based vLLM deployment, a Hugging Face Hub token with access to the
+  [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct) model is required.
+  After obtaining the token and being granted access to the model, set the `HF_TOKEN` environment variable:
+
+   ```sh
+   export HF_TOKEN=<MY_HF_TOKEN>
+   ```
 
 ## Running the End-to-End Tests
 
@@ -22,18 +28,22 @@ Follow these steps to run the end-to-end tests:
    git clone https://github.com/kubernetes-sigs/gateway-api-inference-extension.git && cd gateway-api-inference-extension
    ```
 
-1. **Export Your Hugging Face Hub Token**: The token is required to run the test model server:
+1. **Optional Settings**
 
-   ```sh
-   export HF_TOKEN=<MY_HF_TOKEN>
-   ```
+   - **Set the test namespace**: By default, the e2e test creates resources in the `inf-ext-e2e` namespace.
+     If you would like to change this namespace, set the following environment variable:
 
-1. **(Optional): Set the test namespace**: By default, the e2e test creates resources in the `inf-ext-e2e` namespace.
-   If you would like to change this namespace, set the following environment variable:
+     ```sh
+     export E2E_NS=<MY_NS>
+     ```
 
-   ```sh
-   export E2E_NS=<MY_NS>
-   ```
+   - **Set the model server manifest**: By default, the e2e test uses the [vLLM Simulator](https://github.com/llm-d/llm-d-inference-sim)
+     (`config/manifests/vllm/sim-deployment.yaml`) to simulate a backend model server. If you would like to change the model server
+     deployment type, set the following environment variable to one of the following:
+
+     ```sh
+     export E2E_MANIFEST_PATH=[config/manifests/vllm/gpu-deployment.yaml|config/manifests/vllm/cpu-deployment.yaml]
+     ```
 
 1. **Run the Tests**: Run the `test-e2e` target:
 
@@ -41,5 +51,5 @@ Follow these steps to run the end-to-end tests:
    make test-e2e
    ```
 
-   The test suite prints details for each step. Note that the `vllm-llama3-8b-instruct-pool` model server deployment
-   may take several minutes to report an `Available=True` status due to the time required for bootstraping.
+   The test suite prints details for each step. Note that the `vllm-llama3-8b-instruct` model server deployment
+   may take several minutes to report an `Available=True` status due to the time required for bootstrapping.

--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -45,6 +45,19 @@ Follow these steps to run the end-to-end tests:
      export E2E_MANIFEST_PATH=[config/manifests/vllm/gpu-deployment.yaml|config/manifests/vllm/cpu-deployment.yaml]
      ```
 
+   - **Enable leader election tests**: By default, the e2e test runs the EPP server as a single replica.
+     To test the high-availability (HA) mode with leader election (3 replicas), set the following environment variable:
+
+     ```sh
+     export E2E_LEADER_ELECTION_ENABLED=true
+     ```
+
+   - **Pause before cleanup**: To pause the test run before cleaning up resources, set the `E2E_PAUSE_ON_EXIT` environment variable.
+     This is useful for debugging the state of the cluster after the test has run.
+
+     - To pause indefinitely, set it to `true`: `export E2E_PAUSE_ON_EXIT=true`
+     - To pause for a specific duration, provide a duration string: `export E2E_PAUSE_ON_EXIT=10m`
+
 1. **Run the Tests**: Run the `test-e2e` target:
 
    ```sh

--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -11,7 +11,7 @@ The end-to-end tests are designed to validate end-to-end Gateway API Inference E
 - [Go](https://golang.org/doc/install) installed on your machine.
 - [Make](https://www.gnu.org/software/make/manual/make.html) installed to run the end-to-end test target.
 - (Optional) When using the GPU-based vLLM deployment, a Hugging Face Hub token with access to the
-  [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct) model is required.
+  [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) model is required.
   After obtaining the token and being granted access to the model, set the `HF_TOKEN` environment variable:
 
    ```sh
@@ -64,5 +64,5 @@ Follow these steps to run the end-to-end tests:
    make test-e2e
    ```
 
-   The test suite prints details for each step. Note that the `vllm-llama3-8b-instruct` model server deployment
+   The test suite prints details for each step. Note that the `vllm-qwen3-32b` model server deployment
    may take several minutes to report an `Available=True` status due to the time required for bootstrapping.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -62,6 +62,8 @@ const (
 	modelServerName = "vllm-llama3-8b-instruct"
 	// modelName is the test model name.
 	modelName = "food-review"
+	// targetModelName is the target model name of the test model server.
+	targetModelName = modelName + "-1"
 	// envoyName is the name of the envoy proxy test resources.
 	envoyName = "envoy"
 	// envoyPort is the listener port number of the test envoy proxy.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -40,6 +40,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
 	infextv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	infextv1a2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -81,8 +81,8 @@ const (
 	modelServerSecretManifest = "../../testdata/model-secret.yaml"
 	// xInferPoolManifest is the manifest for the inference pool CRD with 'inference.networking.x-k8s.io' group.
 	xInferPoolManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml"
-	// xInferModelManifest is the manifest for the inference model CRD with 'inference.networking.x-k8s.io' group.
-	xInferModelManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml"
+	// xInferObjectiveManifest is the manifest for the inference model CRD with 'inference.networking.x-k8s.io' group.
+	xInferObjectiveManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml"
 	// inferPoolManifest is the manifest for the inference pool CRD with 'inference.networking.k8s.io' group.
 	inferPoolManifest = "../../../config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
 	// inferExtManifest is the manifest for the inference extension test resources.
@@ -140,9 +140,9 @@ func setupInfra() {
 		createHfSecret(cli, modelServerSecretManifest)
 	}
 	crds := map[string]string{
-		"inferencepools.inference.networking.x-k8s.io":  xInferPoolManifest,
-		"inferencemodels.inference.networking.x-k8s.io": xInferModelManifest,
-		"inferencepools.inference.networking.k8s.io":    inferPoolManifest,
+		"inferencepools.inference.networking.x-k8s.io":      xInferPoolManifest,
+		"inferenceobjectives.inference.networking.x-k8s.io": xInferObjectiveManifest,
+		"inferencepools.inference.networking.k8s.io":        inferPoolManifest,
 	}
 
 	createCRDs(cli, crds)
@@ -196,7 +196,7 @@ func cleanupResources() {
 }
 
 func cleanupInferModelResources() {
-	gomega.Expect(testutils.DeleteInferenceModelResources(ctx, cli, nsName)).To(gomega.Succeed())
+	gomega.Expect(testutils.DeleteInferenceObjectiveResources(ctx, cli, nsName)).To(gomega.Succeed())
 }
 
 func getTimeout(key string, fallback time.Duration) time.Duration {

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -40,6 +40,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	infextv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	infextv1a2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
@@ -77,10 +78,12 @@ const (
 	clientManifest = "../../testdata/client.yaml"
 	// modelServerSecretManifest is the manifest for the model server secret resource.
 	modelServerSecretManifest = "../../testdata/model-secret.yaml"
-	// inferPoolManifest is the manifest for the inference pool CRD.
-	inferPoolManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml"
-	// inferModelManifest is the manifest for the inference model CRD.
-	inferModelManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml"
+	// xInferPoolManifest is the manifest for the inference pool CRD with 'inference.networking.x-k8s.io' group.
+	xInferPoolManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml"
+	// xInferModelManifest is the manifest for the inference model CRD with 'inference.networking.x-k8s.io' group.
+	xInferModelManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml"
+	// inferPoolManifest is the manifest for the inference pool CRD with 'inference.networking.k8s.io' group.
+	inferPoolManifest = "../../../config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
 	// inferExtManifest is the manifest for the inference extension test resources.
 	inferExtManifest = "../../testdata/inferencepool-e2e.yaml"
 	// envoyManifest is the manifest for the envoy proxy test resources.
@@ -136,8 +139,9 @@ func setupInfra() {
 		createHfSecret(cli, modelServerSecretManifest)
 	}
 	crds := map[string]string{
-		"inferencepools.inference.networking.x-k8s.io":  inferPoolManifest,
-		"inferencemodels.inference.networking.x-k8s.io": inferModelManifest,
+		"inferencepools.inference.networking.x-k8s.io":  xInferPoolManifest,
+		"inferencemodels.inference.networking.x-k8s.io": xInferModelManifest,
+		"inferencepools.inference.networking.k8s.io":    inferPoolManifest,
 	}
 
 	createCRDs(cli, crds)
@@ -167,6 +171,9 @@ func setupSuite() {
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	err = infextv1a2.Install(scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	err = infextv1.Install(scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	cli, err = client.New(cfg, client.Options{Scheme: scheme})

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -40,7 +40,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	infextv1a2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	infextv1a2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -267,6 +267,7 @@ func createMetricsRbac(testConfig *testutils.TestConfig, filePath string) {
 	for _, m := range inManifests {
 		outManifests = append(outManifests, strings.ReplaceAll(m, "$E2E_NS", testConfig.NsName))
 	}
+
 	ginkgo.By("Creating RBAC resources for scraping metrics from manifest: " + filePath)
 	testutils.CreateObjsFromYaml(testConfig, outManifests)
 
@@ -320,7 +321,9 @@ func createEnvoy(testConfig *testutils.TestConfig, filePath string) {
 
 // createInferExt creates the inference extension resources used for testing from the given filePath.
 func createInferExt(testConfig *testutils.TestConfig, filePath string) {
-	inManifests := testutils.ReadYaml(filePath)
+
+	// This image needs to be updated to open multiple ports and respond.
+	inManifests := testutils.ReadYaml(filePath) // Modify inference-pool.yaml
 	ginkgo.By("Replacing placeholders with environment variables")
 	outManifests := []string{}
 	replacer := strings.NewReplacer(

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -57,15 +57,15 @@ const (
 	// TODO [danehans]: Must be "default" until https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/227 is fixed
 	nsName = "default"
 	// modelServerName is the name of the model server test resources.
-	modelServerName = "vllm-llama2-7b"
+	modelServerName = "vllm-llama3-8b-instruct"
 	// modelName is the test model name.
-	modelName = "tweet-summary"
+	modelName = "food-review"
 	// envoyName is the name of the envoy proxy test resources.
 	envoyName = "envoy"
 	// envoyPort is the listener port number of the test envoy proxy.
 	envoyPort = "8081"
 	// inferExtName is the name of the inference extension test resources.
-	inferExtName = "vllm-llama2-7b-epp"
+	inferExtName = "vllm-llama3-8b-instruct-epp"
 	// clientManifest is the manifest for the client test resources.
 	clientManifest = "../../testdata/client.yaml"
 	// modelServerSecretManifest is the manifest for the model server secret resource.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -75,7 +75,7 @@ const (
 	// inferModelManifest is the manifest for the inference model CRD.
 	inferModelManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml"
 	// inferExtManifest is the manifest for the inference extension test resources.
-	inferExtManifest = "../../../config/manifests/inferencepool.yaml"
+	inferExtManifest = "../../../config/manifests/inferencepool-resources.yaml"
 	// envoyManifest is the manifest for the envoy proxy test resources.
 	envoyManifest = "../../testdata/envoy.yaml"
 	// modelServerManifestFilepathEnvVar is the env var that holds absolute path to the manifest for the model server test resource.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -103,7 +103,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	if nsName == "" {
 		nsName = defaultNsName
 	}
-	testConfig = testutils.NewTestConfig(nsName)
+	testConfig = testutils.NewTestConfig(nsName, "")
 
 	e2eImage = os.Getenv("E2E_IMAGE")
 	gomega.Expect(e2eImage).NotTo(gomega.BeEmpty(), "E2E_IMAGE environment variable is not set")

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -68,6 +68,8 @@ const (
 	xInferPoolManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml"
 	// xInferObjectiveManifest is the manifest for the inference model CRD with 'inference.networking.x-k8s.io' group.
 	xInferObjectiveManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml"
+	// xInferenceModelRewritesManifest is the manifest for the inference rewrites CRD with 'inference.networking.x-k8s.io' group.
+	xInferenceModelRewritesManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodelrewrites.yaml"
 	// inferPoolManifest is the manifest for the inference pool CRD with 'inference.networking.k8s.io' group.
 	inferPoolManifest = "../../../config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
 	// inferExtManifestDefault is the manifest for the default inference extension test resources (single replica).
@@ -132,9 +134,10 @@ func setupInfra() {
 		createHfSecret(testConfig, modelServerSecretManifest)
 	}
 	crds := map[string]string{
-		"inferencepools.inference.networking.x-k8s.io":      xInferPoolManifest,
-		"inferenceobjectives.inference.networking.x-k8s.io": xInferObjectiveManifest,
-		"inferencepools.inference.networking.k8s.io":        inferPoolManifest,
+		"inferencepools.inference.networking.x-k8s.io":         xInferPoolManifest,
+		"inferenceobjectives.inference.networking.x-k8s.io":    xInferObjectiveManifest,
+		"inferencemodelrewrites.inference.networking.x-k8s.io": xInferenceModelRewritesManifest,
+		"inferencepools.inference.networking.k8s.io":           inferPoolManifest,
 	}
 
 	createCRDs(testConfig, crds)

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -57,7 +57,7 @@ const (
 	// TODO [danehans]: Must be "default" until https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/227 is fixed
 	nsName = "default"
 	// modelServerName is the name of the model server test resources.
-	modelServerName = "vllm-llama2-7b-pool"
+	modelServerName = "my-pool"
 	// modelName is the test model name.
 	modelName = "tweet-summary"
 	// envoyName is the name of the envoy proxy test resources.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -280,7 +280,7 @@ func getYamlsFromModelServerManifest(modelServerManifestPath string) []string {
 	return modelServerManifestArray
 }
 
-// createCRDs creates the Inference ExtensionRef CRDs used for testing.
+// createCRDs creates the Inference Extension CRDs used for testing.
 func createCRDs(k8sClient client.Client, crds map[string]string) {
 	for name, path := range crds {
 		ginkgo.By("Creating CRD resource from manifest: " + path)

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -64,14 +64,6 @@ const (
 	clientManifest = "../../testdata/client.yaml"
 	// modelServerSecretManifest is the manifest for the model server secret resource.
 	modelServerSecretManifest = "../../testdata/model-secret.yaml"
-	// xInferPoolManifest is the manifest for the inference pool CRD with 'inference.networking.x-k8s.io' group.
-	xInferPoolManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml"
-	// xInferObjectiveManifest is the manifest for the inference model CRD with 'inference.networking.x-k8s.io' group.
-	xInferObjectiveManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml"
-	// xInferenceModelRewritesManifest is the manifest for the inference rewrites CRD with 'inference.networking.x-k8s.io' group.
-	xInferenceModelRewritesManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodelrewrites.yaml"
-	// inferPoolManifest is the manifest for the inference pool CRD with 'inference.networking.k8s.io' group.
-	inferPoolManifest = "../../../config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
 	// inferExtManifestDefault is the manifest for the default inference extension test resources (single replica).
 	inferExtManifestDefault = "../../testdata/inferencepool-e2e.yaml"
 	// inferExtManifestLeaderElection is the manifest for the inference extension test resources with leader election enabled (3 replicas).
@@ -82,6 +74,8 @@ const (
 	metricsRbacManifest = "../../testdata/metrics-rbac.yaml"
 	// modelServerManifestFilepathEnvVar is the env var that holds absolute path to the manifest for the model server test resource.
 	modelServerManifestFilepathEnvVar = "MANIFEST_PATH"
+	// crdKustomizePath is the kustomize folder path for the required CRDs.
+	crdKustomizePath = "../../../config/crd/"
 )
 
 const e2eLeaderElectionEnabledEnvVar = "E2E_LEADER_ELECTION_ENABLED"
@@ -133,14 +127,7 @@ func setupInfra() {
 	if strings.Contains(modelServerManifestArray[0], "hf-token") {
 		createHfSecret(testConfig, modelServerSecretManifest)
 	}
-	crds := map[string]string{
-		"inferencepools.inference.networking.x-k8s.io":         xInferPoolManifest,
-		"inferenceobjectives.inference.networking.x-k8s.io":    xInferObjectiveManifest,
-		"inferencemodelrewrites.inference.networking.x-k8s.io": xInferenceModelRewritesManifest,
-		"inferencepools.inference.networking.k8s.io":           inferPoolManifest,
-	}
-
-	createCRDs(testConfig, crds)
+	testutils.CreateCrdsFromKustomize(testConfig, crdKustomizePath)
 
 	inferExtManifestPath := inferExtManifestDefault
 	if leaderElectionEnabled {
@@ -201,7 +188,7 @@ func cleanupResources() {
 	gomega.Expect(testutils.DeleteNamespacedResources(testConfig)).To(gomega.Succeed())
 }
 
-func cleanupInferModelResources() {
+func cleanupInferObjectiveResources() {
 	gomega.Expect(testutils.DeleteInferenceObjectiveResources(testConfig)).To(gomega.Succeed())
 }
 
@@ -243,14 +230,6 @@ func getYamlsFromModelServerManifest(modelServerManifestPath string) []string {
 	modelServerManifestArray := testutils.ReadYaml(modelServerManifestPath)
 	gomega.Expect(modelServerManifestArray).NotTo(gomega.BeEmpty())
 	return modelServerManifestArray
-}
-
-// createCRDs creates the Inference Extension CRDs used for testing.
-func createCRDs(testConfig *testutils.TestConfig, crds map[string]string) {
-	for _, path := range crds {
-		ginkgo.By("Creating CRD resource from manifest: " + path)
-		testutils.ApplyYAMLFile(testConfig, path)
-	}
 }
 
 // createClient creates the client pod used for testing from the given filePath.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -57,7 +57,7 @@ const (
 	// TODO [danehans]: Must be "default" until https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/227 is fixed
 	nsName = "default"
 	// modelServerName is the name of the model server test resources.
-	modelServerName = "my-pool"
+	modelServerName = "vllm-llama2-7b"
 	// modelName is the test model name.
 	modelName = "tweet-summary"
 	// envoyName is the name of the envoy proxy test resources.
@@ -65,7 +65,7 @@ const (
 	// envoyPort is the listener port number of the test envoy proxy.
 	envoyPort = "8081"
 	// inferExtName is the name of the inference extension test resources.
-	inferExtName = "inference-gateway-ext-proc"
+	inferExtName = "vllm-llama2-7b-epp"
 	// clientManifest is the manifest for the client test resources.
 	clientManifest = "../../testdata/client.yaml"
 	// modelServerSecretManifest is the manifest for the model server secret resource.
@@ -75,7 +75,7 @@ const (
 	// inferModelManifest is the manifest for the inference model CRD.
 	inferModelManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml"
 	// inferExtManifest is the manifest for the inference extension test resources.
-	inferExtManifest = "../../../config/manifests/ext_proc.yaml"
+	inferExtManifest = "../../../config/manifests/inferencepool.yaml"
 	// envoyManifest is the manifest for the envoy proxy test resources.
 	envoyManifest = "../../testdata/envoy.yaml"
 	// modelServerManifestFilepathEnvVar is the env var that holds absolute path to the manifest for the model server test resource.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -280,7 +280,7 @@ func getYamlsFromModelServerManifest(modelServerManifestPath string) []string {
 	return modelServerManifestArray
 }
 
-// createCRDs creates the Inference Extension CRDs used for testing.
+// createCRDs creates the Inference ExtensionRef CRDs used for testing.
 func createCRDs(k8sClient client.Client, crds map[string]string) {
 	for name, path := range crds {
 		ginkgo.By("Creating CRD resource from manifest: " + path)

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -242,7 +242,7 @@ func createClient(testConfig *testutils.TestConfig, filePath string) {
 func createMetricsRbac(testConfig *testutils.TestConfig, filePath string) {
 	inManifests := testutils.ReadYaml(filePath)
 	ginkgo.By("Replacing placeholder namespace with E2E_NS environment variable")
-	outManifests := []string{}
+	outManifests := make([]string, 0, len(inManifests))
 	for _, m := range inManifests {
 		outManifests = append(outManifests, strings.ReplaceAll(m, "$E2E_NS", testConfig.NsName))
 	}
@@ -276,7 +276,7 @@ func createHfSecret(testConfig *testutils.TestConfig, secretPath string) {
 
 	inManifests := testutils.ReadYaml(secretPath)
 	ginkgo.By("Replacing placeholder secret data with HF_TOKEN environment variable")
-	outManifests := []string{}
+	outManifests := make([]string, 0, len(inManifests))
 	for _, m := range inManifests {
 		outManifests = append(outManifests, strings.Replace(m, "$HF_TOKEN", token, 1))
 	}
@@ -289,7 +289,7 @@ func createHfSecret(testConfig *testutils.TestConfig, secretPath string) {
 func createEnvoy(testConfig *testutils.TestConfig, filePath string) {
 	inManifests := testutils.ReadYaml(filePath)
 	ginkgo.By("Replacing placeholder namespace with E2E_NS environment variable")
-	outManifests := []string{}
+	outManifests := make([]string, 0, len(inManifests))
 	for _, m := range inManifests {
 		outManifests = append(outManifests, strings.ReplaceAll(m, "$E2E_NS", testConfig.NsName))
 	}
@@ -304,7 +304,7 @@ func createInferExt(testConfig *testutils.TestConfig, filePath string) {
 	// This image needs to be updated to open multiple ports and respond.
 	inManifests := testutils.ReadYaml(filePath) // Modify inference-pool.yaml
 	ginkgo.By("Replacing placeholders with environment variables")
-	outManifests := []string{}
+	outManifests := make([]string, 0, len(inManifests))
 	replacer := strings.NewReplacer(
 		"$E2E_NS", testConfig.NsName,
 		"$E2E_IMAGE", e2eImage,

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -88,7 +88,6 @@ var (
 
 	// expectedCRDs lists the CRD names that must be established after kustomize apply.
 	expectedCRDs = []string{
-		"inferencepools.inference.networking.x-k8s.io",
 		"inferencepools.inference.networking.k8s.io",
 		"inferenceobjectives.inference.networking.x-k8s.io",
 		"inferencemodelrewrites.inference.networking.x-k8s.io",

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -136,7 +136,7 @@ func setupInfra() {
 	if strings.Contains(modelServerManifestArray[0], "hf-token") {
 		createHfSecret(testConfig, modelServerSecretManifest)
 	}
-	testutils.CreateCrdsFromKustomize(testConfig, crdKustomizePath)
+	testutils.ProcessKustomize(testConfig, crdKustomizePath, testutils.CreateAndVerifyObjs)
 	testutils.ValidateCRDsEstablished(testConfig, expectedCRDs)
 
 	inferExtManifestPath := inferExtManifestDefault

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -47,7 +47,7 @@ const (
 	// defaultNsName is the default name of the Namespace used for tests. Can override using the E2E_NS environment variable.
 	defaultNsName = "inf-ext-e2e"
 	// modelServerName is the name of the model server test resources.
-	modelServerName = "vllm-llama3-8b-instruct"
+	modelServerName = "vllm-qwen3-32b"
 	// modelName is the test model name.
 	modelName = "food-review"
 	// targetModelName is the target model name of the test model server.
@@ -57,7 +57,7 @@ const (
 	// envoyPort is the listener port number of the test envoy proxy.
 	envoyPort = "8081"
 	// inferExtName is the name of the inference extension test resources.
-	inferExtName = "vllm-llama3-8b-instruct-epp"
+	inferExtName = "vllm-qwen3-32b-epp"
 	// metricsReaderSecretName is the name of the metrics reader secret which stores sa token to read epp metrics.
 	metricsReaderSecretName = "inference-gateway-sa-metrics-reader-secret"
 	// clientManifest is the manifest for the client test resources.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -85,6 +85,15 @@ var (
 	// Required for exec'ing in curl pod
 	e2eImage              string
 	leaderElectionEnabled bool
+
+	// expectedCRDs lists the CRD names that must be established after kustomize apply.
+	expectedCRDs = []string{
+		"inferencepools.inference.networking.x-k8s.io",
+		"inferencepools.inference.networking.k8s.io",
+		"inferenceobjectives.inference.networking.x-k8s.io",
+		"inferencemodelrewrites.inference.networking.x-k8s.io",
+		"inferencepoolimports.inference.networking.x-k8s.io",
+	}
 )
 
 func TestAPIs(t *testing.T) {
@@ -128,6 +137,7 @@ func setupInfra() {
 		createHfSecret(testConfig, modelServerSecretManifest)
 	}
 	testutils.CreateCrdsFromKustomize(testConfig, crdKustomizePath)
+	testutils.ValidateCRDsEstablished(testConfig, expectedCRDs)
 
 	inferExtManifestPath := inferExtManifestDefault
 	if leaderElectionEnabled {

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package epp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	infextv1a2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
+)
+
+const (
+	// defaultExistsTimeout is the default timeout for a resource to exist in the api server.
+	defaultExistsTimeout = 30 * time.Second
+	// defaultReadyTimeout is the default timeout for a resource to report a ready state.
+	defaultReadyTimeout = 3 * time.Minute
+	// defaultModelReadyTimeout is the default timeout for the model server deployment to report a ready state.
+	defaultModelReadyTimeout = 10 * time.Minute
+	// defaultInterval is the default interval to check if a resource exists or ready conditions.
+	defaultInterval = time.Millisecond * 250
+	// defaultCurlInterval is the default interval to run the test curl command.
+	defaultCurlInterval = time.Second * 5
+	// nsName is the name of the Namespace used for tests.
+	// TODO [danehans]: Must be "default" until https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/227 is fixed
+	nsName = "default"
+	// modelServerName is the name of the model server test resources.
+	modelServerName = "vllm-llama2-7b-pool"
+	// modelName is the test model name.
+	modelName = "tweet-summary"
+	// envoyName is the name of the envoy proxy test resources.
+	envoyName = "envoy"
+	// envoyPort is the listener port number of the test envoy proxy.
+	envoyPort = "8081"
+	// inferExtName is the name of the inference extension test resources.
+	inferExtName = "inference-gateway-ext-proc"
+	// clientManifest is the manifest for the client test resources.
+	clientManifest = "../../testdata/client.yaml"
+	// modelServerManifest is the manifest for the model server test resources.
+	modelServerManifest = "../../../config/manifests/vllm/gpu-deployment.yaml"
+	// modelServerSecretManifest is the manifest for the model server secret resource.
+	modelServerSecretManifest = "../../testdata/model-secret.yaml"
+	// inferPoolManifest is the manifest for the inference pool CRD.
+	inferPoolManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml"
+	// inferModelManifest is the manifest for the inference model CRD.
+	inferModelManifest = "../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml"
+	// inferExtManifest is the manifest for the inference extension test resources.
+	inferExtManifest = "../../../config/manifests/ext_proc.yaml"
+	// envoyManifest is the manifest for the envoy proxy test resources.
+	envoyManifest = "../../testdata/envoy.yaml"
+)
+
+var (
+	ctx context.Context
+	cli client.Client
+	// Required for exec'ing in curl pod
+	kubeCli *kubernetes.Clientset
+	scheme  = runtime.NewScheme()
+	cfg     = config.GetConfigOrDie()
+)
+
+func TestAPIs(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t,
+		"End To End Test Suite",
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	ginkgo.By("Setting up the test suite")
+	setupSuite()
+
+	ginkgo.By("Creating test infrastructure")
+	setupInfra()
+})
+
+func setupInfra() {
+	crds := map[string]string{
+		"inferencepools.inference.networking.x-k8s.io":  inferPoolManifest,
+		"inferencemodels.inference.networking.x-k8s.io": inferModelManifest,
+	}
+	createCRDs(cli, crds)
+	createInferExt(cli, inferExtManifest)
+	createClient(cli, clientManifest)
+	createEnvoy(cli, envoyManifest)
+	// Run this step last, as it requires additional time for the model server to become ready.
+	createModelServer(cli, modelServerSecretManifest, modelServerManifest)
+}
+
+var _ = ginkgo.AfterSuite(func() {
+	ginkgo.By("Performing global cleanup")
+	cleanupResources()
+})
+
+// setupSuite initializes the test suite by setting up the Kubernetes client,
+// loading required API schemes, and validating configuration.
+func setupSuite() {
+	ctx = context.Background()
+	gomega.ExpectWithOffset(1, cfg).NotTo(gomega.BeNil())
+
+	err := clientgoscheme.AddToScheme(scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	err = apiextv1.AddToScheme(scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	err = infextv1a2.AddToScheme(scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	cli, err = client.New(cfg, client.Options{Scheme: scheme})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(cli).NotTo(gomega.BeNil())
+
+	kubeCli, err = kubernetes.NewForConfig(cfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func cleanupResources() {
+	gomega.Expect(testutils.DeleteClusterResources(ctx, cli)).To(gomega.Succeed())
+	gomega.Expect(testutils.DeleteNamespacedResources(ctx, cli, nsName)).To(gomega.Succeed())
+}
+
+func cleanupInferModelResources() {
+	gomega.Expect(testutils.DeleteInferenceModelResources(ctx, cli, nsName)).To(gomega.Succeed())
+}
+
+func getTimeout(key string, fallback time.Duration) time.Duration {
+	if value, ok := os.LookupEnv(key); ok {
+		if parsed, err := time.ParseDuration(value); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+var (
+	existsTimeout     = getTimeout("EXISTS_TIMEOUT", defaultExistsTimeout)
+	readyTimeout      = getTimeout("READY_TIMEOUT", defaultReadyTimeout)
+	modelReadyTimeout = getTimeout("MODEL_READY_TIMEOUT", defaultModelReadyTimeout)
+	interval          = defaultInterval
+	curlInterval      = defaultCurlInterval
+)
+
+// namespaceExists ensures that a specified namespace exists and is ready for use.
+func namespaceExists(k8sClient client.Client, ns string) {
+	ginkgo.By("Ensuring namespace exists: " + ns)
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: ns}, &corev1.Namespace{})
+	}, existsTimeout, interval)
+}
+
+// createCRDs creates the Inference Extension CRDs used for testing.
+func createCRDs(k8sClient client.Client, crds map[string]string) {
+	for name, path := range crds {
+		ginkgo.By("Creating CRD resource from manifest: " + path)
+		applyYAMLFile(k8sClient, path)
+
+		// Wait for the CRD to exist.
+		crd := &apiextv1.CustomResourceDefinition{}
+		testutils.EventuallyExists(ctx, func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: name}, crd)
+		}, existsTimeout, interval)
+
+		// Wait for the CRD to be established.
+		testutils.CRDEstablished(ctx, k8sClient, crd, readyTimeout, interval)
+	}
+}
+
+// createClient creates the client pod used for testing from the given filePath.
+func createClient(k8sClient client.Client, filePath string) {
+	ginkgo.By("Creating client resources from manifest: " + filePath)
+	applyYAMLFile(k8sClient, filePath)
+
+	// Wait for the pod to exist.
+	pod := &corev1.Pod{}
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: "curl"}, pod)
+	}, existsTimeout, interval)
+
+	// Wait for the pod to be ready.
+	testutils.PodReady(ctx, k8sClient, pod, readyTimeout, interval)
+}
+
+// createModelServer creates the model server resources used for testing from the given filePaths.
+func createModelServer(k8sClient client.Client, secretPath, deployPath string) {
+	ginkgo.By("Ensuring the HF_TOKEN environment variable is set")
+	token := os.Getenv("HF_TOKEN")
+	gomega.Expect(token).NotTo(gomega.BeEmpty(), "HF_TOKEN is not set")
+
+	inManifests := readYaml(secretPath)
+	ginkgo.By("Replacing placeholder secret data with HF_TOKEN environment variable")
+	outManifests := []string{}
+	for _, m := range inManifests {
+		outManifests = append(outManifests, strings.Replace(m, "$HF_TOKEN", token, 1))
+	}
+
+	ginkgo.By("Creating model server secret resource from manifest: " + deployPath)
+	createObjsFromYaml(k8sClient, outManifests)
+
+	// Wait for the secret to exist before proceeding with test.
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: "hf-token"}, &corev1.Secret{})
+	}, existsTimeout, interval)
+
+	ginkgo.By("Creating model server resources from manifest: " + deployPath)
+	applyYAMLFile(k8sClient, deployPath)
+
+	// Wait for the deployment to exist.
+	deploy := &appsv1.Deployment{}
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: modelServerName}, deploy)
+	}, existsTimeout, interval)
+
+	// Wait for the deployment to be available.
+	testutils.DeploymentAvailable(ctx, k8sClient, deploy, modelReadyTimeout, interval)
+}
+
+// createEnvoy creates the envoy proxy resources used for testing from the given filePath.
+func createEnvoy(k8sClient client.Client, filePath string) {
+	ginkgo.By("Creating envoy proxy resources from manifest: " + filePath)
+	applyYAMLFile(k8sClient, filePath)
+
+	// Wait for the configmap to exist before proceeding with test.
+	cfgMap := &corev1.ConfigMap{}
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: envoyName}, cfgMap)
+	}, existsTimeout, interval)
+
+	// Wait for the deployment to exist.
+	deploy := &appsv1.Deployment{}
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: envoyName}, deploy)
+	}, existsTimeout, interval)
+
+	// Wait for the deployment to be available.
+	testutils.DeploymentAvailable(ctx, k8sClient, deploy, readyTimeout, interval)
+
+	// Wait for the service to exist.
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: envoyName}, &corev1.Service{})
+	}, existsTimeout, interval)
+}
+
+// createInferExt creates the inference extension resources used for testing from the given filePath.
+func createInferExt(k8sClient client.Client, filePath string) {
+	ginkgo.By("Creating inference extension resources from manifest: " + filePath)
+	applyYAMLFile(k8sClient, filePath)
+
+	// Wait for the clusterrole to exist.
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: "pod-read"}, &rbacv1.ClusterRole{})
+	}, existsTimeout, interval)
+
+	// Wait for the clusterrolebinding to exist.
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: "pod-read-binding"}, &rbacv1.ClusterRoleBinding{})
+	}, existsTimeout, interval)
+
+	// Wait for the deployment to exist.
+	deploy := &appsv1.Deployment{}
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: inferExtName}, deploy)
+	}, existsTimeout, interval)
+
+	// Wait for the deployment to be available.
+	testutils.DeploymentAvailable(ctx, k8sClient, deploy, modelReadyTimeout, interval)
+
+	// Wait for the service to exist.
+	testutils.EventuallyExists(ctx, func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: inferExtName}, &corev1.Service{})
+	}, existsTimeout, interval)
+}
+
+// applyYAMLFile reads a file containing YAML (possibly multiple docs)
+// and applies each object to the cluster.
+func applyYAMLFile(k8sClient client.Client, filePath string) {
+	// Create the resources from the manifest file
+	createObjsFromYaml(k8sClient, readYaml(filePath))
+}
+
+func readYaml(filePath string) []string {
+	ginkgo.By("Reading YAML file: " + filePath)
+	yamlBytes, err := os.ReadFile(filePath)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Split multiple docs, if needed
+	return strings.Split(string(yamlBytes), "\n---")
+}
+
+func createObjsFromYaml(k8sClient client.Client, docs []string) {
+	// For each doc, decode and create
+	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+	for _, doc := range docs {
+		trimmed := strings.TrimSpace(doc)
+		if trimmed == "" {
+			continue
+		}
+		// Decode into a runtime.Object
+		obj, gvk, decodeErr := decoder.Decode([]byte(trimmed), nil, nil)
+		gomega.Expect(decodeErr).NotTo(gomega.HaveOccurred(),
+			"Failed to decode YAML document to a Kubernetes object")
+
+		ginkgo.By(fmt.Sprintf("Decoded GVK: %s", gvk))
+
+		unstrObj, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			// Fallback if it's a typed object
+			unstrObj = &unstructured.Unstructured{}
+			// Convert typed to unstructured
+			err := scheme.Convert(obj, unstrObj, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		unstrObj.SetNamespace(nsName)
+
+		// Create the object
+		err := k8sClient.Create(ctx, unstrObj)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			"Failed to create object from YAML")
+	}
+}

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -96,12 +96,8 @@ var _ = ginkgo.Describe("InferencePool", func() {
 func newInferenceModel(ns string) *v1alpha2.InferenceModel {
 	targets := []v1alpha2.TargetModel{
 		{
-			Name:   modelName,
-			Weight: ptr.To(int32(50)),
-		},
-		{
-			Name:   "cad-fabricator",
-			Weight: ptr.To(int32(50)),
+			Name:   targetModelName,
+			Weight: ptr.To(int32(100)),
 		},
 	}
 	return testutils.MakeModelWrapper("inferencemodel-sample", ns).

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
-	v1alpha2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	v1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 // newInferenceObjective creates an InferenceObjective in the given namespace for testutils.
 func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
 	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
-		SetCriticality(v1alpha2.Critical).
+		SetCriticality(2).
 		SetPoolRef(modelServerName).
 		Obj()
 }

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 		}, existsTimeout, interval).Should(gomega.Succeed())
 	})
 
-	ginkgo.When("The Inference ExtensionRef is running", func() {
+	ginkgo.When("The Inference Extension is running", func() {
 		ginkgo.It("Should route traffic to target model servers", func() {
 			verifyTrafficRouting()
 		})

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -100,7 +100,7 @@ func newInferenceModel(ns string) *v1alpha2.InferenceModel {
 			Weight: ptr.To(int32(100)),
 		},
 	}
-	return testutils.MakeModelWrapper("inferencemodel-sample", ns).
+	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferencemodel-sample", Namespace: ns}).
 		SetCriticality(v1alpha2.Critical).
 		SetModelName(modelName).
 		SetPoolRef(modelServerName).

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -94,11 +94,11 @@ var _ = ginkgo.Describe("InferencePool", func() {
 func newInferenceModel(ns string) *v1alpha2.InferenceModel {
 	targets := []v1alpha2.TargetModel{
 		{
-			Name:   modelName + "-0",
+			Name:   modelName,
 			Weight: ptr.To(int32(50)),
 		},
 		{
-			Name:   modelName + "-1",
+			Name:   "cad-fabricator",
 			Weight: ptr.To(int32(50)),
 		},
 	}

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -18,7 +18,9 @@ package epp
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -53,7 +55,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 			}, existsTimeout, interval).Should(gomega.Succeed())
 
 			ginkgo.By("Verifying connectivity through the inference extension")
-			curlCmd := getCurlCommand(envoyName, nsName, envoyPort, modelName)
+			curlCmd := getCurlCommand(envoyName, nsName, envoyPort, modelName, curlTimeout)
 
 			// Ensure the expected responses include the inferencemodel target model names.
 			var expected []string
@@ -112,10 +114,12 @@ func newInferenceModel(ns string) *v1alpha2.InferenceModel {
 
 // getCurlCommand returns the command, as a slice of strings, for curl'ing
 // the test model server at the given name, namespace, port, and model name.
-func getCurlCommand(name, ns, port, model string) []string {
+func getCurlCommand(name, ns, port, model string, timeout time.Duration) []string {
 	return []string{
 		"curl",
 		"-i",
+		"--max-time",
+		strconv.Itoa((int)(timeout.Seconds())),
 		fmt.Sprintf("%s.%s.svc:%s/v1/completions", name, ns, port),
 		"-H",
 		"Content-Type: application/json",

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 // newInferenceObjective creates an InferenceObjective in the given namespace for testutils.
 func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
 	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
-		SetCriticality(2).
+		SetPriority(2).
 		SetPoolRef(modelServerName).
 		Obj()
 }

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -244,8 +244,7 @@ func verifyMetrics() {
 		"inference_objective_request_total",
 		"inference_objective_request_error_total",
 		"inference_objective_request_duration_seconds",
-		// TODO: normalized_time_per_output_token_seconds is not actually recorded yet
-		// "normalized_time_per_output_token_seconds",
+		"inference_objective_normalized_time_per_output_token_seconds",
 		"inference_objective_request_sizes",
 		"inference_objective_response_sizes",
 		"inference_objective_input_tokens",

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -49,11 +49,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 
 			ginkgo.By("Ensuring the InferenceModel resource exists in the namespace")
 			gomega.Eventually(func() error {
-				err := cli.Get(ctx, types.NamespacedName{Namespace: infModel.Namespace, Name: infModel.Name}, infModel)
-				if err != nil {
-					return err
-				}
-				return nil
+				return cli.Get(ctx, types.NamespacedName{Namespace: infModel.Namespace, Name: infModel.Name}, infModel)
 			}, existsTimeout, interval).Should(gomega.Succeed())
 
 			ginkgo.By("Verifying connectivity through the inference extension")

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -32,8 +32,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
-	v1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 
@@ -241,7 +242,6 @@ func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
 	}
 	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
 		SetCriticality(v1alpha2.Critical).
-		SetModelName(modelName).
 		SetPoolRef(modelServerName).
 		SetTargetModels(targets).
 		Obj()
@@ -287,6 +287,8 @@ func getCurlCommand(name, ns, port, model string, timeout time.Duration, api str
 		fmt.Sprintf("%s.%s.svc:%s/v1%s", name, ns, port, api),
 		"-H",
 		"Content-Type: application/json",
+		"-H",
+		fmt.Sprintf("%v: inferenceobjective-sample", handlers.ObjectiveKey),
 		"-d",
 		string(b),
 	}

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 
@@ -288,7 +288,7 @@ func getCurlCommand(name, ns, port, model string, timeout time.Duration, api str
 		"-H",
 		"Content-Type: application/json",
 		"-H",
-		fmt.Sprintf("%v: inferenceobjective-sample", handlers.ObjectiveKey),
+		fmt.Sprintf("%v: inferenceobjective-sample", metadata.ObjectiveKey),
 		"-d",
 		string(b),
 	}

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -39,28 +39,28 @@ import (
 )
 
 var _ = ginkgo.Describe("InferencePool", func() {
-	var infModel *v1alpha2.InferenceModel
+	var infObjective *v1alpha2.InferenceObjective
 	ginkgo.BeforeEach(func() {
 		ginkgo.By("Waiting for the namespace to exist.")
 		namespaceExists(cli, nsName)
 
-		ginkgo.By("Creating an InferenceModel resource")
-		infModel = newInferenceModel(nsName)
-		gomega.Expect(cli.Create(ctx, infModel)).To(gomega.Succeed())
+		ginkgo.By("Creating an InferenceObjective resource")
+		infObjective = newInferenceObjective(nsName)
+		gomega.Expect(cli.Create(ctx, infObjective)).To(gomega.Succeed())
 
-		ginkgo.By("Ensuring the InferenceModel resource exists in the namespace")
+		ginkgo.By("Ensuring the InferenceObjective resource exists in the namespace")
 		gomega.Eventually(func() error {
-			return cli.Get(ctx, types.NamespacedName{Namespace: infModel.Namespace, Name: infModel.Name}, infModel)
+			return cli.Get(ctx, types.NamespacedName{Namespace: infObjective.Namespace, Name: infObjective.Name}, infObjective)
 		}, existsTimeout, interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.AfterEach(func() {
-		ginkgo.By("Deleting the InferenceModel test resource.")
+		ginkgo.By("Deleting the InferenceObjective test resource.")
 		cleanupInferModelResources()
 		gomega.Eventually(func() error {
-			err := cli.Get(ctx, types.NamespacedName{Namespace: infModel.Namespace, Name: infModel.Name}, infModel)
+			err := cli.Get(ctx, types.NamespacedName{Namespace: infObjective.Namespace, Name: infObjective.Name}, infObjective)
 			if err == nil {
-				return errors.New("InferenceModel resource still exists")
+				return errors.New("InferenceObjective resource still exists")
 			}
 			if !k8serrors.IsNotFound(err) {
 				return nil
@@ -102,9 +102,9 @@ var _ = ginkgo.Describe("InferencePool", func() {
 			} {
 				ginkgo.By(fmt.Sprintf("Verifying connectivity through the inference extension with %s api and prompt/messages: %v", t.api, t.promptOrMessages))
 
-				// Ensure the expected responses include the inferencemodel target model names.
+				// Ensure the expected responses include the InferenceObjective target model names.
 				var expected []string
-				for _, m := range infModel.Spec.TargetModels {
+				for _, m := range infObjective.Spec.TargetModels {
 					expected = append(expected, m.Name)
 				}
 				curlCmd := getCurlCommand(envoyName, nsName, envoyPort, modelName, curlTimeout, t.api, t.promptOrMessages, false)
@@ -231,15 +231,15 @@ var _ = ginkgo.Describe("InferencePool", func() {
 	})
 })
 
-// newInferenceModel creates an InferenceModel in the given namespace for testutils.
-func newInferenceModel(ns string) *v1alpha2.InferenceModel {
+// newInferenceObjective creates an InferenceObjective in the given namespace for testutils.
+func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
 	targets := []v1alpha2.TargetModel{
 		{
 			Name:   targetModelName,
 			Weight: ptr.To(int32(100)),
 		},
 	}
-	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferencemodel-sample", Namespace: ns}).
+	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
 		SetCriticality(v1alpha2.Critical).
 		SetModelName(modelName).
 		SetPoolRef(modelServerName).

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -241,19 +241,19 @@ func verifyMetrics() {
 	ginkgo.By("Verifying metrics exposure")
 	// Define the metrics we expect to see
 	expectedMetrics := []string{
-		"inference_model_request_total",
-		"inference_model_request_error_total",
-		"inference_model_request_duration_seconds",
+		"inference_objective_request_total",
+		"inference_objective_request_error_total",
+		"inference_objective_request_duration_seconds",
 		// TODO: normalized_time_per_output_token_seconds is not actually recorded yet
 		// "normalized_time_per_output_token_seconds",
-		"inference_model_request_sizes",
-		"inference_model_response_sizes",
-		"inference_model_input_tokens",
-		"inference_model_output_tokens",
+		"inference_objective_request_sizes",
+		"inference_objective_response_sizes",
+		"inference_objective_input_tokens",
+		"inference_objective_output_tokens",
 		"inference_pool_average_kv_cache_utilization",
 		"inference_pool_average_queue_size",
 		"inference_pool_per_pod_queue_size",
-		"inference_model_running_requests",
+		"inference_objective_running_requests",
 		"inference_pool_ready_pods",
 		"inference_extension_info",
 	}

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -17,26 +17,37 @@ limitations under the License.
 package epp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
+)
+
+const (
+	firstPort             = 8000
+	numPorts              = 2
+	maxConcurrentRequests = 2 // prevent hammering Envoy and backend
+	maxRetries            = 5
+	backoff               = 5 * time.Second
+	batches               = 20
 )
 
 var _ = ginkgo.Describe("InferencePool", func() {
@@ -44,6 +55,67 @@ var _ = ginkgo.Describe("InferencePool", func() {
 	ginkgo.BeforeEach(func() {
 		ginkgo.By("Waiting for the namespace to exist.")
 		namespaceExists(testConfig)
+
+		ginkgo.By("Modifying deployment using local image for testing (temporary).")
+		deploy := &appsv1.Deployment{}
+		key := types.NamespacedName{Name: modelServerName, Namespace: testConfig.NsName}
+
+		gomega.Eventually(func() error {
+			err := testConfig.K8sClient.Get(testConfig.Context, key, deploy)
+			if err != nil {
+				return err
+			}
+
+			// Instead of hardcoding arguments, we can instead replace the arguments that need
+			// to be changed, preserving any others that may exist.
+			var newArgs []string
+			skipNext := false
+			for _, arg := range deploy.Spec.Template.Spec.Containers[0].Args {
+				if skipNext {
+					skipNext = false
+					continue
+				}
+				// If this is one of the arguments we are updating, skip it AND its value
+				if arg == "--port" || arg == "--data-parallel-size" {
+					skipNext = true
+					continue
+				}
+				newArgs = append(newArgs, arg)
+			} // contains only the args we want to keep
+
+			// add new arguments to open proper ports
+			newArgs = append(newArgs, "--port", strconv.Itoa(firstPort))
+			newArgs = append(newArgs, "--data-parallel-size", strconv.Itoa(numPorts))
+			deploy.Spec.Template.Spec.Containers[0].Args = newArgs
+			deploy.Spec.Template.Spec.Containers[0].Ports = buildContainerPorts(firstPort, numPorts)
+
+			return testConfig.K8sClient.Update(testConfig.Context, deploy)
+
+		}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
+
+		waitForDeploymentRollout(testConfig, deploy)
+
+		pool := &v1.InferencePool{}
+		gomega.Eventually(func() error {
+			err := testConfig.K8sClient.Get(testConfig.Context, key, pool)
+			if err != nil {
+				return err
+			}
+
+			pool.Spec.TargetPorts = buildTargetPorts(firstPort, numPorts)
+
+			return testConfig.K8sClient.Update(testConfig.Context, pool)
+		}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Restarting EPP to force configuration reload")
+		// We delete the EPP *POD*, not the deployment. The Deployment will recreate it immediately.
+		// This forces the new EPP process to read the Multi-Port InferencePool from scratch.
+		eppLabels := client.MatchingLabels{"app": inferExtName}
+		gomega.Expect(testConfig.K8sClient.DeleteAllOf(testConfig.Context, &corev1.Pod{}, client.InNamespace(testConfig.NsName), eppLabels)).To(gomega.Succeed())
+
+		// Wait for the new EPP to be ready
+		eppDeploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: inferExtName, Namespace: testConfig.NsName}}
+		waitForDeploymentReady(testConfig, eppDeploy)
 
 		ginkgo.By("Creating an InferenceObjective resource")
 		infObjective = newInferenceObjective(testConfig.NsName)
@@ -58,6 +130,8 @@ var _ = ginkgo.Describe("InferencePool", func() {
 	ginkgo.AfterEach(func() {
 		ginkgo.By("Deleting the InferenceObjective test resource.")
 		cleanupInferModelResources()
+
+		// Wait for InferenceObjective to be fully deleted.
 		gomega.Eventually(func() error {
 			err := testConfig.K8sClient.Get(testConfig.Context, types.NamespacedName{Namespace: infObjective.Namespace, Name: infObjective.Name}, infObjective)
 			if err == nil {
@@ -68,6 +142,53 @@ var _ = ginkgo.Describe("InferencePool", func() {
 			}
 			return nil
 		}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Restoring vLLM Deployment and InferencePool.")
+		key := types.NamespacedName{Name: modelServerName, Namespace: testConfig.NsName}
+
+		// Restore InferencePool
+		pool := &v1.InferencePool{}
+		gomega.Eventually(func() error {
+			if err := testConfig.K8sClient.Get(testConfig.Context, key, pool); err != nil {
+				return err
+			}
+			pool.Spec.TargetPorts = []v1.Port{{Number: 8000}}
+			return testConfig.K8sClient.Update(testConfig.Context, pool)
+		}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
+
+		// Restore Deployment Args
+		deploy := &appsv1.Deployment{}
+		gomega.Eventually(func() error {
+			if err := testConfig.K8sClient.Get(testConfig.Context, key, deploy); err != nil {
+				return err
+			}
+
+			// Filter out the custom args we added in BeforeEach
+			var originalArgs []string
+			skipNext := false
+			for _, arg := range deploy.Spec.Template.Spec.Containers[0].Args {
+				if skipNext {
+					skipNext = false
+					continue
+				}
+				if arg == "--port" || arg == "--data-parallel-size" {
+					skipNext = true
+					continue
+				}
+				originalArgs = append(originalArgs, arg)
+			}
+			deploy.Spec.Template.Spec.Containers[0].Args = originalArgs
+
+			// Restore container ports to just 8000
+			deploy.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+				{Name: "http-8000", ContainerPort: 8000, Protocol: corev1.ProtocolTCP},
+			}
+
+			return testConfig.K8sClient.Update(testConfig.Context, deploy)
+		}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
+
+		// Wait for rollback to finish.
+		waitForDeploymentRollout(testConfig, deploy)
 	})
 
 	ginkgo.When("The Inference Extension is running", func() {
@@ -204,35 +325,80 @@ func verifyTrafficRouting() {
 	} {
 		ginkgo.By(fmt.Sprintf("Verifying connectivity through the inference extension with %s api and prompt/messages: %v", t.api, t.promptOrMessages))
 
-		// Ensure the expected responses include the InferenceObjective target model names.
-		var expected []string
-		expected = append(expected, targetModelName)
-		curlCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, t.api, t.promptOrMessages, false)
+		// Expected ports and InferenceObjective target models
+		expectedPort := generateSequence(firstPort, numPorts)
+		expectedModel := []string{targetModelName}
 
-		actual := make(map[string]int)
-		gomega.Eventually(func() error {
-			resp, err := testutils.ExecCommandInPod(testConfig, "curl", "curl", curlCmd)
-			if err != nil {
-				return err
+		// Observed ports and InferenceObjective target models
+		actualModel := make(map[string]int)
+		actualPort := make(map[int]int)
+
+		// Send curl requests to verify routing to all target ports in the InferencePool.
+		// Run a small batch per retry (e.g., 5) to keep the test active
+		for i := range batches {
+			uniqueID := time.Now().UnixNano()
+			dynamicHashValue := fmt.Sprintf("Nonce-%d", uniqueID)
+			currentPromptOrMessages := t.promptOrMessages // Start with the original
+
+			// Check if the payload is a slice of maps (e.g., for /chat/completions)
+			if originalMessages, ok := currentPromptOrMessages.([]map[string]any); ok {
+				nonceMsg := map[string]any{
+					"role":    "system",
+					"content": fmt.Sprintf("TestNonce: %s-%d", dynamicHashValue, i),
+				}
+
+				currentPromptOrMessages = append([]map[string]any{nonceMsg}, originalMessages...)
+			} else if originalString, ok := t.promptOrMessages.(string); ok {
+				currentPromptOrMessages = fmt.Sprintf("[TestNonce: %s-%d] %s", dynamicHashValue, i, originalString)
+			} else {
+				currentPromptOrMessages = t.promptOrMessages
 			}
-			if !strings.Contains(resp, "200 OK") {
-				return fmt.Errorf("did not get 200 OK: %s", resp)
-			}
-			for _, m := range expected {
-				if strings.Contains(resp, m) {
-					actual[m] = 0
+
+			curlCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, t.api, currentPromptOrMessages, false)
+
+			var resp string
+			var err error
+			// Repeatedly send a message until we get a successful response.
+			for attempt := 0; attempt <= maxRetries; attempt++ {
+				resp, err = testutils.ExecCommandInPod(testConfig, "curl", "curl", curlCmd)
+				if err == nil && strings.Contains(resp, "200 OK") {
+					break // Success!
+				}
+
+				if attempt < maxRetries {
+					time.Sleep(backoff)
 				}
 			}
-			var got []string
-			for m := range actual {
-				got = append(got, m)
+
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Expected curl command to succeed")
+			gomega.Expect(resp).To(gomega.ContainSubstring("200 OK"), "Expected to receive a 200 OK response...")
+
+			for _, m := range expectedModel {
+				if strings.Contains(resp, m) {
+					actualModel[m] = 0
+				}
 			}
-			// Compare ignoring order
-			if !cmp.Equal(got, expected, cmpopts.SortSlices(func(a, b string) bool { return a < b })) {
-				return fmt.Errorf("actual (%v) != expected (%v); resp=%q", got, expected, resp)
+			for _, p := range expectedPort {
+				if strings.Contains(resp, fmt.Sprintf("x-inference-port: %d", p)) {
+					actualPort[p] = 0
+				}
 			}
-			return nil
-		}, testConfig.ReadyTimeout, curlInterval).Should(gomega.Succeed())
+		}
+
+		var gotModel []string
+		for m := range actualModel {
+			gotModel = append(gotModel, m)
+		}
+		var gotPort []int
+		for p := range actualPort {
+			gotPort = append(gotPort, p)
+		}
+
+		ginkgo.GinkgoWriter.Printf("Port distribution: %v\n", actualPort)
+		ginkgo.GinkgoWriter.Printf("Model distribution: %v\n", actualModel)
+
+		gomega.Expect(gotModel).To(gomega.BeComparableTo(expectedModel, cmpopts.SortSlices(func(a, b string) bool { return a < b })))
+		gomega.Expect(gotPort).To(gomega.BeComparableTo(expectedPort, cmpopts.SortSlices(func(a, b int) bool { return a < b })))
 	}
 }
 
@@ -257,28 +423,27 @@ func verifyMetrics() {
 		"inference_extension_info",
 	}
 
-	// Generate traffic by sending requests through the inference extension
+	// Generate traffic by sending requests through the inference extension.
 	ginkgo.By("Generating traffic through the inference extension")
 	curlCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, "/completions", "Write as if you were a critic: San Francisco", true)
 
-	// Run the curl command multiple times to generate some metrics data
-	for i := 0; i < 5; i++ {
-		_, err := testutils.ExecCommandInPod(testConfig, "curl", "curl", curlCmd)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
+	// Run the curl command multiple times to generate some metrics data.
 
-	// modify the curl command to generate some error metrics
+	semaphore := make(chan struct{}, maxConcurrentRequests)
+
+	errorGood := generateTraffic(curlCmd, batches, semaphore)
+	gomega.Expect(errorGood).NotTo(gomega.HaveOccurred(), "Expected good traffic generation to succeed")
+
+	// Modify the curl command to generate some error metrics.
 	curlCmd[len(curlCmd)-1] = "invalid input"
-	for i := 0; i < 5; i++ {
-		_, err := testutils.ExecCommandInPod(testConfig, "curl", "curl", curlCmd)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
+	errorBad := generateTraffic(curlCmd, batches, semaphore)
+	gomega.Expect(errorBad).NotTo(gomega.HaveOccurred(), "Expected bad traffic generation to succeed")
 
-	// Now scrape metrics from the EPP endpoint via the curl pod
-	ginkgo.By("Scraping metrics from the EPP endpoint")
+	// Now scrape metrics from the EPP endpoint via the curl pod.
+	ginkgo.By("Scraping metrics from the EPP endpoint and verifying all backends were hit")
 	podIP := findReadyPod().Status.PodIP
 
-	// Get the authorization token for reading metrics
+	// Get the authorization token for reading metrics.
 	token := ""
 	gomega.Eventually(func(g gomega.Gomega) {
 		t, err := getMetricsReaderToken(testConfig.K8sClient)
@@ -287,21 +452,36 @@ func verifyMetrics() {
 		token = t
 	}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
 
-	// Construct the metric scraping curl command using Pod IP
+	// Construct the metric scraping curl command using Pod IP.
 	metricScrapeCmd := getMetricsScrapeCommand(podIP, token)
+
+	modelServerPods, err := getPodsByLabel(testConfig.K8sClient, testConfig.Context, testConfig.NsName, "app", modelServerName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected to find model server pods")
+
+	for _, modelServerPod := range modelServerPods {
+		for rank := range numPorts {
+			metricQueueSize := fmt.Sprintf(
+				"inference_pool_per_pod_queue_size{model_server_pod=\"%s-rank-%d\",name=\"%s\"}",
+				modelServerPod.Name,
+				rank,
+				modelServerName,
+			)
+			expectedMetrics = append(expectedMetrics, metricQueueSize)
+		}
+	}
 
 	ginkgo.By("Verifying that all expected metrics are present.")
 	gomega.Eventually(func() error {
-		// Execute the metrics scrape command inside the curl pod
+		// Execute the metrics scrape command inside the curl pod.
 		resp, err := testutils.ExecCommandInPod(testConfig, "curl", "curl", metricScrapeCmd)
 		if err != nil {
 			return err
 		}
-		// Verify that we got a 200 OK responsecurl
+		// Verify that we got a 200 OK response.
 		if !strings.Contains(resp, "200 OK") {
 			return fmt.Errorf("did not get 200 OK: %s", resp)
 		}
-		// Check if all expected metrics are present in the metrics output
+		// Check if all expected metrics are present in the metrics output.
 		for _, metric := range expectedMetrics {
 			if !strings.Contains(resp, metric) {
 				return fmt.Errorf("expected metric %s not found in metrics output", metric)
@@ -352,13 +532,14 @@ func findReadyPod() *corev1.Pod {
 // getMetricsScrapeCommand returns the command to scrape the /metrics endpoint.
 func getMetricsScrapeCommand(podIP, token string) []string {
 	return []string{
-		"curl", "-i", "--max-time", strconv.Itoa((int)(curlTimeout.Seconds())),
+		"curl", "-i", "--max-time", strconv.Itoa((int)(4 * curlTimeout.Seconds())),
 		"-H", "Authorization: Bearer " + token, fmt.Sprintf("http://%s:%d/metrics", podIP, 9090),
 	}
 }
 
 // getCurlCommand returns the command, as a slice of strings, for curl'ing
 // the test model server at the given name, namespace, port, and model name.
+// This command gets executed by a dummy pod that communicates with Envoy
 func getCurlCommand(name, ns, port, model string, timeout time.Duration, api string, promptOrMessages any, streaming bool) []string {
 	body := map[string]any{
 		"model":       model,
@@ -389,10 +570,175 @@ func getCurlCommand(name, ns, port, model string, timeout time.Duration, api str
 		"-H",
 		"Content-Type: application/json",
 		"-H",
+		"Cache-Control: no-cache",
+		"-H",
 		fmt.Sprintf("%v: inferenceobjective-sample", metadata.ObjectiveKey),
 		"-H",
 		fmt.Sprintf("%v: %s", metadata.ModelNameRewriteKey, targetModelName),
+		"-H",
+		"Connection: close",
 		"-d",
 		string(b),
 	}
+}
+
+// buildContainerPorts constructs a slice of corev1.ContainerPort starting from 'start' with 'count' ports.
+func buildContainerPorts(start int, count int) []corev1.ContainerPort {
+	ports := make([]corev1.ContainerPort, count)
+	for i := range count {
+		portNum := int32(start + i)
+		ports[i] = corev1.ContainerPort{
+			Name:          fmt.Sprintf("http-%d", portNum),
+			ContainerPort: portNum,
+			Protocol:      corev1.ProtocolTCP,
+		}
+	}
+	return ports
+}
+
+// buildTargetPorts constructs a slice of v1.Port starting from 'start' with 'count' ports.
+func buildTargetPorts(start int, count int) []v1.Port {
+	ports := make([]v1.Port, count)
+	for i := range count {
+		ports[i] = v1.Port{
+			Number: v1.PortNumber(start + i),
+		}
+	}
+	return ports
+}
+
+// waitForDeploymentRollout waits until the Deployment has completed its update.
+// It ensures that the new version is fully rolled out and available.
+func waitForDeploymentRollout(tc *testutils.TestConfig, deploy *appsv1.Deployment) {
+	ginkgo.By(fmt.Sprintf("Waiting for Deployment %s/%s to complete rollout", deploy.Namespace, deploy.Name))
+
+	key := types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}
+
+	gomega.Eventually(func() error {
+		currentDeploy := &appsv1.Deployment{}
+		if err := tc.K8sClient.Get(tc.Context, key, currentDeploy); err != nil {
+			return err
+		}
+
+		if currentDeploy.Generation > currentDeploy.Status.ObservedGeneration {
+			return errors.New("deployment generation not observed yet")
+		}
+
+		desiredReplicas := *currentDeploy.Spec.Replicas
+
+		if currentDeploy.Status.UpdatedReplicas < desiredReplicas {
+			return fmt.Errorf("waiting for updated replicas: %d/%d", currentDeploy.Status.UpdatedReplicas, desiredReplicas)
+		}
+
+		if currentDeploy.Status.AvailableReplicas < desiredReplicas {
+			return fmt.Errorf("waiting for available replicas: %d/%d", currentDeploy.Status.AvailableReplicas, desiredReplicas)
+		}
+
+		if currentDeploy.Status.Replicas > desiredReplicas {
+			return fmt.Errorf("waiting for old replicas to terminate: %d > %d", currentDeploy.Status.Replicas, desiredReplicas)
+		}
+
+		return nil
+	}, testConfig.ReadyTimeout, testConfig.Interval).Should(gomega.Succeed(), "Deployment failed to roll out within timeout")
+
+	ginkgo.By("Deployment rollout complete")
+}
+
+// waitForDeploymentReady waits for the Deployment to have all replicas ready.
+func waitForDeploymentReady(tc *testutils.TestConfig, deploy *appsv1.Deployment) {
+	ginkgo.By(fmt.Sprintf("waiting for Deployment %s/%s to be ready", deploy.Namespace, deploy.Name))
+
+	key := types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}
+
+	gomega.Eventually(func() error {
+		current := &appsv1.Deployment{}
+		if err := tc.K8sClient.Get(tc.Context, key, current); err != nil {
+			return err
+		}
+
+		if current.Status.Replicas != current.Status.ReadyReplicas {
+			return fmt.Errorf("replicas mismatch: expected %d, got %d ready",
+				current.Status.Replicas, current.Status.ReadyReplicas)
+		}
+
+		if current.Status.ReadyReplicas == 0 {
+			return errors.New("no replicas are ready yet")
+		}
+
+		return nil
+	}, testConfig.ReadyTimeout, testConfig.Interval).Should(gomega.Succeed())
+}
+
+// generateTraffic sends multiple concurrent requests using the provided curl command.
+func generateTraffic(
+	curlCmd []string,
+	batches int,
+	semaphore chan struct{},
+) error {
+	var wg sync.WaitGroup
+	errorCh := make(chan error, batches)
+
+	for i := 0; i < batches; i++ {
+		wg.Add(1)
+		semaphore <- struct{}{}
+
+		go func(requestNum int) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+
+			var err error
+			// RETRY LOOP
+			for attempt := 0; attempt <= maxRetries; attempt++ {
+				_, err = testutils.ExecCommandInPod(testConfig, "curl", "curl", curlCmd)
+				if err == nil {
+					return // Success!
+				}
+
+				time.Sleep(backoff)
+			}
+
+			// If we get here, we failed all retries
+			errorCh <- fmt.Errorf("request %d failed: %w", requestNum, err)
+		}(i)
+	}
+
+	wg.Wait()
+	close(errorCh)
+
+	// Collect any errors that occurred
+	failures := make([]error, 0, batches)
+	for err := range errorCh {
+		failures = append(failures, err)
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("found %d failed requests: %v", len(failures), failures)
+	}
+
+	return nil
+}
+
+// getPodsByLabel lists pods in a given namespace that have a specific label key-value pair.
+func getPodsByLabel(k8sClient client.Client, ctx context.Context, namespace, labelKey, labelValue string) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	labels := map[string]string{labelKey: labelValue}
+
+	listOptions := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels),
+	}
+
+	if err := k8sClient.List(ctx, podList, listOptions...); err != nil {
+		return nil, fmt.Errorf("failed to list pods with label %s=%s in namespace %s: %w", labelKey, labelValue, namespace, err)
+	}
+	return podList.Items, nil
+}
+
+// generateSequence generates a sequence of integers starting from 'start' with 'count' numbers.
+func generateSequence(start int, count int) []int {
+	nums := make([]int, count)
+	for i := range count {
+		nums[i] = start + i
+	}
+	return nums
 }

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 		}, existsTimeout, interval).Should(gomega.Succeed())
 	})
 
-	ginkgo.When("The Inference Extension is running", func() {
+	ginkgo.When("The Inference ExtensionRef is running", func() {
 		ginkgo.It("Should route traffic to target model servers", func() {
 			verifyTrafficRouting()
 		})

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -383,11 +383,11 @@ func verifyTrafficRouting() {
 			}
 		}
 
-		var gotModel []string
+		gotModel := make([]string, 0, len(actualModel))
 		for m := range actualModel {
 			gotModel = append(gotModel, m)
 		}
-		var gotPort []int
+		gotPort := make([]int, 0, len(actualPort))
 		for p := range actualPort {
 			gotPort = append(gotPort, p)
 		}
@@ -403,23 +403,6 @@ func verifyTrafficRouting() {
 // verifyMetrics contains the logic for the "Should expose EPP metrics after generating traffic" test.
 func verifyMetrics() {
 	ginkgo.By("Verifying metrics exposure")
-	// Define the metrics we expect to see
-	expectedMetrics := []string{
-		"inference_objective_request_total",
-		"inference_objective_request_error_total",
-		"inference_objective_request_duration_seconds",
-		"inference_objective_normalized_time_per_output_token_seconds",
-		"inference_objective_request_sizes",
-		"inference_objective_response_sizes",
-		"inference_objective_input_tokens",
-		"inference_objective_output_tokens",
-		"inference_pool_average_kv_cache_utilization",
-		"inference_pool_average_queue_size",
-		"inference_pool_per_pod_queue_size",
-		"inference_objective_running_requests",
-		"inference_pool_ready_pods",
-		"inference_extension_info",
-	}
 
 	// Generate traffic by sending requests through the inference extension.
 	ginkgo.By("Generating traffic through the inference extension")
@@ -455,6 +438,26 @@ func verifyMetrics() {
 
 	modelServerPods, err := getPodsByLabel(testConfig.K8sClient, testConfig.Context, testConfig.NsName, "app", modelServerName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected to find model server pods")
+
+	// Define the metrics we expect to see
+	preset := []string{ //nolint:prealloc
+		"inference_objective_request_total",
+		"inference_objective_request_error_total",
+		"inference_objective_request_duration_seconds",
+		"inference_objective_normalized_time_per_output_token_seconds",
+		"inference_objective_request_sizes",
+		"inference_objective_response_sizes",
+		"inference_objective_input_tokens",
+		"inference_objective_output_tokens",
+		"inference_pool_average_kv_cache_utilization",
+		"inference_pool_average_queue_size",
+		"inference_pool_per_pod_queue_size",
+		"inference_objective_running_requests",
+		"inference_pool_ready_pods",
+		"inference_extension_info",
+	}
+	expectedMetrics := make([]string, 0, len(preset)+len(modelServerPods)*numPorts)
+	expectedMetrics = append(expectedMetrics, preset...)
 
 	for _, modelServerPod := range modelServerPods {
 		for rank := range numPorts {

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -129,9 +129,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 
 	ginkgo.AfterEach(func() {
 		ginkgo.By("Deleting the InferenceObjective test resource.")
-		cleanupInferModelResources()
-
-		// Wait for InferenceObjective to be fully deleted.
+		cleanupInferObjectiveResources()
 		gomega.Eventually(func() error {
 			err := testConfig.K8sClient.Get(testConfig.Context, types.NamespacedName{Namespace: infObjective.Namespace, Name: infObjective.Name}, infObjective)
 			if err == nil {

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -533,7 +533,7 @@ func findReadyPod() *corev1.Pod {
 // getMetricsScrapeCommand returns the command to scrape the /metrics endpoint.
 func getMetricsScrapeCommand(podIP, token string) []string {
 	return []string{
-		"curl", "-i", "--max-time", strconv.Itoa((int)(4 * curlTimeout.Seconds())),
+		"curl", "-i", "--max-time", strconv.Itoa((int)(6 * curlTimeout.Seconds())),
 		"-H", "Authorization: Bearer " + token, fmt.Sprintf("http://%s:%d/metrics", podIP, 9090),
 	}
 }

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -341,9 +341,9 @@ func verifyTrafficRouting() {
 			}
 		}
 
-		// Expected ports and InferenceObjective target models
+		// Expected ports and client-facing model name (response model is rewritten back to the incoming name)
 		expectedPort := generateSequence(firstPort, numPorts)
-		expectedModel := []string{targetModelName}
+		expectedModel := []string{modelName}
 
 		// Observed ports and InferenceObjective target models
 		actualModel := make(map[string]int)

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -48,6 +48,7 @@ const (
 	maxRetries            = 5
 	backoff               = 5 * time.Second
 	batches               = 20
+	apiEmbeddings         = "/embeddings"
 )
 
 var _ = ginkgo.Describe("InferencePool", func() {
@@ -320,8 +321,25 @@ func verifyTrafficRouting() {
 				{"role": "user", "content": "Now summarize your thoughts."},
 			},
 		},
+		{
+			api:              apiEmbeddings,
+			promptOrMessages: "The food was delicious and the service was great.",
+		},
+		{
+			api:              apiEmbeddings,
+			promptOrMessages: []string{"First sentence to embed.", "Second sentence to embed."},
+		},
 	} {
 		ginkgo.By(fmt.Sprintf("Verifying connectivity through the inference extension with %s api and prompt/messages: %v", t.api, t.promptOrMessages))
+
+		// Skip embeddings API if server returns 404 (not all models support embeddings).
+		if t.api == apiEmbeddings {
+			probeCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, t.api, t.promptOrMessages, false)
+			probeResp, probeErr := testutils.ExecCommandInPod(testConfig, "curl", "curl", probeCmd)
+			if probeErr == nil && strings.Contains(probeResp, "404") {
+				ginkgo.Skip("Skipping " + apiEmbeddings + ": server returned 404 (embeddings may not be supported by this model)")
+			}
+		}
 
 		// Expected ports and InferenceObjective target models
 		expectedPort := generateSequence(firstPort, numPorts)
@@ -348,6 +366,12 @@ func verifyTrafficRouting() {
 				currentPromptOrMessages = append([]map[string]any{nonceMsg}, originalMessages...)
 			} else if originalString, ok := t.promptOrMessages.(string); ok {
 				currentPromptOrMessages = fmt.Sprintf("[TestNonce: %s-%d] %s", dynamicHashValue, i, originalString)
+			} else if originalStrings, ok := t.promptOrMessages.([]string); ok {
+				// For embeddings with array input, prepend a unique string so each request is distinct.
+				withNonce := make([]string, 0, len(originalStrings)+1)
+				withNonce = append(withNonce, fmt.Sprintf("[TestNonce: %s-%d]", dynamicHashValue, i))
+				withNonce = append(withNonce, originalStrings...)
+				currentPromptOrMessages = withNonce
 			} else {
 				currentPromptOrMessages = t.promptOrMessages
 			}
@@ -553,8 +577,12 @@ func getCurlCommand(name, ns, port, model string, timeout time.Duration, api str
 		body["prompt"] = promptOrMessages
 	case "/chat/completions":
 		body["messages"] = promptOrMessages
+	case apiEmbeddings:
+		body["input"] = promptOrMessages
+		delete(body, "max_tokens")
+		delete(body, "temperature")
 	}
-	if streaming {
+	if streaming && api != apiEmbeddings {
 		body["stream"] = true
 		body["stream_options"] = map[string]any{
 			"include_usage": true,

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -707,7 +707,7 @@ func generateTraffic(
 	var wg sync.WaitGroup
 	errorCh := make(chan error, batches)
 
-	for i := 0; i < batches; i++ {
+	for i := range batches {
 		wg.Add(1)
 		semaphore <- struct{}{}
 

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package epp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
+)
+
+var _ = ginkgo.Describe("InferencePool", func() {
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Waiting for the namespace to exist.")
+		namespaceExists(cli, nsName)
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Deleting the InferenceModel test resource.")
+		cleanupInferModelResources()
+	})
+
+	ginkgo.When("The Inference Extension is running", func() {
+		ginkgo.It("Should route traffic to target model servers", func() {
+			ginkgo.By("Creating an InferenceModel resource")
+			infModel := newInferenceModel(nsName)
+			gomega.Expect(cli.Create(ctx, infModel)).To(gomega.Succeed())
+
+			ginkgo.By("Ensuring the InferenceModel resource exists in the namespace")
+			gomega.Eventually(func() error {
+				err := cli.Get(ctx, types.NamespacedName{Namespace: infModel.Namespace, Name: infModel.Name}, infModel)
+				if err != nil {
+					return err
+				}
+				return nil
+			}, existsTimeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying connectivity through the inference extension")
+			curlCmd := getCurlCommand(envoyName, nsName, envoyPort, modelName)
+
+			// Ensure the expected responses include the inferencemodel target model names.
+			var expected []string
+			for _, m := range infModel.Spec.TargetModels {
+				expected = append(expected, m.Name)
+			}
+			actual := make(map[string]int)
+			gomega.Eventually(func() error {
+				resp, err := testutils.ExecCommandInPod(ctx, cfg, scheme, kubeCli, nsName, "curl", "curl", curlCmd)
+				if err != nil {
+					return err
+				}
+				if !strings.Contains(resp, "200 OK") {
+					return fmt.Errorf("did not get 200 OK: %s", resp)
+				}
+				for _, m := range expected {
+					if strings.Contains(resp, m) {
+						actual[m] = 0
+					}
+				}
+				var got []string
+				for m := range actual {
+					got = append(got, m)
+				}
+				// Compare ignoring order
+				if !cmp.Equal(got, expected, cmpopts.SortSlices(func(a, b string) bool { return a < b })) {
+					return fmt.Errorf("actual (%v) != expected (%v); resp=%q", got, expected, resp)
+				}
+
+				return nil
+			}, readyTimeout, curlInterval).Should(gomega.Succeed())
+
+		})
+	})
+})
+
+// newInferenceModel creates an InferenceModel in the given namespace for testutils.
+func newInferenceModel(ns string) *v1alpha2.InferenceModel {
+	targets := []v1alpha2.TargetModel{
+		{
+			Name:   modelName + "-0",
+			Weight: ptr.To(int32(50)),
+		},
+		{
+			Name:   modelName + "-1",
+			Weight: ptr.To(int32(50)),
+		},
+	}
+	return testutils.MakeModelWrapper("inferencemodel-sample", ns).
+		SetCriticality(v1alpha2.Critical).
+		SetModelName(modelName).
+		SetPoolRef(modelServerName).
+		SetTargetModels(targets).
+		Obj()
+}
+
+// getCurlCommand returns the command, as a slice of strings, for curl'ing
+// the test model server at the given name, namespace, port, and model name.
+func getCurlCommand(name, ns, port, model string) []string {
+	return []string{
+		"curl",
+		"-i",
+		fmt.Sprintf("%s.%s.svc:%s/v1/completions", name, ns, port),
+		"-H",
+		"Content-Type: application/json",
+		"-d",
+		fmt.Sprintf(`{"model": "%s", "prompt": "Write as if you were a critic: San Francisco", "max_tokens": 100, "temperature": 0}`, model),
+	}
+}


### PR DESCRIPTION
Migrates the following paths from `sigs.k8s.io/gateway-api-inference-extension` (@ 8ed5a0cd) with full git history:

- `test/e2e/epp` → `test/e2e/epp`

To pick up future upstream changes: `migrate-gaie-paths.sh --since 8ed5a0cd test/e2e/epp test/e2e/epp`

**Merge via "Create a merge commit"** — squash or rebase discards the migrated history.