### PR TITLE
Inflightload tokens ttl

### DIFF
--- a/pkg/epp/framework/interface/plugin/plugin_state.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state.go
@@ -60,11 +60,11 @@ type PluginState struct {
 // Read retrieves data with the given "key" in the context of "requestID" from PluginState.
 // If the key is not present, ErrNotFound is returned.
 func (s *PluginState) Read(requestID string, key StateKey) (StateData, error) {
-	s.requestToLastAccessTime.Store(requestID, time.Now())
 	stateMap, ok := s.storage.Load(requestID)
 	if !ok {
 		return nil, ErrNotFound
 	}
+	s.requestToLastAccessTime.Store(requestID, time.Now())
 
 	stateData := stateMap.(*sync.Map)
 	if value, ok := stateData.Load(key); ok {
@@ -75,6 +75,7 @@ func (s *PluginState) Read(requestID string, key StateKey) (StateData, error) {
 }
 
 // Write stores the given "val" in PluginState with the given "key" in the context of the given "requestID".
+// Note: overwriting an existing key does NOT trigger OnEvicted on the displaced value.
 func (s *PluginState) Write(requestID string, key StateKey, val StateData) {
 	s.requestToLastAccessTime.Store(requestID, time.Now())
 	var stateData *sync.Map
@@ -90,13 +91,59 @@ func (s *PluginState) Write(requestID string, key StateKey, val StateData) {
 	s.storage.Store(requestID, stateData)
 }
 
-// Delete deletes data associated with the given requestID.
-// It is possible to call Delete explicitly when the handling of a request is completed
-// or alternatively, if the request failed during its processing, a cleanup goroutine will
-// clean data of stale requests.
+// Delete deletes data associated with the given requestID from PluginState.
+//
+// Triggers OnEvicted for every EvictableStateData entry being removed.
+// OnEvicted is invoked at most once per entry: Delete uses LoadAndDelete
+// per key, so it does not fire OnEvicted on entries that were concurrently
+// removed by a racing DeleteKey (or another Delete) on the same requestID.
 func (s *PluginState) Delete(requestID string) {
-	s.storage.Delete(requestID)
 	s.requestToLastAccessTime.Delete(requestID)
+	val, ok := s.storage.LoadAndDelete(requestID)
+	if !ok {
+		return
+	}
+	stateData := val.(*sync.Map)
+	stateData.Range(func(k, _ any) bool {
+		if claimed, ok := stateData.LoadAndDelete(k); ok {
+			if evictable, ok := claimed.(EvictableStateData); ok {
+				evictable.OnEvicted(requestID, k.(StateKey))
+			}
+		}
+		return true
+	})
+}
+
+// DeleteKey deletes the data associated with the given "key" in the context of "requestID" from PluginState.
+//
+// Note: DeleteKey triggers the OnEvicted callback for the EvictableStateData entry being removed.
+func (s *PluginState) DeleteKey(requestID string, key StateKey) {
+	stateMap, ok := s.storage.Load(requestID)
+	if !ok {
+		return
+	}
+
+	stateData := stateMap.(*sync.Map)
+	if val, ok := stateData.LoadAndDelete(key); ok {
+		if evictable, ok := val.(EvictableStateData); ok {
+			evictable.OnEvicted(requestID, key)
+		}
+	}
+}
+
+// Touch updates the last access time for the given requestID, extending its
+// lifetime before being reaped by the janitor.
+func (s *PluginState) Touch(requestID string) {
+	s.requestToLastAccessTime.Store(requestID, time.Now())
+}
+
+// LastAccessTime returns the last access time for the given requestID and a
+// boolean indicating if the requestID was found.
+func (s *PluginState) LastAccessTime(requestID string) (time.Time, bool) {
+	if val, ok := s.requestToLastAccessTime.Load(requestID); ok {
+		return val.(time.Time), true
+	}
+	return time.Time{}, false
 }
 
 // cleanup periodically deletes data associated with the given requestID.
@@ -122,6 +169,7 @@ func (s *PluginState) cleanStaleRequests() {
 		requestID := k.(string)
 		lastAccessTime := v.(time.Time)
 		if time.Since(lastAccessTime) > stalenessThreshold {
+			log.Log.V(logutil.DEBUG).Info("Cleaning up stale request from PluginState", "requestID", requestID, "lastAccessTime", lastAccessTime)
 			s.Delete(requestID) // cleanup stale requests (this is safe in sync.Map)
 		}
 		return true

--- a/pkg/epp/framework/interface/plugin/plugin_state_test.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state_test.go
@@ -40,12 +40,120 @@ func (d *pluginTestData) Clone() StateData {
 	return &pluginTestData{value: d.value}
 }
 
+type evictableTestData struct {
+	pluginTestData
+	evictedID  string
+	evictedKey StateKey
+}
+
+func (d *evictableTestData) OnEvicted(requestID string, key StateKey) {
+	d.evictedID = requestID
+	d.evictedKey = key
+}
+
+// Clone implements the StateData interface, ensuring that the cloned data
+// remains evictable (OnEvicted is not lost).
+func (d *evictableTestData) Clone() StateData {
+	if d == nil {
+		return nil
+	}
+	return &evictableTestData{
+		pluginTestData: pluginTestData{value: d.value},
+		evictedID:      d.evictedID,
+		evictedKey:     d.evictedKey,
+	}
+}
+
+func TestEvictableTestData_Clone(t *testing.T) {
+	data := &evictableTestData{
+		pluginTestData: pluginTestData{value: "test"},
+	}
+	cloned := data.Clone()
+
+	evictable, ok := cloned.(EvictableStateData)
+	assert.True(t, ok, "cloned data should satisfy EvictableStateData")
+
+	evictable.OnEvicted("req-1", "key-1")
+	assert.Equal(t, "req-1", cloned.(*evictableTestData).evictedID)
+	assert.Equal(t, StateKey("key-1"), cloned.(*evictableTestData).evictedKey)
+}
+
+// TestPluginState_EvictionCallback verifies that OnEvicted is called when data is removed.
+func TestPluginState_EvictionCallback(t *testing.T) {
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
+	state := NewPluginState(ctx)
+
+	requestID := "req-evict"
+	key := StateKey("foo")
+	data := &evictableTestData{pluginTestData: pluginTestData{value: "bar"}}
+
+	state.Write(requestID, key, data)
+
+	// Case 1: DeleteKey
+	state.DeleteKey(requestID, key)
+	assert.Equal(t, requestID, data.evictedID)
+	assert.Equal(t, key, data.evictedKey)
+
+	// Reset
+	data.evictedID = ""
+	data.evictedKey = ""
+	state.Write(requestID, key, data)
+
+	// Case 2: Delete (request wide)
+	state.Delete(requestID)
+	assert.Equal(t, requestID, data.evictedID)
+	assert.Equal(t, key, data.evictedKey)
+
+	// Case 3: Cleanup (stale request)
+	data.evictedID = ""
+	data.evictedKey = ""
+	state.Write(requestID, key, data)
+	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*stalenessThreshold))
+	state.cleanStaleRequests()
+	assert.Equal(t, requestID, data.evictedID)
+	assert.Equal(t, key, data.evictedKey)
+}
+
+// TestPluginState_Touch verifies that Touch extends request lifetime.
+func TestPluginState_Touch(t *testing.T) {
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
+	state := NewPluginState(ctx)
+
+	requestID := "req-touch"
+	key := StateKey("foo")
+	data := &pluginTestData{value: "bar"}
+
+	state.Write(requestID, key, data)
+
+	// Set last access time to near-stale
+	nearStale := time.Now().Add(-stalenessThreshold + time.Second*10)
+	state.requestToLastAccessTime.Store(requestID, nearStale)
+
+	// Touch it
+	state.Touch(requestID)
+
+	// Verify access time was updated to now
+	val, ok := state.requestToLastAccessTime.Load(requestID)
+	assert.True(t, ok)
+	lastAccess := val.(time.Time)
+	assert.True(t, lastAccess.After(nearStale))
+	assert.True(t, time.Since(lastAccess) < time.Second)
+
+	// Manually cleanup, should NOT be removed
+	state.cleanStaleRequests()
+	_, err := state.Read(requestID, key)
+	assert.NoError(t, err)
+}
+
 // TestPluginState_ReadWrite verifies the basic operations of PluginState:
 // - Writing data for a request
 // - Reading the data back
 // - Deleting the data and confirming it's removed
 func TestPluginState_ReadWrite(t *testing.T) {
-	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
 
 	state := NewPluginState(ctx)
 
@@ -91,7 +199,8 @@ func TestPluginState_ReadWrite(t *testing.T) {
 // - Successful type assertion and data retrieval
 // - Error handling for non-existent keys
 func TestReadPluginStateKey(t *testing.T) {
-	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
 	state := NewPluginState(ctx)
 
 	requestID := "req-1"
@@ -114,7 +223,8 @@ func TestReadPluginStateKey(t *testing.T) {
 // It tests that data which hasn't been accessed for longer than stalenessThreshold
 // is properly removed from the storage.
 func TestPluginState_Cleanup(t *testing.T) {
-	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
 
 	state := NewPluginState(ctx)
 
@@ -131,4 +241,32 @@ func TestPluginState_Cleanup(t *testing.T) {
 
 	_, err := state.Read(requestID, key)
 	assert.Equal(t, ErrNotFound, err)
+}
+
+// TestPluginState_DeleteKey verifies that DeleteKey correctly removes only the specified key for a request.
+func TestPluginState_DeleteKey(t *testing.T) {
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
+	state := NewPluginState(ctx)
+
+	requestID := "req-1"
+	key1 := StateKey("key1")
+	key2 := StateKey("key2")
+	data1 := &pluginTestData{value: "val1"}
+	data2 := &pluginTestData{value: "val2"}
+
+	state.Write(requestID, key1, data1)
+	state.Write(requestID, key2, data2)
+
+	// Delete key1
+	state.DeleteKey(requestID, key1)
+
+	// Verify key1 is gone
+	_, err := state.Read(requestID, key1)
+	assert.Equal(t, ErrNotFound, err)
+
+	// Verify key2 is still there
+	val2, err := state.Read(requestID, key2)
+	assert.NoError(t, err)
+	assert.Equal(t, "val2", val2.(*pluginTestData).value)
 }

--- a/pkg/epp/framework/interface/plugin/shared_state.go
+++ b/pkg/epp/framework/interface/plugin/shared_state.go
@@ -33,3 +33,17 @@ type StateData interface {
 	// Clone is an interface to make a copy of StateData.
 	Clone() StateData
 }
+
+// EvictableStateData is an optional interface for StateData that needs
+// to perform cleanup logic when it is removed or expires.
+type EvictableStateData interface {
+	StateData
+	// OnEvicted is called when the data is removed from PluginState,
+	// either manually or by the janitor.
+	//
+	// Implementations MUST be thread-safe and non-blocking, as OnEvicted
+	// may be called from background goroutines and can race with other
+	// request handlers. It must also tolerate being called concurrently
+	// and potentially after partial cleanup.
+	OnEvicted(requestID string, key StateKey)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -219,8 +219,11 @@ func (p *InFlightLoadProducer) ResponseBody(
 			endpoint := profileResult.TargetEndpoints[0]
 
 			if !p.includeOutputTokens {
-				// Tokens were freed at StartOfStream; only release the request counter.
-				p.releaseRequest(endpoint)
+				// Tokens are normally freed at StartOfStream; also call
+				// releaseTokens here as a safety net for non-streaming or
+				// error paths where StartOfStream may not be observed. It is
+				// a no-op via LoadAndDelete if tokens were already released.
+				p.release(endpoint, request, name)
 				continue
 			}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -151,12 +151,11 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		eid := endpoint.GetMetadata().NamespacedName.String()
 		p.requestTracker.inc(eid)
 
-		// Subtract approximate prefix-cache hit (in input tokens) for this endpoint.
-		cached := cachedInputTokens(endpoint)
-		adjustedInput := inputTokens - cached
-		if adjustedInput < 0 {
-			adjustedInput = 0
-		}
+		// Compute the uncached prompt portion this endpoint must actually compute.
+		// Prefer the prefix producer's view (real tokens) when available so the
+		// match-length and the input length are in the same units; fall back to
+		// the (estimated) input tokens otherwise.
+		adjustedInput := uncachedInputTokens(endpoint, inputTokens)
 		tokens := adjustedInput
 		if p.includeOutputTokens {
 			// Output tokens are based on the full input, not the cached portion.
@@ -272,25 +271,53 @@ func addedTokensKey(requestID, endpointID string) string {
 	return requestID + "|" + endpointID
 }
 
-// cachedInputTokens returns the number of input tokens this endpoint already has cached
-// from the approximate prefix cache producer, or 0 if not available.
-func cachedInputTokens(endpoint fwksched.Endpoint) int64 {
+// uncachedInputTokens returns the prompt tokens this endpoint must actually compute,
+// excluding any prefix already cached on it.
+//
+// When the approximate prefix producer has populated PrefixCacheMatchInfo on the
+// endpoint, the matched and total block counts are in real (tokenized) units, so
+// we use them directly: uncached = (TotalBlocks - MatchBlocks) * BlockSizeTokens.
+// For very long prompts where the prefix index is capped (MaxPrefixTokensToMatch),
+// any tail beyond the cap is added back from the (estimated) inputTokens so the
+// full prompt cost is still reflected.
+//
+// When the attribute is missing, we fall back to the estimated inputTokens.
+func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64) int64 {
 	if endpoint == nil {
-		return 0
+		return nonNeg(inputTokens)
 	}
 	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
 	if !ok {
-		return 0
+		return nonNeg(inputTokens)
 	}
 	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
-	if !ok || info == nil {
+	if !ok || info == nil || info.BlockSizeTokens() <= 0 {
+		return nonNeg(inputTokens)
+	}
+
+	blockSize := int64(info.BlockSizeTokens())
+	matched := int64(info.MatchBlocks()) * blockSize
+	indexed := int64(info.TotalBlocks()) * blockSize
+
+	uncachedIndexed := indexed - matched
+	if uncachedIndexed < 0 {
+		uncachedIndexed = 0
+	}
+
+	// Tail beyond the indexed portion (e.g., when MaxPrefixTokensToMatch caps total).
+	tail := inputTokens - indexed
+	if tail < 0 {
+		tail = 0
+	}
+
+	return uncachedIndexed + tail
+}
+
+func nonNeg(v int64) int64 {
+	if v < 0 {
 		return 0
 	}
-	cached := int64(info.MatchBlocks()) * int64(info.BlockSizeTokens())
-	if cached < 0 {
-		return 0
-	}
-	return cached
+	return v
 }
 
 func (p *InFlightLoadProducer) Produces() map[string]any {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -275,7 +275,16 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 
 	// Fallback: re-estimate. Covers tests/legacy paths that bypass PreRequest
 	// (request is nil or has no RequestID, so nothing was stored to release).
-	tokens := p.tokenEstimator.Estimate(request)
+	// Mirror PreRequest's accounting so we subtract the same amount we would
+	// have added: uncached input tokens, plus output tokens only when
+	// includeOutputTokens is true. Using tokenEstimator.Estimate() here would
+	// ignore both the includeOutputTokens=false semantics and any prefix-cache
+	// discount applied at PreRequest time, leading to over/under-decrement.
+	inputTokens := p.tokenEstimator.EstimateInput(request)
+	tokens := uncachedInputTokens(endpoint, inputTokens)
+	if p.includeOutputTokens {
+		tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+	}
 	if tokens != 0 {
 		p.tokenTracker.add(eid, -tokens)
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -254,17 +254,24 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 	eid := endpoint.GetMetadata().NamespacedName.String()
 
 	// Prefer the exact value stored in PreRequest to keep counters balanced.
-	if request != nil {
+	// LoadAndDelete makes this idempotent per (requestID, endpointID, profileName):
+	// a second call for the same key finds nothing and is a no-op below (we do
+	// NOT fall back to Estimate when the request carries a real RequestID, since
+	// the absence of the key means "already released").
+	if request != nil && request.RequestID != "" {
 		key := addedTokensKey(request.RequestID, eid, profileName)
 		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
 			if tokens, ok := v.(int64); ok && tokens != 0 {
 				p.tokenTracker.add(eid, -tokens)
 			}
-			return
 		}
+		// Either we just released the stored value, or the key was already
+		// released by a previous call — both cases are no-ops here.
+		return
 	}
 
-	// Fallback: re-estimate (covers tests/legacy paths that bypass PreRequest).
+	// Fallback: re-estimate. Covers tests/legacy paths that bypass PreRequest
+	// (request is nil or has no RequestID, so nothing was stored to release).
 	tokens := p.tokenEstimator.Estimate(request)
 	if tokens != 0 {
 		p.tokenTracker.add(eid, -tokens)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -82,9 +82,13 @@ type InFlightLoadProducer struct {
 	tokenTracker        *concurrencyTracker
 	tokenEstimator      TokenEstimator
 	includeOutputTokens bool
-	// addedTokens tracks the exact token amount added per (requestID, endpointID)
+	// addedTokens tracks the exact token amount added per (requestID, endpointID, profileName)
 	// so release subtracts the same value (accounting for prefix-cache discount).
-	// Key format: "<requestID>|<endpointID>".
+	// The profile name is part of the key so that multiple profiles targeting the
+	// same endpoint each track their own increment independently and a release
+	// for one profile cannot subtract another profile's value (which would leak
+	// or double-count tokens).
+	// Key format: "<requestID>|<endpointID>|<profileName>".
 	addedTokens sync.Map
 }
 
@@ -139,7 +143,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
 
-	for _, profileResult := range result.ProfileResults {
+	for profileName, profileResult := range result.ProfileResults {
 		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 			continue
 		}
@@ -164,7 +168,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 
 		p.tokenTracker.add(eid, tokens)
 		if request != nil && request.RequestID != "" {
-			p.addedTokens.Store(addedTokensKey(request.RequestID, eid), tokens)
+			p.addedTokens.Store(addedTokensKey(request.RequestID, eid, profileName), tokens)
 		}
 	}
 }
@@ -190,11 +194,11 @@ func (p *InFlightLoadProducer) ResponseBody(
 	// token counters for every targeted endpoint regardless of profile name.
 	// Request counters are still released on EndOfStream below.
 	if !p.includeOutputTokens && resp.StartOfStream {
-		for _, profileResult := range result.ProfileResults {
+		for profileName, profileResult := range result.ProfileResults {
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 				continue
 			}
-			p.releaseTokens(profileResult.TargetEndpoints[0], request)
+			p.releaseTokens(profileResult.TargetEndpoints[0], request, profileName)
 		}
 	}
 
@@ -202,7 +206,7 @@ func (p *InFlightLoadProducer) ResponseBody(
 	// Uses the new StartOfStream signal provided by the framework.
 	if p.includeOutputTokens && resp.StartOfStream {
 		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
-			p.release(prefillResult.TargetEndpoints[0], request)
+			p.release(prefillResult.TargetEndpoints[0], request, profilePrefill)
 		}
 	}
 
@@ -225,14 +229,14 @@ func (p *InFlightLoadProducer) ResponseBody(
 			if name == profilePrefill {
 				continue
 			}
-			p.release(endpoint, request)
+			p.release(endpoint, request, name)
 		}
 	}
 }
 
-func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
 	p.releaseRequest(endpoint)
-	p.releaseTokens(endpoint, request)
+	p.releaseTokens(endpoint, request, profileName)
 }
 
 func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
@@ -243,7 +247,7 @@ func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
 	p.requestTracker.dec(eid)
 }
 
-func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
 	if endpoint == nil || endpoint.GetMetadata() == nil {
 		return
 	}
@@ -251,7 +255,7 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 
 	// Prefer the exact value stored in PreRequest to keep counters balanced.
 	if request != nil {
-		key := addedTokensKey(request.RequestID, eid)
+		key := addedTokensKey(request.RequestID, eid, profileName)
 		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
 			if tokens, ok := v.(int64); ok && tokens != 0 {
 				p.tokenTracker.add(eid, -tokens)
@@ -267,8 +271,8 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 	}
 }
 
-func addedTokensKey(requestID, endpointID string) string {
-	return requestID + "|" + endpointID
+func addedTokensKey(requestID, endpointID, profileName string) string {
+	return requestID + "|" + endpointID + "|" + profileName
 }
 
 // uncachedInputTokens returns the prompt tokens this endpoint must actually compute,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -19,6 +19,7 @@ package inflightload
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	sourcenotifications "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
 
@@ -39,12 +41,30 @@ const (
 	profilePrefill           = "prefill"
 )
 
-func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+// Config controls optional behaviors of InFlightLoadProducer.
+type Config struct {
+	// IncludeOutputTokens controls whether estimated output tokens are added to
+	// the in-flight token counter. Defaults to true to preserve historical behavior.
+	IncludeOutputTokens bool `json:"includeOutputTokens"`
+}
+
+func defaultConfig() Config {
+	return Config{IncludeOutputTokens: true}
+}
+
+func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	cfg := defaultConfig()
+	if len(rawParameters) > 0 {
+		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal inflight-load-producer parameters: %w", err)
+		}
+	}
 	return &InFlightLoadProducer{
-		typedName:      fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: cfg.IncludeOutputTokens,
 	}, nil
 }
 
@@ -57,10 +77,15 @@ var (
 )
 
 type InFlightLoadProducer struct {
-	typedName      fwkplugin.TypedName
-	requestTracker *concurrencyTracker
-	tokenTracker   *concurrencyTracker
-	tokenEstimator TokenEstimator
+	typedName           fwkplugin.TypedName
+	requestTracker      *concurrencyTracker
+	tokenTracker        *concurrencyTracker
+	tokenEstimator      TokenEstimator
+	includeOutputTokens bool
+	// addedTokens tracks the exact token amount added per (requestID, endpointID)
+	// so release subtracts the same value (accounting for prefix-cache discount).
+	// Key format: "<requestID>|<endpointID>".
+	addedTokens sync.Map
 }
 
 func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
@@ -112,6 +137,8 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		return
 	}
 
+	inputTokens := p.tokenEstimator.EstimateInput(request)
+
 	for _, profileResult := range result.ProfileResults {
 		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 			continue
@@ -123,8 +150,23 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		}
 		eid := endpoint.GetMetadata().NamespacedName.String()
 		p.requestTracker.inc(eid)
-		tokens := p.tokenEstimator.Estimate(request)
+
+		// Subtract approximate prefix-cache hit (in input tokens) for this endpoint.
+		cached := cachedInputTokens(endpoint)
+		adjustedInput := inputTokens - cached
+		if adjustedInput < 0 {
+			adjustedInput = 0
+		}
+		tokens := adjustedInput
+		if p.includeOutputTokens {
+			// Output tokens are based on the full input, not the cached portion.
+			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+		}
+
 		p.tokenTracker.add(eid, tokens)
+		if request != nil && request.RequestID != "" {
+			p.addedTokens.Store(addedTokensKey(request.RequestID, eid), tokens)
+		}
 	}
 }
 
@@ -143,9 +185,23 @@ func (p *InFlightLoadProducer) ResponseBody(
 		return
 	}
 
-	// 1. Early Prefill Release (on first chunk)
+	// When output tokens are excluded, the in-flight token estimate represents only
+	// the prompt cost, which is consumed by prefill. As soon as the first chunk
+	// arrives (StartOfStream), prefill is done across all profiles, so free the
+	// token counters for every targeted endpoint regardless of profile name.
+	// Request counters are still released on EndOfStream below.
+	if !p.includeOutputTokens && resp.StartOfStream {
+		for _, profileResult := range result.ProfileResults {
+			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
+				continue
+			}
+			p.releaseTokens(profileResult.TargetEndpoints[0], request)
+		}
+	}
+
+	// 1. Early Prefill Release (on first chunk) — original behavior.
 	// Uses the new StartOfStream signal provided by the framework.
-	if resp.StartOfStream {
+	if p.includeOutputTokens && resp.StartOfStream {
 		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
 			p.release(prefillResult.TargetEndpoints[0], request)
 		}
@@ -157,24 +213,84 @@ func (p *InFlightLoadProducer) ResponseBody(
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 				continue
 			}
+			endpoint := profileResult.TargetEndpoints[0]
+
+			if !p.includeOutputTokens {
+				// Tokens were freed at StartOfStream; only release the request counter.
+				p.releaseRequest(endpoint)
+				continue
+			}
+
 			// Skip "prefill" as it was already released in the StartOfStream block.
 			// This works perfectly even if StartOfStream and EndOfStream are both true (single chunk).
 			if name == profilePrefill {
 				continue
 			}
-			p.release(profileResult.TargetEndpoints[0], request)
+			p.release(endpoint, request)
 		}
 	}
 }
 
 func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+	p.releaseRequest(endpoint)
+	p.releaseTokens(endpoint, request)
+}
+
+func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
 	if endpoint == nil || endpoint.GetMetadata() == nil {
 		return
 	}
 	eid := endpoint.GetMetadata().NamespacedName.String()
 	p.requestTracker.dec(eid)
+}
+
+func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest) {
+	if endpoint == nil || endpoint.GetMetadata() == nil {
+		return
+	}
+	eid := endpoint.GetMetadata().NamespacedName.String()
+
+	// Prefer the exact value stored in PreRequest to keep counters balanced.
+	if request != nil {
+		key := addedTokensKey(request.RequestID, eid)
+		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
+			if tokens, ok := v.(int64); ok && tokens != 0 {
+				p.tokenTracker.add(eid, -tokens)
+			}
+			return
+		}
+	}
+
+	// Fallback: re-estimate (covers tests/legacy paths that bypass PreRequest).
 	tokens := p.tokenEstimator.Estimate(request)
-	p.tokenTracker.add(eid, -tokens)
+	if tokens != 0 {
+		p.tokenTracker.add(eid, -tokens)
+	}
+}
+
+func addedTokensKey(requestID, endpointID string) string {
+	return requestID + "|" + endpointID
+}
+
+// cachedInputTokens returns the number of input tokens this endpoint already has cached
+// from the approximate prefix cache producer, or 0 if not available.
+func cachedInputTokens(endpoint fwksched.Endpoint) int64 {
+	if endpoint == nil {
+		return 0
+	}
+	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
+	if !ok {
+		return 0
+	}
+	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
+	if !ok || info == nil {
+		return 0
+	}
+	cached := int64(info.MatchBlocks()) * int64(info.BlockSizeTokens())
+	if cached < 0 {
+		return 0
+	}
+	return cached
 }
 
 func (p *InFlightLoadProducer) Produces() map[string]any {
@@ -184,7 +300,9 @@ func (p *InFlightLoadProducer) Produces() map[string]any {
 }
 
 func (p *InFlightLoadProducer) Consumes() map[string]any {
-	return nil
+	return map[string]any{
+		attrprefix.PrefixCacheMatchInfoKey: (*attrprefix.PrefixCacheMatchInfo)(nil),
+	}
 }
 
 // DeleteEndpoint removes an endpoint from the concurrency trackers to prevent memory leaks.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -23,7 +23,9 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
@@ -46,26 +48,43 @@ type Config struct {
 	// IncludeOutputTokens controls whether estimated output tokens are added to
 	// the in-flight token counter. Defaults to true to preserve historical behavior.
 	IncludeOutputTokens bool `json:"includeOutputTokens"`
+	// RequestTTL bounds how long a per-request token entry is kept before it is
+	// considered abandoned. If ResponseBody never delivers EndOfStream (e.g.
+	// client disconnect, panic in a downstream plugin, EPP shutdown), the
+	// expiry-driven eviction subtracts the entry's tokens from the token
+	// tracker AND decrements the request tracker for that endpoint, preventing
+	// an unbounded leak of both counters and the per-request map entries.
+	// Defaults to 5 minutes. A non-positive value disables expiration entirely.
+	RequestTTL time.Duration `json:"requestTTL,omitempty"`
 }
 
 func defaultConfig() Config {
-	return Config{IncludeOutputTokens: true}
+	return Config{
+		IncludeOutputTokens: true,
+		RequestTTL:          5 * time.Minute,
+	}
 }
 
-func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	cfg := defaultConfig()
 	if len(rawParameters) > 0 {
 		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal inflight-load-producer parameters: %w", err)
 		}
 	}
