### PR TITLE
[sidecar] strip disaggregation headers before forwarding to model server

### DIFF
--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -77,6 +77,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		)
 
 		prefillHostPorts := r.Header.Values(routing.PrefillEndpointHeader)
+		r.Header.Del(routing.PrefillEndpointHeader)
 
 		if len(prefillHostPorts) == 1 {
 			prefillHostPorts = strings.Split(prefillHostPorts[0], ",")
@@ -125,6 +126,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		}
 
 		encoderHostPorts := r.Header.Values(routing.EncoderEndpointsHeader)
+		r.Header.Del(routing.EncoderEndpointsHeader)
 		if len(encoderHostPorts) == 1 {
 			encoderHostPorts = strings.Split(encoderHostPorts[0], ",")
 		}

--- a/pkg/sidecar/proxy/chat_completions_test.go
+++ b/pkg/sidecar/proxy/chat_completions_test.go
@@ -125,17 +125,21 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 				s.allowlistValidator = &AllowlistValidator{}
 				s.prefillSamplerFn = func(n int) int { return i % n }
 				var hostPort string
-				s.runPDConnectorProtocol = func(_ http.ResponseWriter, _ *http.Request, selectedHostPort string, _ APIType) {
+				var capturedReq *http.Request
+				s.runPDConnectorProtocol = func(_ http.ResponseWriter, r *http.Request, selectedHostPort string, _ APIType) {
 					hostPort = selectedHostPort
+					capturedReq = r
 				}
 				var passthrough bool
-				s.decoderProxy = http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				s.decoderProxy = http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 					passthrough = true
+					capturedReq = r
 				})
 				s.dataParallelProxies = make(map[string]http.Handler)
 				recorder := httptest.NewRecorder()
 				recorder.Code = 0
-				s.disaggregatedPrefillHandler(apiType)(recorder, tt.r)
+				req := tt.r.Clone(tt.r.Context())
+				s.disaggregatedPrefillHandler(apiType)(recorder, req)
 
 				resp := recorder.Result()
 				if passthrough {
@@ -158,6 +162,11 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 					expected, actual := tt.expectedPrefillHostPorts[i%len(tt.expectedPrefillHostPorts)], hostPort
 					if expected != actual {
 						t.Errorf("expected=%s actual=%s", expected, actual)
+					}
+				}
+				if capturedReq != nil {
+					if v := capturedReq.Header.Get(routing.PrefillEndpointHeader); v != "" {
+						t.Errorf("PrefillEndpointHeader should be stripped before forwarding, got %q", v)
 					}
 				}
 			})
@@ -301,24 +310,28 @@ func TestServer_encoderEndpointRouting(t *testing.T) {
 			var epdCalled bool
 			var epdPrefill string
 			var epdEncoders []string
+			var capturedReq *http.Request
 			if tt.epdConfigured {
-				s.runEPDConnectorProtocol = func(_ http.ResponseWriter, _ *http.Request, prefillHost string, encoders []string) {
+				s.runEPDConnectorProtocol = func(_ http.ResponseWriter, r *http.Request, prefillHost string, encoders []string) {
 					epdCalled = true
 					epdPrefill = prefillHost
 					epdEncoders = encoders
+					capturedReq = r
 				}
 			}
 
 			var pdCalled bool
 			var pdHost string
-			s.runPDConnectorProtocol = func(_ http.ResponseWriter, _ *http.Request, host string, _ APIType) {
+			s.runPDConnectorProtocol = func(_ http.ResponseWriter, r *http.Request, host string, _ APIType) {
 				pdCalled = true
 				pdHost = host
+				capturedReq = r
 			}
 
 			var passthrough bool
-			s.decoderProxy = http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			s.decoderProxy = http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				passthrough = true
+				capturedReq = r
 			})
 			s.dataParallelProxies = make(map[string]http.Handler)
 
@@ -372,6 +385,14 @@ func TestServer_encoderEndpointRouting(t *testing.T) {
 					t.Error("P/D protocol should not be called during passthrough")
 				}
 
+			}
+			if capturedReq != nil {
+				if v := capturedReq.Header.Get(routing.PrefillEndpointHeader); v != "" {
+					t.Errorf("PrefillEndpointHeader should be stripped before forwarding, got %q", v)
+				}
+				if v := capturedReq.Header.Get(routing.EncoderEndpointsHeader); v != "" {
+					t.Errorf("EncoderEndpointsHeader should be stripped before forwarding, got %q", v)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The sidecar proxy reads `PrefillEndpointHeader` (`x-prefiller-host-port`) and `EncoderEndpointsHeader` (`x-encoder-hosts-ports`) from incoming requests to orchestrate prefill/decode disaggregation. After consuming these headers, it forwards the request to the model server — but never strips the headers first. These are internal routing headers that should not reach the model server.
This PR removes these headers after they are fully consumed and before the request reaches the model server.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
