### PR TITLE
Inflightload tokens accounting

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -19,6 +19,7 @@ package inflightload
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 	inflightloadconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/constants"
 )
@@ -40,13 +42,31 @@ const (
 	profilePrefill           = "prefill"
 )
 
-func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+// Config controls optional behaviors of InFlightLoadProducer.
+type Config struct {
+	// IncludeOutputTokens controls whether estimated output tokens are added to
+	// the in-flight token counter. Defaults to true to preserve historical behavior.
+	IncludeOutputTokens bool `json:"includeOutputTokens"`
+}
+
+func defaultConfig() Config {
+	return Config{IncludeOutputTokens: true}
+}
+
+func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	cfg := defaultConfig()
+	if len(rawParameters) > 0 {
+		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal inflight-load-producer parameters: %w", err)
+		}
+	}
 	return &InFlightLoadProducer{
-		typedName:      fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
-		dk:             attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: cfg.IncludeOutputTokens,
+		dk:                  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
 	}, nil
 }
 
@@ -59,11 +79,20 @@ var (
 )
 
 type InFlightLoadProducer struct {
-	typedName      fwkplugin.TypedName
-	requestTracker *concurrencyTracker
-	tokenTracker   *concurrencyTracker
-	tokenEstimator TokenEstimator
-	dk             fwkplugin.DataKey
+	typedName           fwkplugin.TypedName
+	requestTracker      *concurrencyTracker
+	tokenTracker        *concurrencyTracker
+	tokenEstimator      TokenEstimator
+	includeOutputTokens bool
+	// addedTokens tracks the exact token amount added per (requestID, endpointID, profileName)
+	// so release subtracts the same value (accounting for prefix-cache discount).
+	// The profile name is part of the key so that multiple profiles targeting the
+	// same endpoint each track their own increment independently and a release
+	// for one profile cannot subtract another profile's value (which would leak
+	// or double-count tokens).
+	// Key format: "<requestID>|<endpointID>|<profileName>".
+	addedTokens sync.Map
+	dk          fwkplugin.DataKey
 }
 
 func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
@@ -99,7 +128,7 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 	return nil
 }
 
-func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, e := range endpoints {
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(p.dk.String(), &attrconcurrency.InFlightLoad{
@@ -115,7 +144,9 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		return
 	}
 
-	for _, profileResult := range result.ProfileResults {
+	inputTokens := p.tokenEstimator.EstimateInput(request)
+
+	for profileName, profileResult := range result.ProfileResults {
 		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 			continue
 		}
@@ -126,8 +157,22 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		}
 		eid := endpoint.GetMetadata().NamespacedName.String()
 		p.requestTracker.inc(eid)
-		tokens := p.tokenEstimator.Estimate(request)
+
+		// Compute the uncached prompt portion this endpoint must actually compute.
+		// Prefer the prefix producer's view (real tokens) when available so the
+		// match-length and the input length are in the same units; fall back to
+		// the (estimated) input tokens otherwise.
+		adjustedInput := uncachedInputTokens(endpoint, inputTokens)
+		tokens := adjustedInput
+		if p.includeOutputTokens {
+			// Output tokens are based on the full input, not the cached portion.
+			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+		}
+
 		p.tokenTracker.add(eid, tokens)
+		if request != nil && request.RequestID != "" {
+			p.addedTokens.Store(addedTokensKey(request.RequestID, eid, profileName), tokens)
+		}
 	}
 }
 
@@ -146,11 +191,25 @@ func (p *InFlightLoadProducer) ResponseBody(
 		return
 	}
 
-	// 1. Early Prefill Release (on first chunk)
+	// When output tokens are excluded, the in-flight token estimate represents only
+	// the prompt cost, which is consumed by prefill. As soon as the first chunk
+	// arrives (StartOfStream), prefill is done across all profiles, so free the
+	// token counters for every targeted endpoint regardless of profile name.
+	// Request counters are still released on EndOfStream below.
+	if !p.includeOutputTokens && resp.StartOfStream {
+		for profileName, profileResult := range result.ProfileResults {
+			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
+				continue
+			}
+			p.releaseTokens(profileResult.TargetEndpoints[0], request, profileName)
+		}
+	}
+
+	// 1. Early Prefill Release (on first chunk) — original behavior.
 	// Uses the new StartOfStream signal provided by the framework.
