### PR TITLE
feat(picker): add limited sampling (topK) to `weighted-random-picker`

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/README.md
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/README.md
@@ -27,6 +27,12 @@ The plugin config supports:
 
 - `maxNumOfEndpoints` (default 1)
   - The maximum number of endpoints to pick and return. Must be > 0. If more candidates are available than this limit, only the top subset is returned.
+- `topK` (optional, integer; default `0` = disabled)
+  - Absolute cap on the candidate-pool size before A-Res sampling. Candidates are sorted by score, descending. Combinable with `topKPercent` — when both are set, the more restrictive bound wins.
+- `topKPercent` (optional, 1-100; default `0` = disabled)
+  - Percentage cap on the candidate-pool size before A-Res sampling, computed as `ceil(N * P / 100)`. Useful when fleet size varies (autoscaling).
+- `minTopK` (default 2)
+  - Floor on the post-filter pool size when `topK`/`topKPercent` is set. Prevents collapse to a single candidate (which would degenerate into argmax). Set to `1` to allow argmax. Ignored when neither `topK` nor `topKPercent` is set.
 
 > [!TIP]
 > In most production scenarios, `maxNumOfEndpoints` is left at its default value of `1` to select a single target endpoint for the request.

--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
@@ -40,7 +40,79 @@ import (
 const (
 	// WeightedRandomPickerType is the registered name of the weighted random picker plugin.
 	WeightedRandomPickerType = "weighted-random-picker"
+
+	// DefaultMinTopK is the lower bound applied after topK / topKPercent. Without a floor,
+	// small fleets or aggressive percentages can collapse to a single candidate (degenerating
+	// into argmax). A default of 2 keeps the picker actually sampling. Set MinTopK = 1 to
+	// allow degeneration to argmax.
+	DefaultMinTopK = 2
 )
+
+// Parameters extends picker.PickerParameters with optional top-K filtering applied
+// before A-Res sampling. When neither TopK nor TopKPercent is set, the picker
+// considers every candidate (default behavior).
+type Parameters struct {
+	picker.PickerParameters
+
+	// TopK is the absolute cap on the candidate pool size after sorting by score.
+	// 0 (the zero value) means disabled. Combinable with TopKPercent — when both
+	// are set, the more restrictive bound wins.
+	TopK int `json:"topK,omitempty"`
+
+	// TopKPercent is the percentage cap, computed as ceil(N * P / 100). Valid
+	// values are 1-100; 0 (the zero value) means disabled. Combinable with TopK.
+	TopKPercent int `json:"topKPercent,omitempty"`
+
+	// MinTopK is the floor on the post-filter pool size. Default DefaultMinTopK.
+	// Set to 1 to allow degeneration to argmax. Ignored when neither TopK nor
+	// TopKPercent is set.
+	MinTopK int `json:"minTopK,omitempty"`
+}
+
+func (p Parameters) validate() error {
+	if p.TopK < 0 {
+		return fmt.Errorf("'topK' must be non-negative, got %d", p.TopK)
+	}
+	if p.TopKPercent < 0 || p.TopKPercent > 100 {
+		return fmt.Errorf("'topKPercent' must be in [0, 100], got %d", p.TopKPercent)
+	}
+	if p.MinTopK < 0 {
+		return fmt.Errorf("'minTopK' must be non-negative, got %d", p.MinTopK)
+	}
+	return nil
+}
+
+// effectiveK returns the candidate-pool size after applying TopK / TopKPercent against
+// n candidates. Returns n when no top-K filter is configured (full pool, default behavior).
+func (p Parameters) effectiveK(n int) int {
+	if n <= 0 || (p.TopK == 0 && p.TopKPercent == 0) {
+		return n
+	}
+
+	k := n
+	if p.TopK > 0 && p.TopK < k {
+		k = p.TopK
+	}
+	if p.TopKPercent > 0 {
+		// ceil(n * pct / 100) — boundary rounds up so a 1% cut keeps at least one.
+		fromPct := (n*p.TopKPercent + 99) / 100
+		if fromPct < k {
+			k = fromPct
+		}
+	}
+
+	floor := p.MinTopK
+	if floor <= 0 {
+		floor = DefaultMinTopK
+	}
+	if k < floor {
+		k = floor
+	}
+	if k > n {
+		k = n
+	}
+	return k
+}
 
 // weightedScoredEndpoint represents a scored endpoint with its A-Res sampling key
 type weightedScoredEndpoint struct {
@@ -53,26 +125,38 @@ var _ framework.Picker = &WeightedRandomPicker{}
 
 // WeightedRandomPickerFactory defines the factory function for WeightedRandomPicker.
 func WeightedRandomPickerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
-	parameters := picker.PickerParameters{MaxNumOfEndpoints: picker.DefaultMaxNumOfEndpoints}
+	parameters := Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: picker.DefaultMaxNumOfEndpoints},
+	}
 	if rawParameters != nil {
 		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' picker - %w", WeightedRandomPickerType, err)
 		}
 	}
