### PR TITLE
improve metrics logging

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -177,10 +177,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Print all flag values
+	// Print flag values, skipping deprecated metric flags configured via engineConfigs
 	flags := make(map[string]any)
 	pflag.VisitAll(func(f *pflag.Flag) {
-		flags[f.Name] = f.Value
+		if !runserver.IsDeprecatedMetricFlag(f.Name) {
+			flags[f.Name] = f.Value
+		}
 	})
 	setupLog.Info("Flags processed", "flags", flags)
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -187,7 +187,10 @@ func (ext *Extractor) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) 
 	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().NamespacedName)
 	if updated {
 		clone.UpdateTime = time.Now()
-		logger.V(logutil.TRACE).Info("Refreshed metrics", "updated", clone)
+		logger.V(logutil.TRACE).Info("Refreshed metrics",
+			"metrics", mapping.MetricNames(),
+			"updated", clone,
+		)
 		ep.UpdateMetrics(clone)
 	}
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -57,21 +57,31 @@ type MappingConfig struct {
 	CacheNumBlocks      string
 }
 
+type namedSpec struct {
+	name    string
+	spec    *Spec
+	enabled bool
+}
+
+func (m *Mapping) specs() []namedSpec {
+	var loraSpec *Spec
+	if m.LoraRequestInfo != nil {
+		loraSpec = m.LoraRequestInfo.Spec
+	}
+	return []namedSpec{
+		{"queue", m.TotalQueuedRequests, m.TotalQueuedRequests != nil},
+		{"running", m.TotalRunningRequests, m.TotalRunningRequests != nil},
+		{"kv", m.KVCacheUtilization, m.KVCacheUtilization != nil},
+		{"lora", loraSpec, m.LoraRequestInfo != nil},
+		{"cacheInfo", m.CacheInfo, m.CacheInfo != nil},
+	}
+}
+
 // String returns a human-readable representation of the Mapping, listing which specs are disabled (nil).
 func (m *Mapping) String() string {
-	specs := []struct {
-		name string
-		val  any
-	}{
-		{"queue", m.TotalQueuedRequests},
-		{"running", m.TotalRunningRequests},
-		{"kv", m.KVCacheUtilization},
-		{"lora", m.LoraRequestInfo},
-		{"cacheInfo", m.CacheInfo},
-	}
 	var disabled []string
-	for _, s := range specs {
-		if s.val == nil {
+	for _, s := range m.specs() {
+		if !s.enabled {
 			disabled = append(disabled, s.name)
 		}
 	}
@@ -79,6 +89,17 @@ func (m *Mapping) String() string {
 		return "Mapping{all specs enabled}"
 	}
 	return fmt.Sprintf("Mapping{disabled: [%s]}", strings.Join(disabled, ", "))
+}
+
+// MetricNames returns the Prometheus metric names for all enabled specs.
+func (m *Mapping) MetricNames() []string {
+	var names []string
+	for _, s := range m.specs() {
+		if s.enabled {
+			names = append(names, s.spec.Name)
+		}
+	}
+	return names
 }
 
 // NewMapping creates a metrics.Mapping from the input specification strings.

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -32,6 +32,22 @@ const (
 	DefaultPoolNamespace = "default" // default when pool namespace is empty (CLI flag default is empty)
 )
 
+// deprecatedMetricFlags lists metric flags that are superseded by engineConfigs
+// in EndpointPickerConfig. They are rejected if explicitly set and suppressed from logs.
+var deprecatedMetricFlags = map[string]struct{}{
+	"total-queued-requests-metric":     {},
+	"total-running-requests-metric":    {},
+	"kv-cache-usage-percentage-metric": {},
+	"lora-info-metric":                 {},
+	"cache-info-metric":                {},
+}
+
+// IsDeprecatedMetricFlag reports whether the given flag name is a deprecated metric flag.
+func IsDeprecatedMetricFlag(name string) bool {
+	_, ok := deprecatedMetricFlags[name]
+	return ok
+}
+
 // Options contains configuration values necessary to create and run the EPP.
 type Options struct {
 	//
@@ -226,14 +242,7 @@ func (opts *Options) Validate() error {
 	}
 
 	// Validate deprecated metric flags are not explicitly set
-	deprecatedMetricFlags := []string{
-		"total-queued-requests-metric",
-		"total-running-requests-metric",
-		"kv-cache-usage-percentage-metric",
-		"lora-info-metric",
-		"cache-info-metric",
-	}
-	for _, flagName := range deprecatedMetricFlags {
+	for flagName := range deprecatedMetricFlags {
 		if f := opts.fs.Lookup(flagName); f != nil && f.Changed {
 			return fmt.Errorf("flag %q is deprecated and cannot be used; configure metrics via engineConfigs in EndpointPickerConfig instead", flagName)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Skip deprecated metric flags (e.g. `--total-queued-requests-metric`) from the
  EPP startup "Flags processed" log.
- Add per-endpoint metric names to the existing TRACE-level "Refreshed metrics" log
  so operators can see which Prometheus metrics are being collected for each endpoint.
- Fix a small bug, causing model server metrics mappings to incorrectly report "all specs enabled".

Before:
```
{"level":"info","ts":1777474399.9769688,"logger":"setup","caller":"runner/runner.go:177","msg":"Flags processed","flags":{"cache-info-metric":"vllm:cache_config_info","cert-path":"","config-file":"/config/optimized-baseline-plugins.yaml","config-text":"","disable-endpoint-subset-filter":false,"enable-cert-reload":false,"enable-pprof":true,"endpoint-selector":"","endpoint-target-ports":{},"grpc-health-port":9003,"grpc-port":9002,"ha-enable-leader-election":false,"health-checking":false,"kv-cache-usage-percentage-metric":"vllm:kv_cache_usage_perc","lora-info-metric":"vllm:lora_requests_info","metrics-endpoint-auth":true,"metrics-port":9090,"metrics-staleness-threshold":2000000000,"model-server-metrics-https-insecure-skip-verify":true,"model-server-metrics-path":"/metrics","model-server-metrics-port":0,"model-server-metrics-scheme":"http","pool-group":"inference.networking.k8s.io","pool-name":"optimized-baseline","pool-namespace":"andreyo","refresh-metrics-interval":50000000,"refresh-prometheus-metrics-interval":5000000000,"secure-serving":true,"total-queued-requests-metric":"vllm:num_requests_waiting","total-running-requests-metric":"vllm:num_requests_running","tracing":false,"v":5,"zap-devel":{},"zap-encoder":{},"zap-log-level":{},"zap-stacktrace-level":{},"zap-time-encoding":{}}}

{"level":"info","ts":1777474399.9879482,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"vllm","mapping":"Mapping{all specs enabled}"}
{"level":"info","ts":1777474399.987983,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"sglang","mapping":"Mapping{all specs enabled}"}
{"level":"info","ts":1777474399.9880147,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"trtllm-serve","mapping":"Mapping{all specs enabled}"}
{"level":"info","ts":1777474399.9880602,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"triton-tensorrt-llm","mapping":"Mapping{all specs enabled}"}

{"level":"trace","ts":1777474400.2647107,"caller":"metrics/extractor.go:190","msg":"Refreshed metrics","endpoint":{"name":"optimized-baseline-nvidia-gpu-sglang-decode-64c79b8665-hprht-rank-0","namespace":"andreyo"},"updated":"{ActiveModels:map[] WaitingModels:map[] MaxActiveModels:0 RunningRequestsSize:0 WaitingQueueSize:0 KVCacheUsagePercent:0 KvCacheMaxTokenCapacity:0 CacheBlockSize:1 CacheNumBlocks:16839 UpdateTime:2026-04-29 14:53:20.264708482 +0000 UTC m=+0.311144575}"}
```

After:
```
{"level":"info","ts":1777792640.84343,"logger":"setup","caller":"runner/runner.go:187","msg":"Flags processed","flags":{"cert-path":"","config-file":"/config/optimized-baseline-plugins.yaml","config-text":"","disable-endpoint-subset-filter":false,"enable-cert-reload":false,"enable-pprof":true,"endpoint-selector":"","endpoint-target-ports":{},"grpc-health-port":9003,"grpc-port":9002,"ha-enable-leader-election":false,"health-checking":false,"metrics-endpoint-auth":true,"metrics-port":9090,"metrics-staleness-threshold":2000000000,"model-server-metrics-https-insecure-skip-verify":true,"model-server-metrics-path":"/metrics","model-server-metrics-port":0,"model-server-metrics-scheme":"http","pool-group":"inference.networking.k8s.io","pool-name":"optimized-baseline","pool-namespace":"andreyo","refresh-metrics-interval":50000000,"refresh-prometheus-metrics-interval":5000000000,"secure-serving":true,"tracing":false,"v":5,"zap-devel":{},"zap-encoder":{},"zap-log-level":{},"zap-stacktrace-level":{},"zap-time-encoding":{}}}

{"level":"info","ts":1777792640.851209,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"vllm","mapping":"Mapping{all specs enabled}"}
{"level":"info","ts":1777792640.8512416,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"sglang","mapping":"Mapping{disabled: [lora]}"}
{"level":"info","ts":1777792640.851273,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"trtllm-serve","mapping":"Mapping{disabled: [lora, cacheInfo]}"}
{"level":"info","ts":1777792640.8513193,"caller":"metrics/factories.go:197","msg":"Registered engine mapping","engine":"triton-tensorrt-llm","mapping":"Mapping{disabled: [lora, cacheInfo]}"}

{"level":"trace","ts":1777792641.3718956,"caller":"metrics/extractor.go:190","msg":"Refreshed metrics","endpoint":{"name":"optimized-baseline-nvidia-gpu-sglang-decode-64c79b8665-pglf7-rank-0","namespace":"andreyo"},"metrics":["sglang:num_queue_reqs","sglang:num_running_reqs","sglang:token_usage","sglang:cache_config_info"],"updated":"{ActiveModels:map[] WaitingModels:map[] MaxActiveModels:0 RunningRequestsSize:0 WaitingQueueSize:0 KVCacheUsagePercent:0 KvCacheMaxTokenCapacity:0 CacheBlockSize:1 CacheNumBlocks:16839 UpdateTime:2026-05-03 07:17:21.371894228 +0000 UTC m=+0.553513174}"}
```
**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
