### PR TITLE
Correct issues related to pulling images in tests

### DIFF
--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -304,20 +304,7 @@ fi
 
 pull_image() {
     local image="$1"
-    if [ "${CONTAINER_RUNTIME}" == "docker" ]; then
-        # Pull with --platform to ensure platform-specific layers are cached.
-        # If the pull fails, check for a local image (e.g. a locally-built :dev tag)
-        # before giving up — only treat the failure as non-fatal when the image
-        # already exists locally. Real failures (network, auth) are surfaced as errors.
-        if ! "${CONTAINER_RUNTIME}" pull ${PLATFORM_ARGS[@]+"${PLATFORM_ARGS[@]}"} "${image}" 2>/dev/null; then
-            if "${CONTAINER_RUNTIME}" image inspect "${image}" > /dev/null 2>&1; then
-                echo "Note: ${image} not found in registry, using local build."
-            else
-                echo "Error: failed to pull ${image} and no local image found." >&2
-                return 1
-            fi
-        fi
-    elif ! "${CONTAINER_RUNTIME}" image inspect "${image}" > /dev/null 2>&1; then
+    if ! "${CONTAINER_RUNTIME}" image inspect "${image}" > /dev/null 2>&1; then
         echo "Image ${image} not found locally, pulling..."
         "${CONTAINER_RUNTIME}" pull ${PLATFORM_ARGS[@]+"${PLATFORM_ARGS[@]}"} "${image}"
     fi

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -249,7 +249,7 @@ nodes:
 - role: control-plane
   # Pin to Kubernetes 1.31+ for Gateway API v1.5.1 compatibility
   # (requires isIP() CEL function and ValidatingAdmissionPolicy)
-  image: kindest/node:v1.31.2
+  image: kindest/node:v1.31.12
   extraPortMappings:
   - containerPort: 30080
     hostPort: ${GATEWAY_HOST_PORT}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -361,7 +361,7 @@ const kindClusterConfig = `
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- image: kindest/node:v1.31.2
+- image: kindest/node:v1.31.12
   extraPortMappings:
   - containerPort: 30080
     hostPort: ${PORT}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -195,17 +194,6 @@ func setupK8sCluster() {
 	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
-
-	// For Docker: pull with --platform to ensure platform-specific layers are cached
-	// before loading into KIND (avoids "content digest not found" with multi-arch images).
-	if containerRuntime == "docker" {
-		arch := runtime.GOARCH
-		for _, img := range []string{vllmSimImage, eppImage, sideCarImage, udsTokenizerImage} {
-			pull := exec.Command("docker", "pull", "--platform", "linux/"+arch, img)
-			pull.Stderr = ginkgo.GinkgoWriter
-			_ = pull.Run() // ignore failure — image may be local-only
-		}
-	}
 
 	kindLoadImage(vllmSimImage)
 	kindLoadImage(eppImage)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
1. The current end to end test suite setup code, always attemps from code to pull a set of images. This is after a pre-requisite Makefile target pulled the images, if necessary. This causes issues if trying to use locally built images for the test.
2. The shell script used to launch the development kind environment, when using docker, trys to pull all needed images, without first checking if they are available locally.
3. Upgraded the patch level of the K8S image used by kind. Includes containerd fixes which may help in loading multi-architecture images.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