-
-	return NewWeightedRandomPicker(parameters.MaxNumOfEndpoints).WithName(name), nil
-}
-
-// NewWeightedRandomPicker initializes a new WeightedRandomPicker and returns its pointer.
-func NewWeightedRandomPicker(maxNumOfEndpoints int) *WeightedRandomPicker {
-	if maxNumOfEndpoints <= 0 {
-		maxNumOfEndpoints = picker.DefaultMaxNumOfEndpoints // on invalid configuration value, fallback to default value
+	if err := parameters.validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration for '%s' picker: %w", WeightedRandomPickerType, err)
 	}
 
+	return New(parameters).WithName(name), nil
+}
+
+// NewWeightedRandomPicker initializes a WeightedRandomPicker considering every candidate
+// (no top-K filtering). Provided for source-compatibility with callers that don't need the
+// new top-K knobs; new code should prefer New(Parameters).
+func NewWeightedRandomPicker(maxNumOfEndpoints int) *WeightedRandomPicker {
+	return New(Parameters{PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: maxNumOfEndpoints}})
+}
+
+// New constructs a WeightedRandomPicker from validated Parameters. MaxNumOfEndpoints <= 0
+// falls back to picker.DefaultMaxNumOfEndpoints, matching the prior constructor's behavior.
+func New(params Parameters) *WeightedRandomPicker {
+	if params.MaxNumOfEndpoints <= 0 {
+		params.MaxNumOfEndpoints = picker.DefaultMaxNumOfEndpoints
+	}
 	return &WeightedRandomPicker{
-		typedName:         fwkplugin.TypedName{Type: WeightedRandomPickerType, Name: WeightedRandomPickerType},
-		maxNumOfEndpoints: maxNumOfEndpoints,
-		randomPicker:      random.NewRandomPicker(maxNumOfEndpoints),
+		typedName:    fwkplugin.TypedName{Type: WeightedRandomPickerType, Name: WeightedRandomPickerType},
+		params:       params,
+		randomPicker: random.NewRandomPicker(params.MaxNumOfEndpoints),
 	}
 }
 