-	return &InFlightLoadProducer{
+	p := &InFlightLoadProducer{
 		typedName:           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
 		requestTracker:      newConcurrencyTracker(),
 		tokenTracker:        newConcurrencyTracker(),
 		tokenEstimator:      NewSimpleTokenEstimator(),
 		includeOutputTokens: cfg.IncludeOutputTokens,
-	}, nil
+		requestTTL:          cfg.RequestTTL,
+	}
+	p.initAddedTokensCache()
+	if handle != nil {
+		p.startCacheLifecycle(handle.Context())
+	}
+	return p, nil
 }
 
 var (
@@ -82,14 +101,81 @@ type InFlightLoadProducer struct {
 	tokenTracker        *concurrencyTracker
 	tokenEstimator      TokenEstimator
 	includeOutputTokens bool
+	requestTTL          time.Duration
+	initOnce            sync.Once
 	// addedTokens tracks the exact token amount added per (requestID, endpointID, profileName)
 	// so release subtracts the same value (accounting for prefix-cache discount).
-	// The profile name is part of the key so that multiple profiles targeting the
-	// same endpoint each track their own increment independently and a release
-	// for one profile cannot subtract another profile's value (which would leak
-	// or double-count tokens).
+	// Including the profile name keeps per-profile increments independent when multiple
+	// profiles target the same endpoint.
 	// Key format: "<requestID>|<endpointID>|<profileName>".
-	addedTokens sync.Map
+	//
+	// A TTL is applied so that abandoned requests (no EndOfStream delivered) are
+	// reaped instead of leaking both the entry and the per-endpoint counters
+	// they own; the eviction handler rolls back the request and token counters.
+	addedTokens *ttlcache.Cache[string, addedTokensEntry]
+}
+
+// addedTokensEntry is the value stored in addedTokens; it carries the endpoint
+// the increment was charged to so the TTL eviction handler can roll it back
+// without consulting the request's SchedulingResult (which the cache does not
+// hold a reference to).
+type addedTokensEntry struct {
+	endpointID  string
+	profileName string
+	tokens      int64
+}
+
+// initAddedTokensCache initializes the per-request token cache with TTL-based
+// eviction. Idempotent; safe to call from both the factory (eager) and from
+// PreRequest (lazy, for callers that build the struct directly without going
+// through the factory — e.g. unit tests). The eviction handler is the leak
+// safety net: when a request times out without ever seeing EndOfStream, it
+// subtracts the entry's tokens and decrements the request tracker so neither
+// counter drifts upward over time.
+func (p *InFlightLoadProducer) initAddedTokensCache() {
+	p.initOnce.Do(func() {
+		ttl := p.requestTTL
+		if ttl <= 0 {
+			ttl = ttlcache.NoTTL
+		}
+		p.addedTokens = ttlcache.New(ttlcache.WithTTL[string, addedTokensEntry](ttl))
+		p.addedTokens.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, addedTokensEntry]) {
+			if reason != ttlcache.EvictionReasonExpired {
+				return
+			}
+			entry := item.Value()
+			// The TTL fired before EndOfStream/StartOfStream cleaned this entry up.
+			// Roll back both counters that PreRequest incremented for this entry to
+			// avoid unbounded drift on long-running EPP processes.
+			if entry.tokens != 0 {
+				p.tokenTracker.add(entry.endpointID, -entry.tokens)
+			}
+			p.requestTracker.dec(entry.endpointID)
+			log.FromContext(ctx).V(logutil.DEFAULT).Info(
+				"in-flight load entry expired without release; rolled back counters",
+				"key", item.Key(),
+				"endpoint", entry.endpointID,
+				"profile", entry.profileName,
+				"tokens", entry.tokens,
+			)
+		})
+	})
+}
+
+// startCacheLifecycle runs the ttlcache janitor and stops it when ctx is
+// canceled. Mirrors the predicted-latency producer's pattern.
+func (p *InFlightLoadProducer) startCacheLifecycle(ctx context.Context) {
+	if p.addedTokens == nil {
+		return
+	}
+	go p.addedTokens.Start()
+	if ctx == nil {
+		return
+	}
+	go func() {
+		<-ctx.Done()
+		p.addedTokens.Stop()
+	}()
 }
 
 func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
