### PR TITLE
inflightload: optional output tokens, early token release, prefix-cache discount

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -23,7 +23,9 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
@@ -46,26 +48,43 @@ type Config struct {
 	// IncludeOutputTokens controls whether estimated output tokens are added to
 	// the in-flight token counter. Defaults to true to preserve historical behavior.
 	IncludeOutputTokens bool `json:"includeOutputTokens"`
+	// RequestTTL bounds how long a per-request token entry is kept before it is
+	// considered abandoned. If ResponseBody never delivers EndOfStream (e.g.
+	// client disconnect, panic in a downstream plugin, EPP shutdown), the
+	// expiry-driven eviction subtracts the entry's tokens from the token
+	// tracker AND decrements the request tracker for that endpoint, preventing
+	// an unbounded leak of both counters and the per-request map entries.
+	// Defaults to 5 minutes. A non-positive value disables expiration entirely.
+	RequestTTL time.Duration `json:"requestTTL,omitempty"`
 }
 
 func defaultConfig() Config {
-	return Config{IncludeOutputTokens: true}
+	return Config{
+		IncludeOutputTokens: true,
+		RequestTTL:          5 * time.Minute,
+	}
 }
 
-func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	cfg := defaultConfig()
 	if len(rawParameters) > 0 {
 		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal inflight-load-producer parameters: %w", err)
 		}
 	}
-	return &InFlightLoadProducer{
+	p := &InFlightLoadProducer{
 		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
 		requestTracker:      newConcurrencyTracker(),
 		tokenTracker:        newConcurrencyTracker(),
 		tokenEstimator:      NewSimpleTokenEstimator(),
 		includeOutputTokens: cfg.IncludeOutputTokens,
-	}, nil
+		requestTTL:          cfg.RequestTTL,
+	}
+	p.initAddedTokensCache()
+	if handle != nil {
+		p.startCacheLifecycle(handle.Context())
+	}
+	return p, nil
 }
 
 var (
@@ -82,14 +101,81 @@ type InFlightLoadProducer struct {
 	tokenTracker        *concurrencyTracker
 	tokenEstimator      TokenEstimator
 	includeOutputTokens bool
+	requestTTL          time.Duration
+	initOnce            sync.Once
 	// addedTokens tracks the exact token amount added per (requestID, endpointID, profileName)
 	// so release subtracts the same value (accounting for prefix-cache discount).
-	// The profile name is part of the key so that multiple profiles targeting the
-	// same endpoint each track their own increment independently and a release
-	// for one profile cannot subtract another profile's value (which would leak
-	// or double-count tokens).
+	// Including the profile name keeps per-profile increments independent when multiple
+	// profiles target the same endpoint.
 	// Key format: "<requestID>|<endpointID>|<profileName>".
-	addedTokens sync.Map
+	//
+	// A TTL is applied so that abandoned requests (no EndOfStream delivered) are
+	// reaped instead of leaking both the entry and the per-endpoint counters
+	// they own; the eviction handler rolls back the request and token counters.
+	addedTokens *ttlcache.Cache[string, addedTokensEntry]
+}
+
+// addedTokensEntry is the value stored in addedTokens; it carries the endpoint
+// the increment was charged to so the TTL eviction handler can roll it back
+// without consulting the request's SchedulingResult (which the cache does not
+// hold a reference to).
+type addedTokensEntry struct {
+	endpointID  string
+	profileName string
+	tokens      int64
+}
+
+// initAddedTokensCache initializes the per-request token cache with TTL-based
+// eviction. Idempotent; safe to call from both the factory (eager) and from
+// PreRequest (lazy, for callers that build the struct directly without going
+// through the factory — e.g. unit tests). The eviction handler is the leak
+// safety net: when a request times out without ever seeing EndOfStream, it
+// subtracts the entry's tokens and decrements the request tracker so neither
+// counter drifts upward over time.
+func (p *InFlightLoadProducer) initAddedTokensCache() {
+	p.initOnce.Do(func() {
+		ttl := p.requestTTL
+		if ttl <= 0 {
+			ttl = ttlcache.NoTTL
+		}
+		p.addedTokens = ttlcache.New(ttlcache.WithTTL[string, addedTokensEntry](ttl))
+		p.addedTokens.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, addedTokensEntry]) {
+			if reason != ttlcache.EvictionReasonExpired {
+				return
+			}
+			entry := item.Value()
+			// The TTL fired before EndOfStream/StartOfStream cleaned this entry up.
+			// Roll back both counters that PreRequest incremented for this entry to
+			// avoid unbounded drift on long-running EPP processes.
+			if entry.tokens != 0 {
+				p.tokenTracker.add(entry.endpointID, -entry.tokens)
+			}
+			p.requestTracker.dec(entry.endpointID)
+			log.FromContext(ctx).V(logutil.DEFAULT).Info(
+				"in-flight load entry expired without release; rolled back counters",
+				"key", item.Key(),
+				"endpoint", entry.endpointID,
+				"profile", entry.profileName,
+				"tokens", entry.tokens,
+			)
+		})
+	})
+}
+
+// startCacheLifecycle runs the ttlcache janitor and stops it when ctx is
+// canceled. Mirrors the predicted-latency producer's pattern.
+func (p *InFlightLoadProducer) startCacheLifecycle(ctx context.Context) {
+	if p.addedTokens == nil {
+		return
+	}
+	go p.addedTokens.Start()
+	if ctx == nil {
+		return
+	}
+	go func() {
+		<-ctx.Done()
+		p.addedTokens.Stop()
+	}()
 }
 
 func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