@@ -81,18 +165,21 @@ func NewWeightedRandomPicker(maxNumOfEndpoints int) *WeightedRandomPicker {
 //
 // The picker at its core is picking endpoints randomly, where the probability of the endpoint to get picked is derived
 // from its weighted score.
-// Algorithm:
-// - Uses A-Res (Algorithm for Reservoir Sampling): keyᵢ = Uᵢ^(1/wᵢ)
-// - Selects k items with largest keys for mathematically correct weighted sampling
-// - More efficient than traditional cumulative probability approach
 //
-// Key characteristics:
-// - Mathematically correct weighted random sampling
-// - Single pass algorithm with O(n + k log k) complexity
+// Algorithm:
+//   - Default path: Uses A-Res (Algorithm for Reservoir Sampling): keyᵢ = Uᵢ^(1/wᵢ).
+//     Selects k items with largest keys for mathematically correct weighted sampling.
+//     Single pass over candidates with O(n + k log k) complexity.
+//   - Top-K path (when TopK or TopKPercent is set): randomly shuffles candidates,
+//     sorts by score, truncates to effectiveK, then runs A-Res over the truncated
+//     pool. The pre-shuffle randomizes tie-breaking at the K-th cutoff so equal-
+//     score endpoints are not deterministically excluded by input order.
+//     Complexity: O(n log n) for the score sort + O(k + maxNumOfEndpoints log
+//     maxNumOfEndpoints) for A-Res.
 type WeightedRandomPicker struct {
-	typedName         fwkplugin.TypedName
-	maxNumOfEndpoints int
-	randomPicker      *random.RandomPicker // fallback for zero weights
+	typedName    fwkplugin.TypedName
+	params       Parameters
+	randomPicker *random.RandomPicker // fallback for zero weights
 }
 
 // WithName sets the name of the picker.
@@ -107,7 +194,7 @@ func (p *WeightedRandomPicker) TypedName() fwkplugin.TypedName {
 }
 
 // Pick selects the endpoint(s) randomly from the list of candidates, where the probability of the endpoint to get picked is derived
-// from its weighted score.
+// from its weighted score. When TopK or TopKPercent is configured, only the top-K candidates by score participate in A-Res sampling.
 func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *framework.CycleState, scoredEndpoints []*framework.ScoredEndpoint) *framework.ProfileRunResult {
 	// Check if there is at least one endpoint with Score > 0, if not let random picker run
 	if slices.IndexFunc(scoredEndpoints, func(scoredEndpoint *framework.ScoredEndpoint) bool { return scoredEndpoint.Score > 0 }) == -1 {
@@ -115,13 +202,37 @@ func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *framework.C
 		return p.randomPicker.Pick(ctx, cycleState, scoredEndpoints)
 	}
 
-	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates by random weighted picker", "max-num-of-endpoints", p.maxNumOfEndpoints,
-		"num-of-candidates", len(scoredEndpoints), "scored-endpoints", scoredEndpoints)
+	// Top-K restriction: when configured, sort by score and truncate so A-Res samples
+	// only from the top tier. Pre-shuffle so the stable sort's tie-break is randomized —
+	// otherwise endpoints with identical scores at the K-th cutoff would be excluded
+	// deterministically by their input position, biasing routing on bucketed scorers.
+	// Default (no top-K knobs) preserves the original full-pool behavior with no copy
+	// or sort.
+	candidates := scoredEndpoints
+	if p.params.TopK > 0 || p.params.TopKPercent > 0 {
+		candidates = make([]*framework.ScoredEndpoint, len(scoredEndpoints))
+		copy(candidates, scoredEndpoints)
+		picker.PickerRand.Shuffle(len(candidates), func(i, j int) {
+			candidates[i], candidates[j] = candidates[j], candidates[i]
+		})
+		sort.SliceStable(candidates, func(i, j int) bool {
+			return candidates[i].Score > candidates[j].Score
+		})
+		k := p.params.effectiveK(len(candidates))
+		candidates = candidates[:k]
+	}
+
+	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates by random weighted picker",
+		"max-num-of-endpoints", p.params.MaxNumOfEndpoints,
+		"num-of-candidates", len(scoredEndpoints),
+		"effective-pool", len(candidates),
+		"scored-endpoints", scoredEndpoints,
+	)
 
 	// A-Res algorithm: keyᵢ = Uᵢ^(1/wᵢ)
-	weightedEndpoints := make([]weightedScoredEndpoint, len(scoredEndpoints))
+	weightedEndpoints := make([]weightedScoredEndpoint, len(candidates))
 
