### PR TITLE
refactor(plugins): rename PrepareRequestData and related refactor

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -612,7 +612,7 @@ func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *conf
 	}
 
 	// The plugins will be executed in topologically sorted order to ensure that data is produced before it is consumed.
-	r.requestControlConfig.OrderPrepareDataPlugins(dag)
+	r.requestControlConfig.OrderDataProducerPlugins(dag)
 
 	r.parser = handlers.NewParser(cfg.ParserConfig)
 	logger.Info("loaded configuration from file/text successfully")

--- a/deploy/config/pd-epp-config.yaml
+++ b/deploy/config/pd-epp-config.yaml
@@ -1,8 +1,6 @@
 # Sample EPP configuration for tunning with P/D
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
-featureGates:
-- prepareDataPlugins
 plugins:
 - type: prefix-cache-scorer
   parameters:

--- a/deploy/config/sim-e-p-d-epp-config.yaml
+++ b/deploy/config/sim-e-p-d-epp-config.yaml
@@ -1,8 +1,6 @@
 # Sample EPP configuration for running with E/P/D
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
-featureGates:
-- prepareDataPlugins
 plugins:
 - type: queue-scorer
 - type: encode-filter

--- a/deploy/config/sim-epp-external-tokenizer-config.yaml
+++ b/deploy/config/sim-epp-external-tokenizer-config.yaml
@@ -5,12 +5,9 @@
 # prompts, attaching the resulting token IDs to the request so the
 # precise-prefix-cache-scorer can skip internal tokenization.
 #
-# Requires featureGates: [prepareDataPlugins] and the tokenizer sidecar
-# container running in the same pod.
+# Requires the tokenizer sidecar container running in the same pod.
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
-featureGates:
-- prepareDataPlugins
 plugins:
 - type: tokenizer
   parameters:

--- a/deploy/config/sim-epp-external-tokenizer-config.yaml
+++ b/deploy/config/sim-epp-external-tokenizer-config.yaml
@@ -1,6 +1,6 @@
 # Sample EPP configuration for running with an external tokenizer sidecar.
 #
-# The tokenizer plugin (PrepareData phase) communicates with a Python gRPC
+# The tokenizer plugin (Produce phase) communicates with a Python gRPC
 # sidecar over a Unix domain socket. It renders chat templates and tokenizes
 # prompts, attaching the resulting token IDs to the request so the
 # precise-prefix-cache-scorer can skip internal tokenization.

--- a/deploy/config/sim-pd-epp-config.yaml
+++ b/deploy/config/sim-pd-epp-config.yaml
@@ -2,8 +2,6 @@
 # Use with small hash block size for simulation purposes
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
-featureGates:
-- prepareDataPlugins
 plugins:
 - type: prefix-cache-scorer
   parameters:

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -258,8 +258,6 @@ Below is a minimal `EndpointPickerConfig` for P/D disaggregation using custom la
 ```yaml
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
-featureGates:
-- prepareDataPlugins
 plugins:
   # Prefill selection: match Pods with label role=prefill
   - type: label-selector-filter
@@ -314,8 +312,6 @@ Below is an `EndpointPickerConfig` for full E/P/D disaggregation using custom la
 ```yaml
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
-featureGates:
-- prepareDataPlugins
 plugins:
   # Encoding selection: match Pods with label role=encode
   - type: label-selector-filter
@@ -416,15 +412,6 @@ The `prefix-based-pd-decider` plugin makes the disaggregation decision according
 
 - `nonCachedTokens`: Number of non-cached tokens that trigger disaggregation
   - If set to 0, disaggregation always occurs for all requests