@@ -140,6 +226,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 	if result == nil || len(result.ProfileResults) == 0 {
 		return
 	}
+	p.initAddedTokensCache()
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
 
@@ -167,8 +254,12 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		}
 
 		p.tokenTracker.add(eid, tokens)
-		if request != nil {
-			p.addedTokens.Store(addedTokensKey(request.RequestID, eid, profileName), tokens)
+		if request != nil && request.RequestID != "" && p.addedTokens != nil {
+			p.addedTokens.Set(
+				addedTokensKey(request.RequestID, eid, profileName),
+				addedTokensEntry{endpointID: eid, profileName: profileName, tokens: tokens},
+				ttlcache.DefaultTTL,
+			)
 		}
 	}
 }
@@ -220,9 +311,9 @@ func (p *InFlightLoadProducer) ResponseBody(
 
 			if !p.includeOutputTokens {
 				// Tokens are normally freed at StartOfStream; also call
-				// releaseTokens here as a safety net for non-streaming or
-				// error paths where StartOfStream may not be observed. It is
-				// a no-op via LoadAndDelete if tokens were already released.
+				// release() here as a safety net for non-streaming or error
+				// paths where StartOfStream may not be observed. releaseTokens
+				// is a no-op via LoadAndDelete if tokens were already released.
 				p.release(endpoint, request, name)
 				continue
 			}
@@ -257,19 +348,20 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 	eid := endpoint.GetMetadata().NamespacedName.String()
 
 	// Prefer the exact value stored in PreRequest to keep counters balanced.
-	// LoadAndDelete makes this idempotent per (requestID, endpointID, profileName):
+	// GetAndDelete makes this idempotent per (requestID, endpointID, profileName):
 	// a second call for the same key finds nothing and is a no-op below (we do
 	// NOT fall back to Estimate when the request carries a real RequestID, since
-	// the absence of the key means "already released").
-	if request != nil && request.RequestID != "" {
+	// the absence of the key means "already released" or "already TTL-evicted").
+	if request != nil && request.RequestID != "" && p.addedTokens != nil {
 		key := addedTokensKey(request.RequestID, eid, profileName)
-		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
-			if tokens, ok := v.(int64); ok && tokens != 0 {
-				p.tokenTracker.add(eid, -tokens)
+		if item := p.addedTokens.Get(key, ttlcache.WithDisableTouchOnHit[string, addedTokensEntry]()); item != nil {
+			p.addedTokens.Delete(key)
+			if entry := item.Value(); entry.tokens != 0 {
+				p.tokenTracker.add(eid, -entry.tokens)
 			}
 		}
 		// Either we just released the stored value, or the key was already
-		// released by a previous call — both cases are no-ops here.
+		// released by a previous call (or TTL-evicted) — both cases are no-ops.
 		return
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -219,8 +219,11 @@ func (p *InFlightLoadProducer) ResponseBody(
 			endpoint := profileResult.TargetEndpoints[0]
 
 			if !p.includeOutputTokens {
-				// Tokens were freed at StartOfStream; only release the request counter.
-				p.releaseRequest(endpoint)
+				// Tokens are normally freed at StartOfStream; also call
+				// releaseTokens here as a safety net for non-streaming or
+				// error paths where StartOfStream may not be observed. It is
+				// a no-op via LoadAndDelete if tokens were already released.
+				p.release(endpoint, request, name)
 				continue
 			}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -151,12 +151,11 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		eid := endpoint.GetMetadata().NamespacedName.String()
 		p.requestTracker.inc(eid)
 
-		// Subtract approximate prefix-cache hit (in input tokens) for this endpoint.
-		cached := cachedInputTokens(endpoint)
-		adjustedInput := inputTokens - cached
-		if adjustedInput < 0 {
-			adjustedInput = 0
-		}
+		// Compute the uncached prompt portion this endpoint must actually compute.
+		// Prefer the prefix producer's view (real tokens) when available so the
+		// match-length and the input length are in the same units; fall back to
+		// the (estimated) input tokens otherwise.
+		adjustedInput := uncachedInputTokens(endpoint, inputTokens)
 		tokens := adjustedInput
 		if p.includeOutputTokens {
 			// Output tokens are based on the full input, not the cached portion.
@@ -272,25 +271,53 @@ func addedTokensKey(requestID, endpointID string) string {
 	return requestID + "|" + endpointID
 }
 
-// cachedInputTokens returns the number of input tokens this endpoint already has cached
-// from the approximate prefix cache producer, or 0 if not available.
-func cachedInputTokens(endpoint fwksched.Endpoint) int64 {
+// uncachedInputTokens returns the prompt tokens this endpoint must actually compute,
+// excluding any prefix already cached on it.
+//
+// When the approximate prefix producer has populated PrefixCacheMatchInfo on the
+// endpoint, the matched and total block counts are in real (tokenized) units, so
+// we use them directly: uncached = (TotalBlocks - MatchBlocks) * BlockSizeTokens.
+// For very long prompts where the prefix index is capped (MaxPrefixTokensToMatch),
+// any tail beyond the cap is added back from the (estimated) inputTokens so the
+// full prompt cost is still reflected.
+//
+// When the attribute is missing, we fall back to the estimated inputTokens.
+func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64) int64 {
 	if endpoint == nil {
-		return 0
+		return nonNeg(inputTokens)
 	}
 	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
 	if !ok {
-		return 0
+		return nonNeg(inputTokens)
 	}
 	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
-	if !ok || info == nil {
+	if !ok || info == nil || info.BlockSizeTokens() <= 0 {
+		return nonNeg(inputTokens)
+	}
+
+	blockSize := int64(info.BlockSizeTokens())
+	matched := int64(info.MatchBlocks()) * blockSize
+	indexed := int64(info.TotalBlocks()) * blockSize
+
+	uncachedIndexed := indexed - matched
+	if uncachedIndexed < 0 {
+		uncachedIndexed = 0
+	}
+
+	// Tail beyond the indexed portion (e.g., when MaxPrefixTokensToMatch caps total).
+	tail := inputTokens - indexed
+	if tail < 0 {
+		tail = 0
+	}
+
+	return uncachedIndexed + tail
+}
+
+func nonNeg(v int64) int64 {
+	if v < 0 {
 		return 0
 	}
-	cached := int64(info.MatchBlocks()) * int64(info.BlockSizeTokens())
-	if cached < 0 {
-		return 0
-	}
-	return cached
+	return v
 }
 
 func (p *InFlightLoadProducer) Produces() map[string]any {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -82,9 +82,13 @@ type InFlightLoadProducer struct {
 	tokenTracker        *concurrencyTracker
 	tokenEstimator      TokenEstimator
 	includeOutputTokens bool
-	// addedTokens tracks the exact token amount added per (requestID, endpointID)
+	// addedTokens tracks the exact token amount added per (requestID, endpointID, profileName)
 	// so release subtracts the same value (accounting for prefix-cache discount).
-	// Key format: "<requestID>|<endpointID>".
+	// The profile name is part of the key so that multiple profiles targeting the
+	// same endpoint each track their own increment independently and a release
+	// for one profile cannot subtract another profile's value (which would leak
+	// or double-count tokens).
+	// Key format: "<requestID>|<endpointID>|<profileName>".
 	addedTokens sync.Map
 }
 
@@ -139,7 +143,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
 
-	for _, profileResult := range result.ProfileResults {
+	for profileName, profileResult := range result.ProfileResults {
 		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 			continue
 		}
@@ -164,7 +168,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 
 		p.tokenTracker.add(eid, tokens)
 		if request != nil {
-			p.addedTokens.Store(addedTokensKey(request.RequestID, eid), tokens)
+			p.addedTokens.Store(addedTokensKey(request.RequestID, eid, profileName), tokens)
 		}
 	}
 }
@@ -190,11 +194,11 @@ func (p *InFlightLoadProducer) ResponseBody(
 	// token counters for every targeted endpoint regardless of profile name.
 	// Request counters are still released on EndOfStream below.
 	if !p.includeOutputTokens && resp.StartOfStream {
-		for _, profileResult := range result.ProfileResults {
+		for profileName, profileResult := range result.ProfileResults {
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 				continue
 			}
-			p.releaseTokens(profileResult.TargetEndpoints[0], request)
+			p.releaseTokens(profileResult.TargetEndpoints[0], request, profileName)
 		}
 	}
 
@@ -202,7 +206,7 @@ func (p *InFlightLoadProducer) ResponseBody(
 	// Uses the new StartOfStream signal provided by the framework.
 	if p.includeOutputTokens && resp.StartOfStream {
 		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
-			p.release(prefillResult.TargetEndpoints[0], request)
+			p.release(prefillResult.TargetEndpoints[0], request, profilePrefill)
 		}
 	}
 
@@ -225,14 +229,14 @@ func (p *InFlightLoadProducer) ResponseBody(
 			if name == profilePrefill {
 				continue
 			}
-			p.release(endpoint, request)
+			p.release(endpoint, request, name)
 		}
 	}
 }
 
-func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
 	p.releaseRequest(endpoint)
-	p.releaseTokens(endpoint, request)
+	p.releaseTokens(endpoint, request, profileName)
 }
 
 func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
@@ -243,7 +247,7 @@ func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
 	p.requestTracker.dec(eid)
 }
 
-func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
 	if endpoint == nil || endpoint.GetMetadata() == nil {
 		return
 	}
@@ -251,7 +255,7 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 
 	// Prefer the exact value stored in PreRequest to keep counters balanced.
 	if request != nil {
-		key := addedTokensKey(request.RequestID, eid)
+		key := addedTokensKey(request.RequestID, eid, profileName)
 		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
 			if tokens, ok := v.(int64); ok && tokens != 0 {
 				p.tokenTracker.add(eid, -tokens)
@@ -267,8 +271,8 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 	}
 }
 
-func addedTokensKey(requestID, endpointID string) string {
-	return requestID + "|" + endpointID
+func addedTokensKey(requestID, endpointID, profileName string) string {
+	return requestID + "|" + endpointID + "|" + profileName
 }
 
 // uncachedInputTokens returns the prompt tokens this endpoint must actually compute,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -275,7 +275,16 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 
 	// Fallback: re-estimate. Covers tests/legacy paths that bypass PreRequest
 	// (request is nil or has no RequestID, so nothing was stored to release).
-	tokens := p.tokenEstimator.Estimate(request)
+	// Mirror PreRequest's accounting so we subtract the same amount we would
+	// have added: uncached input tokens, plus output tokens only when
+	// includeOutputTokens is true. Using tokenEstimator.Estimate() here would
+	// ignore both the includeOutputTokens=false semantics and any prefix-cache
+	// discount applied at PreRequest time, leading to over/under-decrement.
+	inputTokens := p.tokenEstimator.EstimateInput(request)
+	tokens := uncachedInputTokens(endpoint, inputTokens)
+	if p.includeOutputTokens {
+		tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+	}
 	if tokens != 0 {
 		p.tokenTracker.add(eid, -tokens)
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -19,6 +19,7 @@ package inflightload
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	sourcenotifications "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
 
@@ -39,12 +41,30 @@ const (
 	profilePrefill           = "prefill"
 )
 
-func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+// Config controls optional behaviors of InFlightLoadProducer.
+type Config struct {
+	// IncludeOutputTokens controls whether estimated output tokens are added to
+	// the in-flight token counter. Defaults to true to preserve historical behavior.
+	IncludeOutputTokens bool `json:"includeOutputTokens"`
+}
+
+func defaultConfig() Config {
+	return Config{IncludeOutputTokens: true}
+}
+
+func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	cfg := defaultConfig()
+	if len(rawParameters) > 0 {
+		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal inflight-load-producer parameters: %w", err)
+		}
+	}
 	return &InFlightLoadProducer{
-		typedName:      fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: cfg.IncludeOutputTokens,
 	}, nil
 }
 
@@ -57,10 +77,15 @@ var (
 )
 
 type InFlightLoadProducer struct {
-	typedName      fwkplugin.TypedName
-	requestTracker *concurrencyTracker
-	tokenTracker   *concurrencyTracker
-	tokenEstimator TokenEstimator
+	typedName           fwkplugin.TypedName
+	requestTracker      *concurrencyTracker
+	tokenTracker        *concurrencyTracker
+	tokenEstimator      TokenEstimator
+	includeOutputTokens bool
+	// addedTokens tracks the exact token amount added per (requestID, endpointID)
+	// so release subtracts the same value (accounting for prefix-cache discount).
+	// Key format: "<requestID>|<endpointID>".
+	addedTokens sync.Map
 }
 
 func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
@@ -112,6 +137,8 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		return
 	}
 
+	inputTokens := p.tokenEstimator.EstimateInput(request)
+
 	for _, profileResult := range result.ProfileResults {
 		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 			continue
@@ -123,8 +150,23 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		}
 		eid := endpoint.GetMetadata().NamespacedName.String()
 		p.requestTracker.inc(eid)
-		tokens := p.tokenEstimator.Estimate(request)
+
+		// Subtract approximate prefix-cache hit (in input tokens) for this endpoint.
+		cached := cachedInputTokens(endpoint)
+		adjustedInput := inputTokens - cached
+		if adjustedInput < 0 {
+			adjustedInput = 0
+		}
+		tokens := adjustedInput
+		if p.includeOutputTokens {
+			// Output tokens are based on the full input, not the cached portion.
+			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+		}
+
 		p.tokenTracker.add(eid, tokens)
+		if request != nil {
+			p.addedTokens.Store(addedTokensKey(request.RequestID, eid), tokens)
+		}
 	}
 }
 
@@ -143,9 +185,23 @@ func (p *InFlightLoadProducer) ResponseBody(
 		return
 	}
 
-	// 1. Early Prefill Release (on first chunk)
+	// When output tokens are excluded, the in-flight token estimate represents only
+	// the prompt cost, which is consumed by prefill. As soon as the first chunk
+	// arrives (StartOfStream), prefill is done across all profiles, so free the
+	// token counters for every targeted endpoint regardless of profile name.
+	// Request counters are still released on EndOfStream below.
+	if !p.includeOutputTokens && resp.StartOfStream {
+		for _, profileResult := range result.ProfileResults {
+			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
+				continue
+			}
+			p.releaseTokens(profileResult.TargetEndpoints[0], request)
+		}
+	}
+
+	// 1. Early Prefill Release (on first chunk) — original behavior.
 	// Uses the new StartOfStream signal provided by the framework.