@@ -140,6 +226,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 	if result == nil || len(result.ProfileResults) == 0 {
 		return
 	}
+	p.initAddedTokensCache()
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
 
@@ -167,8 +254,12 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		}
 
 		p.tokenTracker.add(eid, tokens)
-		if request != nil && request.RequestID != "" {
-			p.addedTokens.Store(addedTokensKey(request.RequestID, eid, profileName), tokens)
+		if request != nil && request.RequestID != "" && p.addedTokens != nil {
+			p.addedTokens.Set(
+				addedTokensKey(request.RequestID, eid, profileName),
+				addedTokensEntry{endpointID: eid, profileName: profileName, tokens: tokens},
+				ttlcache.DefaultTTL,
+			)
 		}
 	}
 }
@@ -220,9 +311,9 @@ func (p *InFlightLoadProducer) ResponseBody(
 
 			if !p.includeOutputTokens {
 				// Tokens are normally freed at StartOfStream; also call
-				// releaseTokens here as a safety net for non-streaming or
-				// error paths where StartOfStream may not be observed. It is
-				// a no-op via LoadAndDelete if tokens were already released.
+				// release() here as a safety net for non-streaming or error
+				// paths where StartOfStream may not be observed. releaseTokens
+				// is a no-op via LoadAndDelete if tokens were already released.
 				p.release(endpoint, request, name)
 				continue
 			}
@@ -257,19 +348,20 @@ func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request
 	eid := endpoint.GetMetadata().NamespacedName.String()
 
 	// Prefer the exact value stored in PreRequest to keep counters balanced.
-	// LoadAndDelete makes this idempotent per (requestID, endpointID, profileName):
+	// GetAndDelete makes this idempotent per (requestID, endpointID, profileName):
 	// a second call for the same key finds nothing and is a no-op below (we do
 	// NOT fall back to Estimate when the request carries a real RequestID, since
-	// the absence of the key means "already released").
-	if request != nil && request.RequestID != "" {
+	// the absence of the key means "already released" or "already TTL-evicted").
+	if request != nil && request.RequestID != "" && p.addedTokens != nil {
 		key := addedTokensKey(request.RequestID, eid, profileName)
-		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
-			if tokens, ok := v.(int64); ok && tokens != 0 {
-				p.tokenTracker.add(eid, -tokens)
+		if item := p.addedTokens.Get(key, ttlcache.WithDisableTouchOnHit[string, addedTokensEntry]()); item != nil {
+			p.addedTokens.Delete(key)
+			if entry := item.Value(); entry.tokens != 0 {
+				p.tokenTracker.add(eid, -entry.tokens)
 			}
 		}
 		// Either we just released the stored value, or the key was already
-		// released by a previous call — both cases are no-ops here.
+		// released by a previous call (or TTL-evicted) — both cases are no-ops.
 		return
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -19,6 +19,7 @@ package inflightload
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -53,13 +54,22 @@ func defaultConfig() Config {
 	return Config{AddEstimatedOutputTokens: false}
 }
 
-func InFlightLoadProducerFactory(name string, decoder *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	if handle == nil {
+		return nil, errors.New("handle is nil")
+	}
+	ctx := handle.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	cfg := defaultConfig()
 	if decoder != nil {
 		if err := decoder.Decode(&cfg); err != nil {
 			return nil, fmt.Errorf("failed to decode inflight-load-producer parameters: %w", err)
 		}
 	}
+
 	return &InFlightLoadProducer{
 		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
 		requestTracker:           newConcurrencyTracker(),
@@ -67,6 +77,7 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, _ fwkplugin
 		tokenEstimator:           NewSimpleTokenEstimator(),
 		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
 		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		PluginState:              fwkplugin.NewPluginState(ctx),
 	}, nil
 }
 
@@ -74,7 +85,7 @@ var (
 	_ requestcontrol.PreRequest            = &InFlightLoadProducer{}
 	_ requestcontrol.ResponseBodyProcessor = &InFlightLoadProducer{}
 	_ requestcontrol.DataProducer          = &InFlightLoadProducer{}
-	_ datalayer.EndpointExtractor          = &InFlightLoadProducer{}
+	_ datalayer.EndpointExtractor          = (*InFlightLoadProducer)(nil)
 	_ datalayer.Registrant                 = &InFlightLoadProducer{}
 )
 
@@ -84,15 +95,70 @@ type InFlightLoadProducer struct {
 	tokenTracker             *concurrencyTracker
 	tokenEstimator           TokenEstimator
 	addEstimatedOutputTokens bool
-	// addedTokens tracks the exact token amount added per (requestID, endpointID, profileName)
-	// so release subtracts the same value (accounting for prefix-cache discount).
-	// The profile name is part of the key so that multiple profiles targeting the
-	// same endpoint each track their own increment independently and a release
-	// for one profile cannot subtract another profile's value (which would leak
-	// or double-count tokens).
-	// Key format: "<requestID>|<endpointID>|<profileName>".
-	addedTokens sync.Map
-	dk          fwkplugin.DataKey
+	PluginState              *fwkplugin.PluginState
+	dk                       fwkplugin.DataKey
+}
+
+// addedTokensEntry tracks a request's contribution to the global token and
+// request counters. OnEvicted rolls back the contribution exactly once,
+// whether triggered by explicit release at end-of-stream or by the janitor's
+// TTL reaper. The fields are atomic so releaseTokensEarly and OnEvicted
+// can race safely: whichever swaps first does the decrement, the other
+// sees 0 and is a no-op.
+type addedTokensEntry struct {
+	endpointID     string
+	tokens         atomic.Int64
+	tokenTracker   *concurrencyTracker
+	requestTracker *concurrencyTracker
+	requests       atomic.Int32
+}
+
+var _ fwkplugin.EvictableStateData = (*addedTokensEntry)(nil)
+
+// Clone returns a distinct copy of the entry with the current atomic values.
+// The tracker references remain shared, but the cloned state object itself is
+// independent so later mutation or eviction of the clone does not alias the
+// original entry.
+func (e *addedTokensEntry) Clone() fwkplugin.StateData {
+	if e == nil {
+		return nil
+	}
+	clone := &addedTokensEntry{
+		endpointID:     e.endpointID,
+		tokenTracker:   e.tokenTracker,
+		requestTracker: e.requestTracker,
+	}
+	clone.tokens.Store(e.tokens.Load())
+	clone.requests.Store(e.requests.Load())
+	return clone
+}
+
+// addIfPresent applies delta only when the endpoint is still tracked.
+// This avoids recreating a deleted endpoint with a negative in-flight count
+// during delayed eviction cleanup.
+func (t *concurrencyTracker) addIfPresent(endpointID string, delta int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	counter, ok := t.counts[endpointID]
+	if !ok {
+		return
+	}
+	counter.Add(delta)
+}
+
+// decIfPresent decrements the endpoint only when it is still tracked.
+func (t *concurrencyTracker) decIfPresent(endpointID string) {
+	t.addIfPresent(endpointID, -1)
+}
+
+func (e *addedTokensEntry) OnEvicted(_ string, _ fwkplugin.StateKey) {
+	if t := e.tokens.Swap(0); t != 0 {
+		e.tokenTracker.addIfPresent(e.endpointID, -t)
+	}
+	if e.requests.Swap(0) != 0 {
+		e.requestTracker.decIfPresent(e.endpointID)
+	}
 }
 
 func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
@@ -117,7 +183,7 @@ func (p *InFlightLoadProducer) ExpectedInputType() reflect.Type {
 
 // ExtractEndpoint handles endpoint deletion events to prune stateful trackers.
 func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datalayer.EndpointEvent) error {
-	if event.Type != datalayer.EventDelete || event.Endpoint == nil {
+	if event.Type != datalayer.EventDelete || event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
 		return nil
 	}
 
@@ -130,6 +196,9 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 
 func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	for _, e := range endpoints {
+		if e == nil || e.GetMetadata() == nil {
+			continue
+		}
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(p.dk.String(), &attrconcurrency.InFlightLoad{
 			Tokens:   p.tokenTracker.get(endpointID),
@@ -139,8 +208,23 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceR
 	return nil
 }
 
-func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.InferenceRequest, result *fwksched.SchedulingResult) {
+func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, result *fwksched.SchedulingResult) {
 	if result == nil || len(result.ProfileResults) == 0 {
+		return
+	}
+
+	if request == nil {
+		log.FromContext(ctx).V(logutil.VERBOSE).Info("Skipping in-flight load tracking: request is nil")
+		return
+	}
+
+	if request.RequestID == "" {
+		log.FromContext(ctx).V(logutil.VERBOSE).Info("Skipping in-flight load tracking: missing RequestID")
+		return
+	}
+
+	if p.PluginState == nil {
+		log.FromContext(ctx).V(logutil.VERBOSE).Info("Skipping in-flight load tracking: PluginState is nil", "requestID", request.RequestID)
 		return
 	}
 
@@ -170,19 +254,29 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *fwksched.I
 		}
 
 		p.tokenTracker.add(eid, tokens)
-		if request != nil && request.RequestID != "" {
-			p.addedTokens.Store(addedTokensKey(request.RequestID, eid, profileName), tokens)
+
+		entry := &addedTokensEntry{
+			endpointID:     eid,
+			tokenTracker:   p.tokenTracker,
+			requestTracker: p.requestTracker,
 		}
+		entry.tokens.Store(tokens)
+		entry.requests.Store(1)
+		p.PluginState.Write(
+			request.RequestID,
+			fwkplugin.StateKey(addedTokensKey(eid, profileName)),
+			entry,
+		)
 	}
 }
 
 func (p *InFlightLoadProducer) ResponseBody(
-	ctx context.Context,
+	_ context.Context,
 	request *fwksched.InferenceRequest,
 	resp *requestcontrol.Response,
 	_ *datalayer.EndpointMetadata,
 ) {
-	if request == nil || resp == nil {
+	if request == nil || resp == nil || request.RequestID == "" || p.PluginState == nil {
 		return
 	}
 
@@ -195,106 +289,87 @@ func (p *InFlightLoadProducer) ResponseBody(
 	// the prompt cost, which is consumed by prefill. As soon as the first chunk
 	// arrives (StartOfStream), prefill is done across all profiles, so free the
 	// token counters for every targeted endpoint regardless of profile name.
-	// Request counters are still released on EndOfStream below.
+	// Request counters are still released on EndOfStream below via PluginState.Delete.
 	if !p.addEstimatedOutputTokens && resp.StartOfStream {
 		for profileName, profileResult := range result.ProfileResults {
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 				continue
 			}
-			p.releaseTokens(profileResult.TargetEndpoints[0], request, profileName)
+			endpoint := profileResult.TargetEndpoints[0]
+			if endpoint == nil || endpoint.GetMetadata() == nil {
+				continue
+			}
+			p.releaseTokensEarly(endpoint, request, profileName)
 		}
 	}
 
-	// 1. Early Prefill Release (on first chunk) — original behavior.
-	// Uses the new StartOfStream signal provided by the framework.
+	// Early prefill release (on first chunk). Frees the primary profile's
+	// prefill contribution as soon as prefill completes, while other profiles'
+	// entries remain until EndOfStream.
 	if p.addEstimatedOutputTokens && resp.StartOfStream {
 		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
-			p.release(prefillResult.TargetEndpoints[0], request, profilePrefill)
+			endpoint := prefillResult.TargetEndpoints[0]
+			if endpoint != nil && endpoint.GetMetadata() != nil {
+				p.release(endpoint, request, profilePrefill)
+			}
 		}
 	}
 
-	// 2. Full Cleanup (on completion)
+	// Full cleanup on completion vs. lifetime extension on an intermediate chunk.
+	// PluginState.Delete iterates remaining entries via per-key LoadAndDelete,
+	// firing OnEvicted at most once per entry; entries already released at
+	// StartOfStream are gracefully no-op'd (LoadAndDelete miss / atomic Swap-to-0).
 	if resp.EndOfStream {
-		for name, profileResult := range result.ProfileResults {
-			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
-				continue
-			}
-			endpoint := profileResult.TargetEndpoints[0]
-
-			if !p.addEstimatedOutputTokens {
-				// Tokens are normally freed at StartOfStream; also call
-				// releaseTokens here as a safety net for non-streaming or
-				// error paths where StartOfStream may not be observed. It is
-				// a no-op via LoadAndDelete if tokens were already released.
-				p.release(endpoint, request, name)
-				continue
-			}
-
-			// Skip "prefill" as it was already released in the StartOfStream block.
-			// This works perfectly even if StartOfStream and EndOfStream are both true (single chunk).
-			if name == profilePrefill {
-				continue
-			}
-			p.release(endpoint, request, name)
-		}
+		p.PluginState.Delete(request.RequestID)
+	} else {
+		p.PluginState.Touch(request.RequestID)
 	}
 }
 
+// release surgically deletes a single profile's entry from PluginState,
+// triggering OnEvicted to roll back that profile's counter contribution.
+// Used at StartOfStream when a single profile needs to be released ahead of
+// the EndOfStream bulk Delete.
 func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
-	p.releaseRequest(endpoint)
-	p.releaseTokens(endpoint, request, profileName)
-}
-
-func (p *InFlightLoadProducer) releaseRequest(endpoint fwksched.Endpoint) {
-	if endpoint == nil || endpoint.GetMetadata() == nil {
+	if endpoint == nil || request == nil || request.RequestID == "" || p.PluginState == nil {
 		return
 	}
-	eid := endpoint.GetMetadata().NamespacedName.String()
-	p.requestTracker.dec(eid)
-}
-
-func (p *InFlightLoadProducer) releaseTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
-	if endpoint == nil || endpoint.GetMetadata() == nil {
+	meta := endpoint.GetMetadata()
+	if meta == nil {
 		return
 	}
-	eid := endpoint.GetMetadata().NamespacedName.String()
+	eid := meta.NamespacedName.String()
+	key := fwkplugin.StateKey(addedTokensKey(eid, profileName))
 
-	// Prefer the exact value stored in PreRequest to keep counters balanced.
-	// LoadAndDelete makes this idempotent per (requestID, endpointID, profileName):
-	// a second call for the same key finds nothing and is a no-op below (we do
-	// NOT fall back to Estimate when the request carries a real RequestID, since
-	// the absence of the key means "already released").
-	if request != nil && request.RequestID != "" {
-		key := addedTokensKey(request.RequestID, eid, profileName)
-		if v, ok := p.addedTokens.LoadAndDelete(key); ok {
-			if tokens, ok := v.(int64); ok && tokens != 0 {
-				p.tokenTracker.add(eid, -tokens)
-			}
+	// DeleteKey triggers OnEvicted, which decrements the counters exactly once.
+	// If the janitor already reaped the request, this is a no-op.
+	p.PluginState.DeleteKey(request.RequestID, key)
+}
+
+// releaseTokensEarly frees only the token portion of a profile's entry
+// (request counter stays held), used at StartOfStream for the
+// addEstimatedOutputTokens=false path where prefill completion frees tokens
+// but the request remains in-flight until EndOfStream.
+func (p *InFlightLoadProducer) releaseTokensEarly(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, profileName string) {
+	if endpoint == nil || request == nil || request.RequestID == "" || p.PluginState == nil {
+		return
+	}
+	meta := endpoint.GetMetadata()
+	if meta == nil {
+		return
+	}
+	eid := meta.NamespacedName.String()
+
+	key := fwkplugin.StateKey(addedTokensKey(eid, profileName))
+	if entry, err := fwkplugin.ReadPluginStateKey[*addedTokensEntry](p.PluginState, request.RequestID, key); err == nil {
+		if t := entry.tokens.Swap(0); t != 0 {
+			entry.tokenTracker.addIfPresent(entry.endpointID, -t)
 		}
-		// Either we just released the stored value, or the key was already
-		// released by a previous call — both cases are no-ops here.
-		return
-	}
-
-	// Fallback: re-estimate. Covers tests/legacy paths that bypass PreRequest
-	// (request is nil or has no RequestID, so nothing was stored to release).
-	// Mirror PreRequest's accounting so we subtract the same amount we would
-	// have added: uncached input tokens, plus output tokens only when
-	// addEstimatedOutputTokens is true. Using tokenEstimator.Estimate() here would
-	// ignore both the addEstimatedOutputTokens=false semantics and any prefix-cache
-	// discount applied at PreRequest time, leading over/under-decrement.
-	inputTokens := p.tokenEstimator.EstimateInput(request)
-	tokens := uncachedInputTokens(endpoint, inputTokens)
-	if p.addEstimatedOutputTokens {
-		tokens += p.tokenEstimator.EstimateOutput(inputTokens)
-	}
-	if tokens != 0 {
-		p.tokenTracker.add(eid, -tokens)
 	}
 }
 
-func addedTokensKey(requestID, endpointID, profileName string) string {
-	return requestID + "|" + endpointID + "|" + profileName
+func addedTokensKey(endpointID, profileName string) string {
+	return endpointID + "|" + profileName + "|added"
 }
 
 // uncachedInputTokens returns the prompt tokens this endpoint must actually compute,
@@ -378,10 +453,10 @@ func newConcurrencyTracker() *concurrencyTracker {
 	}
 }
 
-func (ct *concurrencyTracker) get(endpointID string) int64 {
-	ct.mu.RLock()
-	counter, exists := ct.counts[endpointID]
-	ct.mu.RUnlock()
+func (t *concurrencyTracker) get(endpointID string) int64 {
+	t.mu.RLock()
+	counter, exists := t.counts[endpointID]
+	t.mu.RUnlock()
 
 	if !exists {
 		return 0
@@ -389,39 +464,35 @@ func (ct *concurrencyTracker) get(endpointID string) int64 {
 	return counter.Load()
 }
 
-func (ct *concurrencyTracker) inc(endpointID string) {
-	ct.add(endpointID, 1)
+func (t *concurrencyTracker) inc(endpointID string) {
+	t.add(endpointID, 1)
 }
 
-func (ct *concurrencyTracker) add(endpointID string, delta int64) {
-	ct.mu.RLock()
-	counter, exists := ct.counts[endpointID]
-	ct.mu.RUnlock()
+func (t *concurrencyTracker) add(endpointID string, delta int64) {
+	t.mu.RLock()
+	counter, exists := t.counts[endpointID]
+	t.mu.RUnlock()
 
 	if exists {
 		counter.Add(delta)
 		return
 	}
 
-	ct.mu.Lock()
-	defer ct.mu.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
-	if counter, exists = ct.counts[endpointID]; exists {
+	if counter, exists = t.counts[endpointID]; exists {
 		counter.Add(delta)
 		return
 	}
 
 	counter = &atomic.Int64{}
 	counter.Store(delta)
-	ct.counts[endpointID] = counter
+	t.counts[endpointID] = counter
 }
 
-func (ct *concurrencyTracker) dec(endpointID string) {
-	ct.add(endpointID, -1)
-}
-
-func (ct *concurrencyTracker) delete(endpointID string) {
-	ct.mu.Lock()
-	defer ct.mu.Unlock()
-	delete(ct.counts, endpointID)
+func (t *concurrencyTracker) delete(endpointID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.counts, endpointID)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -456,3 +456,46 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
 		"counters must return to zero with no drift across profiles")
 }
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart verifies the
+// safety net for non-streaming or error paths: when includeOutputTokens=false and
+// ResponseBody delivers EndOfStream without ever seeing StartOfStream, the token
+// counter and request counter must both drain (tokens are normally released at
+// StartOfStream, so a missing StartOfStream would otherwise leak them). Also
+// asserts the addedTokens map entry is removed so accounting stays balanced.
+func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "no-start-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-no-start", "1234567890123456") // 4 input tokens
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
+
+	// EndOfStream only (no StartOfStream): both counters must drain.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"tokens must be released on EndOfStream even if StartOfStream was never seen")
+
+	// addedTokens entry should be gone too (no leak).
+	_, loaded := producer.addedTokens.Load(addedTokensKey(req.RequestID, endpointID, "default"))
+	require.False(t, loaded, "addedTokens entry must be released")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -64,9 +64,10 @@ func TestInFlightLoadProducer_Lifecycle(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
 	}
 	ctx := context.Background()
 	endpointName := "lifecycle-endpoint"
@@ -92,9 +93,10 @@ func TestInFlightLoadProducer_MultiPodLifecycle(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
 	}
 	ctx := context.Background()
 	podA := "pod-a"
@@ -161,9 +163,10 @@ func TestInFlightLoadProducer_ConcurrencyStress(t *testing.T) {
 	t.Parallel()
 
 	producer := &InFlightLoadProducer{
-		requestTracker: newConcurrencyTracker(),
-		tokenTracker:   newConcurrencyTracker(),
-		tokenEstimator: NewSimpleTokenEstimator(),
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
 	}
 	ctx := context.Background()
 	endpointName := "stress-endpoint"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -29,6 +29,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 func TestInFlightLoadProducer_PrepareRequestData(t *testing.T) {
@@ -257,4 +258,201 @@ func makeTokenRequest(requestID, prompt string) *fwksched.InferenceRequest {
 			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
 		},
 	}
+}
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease verifies that when
+// IncludeOutputTokens is false, token counters are released as soon as the first chunk
+// arrives (StartOfStream), while request counters are released only on EndOfStream.
+func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "exclude-output-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// 16 chars / 4 = 4 input tokens. Output tokens are excluded.
+	req := makeTokenRequest("req-no-output", "1234567890123456")
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID), "only input tokens should be tracked")
+
+	// First chunk arrives: tokens released, request still in flight.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID), "request counter should still be held")
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID), "tokens should be released at StartOfStream")
+
+	// EndOfStream releases the request counter.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+// TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk verifies that a single-chunk
+// response (StartOfStream && EndOfStream both true) releases both tokens and the request.
+func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: false,
+	}
+	ctx := context.Background()
+	endpointName := "single-chunk-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-single", "1234567890123456")
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
+
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true, EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+// TestInFlightLoadProducer_PrefixCacheDiscount verifies that when PrefixCacheMatchInfo
+// is published on the endpoint, the matched prefix is excluded from the tracked input
+// tokens, and that release subtracts the same (discounted) amount.
+func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	endpointName := "prefix-cache-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// Prompt: 32 chars / 4 = 8 input tokens. Output = 8 * 1.5 = 12.
+	// With block_size=4, total=2 blocks, matched=1 block (4 tokens cached):
+	//   uncached_input = (2-1)*4 + max(0, 8-2*4) = 4
+	//   total tokens = 4 + 12 = 16
+	endpoint := newStubSchedulingEndpoint(endpointName)
+	endpoint.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+
+	req := makeTokenRequest("req-prefix", "12345678901234567890123456789012")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{endpoint}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(16), producer.tokenTracker.get(endpointID),
+		"only uncached input (4) plus output (12) should be tracked")
+
+	// Release uses the exact stored value, returning to zero.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"release should subtract the same discounted amount that was added")
+}
+
+// TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint verifies that two profiles
+// targeting different endpoints with different prefix-cache match levels each get their
+// own discounted token amount, and that both counters return to zero after release.
+func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	podA := "pod-a-cached"
+	podB := "pod-b-uncached"
+	idA := fullEndpointName(podA)
+	idB := fullEndpointName(podB)
+
+	// 8 input tokens, output 12.
+	epA := newStubSchedulingEndpoint(podA)
+	epA.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(2, 2, 4)) // fully cached
+	epB := newStubSchedulingEndpoint(podB)
+	epB.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(0, 2, 4)) // none cached
+
+	req := makeTokenRequest("req-multi-cache", "12345678901234567890123456789012")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{epA}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{epB}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(0+12), producer.tokenTracker.get(idA), "fully cached: only output tokens")
+	require.Equal(t, int64(8+12), producer.tokenTracker.get(idB), "uncached: input + output")
+
+	// Drive the response lifecycle: StartOfStream releases prefill, EndOfStream releases decode.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.tokenTracker.get(idA))
+	require.Equal(t, int64(0), producer.tokenTracker.get(idB))
+	require.Equal(t, int64(0), producer.requestTracker.get(idA))
+	require.Equal(t, int64(0), producer.requestTracker.get(idB))
+}
+
+// TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint verifies that
+// when multiple profiles target the same endpoint, each contributes to the counters
+// independently and each release subtracts the exact added amount, returning counters
+// to their pre-request baseline.
+func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+	}
+	ctx := context.Background()
+	endpointName := "shared-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// 16 chars / 4 = 4 input tokens, 6 output, total 10 tokens per profile.
+	// Two profiles both targeting the same endpoint => 2 requests, 20 tokens.
+	req := makeTokenRequest("req-shared", "1234567890123456")
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(2), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(20), producer.tokenTracker.get(endpointID))
+
+	// StartOfStream releases the prefill profile only (1 request, 10 tokens).
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// EndOfStream releases the remaining (decode) profile.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
+		"counters must return to zero with no drift across profiles")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -495,7 +495,7 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *tes
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
 		"tokens must be released on EndOfStream even if StartOfStream was never seen")
 
