### PR TITLE
ci(deps): allow only patch bumps by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
       # Ignore *all* updates to GAIE package - manually update go.mod only
       - dependency-name: "sigs.k8s.io/gateway-api-inference-extension"
         update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+      # Ignore major and minor updates to kv-cache - v0.8.0 removed preprocessing/chat_completions
+      # which is still imported by preciseprefixcache tests; unblock once that import is removed
+      - dependency-name: "github.com/llm-d/llm-d-kv-cache"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore major and minor version updates to k8s packages
       - dependency-name: "k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,24 +13,12 @@ updates:
       - "dependencies"
       - "release-note-none"
     ignore:
-      # Ignore major and minor updates to Go toolchain (ensure go version is consistent in builds, actions, etc.)
-      - dependency-name: "go"
+      # Major/minor upgrades are handled intentionally via `make upgrade-deps`; dependabot covers patches only
+      - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore *all* updates to GAIE package - manually update go.mod only
+      # GAIE is updated manually only (all versions)
       - dependency-name: "sigs.k8s.io/gateway-api-inference-extension"
         update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
-      # Ignore major and minor updates to kv-cache - v0.8.0 removed preprocessing/chat_completions
-      # which is still imported by preciseprefixcache tests; unblock once that import is removed
-      - dependency-name: "github.com/llm-d/llm-d-kv-cache"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore major and minor version updates to k8s packages
-      - dependency-name: "k8s.io/*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "sigs.k8s.io/*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore major updates for all Go packages
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     groups:
       go-dependencies:
         patterns:

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,11 @@ builder-e2e-shell: image-build-builder ## Open a shell with e2e test access
 install-hooks: ## Install git hooks
 	git config core.hooksPath hooks
 
+.PHONY: upgrade-deps
+upgrade-deps: ## Upgrade all Go dependencies to latest minor/patch versions and tidy; review diff before committing
+	go get -u ./...
+	go mod tidy
+
 .PHONY: vulncheck
 vulncheck: image-build-builder ## Run govulncheck for known vulnerabilities
 	@printf "\033[33;1m==== Running govulncheck ====\033[0m\n"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Prevent breaking API changes in dependabot updates.
- Only patch updates are done automatically by dependabot
- a new makefile target to update major/minor across all dependencies. A failure in one does not block the others as can intervene by removing the offending update and keeping valid ones. **Downside**: manual run... (can be run on schedule via an action, to provide maintainers a hint on when can run safely locally and result in a clean PR).

For example, kv-cache v0.8.0 dropped `preprocessing/chat_completions`, which breaks precise-prefix-cache scorer tests.
Another issue was with `github.com/go-openapi/testify/v2/assert` update. Between v2.0.2 (pinned today) and v2.5.0 (the updated dependency), the entire module was restructured, resulting in file paths that no longer exist.
See log of action output below.

**Which issue(s) this PR fixes**:
None. 
Observed as part of dependabot #986 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Failure log from #986**:
```console
...
go: finding module for package github.com/go-openapi/testify/v2/assert/yaml
go: finding module for package github.com/llm-d/llm-d-kv-cache/pkg/preprocessing/chat_completions
go: downloading github.com/go-openapi/testify/v2 v2.5.0
go: downloading github.com/go-openapi/testify v0.0.0-20251001202347-e909893202bd
go: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache tested by
	github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache.test imports
	github.com/llm-d/llm-d-kv-cache/pkg/preprocessing/chat_completions: module github.com/llm-d/llm-d-kv-cache@latest found (v0.8.0), but does not contain package github.com/llm-d/llm-d-kv-cache/pkg/preprocessing/chat_completions
go: github.com/llm-d/llm-d-inference-scheduler/cmd/epp/runner imports
	sigs.k8s.io/controller-runtime/pkg/metrics/filters imports
	k8s.io/apiserver/pkg/authentication/authenticatorfactory imports
	k8s.io/kube-openapi/pkg/validation/spec imports
	github.com/go-openapi/swag imports
	github.com/go-openapi/swag/loading tested by
	github.com/go-openapi/swag/loading.test imports
	github.com/go-openapi/testify/enable/yaml/v2 imports
	github.com/go-openapi/testify/v2/assert/yaml: module github.com/go-openapi/testify/v2@latest found (v2.5.0), but does not contain package github.com/go-openapi/testify/v2/assert/yaml
```