-	if resp.StartOfStream {
+	if p.includeOutputTokens && resp.StartOfStream {
 		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
-			p.release(prefillResult.TargetEndpoints[0], request)
+			p.release(prefillResult.TargetEndpoints[0], request, profilePrefill)
 		}
 	}
 
@@ -160,29 +219,142 @@ func (p *InFlightLoadProducer) ResponseBody(
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 				continue
 			}
+			endpoint := profileResult.TargetEndpoints[0]
+
+			if !p.includeOutputTokens {
+				// Tokens are normally freed at StartOfStream; also call
+				// releaseTokens here as a safety net for non-streaming or
+				// error paths where StartOfStream may not be observed. It is
+				// a no-op via LoadAndDelete if tokens were already released.
+				p.release(endpoint, request, name)
+				continue
+			}
+
 			// Skip "prefill" as it was already released in the StartOfStream block.
 			// This works perfectly even if StartOfStream and EndOfStream are both true (single chunk).
 			if name == profilePrefill {
 				continue
 			}
-			p.release(profileResult.TargetEndpoints[0], request)
+			p.release(endpoint, request, name)
 		}
 	}
 }
 
-func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
+	p.releaseRequest(endpoint)
+	p.releaseTokens(endpoint, request, profileName)
+}
+
+func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
 	if endpoint == nil || endpoint.GetMetadata() == nil {
 		return
 	}
 	eid := endpoint.GetMetadata().NamespacedName.String()
 	p.requestTracker.dec(eid)
-	tokens := p.tokenEstimator.Estimate(request)
-	p.tokenTracker.add(eid, -tokens)
+}
+
+func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
+	if endpoint == nil || endpoint.GetMetadata() == nil {
+		return
+	}
+	eid := endpoint.GetMetadata().NamespacedName.String()
+
+	// Prefer the exact value stored in PreRequest to keep counters balanced.
+	// LoadAndDelete makes this idempotent per (requestID, endpointID, profileName):
+	// a second call for the same key finds nothing and is a no-op below (we do
+	// NOT fall back to Estimate when the request carries a real RequestID, since
+	// the absence of the key means "already released").
+	if request != nil && request.RequestID != "" {
+		key := addedTokensKey(request.RequestID, eid, profileName)
+		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
+			if tokens, ok := v.(int64); ok && tokens != 0 {
+				p.tokenTracker.add(eid, -tokens)
+			}
+		}
+		// Either we just released the stored value, or the key was already
+		// released by a previous call — both cases are no-ops here.
+		return
+	}
+
+	// Fallback: re-estimate. Covers tests/legacy paths that bypass PreRequest
+	// (request is nil or has no RequestID, so nothing was stored to release).
+	// Mirror PreRequest's accounting so we subtract the same amount we would
+	// have added: uncached input tokens, plus output tokens only when
+	// includeOutputTokens is true. Using tokenEstimator.Estimate() here would
+	// ignore both the includeOutputTokens=false semantics and any prefix-cache
+	// discount applied at PreRequest time, leading to over/under-decrement.
+	inputTokens := p.tokenEstimator.EstimateInput(request)
+	tokens := uncachedInputTokens(endpoint, inputTokens)
+	if p.includeOutputTokens {
+		tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+	}
+	if tokens != 0 {
+		p.tokenTracker.add(eid, -tokens)
+	}
+}
+
+func addedTokensKey(requestID, endpointID, profileName string) string {
+	return requestID + "|" + endpointID + "|" + profileName
+}
+
+// uncachedInputTokens returns the prompt tokens this endpoint must actually compute,
+// excluding any prefix already cached on it.
+//
+// When the approximate prefix producer has populated PrefixCacheMatchInfo on the
+// endpoint, the matched and total block counts are in real (tokenized) units, so
+// we use them directly: uncached = (TotalBlocks - MatchBlocks) * BlockSizeTokens.
+// For very long prompts where the prefix index is capped (MaxPrefixTokensToMatch),
+// any tail beyond the cap is added back from the (estimated) inputTokens so the
+// full prompt cost is still reflected.
+//
+// When the attribute is missing, we fall back to the estimated inputTokens.
+func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64) int64 {
+	if endpoint == nil {
+		return nonNeg(inputTokens)
+	}
+	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
+	if !ok {
+		return nonNeg(inputTokens)
+	}
+	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
+	if !ok || info == nil || info.BlockSizeTokens() <= 0 {
+		return nonNeg(inputTokens)
+	}
+
+	blockSize := int64(info.BlockSizeTokens())
+	matched := int64(info.MatchBlocks()) * blockSize
+	indexed := int64(info.TotalBlocks()) * blockSize
+
+	uncachedIndexed := indexed - matched
+	if uncachedIndexed < 0 {
+		uncachedIndexed = 0
+	}
+
+	// Tail beyond the indexed portion (e.g., when MaxPrefixTokensToMatch caps total).
+	tail := inputTokens - indexed
+	if tail < 0 {
+		tail = 0
+	}
+
+	return uncachedIndexed + tail
+}
+
+func nonNeg(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
 }
 
 func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
 		p.dk: attrconcurrency.InFlightLoad{},