-	// addedTokens entry should be gone too (no leak).
-	_, loaded := producer.addedTokens.Load(addedTokensKey(req.RequestID, endpointID, "default"))
-	require.False(t, loaded, "addedTokens entry must be released")
+	// addedTokens entry should be gone too (no leak, no future double-subtract).
+	require.False(t, producer.addedTokens.Has(addedTokensKey(req.RequestID, endpointID, "default")),
+		"addedTokens entry must be released")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -462,7 +463,8 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 // ResponseBody delivers EndOfStream without ever seeing StartOfStream, the token
 // counter and request counter must both drain (tokens are normally released at
 // StartOfStream, so a missing StartOfStream would otherwise leak them). Also
-// asserts the addedTokens map entry is removed so accounting stays balanced.
+// asserts the addedTokens entry is removed so the TTL safety net doesn't later
+// double-subtract via OnEviction.
 func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *testing.T) {
 	t.Parallel()
 
@@ -498,4 +500,53 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *tes
 	// addedTokens entry should be gone too (no leak, no future double-subtract).
 	require.False(t, producer.addedTokens.Has(addedTokensKey(req.RequestID, endpointID, "default")),
 		"addedTokens entry must be released")
+}
+
+// TestInFlightLoadProducer_TTLEviction_RollsBackCounters verifies the leak
+// safety net: when ResponseBody never delivers EndOfStream for a request, the
+// addedTokens entry expires via TTL and the OnEviction handler rolls back both
+// the token tracker and the request tracker for that endpoint, so neither
+// counter (nor the cache itself) drifts upward over time.
+func TestInFlightLoadProducer_TTLEviction_RollsBackCounters(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker:      newConcurrencyTracker(),
+		tokenTracker:        newConcurrencyTracker(),
+		tokenEstimator:      NewSimpleTokenEstimator(),
+		includeOutputTokens: true,
+		requestTTL:          10 * time.Millisecond,
+	}
+	ctx := context.Background()
+	endpointName := "abandoned-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-abandoned", "1234567890123456") // 4 input + 6 output = 10
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(endpointName)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+	require.True(t, producer.addedTokens.Has(addedTokensKey(req.RequestID, endpointID, "default")))
+
+	// Simulate an abandoned request: never call ResponseBody. Wait for the TTL
+	// to elapse, then deterministically trigger eviction (DeleteExpired runs
+	// the same OnEviction path as the background janitor would).
+	time.Sleep(15 * time.Millisecond)
+	producer.addedTokens.DeleteExpired()
+
+	require.False(t, producer.addedTokens.Has(addedTokensKey(req.RequestID, endpointID, "default")),
+		"expired addedTokens entry must be removed from the cache")
+	// OnEviction subscribers run on a goroutine in ttlcache v3, so wait briefly
+	// for the rollback to be observed on both counters.
+	require.Eventually(t, func() bool {
+		return producer.tokenTracker.get(endpointID) == 0 &&
+			producer.requestTracker.get(endpointID) == 0
+	}, time.Second, time.Millisecond,
+		"TTL eviction must roll back both token and request trackers for the endpoint")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package inflightload
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,23 +35,25 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
 )
 