-
-**Feature Gate Requirement**
-To activate this decider, ensure the following feature gate is enabled in your EndpointPickerConfig
-
-```yaml
-featureGates:
-- prepareDataPlugins
-```
-
 
 #### Always-Disagg PD Decider
 The `always-disagg-pd-decider` is a simpler alternative used mainly for testing or benchmarking.

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -36,7 +36,7 @@ import (
 
 const mockProducedDataKey = "mockProducedData"
 
-type mockPrepareRequestDataP struct {
+type mockDataProducerP struct {
 	name     string
 	produces map[string]any
 	consumes map[string]any
@@ -50,19 +50,19 @@ func (m *mockProducedDataType) Clone() fwkdl.Cloneable {
 	return &mockProducedDataType{value: m.value}
 }
 
-func (m *mockPrepareRequestDataP) TypedName() fwkplugin.TypedName {
+func (m *mockDataProducerP) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockPrepareRequestDataP) Produces() map[string]any {
+func (m *mockDataProducerP) Produces() map[string]any {
 	return m.produces
 }
 
-func (m *mockPrepareRequestDataP) Consumes() map[string]any {
+func (m *mockDataProducerP) Consumes() map[string]any {
 	return m.consumes
 }
 
-func (m *mockPrepareRequestDataP) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (m *mockDataProducerP) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, &mockProducedDataType{value: 42})
 	return nil
 }
@@ -79,7 +79,7 @@ func (m *typedMockPlugin) TypedName() fwkplugin.TypedName {
 }
 
 func (m *typedMockPlugin) Produces() map[string]any { return m.produces }
-func (m *typedMockPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (m *typedMockPlugin) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	return nil
 }
 
@@ -107,7 +107,7 @@ func (m *MockSchedulingPlugin) Consumes() map[string]any {
 
 func TestValidatePluginExecutionOrder(t *testing.T) {
 	// Request control plugin that produces data.
-	pluginA := &mockPrepareRequestDataP{name: "A", produces: map[string]any{"keyA": nil}}
+	pluginA := &mockDataProducerP{name: "A", produces: map[string]any{"keyA": nil}}
 	// Flow control plugin.
 	consumerFairnessPolicyPlugin := MockConsumerFairnessPolicy{consumes: map[string]any{"keyA": nil}}
 	// Scheduling plugin.
@@ -152,23 +152,23 @@ func TestValidatePluginExecutionOrder(t *testing.T) {
 }
 
 func TestDAGAndTopologicalOrder(t *testing.T) {
-	pluginA := &mockPrepareRequestDataP{name: "A", produces: map[string]any{"keyA": nil}}
-	pluginB := &mockPrepareRequestDataP{name: "B", consumes: map[string]any{"keyA": nil}, produces: map[string]any{"keyB": nil}}
-	pluginC := &mockPrepareRequestDataP{name: "C", consumes: map[string]any{"keyB": nil}}
-	pluginD := &mockPrepareRequestDataP{name: "D", consumes: map[string]any{"keyA": nil}}
-	pluginE := &mockPrepareRequestDataP{name: "E"} // No dependencies
+	pluginA := &mockDataProducerP{name: "A", produces: map[string]any{"keyA": nil}}
+	pluginB := &mockDataProducerP{name: "B", consumes: map[string]any{"keyA": nil}, produces: map[string]any{"keyB": nil}}
+	pluginC := &mockDataProducerP{name: "C", consumes: map[string]any{"keyB": nil}}
+	pluginD := &mockDataProducerP{name: "D", consumes: map[string]any{"keyA": nil}}
+	pluginE := &mockDataProducerP{name: "E"} // No dependencies
 
 	// Cycle plugins
-	pluginX := &mockPrepareRequestDataP{name: "X", produces: map[string]any{"keyX": nil}, consumes: map[string]any{"keyY": nil}}
-	pluginY := &mockPrepareRequestDataP{name: "Y", produces: map[string]any{"keyY": nil}, consumes: map[string]any{"keyX": nil}}
+	pluginX := &mockDataProducerP{name: "X", produces: map[string]any{"keyX": nil}, consumes: map[string]any{"keyY": nil}}
+	pluginY := &mockDataProducerP{name: "Y", produces: map[string]any{"keyY": nil}, consumes: map[string]any{"keyX": nil}}
 
 	// Data type mismatch plugin.
-	pluginZ1 := &mockPrepareRequestDataP{name: "Z1", produces: map[string]any{"keyZ": int(0)}}
-	pluginZ2 := &mockPrepareRequestDataP{name: "Z2", consumes: map[string]any{"keyZ": string("")}}
+	pluginZ1 := &mockDataProducerP{name: "Z1", produces: map[string]any{"keyZ": int(0)}}
+	pluginZ2 := &mockDataProducerP{name: "Z2", consumes: map[string]any{"keyZ": string("")}}
 
 	// Same type different pointers.
-	pluginP1 := &mockPrepareRequestDataP{name: "P1", produces: map[string]any{"keyP": &mockProducedDataType{}}}
-	pluginP2 := &mockPrepareRequestDataP{name: "P2", consumes: map[string]any{"keyP": &mockProducedDataType{}}}
+	pluginP1 := &mockDataProducerP{name: "P1", produces: map[string]any{"keyP": &mockProducedDataType{}}}
+	pluginP2 := &mockDataProducerP{name: "P2", consumes: map[string]any{"keyP": &mockProducedDataType{}}}
 
 	testCases := []struct {
 		name        string
@@ -289,13 +289,13 @@ func TestCreateMissingDataProducers(t *testing.T) {
 	// A DataProducer that produces keyA.
 	producerTypeA := "producer-a"
 	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
-		return &mockPrepareRequestDataP{name: name, produces: map[string]any{keyA: nil}}, nil
+		return &mockDataProducerP{name: name, produces: map[string]any{keyA: nil}}, nil
 	})
 
 	// A DataProducer that produces keyB.
 	producerTypeB := "producer-b"
 	producerBFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
-		return &mockPrepareRequestDataP{name: name, produces: map[string]any{keyB: nil}}, nil
+		return &mockDataProducerP{name: name, produces: map[string]any{keyB: nil}}, nil
 	})
 
 	// A non-ProducerPlugin registry entry (e.g. a scheduling scorer).
@@ -332,7 +332,7 @@ func TestCreateMissingDataProducers(t *testing.T) {
 		{
 			name: "no missing keys - nothing created",
 			existingPlugins: []fwkplugin.Plugin{
-				&mockPrepareRequestDataP{name: "existing-a", produces: map[string]any{keyA: nil}},
+				&mockDataProducerP{name: "existing-a", produces: map[string]any{keyA: nil}},
 				&MockSchedulingPlugin{consumes: map[string]any{keyA: nil}},
 			},
 			defaultProducerRegistry: map[string]string{keyA: producerTypeA},

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -272,7 +272,7 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 			maps.Copy(normalizedExpectedDAG, tc.expectedDAG)
 
 			if diff := cmp.Diff(normalizedExpectedDAG, normalizedDAG); diff != "" {
-				t.Errorf("prepareDataGraph() mismatch (-want +got):\n%s", diff)
+				t.Errorf("dataProducerGraph() mismatch (-want +got):\n%s", diff)
 			}
 
 			assertTopologicalOrder(t, dag, orderedPlugins)

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -65,10 +65,10 @@ type ResponseBodyProcessor interface {
 }
 
 // DataProducer is implemented by data producers which produce data from different sources.
-// PrepareRequestData is called by the director before scheduling requests.
+// Produce is called by the director before scheduling requests.
 type DataProducer interface {
 	plugin.ProducerPlugin
-	PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error
+	Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error
 }
 
 // Admitter is called by the director after the data producer and before scheduling.

--- a/pkg/epp/framework/interface/scheduling/cycle_state.go
+++ b/pkg/epp/framework/interface/scheduling/cycle_state.go
@@ -36,7 +36,7 @@ func NewCycleState() *CycleState {
 //
 // CycleState is possibly being deprecated in favor of plugin.PluginState
 // for per-request state management or Data Layer attributes for sharing data
-// between PrepareData and Scheduling phases.
+// between Produce and Scheduling phases.
 // See https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2657 for the ongoing discussion.
 // TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2657):
 // Remove CycleState once all plugins are migrated and the discussion is finalized.

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/README.md
@@ -31,7 +31,7 @@ because the predictor already neutralizes TPOT for non-streaming mode and prefil
 
 ## Dependencies
 
-- Requires `predicted-latency-producer` to run first (in PrepareRequestData) to populate
+- Requires `predicted-latency-producer` to run first (in Produce) to populate
   `LatencyPredictionInfo` attributes on endpoints.
 - Reads `DispatchedRequestCount` from the same attributes for idle detection.
 - Reads `KVCacheUsagePercent` from endpoint metrics for cold detection.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -131,8 +131,8 @@ func (p *prepareData) PluginState() *plugin.PluginState {
 	return p.pluginState
 }
 
-// PrepareRequestData is called by the director before scheduling requests.
-func (p *prepareData) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
+// Produce is called by the director before scheduling requests.
+func (p *prepareData) Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
 	blockSize := p.GetBlockSize(pods)
 	maxBlocks := p.config.MaxPrefixBlocksToMatch
 	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
@@ -177,7 +177,7 @@ func (p *prepareData) PreRequest(ctx context.Context, request *fwksched.Inferenc
 		servers = append(servers, p.makeserver(pr.TargetEndpoints[0]))
 	}
 
-	// Read state saved during PrepareRequestData.
+	// Read state saved during Produce.
 	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.pluginState, request.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to read prefix plugin state", "requestID", request.RequestID)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -38,12 +38,12 @@ const (
 )
 
 var (
-	_ requestcontrol.DataProducer = &prepareData{}
-	_ requestcontrol.PreRequest   = &prepareData{}
+	_ requestcontrol.DataProducer = &dataProducer{}
+	_ requestcontrol.PreRequest   = &dataProducer{}
 )
 
-// prepareData is a plugin that prepares data consumed by approx prefix cache aware scheduling.
-type prepareData struct {
+// dataProducer is a plugin that produces data consumed by approx prefix cache aware scheduling.
+type dataProducer struct {
 	typedName   plugin.TypedName
 	config      config
 	indexerInst indexerInterface
@@ -52,18 +52,18 @@ type prepareData struct {
 }
 
 // TypedName returns the type and name of the plugin.
-func (p *prepareData) TypedName() plugin.TypedName {
+func (p *dataProducer) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
 // Produces returns the data produced by the plugin.
-func (p *prepareData) Produces() map[string]any {
+func (p *dataProducer) Produces() map[string]any {
 	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
 }
 
-// newPrepareData returns a new PrepareData plugin.
-func newPrepareData(ctx context.Context, config config, handle plugin.Handle) (*prepareData, error) {
-	log.FromContext(ctx).V(logutil.DEFAULT).Info("Prefix PrepareData initialized", "config", config)
+// newDataProducer returns a new DataProducer plugin.
+func newDataProducer(ctx context.Context, config config, handle plugin.Handle) (*dataProducer, error) {
+	log.FromContext(ctx).V(logutil.DEFAULT).Info("Prefix DataProducer initialized", "config", config)
 
 	//nolint:staticcheck // BlockSize is deprecated, but we check it here to provide a migration path for users.
 	if config.BlockSize > 0 && config.BlockSizeTokens <= 0 {
@@ -78,7 +78,7 @@ func newPrepareData(ctx context.Context, config config, handle plugin.Handle) (*
 	}
 	indexer := newIndexer(ctx, config.LRUCapacityPerServer)
 
-	p := &prepareData{
+	p := &dataProducer{
 		typedName: plugin.TypedName{
 			Type: ApproxPrefixCachePluginType,
 			Name: ApproxPrefixCachePluginType,
@@ -96,7 +96,7 @@ func newPrepareData(ctx context.Context, config config, handle plugin.Handle) (*
 }
 
 // CleanUpInactivePods starts a goroutine that periodically removes inactive pods from the indexer.
-func (p *prepareData) CleanUpInactivePods(ctx context.Context, handle plugin.Handle) {
+func (p *dataProducer) CleanUpInactivePods(ctx context.Context, handle plugin.Handle) {
 	ticker := time.NewTicker(podActiveCheckInterval)
 	defer ticker.Stop()
 
@@ -122,17 +122,17 @@ func (p *prepareData) CleanUpInactivePods(ctx context.Context, handle plugin.Han
 }
 
 // indexer returns the shared indexer.
-func (p *prepareData) indexer() indexerInterface {
+func (p *dataProducer) indexer() indexerInterface {
 	return p.indexerInst
 }
 
 // PluginState returns the shared plugin state.
-func (p *prepareData) PluginState() *plugin.PluginState {
+func (p *dataProducer) PluginState() *plugin.PluginState {
 	return p.pluginState
 }
 
 // Produce is called by the director before scheduling requests.
-func (p *prepareData) Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
+func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
 	blockSize := p.GetBlockSize(pods)
 	maxBlocks := p.config.MaxPrefixBlocksToMatch
 	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
@@ -161,7 +161,7 @@ func (p *prepareData) Produce(ctx context.Context, request *fwksched.InferenceRe
 
 // PreRequest records in the shared indexer the result of the scheduling selection.
 // It updates the indexer with the prefix hashes for the selected endpoint(s).
-func (p *prepareData) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
+func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
 	// Delete the state to avoid memory leak.
 	defer p.pluginState.Delete(request.RequestID)
 	primaryProfileResult := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
@@ -199,7 +199,7 @@ func (p *prepareData) PreRequest(ctx context.Context, request *fwksched.Inferenc
 	metrics.RecordPrefixCacheMatch(matchLen*blockSize*avgChars, total*blockSize*avgChars)
 }
 
-func (p *prepareData) makeserver(targetEndpoint fwksched.Endpoint) server {
+func (p *dataProducer) makeserver(targetEndpoint fwksched.Endpoint) server {
 	gpuBlocks := defaultLRUCapacityPerServer
 	if p.config.AutoTune && targetEndpoint.GetMetrics().CacheNumBlocks > 0 {
 		gpuBlocks = targetEndpoint.GetMetrics().CacheNumBlocks
@@ -211,7 +211,7 @@ func (p *prepareData) makeserver(targetEndpoint fwksched.Endpoint) server {
 }
 
 // matchLongestPrefix returns a map of servers and length of prefix that each server caches, prefix length is defined in blocks.
-func (p *prepareData) matchLongestPrefix(ctx context.Context, hashes []blockHash) map[ServerID]int {
+func (p *dataProducer) matchLongestPrefix(ctx context.Context, hashes []blockHash) map[ServerID]int {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)
 	res := make(map[ServerID]int)
 
@@ -230,7 +230,7 @@ func (p *prepareData) matchLongestPrefix(ctx context.Context, hashes []blockHash
 }
 
 // GetBlockSize returns the block size in tokens, potentially auto-tuned from endpoint metrics.
-func (p *prepareData) GetBlockSize(endpoints []fwksched.Endpoint) int {
+func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 	if !p.config.AutoTune || len(endpoints) == 0 {
 		return p.config.BlockSizeTokens
 	}
@@ -244,7 +244,7 @@ func (p *prepareData) GetBlockSize(endpoints []fwksched.Endpoint) int {
 	return p.config.BlockSizeTokens
 }
 
-// ApproxPrefixCacheFactory is the factory function for the prefix cache prepare data plugin.
+// ApproxPrefixCacheFactory is the factory function for the prefix cache data producer plugin.
 func ApproxPrefixCacheFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := defaultConfig
 	if rawParameters != nil {
@@ -253,8 +253,8 @@ func ApproxPrefixCacheFactory(name string, rawParameters json.RawMessage, handle
 		}
 	}
 
-	// pluginState will be initialized by newPrepareData as we pass nil here.
-	p, err := newPrepareData(handle.Context(), parameters, handle)
+	// pluginState will be initialized by newDataProducer as we pass nil here.
+	p, err := newDataProducer(handle.Context(), parameters, handle)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -34,7 +34,7 @@ import (
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
-func TestPrepareRequestData(t *testing.T) {
+func TestProduce(t *testing.T) {
 	config := config{
 		BlockSizeTokens:        1,
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
@@ -60,9 +60,9 @@ func TestPrepareRequestData(t *testing.T) {
 		},
 	}
 
-	// We need to simulate the PreRequest logic since PrepareRequestData only reads from the indexer.
-	// But first let's see if PrepareRequestData correctly handles an empty indexer.
-	err = p.PrepareRequestData(context.Background(), req1, endpoints)
+	// We need to simulate the PreRequest logic since Produce only reads from the indexer.
+	// But first let's see if Produce correctly handles an empty indexer.
+	err = p.Produce(context.Background(), req1, endpoints)
 	assert.NoError(t, err)
 
 	// Verify state was written to PluginState
@@ -101,7 +101,7 @@ func TestPreRequest(t *testing.T) {
 	}
 
 	// 1. Prepare data (this saves state)
-	_ = p.PrepareRequestData(context.Background(), req1, []fwksched.Endpoint{endpoint1})
+	_ = p.Produce(context.Background(), req1, []fwksched.Endpoint{endpoint1})
 
 	// 2. Simulate scheduling result
 	res := &fwksched.SchedulingResult{
@@ -181,7 +181,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
+	_ = p.Produce(context.Background(), req1, endpoints)
 	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	// Input size is 6, block size is 4, so 1 body block. Total hashes = 1 (model only is not a block)
 	assert.Equal(t, 2, len(state.PrefixHashes))
@@ -207,7 +207,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req3, endpoints)
+	_ = p.Produce(context.Background(), req3, endpoints)
 
 	// Verify pod1 has the correct prefix match info
 	info1, _ := endpoint1.Get(attrprefix.PrefixCacheMatchInfoKey)
@@ -251,7 +251,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
+	_ = p.Produce(context.Background(), req1, endpoints)
 	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	initialHashCount := len(state1.PrefixHashes)
 	assert.Greater(t, initialHashCount, 0)
@@ -281,7 +281,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req2, endpoints)
+	_ = p.Produce(context.Background(), req2, endpoints)
 	state2, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req2.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	extendedHashCount := len(state2.PrefixHashes)
 	assert.Greater(t, extendedHashCount, initialHashCount)
@@ -323,7 +323,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
+	_ = p.Produce(context.Background(), req1, endpoints)
 	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	initialHashCount := len(state1.PrefixHashes)
 	assert.Greater(t, initialHashCount, 0)
@@ -356,7 +356,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req2, endpoints)
+	_ = p.Produce(context.Background(), req2, endpoints)
 	info, _ := endpoint1.Get(attrprefix.PrefixCacheMatchInfoKey)
 	prefixInfo := info.(*attrprefix.PrefixCacheMatchInfo)
 
@@ -395,7 +395,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req1, endpoints)
+	_ = p.Produce(context.Background(), req1, endpoints)
 	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	initialHashCount := len(state1.PrefixHashes)
 	assert.Greater(t, initialHashCount, 0)
@@ -430,7 +430,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 			},
 		},
 	}
-	_ = p.PrepareRequestData(context.Background(), req2, endpoints)
+	_ = p.Produce(context.Background(), req2, endpoints)
 	info, _ := endpoint1.Get(attrprefix.PrefixCacheMatchInfoKey)
 	prefixInfo := info.(*attrprefix.PrefixCacheMatchInfo)
 	// Not a full cache hit as the image url has changed
@@ -466,7 +466,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	}
 	p, _ := newPrepareData(context.Background(), config, nil)
 
-	_ = p.PrepareRequestData(context.Background(), req, endpoints)
+	_ = p.Produce(context.Background(), req, endpoints)
 	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	// 128 chars / (16 tokens * 4 chars/token) = 2 blocks
 	assert.Equal(t, 2, len(state.PrefixHashes), "Should use pod block size (16 tokens) -> 2 body blocks")
@@ -512,7 +512,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 		},
 	}
 
-	err = p.PrepareRequestData(context.Background(), req, []fwksched.Endpoint{endpoint})
+	err = p.Produce(context.Background(), req, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
 	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
@@ -539,7 +539,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 		},
 	}
 
-	err = p2.PrepareRequestData(context.Background(), req2, []fwksched.Endpoint{endpoint})
+	err = p2.Produce(context.Background(), req2, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
 	state2, err := plugin.ReadPluginStateKey[*SchedulingContextState](p2.PluginState(), req2.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
@@ -577,7 +577,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = p.PrepareRequestData(context.Background(), req, endpoints)
+				_ = p.Produce(context.Background(), req, endpoints)
 				p.PluginState().Delete(req.RequestID)
 			}
 		})

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -100,7 +100,7 @@ func TestPreRequest(t *testing.T) {
 		},
 	}
 
-	// 1. Prepare data (this saves state)
+	// 1. Produce data (this saves state)
 	_ = p.Produce(context.Background(), req1, []fwksched.Endpoint{endpoint1})
 
 	// 2. Simulate scheduling result

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -41,7 +41,7 @@ func TestProduce(t *testing.T) {
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
 	// Test the "initialize if nil" pattern
-	p, err := newPrepareData(context.Background(), config, nil)
+	p, err := newDataProducer(context.Background(), config, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, p.PluginState())
 
@@ -87,7 +87,7 @@ func TestPreRequest(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newPrepareData(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil)
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 	req1 := &fwksched.InferenceRequest{
@@ -127,7 +127,7 @@ func TestPreRequest(t *testing.T) {
 	}
 }
 
-func TestPrepareDataValidation(t *testing.T) {
+func TestDataProducerValidation(t *testing.T) {
 	validConfigs := []config{{
 		AutoTune:        false,
 		BlockSizeTokens: 1,
@@ -148,12 +148,12 @@ func TestPrepareDataValidation(t *testing.T) {
 	}}
 
 	for _, config := range validConfigs {
-		_, err := newPrepareData(context.Background(), config, nil)
+		_, err := newDataProducer(context.Background(), config, nil)
 		assert.NoError(t, err)
 	}
 
 	for _, config := range invalidConfigs {
-		_, err := newPrepareData(context.Background(), config, nil)
+		_, err := newDataProducer(context.Background(), config, nil)
 		assert.Error(t, err)
 	}
 }
@@ -164,7 +164,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newPrepareData(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil)
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
@@ -233,7 +233,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newPrepareData(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil)
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1}
@@ -299,7 +299,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newPrepareData(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil)
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1}
@@ -371,7 +371,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newPrepareData(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil)
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1}
@@ -464,7 +464,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   1,
 	}
-	p, _ := newPrepareData(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil)
 
 	_ = p.Produce(context.Background(), req, endpoints)
 	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
@@ -493,7 +493,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 		MaxPrefixTokensToMatch: 2,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, err := newPrepareData(context.Background(), cfg, nil)
+	p, err := newDataProducer(context.Background(), cfg, nil)
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
@@ -526,7 +526,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 		MaxPrefixBlocksToMatch: 3,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p2, err := newPrepareData(context.Background(), cfg2, nil)
+	p2, err := newDataProducer(context.Background(), cfg2, nil)
 	assert.NoError(t, err)
 
 	req2 := &fwksched.InferenceRequest{
@@ -554,7 +554,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 		MaxPrefixBlocksToMatch: 50000,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newPrepareData(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil)
 
 	promptLen := []int{1024, 4096, 10000, 50000}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
@@ -2,10 +2,10 @@
 
 **Type:** `inflight-load-producer`
 
-Tracks real-time in-flight request and token counts per endpoint by hooking into the request lifecycle. Writes an `InFlightLoad` attribute onto each endpoint in the `PrepareRequestData` phase, consumed by the `token-load-scorer` and the `concurrency-detector`.
+Tracks real-time in-flight request and token counts per endpoint by hooking into the request lifecycle. Writes an `InFlightLoad` attribute onto each endpoint in the `Produce` phase, consumed by the `token-load-scorer` and the `concurrency-detector`.
 
 The producer hooks three lifecycle phases:
-- **PrepareRequestData**: Writes current in-flight counts to each endpoint's attributes.
+- **Produce**: Writes current in-flight counts to each endpoint's attributes.
 - **PreRequest**: Increments counters when a request is dispatched to an endpoint.
 - **ResponseBody**: Decrements counters when a response completes or the request is aborted.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -96,7 +96,7 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 	return nil
 }
 
-func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, e := range endpoints {
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(attrconcurrency.InFlightLoadKey, &attrconcurrency.InFlightLoad{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -31,7 +31,7 @@ import (
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 )
 
-func TestInFlightLoadProducer_PrepareRequestData(t *testing.T) {
+func TestInFlightLoadProducer_Produce(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
@@ -49,7 +49,7 @@ func TestInFlightLoadProducer_PrepareRequestData(t *testing.T) {
 	ctx := context.Background()
 	endpoints := []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}
 
-	err := producer.PrepareRequestData(ctx, nil, endpoints)
+	err := producer.Produce(ctx, nil, endpoints)
 	require.NoError(t, err)
 
 	// Verify AttributeMap population

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
@@ -6,11 +6,11 @@ Trains XGBoost models via a sidecar and generates per-endpoint TTFT/TPOT predict
 
 ## Interfaces
 
-PrepareDataPlugin, PreRequest, ResponseHeader, ResponseBody, Producer, Consumer
+DataProducerPlugin, PreRequest, ResponseHeader, ResponseBody, Producer, Consumer
 
 ## Responsibilities
 
-- Bulk predictions during `PrepareRequestData` (writes `LatencyPredictionInfo` to endpoint attributes)
+- Bulk predictions during `Produce` (writes `LatencyPredictionInfo` to endpoint attributes)
 - SLO headroom calculation per endpoint: `headroom = SLO - predicted_latency` (used by downstream scorer and admission plugins)
 - TTFT training data collection on first token / EOS
 - TPOT training data collection at EOS (streaming mode)
@@ -57,7 +57,7 @@ ensuring TPOT doesn't affect scoring, admission, or tier classification for pref
 |------|---------|
 | `plugin.go` | Struct, factory, config, per-request context, queue helpers |
 | `requestcontrol_hooks.go` | PreRequest, ResponseHeader, ResponseBody hooks |
-| `preparedata_hooks.go` | PrepareRequestData, Produces, Consumes |
+| `preparedata_hooks.go` | Produce, Produces, Consumes |
 | `training.go` | buildTrainingEntry, buildPredictionRequest, bulkPredict |
 | `prediction.go` | generatePredictions, validatePrediction, TPOT neutralization |
 | `decode_token_sampler.go` | Poisson-distributed token sampling for TPOT |

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
@@ -29,7 +29,7 @@ DataProducerPlugin, PreRequest, ResponseHeader, ResponseBody, Producer, Consumer
 | `contextTTL` | `5m` | TTL for per-request context in the cache |
 | `streamingMode` | `false` | Record TTFT on first chunk (true) vs EOS (false) |
 | `endpointRoleLabel` | `""` | Label key for disaggregated serving roles |
-| `predictInPrepareData` | `true` | Enable/disable bulk predictions. Set false for training-only mode |
+| `predictInProduce` | `true` | Enable/disable bulk predictions. Set false for training-only mode |
 
 ## Default Behavior (`streamingMode: false`)
 
@@ -57,7 +57,11 @@ ensuring TPOT doesn't affect scoring, admission, or tier classification for pref
 |------|---------|
 | `plugin.go` | Struct, factory, config, per-request context, queue helpers |
 | `requestcontrol_hooks.go` | PreRequest, ResponseHeader, ResponseBody hooks |
+<<<<<<< HEAD
 | `preparedata_hooks.go` | Produce, Produces, Consumes |
+=======
+| `dataproducer_hooks.go` | Produce, Produces, Consumes |
+>>>>>>> 5670f5c1 (refactor: complete internal naming and doc alignment with Produce/DataProducer terminology)
 | `training.go` | buildTrainingEntry, buildPredictionRequest, bulkPredict |
 | `prediction.go` | generatePredictions, validatePrediction, TPOT neutralization |
 | `decode_token_sampler.go` | Poisson-distributed token sampling for TPOT |

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
@@ -57,11 +57,7 @@ ensuring TPOT doesn't affect scoring, admission, or tier classification for pref
 |------|---------|
 | `plugin.go` | Struct, factory, config, per-request context, queue helpers |
 | `requestcontrol_hooks.go` | PreRequest, ResponseHeader, ResponseBody hooks |
-<<<<<<< HEAD
-| `preparedata_hooks.go` | Produce, Produces, Consumes |
-=======
 | `dataproducer_hooks.go` | Produce, Produces, Consumes |
->>>>>>> 5670f5c1 (refactor: complete internal naming and doc alignment with Produce/DataProducer terminology)
 | `training.go` | buildTrainingEntry, buildPredictionRequest, bulkPredict |
 | `prediction.go` | generatePredictions, validatePrediction, TPOT neutralization |
 | `decode_token_sampler.go` | Poisson-distributed token sampling for TPOT |

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/README.md
@@ -6,7 +6,7 @@ Trains XGBoost models via a sidecar and generates per-endpoint TTFT/TPOT predict
 
 ## Interfaces
 
-DataProducerPlugin, PreRequest, ResponseHeader, ResponseBody, Producer, Consumer
+DataProducer, PreRequest, ResponseHeader, ResponseBody, ProducerPlugin, ConsumerPlugin
 
 ## Responsibilities
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
@@ -56,8 +56,8 @@ func (pl *PredictedLatency) Produce(ctx context.Context, request *fwksched.Infer
 		}
 		predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().NamespacedName.Name] = prefixCacheScore
 	}
-	if !pl.config.PredictInPrepareData {
-		logger.V(logutil.DEBUG).Info("PredictInPrepareData disabled, skipping predictions")
+	if !pl.config.PredictInProduce {
+		logger.V(logutil.DEBUG).Info("PredictInProduce disabled, skipping predictions")
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -94,7 +94,7 @@ func (pl *PredictedLatency) Produce(ctx context.Context, request *fwksched.Infer
 		}
 	}
 
-	// Don't publish the SLO context after the director's PrepareData window has closed.
+	// Don't publish the SLO context after the director's Produce window has closed.
 	// If we did, PreRequest has already run (and skipped incrementing counters because the
 	// context wasn't yet present), but ResponseBody would later find the context and issue
 	// an orphan decrement — drifting prefillTokensInFlight negative under sustained load.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks_test.go
@@ -38,13 +38,13 @@ func TestProducesConsumes(t *testing.T) {
 }
 
 // TestProduce_CancelledContextDoesNotPublish verifies that when the
-// director's PrepareData window has already closed (ctx cancelled), the plugin
+// director's Produce window has already closed (ctx cancelled), the plugin
 // does not publish the SLO context into the ttlcache. If it did, ResponseBody
 // would later find the context and issue an orphan decrement against counters
 // PreRequest never incremented — draining prefillTokensInFlight negative.
 func TestProduce_CancelledContextDoesNotPublish(t *testing.T) {
 	cfg := DefaultConfig
-	cfg.PredictInPrepareData = false // skip the prediction sidecar path
+	cfg.PredictInProduce = false // skip the prediction sidecar path
 	pl := NewPredictedLatency(cfg, nil)
 
 	request := createTestInferenceRequest("cancel-test", 0, 0)
@@ -64,7 +64,7 @@ func TestProduce_CancelledContextDoesNotPublish(t *testing.T) {
 // cancellation test above: with a live context, the fast-path store still fires.
 func TestProduce_LiveContextPublishes(t *testing.T) {
 	cfg := DefaultConfig
-	cfg.PredictInPrepareData = false
+	cfg.PredictInProduce = false
 	pl := NewPredictedLatency(cfg, nil)
 
 	request := createTestInferenceRequest("live-test", 0, 0)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -56,7 +56,7 @@ const (
 )
 
 // PredictedLatency is the latency data provider plugin. It handles:
-//   - PrepareRequestData: bulk predictions via the latency predictor sidecar
+//   - Produce: bulk predictions via the latency predictor sidecar
 //   - PreRequest: dispatch-time bookkeeping (token counters, request queues)
 //   - ResponseHeader/ResponseBody: training data collection (TTFT/TPOT)
 //   - Produces/Consumes: endpoint attribute declarations
@@ -119,7 +119,7 @@ type Config struct {
 	StreamingMode                      bool          `json:"streamingMode,omitempty"`
 	EndpointRoleLabel                  string        `json:"endpointRoleLabel,omitempty"`
 	// PredictInPrepareData controls whether bulk predictions are generated during
-	// PrepareRequestData. Set to false to disable predictions (training-only mode).
+	// Produce. Set to false to disable predictions (training-only mode).
 	// When false, the predictor still collects training data but does not call the
 	// sidecar for predictions. Default: true.
 	PredictInPrepareData bool `json:"predictInPrepareData,omitempty"`

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -82,8 +82,8 @@ func (pl *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int
 // floor at zero, and removes the entry from the map once the counter reaches
 // zero. This is the only sanctioned way to decrement prefillTokensInFlight
 // (or any counter with the same shape): a naive Add(-delta) can drift the
-// counter negative if callers race (e.g. PrepareData publishing an SLO
-// context after PreRequest already skipped the increment), which used to
+// counter negative if callers race (e.g. Produce publishing an SLO
+// context after PreRequest already skipped the increment)
 // break prediction requests with `greater_than_equal: 0` validation errors.
 // Decrementing a missing key is a no-op and does not create a zero entry.
 func (pl *PredictedLatency) decrementEndpointCounter(m *sync.Map, key string, delta int64) {
@@ -118,11 +118,11 @@ type Config struct {
 	ContextTTL                         time.Duration `json:"contextTTL,omitempty"`
 	StreamingMode                      bool          `json:"streamingMode,omitempty"`
 	EndpointRoleLabel                  string        `json:"endpointRoleLabel,omitempty"`
-	// PredictInPrepareData controls whether bulk predictions are generated during
+	// PredictInProduce controls whether bulk predictions are generated during
 	// Produce. Set to false to disable predictions (training-only mode).
 	// When false, the predictor still collects training data but does not call the
 	// sidecar for predictions. Default: true.
-	PredictInPrepareData bool `json:"predictInPrepareData,omitempty"`
+	PredictInProduce bool `json:"predictInProduce,omitempty"`
 }
 
 var DefaultConfig = Config{
@@ -131,7 +131,7 @@ var DefaultConfig = Config{
 	SLOBufferFactor:                    1,
 	ContextTTL:                         5 * time.Minute,
 	StreamingMode:                      false,
-	PredictInPrepareData:               true,
+	PredictInProduce:                   true,
 }
 
 func PredictedLatencyFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks.go
@@ -31,9 +31,9 @@ import (
 
 var _ requestcontrol.DataProducer = &PredictedLatency{}
 
-// PrepareRequestData prepares the SLO context for the request, including
+// Produce prepares the SLO context for the request, including
 // parsing SLO headers, gathering prefix cache scores, and generating predictions.
-func (pl *PredictedLatency) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (pl *PredictedLatency) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	logger := log.FromContext(ctx)
 	predictedLatencyCtx := pl.getOrMakePredictedLatencyContextForRequest(request)
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/preparedata_hooks_test.go
@@ -37,12 +37,12 @@ func TestProducesConsumes(t *testing.T) {
 	assert.Contains(t, consumes, attrprefix.PrefixCacheMatchInfoKey)
 }
 
-// TestPrepareRequestData_CancelledContextDoesNotPublish verifies that when the
+// TestProduce_CancelledContextDoesNotPublish verifies that when the
 // director's PrepareData window has already closed (ctx cancelled), the plugin
 // does not publish the SLO context into the ttlcache. If it did, ResponseBody
 // would later find the context and issue an orphan decrement against counters
 // PreRequest never incremented — draining prefillTokensInFlight negative.
-func TestPrepareRequestData_CancelledContextDoesNotPublish(t *testing.T) {
+func TestProduce_CancelledContextDoesNotPublish(t *testing.T) {
 	cfg := DefaultConfig
 	cfg.PredictInPrepareData = false // skip the prediction sidecar path
 	pl := NewPredictedLatency(cfg, nil)
@@ -53,16 +53,16 @@ func TestPrepareRequestData_CancelledContextDoesNotPublish(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before the plugin runs
 
-	err := pl.PrepareRequestData(ctx, request, []fwksched.Endpoint{endpoint})
+	err := pl.Produce(ctx, request, []fwksched.Endpoint{endpoint})
 	assert.ErrorIs(t, err, context.Canceled, "should propagate ctx.Err() on cancelled context")
 
 	_, getErr := pl.getPredictedLatencyContextForRequest(request)
 	assert.Error(t, getErr, "SLO context should NOT be stored when ctx is cancelled")
 }
 
-// TestPrepareRequestData_LivesContextPublishes is the positive control for the
+// TestProduce_LivesContextPublishes is the positive control for the
 // cancellation test above: with a live context, the fast-path store still fires.
-func TestPrepareRequestData_LiveContextPublishes(t *testing.T) {
+func TestProduce_LiveContextPublishes(t *testing.T) {
 	cfg := DefaultConfig
 	cfg.PredictInPrepareData = false
 	pl := NewPredictedLatency(cfg, nil)
@@ -70,7 +70,7 @@ func TestPrepareRequestData_LiveContextPublishes(t *testing.T) {
 	request := createTestInferenceRequest("live-test", 0, 0)
 	endpoint := createTestEndpoint("pod-a", 0.1, 0, 0)
 
-	err := pl.PrepareRequestData(context.Background(), request, []fwksched.Endpoint{endpoint})
+	err := pl.Produce(context.Background(), request, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
 	_, getErr := pl.getPredictedLatencyContextForRequest(request)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -142,7 +142,7 @@ func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.
 			processFirstTokenForLatencyPrediction(ctx, pl.latencypredictor, pl.config.StreamingMode, pl.config.EndpointRoleLabel, predictedLatencyCtx, now, pl.config.SamplingMean, pl.config.MaxDecodeTokenSamplesForPrediction)
 
 			// Only decrement if PreRequest actually incremented the prefill pod counter.
-			// If PrepareData timed out, PreRequest may have skipped incrementing, and
+			// If Produce timed out, PreRequest may have skipped incrementing, and
 			// decrementing here would drift the counter negative.
 			if predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
 				prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
@@ -204,7 +204,7 @@ func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.
 
 		decodePodKey := targetMetadata.NamespacedName.String()
 		// Only decrement counters that PreRequest actually incremented. See the TTFT
-		// branch above for the rationale: PrepareData timeouts can leave PreRequest
+		// branch above for the rationale: Produce timeouts can leave PreRequest
 		// without an SLO context, so the counter was never bumped up, and decrementing
 		// here would orphan the pod's counter into negative territory.
 		if ttftNotYetRecorded && predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -811,8 +811,8 @@ func TestDecrementEndpointCounter_FloorAtZero(t *testing.T) {
 
 // TestPredictedLatency_ResponseBody_NoOrphanDecrement_WhenPreRequestSkipped
 // simulates the race that drove prefill counters negative in production: the
-// director's PrepareData window timed out, PreRequest saw no SLO context and
-// skipped the counter increment, but the PrepareData goroutine later published
+// director's Produce window timed out, PreRequest saw no SLO context and
+// skipped the counter increment, but the Produce goroutine later published
 // the context anyway. ResponseBody must refuse to decrement counters that
 // PreRequest never bumped up — otherwise prefillTokensInFlight drifts below
 // zero and the prediction server rejects every subsequent request with 422.
@@ -828,9 +828,9 @@ func TestPredictedLatency_ResponseBody_NoOrphanDecrement_WhenPreRequestSkipped(t
 	response := &requestcontrol.Response{EndOfStream: true}
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
-	// Build an SLO context the way PrepareData would have, but skip the
+	// Build an SLO context the way Produce would have, but skip the
 	// PreRequest step that would have incremented prefillTokensAtDispatch.
-	// This mirrors the production bug: PrepareData raced past the director's
+	// This mirrors the production bug: Produce raced past the director's
 	// timeout and published a context that PreRequest never saw.
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -36,11 +36,7 @@ schedulingProfiles:
         weight: 10
 ```
 
-<<<<<<< HEAD
-The framework auto-registers any plugin implementing `requestcontrol.DataProducer` into the `Produce` phase; no separate `prepareData:` block is required.
-=======
 The framework auto-registers any plugin implementing `requestcontrol.DataProducer` into the `Produce` phase; no separate `dataProducer:` block is required.
->>>>>>> 5670f5c1 (refactor: complete internal naming and doc alignment with Produce/DataProducer terminology)
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -36,7 +36,11 @@ schedulingProfiles:
         weight: 10
 ```
 
+<<<<<<< HEAD
 The framework auto-registers any plugin implementing `requestcontrol.DataProducer` into the `Produce` phase; no separate `prepareData:` block is required.
+=======
+The framework auto-registers any plugin implementing `requestcontrol.DataProducer` into the `Produce` phase; no separate `dataProducer:` block is required.
+>>>>>>> 5670f5c1 (refactor: complete internal naming and doc alignment with Produce/DataProducer terminology)
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -4,7 +4,7 @@
 
 Tokenizes the request prompt (text completions and multi-modal chat) and publishes the result on `InferenceRequestBody.TokenizedPrompt` for downstream consumers (scorers, filters, other data producers). Communicates over a Unix domain socket with a tokenizer sidecar from [`github.com/llm-d/llm-d-kv-cache`](https://github.com/llm-d/llm-d-kv-cache). Fail-open: tokenization errors are logged and scheduling continues with `TokenizedPrompt` left nil.
 
-Implements `requestcontrol.DataProducer` and runs in the `PrepareRequestData` phase, before filters and scorers. The plugin is idempotent: if `InferenceRequestBody.TokenizedPrompt` is already populated by an earlier producer, tokenization is skipped. Multi-modal features are flattened into the upstream list shape, sorted by placeholder offset.
+Implements `requestcontrol.DataProducer` and runs in the `Produce` phase, before filters and scorers. The plugin is idempotent: if `InferenceRequestBody.TokenizedPrompt` is already populated by an earlier producer, tokenization is skipped. Multi-modal features are flattened into the upstream list shape, sorted by placeholder offset.
 
 **Parameters:**
 - `modelName` (string, required): Model name whose tokenizer to load.
@@ -36,7 +36,7 @@ schedulingProfiles:
         weight: 10
 ```
 
-The framework auto-registers any plugin implementing `requestcontrol.DataProducer` into the `PrepareRequestData` phase; no separate `prepareData:` block is required.
+The framework auto-registers any plugin implementing `requestcontrol.DataProducer` into the `Produce` phase; no separate `prepareData:` block is required.
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -146,9 +146,6 @@ func (p *Plugin) Produces() map[string]any {
 // policy (currently: log and continue). If the request already carries a
 // TokenizedPrompt, tokenization is skipped.
 func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceRequest, _ []scheduling.Endpoint) error {
-	if request != nil && request.Body != nil && request.Body.TokenizedPrompt != nil {
-		return nil
-	}
 	tp, err := p.tokenize(ctx, request)
 	if err != nil {
 		return err

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -140,12 +140,15 @@ func (p *Plugin) Produces() map[string]any {
 	return map[string]any{TokenizedPromptKey: fwkrh.TokenizedPrompt{}}
 }
 
-// PrepareRequestData tokenizes the request prompt and stores the result on
+// Produce tokenizes the request prompt and stores the result on
 // InferenceRequestBody.TokenizedPrompt (TokenIDs + MultiModalFeatures in flat shape).
 // Returns an error when tokenization fails; the caller (Director) decides the
 // policy (currently: log and continue). If the request already carries a
 // TokenizedPrompt, tokenization is skipped.
-func (p *Plugin) PrepareRequestData(ctx context.Context, request *scheduling.InferenceRequest, _ []scheduling.Endpoint) error {
+func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceRequest, _ []scheduling.Endpoint) error {
+	if request != nil && request.Body != nil && request.Body.TokenizedPrompt != nil {
+		return nil
+	}
 	tp, err := p.tokenize(ctx, request)
 	if err != nil {
 		return err

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -103,7 +103,7 @@ func TestPluginFactory_Validation(t *testing.T) {
 	}
 }
 
-func TestPrepareRequestData_PopulatesTokenizedPrompt(t *testing.T) {
+func TestProduce_PopulatesTokenizedPrompt(t *testing.T) {
 	mm := &tokenization.MultiModalFeatures{
 		MMHashes: map[string][]string{"image": {"hash-a", "hash-b"}},
 		MMPlaceholders: map[string][]kvblock.PlaceholderRange{
@@ -124,7 +124,7 @@ func TestPrepareRequestData_PopulatesTokenizedPrompt(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, p.PrepareRequestData(context.Background(), req, nil))
+	require.NoError(t, p.Produce(context.Background(), req, nil))
 	require.NotNil(t, req.Body.TokenizedPrompt)
 	assert.Equal(t, []uint32{1, 2, 3, 4}, req.Body.TokenizedPrompt.TokenIDs)
 	require.Len(t, req.Body.TokenizedPrompt.MultiModalFeatures, 2)
@@ -136,25 +136,25 @@ func TestPrepareRequestData_PopulatesTokenizedPrompt(t *testing.T) {
 	assert.Equal(t, fwkrh.ModalityImage, req.Body.TokenizedPrompt.MultiModalFeatures[0].Modality)
 }
 
-func TestPrepareRequestData_SkipsWhenAlreadyPopulated(t *testing.T) {
+func TestProduce_SkipsWhenAlreadyPopulated(t *testing.T) {
 	existing := &fwkrh.TokenizedPrompt{TokenIDs: []uint32{42}}
 	p := newTestPlugin(&mockTokenizer{})
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{TokenizedPrompt: existing},
 	}
-	require.NoError(t, p.PrepareRequestData(context.Background(), req, nil))
+	require.NoError(t, p.Produce(context.Background(), req, nil))
 	assert.Same(t, existing, req.Body.TokenizedPrompt)
 }
 
-func TestPrepareRequestData_NilBody(t *testing.T) {
+func TestProduce_NilBody(t *testing.T) {
 	p := newTestPlugin(&mockTokenizer{})
 	req := &scheduling.InferenceRequest{}
-	err := p.PrepareRequestData(context.Background(), req, nil)
+	err := p.Produce(context.Background(), req, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "request body is nil")
 }
 
-func TestPrepareRequestData_TokenizerError(t *testing.T) {
+func TestProduce_TokenizerError(t *testing.T) {
 	tok := &mockTokenizer{
 		renderChatFunc: func(_ *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error) {
 			return nil, nil, assert.AnError
@@ -168,21 +168,22 @@ func TestPrepareRequestData_TokenizerError(t *testing.T) {
 			},
 		},
 	}
-	err := p.PrepareRequestData(context.Background(), req, nil)
+	err := p.Produce(context.Background(), req, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tokenization failed")
 	assert.Nil(t, req.Body.TokenizedPrompt)
 }
 
-func TestPrepareRequestData_UnsupportedBodyType(t *testing.T) {
+func TestProduce_UnsupportedBodyType(t *testing.T) {
 	p := newTestPlugin(&mockTokenizer{})
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{}, // no Completions or ChatCompletions
 	}
-	err := p.PrepareRequestData(context.Background(), req, nil)
+	err := p.Produce(context.Background(), req, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported request body type")
 	assert.Nil(t, req.Body.TokenizedPrompt)
+}
 }
 
 func TestConvertMMFeaturesRoundTrip(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -184,7 +184,6 @@ func TestProduce_UnsupportedBodyType(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported request body type")
 	assert.Nil(t, req.Body.TokenizedPrompt)
 }
-}
 
 func TestConvertMMFeaturesRoundTrip(t *testing.T) {
 	src := &tokenization.MultiModalFeatures{

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
@@ -199,8 +199,6 @@ Token count is estimated by dividing raw character length by 4 (a fixed approxim
 
 ##### Example
 ```yaml
-featureGates:
-- prepareDataPlugins
 plugins:
   - type: prefix-based-pd-decider
     parameters:
@@ -216,7 +214,6 @@ plugins:
 - `nonCachedTokens: 0` disables disaggregation entirely (the decider always returns false).
 - Token count is estimated (characters ÷ 4), not exact; behavior may differ for non-ASCII content.
 - Requires `PrefixCacheMatchInfo` on the decode endpoint; if absent, disaggregation is skipped with an error log.
-- Requires the `prepareDataPlugins` feature gate to be enabled.
 
 ---
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -112,7 +112,7 @@ func TestActiveRequestScorer_UsesInFlightLoadProducerLifecycle(t *testing.T) {
 	}
 
 	producer.PreRequest(ctx, req, result)
-	require.NoError(t, producer.PrepareRequestData(ctx, req, endpoints))
+	require.NoError(t, producer.Produce(ctx, req, endpoints))
 
 	require.Equal(t, int64(1), inFlightRequests(t, podA))
 	require.Equal(t, int64(0), inFlightRequests(t, podB))
@@ -122,7 +122,7 @@ func TestActiveRequestScorer_UsesInFlightLoadProducerLifecycle(t *testing.T) {
 
 	req.SchedulingResult = result
 	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
-	require.NoError(t, producer.PrepareRequestData(ctx, req, endpoints))
+	require.NoError(t, producer.Produce(ctx, req, endpoints))
 
 	require.Equal(t, int64(0), inFlightRequests(t, podA))
 	require.Equal(t, int64(0), inFlightRequests(t, podB))

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
@@ -146,7 +146,7 @@ The same scorer instance serves both roles (Scorer and EndpointExtractor),
 no second factory is needed.
 
 > [!NOTE]
-> The `tokenizer` PrepareData plugin is the preferred source of tokenized
+> The `tokenizer` DataProducer plugin is the preferred source of tokenized
 > prompts; the scorer's internal tokenization (via
 > `indexerConfig.tokenizersPoolConfig`) is a fallback and is being phased
 > out. New configs should declare a `tokenizer` plugin and reference it in

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -42,7 +42,7 @@ const (
 	defaultSpeculativeTTL = 2 * time.Second
 
 	// stateKey is the PluginState key used to share data between
-	// PrepareRequestData, Score, and PreRequest.
+	// Produce, Score, and PreRequest.
 	stateKey = plugin.StateKey("prefix-cache-state")
 
 	// experimentalPrefillProfile is the profile name for P/D disaggregation mode.
@@ -71,7 +71,7 @@ type PluginConfig struct {
 	KVEventsConfig *kvevents.Config `json:"kvEventsConfig"`
 	// SpeculativeIndexing enables speculative indexing. When true, the plugin
 	// proactively adds predicted cache entries to the index immediately after
-	// a routing decision (via PrepareRequestData and PreRequest), closing the
+	// a routing decision (via Produce and PreRequest), closing the
 	// blind spot between routing and KV event arrival.
 	// When false, only confirmed KV events populate the index.
 	SpeculativeIndexing bool `json:"speculativeIndexing"`
@@ -97,7 +97,7 @@ type speculativeEntries struct {
 	podEntries []kvblock.PodEntry
 }
 
-// precisePluginState holds data shared between PrepareRequestData, Score,
+// precisePluginState holds data shared between Produce, Score,
 // and PreRequest via PluginState.
 type precisePluginState struct {
 	blockKeys []kvblock.BlockHash
@@ -260,7 +260,7 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 // state, and the `kvevents.Pool` to subscribe to KV-cache events
 // to keep the internal KV-cache index state up-to-date.
 //
-// With speculative indexing, the scorer also implements PrepareDataPlugin and
+// With speculative indexing, the scorer also implements DataProducerPlugin and
 // PreRequest to proactively populate the index with expected cache entries
 // immediately after a routing decision, closing the blind spot between the
 // routing decision and the arrival of actual KV events from the engine.
@@ -276,7 +276,7 @@ type Scorer struct {
 	kvEventsConfig     *kvevents.Config
 
 	// pluginState stores per-request data (block keys, scores) shared
-	// between PrepareRequestData, Score, and PreRequest extension points.
+	// between Produce, Score, and PreRequest extension points.
 	pluginState *plugin.PluginState
 
 	// speculativeCache tracks speculative entries added to the index so that
@@ -288,7 +288,7 @@ type Scorer struct {
 	kvBlockScorer kvcache.KVBlockScorer
 
 	// blockSizeTokens is the number of tokens per KV-block, used for
-	// constructing PrefixCacheMatchInfo in PrepareRequestData.
+	// constructing PrefixCacheMatchInfo in Produce.
 	blockSizeTokens int
 
 	// speculativeEnabled controls whether speculative indexing is active.
@@ -328,7 +328,7 @@ func (s *Scorer) Category() scheduling.ScorerCategory {
 	return scheduling.Affinity
 }
 
-// --- PrepareDataPlugin implementation ---
+// --- DataProducerPlugin implementation ---
 
 // Produces declares the data keys this plugin writes to endpoints.
 func (s *Scorer) Produces() map[string]any {
@@ -337,11 +337,11 @@ func (s *Scorer) Produces() map[string]any {
 	}
 }
 
-// PrepareRequestData computes block keys, looks up the index, and stores
+// Produce computes block keys, looks up the index, and stores
 // per-endpoint prefix match information. The computed block keys and scores
 // are saved to PluginState for reuse by Score() and PreRequest().
 // This is a no-op when speculative indexing is disabled.
-func (s *Scorer) PrepareRequestData(ctx context.Context,
+func (s *Scorer) Produce(ctx context.Context,
 	request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) error {
 	if !s.speculativeEnabled {
 		return nil
@@ -395,7 +395,7 @@ func (s *Scorer) PrepareRequestData(ctx context.Context,
 		scores:    scores,
 	})
 
-	logger.V(logging.TRACE).Info("PrepareRequestData completed",
+	logger.V(logging.TRACE).Info("Produce completed",
 		"blockKeys", len(blockKeys), "scores", scores)
 
 	return nil
@@ -405,7 +405,7 @@ func (s *Scorer) PrepareRequestData(ctx context.Context,
 
 // Score scores the provided endpoint based on the KVCache index state.
 // The returned scores are normalized to a range of 0-1.
-// If PrepareRequestData was called beforehand, Score reuses the pre-computed
+// If Produce was called beforehand, Score reuses the pre-computed
 // results from PluginState. Otherwise, it falls back to computing scores
 // directly via getScores (backward compatible).
 func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
@@ -448,12 +448,12 @@ func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, r
 		span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
 	}
 
-	// Try to reuse pre-computed scores from PrepareRequestData
+	// Try to reuse pre-computed scores from Produce
 	var scores map[string]float64
 	if pluginStateData, err := plugin.ReadPluginStateKey[*precisePluginState](
 		s.pluginState, request.RequestID, stateKey); err == nil {
 		scores = pluginStateData.scores
-		debugLogger.Info("Reusing pre-computed scores from PrepareRequestData")
+		debugLogger.Info("Reusing pre-computed scores from Produce")
 	} else {
 		// Fallback: compute scores directly (backward compatible path).
 		var scoreErr error

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -633,9 +633,9 @@ func newTestScorer(t *testing.T) *Scorer {
 	return scorer
 }
 
-// TestPrepareRequestData_PopulatesPluginState verifies that PrepareRequestData
+// TestProduce_PopulatesPluginState verifies that Produce
 // stores block keys and scores in PluginState for later reuse by Score().
-func TestPrepareRequestData_PopulatesPluginState(t *testing.T) {
+func TestProduce_PopulatesPluginState(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	scorer := newTestScorer(t)
 
@@ -663,18 +663,18 @@ func TestPrepareRequestData_PopulatesPluginState(t *testing.T) {
 			}, nil, nil),
 	}
 
-	err := scorer.PrepareRequestData(ctx, request, endpoints)
+	err := scorer.Produce(ctx, request, endpoints)
 	require.NoError(t, err)
 
 	// Verify that PluginState was populated
 	state, err := readPrecisePluginState(scorer.pluginState, request.RequestId)
 	require.NoError(t, err)
 	require.NotNil(t, state)
-	assert.NotEmpty(t, state.blockKeys, "block keys should be populated after PrepareRequestData")
+	assert.NotEmpty(t, state.blockKeys, "block keys should be populated after Produce")
 }
 
 // TestScoreReusesPluginState verifies that Score() picks up the pre-computed
-// scores from PrepareRequestData via PluginState.
+// scores from Produce via PluginState.
 func TestScoreReusesPluginState(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	scorer := newTestScorer(t)
@@ -737,8 +737,8 @@ func TestScoreReusesPluginState(t *testing.T) {
 		},
 	}
 
-	// Call PrepareRequestData first (as would happen in a real flow)
-	err = scorer.PrepareRequestData(ctx, request, endpoints)
+	// Call Produce first (as would happen in a real flow)
+	err = scorer.Produce(ctx, request, endpoints)
 	require.NoError(t, err)
 
 	// Now call Score - it should reuse the state
@@ -790,8 +790,8 @@ func TestPreRequest_AddsSpeculativeEntries(t *testing.T) {
 		},
 	}
 
-	// 1. Call PrepareRequestData to populate PluginState
-	err := scorer.PrepareRequestData(ctx, request, endpoints)
+	// 1. Call Produce to populate PluginState
+	err := scorer.Produce(ctx, request, endpoints)
 	require.NoError(t, err)
 
 	// 2. Simulate scheduling result: selected pod-a as primary target
@@ -890,8 +890,8 @@ func TestSpeculativeEntriesEvictOnTTL(t *testing.T) {
 		},
 	}
 
-	// 1. PrepareRequestData + PreRequest
-	err = scorer.PrepareRequestData(ctx, request, endpoints)
+	// 1. Produce + PreRequest
+	err = scorer.Produce(ctx, request, endpoints)
 	require.NoError(t, err)
 
 	schedulingResult := &scheduling.SchedulingResult{

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -79,7 +79,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body:        nil,
 			},
@@ -123,7 +123,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -207,7 +207,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -318,7 +318,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -390,7 +390,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -460,7 +460,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -508,7 +508,7 @@ func TestPrefixCacheTracking_Score(t *testing.T) {
 				),
 			},
 			request: &scheduling.InferenceRequest{
-				RequestId:   "test-request",
+				RequestID:   "test-request",
 				TargetModel: "test-model",
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
@@ -645,7 +645,7 @@ func TestProduce_PopulatesPluginState(t *testing.T) {
 		"slightly domed and divided by arches into stiff sections."
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-prepare-request",
+		RequestID:   "test-prepare-request",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -667,7 +667,7 @@ func TestProduce_PopulatesPluginState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that PluginState was populated
-	state, err := readPrecisePluginState(scorer.pluginState, request.RequestId)
+	state, err := readPrecisePluginState(scorer.pluginState, request.RequestID)
 	require.NoError(t, err)
 	require.NotNil(t, state)
 	assert.NotEmpty(t, state.blockKeys, "block keys should be populated after Produce")
@@ -728,7 +728,7 @@ func TestScoreReusesPluginState(t *testing.T) {
 	}
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-reuse",
+		RequestID:   "test-reuse",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -781,7 +781,7 @@ func TestPreRequest_AddsSpeculativeEntries(t *testing.T) {
 	}
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-speculative",
+		RequestID:   "test-speculative",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -831,7 +831,7 @@ func TestPreRequest_AddsSpeculativeEntries(t *testing.T) {
 	assert.True(t, found, "Expected to find speculative entry for 10.0.0.1:8080")
 
 	// 5. Verify speculative entries appear in the TTL cache
-	item := scorer.speculativeCache.Get(request.RequestId)
+	item := scorer.speculativeCache.Get(request.RequestID)
 	require.NotNil(t, item, "Speculative entry should be in TTL cache")
 	assert.Equal(t, len(blockKeys), len(item.Value().blockKeys))
 }
@@ -881,7 +881,7 @@ func TestSpeculativeEntriesEvictOnTTL(t *testing.T) {
 	}
 
 	request := &scheduling.InferenceRequest{
-		RequestId:   "test-ttl-evict",
+		RequestID:   "test-ttl-evict",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -52,7 +52,7 @@ const (
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2081):
 	// Make this timeout configurable per-plugin or globally via the Director configuration to support plugins with
 	// varying latency profiles.
-	prepareDataTimeout = 400 * time.Millisecond
+	dataProducerTimeout = 400 * time.Millisecond
 )
 
 // Datastore defines the interface required by the Director.
@@ -197,10 +197,10 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 
 	snapshotOfCandidatePods := d.toSchedulerEndpoints(endpointCandidates)
-	// Prepare per request data by running PrepareData plugins.
-	err = d.runPrepareDataPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
+	// Prepare per request data by running DataProducer plugins.
+	err = d.runDataProducerPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if err != nil {
-		// Don't fail the request if PrepareData plugins fail.
+		// Don't fail the request if DataProducer plugins fail.
 		logger.Error(err, "failed to prepare per request data")
 	}
 
@@ -449,12 +449,12 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.I
 	}
 }
 
-func (d *Director) runPrepareDataPlugins(ctx context.Context,
+func (d *Director) runDataProducerPlugins(ctx context.Context,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
-	if len(d.requestControlPlugins.prepareDataPlugins) == 0 {
+	if len(d.requestControlPlugins.dataProducerPlugins) == 0 {
 		return nil
 	}
-	return prepareDataPluginsWithTimeout(ctx, prepareDataTimeout, d.requestControlPlugins.prepareDataPlugins, request, endpoints)
+	return dataProducerPluginsWithTimeout(ctx, dataProducerTimeout, d.requestControlPlugins.dataProducerPlugins, request, endpoints)
 }
 
 func (d *Director) runAdmissionPlugins(ctx context.Context,

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -456,7 +456,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 			targetModelName: model,
 		},
 		{
-			name: "successful chat completions request with prepare data plugins",
+			name: "successful chat completions request with DataProducer plugins",
 			reqBodyMap: map[string]any{
 				"model": model,
 				"messages": []any{

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -323,7 +323,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		wantReqCtx              *handlers.RequestContext // Fields to check in the returned RequestContext
 		targetModelName         string                   // Expected model name after target model resolution
 		admitRequestDenialError error                    // Expected denial error from admission plugin
-		dataProducerPlugin       *mockDataProducerPlugin
+		dataProducerPlugin      *mockDataProducerPlugin
 		preRequestPlugin        *mockPreRequestPlugin
 		wantMutatedBody         map[string]any
 	}{
@@ -490,7 +490,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 					},
 				},
 			},
-			targetModelName:   model,
+			targetModelName:    model,
 			dataProducerPlugin: newMockDataProducerPlugin("test-plugin"),
 		},
 		{

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -109,31 +109,31 @@ func (ds *mockDatastore) PodList(predicate func(fwkdl.Endpoint) bool) []fwkdl.En
 	return res
 }
 
-type mockPrepareDataPlugin struct {
+type mockDataProducerPlugin struct {
 	name     string
 	produces map[string]any
 	consumes map[string]any
 }
 
-func (m *mockPrepareDataPlugin) TypedName() fwkplugin.TypedName {
+func (m *mockDataProducerPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockPrepareDataPlugin) Produces() map[string]any {
+func (m *mockDataProducerPlugin) Produces() map[string]any {
 	return m.produces
 }
 
-func (m *mockPrepareDataPlugin) Consumes() map[string]any {
+func (m *mockDataProducerPlugin) Consumes() map[string]any {
 	return m.consumes
 }
 
-func (m *mockPrepareDataPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (m *mockDataProducerPlugin) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, mockProducedDataType{value: 42})
 	return nil
 }
 
-func newMockPrepareDataPlugin(name string) *mockPrepareDataPlugin {
-	return &mockPrepareDataPlugin{
+func newMockDataProducerPlugin(name string) *mockDataProducerPlugin {
+	return &mockDataProducerPlugin{
 		name:     name,
 		produces: map[string]any{mockProducedDataKey: 0},
 		consumes: map[string]any{},
@@ -323,7 +323,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		wantReqCtx              *handlers.RequestContext // Fields to check in the returned RequestContext
 		targetModelName         string                   // Expected model name after target model resolution
 		admitRequestDenialError error                    // Expected denial error from admission plugin
-		prepareDataPlugin       *mockPrepareDataPlugin
+		dataProducerPlugin       *mockDataProducerPlugin
 		preRequestPlugin        *mockPreRequestPlugin
 		wantMutatedBody         map[string]any
 	}{
@@ -491,7 +491,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 			},
 			targetModelName:   model,
-			prepareDataPlugin: newMockPrepareDataPlugin("test-plugin"),
+			dataProducerPlugin: newMockDataProducerPlugin("test-plugin"),
 		},
 		{
 			name: "successful chat completions request with admit request plugins",
@@ -749,8 +749,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 					test.schedulerMockSetup(mockSched)
 				}
 				config := NewConfig()
-				if test.prepareDataPlugin != nil {
-					config = config.WithPrepareDataPlugins(test.prepareDataPlugin)
+				if test.dataProducerPlugin != nil {
+					config = config.WithDataProducerPlugins(test.dataProducerPlugin)
 				}
 				if test.preRequestPlugin != nil {
 					config = config.WithPreRequestPlugins(test.preRequestPlugin)

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -19,6 +19,7 @@ package requestcontrol
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	fwkrc "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
@@ -31,7 +32,7 @@ import (
 func executePluginsAsDAG(ctx context.Context, plugins []fwkrc.DataProducer, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, plugin := range plugins {
 		if err := plugin.Produce(ctx, request, endpoints); err != nil {
-			return errors.New("prepare data plugin " + plugin.TypedName().String() + " failed: " + err.Error())
+			return fmt.Errorf("DataProducer %q failed: %w", plugin.TypedName().String(), err)
 		}
 	}
 	return nil
@@ -55,7 +56,7 @@ func dataProducerPluginsWithTimeout(ctx context.Context, timeout time.Duration, 
 		return err
 	case <-ctx.Done():
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return errors.New("prepare data plugin timed out")
+			return fmt.Errorf("DataProducer execution timed out: %w", ctx.Err())
 		}
 		return ctx.Err()
 	}

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -25,7 +25,7 @@ import (
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
-// executePluginsAsDAG executes PrepareData plugins as a DAG based on their dependencies asynchronously.
+// executePluginsAsDAG executes DataProducer plugins as a DAG based on their dependencies asynchronously.
 // So, a plugin is executed only after all its dependencies have been executed.
 // If there is a cycle or any plugin fails with error, it returns an error.
 func executePluginsAsDAG(ctx context.Context, plugins []fwkrc.DataProducer, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -30,17 +30,17 @@ import (
 // If there is a cycle or any plugin fails with error, it returns an error.
 func executePluginsAsDAG(ctx context.Context, plugins []fwkrc.DataProducer, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, plugin := range plugins {
-		if err := plugin.PrepareRequestData(ctx, request, endpoints); err != nil {
+		if err := plugin.Produce(ctx, request, endpoints); err != nil {
 			return errors.New("prepare data plugin " + plugin.TypedName().String() + " failed: " + err.Error())
 		}
 	}
 	return nil
 }
 
-// prepareDataPluginsWithTimeout executes the PrepareRequestData plugins with retries and timeout.
+// dataProducerPluginsWithTimeout executes DataProducer plugins with a timeout.
 // The child context is cancelled when the timeout fires so plugins can observe cancellation
 // (e.g. abort outbound HTTP calls) and avoid committing state after the director has moved on.
-func prepareDataPluginsWithTimeout(ctx context.Context, timeout time.Duration, plugins []fwkrc.DataProducer,
+func dataProducerPluginsWithTimeout(ctx context.Context, timeout time.Duration, plugins []fwkrc.DataProducer,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -30,20 +30,20 @@ import (
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
-var _ fwkrc.DataProducer = &mockPrepareRequestDataPlugin{}
+var _ fwkrc.DataProducer = &executorMockDataProducerPlugin{}
 
-type mockPrepareRequestDataPlugin struct {
+type executorMockDataProducerPlugin struct {
 	name      string
 	delay     time.Duration
 	returnErr error
 	executed  bool
 }
 
-func (m *mockPrepareRequestDataPlugin) TypedName() fwkplugin.TypedName {
+func (m *executorMockDataProducerPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock", Name: m.name}
 }
 
-func (m *mockPrepareRequestDataPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (m *executorMockDataProducerPlugin) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	m.executed = true
 	if m.delay > 0 {
 		select {
@@ -55,10 +55,9 @@ func (m *mockPrepareRequestDataPlugin) PrepareRequestData(ctx context.Context, r
 	return m.returnErr
 }
 
-func (m *mockPrepareRequestDataPlugin) Produces() map[string]any {
+func (m *executorMockDataProducerPlugin) Produces() map[string]any {
 	return nil
 }
-
 // ctxObservingPlugin records the context it received so tests can verify the
 // timeout wrapper cancels the plugin's context when the deadline fires.
 type ctxObservingPlugin struct {
@@ -72,7 +71,7 @@ func (p *ctxObservingPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock", Name: p.name}
 }
 
-func (p *ctxObservingPlugin) PrepareRequestData(ctx context.Context, _ *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
+func (p *ctxObservingPlugin) Produce(ctx context.Context, _ *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
 	defer p.wg.Done()
 	select {
 	case <-time.After(p.block):
@@ -84,17 +83,17 @@ func (p *ctxObservingPlugin) PrepareRequestData(ctx context.Context, _ *fwksched
 
 func (p *ctxObservingPlugin) Produces() map[string]any { return nil }
 
-// TestPrepareDataPluginsWithTimeout_CancelsPluginContext verifies that the
+// TestDataProducerPluginsWithTimeout_CancelsPluginContext verifies that the
 // child context passed to plugins is cancelled with DeadlineExceeded when the
 // timeout fires. Without this cancellation, a slow plugin would continue
 // executing past the director's deadline and potentially commit state after
 // downstream hooks have already observed an "empty" state — the root cause of
 // the orphan-decrement drift we're fixing in the predicted-latency producer.
-func TestPrepareDataPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
+func TestDataProducerPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
 	plugin := &ctxObservingPlugin{name: "slow", block: time.Second}
 	plugin.wg.Add(1)
 
-	err := prepareDataPluginsWithTimeout(
+	err := dataProducerPluginsWithTimeout(
 		context.Background(),
 		20*time.Millisecond,
 		[]fwkrc.DataProducer{plugin},
@@ -111,7 +110,7 @@ func TestPrepareDataPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
 		"plugin's context should be cancelled with DeadlineExceeded when timeout fires")
 }
 
-func TestPrepareDataPluginsWithTimeout(t *testing.T) {
+func TestDataProducerPluginsWithTimeout(t *testing.T) {
 	testCases := []struct {
 		name          string
 		timeout       time.Duration
@@ -125,21 +124,21 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			name:    "success with one plugin",
 			timeout: 100 * time.Millisecond,
 			plugins: []fwkrc.DataProducer{
-				&mockPrepareRequestDataPlugin{name: "p1"},
+				&executorMockDataProducerPlugin{name: "p1"},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
 			checkPlugins: func(t *testing.T, plugins []fwkrc.DataProducer) {
-				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
+				assert.True(t, plugins[0].(*executorMockDataProducerPlugin).executed)
 			},
 		},
 		{
 			name:    "plugin returns error",
 			timeout: 100 * time.Millisecond,
 			plugins: []fwkrc.DataProducer{
-				&mockPrepareRequestDataPlugin{name: "p1", returnErr: errors.New("plugin failed")},
+				&executorMockDataProducerPlugin{name: "p1", returnErr: errors.New("plugin failed")},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
@@ -150,7 +149,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			name:    "plugins time out",
 			timeout: 50 * time.Millisecond,
 			plugins: []fwkrc.DataProducer{
-				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
+				&executorMockDataProducerPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
@@ -161,7 +160,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			name:    "context cancelled",
 			timeout: 200 * time.Millisecond,
 			plugins: []fwkrc.DataProducer{
-				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
+				&executorMockDataProducerPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				ctx, cancel := context.WithCancel(context.Background())
@@ -174,16 +173,16 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			name:    "multiple plugins success",
 			timeout: 100 * time.Millisecond,
 			plugins: []fwkrc.DataProducer{
-				&mockPrepareRequestDataPlugin{name: "p1"},
-				&mockPrepareRequestDataPlugin{name: "p2"},
+				&executorMockDataProducerPlugin{name: "p1"},
+				&executorMockDataProducerPlugin{name: "p2"},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
 			checkPlugins: func(t *testing.T, plugins []fwkrc.DataProducer) {
-				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
-				assert.True(t, plugins[1].(*mockPrepareRequestDataPlugin).executed)
+				assert.True(t, plugins[0].(*executorMockDataProducerPlugin).executed)
+				assert.True(t, plugins[1].(*executorMockDataProducerPlugin).executed)
 			},
 		},
 	}
@@ -193,7 +192,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			ctx, cancel := tc.ctxFn()
 			defer cancel()
 
-			err := prepareDataPluginsWithTimeout(ctx, tc.timeout, tc.plugins, &fwksched.InferenceRequest{}, nil)
+			err := dataProducerPluginsWithTimeout(ctx, tc.timeout, tc.plugins, &fwksched.InferenceRequest{}, nil)
 
 			if tc.expectSuccess {
 				assert.NoError(t, err)
@@ -210,18 +209,18 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 }
 
 type dagTestPlugin struct {
-	mockPrepareRequestDataPlugin
+	executorMockDataProducerPlugin
 	produces map[string]any
 	consumes map[string]any
 	execTime time.Time
 	mu       sync.Mutex
 }
 
-func (p *dagTestPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (p *dagTestPlugin) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.execTime = time.Now()
-	return p.mockPrepareRequestDataPlugin.PrepareRequestData(ctx, request, endpoints)
+	return p.executorMockDataProducerPlugin.Produce(ctx, request, endpoints)
 }
 
 func (p *dagTestPlugin) Produces() map[string]any {
@@ -234,31 +233,31 @@ func (p *dagTestPlugin) Consumes() map[string]any {
 
 func TestExecutePluginsAsDAG(t *testing.T) {
 	pluginA := &dagTestPlugin{
-		mockPrepareRequestDataPlugin: mockPrepareRequestDataPlugin{name: "A", delay: 20 * time.Millisecond},
+		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "A", delay: 20 * time.Millisecond},
 		produces:                     map[string]any{"keyA": nil},
 	}
 	pluginB := &dagTestPlugin{
-		mockPrepareRequestDataPlugin: mockPrepareRequestDataPlugin{name: "B"},
+		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "B"},
 		consumes:                     map[string]any{"keyA": nil},
 		produces:                     map[string]any{"keyB": nil},
 	}
 	pluginC := &dagTestPlugin{
-		mockPrepareRequestDataPlugin: mockPrepareRequestDataPlugin{name: "C"},
+		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "C"},
 		consumes:                     map[string]any{"keyB": nil},
 	}
 	pluginD := &dagTestPlugin{
-		mockPrepareRequestDataPlugin: mockPrepareRequestDataPlugin{name: "D"},
+		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "D"},
 		consumes:                     map[string]any{"keyA": nil},
 	}
 	pluginE := &dagTestPlugin{
-		mockPrepareRequestDataPlugin: mockPrepareRequestDataPlugin{name: "E"},
+		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "E"},
 	}
 	pluginFail := &dagTestPlugin{
-		mockPrepareRequestDataPlugin: mockPrepareRequestDataPlugin{name: "Fail", returnErr: errors.New("plugin failed")},
+		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "Fail", returnErr: errors.New("plugin failed")},
 		produces:                     map[string]any{"keyFail": nil},
 	}
 	pluginDependsOnFail := &dagTestPlugin{
-		mockPrepareRequestDataPlugin: mockPrepareRequestDataPlugin{name: "DependsOnFail"},
+		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "DependsOnFail"},
 		consumes:                     map[string]any{"keyFail": nil},
 	}
 

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -58,6 +58,7 @@ func (m *executorMockDataProducerPlugin) Produce(ctx context.Context, request *f
 func (m *executorMockDataProducerPlugin) Produces() map[string]any {
 	return nil
 }
+
 // ctxObservingPlugin records the context it received so tests can verify the
 // timeout wrapper cancels the plugin's context when the deadline fires.
 type ctxObservingPlugin struct {
@@ -234,31 +235,31 @@ func (p *dagTestPlugin) Consumes() map[string]any {
 func TestExecutePluginsAsDAG(t *testing.T) {
 	pluginA := &dagTestPlugin{
 		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "A", delay: 20 * time.Millisecond},
-		produces:                     map[string]any{"keyA": nil},
+		produces:                       map[string]any{"keyA": nil},
 	}
 	pluginB := &dagTestPlugin{
 		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "B"},
-		consumes:                     map[string]any{"keyA": nil},
-		produces:                     map[string]any{"keyB": nil},
+		consumes:                       map[string]any{"keyA": nil},
+		produces:                       map[string]any{"keyB": nil},
 	}
 	pluginC := &dagTestPlugin{
 		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "C"},
-		consumes:                     map[string]any{"keyB": nil},
+		consumes:                       map[string]any{"keyB": nil},
 	}
 	pluginD := &dagTestPlugin{
 		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "D"},
-		consumes:                     map[string]any{"keyA": nil},
+		consumes:                       map[string]any{"keyA": nil},
 	}
 	pluginE := &dagTestPlugin{
 		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "E"},
 	}
 	pluginFail := &dagTestPlugin{
 		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "Fail", returnErr: errors.New("plugin failed")},
-		produces:                     map[string]any{"keyFail": nil},
+		produces:                       map[string]any{"keyFail": nil},
 	}
 	pluginDependsOnFail := &dagTestPlugin{
 		executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "DependsOnFail"},
-		consumes:                     map[string]any{"keyFail": nil},
+		consumes:                       map[string]any{"keyFail": nil},
 	}
 
 	testCases := []struct {

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -101,7 +101,7 @@ func TestDataProducerPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
 		nil,
 	)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "prepare data plugin timed out")
+	assert.Contains(t, err.Error(), "DataProducer execution timed out")
 
 	// Wait for the plugin goroutine to observe cancellation before asserting
 	// on the recorded context error.
@@ -143,7 +143,7 @@ func TestDataProducerPluginsWithTimeout(t *testing.T) {
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
-			expectErrStr: "prepare data plugin p1/mock failed: plugin failed",
+			expectErrStr: "DataProducer \"p1/mock\" failed: plugin failed",
 		},
 		{
 			name:    "plugins time out",
@@ -154,7 +154,7 @@ func TestDataProducerPluginsWithTimeout(t *testing.T) {
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
-			expectErrStr: "prepare data plugin timed out",
+			expectErrStr: "DataProducer execution timed out",
 		},
 		{
 			name:    "context cancelled",

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -25,7 +25,7 @@ import (
 func NewConfig() *Config {
 	return &Config{
 		admissionPlugins:         []fwkrc.Admitter{},
-		dataProducerPlugins:       []fwkrc.DataProducer{},
+		dataProducerPlugins:      []fwkrc.DataProducer{},
 		preRequestPlugins:        []fwkrc.PreRequest{},
 		responseReceivedPlugins:  []fwkrc.ResponseHeaderProcessor{},
 		responseStreamingPlugins: []fwkrc.ResponseBodyProcessor{},
@@ -35,7 +35,7 @@ func NewConfig() *Config {
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
 	admissionPlugins         []fwkrc.Admitter
-	dataProducerPlugins       []fwkrc.DataProducer
+	dataProducerPlugins      []fwkrc.DataProducer
 	preRequestPlugins        []fwkrc.PreRequest
 	responseReceivedPlugins  []fwkrc.ResponseHeaderProcessor
 	responseStreamingPlugins []fwkrc.ResponseBodyProcessor

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -25,7 +25,7 @@ import (
 func NewConfig() *Config {
 	return &Config{
 		admissionPlugins:         []fwkrc.Admitter{},
-		prepareDataPlugins:       []fwkrc.DataProducer{},
+		dataProducerPlugins:       []fwkrc.DataProducer{},
 		preRequestPlugins:        []fwkrc.PreRequest{},
 		responseReceivedPlugins:  []fwkrc.ResponseHeaderProcessor{},
 		responseStreamingPlugins: []fwkrc.ResponseBodyProcessor{},
@@ -35,7 +35,7 @@ func NewConfig() *Config {
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
 	admissionPlugins         []fwkrc.Admitter
-	prepareDataPlugins       []fwkrc.DataProducer
+	dataProducerPlugins       []fwkrc.DataProducer
 	preRequestPlugins        []fwkrc.PreRequest
 	responseReceivedPlugins  []fwkrc.ResponseHeaderProcessor
 	responseStreamingPlugins []fwkrc.ResponseBodyProcessor
@@ -62,9 +62,9 @@ func (c *Config) WithResponseStreamingPlugins(plugins ...fwkrc.ResponseBodyProce
 	return c
 }
 
-// WithPrepareDataPlugins sets the given plugins as the PrepareData plugins.
-func (c *Config) WithPrepareDataPlugins(plugins ...fwkrc.DataProducer) *Config {
-	c.prepareDataPlugins = plugins
+// WithDataProducerPlugins sets the given plugins as the DataProducer plugins.
+func (c *Config) WithDataProducerPlugins(plugins ...fwkrc.DataProducer) *Config {
+	c.dataProducerPlugins = plugins
 	return c
 }
 
@@ -88,8 +88,8 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 		if responseStreamingPlugin, ok := plugin.(fwkrc.ResponseBodyProcessor); ok {
 			c.responseStreamingPlugins = append(c.responseStreamingPlugins, responseStreamingPlugin)
 		}
-		if prepareDataPlugin, ok := plugin.(fwkrc.DataProducer); ok {
-			c.prepareDataPlugins = append(c.prepareDataPlugins, prepareDataPlugin)
+		if dataProducerPlugin, ok := plugin.(fwkrc.DataProducer); ok {
+			c.dataProducerPlugins = append(c.dataProducerPlugins, dataProducerPlugin)
 		}
 		if admissionPlugin, ok := plugin.(fwkrc.Admitter); ok {
 			c.admissionPlugins = append(c.admissionPlugins, admissionPlugin)
@@ -97,11 +97,11 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 	}
 }
 
-// OrderPrepareDataPlugins reorders the prepareDataPlugins in the Config based on the given sorted plugin names.
-func (c *Config) OrderPrepareDataPlugins(sortedPluginNames []string) {
+// OrderDataProducerPlugins reorders the DataProducer plugins in the Config based on the given sorted plugin names.
+func (c *Config) OrderDataProducerPlugins(sortedPluginNames []string) {
 	sortedPlugins := make([]fwkrc.DataProducer, 0, len(sortedPluginNames))
 	nameToPlugin := make(map[string]fwkrc.DataProducer)
-	for _, plugin := range c.prepareDataPlugins {
+	for _, plugin := range c.dataProducerPlugins {
 		nameToPlugin[plugin.TypedName().String()] = plugin
 	}
 	for _, name := range sortedPluginNames {
@@ -109,5 +109,5 @@ func (c *Config) OrderPrepareDataPlugins(sortedPluginNames []string) {
 			sortedPlugins = append(sortedPlugins, plugin)
 		}
 	}
-	c.prepareDataPlugins = sortedPlugins
+	c.dataProducerPlugins = sortedPlugins
 }

--- a/test/config/prefix_cache_mode_test.go
+++ b/test/config/prefix_cache_mode_test.go
@@ -48,9 +48,6 @@ schedulingProfiles:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.pluginName == "precisePrefixCache" {
-				t.Skip("Skipping precisePrefixCache test as it requires an external gRPC tokenizer (UDS socket) not available in this environment")
-			}
 			_ = os.Setenv("HF_TOKEN", "dummy_token") // needed for cache_tracking
 			rawConfig, _, err := loader.LoadRawConfig([]byte(test.configText), logr.Discard())
 			if err != nil {

--- a/test/config/prefix_cache_mode_test.go
+++ b/test/config/prefix_cache_mode_test.go
@@ -31,6 +31,9 @@ plugins:
 - name: precisePrefixCache
   type: precise-prefix-cache-scorer
   parameters:
+    indexerConfig:
+      tokenizersPoolConfig:
+        modelName: "test-model"
     kvEventsConfig:
       zmqEndpoint: "tcp://localhost:5557"
 - name: profileHandler
@@ -48,6 +51,9 @@ schedulingProfiles:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.pluginName == "precisePrefixCache" {
+				t.Skip("Skipping precisePrefixCache test as it requires an external gRPC tokenizer (UDS socket) not available in this environment")
+			}
 			_ = os.Setenv("HF_TOKEN", "dummy_token") // needed for cache_tracking
 			rawConfig, _, err := loader.LoadRawConfig([]byte(test.configText), logr.Discard())
 			if err != nil {

--- a/test/config/prefix_cache_mode_test.go
+++ b/test/config/prefix_cache_mode_test.go
@@ -31,9 +31,6 @@ plugins:
 - name: precisePrefixCache
   type: precise-prefix-cache-scorer
   parameters:
-    indexerConfig:
-      tokenizersPoolConfig:
-        modelName: "test-model"
     kvEventsConfig:
       zmqEndpoint: "tcp://localhost:5557"
 - name: profileHandler

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -209,8 +209,8 @@ schedulingProfiles:
     weight: 10
 `
 
-// EPP config for running with precise prefix scoring and external tokenizer PrepareData plugin.
-// The tokenizer plugin runs in the PrepareData phase (before scoring) and attaches
+// EPP config for running with precise prefix scoring and external tokenizer DataProducer plugin.
+// The tokenizer plugin runs in the Produce phase (before scoring) and attaches
 // pre-computed token IDs to the request, so the scorer skips internal tokenization.
 const kvExternalTokenizerConfig = `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -644,7 +644,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 		})
 	})
 
-	ginkgo.When("Running KV configuration with external tokenizer PrepareData plugin", func() {
+	ginkgo.When("Running KV configuration with external tokenizer DataProducer plugin", func() {
 		ginkgo.It("should run successfully", func() {
 			infPoolObjects = createInferencePool(1, true)
 

--- a/test/profiling/tokenizerbench/benchmark_test.go
+++ b/test/profiling/tokenizerbench/benchmark_test.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package external_tokenizer_scorer benchmarks the end-to-end request flow
-// through the EPP when using the external tokenizer PrepareData plugin
+// through the EPP when using the external tokenizer DataProducer plugin
 // combined with the precise-prefix-cache-scorer.
 //
 // Prerequisites:


### PR DESCRIPTION

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind cleanup
**What this PR does / why we need it**:
Renames the DataProducer interface method from PrepareRequestData to Produce and the prepareDataPlugins field to dataProducerPlugins. Also removes the now obsolete prepareDataPlugins feature gate from configurations and documentation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #971

**Testing**

unit tests

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
prepareDataPlugins feature gate has been graduated fully. It will no longer be supported.
```
