### PR TITLE
Enabled more lint rules and corrected related code issues - part three

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,6 @@ linters:
         - name: error-strings
         - name: error-naming
         - name: errorf
-        #- name: exported
         - name: if-return
         - name: increment-decrement
         - name: indent-error-flow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - nilnil
     - perfsprint
     - prealloc
     - revive
@@ -57,11 +58,13 @@ linters:
         - name: error-strings
         - name: error-naming
         - name: errorf
+        #- name: exported
         - name: if-return
         - name: increment-decrement
         - name: indent-error-flow
         - name: package-comments
         - name: range
+        - name: receiver-naming
         - name: time-naming
         - name: unexported-return
         - name: var-declaration

--- a/pkg/epp/backend/metrics/metrics.go
+++ b/pkg/epp/backend/metrics/metrics.go
@@ -245,7 +245,8 @@ func (p *PodMetricsClientImpl) promToPodMetrics(
 // retrieve the latest by sorting the value.
 func (p *PodMetricsClientImpl) getLatestLoraMetric(metricFamilies map[string]*dto.MetricFamily) (*dto.Metric, error) {
 	if p.MetricMapping.LoraRequestInfo == nil {
-		return nil, nil // No LoRA metrics configured
+		// No LoRA metrics configured
+		return nil, nil //nolint:nilnil
 	}
 
 	loraRequests, ok := metricFamilies[p.MetricMapping.LoraRequestInfo.MetricName]
@@ -281,7 +282,8 @@ func (p *PodMetricsClientImpl) getLatestLoraMetric(metricFamilies map[string]*dt
 		}
 	}
 	if latest == nil {
-		return nil, nil
+		// nothing to return
+		return nil, nil //nolint:nilnil
 	}
 
 	return latest, nil // Convert nanoseconds to time.Time

--- a/pkg/epp/backend/metrics/metrics_spec.go
+++ b/pkg/epp/backend/metrics/metrics_spec.go
@@ -44,7 +44,8 @@ type MetricMapping struct {
 //	"metric_name{label1=value1,label2=value2}"
 func stringToMetricSpec(specStr string) (*MetricSpec, error) {
 	if specStr == "" {
-		return nil, nil // Allow empty strings to represent nil MetricSpecs
+		// Allow empty strings to represent nil MetricSpecs
+		return nil, nil //nolint:nilnil
 	}
 	specStr = strings.TrimSpace(specStr)
 	metricName := specStr

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -19,6 +19,7 @@ package loader
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -681,7 +682,7 @@ func (m *mockHandler) Pick(context.Context, *framework.CycleState, *framework.In
 }
 func (m *mockHandler) ProcessResults(context.Context, *framework.CycleState, *framework.InferenceRequest,
 	map[string]*framework.ProfileRunResult) (*framework.SchedulingResult, error) {
-	return nil, nil
+	return nil, errors.New("sentinel error for mock handler")
 }
 
 // Mock Source

--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -31,6 +31,7 @@ package mocks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -73,21 +74,21 @@ func (m *MockRegistryShard) ManagedQueue(key flowcontrol.FlowKey) (contracts.Man
 	if m.ManagedQueueFunc != nil {
 		return m.ManagedQueueFunc(key)
 	}
-	return nil, nil
+	return nil, errors.New("sentinel error for mock shard")
 }
 
 func (m *MockRegistryShard) FairnessPolicy(priority int) (flowcontrol.FairnessPolicy, error) {
 	if m.FairnessPolicyFunc != nil {
 		return m.FairnessPolicyFunc(priority)
 	}
-	return nil, nil
+	return nil, errors.New("sentinel error for mock shard")
 }
 
 func (m *MockRegistryShard) PriorityBandAccessor(priority int) (flowcontrol.PriorityBandAccessor, error) {
 	if m.PriorityBandAccessorFunc != nil {
 		return m.PriorityBandAccessorFunc(priority)
 	}
-	return nil, nil
+	return nil, errors.New("sentinel error for mock shard")
 }
 
 func (m *MockRegistryShard) AllOrderedPriorityLevels() []int {
@@ -184,7 +185,7 @@ func (m *MockSafeQueue) Remove(handle flowcontrol.QueueItemHandle) (flowcontrol.
 	if m.RemoveFunc != nil {
 		return m.RemoveFunc(handle)
 	}
-	return nil, nil
+	return nil, errors.New("sentinel error for mock queue")
 }
 
 func (m *MockSafeQueue) Cleanup(predicate contracts.PredicateFunc) []flowcontrol.QueueItemAccessor {

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -388,7 +388,8 @@ func (sp *ShardProcessor) selectItem(
 		return nil, fmt.Errorf("FairnessPolicy %q failed to select queue: %w", fairnessP.TypedName(), err)
 	}
 	if queue == nil {
-		return nil, nil
+		// nothing to select
+		return nil, nil //nolint:nilnil
 	}
 	// The queue itself is responsible for explicit ordering via its configured OrderingPolicy.
 	// We simply peek at the head.

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -393,7 +393,7 @@ func TestShardProcessor(t *testing.T) {
 				context.Context,
 				flowcontrol.PriorityBandAccessor,
 			) (flowcontrol.FlowQueueAccessor, error) {
-				return nil, nil
+				return nil, errors.New("sentinel no item selected")
 			}
 
 			// --- ACT ---
@@ -954,7 +954,8 @@ func TestShardProcessor(t *testing.T) {
 								context.Context,
 								flowcontrol.PriorityBandAccessor,
 							) (flowcontrol.FlowQueueAccessor, error) {
-								return nil, nil // Simulate band being empty or policy choosing to pause.
+								// Simulate band being empty or policy choosing to pause.
+								return nil, errors.New("sentinel no item selected")
 							}
 						},
 						expectDidDispatch: false,

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -34,50 +34,50 @@ type EndpointMetadata struct {
 }
 
 // String returns a string representation of the endpoint.
-func (e *EndpointMetadata) String() string {
-	if e == nil {
+func (epm *EndpointMetadata) String() string {
+	if epm == nil {
 		return ""
 	}
-	return fmt.Sprintf("%+v", *e)
+	return fmt.Sprintf("%+v", *epm)
 }
 
 // Clone returns a full copy of the object.
-func (e *EndpointMetadata) Clone() *EndpointMetadata {
-	if e == nil {
+func (epm *EndpointMetadata) Clone() *EndpointMetadata {
+	if epm == nil {
 		return nil
 	}
 
-	clonedLabels := make(map[string]string, len(e.Labels))
-	maps.Copy(clonedLabels, e.Labels)
+	clonedLabels := make(map[string]string, len(epm.Labels))
+	maps.Copy(clonedLabels, epm.Labels)
 	return &EndpointMetadata{
 		NamespacedName: types.NamespacedName{
-			Name:      e.NamespacedName.Name,
-			Namespace: e.NamespacedName.Namespace,
+			Name:      epm.NamespacedName.Name,
+			Namespace: epm.NamespacedName.Namespace,
 		},
-		PodName:     e.PodName,
-		Address:     e.Address,
-		Port:        e.Port,
-		MetricsHost: e.MetricsHost,
+		PodName:     epm.PodName,
+		Address:     epm.Address,
+		Port:        epm.Port,
+		MetricsHost: epm.MetricsHost,
 		Labels:      clonedLabels,
 	}
 }
 
 // GetNamespacedName gets the namespace name of the Endpoint.
-func (e *EndpointMetadata) GetNamespacedName() types.NamespacedName {
-	return e.NamespacedName
+func (epm *EndpointMetadata) GetNamespacedName() types.NamespacedName {
+	return epm.NamespacedName
 }
 
 // GetIPAddress returns the Endpoint's IP address.
-func (e *EndpointMetadata) GetIPAddress() string {
-	return e.Address
+func (epm *EndpointMetadata) GetIPAddress() string {
+	return epm.Address
 }
 
 // GetPort returns the Endpoint's inference port.
-func (e *EndpointMetadata) GetPort() string {
-	return e.Port
+func (epm *EndpointMetadata) GetPort() string {
+	return epm.Port
 }
 
 // GetMetricsHost returns the Endpoint's metrics host (ip:port)
-func (e *EndpointMetadata) GetMetricsHost() string {
-	return e.MetricsHost
+func (epm *EndpointMetadata) GetMetricsHost() string {
+	return epm.MetricsHost
 }

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -42,22 +42,22 @@ func (e *EndpointMetadata) String() string {
 }
 
 // Clone returns a full copy of the object.
-func (p *EndpointMetadata) Clone() *EndpointMetadata {
-	if p == nil {
+func (e *EndpointMetadata) Clone() *EndpointMetadata {
+	if e == nil {
 		return nil
 	}
 
-	clonedLabels := make(map[string]string, len(p.Labels))
-	maps.Copy(clonedLabels, p.Labels)
+	clonedLabels := make(map[string]string, len(e.Labels))
+	maps.Copy(clonedLabels, e.Labels)
 	return &EndpointMetadata{
 		NamespacedName: types.NamespacedName{
-			Name:      p.NamespacedName.Name,
-			Namespace: p.NamespacedName.Namespace,
+			Name:      e.NamespacedName.Name,
+			Namespace: e.NamespacedName.Namespace,
 		},
-		PodName:     p.PodName,
-		Address:     p.Address,
-		Port:        p.Port,
-		MetricsHost: p.MetricsHost,
+		PodName:     e.PodName,
+		Address:     e.Address,
+		Port:        e.Port,
+		MetricsHost: e.MetricsHost,
 		Labels:      clonedLabels,
 	}
 }

--- a/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
+++ b/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
@@ -18,6 +18,7 @@ package mocks
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol"
@@ -250,7 +251,7 @@ func (m *MockFairnessPolicy) Pick(ctx context.Context, flowGroup flowcontrol.Pri
 	if m.PickFunc != nil {
 		return m.PickFunc(ctx, flowGroup)
 	}
-	return nil, nil
+	return nil, errors.New("sentinel nothing to pick")
 }
 
 var _ flowcontrol.FairnessPolicy = &MockFairnessPolicy{}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/loraspec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/loraspec.go
@@ -38,7 +38,8 @@ func parseStringToLoRASpec(spec string) (*LoRASpec, error) {
 		return nil, err
 	}
 	if baseSpec == nil {
-		return nil, nil // empty string → disabled; preserve nil-means-disabled contract
+		// empty string → disabled; preserve nil-means-disabled contract
+		return nil, nil //nolint:nilnil
 	}
 	return &LoRASpec{Spec: baseSpec}, nil
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
@@ -40,7 +40,8 @@ type Spec struct {
 // metric_name{label1=value1,label2=value2}, where labels are optional.
 func parseStringToSpec(spec string) (*Spec, error) {
 	if spec == "" {
-		return nil, nil // allow empty string to represent the nil Spec
+		// allow empty string to represent the nil Spec
+		return nil, nil //nolint:nilnil
 	}
 
 	// Be liberal in accepting inputs that are missing quotes around label values,

--- a/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
+++ b/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
@@ -18,6 +18,7 @@ package mocks
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -83,7 +84,7 @@ func (fds *MetricsDataSource) Poll(ctx context.Context, ep fwkdl.Endpoint) (any,
 			ep.UpdateMetrics(clone)
 		}
 	}
-	return nil, nil
+	return nil, errors.New("sentinel nothing polled")
 }
 
 // NotificationSource implements both DataSource and NotificationSource for testing.

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict.go
@@ -75,7 +75,8 @@ func (p *globalStrict) Pick(
 	flowGroup flowcontrol.PriorityBandAccessor,
 ) (flowcontrol.FlowQueueAccessor, error) {
 	if flowGroup == nil {
-		return nil, nil
+		// Nothing to pick
+		return nil, nil //nolint:nilnil
 	}
 
 	var bestQueue flowcontrol.FlowQueueAccessor

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
@@ -80,7 +80,8 @@ func (p *roundRobin) Pick(
 	flowGroup flowcontrol.PriorityBandAccessor,
 ) (flowcontrol.FlowQueueAccessor, error) {
 	if flowGroup == nil {
-		return nil, nil
+		// Nothing to pick
+		return nil, nil //nolint:nilnil
 	}
 
 	v := flowGroup.PolicyState()
@@ -95,7 +96,7 @@ func (p *roundRobin) Pick(
 	keys := flowGroup.FlowKeys()
 	if len(keys) == 0 {
 		c.lastSelected = nil // Reset cursor if no flows are present.
-		return nil, nil
+		return nil, nil      //nolint:nilnil
 	}
 
 	// Sort for deterministic ordering.
@@ -123,5 +124,5 @@ func (p *roundRobin) Pick(
 
 	// No non-empty queue was found.
 	c.lastSelected = nil
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -73,7 +73,7 @@ type PredictedLatency struct {
 }
 
 // endpointCounter returns the atomic counter for the given endpoint key, creating it if necessary.
-func (t *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int64 {
+func (s *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int64 {
 	v, _ := m.LoadOrStore(key, new(atomic.Int64))
 	return v.(*atomic.Int64)
 }
@@ -86,7 +86,7 @@ func (t *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int6
 // context after PreRequest already skipped the increment), which used to
 // break prediction requests with `greater_than_equal: 0` validation errors.
 // Decrementing a missing key is a no-op and does not create a zero entry.
-func (t *PredictedLatency) decrementEndpointCounter(m *sync.Map, key string, delta int64) {
+func (s *PredictedLatency) decrementEndpointCounter(m *sync.Map, key string, delta int64) {
 	v, ok := m.Load(key)
 	if !ok {
 		return
@@ -230,8 +230,8 @@ func (s *PredictedLatency) WithName(name string) *PredictedLatency {
 	return s
 }
 
-func (t *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.InferenceRequest) *predictedLatencyCtx {
-	sloCtx, err := t.getPredictedLatencyContextForRequest(request)
+func (s *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.InferenceRequest) *predictedLatencyCtx {
+	sloCtx, err := s.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		sloCtx = newPredictedLatencyContext(request)
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -73,7 +73,7 @@ type PredictedLatency struct {
 }
 
 // endpointCounter returns the atomic counter for the given endpoint key, creating it if necessary.
-func (s *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int64 {
+func (pl *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int64 {
 	v, _ := m.LoadOrStore(key, new(atomic.Int64))
 	return v.(*atomic.Int64)
 }
@@ -86,7 +86,7 @@ func (s *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int6
 // context after PreRequest already skipped the increment), which used to
 // break prediction requests with `greater_than_equal: 0` validation errors.
 // Decrementing a missing key is a no-op and does not create a zero entry.
-func (s *PredictedLatency) decrementEndpointCounter(m *sync.Map, key string, delta int64) {
+func (pl *PredictedLatency) decrementEndpointCounter(m *sync.Map, key string, delta int64) {
 	v, ok := m.Load(key)
 	if !ok {
 		return
@@ -221,17 +221,17 @@ func startPredictor(handle plugin.Handle) (latencypredictor.PredictorInterface, 
 	return predictor, nil
 }
 
-func (s *PredictedLatency) TypedName() plugin.TypedName {
-	return s.typedName
+func (pl *PredictedLatency) TypedName() plugin.TypedName {
+	return pl.typedName
 }
 
-func (s *PredictedLatency) WithName(name string) *PredictedLatency {
-	s.typedName.Name = name
-	return s
+func (pl *PredictedLatency) WithName(name string) *PredictedLatency {
+	pl.typedName.Name = name
+	return pl
 }
 
-func (s *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.InferenceRequest) *predictedLatencyCtx {
-	sloCtx, err := s.getPredictedLatencyContextForRequest(request)
+func (pl *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.InferenceRequest) *predictedLatencyCtx {
+	sloCtx, err := pl.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		sloCtx = newPredictedLatencyContext(request)
 	}
@@ -289,22 +289,22 @@ func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedL
 	}
 }
 
-func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *framework.InferenceRequest) (*predictedLatencyCtx, error) {
+func (pl *PredictedLatency) getPredictedLatencyContextForRequest(request *framework.InferenceRequest) (*predictedLatencyCtx, error) {
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
-	if item := s.sloContextStore.Get(id); item != nil {
+	if item := pl.sloContextStore.Get(id); item != nil {
 		return item.Value(), nil
 	}
 	return nil, fmt.Errorf("SLO context not found for request ID: %s", id)
 }
 
-func (s *PredictedLatency) setPredictedLatencyContextForRequest(request *framework.InferenceRequest, ctx *predictedLatencyCtx) {
+func (pl *PredictedLatency) setPredictedLatencyContextForRequest(request *framework.InferenceRequest, ctx *predictedLatencyCtx) {
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
-	s.sloContextStore.Set(id, ctx, ttlcache.DefaultTTL)
+	pl.sloContextStore.Set(id, ctx, ttlcache.DefaultTTL)
 }
 
-func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *framework.InferenceRequest) {
+func (pl *PredictedLatency) deletePredictedLatencyContextForRequest(request *framework.InferenceRequest) {
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
-	s.sloContextStore.Delete(id)
+	pl.sloContextStore.Delete(id)
 }
 
 // --- Header parsing ---
@@ -326,7 +326,7 @@ func parseFloatHeader(request framework.InferenceRequest, headerName string) (fl
 	return parsedFloat, nil
 }
 
-func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framework.InferenceRequest, predictedLatencyCtx *predictedLatencyCtx) {
+func (pl *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framework.InferenceRequest, predictedLatencyCtx *predictedLatencyCtx) {
 	logger := log.FromContext(ctx)
 	var err error
 
@@ -343,9 +343,9 @@ func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framewo
 
 // --- Running request queue helpers ---
 
-func (s *PredictedLatency) getEndpointMinTPOTSLO(endpoint framework.Endpoint) float64 {
+func (pl *PredictedLatency) getEndpointMinTPOTSLO(endpoint framework.Endpoint) float64 {
 	endpointName := endpoint.GetMetadata().NamespacedName
-	if runningReqs := s.getRunningRequestList(endpointName); runningReqs != nil && runningReqs.GetSize() > 0 {
+	if runningReqs := pl.getRunningRequestList(endpointName); runningReqs != nil && runningReqs.GetSize() > 0 {
 		if min := runningReqs.Peek(); min != nil {
 			return min.tpot
 		}
@@ -353,31 +353,31 @@ func (s *PredictedLatency) getEndpointMinTPOTSLO(endpoint framework.Endpoint) fl
 	return 0
 }
 
-func (s *PredictedLatency) getEndpointRunningRequestCount(endpoint framework.Endpoint) int {
+func (pl *PredictedLatency) getEndpointRunningRequestCount(endpoint framework.Endpoint) int {
 	endpointName := endpoint.GetMetadata().NamespacedName
-	if runningReqs := s.getRunningRequestList(endpointName); runningReqs != nil {
+	if runningReqs := pl.getRunningRequestList(endpointName); runningReqs != nil {
 		return runningReqs.GetSize()
 	}
 	return 0
 }
 
-func (s *PredictedLatency) getRunningRequestList(endpointName types.NamespacedName) *requestPriorityQueue {
-	if value, ok := s.runningRequestLists.Load(endpointName); ok {
+func (pl *PredictedLatency) getRunningRequestList(endpointName types.NamespacedName) *requestPriorityQueue {
+	if value, ok := pl.runningRequestLists.Load(endpointName); ok {
 		return value.(*requestPriorityQueue)
 	}
 	return nil
 }
 
-func (s *PredictedLatency) removeRequestFromEndpoint(endpointName types.NamespacedName, requestID string) {
-	if queue := s.getRunningRequestList(endpointName); queue != nil {
+func (pl *PredictedLatency) removeRequestFromEndpoint(endpointName types.NamespacedName, requestID string) {
+	if queue := pl.getRunningRequestList(endpointName); queue != nil {
 		queue.Remove(requestID)
 		if queue.GetSize() == 0 {
-			s.runningRequestLists.Delete(endpointName)
+			pl.runningRequestLists.Delete(endpointName)
 		}
 	}
 }
 
-func (s *PredictedLatency) removeRequestFromQueue(requestID string, ctx *predictedLatencyCtx) {
+func (pl *PredictedLatency) removeRequestFromQueue(requestID string, ctx *predictedLatencyCtx) {
 	if ctx == nil || ctx.targetMetadata == nil {
 		return
 	}
@@ -385,5 +385,5 @@ func (s *PredictedLatency) removeRequestFromQueue(requestID string, ctx *predict
 		Name:      ctx.targetMetadata.NamespacedName.Name,
 		Namespace: ctx.targetMetadata.NamespacedName.Namespace,
 	}
-	s.removeRequestFromEndpoint(endpointName, requestID)
+	pl.removeRequestFromEndpoint(endpointName, requestID)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
@@ -42,7 +42,7 @@ type endpointPredictionResult struct {
 }
 
 // generatePredictions creates prediction results for all candidate pods
-func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, candidateEndpoints []schedulingtypes.Endpoint) ([]endpointPredictionResult, error) {
+func (pl *PredictedLatency) generatePredictions(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, candidateEndpoints []schedulingtypes.Endpoint) ([]endpointPredictionResult, error) {
 	logger := log.FromContext(ctx)
 	predictions := make([]endpointPredictionResult, 0, len(candidateEndpoints))
 
@@ -69,11 +69,11 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 		prefixCacheScores[i] = prefixCacheScore
 
 		podKey := endpoint.GetMetadata().NamespacedName.String()
-		prefillTokensInFlights[i] = s.endpointCounter(&s.prefillTokensInFlight, podKey).Load()
+		prefillTokensInFlights[i] = pl.endpointCounter(&pl.prefillTokensInFlight, podKey).Load()
 	}
 
 	// Bulk predict
-	bulkPredictions, err := bulkPredictWithMetrics(ctx, predictedLatencyCtx, s.latencypredictor, metricsStates, s.config.EndpointRoleLabel, targetEndpointsMetadatas, prompts, generatedTokenCounts, prefixCacheScores, prefillTokensInFlights)
+	bulkPredictions, err := bulkPredictWithMetrics(ctx, predictedLatencyCtx, pl.latencypredictor, metricsStates, pl.config.EndpointRoleLabel, targetEndpointsMetadatas, prompts, generatedTokenCounts, prefixCacheScores, prefillTokensInFlights)
 	if err != nil {
 		logger.V(logutil.DEBUG).Error(err, "Bulk prediction failed")
 		return nil, err
@@ -88,15 +88,15 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 		predResult.TTFT = prediction.TTFT
 		predResult.TPOT = prediction.TPOT
 
-		podMinTPOTSLO := s.getEndpointMinTPOTSLO(endpoint)
-		predResult.TTFTValid, predResult.TPOTValid, predResult.IsValid, predResult.Headroom, predResult.TTFTHeadroom = s.validatePrediction(prediction, predictedLatencyCtx, podMinTPOTSLO)
+		podMinTPOTSLO := pl.getEndpointMinTPOTSLO(endpoint)
+		predResult.TTFTValid, predResult.TPOTValid, predResult.IsValid, predResult.Headroom, predResult.TTFTHeadroom = pl.validatePrediction(prediction, predictedLatencyCtx, podMinTPOTSLO)
 
 		// Neutralize TPOT when it's not meaningful:
 		// - Non-streaming mode: TPOT is never trained (no per-token observations)
 		// - Disaggregated prefill: prefill pods don't generate tokens
 		// Setting TPOTValid=true and Headroom=0 prevents untrained TPOT
 		// predictions from polluting scoring, tier classification, or admission.
-		if !s.config.StreamingMode || hasPrefillRole(s.config.EndpointRoleLabel, endpoint) {
+		if !pl.config.StreamingMode || hasPrefillRole(pl.config.EndpointRoleLabel, endpoint) {
 			predResult.TPOTValid = true
 			predResult.Headroom = 0
 			predResult.IsValid = predResult.TTFTValid
@@ -107,7 +107,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 			"prefixCacheScore", predResult.PrefixCacheScore,
 			"TTFT", prediction.TTFT,
 			"TPOT", prediction.TPOT,
-			"buffer", s.config.SLOBufferFactor,
+			"buffer", pl.config.SLOBufferFactor,
 			"podMinTPOTSLO", podMinTPOTSLO,
 			"ttftSLO", predictedLatencyCtx.ttftSLO,
 			"requestTPOTSLO", predictedLatencyCtx.avgTPOTSLO,
@@ -124,7 +124,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 }
 
 // updateRequestContextWithPredictions updates the request context with prediction data
-func (s *PredictedLatency) updateRequestContextWithPredictions(predictedLatencyCtx *predictedLatencyCtx, predictions []endpointPredictionResult) {
+func (pl *PredictedLatency) updateRequestContextWithPredictions(predictedLatencyCtx *predictedLatencyCtx, predictions []endpointPredictionResult) {
 	predMap := make(map[string]endpointPredictionResult, len(predictions))
 	for _, pred := range predictions {
 		if pred.Endpoint != nil && pred.Endpoint.GetMetadata() != nil {
@@ -134,7 +134,7 @@ func (s *PredictedLatency) updateRequestContextWithPredictions(predictedLatencyC
 	predictedLatencyCtx.predictionsForScheduling = predMap
 }
 
-func (s *PredictedLatency) validatePrediction(
+func (pl *PredictedLatency) validatePrediction(
 	pred *latencypredictor.PredictionResponse,
 	predictedLatencyCtx *predictedLatencyCtx,
 	podMinTPOTSLO float64,
@@ -146,14 +146,14 @@ func (s *PredictedLatency) validatePrediction(
 	tpotOk = true
 	headroom = 0.0
 
-	if s.config.StreamingMode {
-		bufferedTPOT := predictedLatencyCtx.avgTPOTSLO * s.config.SLOBufferFactor
+	if pl.config.StreamingMode {
+		bufferedTPOT := predictedLatencyCtx.avgTPOTSLO * pl.config.SLOBufferFactor
 		// a podMinTPOTSLO of 0 means no either no requests, or no TPOT SLOs specified on running requests
 		if podMinTPOTSLO > 0 {
 			if podMinTPOTSLO < predictedLatencyCtx.avgTPOTSLO {
 				log.FromContext(context.Background()).V(logutil.DEBUG).Info("Endpoint min TPOT SLO is less than the req SLO, adjusting", "podMinTPOTSLO", podMinTPOTSLO, "bufferedTPOT", predictedLatencyCtx.avgTPOTSLO)
 			}
-			bufferedTPOT = min(bufferedTPOT, podMinTPOTSLO*s.config.SLOBufferFactor)
+			bufferedTPOT = min(bufferedTPOT, podMinTPOTSLO*pl.config.SLOBufferFactor)
 		}
 
 		tpotOk = pred.TPOT < bufferedTPOT

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
@@ -33,11 +33,11 @@ var _ requestcontrol.DataProducer = &PredictedLatency{}
 
 // PrepareRequestData prepares the SLO context for the request, including
 // parsing SLO headers, gathering prefix cache scores, and generating predictions.
-func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func (pl *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	logger := log.FromContext(ctx)
-	predictedLatencyCtx := s.getOrMakePredictedLatencyContextForRequest(request)
+	predictedLatencyCtx := pl.getOrMakePredictedLatencyContextForRequest(request)
 
-	s.parseSLOHeaders(ctx, request, predictedLatencyCtx)
+	pl.parseSLOHeaders(ctx, request, predictedLatencyCtx)
 	var prefixCacheScore float64
 	for _, endpoint := range endpoints {
 
@@ -56,18 +56,18 @@ func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *sche
 		}
 		predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().NamespacedName.Name] = prefixCacheScore
 	}
-	if !s.config.PredictInPrepareData {
+	if !pl.config.PredictInPrepareData {
 		logger.V(logutil.DEBUG).Info("PredictInPrepareData disabled, skipping predictions")
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		s.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+		pl.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 		return nil
 	}
 
-	predictions, err := s.generatePredictions(ctx, predictedLatencyCtx, endpoints)
+	predictions, err := pl.generatePredictions(ctx, predictedLatencyCtx, endpoints)
 	if err == nil && len(predictions) == len(endpoints) {
-		s.updateRequestContextWithPredictions(predictedLatencyCtx, predictions)
+		pl.updateRequestContextWithPredictions(predictedLatencyCtx, predictions)
 
 		// Store predictions in endpoint attributes
 		for _, pred := range predictions {
@@ -79,7 +79,7 @@ func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *sche
 					pred.Headroom, // Maps to TPOTHeadroom
 					pred.TTFT,
 					pred.TPOT,
-					s.getEndpointRunningRequestCount(pred.Endpoint),
+					pl.getEndpointRunningRequestCount(pred.Endpoint),
 				)
 				pred.Endpoint.Put(attrlatency.LatencyPredictionInfoKey, latencyInfo)
 				logger.V(logutil.DEBUG).Info("Stored latency prediction in endpoint",
@@ -101,16 +101,16 @@ func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *sche
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	s.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+	pl.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 	return nil
 }
 
-func (s *PredictedLatency) Produces() map[string]any {
+func (pl *PredictedLatency) Produces() map[string]any {
 	return map[string]any{
 		attrlatency.LatencyPredictionInfoKey: attrlatency.LatencyPredictionInfo{},
 	}
 }
 
-func (s *PredictedLatency) Consumes() map[string]any {
+func (pl *PredictedLatency) Consumes() map[string]any {
 	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
@@ -105,12 +105,12 @@ func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *sche
 	return nil
 }
 
-func (p *PredictedLatency) Produces() map[string]any {
+func (s *PredictedLatency) Produces() map[string]any {
 	return map[string]any{
 		attrlatency.LatencyPredictionInfoKey: attrlatency.LatencyPredictionInfo{},
 	}
 }
 
-func (p *PredictedLatency) Consumes() map[string]any {
+func (s *PredictedLatency) Consumes() map[string]any {
 	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -40,7 +40,7 @@ var _ requestcontrol.ResponseBodyProcessor = &PredictedLatency{}
 
 // --- RequestControl Hooks ---
 
-func (s *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, schedulingResult *schedulingtypes.SchedulingResult) {
+func (pl *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, schedulingResult *schedulingtypes.SchedulingResult) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: request is nil, skipping")
@@ -53,7 +53,7 @@ func (s *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	}
 
 	targetMetadata := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName].TargetEndpoints[0].GetMetadata()
-	if !s.checkPredictor(logger, targetMetadata) {
+	if !pl.checkPredictor(logger, targetMetadata) {
 		return
 	}
 
@@ -70,10 +70,10 @@ func (s *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
 
-	actual, _ := s.runningRequestLists.LoadOrStore(endpointName, newRequestPriorityQueue())
+	actual, _ := pl.runningRequestLists.LoadOrStore(endpointName, newRequestPriorityQueue())
 	endpointRequestList := actual.(*requestPriorityQueue)
 
-	predictedLatencyCtx, err := s.getPredictedLatencyContextForRequest(request)
+	predictedLatencyCtx, err := pl.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: Failed to get SLO context for request", "error", err, "requestID", id)
@@ -100,17 +100,17 @@ func (s *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	decodePodKey := endpointName.String()
 	if predictedLatencyCtx.prefillTargetMetadata != nil {
 		prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-		s.endpointCounter(&s.prefillTokensInFlight, prefillPodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
-		predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = s.endpointCounter(&s.prefillTokensInFlight, prefillPodKey).Load()
+		pl.endpointCounter(&pl.prefillTokensInFlight, prefillPodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+		predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = pl.endpointCounter(&pl.prefillTokensInFlight, prefillPodKey).Load()
 	}
-	s.endpointCounter(&s.prefillTokensInFlight, decodePodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
-	predictedLatencyCtx.prefillTokensAtDispatch = s.endpointCounter(&s.prefillTokensInFlight, decodePodKey).Load()
+	pl.endpointCounter(&pl.prefillTokensInFlight, decodePodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+	predictedLatencyCtx.prefillTokensAtDispatch = pl.endpointCounter(&pl.prefillTokensInFlight, decodePodKey).Load()
 	predictedLatencyCtx.decodeTokensAtDispatch = 0
 
 	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
 }
 
-func (s *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (pl *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseReceived: request is nil, skipping")
@@ -119,18 +119,18 @@ func (s *PredictedLatency) ResponseHeader(ctx context.Context, request *scheduli
 }
 
 // ResponseBody handles both per-chunk processing and request completion logic.
-func (s *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: request is nil, skipping")
 		return
 	}
-	if !s.checkPredictor(logger, targetMetadata) {
+	if !pl.checkPredictor(logger, targetMetadata) {
 		return
 	}
 
 	now := time.Now()
-	predictedLatencyCtx, err := s.getPredictedLatencyContextForRequest(request)
+	predictedLatencyCtx, err := pl.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: Failed to get SLO context", "error", err, "requestID", id)
@@ -138,25 +138,25 @@ func (s *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 	}
 
 	if predictedLatencyCtx.ttft == 0 {
-		if s.config.StreamingMode && !response.EndOfStream {
-			processFirstTokenForLatencyPrediction(ctx, s.latencypredictor, s.config.StreamingMode, s.config.EndpointRoleLabel, predictedLatencyCtx, now, s.config.SamplingMean, s.config.MaxDecodeTokenSamplesForPrediction)
+		if pl.config.StreamingMode && !response.EndOfStream {
+			processFirstTokenForLatencyPrediction(ctx, pl.latencypredictor, pl.config.StreamingMode, pl.config.EndpointRoleLabel, predictedLatencyCtx, now, pl.config.SamplingMean, pl.config.MaxDecodeTokenSamplesForPrediction)
 
 			// Only decrement if PreRequest actually incremented the prefill pod counter.
 			// If PrepareData timed out, PreRequest may have skipped incrementing, and
 			// decrementing here would drift the counter negative.
 			if predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
 				prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-				s.decrementEndpointCounter(&s.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
+				pl.decrementEndpointCounter(&pl.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
 			}
 		}
 	} else {
-		processTokenForLatencyPrediction(ctx, s.latencypredictor, s.config.EndpointRoleLabel, predictedLatencyCtx, targetMetadata, now, s.config.SamplingMean, s.config.MaxDecodeTokenSamplesForPrediction)
+		processTokenForLatencyPrediction(ctx, pl.latencypredictor, pl.config.EndpointRoleLabel, predictedLatencyCtx, targetMetadata, now, pl.config.SamplingMean, pl.config.MaxDecodeTokenSamplesForPrediction)
 	}
 
 	if response.EndOfStream {
 		ttftNotYetRecorded := predictedLatencyCtx.ttft == 0
-		if !s.config.StreamingMode {
-			processFirstTokenForLatencyPrediction(ctx, s.latencypredictor, s.config.StreamingMode, s.config.EndpointRoleLabel, predictedLatencyCtx, now, s.config.SamplingMean, s.config.MaxDecodeTokenSamplesForPrediction)
+		if !pl.config.StreamingMode {
+			processFirstTokenForLatencyPrediction(ctx, pl.latencypredictor, pl.config.StreamingMode, pl.config.EndpointRoleLabel, predictedLatencyCtx, now, pl.config.SamplingMean, pl.config.MaxDecodeTokenSamplesForPrediction)
 		}
 
 		if predictedLatencyCtx.ttft > 0 {
@@ -184,7 +184,7 @@ func (s *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 
 			if m, err := getLatestMetricsForProfile(predictedLatencyCtx, ""); err == nil {
 				entry := buildTrainingEntry(
-					s.config.EndpointRoleLabel,
+					pl.config.EndpointRoleLabel,
 					targetMetadata,
 					m,
 					predictedLatencyCtx.promptText,
@@ -196,7 +196,7 @@ func (s *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 				)
 				entry.PrefillTokensInFlight = predictedLatencyCtx.prefillTokensAtDispatch
 				entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
-				if err := s.latencypredictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
+				if err := pl.latencypredictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
 					logger.V(logutil.DEBUG).Error(err, "record TPOT training failed")
 				}
 			}
@@ -209,24 +209,24 @@ func (s *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 		// here would orphan the pod's counter into negative territory.
 		if ttftNotYetRecorded && predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
 			prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-			s.decrementEndpointCounter(&s.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
+			pl.decrementEndpointCounter(&pl.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
 		}
 		if predictedLatencyCtx.prefillTokensAtDispatch > 0 {
-			s.decrementEndpointCounter(&s.prefillTokensInFlight, decodePodKey, int64(predictedLatencyCtx.inputTokenCount))
+			pl.decrementEndpointCounter(&pl.prefillTokensInFlight, decodePodKey, int64(predictedLatencyCtx.inputTokenCount))
 		}
 
 		id := request.Headers[reqcommon.RequestIDHeaderKey]
-		s.removeRequestFromQueue(id, predictedLatencyCtx)
-		s.deletePredictedLatencyContextForRequest(request)
+		pl.removeRequestFromQueue(id, predictedLatencyCtx)
+		pl.deletePredictedLatencyContextForRequest(request)
 	}
 }
 
-func (s *PredictedLatency) checkPredictor(logger logr.Logger, metadata *fwkdl.EndpointMetadata) bool {
+func (pl *PredictedLatency) checkPredictor(logger logr.Logger, metadata *fwkdl.EndpointMetadata) bool {
 	if metadata == nil {
 		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping hook because no target metadata was provided.")
 		return false
 	}
-	if s.latencypredictor == nil {
+	if pl.latencypredictor == nil {
 		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping hook because predictor missing")
 		return false
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -40,7 +40,7 @@ var _ requestcontrol.ResponseBodyProcessor = &PredictedLatency{}
 
 // --- RequestControl Hooks ---
 
-func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, schedulingResult *schedulingtypes.SchedulingResult) {
+func (s *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, schedulingResult *schedulingtypes.SchedulingResult) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: request is nil, skipping")
@@ -53,7 +53,7 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	}
 
 	targetMetadata := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName].TargetEndpoints[0].GetMetadata()
-	if !t.checkPredictor(logger, targetMetadata) {
+	if !s.checkPredictor(logger, targetMetadata) {
 		return
 	}
 
@@ -70,10 +70,10 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
 
-	actual, _ := t.runningRequestLists.LoadOrStore(endpointName, newRequestPriorityQueue())
+	actual, _ := s.runningRequestLists.LoadOrStore(endpointName, newRequestPriorityQueue())
 	endpointRequestList := actual.(*requestPriorityQueue)
 
-	predictedLatencyCtx, err := t.getPredictedLatencyContextForRequest(request)
+	predictedLatencyCtx, err := s.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: Failed to get SLO context for request", "error", err, "requestID", id)
@@ -100,17 +100,17 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	decodePodKey := endpointName.String()
 	if predictedLatencyCtx.prefillTargetMetadata != nil {
 		prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-		t.endpointCounter(&t.prefillTokensInFlight, prefillPodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
-		predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = t.endpointCounter(&t.prefillTokensInFlight, prefillPodKey).Load()
+		s.endpointCounter(&s.prefillTokensInFlight, prefillPodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+		predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = s.endpointCounter(&s.prefillTokensInFlight, prefillPodKey).Load()
 	}
-	t.endpointCounter(&t.prefillTokensInFlight, decodePodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
-	predictedLatencyCtx.prefillTokensAtDispatch = t.endpointCounter(&t.prefillTokensInFlight, decodePodKey).Load()
+	s.endpointCounter(&s.prefillTokensInFlight, decodePodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+	predictedLatencyCtx.prefillTokensAtDispatch = s.endpointCounter(&s.prefillTokensInFlight, decodePodKey).Load()
 	predictedLatencyCtx.decodeTokensAtDispatch = 0
 
 	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
 }
 
-func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (s *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseReceived: request is nil, skipping")
@@ -119,18 +119,18 @@ func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *scheduli
 }
 
 // ResponseBody handles both per-chunk processing and request completion logic.
-func (t *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (s *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: request is nil, skipping")
 		return
 	}
-	if !t.checkPredictor(logger, targetMetadata) {
+	if !s.checkPredictor(logger, targetMetadata) {
 		return
 	}
 
 	now := time.Now()
-	predictedLatencyCtx, err := t.getPredictedLatencyContextForRequest(request)
+	predictedLatencyCtx, err := s.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: Failed to get SLO context", "error", err, "requestID", id)
@@ -138,25 +138,25 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 	}
 
 	if predictedLatencyCtx.ttft == 0 {
-		if t.config.StreamingMode && !response.EndOfStream {
-			processFirstTokenForLatencyPrediction(ctx, t.latencypredictor, t.config.StreamingMode, t.config.EndpointRoleLabel, predictedLatencyCtx, now, t.config.SamplingMean, t.config.MaxDecodeTokenSamplesForPrediction)
+		if s.config.StreamingMode && !response.EndOfStream {
+			processFirstTokenForLatencyPrediction(ctx, s.latencypredictor, s.config.StreamingMode, s.config.EndpointRoleLabel, predictedLatencyCtx, now, s.config.SamplingMean, s.config.MaxDecodeTokenSamplesForPrediction)
 
 			// Only decrement if PreRequest actually incremented the prefill pod counter.
 			// If PrepareData timed out, PreRequest may have skipped incrementing, and
 			// decrementing here would drift the counter negative.
 			if predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
 				prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-				t.decrementEndpointCounter(&t.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
+				s.decrementEndpointCounter(&s.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
 			}
 		}
 	} else {
-		processTokenForLatencyPrediction(ctx, t.latencypredictor, t.config.EndpointRoleLabel, predictedLatencyCtx, targetMetadata, now, t.config.SamplingMean, t.config.MaxDecodeTokenSamplesForPrediction)
+		processTokenForLatencyPrediction(ctx, s.latencypredictor, s.config.EndpointRoleLabel, predictedLatencyCtx, targetMetadata, now, s.config.SamplingMean, s.config.MaxDecodeTokenSamplesForPrediction)
 	}
 
 	if response.EndOfStream {
 		ttftNotYetRecorded := predictedLatencyCtx.ttft == 0
-		if !t.config.StreamingMode {
-			processFirstTokenForLatencyPrediction(ctx, t.latencypredictor, t.config.StreamingMode, t.config.EndpointRoleLabel, predictedLatencyCtx, now, t.config.SamplingMean, t.config.MaxDecodeTokenSamplesForPrediction)
+		if !s.config.StreamingMode {
+			processFirstTokenForLatencyPrediction(ctx, s.latencypredictor, s.config.StreamingMode, s.config.EndpointRoleLabel, predictedLatencyCtx, now, s.config.SamplingMean, s.config.MaxDecodeTokenSamplesForPrediction)
 		}
 
 		if predictedLatencyCtx.ttft > 0 {
@@ -184,7 +184,7 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 
 			if m, err := getLatestMetricsForProfile(predictedLatencyCtx, ""); err == nil {
 				entry := buildTrainingEntry(
-					t.config.EndpointRoleLabel,
+					s.config.EndpointRoleLabel,
 					targetMetadata,
 					m,
 					predictedLatencyCtx.promptText,
@@ -196,7 +196,7 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 				)
 				entry.PrefillTokensInFlight = predictedLatencyCtx.prefillTokensAtDispatch
 				entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
-				if err := t.latencypredictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
+				if err := s.latencypredictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
 					logger.V(logutil.DEBUG).Error(err, "record TPOT training failed")
 				}
 			}
@@ -209,24 +209,24 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 		// here would orphan the pod's counter into negative territory.
 		if ttftNotYetRecorded && predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
 			prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-			t.decrementEndpointCounter(&t.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
+			s.decrementEndpointCounter(&s.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
 		}
 		if predictedLatencyCtx.prefillTokensAtDispatch > 0 {
-			t.decrementEndpointCounter(&t.prefillTokensInFlight, decodePodKey, int64(predictedLatencyCtx.inputTokenCount))
+			s.decrementEndpointCounter(&s.prefillTokensInFlight, decodePodKey, int64(predictedLatencyCtx.inputTokenCount))
 		}
 
 		id := request.Headers[reqcommon.RequestIDHeaderKey]
-		t.removeRequestFromQueue(id, predictedLatencyCtx)
-		t.deletePredictedLatencyContextForRequest(request)
+		s.removeRequestFromQueue(id, predictedLatencyCtx)
+		s.deletePredictedLatencyContextForRequest(request)
 	}
 }
 
-func (t *PredictedLatency) checkPredictor(logger logr.Logger, metadata *fwkdl.EndpointMetadata) bool {
+func (s *PredictedLatency) checkPredictor(logger logr.Logger, metadata *fwkdl.EndpointMetadata) bool {
 	if metadata == nil {
 		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping hook because no target metadata was provided.")
 		return false
 	}
-	if t.latencypredictor == nil {
+	if s.latencypredictor == nil {
 		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping hook because predictor missing")
 		return false
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
@@ -146,20 +146,20 @@ func (p *Plugin) WithName(name string) *Plugin {
 }
 
 // TypedName returns the typed name of the plugin.
-func (c *Plugin) TypedName() plugin.TypedName {
-	return c.typedName
+func (p *Plugin) TypedName() plugin.TypedName {
+	return p.typedName
 }
 
-func (c *Plugin) ResponseBody(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response,
+func (p *Plugin) ResponseBody(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response,
 	_ *datalayer.EndpointMetadata) {
 	// Convert the request usage Go struct into a protobuf struct so that it can be used as a CEL variable.
-	celData, err := c.getCelData(response)
+	celData, err := p.getCelData(response)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to convert usage into CEL data")
 		return
 	}
 
-	shouldCalculateValue, err := c.shouldCalculateValue(ctx, celData)
+	shouldCalculateValue, err := p.shouldCalculateValue(ctx, celData)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Error in shouldCalculateValue")
 		return
@@ -169,7 +169,7 @@ func (c *Plugin) ResponseBody(ctx context.Context, request *scheduling.Inference
 		return
 	}
 
-	intVal, err := c.calculateValue(ctx, celData)
+	intVal, err := p.calculateValue(ctx, celData)
 	if err != nil {
 		return // Error already logged
 	}
@@ -188,7 +188,7 @@ func (c *Plugin) ResponseBody(ctx context.Context, request *scheduling.Inference
 		response.DynamicMetadata.Fields = make(map[string]*structpb.Value)
 	}
 
-	attributeKey := c.config.Attributes[0].Key
+	attributeKey := p.config.Attributes[0].Key
 	attributeValue := &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(intVal)}}
 
 	namespaceMap, ok := response.DynamicMetadata.Fields[attributeKey.Namespace]
@@ -201,7 +201,7 @@ func (c *Plugin) ResponseBody(ctx context.Context, request *scheduling.Inference
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("Wrote dynamic metadata value to dynamic metadata", "value", intVal)
 }
 
-func (c *Plugin) getCelData(response *requestcontrol.Response) (any, error) {
+func (p *Plugin) getCelData(response *requestcontrol.Response) (any, error) {
 	usageBytes, err := json.Marshal(response.Usage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request.Usage to JSON: %w", err)
@@ -213,22 +213,22 @@ func (c *Plugin) getCelData(response *requestcontrol.Response) (any, error) {
 	return usageStruct, nil
 }
 
-func (c *Plugin) shouldCalculateValue(ctx context.Context, celData any) (bool, error) {
-	if c.conditionProg != nil {
-		val, err := c.maybeExecuteProg(ctx, c.conditionProg, celData, "condition", c.config.Attributes[0].Condition)
+func (p *Plugin) shouldCalculateValue(ctx context.Context, celData any) (bool, error) {
+	if p.conditionProg != nil {
+		val, err := p.maybeExecuteProg(ctx, p.conditionProg, celData, "condition", p.config.Attributes[0].Condition)
 		if err != nil {
 			return false, err // Error already logged in maybeExecuteProg
 		}
 		if bVal, ok := val.(bool); !ok || !bVal {
-			log.FromContext(ctx).V(logutil.VERBOSE).Info("Condition not met", "condition", c.config.Attributes[0].Condition)
+			log.FromContext(ctx).V(logutil.VERBOSE).Info("Condition not met", "condition", p.config.Attributes[0].Condition)
 			return false, nil
 		}
 	}
 	return true, nil
 }
 
-func (c *Plugin) calculateValue(ctx context.Context, celData any) (int64, error) {
-	val, err := c.maybeExecuteProg(ctx, c.expressionProg, celData, "expression", c.config.Attributes[0].Expression)
+func (p *Plugin) calculateValue(ctx context.Context, celData any) (int64, error) {
+	val, err := p.maybeExecuteProg(ctx, p.expressionProg, celData, "expression", p.config.Attributes[0].Expression)
 	if err != nil {
 		return -1, err // Error already logged
 	}
@@ -238,7 +238,7 @@ func (c *Plugin) calculateValue(ctx context.Context, celData any) (int64, error)
 		// Try int64 as well
 		int64Val, ok := val.(int64)
 		if !ok {
-			log.FromContext(ctx).Error(errors.New("type conversion error"), "Expression result could not be converted to float64 or int64", "expression", c.config.Attributes[0].Expression, "result", val)
+			log.FromContext(ctx).Error(errors.New("type conversion error"), "Expression result could not be converted to float64 or int64", "expression", p.config.Attributes[0].Expression, "result", val)
 			return -1, nil
 		}
 		doubleVal = float64(int64Val)
@@ -246,7 +246,7 @@ func (c *Plugin) calculateValue(ctx context.Context, celData any) (int64, error)
 	return int64(doubleVal), nil
 }
 
-func (c *Plugin) maybeExecuteProg(ctx context.Context, prog cel.Program, celData any, exprType string, expression string) (any, error) {
+func (p *Plugin) maybeExecuteProg(ctx context.Context, prog cel.Program, celData any, exprType string, expression string) (any, error) {
 	val, _, err := prog.Eval(map[string]any{"usage": celData})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to evaluate "+exprType, exprType, expression)

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
@@ -71,8 +71,8 @@ func NewDestinationEndpointServedVerifier() *DestinationEndpointServedVerifier {
 }
 
 // ResponseHeader is the handler for the ResponseHeader extension point.
-func (p *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
-	logger := log.FromContext(ctx).WithName(p.TypedName().String())
+func (f *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
+	logger := log.FromContext(ctx).WithName(f.TypedName().String())
 	logger.V(logging.DEBUG).Info("Verifying destination endpoint served")
 
 	reqMetadata := response.ReqMetadata

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
@@ -51,14 +51,14 @@ type DestinationEndpointServedVerifier struct {
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (f *DestinationEndpointServedVerifier) TypedName() fwkplugin.TypedName {
-	return f.typedName
+func (desv *DestinationEndpointServedVerifier) TypedName() fwkplugin.TypedName {
+	return desv.typedName
 }
 
 // WithName sets the name of the filter.
-func (f *DestinationEndpointServedVerifier) WithName(name string) *DestinationEndpointServedVerifier {
-	f.typedName.Name = name
-	return f
+func (desv *DestinationEndpointServedVerifier) WithName(name string) *DestinationEndpointServedVerifier {
+	desv.typedName.Name = name
+	return desv
 }
 
 // DestinationEndpointServedVerifierFactory defines the factory function for DestinationEndpointServedVerifier.
@@ -71,8 +71,8 @@ func NewDestinationEndpointServedVerifier() *DestinationEndpointServedVerifier {
 }
 
 // ResponseHeader is the handler for the ResponseHeader extension point.
-func (f *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
-	logger := log.FromContext(ctx).WithName(f.TypedName().String())
+func (desv *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
+	logger := log.FromContext(ctx).WithName(desv.TypedName().String())
 	logger.V(logging.DEBUG).Info("Verifying destination endpoint served")
 
 	reqMetadata := response.ReqMetadata

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -115,7 +115,7 @@ func (p *OpenAIParser) ParseResponse(ctx context.Context, body []byte, headers m
 	if len(body) == 0 {
 		// An empty body can occur during streaming; for instance, Envoy proxies
 		// may emit a trailing empty body with the EndOfStream flag set to true.
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	isStream := false
@@ -266,7 +266,8 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 		}
 		return &usage, nil
 	}
-	return nil, nil
+	// No usage data
+	return nil, nil //nolint:nilnil
 }
 
 // extractUsageByAPIType extracts usage statistics using the appropriate field names

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -78,5 +78,5 @@ func (p *PassthroughParser) ParseRequest(ctx context.Context, body []byte, heade
 
 // ParseResponse does nothing and returns nil.
 func (p *PassthroughParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, isEnd bool) (*fwkrh.ParsedResponse, error) {
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -128,7 +128,8 @@ func (p *VertexAIParser) ParseRequest(ctx context.Context, body []byte, headers 
 // ParseResponse parses the response body and returns a ParsedResponse
 func (p *VertexAIParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, _ bool) (*fwkrh.ParsedResponse, error) {
 	if len(body) == 0 {
-		return nil, nil
+		// Nothing to parse
+		return nil, nil //nolint:nilnil
 	}
 
 	parsedPayload, err := grpcutil.ParseGrpcPayload(body)

--- a/pkg/epp/handlers/server_abort_test.go
+++ b/pkg/epp/handlers/server_abort_test.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -39,13 +40,15 @@ func (m *mockProcessServer) Send(resp *extProcPb.ProcessingResponse) error {
 }
 
 // Unused methods to satisfy the interface.
-func (m *mockProcessServer) Recv() (*extProcPb.ProcessingRequest, error) { return nil, nil }
-func (m *mockProcessServer) SetHeader(metadata.MD) error                 { return nil }
-func (m *mockProcessServer) SendHeader(metadata.MD) error                { return nil }
-func (m *mockProcessServer) SetTrailer(metadata.MD)                      {}
-func (m *mockProcessServer) Context() context.Context                    { return context.Background() }
-func (m *mockProcessServer) SendMsg(any) error                           { return nil }
-func (m *mockProcessServer) RecvMsg(any) error                           { return nil }
+func (m *mockProcessServer) Recv() (*extProcPb.ProcessingRequest, error) {
+	return nil, errors.New("sentinel error for mock process server")
+}
+func (m *mockProcessServer) SetHeader(metadata.MD) error  { return nil }
+func (m *mockProcessServer) SendHeader(metadata.MD) error { return nil }
+func (m *mockProcessServer) SetTrailer(metadata.MD)       {}
+func (m *mockProcessServer) Context() context.Context     { return context.Background() }
+func (m *mockProcessServer) SendMsg(any) error            { return nil }
+func (m *mockProcessServer) RecvMsg(any) error            { return nil }
 
 func TestUpdateStateAndSendIfNeeded_Evicted(t *testing.T) {
 	t.Parallel()

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -93,7 +93,7 @@ type mockDatastore struct {
 }
 
 func (ds *mockDatastore) PoolGet() (*datalayer.EndpointPool, error) {
-	return nil, nil
+	return nil, errors.New("sentinel error for mock datastore")
 }
 func (ds *mockDatastore) ObjectiveGet(_ string) *v1alpha2.InferenceObjective {
 	return nil

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -397,7 +398,7 @@ func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[
 }
 
 func (m *mockParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*fwkrh.ParsedResponse, error) {
-	return nil, nil
+	return nil, errors.New("sentinel error for mock parser")
 }
 
 func (m *mockParser) SupportedAppProtocols() []extv1.AppProtocol {


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
The Inference Gateway Extension (IGW) project had a less strict configuration for linting the code using golangci-lint than was used in the llm-d-inference-scheduler. A number of the lint rules were removed to enable the migration of the code to the llm-d-inference-scheduler repo.

This PR is an additional step in re-enabling the golangci-lint rules that were removed. It re-enables several rules and corrected the issues in the IGW code to enable CI to pass.

Which issue(s) this PR fixes:
refs #832 and #934

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