-	if resp.StartOfStream {
+	if p.includeOutputTokens && resp.StartOfStream {
 		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
 			p.release(prefillResult.TargetEndpoints[0], request)
 		}
@@ -157,24 +213,84 @@ func (p *InFlightLoadProducer) ResponseBody(
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 				continue
 			}
+			endpoint := profileResult.TargetEndpoints[0]
+
+			if !p.includeOutputTokens {
+				// Tokens were freed at StartOfStream; only release the request counter.
+				p.releaseRequest(endpoint)
+				continue
+			}
+
 			// Skip "prefill" as it was already released in the StartOfStream block.
 			// This works perfectly even if StartOfStream and EndOfStream are both true (single chunk).
 			if name == profilePrefill {
 				continue
 			}
-			p.release(profileResult.TargetEndpoints[0], request)
+			p.release(endpoint, request)
 		}
 	}
 }
 
 func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+	p.releaseRequest(endpoint)
+	p.releaseTokens(endpoint, request)
+}
+
+func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
 	if endpoint == nil || endpoint.GetMetadata() == nil {
 		return
 	}
 	eid := endpoint.GetMetadata().NamespacedName.String()
 	p.requestTracker.dec(eid)
+}
+
+func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+	if endpoint == nil || endpoint.GetMetadata() == nil {
+		return
+	}
+	eid := endpoint.GetMetadata().NamespacedName.String()
+
+	// Prefer the exact value stored in PreRequest to keep counters balanced.
+	if request != nil {
+		key := addedTokensKey(request.RequestID, eid)
+		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
+			if tokens, ok := v.(int64); ok && tokens != 0 {
+				p.tokenTracker.add(eid, -tokens)
+			}
+			return
+		}
+	}
+
+	// Fallback: re-estimate (covers tests/legacy paths that bypass PreRequest).
 	tokens := p.tokenEstimator.Estimate(request)