-func newTestProducer() *InFlightLoadProducer {
-	return &InFlightLoadProducer{
-		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: "inflight-load-producer"},
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: true,
-		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName("inflight-load-producer"),
-	}
+func newTestProducer(t testing.TB) *InFlightLoadProducer {
+	params := Config{AddEstimatedOutputTokens: true}
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	p, err := InFlightLoadProducerFactory("inflight-load-producer", decoder, igwtestutils.NewTestHandle(ctx))
+	require.NoError(t, err)
+	return p.(*InFlightLoadProducer)
 }
 
 func TestInFlightLoadProducer_Produce(t *testing.T) {
 	t.Parallel()
 
-	producer := newTestProducer()
+	producer := newTestProducer(t)
 
 	endpointName := "test-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -74,7 +80,7 @@ func TestInFlightLoadProducer_Produce(t *testing.T) {
 func TestInFlightLoadProducer_Lifecycle(t *testing.T) {
 	t.Parallel()
 
-	producer := newTestProducer()
+	producer := newTestProducer(t)
 	ctx := context.Background()
 	endpointName := "lifecycle-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -98,7 +104,7 @@ func TestInFlightLoadProducer_Lifecycle(t *testing.T) {
 func TestInFlightLoadProducer_MultiPodLifecycle(t *testing.T) {
 	t.Parallel()
 
-	producer := newTestProducer()
+	producer := newTestProducer(t)
 	ctx := context.Background()
 	podA := "pod-a"
 	podB := "pod-b"
@@ -134,7 +140,7 @@ func TestInFlightLoadProducer_MultiPodLifecycle(t *testing.T) {
 func TestInFlightLoadProducer_NotificationCleanup(t *testing.T) {
 	t.Parallel()
 
-	producer := newTestProducer()
+	producer := newTestProducer(t)
 	ctx := context.Background()
 	endpointName := "deleted-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -160,45 +166,37 @@ func TestInFlightLoadProducer_NotificationCleanup(t *testing.T) {
 func TestInFlightLoadProducer_ConcurrencyStress(t *testing.T) {
 	t.Parallel()
 
-	producer := newTestProducer()
+	producer := newTestProducer(t)
 	ctx := context.Background()
 	endpointName := "stress-endpoint"
 	endpointID := fullEndpointName(endpointName)
 
 	const (
 		numGoroutines = 50
-		opsPerRoutine = 1000
+		opsPerRoutine = 100
 	)
 
 	var wg sync.WaitGroup
-	wg.Add(numGoroutines * 2)
+	wg.Add(numGoroutines)
 
-	// Launch increments
-	for range numGoroutines {
-		go func() {
+	for i := 0; i < numGoroutines; i++ {
+		go func(g int) {
 			defer wg.Done()
-			res := makeSchedulingResult(endpointName)
-			for range opsPerRoutine {
-				producer.PreRequest(ctx, nil, res)
-			}
-		}()
-	}
+			for j := 0; j < opsPerRoutine; j++ {
+				reqID := fmt.Sprintf("req-%d-%d", g, j)
+				res := makeSchedulingResult(endpointName)
+				req := &fwksched.InferenceRequest{RequestID: reqID, SchedulingResult: res}
 
-	// Launch decrements
-	for range numGoroutines {
-		go func() {
-			defer wg.Done()
-			res := makeSchedulingResult(endpointName)
-			req := &fwksched.InferenceRequest{SchedulingResult: res}
-			for range opsPerRoutine {
+				producer.PreRequest(ctx, req, res)
 				producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
 			}
-		}()
+		}(i)
 	}
 
 	wg.Wait()
 
 	require.Equal(t, int64(0), producer.requestTracker.get(endpointID), "request count drift detected")
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID), "token count drift detected")
 }
 
 // --- Helpers ---
@@ -258,12 +256,8 @@ func makeTokenRequest(requestID, prompt string) *fwksched.InferenceRequest {
 func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testing.T) {
 	t.Parallel()
 
-	producer := &InFlightLoadProducer{
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: false,
-	}
+	producer := newTestProducer(t)
+	producer.addEstimatedOutputTokens = false
 	ctx := context.Background()
 	endpointName := "exclude-output-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -292,12 +286,8 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testin
 func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
 	t.Parallel()
 
-	producer := &InFlightLoadProducer{
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: false,
-	}
+	producer := newTestProducer(t)
+	producer.addEstimatedOutputTokens = false
 	ctx := context.Background()
 	endpointName := "single-chunk-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -319,12 +309,7 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
 func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
 	t.Parallel()
 
-	producer := &InFlightLoadProducer{
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: true,
-	}
+	producer := newTestProducer(t)
 	ctx := context.Background()
 	endpointName := "prefix-cache-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -363,12 +348,7 @@ func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
 func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
 	t.Parallel()
 
-	producer := &InFlightLoadProducer{
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: true,
-	}
+	producer := newTestProducer(t)
 	ctx := context.Background()
 	podA := "pod-a-cached"
 	podB := "pod-b-uncached"
@@ -411,12 +391,7 @@ func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
 func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t *testing.T) {
 	t.Parallel()
 
-	producer := &InFlightLoadProducer{
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: true,
-	}
+	producer := newTestProducer(t)
 	ctx := context.Background()
 	endpointName := "shared-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -453,17 +428,12 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 // safety net for non-streaming or error paths: when addEstimatedOutputTokens=false and
 // ResponseBody delivers EndOfStream without ever seeing StartOfStream, the token
 // counter and request counter must both drain (tokens are normally released at
-// StartOfStream, so a missing StartOfStream would otherwise leak them). Also
-// asserts the addedTokens map entry is removed so accounting stays balanced.
+// StartOfStream, so a missing StartOfStream would otherwise leak them).
 func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *testing.T) {
 	t.Parallel()
 
-	producer := &InFlightLoadProducer{
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: false,
-	}
+	producer := newTestProducer(t)
+	producer.addEstimatedOutputTokens = false
 	ctx := context.Background()
 	endpointName := "no-start-endpoint"
 	endpointID := fullEndpointName(endpointName)
@@ -487,7 +457,292 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *tes
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID),
 		"tokens must be released on EndOfStream even if StartOfStream was never seen")
 
-	// addedTokens entry should be gone too (no leak).
-	_, loaded := producer.addedTokens.Load(addedTokensKey(req.RequestID, endpointID, "default"))
-	require.False(t, loaded, "addedTokens entry must be released")
+	// PluginState entry should be gone too (no leak).
+	key := fwkplugin.StateKey(addedTokensKey(endpointID, "default"))
+	_, err := producer.PluginState.Read(req.RequestID, key)
+	require.ErrorIs(t, err, fwkplugin.ErrNotFound, "PluginState entry must be released")
+}
+
+// TestInFlightLoadProducer_Eviction verifies that global counters are rolled back
+// when a request is explicitly deleted from PluginState (simulating either
+// end-of-stream cleanup or janitor reaping).
+func TestInFlightLoadProducer_Eviction(t *testing.T) {
+	producer := newTestProducer(t)
+	ctx := context.Background()
+	endpointName := "eviction-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	// 1. PreRequest: Adds load
+	req := makeTokenRequest("req-eviction", "1234567890123456") // 10 tokens
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// 2. Explicitly delete the request (simulates what the janitor or EOS cleanup does).
+	producer.PluginState.Delete(req.RequestID)
+
+	// 3. Verify counters rolled back automatically via OnEvicted callback
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID), "request counter should have rolled back via Eviction")
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID), "token counter should have rolled back via Eviction")
+}
+
+// TestInFlightLoadProducer_Touch verifies that intermediate chunks extend the
+// request's lifetime in PluginState.
+func TestInFlightLoadProducer_Touch(t *testing.T) {
+	producer := newTestProducer(t)
+	ctx := context.Background()
+	endpointName := "touch-endpoint"
+
+	req := makeTokenRequest("req-touch", "1234567890123456")
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+
+	// Get initial access time
+	t1, ok := producer.PluginState.LastAccessTime(req.RequestID)
+	require.True(t, ok)
+
+	// Simulate intermediate chunks until access time is updated.
+	// We use Eventually to handle coarse timer resolution or busy CI runners.
+	require.Eventually(t, func() bool {
+		req.SchedulingResult = res
+		producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: false, StartOfStream: false}, nil)
+
+		t2, ok := producer.PluginState.LastAccessTime(req.RequestID)
+		return ok && t2.After(t1)
+	}, 1*time.Second, 10*time.Millisecond, "Touch should have extended the lifetime")
+}
+
+// TestInFlightLoadProducer_LateResponseAfterReap verifies that if a ResponseBody
+// arrives after the janitor has already reaped the request, we do NOT double-decrement.
+func TestInFlightLoadProducer_LateResponseAfterReap(t *testing.T) {
+	producer := newTestProducer(t)
+	ctx := context.Background()
+	endpointName := "late-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-late", "1234567890123456") // 10 tokens
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// Simulate janitor reap
+	producer.PluginState.Delete(req.RequestID)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID), "counters should be 0 after reap")
+
+	// Late ResponseBody arrives
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+
+	// Verify no double-decrement
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID), "counters should NOT go negative")
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+func TestInFlightLoadProducer_AtomicTokenRelease_Concurrent(t *testing.T) {
+	producer := newTestProducer(t)
+	ctx := context.Background()
+	endpointName := "race-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	req := makeTokenRequest("req-race", "1234567890123456") // 10 tokens
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// Fire releaseTokensEarly and an explicit Delete concurrently. Whichever
+	// wins the Swap does the -10; the other is a no-op. Net must be 0.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		producer.releaseTokensEarly(res.ProfileResults["default"].TargetEndpoints[0], req, "default")
+	}()
+	go func() {
+		defer wg.Done()
+		producer.PluginState.Delete(req.RequestID)
+	}()
+	wg.Wait()
+
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+}
+
+func TestUncachedInputTokens_Overestimate(t *testing.T) {
+	// Setup:
+	// inputTokens (estimated) = 5
+	// PrefixCacheMatchInfo: matchBlocks=1, totalBlocks=2, blockSizeTokens=4
+	//   indexedTokens = 2 * 4 = 8
+	//   matchedTokens = 1 * 4 = 4
+
+	endpoint := newStubSchedulingEndpoint("test-ep")
+	endpoint.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+
+	inputTokens := int64(5)
+
+	uncached := uncachedInputTokens(endpoint, inputTokens)
+
+	// When the prefix cache says 4 tokens are definitely uncached in the indexed portion (8-4),
+	// we trust that over the smaller (approximate) estimate of 5.
+	require.Equal(t, int64(4), uncached, "should trust the prefix cache's uncached count (indexed-matched) over the smaller estimate")
+}
+
+func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
+	producer := newTestProducer(t)
+	ctx := context.Background()
+
+	t.Run("ExtractEndpoint", func(t *testing.T) {
+		// 1. Nil Endpoint
+		require.NotPanics(t, func() {
+			_ = producer.ExtractEndpoint(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: nil})
+		})
+
+		// 2. Nil Metadata
+		stub := newStubSchedulingEndpoint("nil-meta")
+		stub.metadata = nil
+		require.NotPanics(t, func() {
+			_ = producer.ExtractEndpoint(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: stub})
+		})
+	})
+
+	t.Run("Produce", func(t *testing.T) {
+		// 1. Nil Endpoints slice
+		require.NotPanics(t, func() {
+			_ = producer.Produce(ctx, nil, nil)
+		})
+
+		// 2. Slice with nil endpoint
+		require.NotPanics(t, func() {
+			_ = producer.Produce(ctx, nil, []fwksched.Endpoint{nil})
+		})
+
+		// 3. Endpoint with nil metadata
+		stub := newStubSchedulingEndpoint("nil-meta")
+		stub.metadata = nil
+		require.NotPanics(t, func() {
+			_ = producer.Produce(ctx, nil, []fwksched.Endpoint{stub})
+		})
+	})
+
+	t.Run("PreRequest", func(t *testing.T) {
+		// 1. Nil Result
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, nil, nil)
+		})
+
+		// 2. Nil Request, non-nil Result
+		res := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"default": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint("ep1")}},
+			},
+		}
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, nil, res)
+		})
+		require.Equal(t, int64(0), producer.requestTracker.get(fullEndpointName("ep1")), "should not increment counters without request")
+
+		// 3. Empty ProfileResults
+		resEmpty := &fwksched.SchedulingResult{ProfileResults: map[string]*fwksched.ProfileRunResult{}}
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, &fwksched.InferenceRequest{}, resEmpty)
+		})
+
+		// 4. Nil ProfileResult
+		resNilProfile := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{"default": nil},
+		}
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilProfile)
+		})
+
+		// 5. Empty TargetEndpoints
+		resEmptyEndpoints := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"default": {TargetEndpoints: []fwksched.Endpoint{}},
+			},
+		}
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resEmptyEndpoints)
+		})
+
+		// 6. Nil Endpoint in TargetEndpoints
+		resNilEndpoint := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"default": {TargetEndpoints: []fwksched.Endpoint{nil}},
+			},
+		}
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilEndpoint)
+		})
+
+		// 7. Endpoint with nil metadata
+		stub := newStubSchedulingEndpoint("nil-meta")
+		stub.metadata = nil
+		resNilMeta := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"default": {TargetEndpoints: []fwksched.Endpoint{stub}},
+			},
+		}
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilMeta)
+		})
+
+		// 8. Missing RequestID (Leak check)
+		resLeak := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"default": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint("ep-leak")}},
+			},
+		}
+		require.NotPanics(t, func() {
+			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: ""}, resLeak)
+		})
+		require.Equal(t, int64(0), producer.requestTracker.get(fullEndpointName("ep-leak")), "should not increment counters with empty RequestID")
+	})
+
+	t.Run("ResponseBody", func(t *testing.T) {
+		// 1. Nil Request or Response
+		require.NotPanics(t, func() {
+			producer.ResponseBody(ctx, nil, nil, nil)
+		})
+		require.NotPanics(t, func() {
+			producer.ResponseBody(ctx, &fwksched.InferenceRequest{}, nil, nil)
+		})
+		require.NotPanics(t, func() {
+			producer.ResponseBody(ctx, nil, &requestcontrol.Response{}, nil)
+		})
+
+		// 2. Nil SchedulingResult
+		reqNoRes := &fwksched.InferenceRequest{SchedulingResult: nil}
+		require.NotPanics(t, func() {
+			producer.ResponseBody(ctx, reqNoRes, &requestcontrol.Response{}, nil)
+		})
+
+		// 3. Various nil components in result
+		resNilProfile := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{"default": nil},
+		}
+		reqNilProfile := &fwksched.InferenceRequest{SchedulingResult: resNilProfile}
+		require.NotPanics(t, func() {
+			producer.ResponseBody(ctx, reqNilProfile, &requestcontrol.Response{EndOfStream: true}, nil)
+		})
+
+		resNilEndpoint := &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"default": {TargetEndpoints: []fwksched.Endpoint{nil}},
+			},
+		}
+		reqNilEndpoint := &fwksched.InferenceRequest{SchedulingResult: resNilEndpoint}
+		require.NotPanics(t, func() {
+			producer.ResponseBody(ctx, reqNilEndpoint, &requestcontrol.Response{EndOfStream: true}, nil)
+		})
+	})
+
+	t.Run("Factory_NilHandle", func(t *testing.T) {
+		p, err := InFlightLoadProducerFactory("test", nil, nil)
+		require.Error(t, err)
+		require.Nil(t, p)
+	})
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -24,7 +24,12 @@ import (
 
 // TokenEstimator estimates the number of tokens for an LLM request.
 type TokenEstimator interface {
+	// Estimate returns the total estimated token count (input + output) for the request.
 	Estimate(request *fwksched.InferenceRequest) int64
+	// EstimateInput returns only the estimated input token count for the request.
+	EstimateInput(request *fwksched.InferenceRequest) int64
+	// EstimateOutput returns the estimated output token count given the input token count.
+	EstimateOutput(inputTokens int64) int64
 }
 
 // SimpleTokenEstimator estimates tokens from character count. tokens = characters / CharactersPerToken.
@@ -46,27 +51,40 @@ func NewSimpleTokenEstimator() TokenEstimator {
 // to avoid allocations. Otherwise, input tokens are estimated from prompt/message character count
 // using CharactersPerToken; output tokens are estimated as inputTokens * OutputRatio.
 func (e *SimpleTokenEstimator) Estimate(request *fwksched.InferenceRequest) int64 {
+	inputTokens := e.EstimateInput(request)
+	if inputTokens == 0 {
+		return 0
+	}
+	return inputTokens + e.EstimateOutput(inputTokens)
+}
+
+// EstimateInput returns only the estimated input token count for the request.
+func (e *SimpleTokenEstimator) EstimateInput(request *fwksched.InferenceRequest) int64 {
 	if request == nil {
 		return 0
 	}
 	// Prefer request body size when available: avoids PlainText() and reduces GC pressure.
-	var inputTokens int64
 	switch {
 	case request.RequestSizeBytes > 0:
-		inputTokens = max(int64(request.RequestSizeBytes)/4, 1)
+		return max(int64(request.RequestSizeBytes)/4, 1)
 	case request.Body != nil:
 		hint := request.Body.InputTokenCountHint()
 		if hint >= 0 {
-			inputTokens = int64(hint)
-		} else {
-			// Fallback: character count from prompt text across all API types
-			// (completions, chat/completions, responses, conversations).
-			chars := len(request.Body.PromptText())
-			inputTokens = int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
+			return int64(hint)
 		}
+		// Fallback: character count from prompt text across all API types
+		// (completions, chat/completions, responses, conversations).
+		chars := len(request.Body.PromptText())
+		return int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
 	default:
 		return 0
 	}
-	outputTokens := int64(math.Round(float64(inputTokens) * e.OutputRatio))
-	return inputTokens + outputTokens
+}
+
+// EstimateOutput returns the estimated output token count given the input token count.
+func (e *SimpleTokenEstimator) EstimateOutput(inputTokens int64) int64 {
+	if inputTokens <= 0 {
+		return 0
+	}
+	return int64(math.Round(float64(inputTokens) * e.OutputRatio))
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -7,20 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload"
 	"github.com/llm-d/llm-d-router/test/utils"
+	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
 )
 
 // Test helper functions
 
 func newTestEndpoint(name string, queueSize int) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
-		&fwkdl.Metrics{
+		&datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
+		&datalayer.Metrics{
 			WaitingQueueSize: queueSize,
 		},
 		nil,
@@ -94,7 +95,7 @@ func TestActiveRequestScorer_Score(t *testing.T) {
 func TestActiveRequestScorer_UsesInFlightLoadProducerLifecycle(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 
-	producerPlugin, err := inflightload.InFlightLoadProducerFactory(inflightload.InFlightLoadProducerType, nil, nil)
+	producerPlugin, err := inflightload.InFlightLoadProducerFactory(inflightload.InFlightLoadProducerType, nil, igwtestutils.NewTestHandle(ctx))
 	require.NoError(t, err)
 	producer := producerPlugin.(*inflightload.InFlightLoadProducer)
 	scorer := NewActiveRequest(ctx, nil)


### PR DESCRIPTION
## Description
This PR enhances `PluginState` lifecycle management by adding support for eviction callbacks and state lifetime extension. These features are integrated into the `InFlightLoadProducer` to ensure reliable tracking of global token and request counters, even in cases of request timeouts, network disconnects, or long-lived streams.

### Key Changes

#### 1. Framework: PluginState Enhancements
*   **Eviction Callbacks (`OnEvicted`):** Added the `EvictableStateData` interface in `shared_state.go`. `PluginState` now triggers an `OnEvicted` callback whenever data is removed manually or reaped by the background janitor. This allows plugins to perform deterministic cleanup of external resources (like global counters).
*   **Lifetime Extension (`Touch`):** Added a `Touch(requestID)` method to `PluginState`. This allows active processes to signal that a request is still alive, preventing the janitor from prematurely reaping its state during long operations.

#### 2. Plugin: InFlightLoadProducer Integration
*   **Robust Counter Rollback:** The producer now implements `EvictableStateData` for its internal token records. If a request is abandoned and eventually reaped by the TTL janitor, the global token and request trackers are automatically decremented via the callback, preventing "counter leaks."
*   **Streaming Support:** Updated the `ResponseBody` hook to "touch" the request state on every incoming chunk. This ensures that slow or long-running streams remain active in `PluginState` for their entire duration, even if they exceed the default staleness threshold.
*   **Unified Cleanup:** Refactored the `release` logic to be "PluginState-first." Explicitly deleting the state entry now acts as the single source of truth for rolling back counters.

### Impact
*   **Correctness:** Eliminates scenarios where global inflight token/request counts could drift upwards due to failed or timed-out requests that never hit the final response hooks.
*   **Stability:** Prevents memory leaks by ensuring `PluginState` entries are always reaped while maintaining the integrity of the scheduling metrics.

### Verification Results
*   **Unit Tests:** Expanded `plugin_state_test.go` with `TestPluginState_EvictionCallback` and `TestPluginState_Touch`.
*   **Functional Tests:** Verified all `inflightload` producer tests pass, including:
    *   `TestInFlightLoadProducer_TTL`: Regression test for TTL-driven counter rollback.
    *   `TestInFlightLoadProducer_Touch`: Verifies lifetime extension during streaming.
    *   `TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint`: Ensures counters return to baseline across complex scheduling results.
*   **Rebase:** Fully rebased onto `upstream/main`, aligning with the project rename to `llm-d-router` and the new `DataKey` API.

***

**Signed-off-by:** Kaushik Mitra <kaushikmitra@google.com>
