### PR TITLE
[flake] Testing: wait for manager shutdown before releasing test cleanup

### DIFF
--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -277,7 +277,9 @@ func NewTestHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *T
 	mgrCtx, mgrCancel := context.WithCancel(ctx)
 
 	// Start Manager.
+	mgrDone := make(chan struct{})
 	go func() {
+		defer close(mgrDone)
 		if err := mgr.Start(mgrCtx); err != nil {
 			// Context cancellation is expected during teardown.
 			if !strings.Contains(err.Error(), "context canceled") {
@@ -312,6 +314,10 @@ func NewTestHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *T
 
 	t.Cleanup(func() {
 		mgrCancel()
+		// Wait for the manager (and its gRPC server) to fully stop before returning.
+		// Without this, the gRPC server may still hold its port when the next test
+		// calls GetFreePort(), causing a bind: address already in use race.
+		<-mgrDone
 		if config.Tracing {
 			_ = tp.Shutdown(ctx)
 			// Reset to no-op to avoid pollution between tests.


### PR DESCRIPTION
/kind bug
/kind test

**What this PR does / why we need it**:
Fixes a flaky integration test: `TestFullDuplexStreamed_KubeInferenceObjectiveRequest/Standalone-NoCRD/subsetting:_partial_match`.

Fix adds a `mgrDone` channel (closed when the manager goroutine exits) and wait on it in `t.Cleanup()` after `mgrCancel()`. This guarantees the gRPC port is released before cleanup returns and before the next subtest can start.

Ref #988 ?

_Root cause_
The test harness `t.Cleanup` called `mgrCancel()` but returned immediately, without waiting for the manager goroutine (and its embedded gRPC server) to fully stop. This created a port-reuse race where subtest N+1 starts and `GetFreePort()` gets the port released by subtest N, resulting in harness setup fails.

Example failure in CI run [#25378090497](https://github.com/llm-d/llm-d-inference-scheduler/actions/runs/25378090497/job/74418628627)