+	}
+}
+
+func (p *InFlightLoadProducer) Consumes() map[string]any {
+	return map[string]any{
+		attrprefix.PrefixCacheMatchInfoKey: (*attrprefix.PrefixCacheMatchInfo)(nil),
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -45,12 +45,12 @@ const (
 // Config controls optional behaviors of InFlightLoadProducer.
 type Config struct {
 	// AddEstimatedOutputTokens controls whether estimated output tokens are added to
-	// the in-flight token counter. Defaults to true to preserve historical behavior.
+	// the in-flight token counter. Defaults to false.
 	AddEstimatedOutputTokens bool `json:"addEstimatedOutputTokens"`
 }
 
 func defaultConfig() Config {
-	return Config{AddEstimatedOutputTokens: true}
+	return Config{AddEstimatedOutputTokens: false}
 }
 
 func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -44,13 +44,13 @@ const (
 
 // Config controls optional behaviors of InFlightLoadProducer.
 type Config struct {
-	// IncludeOutputTokens controls whether estimated output tokens are added to
+	// AddEstimatedOutputTokens controls whether estimated output tokens are added to
 	// the in-flight token counter. Defaults to true to preserve historical behavior.
-	IncludeOutputTokens bool `json:"includeOutputTokens"`
+	AddEstimatedOutputTokens bool `json:"addEstimatedOutputTokens"`
 }
 
 func defaultConfig() Config {
-	return Config{IncludeOutputTokens: true}
+	return Config{AddEstimatedOutputTokens: true}
 }
 
 func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -61,12 +61,12 @@ func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ f
 		}
 	}
 	return &InFlightLoadProducer{
-		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: cfg.IncludeOutputTokens,
-		dk:                  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
+		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
 	}, nil
 }
 
@@ -79,11 +79,11 @@ var (
 )
 
 type InFlightLoadProducer struct {
-	typedName           fwkplugin.TypedName
-	requestTracker      *concurrencyTracker
-	tokenTracker        *concurrencyTracker
-	tokenEstimator      TokenEstimator
-	includeOutputTokens bool
+	typedName                fwkplugin.TypedName
+	requestTracker           *concurrencyTracker
+	tokenTracker             *concurrencyTracker
+	tokenEstimator           TokenEstimator
+	addEstimatedOutputTokens bool
 	// addedTokens tracks the exact token amount added per (requestID, endpointID, profileName)
 	// so release subtracts the same value (accounting for prefix-cache discount).
 	// The profile name is part of the key so that multiple profiles targeting the
@@ -128,7 +128,7 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 	return nil
 }
 
-func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, e := range endpoints {
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(p.dk.String(), &attrconcurrency.InFlightLoad{
@@ -164,7 +164,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		// the (estimated) input tokens otherwise.
 		adjustedInput := uncachedInputTokens(endpoint, inputTokens)
 		tokens := adjustedInput
-		if p.includeOutputTokens {
+		if p.addEstimatedOutputTokens {
 			// Output tokens are based on the full input, not the cached portion.
 			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
 		}
@@ -196,7 +196,7 @@ func (p *InFlightLoadProducer) ResponseBody(
 	// arrives (StartOfStream), prefill is done across all profiles, so free the
 	// token counters for every targeted endpoint regardless of profile name.
 	// Request counters are still released on EndOfStream below.
-	if !p.includeOutputTokens && resp.StartOfStream {
+	if !p.addEstimatedOutputTokens && resp.StartOfStream {
 		for profileName, profileResult := range result.ProfileResults {
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 				continue
@@ -207,7 +207,7 @@ func (p *InFlightLoadProducer) ResponseBody(
 
 	// 1. Early Prefill Release (on first chunk) — original behavior.
 	// Uses the new StartOfStream signal provided by the framework.
-	if p.includeOutputTokens && resp.StartOfStream {
+	if p.addEstimatedOutputTokens && resp.StartOfStream {
 		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
 			p.release(prefillResult.TargetEndpoints[0], request, profilePrefill)
 		}
@@ -221,7 +221,7 @@ func (p *InFlightLoadProducer) ResponseBody(
 			}
 			endpoint := profileResult.TargetEndpoints[0]
 
-			if !p.includeOutputTokens {
+			if !p.addEstimatedOutputTokens {
 				// Tokens are normally freed at StartOfStream; also call
 				// releaseTokens here as a safety net for non-streaming or
 				// error paths where StartOfStream may not be observed. It is
@@ -280,12 +280,12 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 	// (request is nil or has no RequestID, so nothing was stored to release).
 	// Mirror PreRequest's accounting so we subtract the same amount we would
 	// have added: uncached input tokens, plus output tokens only when
-	// includeOutputTokens is true. Using tokenEstimator.Estimate() here would
-	// ignore both the includeOutputTokens=false semantics and any prefix-cache
-	// discount applied at PreRequest time, leading to over/under-decrement.
+	// addEstimatedOutputTokens is true. Using tokenEstimator.Estimate() here would
+	// ignore both the addEstimatedOutputTokens=false semantics and any prefix-cache
+	// discount applied at PreRequest time, leading over/under-decrement.
 	inputTokens := p.tokenEstimator.EstimateInput(request)
 	tokens := uncachedInputTokens(endpoint, inputTokens)
-	if p.includeOutputTokens {
+	if p.addEstimatedOutputTokens {
 		tokens += p.tokenEstimator.EstimateOutput(inputTokens)
 	}
 	if tokens != 0 {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -128,7 +128,7 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 	return nil
 }
 
-func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, e := range endpoints {
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(p.dk.String(), &attrconcurrency.InFlightLoad{
@@ -312,7 +312,7 @@ func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64) int64 {
 	if endpoint == nil {
 		return nonNeg(inputTokens)
 	}
-	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
+	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoDataKey.String())
 	if !ok {
 		return nonNeg(inputTokens)
 	}
@@ -354,7 +354,7 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 
 func (p *InFlightLoadProducer) Consumes() map[string]any {
 	return map[string]any{
-		attrprefix.PrefixCacheMatchInfoKey: (*attrprefix.PrefixCacheMatchInfo)(nil),
+		attrprefix.PrefixCacheMatchInfoDataKey.String(): (*attrprefix.PrefixCacheMatchInfo)(nil),
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -128,7 +128,7 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 	return nil
 }
 
-func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, e := range endpoints {
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(p.dk.String(), &attrconcurrency.InFlightLoad{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -34,11 +34,12 @@ import (
 
 func newTestProducer() *InFlightLoadProducer {
 	return &InFlightLoadProducer{
-		typedName:      fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: "inflight-load-producer"},
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
-		dk:             attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
+		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: "inflight-load-producer"},
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+		dk:                  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName("inflight-load-producer"),
 	}
 }
 
@@ -57,11 +58,11 @@ func TestInFlightLoadProducer_Produce(t *testing.T) {
 	ctx := context.Background()
 	endpoints := []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}
 
-	err := producer.Produce(ctx, nil, endpoints)
+	err := producer.PrepareRequestData(ctx, nil, endpoints)
 	require.NoError(t, err)
 
 	// Verify AttributeMap population
-	key := attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(producer.typedName.Name).String()
+	key := producer.dk.String()
 	val, ok := endpoints[0].Get(key)
 	require.True(t, ok)
 	load := val.(*attrconcurrency.InFlightLoad)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -59,7 +59,7 @@ func TestInFlightLoadProducer_Produce(t *testing.T) {
 	ctx := context.Background()
 	endpoints := []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}
 
-	err := producer.PrepareRequestData(ctx, nil, endpoints)
+	err := producer.Produce(ctx, nil, endpoints)
 	require.NoError(t, err)
 
 	// Verify AttributeMap population
@@ -334,7 +334,7 @@ func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
 	//   uncached_input = (2-1)*4 + max(0, 8-2*4) = 4
 	//   total tokens = 4 + 12 = 16
 	endpoint := newStubSchedulingEndpoint(endpointName)
-	endpoint.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+	endpoint.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
 
 	req := makeTokenRequest("req-prefix", "12345678901234567890123456789012")
 	res := &fwksched.SchedulingResult{
@@ -377,9 +377,9 @@ func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
 
 	// 8 input tokens, output 12.
 	epA := newStubSchedulingEndpoint(podA)
-	epA.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(2, 2, 4)) // fully cached
+	epA.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), attrprefix.NewPrefixCacheMatchInfo(2, 2, 4)) // fully cached
 	epB := newStubSchedulingEndpoint(podB)
-	epB.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(0, 2, 4)) // none cached
+	epB.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), attrprefix.NewPrefixCacheMatchInfo(0, 2, 4)) // none cached
 
 	req := makeTokenRequest("req-multi-cache", "12345678901234567890123456789012")
 	res := &fwksched.SchedulingResult{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -35,12 +35,12 @@ import (
 
 func newTestProducer() *InFlightLoadProducer {
 	return &InFlightLoadProducer{
-		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: "inflight-load-producer"},
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: true,
-		dk:                  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName("inflight-load-producer"),
+		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: "inflight-load-producer"},
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: true,
+		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName("inflight-load-producer"),
 	}
 }
 
@@ -253,16 +253,16 @@ func makeTokenRequest(requestID, prompt string) *fwksched.InferenceRequest {
 }
 
 // TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease verifies that when
-// IncludeOutputTokens is false, token counters are released as soon as the first chunk
+// AddEstimatedOutputTokens is false, token counters are released as soon as the first chunk
 // arrives (StartOfStream), while request counters are released only on EndOfStream.
 func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: false,
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: false,
 	}
 	ctx := context.Background()
 	endpointName := "exclude-output-endpoint"
@@ -293,10 +293,10 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: false,
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: false,
 	}
 	ctx := context.Background()
 	endpointName := "single-chunk-endpoint"
@@ -320,10 +320,10 @@ func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: true,
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: true,
 	}
 	ctx := context.Background()
 	endpointName := "prefix-cache-endpoint"
@@ -364,10 +364,10 @@ func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: true,
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: true,
 	}
 	ctx := context.Background()
 	podA := "pod-a-cached"
@@ -412,10 +412,10 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: true,
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: true,
 	}
 	ctx := context.Background()
 	endpointName := "shared-endpoint"
@@ -450,7 +450,7 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 }
 
 // TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart verifies the
-// safety net for non-streaming or error paths: when includeOutputTokens=false and
+// safety net for non-streaming or error paths: when addEstimatedOutputTokens=false and
 // ResponseBody delivers EndOfStream without ever seeing StartOfStream, the token
 // counter and request counter must both drain (tokens are normally released at
 // StartOfStream, so a missing StartOfStream would otherwise leak them). Also
@@ -459,10 +459,10 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *tes
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker:      newConcurrencyTracker(),
-		tokenTracker:        newConcurrencyTracker(),
-		tokenEstimator:      NewSimpleTokenEstimator(),
-		includeOutputTokens: false,
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: false,
 	}
 	ctx := context.Background()
 	endpointName := "no-start-endpoint"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 func newTestProducer() *InFlightLoadProducer {
@@ -249,4 +251,201 @@ func makeTokenRequest(requestID, prompt string) *fwksched.InferenceRequest {
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
 		},
 	}
+}
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease verifies that when
+// IncludeOutputTokens is false, token counters are released as soon as the first chunk
+// arrives (StartOfStream), while request counters are released only on EndOfStream.
+func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "exclude-output-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// 16 chars / 4 = 4 input tokens. Output tokens are excluded.
+	req := makeTokenRequest("req-no-output", "1234567890123456")
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID), "only input tokens should be tracked")
+
+	// First chunk arrives: tokens released, request still in flight.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID), "request counter should still be held")
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID), "tokens should be released at StartOfStream")
+
+	// EndOfStream releases the request counter.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk verifies that a single-chunk
+// response (StartOfStream && EndOfStream both true) releases both tokens and the request.
+func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "single-chunk-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-single", "1234567890123456")
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
+
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true, EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+// TestInFlightLoadProducer_PrefixCacheDiscount verifies that when PrefixCacheMatchInfo
+// is published on the endpoint, the matched prefix is excluded from the tracked input
+// tokens, and that release subtracts the same (discounted) amount.
+func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	endpointName := "prefix-cache-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// Prompt: 32 chars / 4 = 8 input tokens. Output = 8 * 1.5 = 12.
+	// With block_size=4, total=2 blocks, matched=1 block (4 tokens cached):
+	//   uncached_input = (2-1)*4 + max(0, 8-2*4) = 4
+	//   total tokens = 4 + 12 = 16
+	endpoint := newStubSchedulingEndpoint(endpointName)
+	endpoint.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+
+	req := makeTokenRequest("req-prefix", "12345678901234567890123456789012")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{endpoint}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(16), producer.tokenTracker.get(endpointID),
+		"only uncached input (4) plus output (12) should be tracked")
+
+	// Release uses the exact stored value, returning to zero.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"release should subtract the same discounted amount that was added")
+}
+
+// TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint verifies that two profiles
+// targeting different endpoints with different prefix-cache match levels each get their
+// own discounted token amount, and that both counters return to zero after release.
+func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	podA := "pod-a-cached"
+	podB := "pod-b-uncached"
+	idA := fullEndpointName(podA)
+	idB := fullEndpointName(podB)
+
+	// 8 input tokens, output 12.
+	epA := newStubSchedulingEndpoint(podA)
+	epA.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(2, 2, 4)) // fully cached
+	epB := newStubSchedulingEndpoint(podB)
+	epB.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(0, 2, 4)) // none cached
+
+	req := makeTokenRequest("req-multi-cache", "12345678901234567890123456789012")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{epA}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{epB}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(0+12), producer.tokenTracker.get(idA), "fully cached: only output tokens")
+	require.Equal(t, int64(8+12), producer.tokenTracker.get(idB), "uncached: input + output")
+
+	// Drive the response lifecycle: StartOfStream releases prefill, EndOfStream releases decode.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.tokenTracker.get(idA))
+	require.Equal(t, int64(0), producer.tokenTracker.get(idB))
+	require.Equal(t, int64(0), producer.requestTracker.get(idA))
+	require.Equal(t, int64(0), producer.requestTracker.get(idB))
+}
+
+// TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint verifies that
+// when multiple profiles target the same endpoint, each contributes to the counters
+// independently and each release subtracts the exact added amount, returning counters
+// to their pre-request baseline.
+func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	endpointName := "shared-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// 16 chars / 4 = 4 input tokens, 6 output, total 10 tokens per profile.
+	// Two profiles both targeting the same endpoint => 2 requests, 20 tokens.
+	req := makeTokenRequest("req-shared", "1234567890123456")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(2), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(20), producer.tokenTracker.get(endpointID))
+
+	// StartOfStream releases the prefill profile only (1 request, 10 tokens).
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// EndOfStream releases the remaining (decode) profile.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"counters must return to zero with no drift across profiles")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -449,3 +449,46 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
 		"counters must return to zero with no drift across profiles")
 }
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart verifies the
+// safety net for non-streaming or error paths: when includeOutputTokens=false and
+// ResponseBody delivers EndOfStream without ever seeing StartOfStream, the token
+// counter and request counter must both drain (tokens are normally released at
+// StartOfStream, so a missing StartOfStream would otherwise leak them). Also
+// asserts the addedTokens map entry is removed so accounting stays balanced.
+func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "no-start-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-no-start", "1234567890123456") // 4 input tokens
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
+
+	// EndOfStream only (no StartOfStream): both counters must drain.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"tokens must be released on EndOfStream even if StartOfStream was never seen")
+
+	// addedTokens entry should be gone too (no leak).
+	_, loaded := producer.addedTokens.Load(addedTokensKey(req.RequestID, endpointID, "default"))
+	require.False(t, loaded, "addedTokens entry must be released")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -24,7 +24,12 @@ import (
 
 // TokenEstimator estimates the number of tokens for an LLM request.
 type TokenEstimator interface {
+	// Estimate returns the total estimated token count (input + output) for the request.
 	Estimate(request *fwksched.InferenceRequest) int64
+	// EstimateInput returns only the estimated input token count for the request.
+	EstimateInput(request *fwksched.InferenceRequest) int64
+	// EstimateOutput returns the estimated output token count given the input token count.
+	EstimateOutput(inputTokens int64) int64
 }
 
 // SimpleTokenEstimator estimates tokens from character count. tokens = characters / CharactersPerToken.
@@ -46,27 +51,40 @@ func NewSimpleTokenEstimator() TokenEstimator {
 // to avoid allocations. Otherwise, input tokens are estimated from prompt/message character count
 // using CharactersPerToken; output tokens are estimated as inputTokens * OutputRatio.
 func (e *SimpleTokenEstimator) Estimate(request *fwksched.InferenceRequest) int64 {
+	inputTokens := e.EstimateInput(request)
+	if inputTokens == 0 {
+		return 0
+	}
+	return inputTokens + e.EstimateOutput(inputTokens)
+}
+
+// EstimateInput returns only the estimated input token count for the request.
+func (e *SimpleTokenEstimator) EstimateInput(request *fwksched.InferenceRequest) int64 {
 	if request == nil {
 		return 0
 	}
 	// Prefer request body size when available: avoids PlainText() and reduces GC pressure.
-	var inputTokens int64
 	switch {
 	case request.RequestSizeBytes > 0:
-		inputTokens = max(int64(request.RequestSizeBytes)/4, 1)
+		return max(int64(request.RequestSizeBytes)/4, 1)
 	case request.Body != nil:
 		hint := request.Body.InputTokenCountHint()
 		if hint >= 0 {
-			inputTokens = int64(hint)
-		} else {
-			// Fallback: character count from prompt text across all API types
-			// (completions, chat/completions, responses, conversations).
-			chars := len(request.Body.PromptText())
-			inputTokens = int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
+			return int64(hint)
 		}
+		// Fallback: character count from prompt text across all API types
+		// (completions, chat/completions, responses, conversations).
+		chars := len(request.Body.PromptText())
+		return int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
 	default:
 		return 0
 	}
-	outputTokens := int64(math.Round(float64(inputTokens) * e.OutputRatio))
-	return inputTokens + outputTokens
+}
+
+// EstimateOutput returns the estimated output token count given the input token count.
+func (e *SimpleTokenEstimator) EstimateOutput(inputTokens int64) int64 {
+	if inputTokens <= 0 {
+		return 0
+	}
+	return int64(math.Round(float64(inputTokens) * e.OutputRatio))
 }


### PR DESCRIPTION
# Summary

Improves inflight-load token accounting in the `inflightload` data producer:

- Makes output-token contribution **optional** (configurable), so the producer can model load purely from input/prompt tokens when desired.
- Releases tokens **early** at first response chunk instead of waiting for stream end, so inflight load reflects what the model is still actively generating.
- Discounts tokens served from the **prefix cache** when computing uncached-input load, using prefix-cache plugin info in unit-consistent terms.
- Hardens the release path to be **idempotent** and **balanced** with `PreRequest`, including an `EndOfStream` safety net so a missed release path cannot leak tracker counters.
- Includes the **profile name** in the `addedTokens` key so concurrent profiles for the same request don't clobber each other.

## Motivation

Inflight load was previously over-counting in two ways:
1. Output tokens stayed counted long after the model had emitted them, inflating perceived load on producers running long generations.
2. Tokens served from the prefix cache were charged as uncached input, biasing scheduling away from pods with warm caches.

It was also under-counting / leaking in edge cases: release paths weren't symmetric with `PreRequest`, and `EndOfStream` had no fallback if the response-chunk release was skipped.

## Changes

| Commit | Change |
|---|---|
| `198710a4` | Optional output-token contribution, early release on first response chunk, prefix-cache discount |
| `fa03cd8b` | Use prefix info to compute uncached-input load in consistent units |
| `6ea4c7d5` | Tests: output-token exclusion, prefix discount, balanced release |
| `1d6d4664` | Include profile name in `addedTokens` key |
| `fd57ab23` | Make `releaseTokens` idempotent per `addedTokens` key |
| `cd21408f` | Release on `EndOfStream` as a safety net |
| `b456641f` | Make `releaseTokens` fallback consistent with `PreRequest` |
| `df228e5e` | Test: `EndOfStream`-only release when output tokens are excluded |

## Testing

- `go build ./...`
- `go test ./pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/...`

## Follow-up

A stacked PR (`inflightload-tokens-ttl`) adds a TTL-bounded cache to evict abandoned `addedTokens` entries and roll back tracker counters, preventing leaks if a request never reaches `EndOfStream`. It will be opened against this branch and rebased onto `main` once this PR lands.