### PR TITLE
Re-enable two more lint rules that were disabled for the IGW migration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,9 +44,6 @@ linters:
         text: "avoid meaningless package names"
       - linters: [revive]
         text: "avoid package names that conflict with Go standard library package names"
-      # goconst and prealloc findings in tests are low-value noise
-      - linters: [goconst, prealloc]
-        path: "_test\\.go"
   settings:
     revive: # see https://github.com/mgechev/revive#available-rules for all options
       rules:

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -217,10 +217,13 @@ func TestPodReconciler(t *testing.T) {
 					t.Errorf("Unexpected InferencePool reconcile error: %v", err)
 				}
 
-				var gotPods []*corev1.Pod
-				for _, pm := range store.PodList(datastore.AllPodsPredicate) {
-					pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().PodName, Namespace: pm.GetMetadata().NamespacedName.Namespace}, Status: corev1.PodStatus{PodIP: pm.GetMetadata().GetIPAddress()}}
-					gotPods = append(gotPods, pod)
+				podList := store.PodList(datastore.AllPodsPredicate)
+				gotPods := make([]*corev1.Pod, len(podList))
+				for idx, pm := range podList {
+					gotPods[idx] = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().PodName, Namespace: pm.GetMetadata().NamespacedName.Namespace},
+						Status:     corev1.PodStatus{PodIP: pm.GetMetadata().GetIPAddress()},
+					}
 				}
 				if !cmp.Equal(gotPods, test.wantPods, cmpopts.SortSlices(func(a, b *corev1.Pod) bool { return a.Name < b.Name })) {
 					t.Errorf("got (%v) != want (%v);", gotPods, test.wantPods)

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -396,9 +396,9 @@ func TestMetrics(t *testing.T) {
 				}
 				assert.EventuallyWithT(t, func(t *assert.CollectT) {
 					got := ds.PodList(test.predict)
-					metrics := []*fwkdl.Metrics{}
-					for _, one := range got {
-						metrics = append(metrics, one.GetMetrics())
+					metrics := make([]*fwkdl.Metrics, len(got))
+					for idx, one := range got {
+						metrics[idx] = one.GetMetrics()
 					}
 					diff := cmp.Diff(test.want, metrics, cmpopts.IgnoreFields(fwkdl.Metrics{}, "UpdateTime"), cmpopts.SortSlices(func(a, b *fwkdl.Metrics) bool {
 						return a.String() < b.String()
@@ -469,10 +469,13 @@ func TestPods(t *testing.T) {
 				}
 
 				test.op(ctx, ds)
-				var gotPods []*corev1.Pod
-				for _, pm := range ds.PodList(AllPodsPredicate) {
-					pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().PodName, Namespace: pm.GetMetadata().NamespacedName.Namespace}, Status: corev1.PodStatus{PodIP: pm.GetMetadata().GetIPAddress()}}
-					gotPods = append(gotPods, pod)
+				podList := ds.PodList(AllPodsPredicate)
+				gotPods := make([]*corev1.Pod, len(podList))
+				for idx, pm := range podList {
+					gotPods[idx] = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().PodName, Namespace: pm.GetMetadata().NamespacedName.Namespace},
+						Status:     corev1.PodStatus{PodIP: pm.GetMetadata().GetIPAddress()},
+					}
 				}
 				if !cmp.Equal(gotPods, test.wantPods, cmpopts.SortSlices(func(a, b *corev1.Pod) bool { return a.Name < b.Name })) {
 					t.Errorf("got (%v) != want (%v);", gotPods, test.wantPods)
@@ -772,9 +775,10 @@ func TestEndpointMetadata(t *testing.T) {
 				}
 
 				test.op(ctx, ds)
-				var gotMetadata []*fwkdl.EndpointMetadata
-				for _, pm := range ds.PodList(AllPodsPredicate) {
-					gotMetadata = append(gotMetadata, pm.GetMetadata())
+				podList := ds.PodList(AllPodsPredicate)
+				gotMetadata := make([]*fwkdl.EndpointMetadata, len(podList))
+				for idx, pm := range podList {
+					gotMetadata[idx] = pm.GetMetadata()
 				}
 				if diff := cmp.Diff(test.wantEndpointMetas, gotMetadata, cmpopts.SortSlices(func(a, b *fwkdl.EndpointMetadata) bool { return a.NamespacedName.Name < b.NamespacedName.Name })); diff != "" {
 					t.Errorf("ConvertTo() mismatch (-want +got):\n%s", diff)

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
@@ -30,10 +30,16 @@ import (
 	frameworkmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/flowcontrol/mocks"
 )
 
+const (
+	flow1ID = "flow1"
+	flow2ID = "flow2"
+	flow3ID = "flow3"
+)
+
 var (
-	flow1Key = flowcontrol.FlowKey{ID: "flow1", Priority: 0}
-	flow2Key = flowcontrol.FlowKey{ID: "flow2", Priority: 0}
-	flow3Key = flowcontrol.FlowKey{ID: "flow3", Priority: 0}
+	flow1Key = flowcontrol.FlowKey{ID: flow1ID, Priority: 0}
+	flow2Key = flowcontrol.FlowKey{ID: flow2ID, Priority: 0}
+	flow3Key = flowcontrol.FlowKey{ID: flow3ID, Priority: 0}
 )
 
 func TestRoundRobin_Name(t *testing.T) {
@@ -59,11 +65,11 @@ func TestRoundRobin_Pick_Logic(t *testing.T) {
 		FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow3Key, flow1Key, flow2Key} }, // Unsorted to test sorting
 		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
 			switch id {
-			case "flow1":
+			case flow1ID:
 				return queue1
-			case "flow2":
+			case flow2ID:
 				return queue2
-			case "flow3":
+			case flow3ID:
 				return queue3
 			}
 			return nil
@@ -71,7 +77,7 @@ func TestRoundRobin_Pick_Logic(t *testing.T) {
 	}
 
 	// Expected order is based on sorted FlowKeys: flow1, flow2, flow3
-	expectedOrder := []string{"flow1", "flow2", "flow3"}
+	expectedOrder := []string{flow1ID, flow2ID, flow3ID}
 
 	// First cycle
 	for i := range expectedOrder {
@@ -109,11 +115,11 @@ func TestRoundRobin_Pick_SkipsEmptyQueues(t *testing.T) {
 		FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flowEmptyKey, flow3Key} },
 		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
 			switch id {
-			case "flow1":
+			case flow1ID:
 				return queue1
 			case "flowEmpty":
 				return queueEmpty
-			case "flow3":
+			case flow3ID:
 				return queue3
 			}
 			return nil
@@ -124,17 +130,17 @@ func TestRoundRobin_Pick_SkipsEmptyQueues(t *testing.T) {
 	selected, err := policy.Pick(ctx, mockBand)
 	require.NoError(t, err, "Pick should not error when skipping queues")
 	require.NotNil(t, selected, "Pick should select the first non-empty queue")
-	assert.Equal(t, "flow1", selected.FlowKey().ID, "First selection should be flow1")
+	assert.Equal(t, flow1ID, selected.FlowKey().ID, "First selection should be flow1")
 
 	selected, err = policy.Pick(ctx, mockBand)
 	require.NoError(t, err, "Pick should not error when skipping queues")
 	require.NotNil(t, selected, "Pick should select the second non-empty queue")
-	assert.Equal(t, "flow3", selected.FlowKey().ID, "Second selection should be flow3, skipping flowEmpty")
+	assert.Equal(t, flow3ID, selected.FlowKey().ID, "Second selection should be flow3, skipping flowEmpty")
 
 	selected, err = policy.Pick(ctx, mockBand)
 	require.NoError(t, err, "Pick should not error when wrapping around")
 	require.NotNil(t, selected, "Pick should wrap around and select a queue")
-	assert.Equal(t, "flow1", selected.FlowKey().ID, "Should wrap around and select flow1 again")
+	assert.Equal(t, flow1ID, selected.FlowKey().ID, "Should wrap around and select flow1 again")
 }
 
 func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
@@ -150,7 +156,7 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 		PolicyStateV: state,
 		FlowKeysFunc: func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flow2Key} },
 		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
-			if id == "flow1" {
+			if id == flow1ID {
 				return queue1
 			}
 			return queue2
@@ -161,18 +167,18 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 	selected, err := policy.Pick(ctx, mockBand)
 	require.NoError(t, err, "Pick should not error on initial selection")
 	require.NotNil(t, selected, "Pick should select a queue initially")
-	assert.Equal(t, "flow1", selected.FlowKey().ID, "First selection should be flow1")
+	assert.Equal(t, flow1ID, selected.FlowKey().ID, "First selection should be flow1")
 
 	// --- Simulate adding a flow ---
 	queue3 := &frameworkmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow3Key}
 	mockBand.FlowKeysFunc = func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flow2Key, flow3Key} }
 	mockBand.QueueFunc = func(id string) flowcontrol.FlowQueueAccessor {
 		switch id {
-		case "flow1":
+		case flow1ID:
 			return queue1
-		case "flow2":
+		case flow2ID:
 			return queue2
-		case "flow3":
+		case flow3ID:
 			return queue3
 		}
 		return nil
@@ -182,13 +188,13 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 	selected, err = policy.Pick(ctx, mockBand)
 	require.NoError(t, err, "Pick should not error after adding a flow")
 	require.NotNil(t, selected, "Pick should select a queue after adding a flow")
-	assert.Equal(t, "flow2", selected.FlowKey().ID, "Next selection should be flow2")
+	assert.Equal(t, flow2ID, selected.FlowKey().ID, "Next selection should be flow2")
 
 	// Next selection should be flow3
 	selected, err = policy.Pick(ctx, mockBand)
 	require.NoError(t, err, "Pick should not error on the third selection")
 	require.NotNil(t, selected, "Pick should select the new flow")
-	assert.Equal(t, "flow3", selected.FlowKey().ID, "Next selection should be the new flow3")
+	assert.Equal(t, flow3ID, selected.FlowKey().ID, "Next selection should be the new flow3")
 
 	// --- Simulate removing a flow ---
 	mockBand.FlowKeysFunc = func() []flowcontrol.FlowKey { return []flowcontrol.FlowKey{flow1Key, flow3Key} } // flow2 is removed
@@ -197,7 +203,7 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 	selected, err = policy.Pick(ctx, mockBand)
 	require.NoError(t, err, "Pick should not error after removing a flow")
 	require.NotNil(t, selected, "Pick should select a queue after removing a flow")
-	assert.Equal(t, "flow1", selected.FlowKey().ID, "Next selection should wrap around to flow1 after a removal")
+	assert.Equal(t, flow1ID, selected.FlowKey().ID, "Next selection should wrap around to flow1 after a removal")
 }
 
 func TestRoundRobin_Pick_Concurrency(t *testing.T) {

--- a/pkg/epp/requestcontrol/candidates_test.go
+++ b/pkg/epp/requestcontrol/candidates_test.go
@@ -141,9 +141,9 @@ func TestDatastoreEndpointCandidates_Locate(t *testing.T) {
 			endpointCandidates := NewDatastoreEndpointCandidates(mockDS, tc.opts...)
 			result := endpointCandidates.Locate(context.Background(), tc.metadata)
 
-			var gotIPs []string
-			for _, ep := range result {
-				gotIPs = append(gotIPs, ep.GetMetadata().GetIPAddress())
+			gotIPs := make([]string, len(result))
+			for idx, ep := range result {
+				gotIPs[idx] = ep.GetMetadata().GetIPAddress()
 			}
 			assert.ElementsMatch(t, tc.expectedEndpointIPs, gotIPs, "Locate returned unexpected set of endpoint candidates")
 		})


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
The Inference Gateway Extension (IGW) project had a less strict configuration for linting the code using golangci-lint than was used in the llm-d-inference-scheduler. A number of the lint rules were removed to enable the migration of the code to the llm-d-inference-scheduler repo.

This PR is an additional step in re-enabling the golangci-lint rules that were removed. It re-enables several rules and corrected the issues in the IGW code to enable CI to pass.

Which issue(s) this PR fixes:
refs #832 and #934

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
