### PR TITLE
prefixcacheaffinity: add MaxTokensInFlightPenalty load gate

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
@@ -2,7 +2,19 @@
 
 **Type:** `inflight-load-producer`
 
-Tracks real-time in-flight request and token counts per endpoint by hooking into the request lifecycle. Writes an `InFlightLoad` attribute onto each endpoint in the `Produce` phase, consumed by the `token-load-scorer` and the `concurrency-detector`.
+Tracks real-time in-flight request and token counts per endpoint by hooking into the request lifecycle. Writes an `InFlightLoad` attribute onto each endpoint in the `Produce` phase, consumed by the following plugins:
+- `token-load-scorer`: Scores endpoints based on in-flight tokens.
+- `active-request-scorer`: Scores endpoints based on in-flight requests.
+- `concurrency-detector`: Provides admission control based on in-flight requests/tokens.
+- `prefix-cache-affinity-filter`: Uses in-flight tokens as a load gate to break stickiness.
+
+## Behavior
+
+- **Prefix Cache Discounting**: Automatically detects if an endpoint has a prefix cache hit (via `PrefixCacheMatchInfo`). Only the **uncached** portion of the prompt is added to the in-flight token counter, providing a more accurate estimate of the actual compute load.
+- **Token Release Timing**: 
+    - If `addEstimatedOutputTokens` is `false` (default): For streaming requests, all tokens are released as soon as the first chunk of the response is received (`StartOfStream`), as the prefill compute is complete. For non-streaming requests (or as a safety net), tokens are released when the response completes (`EndOfStream`).
+    - If `addEstimatedOutputTokens` is `true`: The prompt portion is released at `StartOfStream` (for streaming) or `EndOfStream`, and the estimated output portion is released only when the response completes (`EndOfStream`).
+- **Request Release**: In-flight request counters are always released when the response completes (`EndOfStream`).
 
 The producer hooks three lifecycle phases:
 - **Produce**: Writes current in-flight counts to each endpoint's attributes.
@@ -11,10 +23,26 @@ The producer hooks three lifecycle phases:
 
 Endpoint departure events (pod removed from the pool) are handled via the `EndpointExtractor` interface to clean up stale counters.
 
-**Parameters:** None.
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `addEstimatedOutputTokens` | `bool` | No | `false` | If true, adds an estimate of the generated output tokens to the in-flight counter. |
 
 ---
 
 ## Related Documentation
 - [Token Load Scorer](../../../scheduling/scorer/tokenload/README.md)
+- [Active Request Scorer](../../../scheduling/scorer/activerequest/README.md)
+- [Concurrency Detector](../../../flowcontrol/saturationdetector/concurrency/README.md)
+- [Prefix Cache Affinity Filter](../../../scheduling/filter/prefixcacheaffinity/README.md)
 - [Concurrency Attributes](../../../datalayer/attribute/concurrency/README.md)
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: inflight-load-producer
+    name: inflight-load
+    parameters:
+      addEstimatedOutputTokens: true
+```

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -35,10 +35,10 @@ This filter resolves the trade-off by operating as a **pre-filter** rather than 
 It narrows the candidate set to only the sticky endpoints (those above `affinityThreshold`),
 then passes them to downstream plugins. When paired with `weighted-random-picker`, requests
 are spread across the sticky set — maintaining cache affinity while distributing load. The
-TTFT load gate (`maxTTFTPenaltyMs`) adds automatic back-off: if sticky endpoints become
-overloaded and their predicted TTFT exceeds non-sticky endpoints by more than the configured
-penalty, the filter breaks stickiness and opens up all endpoints, preventing the hot-spotting
-problem. The exploration mechanism (`explorationProbability`) seeds cache state on other
+load gates (`maxTTFTPenaltyMs` and `maxTokensInFlightPenalty`) add automatic back-off: if
+sticky endpoints become overloaded and their predicted TTFT or in-flight tokens exceed
+non-sticky endpoints by more than the configured penalty, the filter breaks stickiness and
+opens up all endpoints, preventing the hot-spotting problem. The exploration mechanism (`explorationProbability`) seeds cache state on other
 endpoints over time, preventing permanent stickiness to a fixed subset.
 
 ## Overview
@@ -59,6 +59,8 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 - With probability `explorationProbability` (default 1%), skip the gate entirely for exploration
 - TTFT load gate: if best sticky endpoint's predicted TTFT exceeds best non-sticky by
   more than `maxTTFTPenaltyMs`, break stickiness and keep all endpoints
+- In-flight tokens load gate: if best sticky endpoint's in-flight tokens exceed best non-sticky
+  by more than `maxTokensInFlightPenalty`, break stickiness and keep all endpoints (if > 0)
 - If no endpoints have `LatencyPredictionInfo` (predictions absent), the TTFT load gate
   is skipped. If no endpoints have `PrefixCacheMatchInfo`, all prefix scores default to 0
   and no endpoints pass the affinity threshold, so all are kept (no-op)
@@ -70,11 +72,13 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
 | `explorationProbability` | `float64` | No | `0.01` | Probability of skipping the gate |
 | `maxTTFTPenaltyMs` | `float64` | No | `5000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