-	p.tokenTracker.add(eid, -tokens)
+	if tokens != 0 {
+		p.tokenTracker.add(eid, -tokens)
+	}
+}
+
+func addedTokensKey(requestID, endpointID string) string {
+	return requestID + "|" + endpointID
+}
+
+// cachedInputTokens returns the number of input tokens this endpoint already has cached
+// from the approximate prefix cache producer, or 0 if not available.
+func cachedInputTokens(endpoint fwksched.Endpoint) int64 {
+	if endpoint == nil {
+		return 0
+	}
+	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
+	if !ok {
+		return 0
+	}
+	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
+	if !ok || info == nil {
+		return 0
+	}
+	cached := int64(info.MatchBlocks()) * int64(info.BlockSizeTokens())
+	if cached < 0 {
+		return 0
+	}
+	return cached
 }
 
 func (p *InFlightLoadProducer) Produces() map[string]any {
@@ -184,7 +300,9 @@ func (p *InFlightLoadProducer) Produces() map[string]any {
 }
 
 func (p *InFlightLoadProducer) Consumes() map[string]any {
-	return nil
+	return map[string]any{
+		attrprefix.PrefixCacheMatchInfoKey: (*attrprefix.PrefixCacheMatchInfo)(nil),
+	}
 }
 
 // DeleteEndpoint removes an endpoint from the concurrency trackers to prevent memory leaks.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -254,17 +254,24 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 	eid := endpoint.GetMetadata().NamespacedName.String()
 
 	// Prefer the exact value stored in PreRequest to keep counters balanced.
-	if request != nil {
+	// LoadAndDelete makes this idempotent per (requestID, endpointID, profileName):
+	// a second call for the same key finds nothing and is a no-op below (we do
+	// NOT fall back to Estimate when the request carries a real RequestID, since
+	// the absence of the key means "already released").
+	if request != nil && request.RequestID != "" {
 		key := addedTokensKey(request.RequestID, eid, profileName)
 		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
 			if tokens, ok := v.(int64); ok && tokens != 0 {
 				p.tokenTracker.add(eid, -tokens)
 			}
-			return
 		}
+		// Either we just released the stored value, or the key was already
+		// released by a previous call — both cases are no-ops here.
+		return
 	}
 
-	// Fallback: re-estimate (covers tests/legacy paths that bypass PreRequest).
+	// Fallback: re-estimate. Covers tests/legacy paths that bypass PreRequest
+	// (request is nil or has no RequestID, so nothing was stored to release).
 	tokens := p.tokenEstimator.Estimate(request)
 	if tokens != 0 {
 		p.tokenTracker.add(eid, -tokens)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -64,9 +64,10 @@ func TestInFlightLoadProducer_Lifecycle(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
 	}
 	ctx := context.Background()
 	endpointName := "lifecycle-endpoint"
@@ -92,9 +93,10 @@ func TestInFlightLoadProducer_MultiPodLifecycle(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
 	}
 	ctx := context.Background()
 	podA := "pod-a"
@@ -161,9 +163,10 @@ func TestInFlightLoadProducer_ConcurrencyStress(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
 	}
 	ctx := context.Background()
 	endpointName := "stress-endpoint"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -455,4 +456,53 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
 		"counters must return to zero with no drift across profiles")
+}
+
+// TestInFlightLoadProducer_TTLEviction_RollsBackCounters verifies the leak
+// safety net: when ResponseBody never delivers EndOfStream for a request, the
+// addedTokens entry expires via TTL and the OnEviction handler rolls back both
+// the token tracker and the request tracker for that endpoint, so neither
+// counter (nor the cache itself) drifts upward over time.
+func TestInFlightLoadProducer_TTLEviction_RollsBackCounters(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+		requestTTL:          10 * time.Millisecond,
+	}
+	ctx := context.Background()
+	endpointName := "abandoned-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-abandoned", "1234567890123456") // 4 input + 6 output = 10
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+	require.True(t, producer.addedTokens.Has(addedTokensKey(req.RequestID, endpointID, "default")))
+
+	// Simulate an abandoned request: never call ResponseBody. Wait for the TTL
+	// to elapse, then deterministically trigger eviction (DeleteExpired runs
+	// the same OnEviction path as the background janitor would).
+	time.Sleep(15 * time.Millisecond)
+	producer.addedTokens.DeleteExpired()
+
+	require.False(t, producer.addedTokens.Has(addedTokensKey(req.RequestID, endpointID, "default")),
+		"expired addedTokens entry must be removed from the cache")
+	// OnEviction subscribers run on a goroutine in ttlcache v3, so wait briefly
+	// for the rollback to be observed on both counters.
+	require.Eventually(t, func() bool {
+		return producer.tokenTracker.get(endpointID) == 0 &&
+			producer.requestTracker.get(endpointID) == 0
+	}, time.Second, time.Millisecond,
+		"TTL eviction must roll back both token and request trackers for the endpoint")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -29,6 +29,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 func TestInFlightLoadProducer_PrepareRequestData(t *testing.T) {
@@ -257,4 +258,201 @@ func makeTokenRequest(requestID, prompt string) *fwksched.InferenceRequest {
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
 		},
 	}