-	for i, scoredEndpoint := range scoredEndpoints {
+	for i, scoredEndpoint := range candidates {
 		// Handle zero score
 		if scoredEndpoint.Score <= 0 {
 			// Assign key=0 for zero-score endpoints (effectively excludes them from selection)
@@ -144,7 +255,7 @@ func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *framework.C
 	})
 
 	// Select top k endpoints
-	selectedCount := min(p.maxNumOfEndpoints, len(weightedEndpoints))
+	selectedCount := min(p.params.MaxNumOfEndpoints, len(weightedEndpoints))
 
 	targetEndpoints := make([]framework.Endpoint, selectedCount)
 	for i := range selectedCount {

--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker_topk_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker_topk_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package weightedrandom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/picker"
+)
+
+func makeScored(name string, score float64) *fwksched.ScoredEndpoint {
+	ep := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}}, nil, nil,
+	)
+	return &fwksched.ScoredEndpoint{Endpoint: ep, Score: score}
+}
+
+func TestParameters_validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      Parameters
+		wantErr bool
+	}{
+		{name: "no top-K (legacy default)", in: Parameters{}, wantErr: false},
+		{name: "topK only", in: Parameters{TopK: 5}, wantErr: false},
+		{name: "topKPercent only", in: Parameters{TopKPercent: 25}, wantErr: false},
+		{name: "both set", in: Parameters{TopK: 5, TopKPercent: 25}, wantErr: false},
+		{name: "negative topK", in: Parameters{TopK: -1}, wantErr: true},
+		{name: "topKPercent below 0", in: Parameters{TopKPercent: -1}, wantErr: true},
+		{name: "topKPercent above 100", in: Parameters{TopKPercent: 101}, wantErr: true},
+		{name: "negative minTopK", in: Parameters{TopK: 5, MinTopK: -1}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParameters_effectiveK(t *testing.T) {
+	tests := []struct {
+		name string
+		p    Parameters
+		n    int
+		want int
+	}{
+		{name: "no top-K returns n", p: Parameters{}, n: 40, want: 40},
+		{name: "no candidates", p: Parameters{TopKPercent: 25}, n: 0, want: 0},
+		{name: "topKPercent 25% of 40", p: Parameters{TopKPercent: 25, MinTopK: 2}, n: 40, want: 10},
+		{name: "topKPercent ceil rounds up", p: Parameters{TopKPercent: 25, MinTopK: 1}, n: 7, want: 2}, // ceil(7*25/100)=2
+		{name: "topKPercent 1% with default floor", p: Parameters{TopKPercent: 1}, n: 100, want: 2},
+		{name: "topKPercent 100% returns N", p: Parameters{TopKPercent: 100}, n: 40, want: 40},
+		{name: "topK=5 with N=40", p: Parameters{TopK: 5}, n: 40, want: 5},
+		{name: "topK exceeds N caps at N", p: Parameters{TopK: 100}, n: 10, want: 10},
+		{name: "topK below floor lifts to floor", p: Parameters{TopK: 1, MinTopK: 3}, n: 40, want: 3},
+		{name: "both: topK is tighter", p: Parameters{TopK: 3, TopKPercent: 25, MinTopK: 1}, n: 40, want: 3},
+		{name: "both: percent is tighter", p: Parameters{TopK: 50, TopKPercent: 10, MinTopK: 1}, n: 40, want: 4},
+		{name: "MinTopK=1 allows argmax", p: Parameters{TopKPercent: 1, MinTopK: 1}, n: 100, want: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.p.effectiveK(tc.n))
+		})
+	}
+}
+
+// TestPick_NoTopK_PreservesLegacyBehavior verifies that with neither TopK nor TopKPercent set,
+// the picker considers every candidate (any pod with positive score can win).
+func TestPick_NoTopK_PreservesLegacyBehavior(t *testing.T) {
+	const trials = 4000
+	candidates := []*fwksched.ScoredEndpoint{
+		makeScored("a", 1), makeScored("b", 2), makeScored("c", 3),
+		makeScored("d", 4), makeScored("e", 5),
+	}
+	pkr := New(Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: 1},
+	})
+
+	hits := map[string]int{}
+	for i := 0; i < trials; i++ {
+		res := pkr.Pick(context.Background(), nil, candidates)
+		hits[res.TargetEndpoints[0].GetMetadata().NamespacedName.Name]++
+	}
+	// Every positive-score pod must be sampled at least once when no top-K is set.
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		assert.Greater(t, hits[n], 0, "pod %q never sampled — legacy full-pool behavior broken", n)
+	}
+}
+
+// TestPick_TopKPercent_RestrictsPool verifies that with TopKPercent=30, only the top 3 of 10
+// candidates can ever be selected over many trials.
+func TestPick_TopKPercent_RestrictsPool(t *testing.T) {
+	const trials = 4000
+	cands := make([]*fwksched.ScoredEndpoint, 10)
+	for i := 0; i < 10; i++ {
+		cands[i] = makeScored(fmt.Sprintf("p-%d", i), float64(i+1))
+	}
+	pkr := New(Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: 1},
+		TopKPercent:      30, // top 3 (ceil(10*30/100)=3)
+	})
+
+	allowed := map[string]bool{"p-7": true, "p-8": true, "p-9": true}
+	for i := 0; i < trials; i++ {
+		// Shuffle each call to verify Pick doesn't rely on input order.
+		shuffled := append([]*fwksched.ScoredEndpoint(nil), cands...)
+		shuffled[0], shuffled[5] = shuffled[5], shuffled[0]
+		shuffled[2], shuffled[8] = shuffled[8], shuffled[2]
+
+		res := pkr.Pick(context.Background(), nil, shuffled)
+		require.Len(t, res.TargetEndpoints, 1)
+		name := res.TargetEndpoints[0].GetMetadata().NamespacedName.Name
+		assert.True(t, allowed[name], "selected pod %q is outside the top-3 by score", name)
+	}
+}
+
+// TestPick_MinTopK_AvoidsArgmax verifies the floor: TopKPercent=1 on 5 candidates would otherwise
+// give K=1, but MinTopK=2 keeps two so the picker actually samples between them.
+func TestPick_MinTopK_AvoidsArgmax(t *testing.T) {
+	const trials = 4000
+	cands := []*fwksched.ScoredEndpoint{
+		makeScored("low", 1), makeScored("mid", 5),
+		makeScored("high1", 9), makeScored("high2", 10),
+		makeScored("verylow", 0.5),
+	}
+	pkr := New(Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: 1},
+		TopKPercent:      1,
+		MinTopK:          2,
+	})
+
+	hits := map[string]int{}
+	for i := 0; i < trials; i++ {
+		res := pkr.Pick(context.Background(), nil, cands)
+		hits[res.TargetEndpoints[0].GetMetadata().NamespacedName.Name]++
+	}
+	assert.Greater(t, hits["high1"], 0)
+	assert.Greater(t, hits["high2"], 0)
+	for _, n := range []string{"low", "mid", "verylow"} {
+		assert.Equal(t, 0, hits[n], "pod %q outside top-2 must never be picked", n)
+	}
+	// A-Res still weights inside the top-K.
+	assert.Greater(t, hits["high2"], hits["high1"], "score 10 should beat score 9 inside top-K")
+}
+
+// TestPick_AllZero_WithTopK_DelegatesToRandom verifies the existing all-zero shortcut still
+// fires before top-K filtering — the random-picker fallback runs over the full input, matching
+// pre-change behavior on cold clusters.
+func TestPick_AllZero_WithTopK_DelegatesToRandom(t *testing.T) {
+	const trials = 4000
+	cands := []*fwksched.ScoredEndpoint{
+		makeScored("a", 0), makeScored("b", 0), makeScored("c", 0), makeScored("d", 0),
+	}
+	pkr := New(Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: 1},
+		TopK:             2,
+	})
+
+	hits := map[string]int{}
+	for i := 0; i < trials; i++ {
+		res := pkr.Pick(context.Background(), nil, cands)
+		hits[res.TargetEndpoints[0].GetMetadata().NamespacedName.Name]++
+	}
+	require.GreaterOrEqual(t, len(hits), 3, "all-zero must uniformly sample, not collapse to top-K=2")
+}
+
+// TestPick_TopK_NeverPicksZeroOutsidePool verifies that when some candidates are positive and
+// others zero, only positive-score candidates within the top-K participate — A-Res key=0
+// excludes zero-score pods even within the restricted pool.
+func TestPick_TopK_NeverPicksZeroOutsidePool(t *testing.T) {
+	const trials = 4000
+	cands := []*fwksched.ScoredEndpoint{
+		makeScored("a", 7), makeScored("b", 3),
+		makeScored("c", 0), makeScored("d", 0), makeScored("e", 0),
+	}
+	pkr := New(Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: 1},
+		TopK:             2, MinTopK: 1,
+	})
+
+	for i := 0; i < trials; i++ {
+		res := pkr.Pick(context.Background(), nil, cands)
+		require.Contains(t, []string{"a", "b"},
+			res.TargetEndpoints[0].GetMetadata().NamespacedName.Name)
+	}
+}
+
+// TestPick_MaxNumOfEndpointsBounded verifies maxNumOfEndpoints respects the top-K pool.
+func TestPick_MaxNumOfEndpointsBounded(t *testing.T) {
+	cands := make([]*fwksched.ScoredEndpoint, 20)
+	for i := 0; i < 20; i++ {
+		cands[i] = makeScored(fmt.Sprintf("p-%d", i), float64(i+1))
+	}
+	pkr := New(Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: 3},
+		TopKPercent:      25, // top 5
+		MinTopK:          2,
+	})
+
+	res := pkr.Pick(context.Background(), nil, cands)
+	require.Len(t, res.TargetEndpoints, 3)
+	allowed := map[string]bool{"p-15": true, "p-16": true, "p-17": true, "p-18": true, "p-19": true}
+	for _, ep := range res.TargetEndpoints {
+		assert.True(t, allowed[ep.GetMetadata().NamespacedName.Name],
+			"output endpoint %q outside top-5 by score", ep.GetMetadata().NamespacedName.Name)
+	}
+}
+
+// TestPick_TopK_TiesAtCutoffSampleAll is a regression guard against deterministic
+// input-order bias at the K-th cutoff. Five candidates share the same score; with
+// TopK=3 the picker must still be able to sample every one of them across many
+// trials (pre-shuffle randomizes the stable sort's tie-break).
+func TestPick_TopK_TiesAtCutoffSampleAll(t *testing.T) {
+	const trials = 4000
+	cands := []*fwksched.ScoredEndpoint{
+		makeScored("a", 5), makeScored("b", 5), makeScored("c", 5),
+		makeScored("d", 5), makeScored("e", 5),
+	}
+	pkr := New(Parameters{
+		PickerParameters: picker.PickerParameters{MaxNumOfEndpoints: 1},
+		TopK:             3, MinTopK: 1,
+	})
+
+	hits := map[string]int{}
+	for i := 0; i < trials; i++ {
+		res := pkr.Pick(context.Background(), nil, cands)
+		hits[res.TargetEndpoints[0].GetMetadata().NamespacedName.Name]++
+	}
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		assert.Greater(t, hits[n], 0,
+			"endpoint %q never sampled — input-order bias on tied scores at K-th cutoff", n)
+	}
+}
+
+// TestFactory_RejectsInvalidConfig covers the JSON entry point's validation.
+func TestFactory_RejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "empty config (legacy)", raw: `{}`, wantErr: false},
+		{name: "topK only", raw: `{"topK": 5}`, wantErr: false},
+		{name: "topKPercent only", raw: `{"topKPercent": 25}`, wantErr: false},
+		{name: "topKPercent above 100", raw: `{"topKPercent": 200}`, wantErr: true},
+		{name: "negative topK", raw: `{"topK": -3}`, wantErr: true},
+		{name: "invalid json", raw: `{not json}`, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := WeightedRandomPickerFactory("wr", json.RawMessage(tc.raw), nil)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, p)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds optional candidate-pool restriction before A-Res sampling. Default behavior (no top-K knobs) is unchanged.

  - topK: absolute cap on candidates by score
  - topKPercent: percentage cap, ceil(N * P / 100)
  - minTopK: floor (default 2) so small fleets don't collapse to argmax

Useful on large fleets where the long low-score tail otherwise pulls non-trivial traffic. Bounds the worst case while preserving sampling variance within the top tier.

If we had perfect scorers expression and composability, this would not be needed.

< Note: Alternative is a new picker.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
New configuration knobs added.
```