+| `maxTokensInFlightPenalty` | `int64` | No | `0` | Max in-flight tokens penalty before breaking stickiness. 0 = disabled |
 
 ## Dependencies
 
 - Reads `PrefixCacheMatchInfo` from endpoint attributes (from `prefix-cache-scorer`)
 - Reads `LatencyPredictionInfo` for TTFT load gate (from `predicted-latency-producer`)
+- Reads `InFlightLoad` for in-flight tokens load gate (from `in-flight-load-producer`)
 
 **Configuration Example:**
 ```yaml
@@ -85,6 +89,7 @@ plugins:
       affinityThreshold: 0.80
       explorationProbability: 0.01
       maxTTFTPenaltyMs: 5000
+      maxTokensInFlightPenalty: 1000
 schedulingProfiles:
   - name: default
     plugins:

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -32,6 +32,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
@@ -57,8 +58,15 @@ type Config struct {
 	// Set to 0 to always stick. Default: 5000.
 	MaxTTFTPenaltyMs float64 `json:"maxTTFTPenaltyMs,omitempty"`
 
+	// MaxTokensInFlightPenalty is the max in-flight token penalty before breaking
+	// stickiness. If the best sticky endpoint's in-flight tokens exceed the best
+	// non-sticky endpoint's in-flight tokens by more than this value, all endpoints
+	// are kept. Set to 0 to disable this gate. Default: 0 (disabled).
+	MaxTokensInFlightPenalty int64 `json:"maxTokensInFlightPenalty,omitempty"`
+
 	PrefixMatchInfoProducerName       string `json:"prefixMatchInfoProducerName,omitempty"`
 	LatencyPredictionInfoProducerName string `json:"latencyPredictionInfoProducerName,omitempty"`
+	InFlightLoadProducerName          string `json:"inFlightLoadProducerName,omitempty"`
 }
 
 var DefaultConfig = Config{
@@ -72,6 +80,7 @@ type Plugin struct {
 	config                       Config
 	prefixMatchDataKey           fwkplugin.DataKey
 	latencyPredictionInfoDataKey fwkplugin.DataKey
+	inFlightLoadDataKey          fwkplugin.DataKey
 }
 
 func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -89,6 +98,7 @@ func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fw
 		config:                       config,
 		prefixMatchDataKey:           attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(config.PrefixMatchInfoProducerName),
 		latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfoDataKey.WithNonEmptyProducerName(config.LatencyPredictionInfoProducerName),
+		inFlightLoadDataKey:          attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(config.InFlightLoadProducerName),
 	}, nil
 }
 
@@ -101,6 +111,9 @@ func (c *Config) validate() error {
 	}
 	if c.MaxTTFTPenaltyMs < 0 {
 		return fmt.Errorf("maxTTFTPenaltyMs must be >= 0, got %f", c.MaxTTFTPenaltyMs)
+	}
+	if c.MaxTokensInFlightPenalty < 0 {
+		return fmt.Errorf("maxTokensInFlightPenalty must be >= 0, got %d", c.MaxTokensInFlightPenalty)
 	}
 	return nil
 }
@@ -152,16 +165,34 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.CycleState, _ *fwksched
 		}
 	}
 
+	// In-flight tokens load gate: break stickiness if sticky endpoints are too loaded.
+	if p.config.MaxTokensInFlightPenalty > 0 && len(nonSticky) > 0 {
+		bestStickyTokens := p.bestInFlightTokens(sticky)
+		bestNonStickyTokens := p.bestInFlightTokens(nonSticky)
+		if bestStickyTokens-bestNonStickyTokens > p.config.MaxTokensInFlightPenalty {
+			logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: in-flight tokens load gate broken",
+				"bestStickyTokens", bestStickyTokens, "bestNonStickyTokens", bestNonStickyTokens,
+				"penalty", bestStickyTokens-bestNonStickyTokens, "maxPenalty", p.config.MaxTokensInFlightPenalty)
+			return endpoints
+		}
+	}
+
 	logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: narrowed to sticky",
 		"affinityThreshold", p.config.AffinityThreshold, "sticky", len(sticky), "total", len(endpoints))
 	return sticky
 }
 
 func (p *Plugin) Consumes() map[fwkplugin.DataKey]any {
-	return map[fwkplugin.DataKey]any{
-		p.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{},
-		p.prefixMatchDataKey:           attrprefix.PrefixCacheMatchInfo{},
+	res := map[fwkplugin.DataKey]any{
+		p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{},
 	}
+	if p.config.MaxTTFTPenaltyMs > 0 {
+		res[p.latencyPredictionInfoDataKey] = attrlatency.LatencyPredictionInfo{}
+	}
+	if p.config.MaxTokensInFlightPenalty > 0 {
+		res[p.inFlightLoadDataKey] = attrconcurrency.InFlightLoad{}
+	}
+	return res
 }
 
 func (p *Plugin) prefixCacheScore(ep fwksched.Endpoint) float64 {
@@ -185,6 +216,24 @@ func (p *Plugin) bestTTFT(endpoints []fwksched.Endpoint) float64 {
 			if info.TTFT() < best {
 				best = info.TTFT()
 			}
+		}
+	}
+	return best
+}
+
+// bestInFlightTokens returns the lowest in-flight token count across endpoints.
+// Endpoints without the attribute are treated as 0 (no observed load).
+func (p *Plugin) bestInFlightTokens(endpoints []fwksched.Endpoint) int64 {
+	best := int64(math.MaxInt64)
+	for _, ep := range endpoints {
+		var tokens int64
+		if raw, ok := ep.Get(p.inFlightLoadDataKey.String()); ok {
+			if load, ok := raw.(*attrconcurrency.InFlightLoad); ok && load != nil {
+				tokens = load.Tokens
+			}
+		}
+		if tokens < best {
+			best = tokens
 		}
 	}
 	return best

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -26,13 +26,14 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 // makeEndpoint creates a test endpoint with the given prefix cache match ratio
-// (prefixMatch out of 100 total blocks) and predicted TTFT.
-func makeEndpoint(name string, prefixMatch int, ttft float64) fwksched.Endpoint {
+// (prefixMatch out of 100 total blocks), predicted TTFT, and in-flight tokens.
+func makeEndpoint(name string, prefixMatch int, ttft float64, tokens int64) fwksched.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
 		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
 	}
@@ -43,6 +44,9 @@ func makeEndpoint(name string, prefixMatch int, ttft float64) fwksched.Endpoint 
 	if ttft >= 0 {
 		ep.Put(attrlatency.LatencyPredictionInfoDataKey.String(), attrlatency.NewLatencyPredictionInfo(true, true, 0, 0, ttft, 0, 0))
 	}
+	if tokens >= 0 {
+		ep.Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: tokens})
+	}
 	return ep
 }
 
@@ -52,14 +56,15 @@ func newTestPlugin(config Config) *Plugin {
 		config:                       config,
 		prefixMatchDataKey:           attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(config.PrefixMatchInfoProducerName),
 		latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfoDataKey.WithNonEmptyProducerName(config.LatencyPredictionInfoProducerName),
+		inFlightLoadDataKey:          attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(config.InFlightLoadProducerName),
 	}
 }
 
 func TestFilter_AffinityThresholdDisabled(t *testing.T) {
 	p := newTestPlugin(Config{AffinityThreshold: 0})
 	endpoints := []fwksched.Endpoint{
-		makeEndpoint("a", 0, 10),
-		makeEndpoint("b", 90, 20),
+		makeEndpoint("a", 0, 10, 0),
+		makeEndpoint("b", 90, 20, 0),
 	}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 2, len(result), "affinityThreshold=0 should return all")
@@ -67,7 +72,7 @@ func TestFilter_AffinityThresholdDisabled(t *testing.T) {
 
 func TestFilter_SingleEndpoint(t *testing.T) {
 	p := newTestPlugin(Config{AffinityThreshold: 0.80})
-	endpoints := []fwksched.Endpoint{makeEndpoint("a", 90, 10)}
+	endpoints := []fwksched.Endpoint{makeEndpoint("a", 90, 10, 0)}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 1, len(result), "single endpoint should always pass")
 }
@@ -75,9 +80,9 @@ func TestFilter_SingleEndpoint(t *testing.T) {
 func TestFilter_NoStickyEndpoints(t *testing.T) {
 	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0})
 	endpoints := []fwksched.Endpoint{
-		makeEndpoint("a", 10, 10),
-		makeEndpoint("b", 20, 20),
-		makeEndpoint("c", 50, 30),
+		makeEndpoint("a", 10, 10, 0),
+		makeEndpoint("b", 20, 20, 0),
+		makeEndpoint("c", 50, 30, 0),
 	}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 3, len(result), "no sticky endpoints should return all")
@@ -86,9 +91,9 @@ func TestFilter_NoStickyEndpoints(t *testing.T) {
 func TestFilter_NarrowToSticky(t *testing.T) {
 	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 5000})
 	endpoints := []fwksched.Endpoint{
-		makeEndpoint("a", 90, 100),
-		makeEndpoint("b", 85, 120),
-		makeEndpoint("c", 10, 50),
+		makeEndpoint("a", 90, 100, 0),
+		makeEndpoint("b", 85, 120, 0),
+		makeEndpoint("c", 10, 50, 0),
 	}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 2, len(result), "should narrow to sticky endpoints")
@@ -97,21 +102,87 @@ func TestFilter_NarrowToSticky(t *testing.T) {
 func TestFilter_TTFTPenaltyBreaksStickiness(t *testing.T) {
 	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100})
 	endpoints := []fwksched.Endpoint{
-		makeEndpoint("a", 90, 500),
-		makeEndpoint("b", 10, 50),
+		makeEndpoint("a", 90, 500, 0),
+		makeEndpoint("b", 10, 50, 0),
 	}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 2, len(result), "TTFT penalty should break stickiness")
 }
 
+func TestFilter_InFlightTokenPenaltyBreaksStickiness(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTokensInFlightPenalty: 100})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, 10, 500),
+		makeEndpoint("b", 10, 10, 50),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 2, len(result), "In-flight token penalty should break stickiness")
+}
+
+func TestFilter_InFlightTokenPenaltyWithinThreshold(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTokensInFlightPenalty: 1000})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, 10, 500),
+		makeEndpoint("b", 10, 10, 50),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 1, len(result), "In-flight token penalty within threshold should NOT break stickiness")
+	assert.Equal(t, "a", result[0].GetMetadata().NamespacedName.Name)
+}
+
+func TestFilter_InFlightTokenPenaltyDisabled(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTokensInFlightPenalty: 0})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, 10, 5000), // Huge penalty
+		makeEndpoint("b", 10, 10, 50),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 1, len(result), "In-flight token penalty=0 should NOT break stickiness")
+	assert.Equal(t, "a", result[0].GetMetadata().NamespacedName.Name)
+}
+
 func TestFilter_ExplorationProbability(t *testing.T) {
 	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 1.0})
 	endpoints := []fwksched.Endpoint{
-		makeEndpoint("a", 90, 100),
-		makeEndpoint("b", 10, 50),
+		makeEndpoint("a", 90, 100, 0),
+		makeEndpoint("b", 10, 50, 0),
 	}
 	result := p.Filter(context.Background(), nil, nil, endpoints)
 	assert.Equal(t, 2, len(result), "epsilon=1.0 should always skip gate")
+}
+
+func TestConsumes_ConditionalAttributes(t *testing.T) {
+	// Everything disabled
+	p := newTestPlugin(Config{MaxTTFTPenaltyMs: 0, MaxTokensInFlightPenalty: 0})
+	consumed := p.Consumes()
+	_, ok := consumed[p.inFlightLoadDataKey]
+	assert.False(t, ok, "InFlightLoadDataKey should not be consumed when penalty is 0")
+	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	assert.False(t, ok, "LatencyPredictionInfoDataKey should not be consumed when penalty is 0")
+
+	// Only TTFT enabled
+	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, MaxTokensInFlightPenalty: 0})
+	consumed = p.Consumes()
+	_, ok = consumed[p.inFlightLoadDataKey]
+	assert.False(t, ok)
+	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	assert.True(t, ok)
+
+	// Only In-flight enabled
+	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 0, MaxTokensInFlightPenalty: 100})
+	consumed = p.Consumes()
+	_, ok = consumed[p.inFlightLoadDataKey]
+	assert.True(t, ok)
+	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	assert.False(t, ok)
+
+	// Both enabled
+	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, MaxTokensInFlightPenalty: 100})
+	consumed = p.Consumes()
+	_, ok = consumed[p.inFlightLoadDataKey]
+	assert.True(t, ok)
+	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	assert.True(t, ok)
 }
 
 func TestFactory_ValidConfig(t *testing.T) {


### PR DESCRIPTION
Consume attrconcurrency.InFlightLoadKey and break stickiness when the best sticky endpoint's in-flight tokens exceed the best non-sticky endpoint's by more than MaxTokensInFlightPenalty (default 0 = disabled), mirroring the existing TTFT penalty gate.