+}
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease verifies that when
+// IncludeOutputTokens is false, token counters are released as soon as the first chunk
+// arrives (StartOfStream), while request counters are released only on EndOfStream.
+func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "exclude-output-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// 16 chars / 4 = 4 input tokens. Output tokens are excluded.
+	req := makeTokenRequest("req-no-output", "1234567890123456")
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID), "only input tokens should be tracked")
+
+	// First chunk arrives: tokens released, request still in flight.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID), "request counter should still be held")
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID), "tokens should be released at StartOfStream")
+
+	// EndOfStream releases the request counter.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk verifies that a single-chunk
+// response (StartOfStream && EndOfStream both true) releases both tokens and the request.
+func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "single-chunk-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-single", "1234567890123456")
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
+
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true, EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+// TestInFlightLoadProducer_PrefixCacheDiscount verifies that when PrefixCacheMatchInfo
+// is published on the endpoint, the matched prefix is excluded from the tracked input
+// tokens, and that release subtracts the same (discounted) amount.
+func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	endpointName := "prefix-cache-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// Prompt: 32 chars / 4 = 8 input tokens. Output = 8 * 1.5 = 12.
+	// With block_size=4, total=2 blocks, matched=1 block (4 tokens cached):
+	//   uncached_input = (2-1)*4 + max(0, 8-2*4) = 4
+	//   total tokens = 4 + 12 = 16
+	endpoint := newStubSchedulingEndpoint(endpointName)
+	endpoint.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+
+	req := makeTokenRequest("req-prefix", "12345678901234567890123456789012")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{endpoint}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(16), producer.tokenTracker.get(endpointID),
+		"only uncached input (4) plus output (12) should be tracked")
+
+	// Release uses the exact stored value, returning to zero.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"release should subtract the same discounted amount that was added")
+}
+
+// TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint verifies that two profiles
+// targeting different endpoints with different prefix-cache match levels each get their
+// own discounted token amount, and that both counters return to zero after release.
+func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	podA := "pod-a-cached"
+	podB := "pod-b-uncached"
+	idA := fullEndpointName(podA)
+	idB := fullEndpointName(podB)
+
+	// 8 input tokens, output 12.
+	epA := newStubSchedulingEndpoint(podA)
+	epA.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(2, 2, 4)) // fully cached
+	epB := newStubSchedulingEndpoint(podB)
+	epB.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(0, 2, 4)) // none cached
+
+	req := makeTokenRequest("req-multi-cache", "12345678901234567890123456789012")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{epA}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{epB}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(0+12), producer.tokenTracker.get(idA), "fully cached: only output tokens")
+	require.Equal(t, int64(8+12), producer.tokenTracker.get(idB), "uncached: input + output")
+
+	// Drive the response lifecycle: StartOfStream releases prefill, EndOfStream releases decode.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.tokenTracker.get(idA))
+	require.Equal(t, int64(0), producer.tokenTracker.get(idB))
+	require.Equal(t, int64(0), producer.requestTracker.get(idA))
+	require.Equal(t, int64(0), producer.requestTracker.get(idB))
+}
+
+// TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint verifies that
+// when multiple profiles target the same endpoint, each contributes to the counters
+// independently and each release subtracts the exact added amount, returning counters
+// to their pre-request baseline.
+func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	endpointName := "shared-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// 16 chars / 4 = 4 input tokens, 6 output, total 10 tokens per profile.
+	// Two profiles both targeting the same endpoint => 2 requests, 20 tokens.
+	req := makeTokenRequest("req-shared", "1234567890123456")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(2), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(20), producer.tokenTracker.get(endpointID))
+
+	// StartOfStream releases the prefill profile only (1 request, 10 tokens).
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// EndOfStream releases the remaining (decode) profile.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"counters must return to zero with no drift across profiles")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -506,3 +506,47 @@ func TestInFlightLoadProducer_TTLEviction_RollsBackCounters(t *testing.T) {
 	}, time.Second, time.Millisecond,
 		"TTL eviction must roll back both token and request trackers for the endpoint")
 }
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart verifies the
+// safety net for non-streaming or error paths: when includeOutputTokens=false and
+// ResponseBody delivers EndOfStream without ever seeing StartOfStream, the token
+// counter and request counter must both drain (tokens are normally released at
+// StartOfStream, so a missing StartOfStream would otherwise leak them). Also
+// asserts the addedTokens cache entry is removed so the TTL safety net doesn't
+// later double-subtract via OnEviction.
+func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "no-start-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-no-start", "1234567890123456") // 4 input tokens
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
+
+	// EndOfStream only (no StartOfStream): both counters must drain.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"tokens must be released on EndOfStream even if StartOfStream was never seen")
+
+	// addedTokens entry should be gone too (no leak, no future double-subtract).
+	require.False(t, producer.addedTokens.Has(addedTokensKey(req.RequestID, endpointID, "default")),
+		"addedTokens entry must be released")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -24,7 +24,12 @@ import (
 
 // TokenEstimator estimates the number of tokens for an LLM request.
 type TokenEstimator interface {
+	// Estimate returns the total estimated token count (input + output) for the request.
 	Estimate(request *fwksched.InferenceRequest) int64
+	// EstimateInput returns only the estimated input token count for the request.
+	EstimateInput(request *fwksched.InferenceRequest) int64
+	// EstimateOutput returns the estimated output token count given the input token count.
+	EstimateOutput(inputTokens int64) int64
 }
 
 // SimpleTokenEstimator estimates tokens from character count. tokens = characters / CharactersPerToken.
@@ -46,27 +51,40 @@ func NewSimpleTokenEstimator() TokenEstimator {
 // to avoid allocations. Otherwise, input tokens are estimated from prompt/message character count
 // using CharactersPerToken; output tokens are estimated as inputTokens * OutputRatio.
 func (e *SimpleTokenEstimator) Estimate(request *fwksched.InferenceRequest) int64 {
+	inputTokens := e.EstimateInput(request)
+	if inputTokens == 0 {
+		return 0
+	}
+	return inputTokens + e.EstimateOutput(inputTokens)
+}
+
+// EstimateInput returns only the estimated input token count for the request.
+func (e *SimpleTokenEstimator) EstimateInput(request *fwksched.InferenceRequest) int64 {
 	if request == nil {
 		return 0
 	}
 	// Prefer request body size when available: avoids PlainText() and reduces GC pressure.
-	var inputTokens int64
 	switch {
 	case request.RequestSizeBytes > 0:
-		inputTokens = max(int64(request.RequestSizeBytes)/4, 1)
+		return max(int64(request.RequestSizeBytes)/4, 1)
 	case request.Body != nil:
 		hint := request.Body.InputTokenCountHint()
 		if hint >= 0 {
-			inputTokens = int64(hint)
-		} else {
-			// Fallback: character count from prompt text across all API types
-			// (completions, chat/completions, responses, conversations).
-			chars := len(request.Body.PromptText())
-			inputTokens = int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
+			return int64(hint)
 		}
+		// Fallback: character count from prompt text across all API types
+		// (completions, chat/completions, responses, conversations).
+		chars := len(request.Body.PromptText())
+		return int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
 	default:
 		return 0
 	}
-	outputTokens := int64(math.Round(float64(inputTokens) * e.OutputRatio))
-	return inputTokens + outputTokens
+}
+
+// EstimateOutput returns the estimated output token count given the input token count.
+func (e *SimpleTokenEstimator) EstimateOutput(inputTokens int64) int64 {
+	if inputTokens <= 0 {
+		return 0
+	}
+	return int64(math.Round(float64(inputTokens) * e.OutputRatio))
 }


### PR DESCRIPTION

- Add Config.IncludeOutputTokens (default true) to InFlightLoadProducer.
- When disabled, free token counters at StartOfStream for all targeted endpoints (prompt cost is consumed by prefill); request counters still release at EndOfStream.
- Consume approximate prefix-cache match info and subtract cached input tokens per endpoint when adding to the token tracker. Track exact added amount per (requestID, endpointID) so release stays balanced.
- Split TokenEstimator into Estimate / EstimateInput / EstimateOutput.
