### PR TITLE
fix: use int32 for InferenceObjective priority

### DIFF
--- a/apix/v1alpha2/inferenceobjective_types.go
+++ b/apix/v1alpha2/inferenceobjective_types.go
@@ -70,7 +70,7 @@ type InferenceObjectiveSpec struct {
 	// requests with Priority of 0 (the value used if Priority is unset or no InferenceObjective is specified).
 	// Similarly requests with a Priority of -10 will always be served after requests with Priority of 0.
 	// +optional
-	Priority *int `json:"priority,omitempty"`
+	Priority *int32 `json:"priority,omitempty"`
 
 	// PoolRef is a reference to the inference pool, the pool must exist in the same namespace.
 	//

--- a/apix/v1alpha2/zz_generated.deepcopy.go
+++ b/apix/v1alpha2/zz_generated.deepcopy.go
@@ -208,7 +208,7 @@ func (in *InferenceObjectiveSpec) DeepCopyInto(out *InferenceObjectiveSpec) {
 	*out = *in
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	out.PoolRef = in.PoolRef

--- a/client-go/applyconfiguration/apix/v1alpha2/inferenceobjectivespec.go
+++ b/client-go/applyconfiguration/apix/v1alpha2/inferenceobjectivespec.go
@@ -27,7 +27,7 @@ type InferenceObjectiveSpecApplyConfiguration struct {
 	// Example: requests with Priority 10 will always be served before
 	// requests with Priority of 0 (the value used if Priority is unset or no InferenceObjective is specified).
 	// Similarly requests with a Priority of -10 will always be served after requests with Priority of 0.
-	Priority *int `json:"priority,omitempty"`
+	Priority *int32 `json:"priority,omitempty"`
 	// PoolRef is a reference to the inference pool, the pool must exist in the same namespace.
 	PoolRef *PoolObjectReferenceApplyConfiguration `json:"poolRef,omitempty"`
 }
@@ -41,7 +41,7 @@ func InferenceObjectiveSpec() *InferenceObjectiveSpecApplyConfiguration {
 // WithPriority sets the Priority field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Priority field is set to the value of the last call.
-func (b *InferenceObjectiveSpecApplyConfiguration) WithPriority(value int) *InferenceObjectiveSpecApplyConfiguration {
+func (b *InferenceObjectiveSpecApplyConfiguration) WithPriority(value int32) *InferenceObjectiveSpecApplyConfiguration {
 	b.Priority = &value
 	return b
 }

--- a/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
@@ -97,6 +97,7 @@ spec:
                   Example: requests with Priority 10 will always be served before
                   requests with Priority of 0 (the value used if Priority is unset or no InferenceObjective is specified).
                   Similarly requests with a Priority of -10 will always be served after requests with Priority of 0.
+                format: int32
                 type: integer
             required:
             - poolRef

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -45,7 +45,7 @@ var (
 	inferencePool = testutil.MakeInferencePool("test-pool1").Namespace("ns1").ObjRef()
 	infObjective1 = testutil.MakeInferenceObjective("model1").
 			Namespace(inferencePool.Namespace).
-			Priority(1).
+			Priority(int32(1)).
 			CreationTimestamp(metav1.Unix(1000, 0)).
 			PoolName(inferencePool.Name).
 			PoolGroup("inference.networking.k8s.io").ObjRef()
@@ -57,7 +57,7 @@ var (
 				PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1Critical = testutil.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
-				Priority(2).
+				Priority(int32(2)).
 				CreationTimestamp(metav1.Unix(1003, 0)).
 				PoolName(inferencePool.Name).
 				PoolGroup("inference.networking.k8s.io").ObjRef()
@@ -69,7 +69,7 @@ var (
 				PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1DiffGroup = testutil.MakeInferenceObjective(infObjective1.Name).
 				Namespace(inferencePool.Namespace).
-				Priority(1).
+				Priority(int32(1)).
 				CreationTimestamp(metav1.Unix(1005, 0)).
 				PoolName(inferencePool.Name).
 				PoolGroup("inference.networking.x-k8s.io").ObjRef()

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -118,10 +118,10 @@ type Director struct {
 	admissionController   AdmissionController
 	endpointCandidates    contracts.EndpointCandidates
 	requestControlPlugins Config
-	// we just need a pointer to an int variable since priority is a pointer in InferenceObjective
-	// no need to set this in the constructor, since the value we want is the default int val
+	// We just need a pointer to an int32 variable since Priority is a pointer in InferenceObjective.
+	// No need to set this in the constructor, since the value we want is the default (0) and
 	// and value types cannot be nil
-	defaultPriority int
+	defaultPriority int32
 
 	// responseBodyQueues maps request IDs to their async processing channels.
 	// Each request gets a dedicated channel and goroutine to ensure chunks are
@@ -161,12 +161,13 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 
 	infObjective := d.getInferenceObjective(ctx, reqCtx)
-	reqCtx.Priority = *infObjective.Spec.Priority
-	requestObjectives := fwksched.RequestObjectives{Priority: *infObjective.Spec.Priority}
+	priority := int(*infObjective.Spec.Priority)
+	reqCtx.Priority = priority
+	requestObjectives := fwksched.RequestObjectives{Priority: priority}
 
 	span.SetAttributes(
 		attribute.String("target_model", reqCtx.TargetModelName),
-		attribute.Int("request_prio", *infObjective.Spec.Priority),
+		attribute.Int("request_prio", priority),
 	)
 
 	// Prepare InferenceRequest (needed for both saturation detection and Scheduler)
@@ -183,7 +184,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	ctx = log.IntoContext(ctx, logger)
 	logger.V(logutil.DEBUG).Info("LLM request assembled")
 
-	if err := d.admissionController.Admit(ctx, reqCtx, *infObjective.Spec.Priority); err != nil {
+	if err := d.admissionController.Admit(ctx, reqCtx, priority); err != nil {
 		return reqCtx, err
 	}
 

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -119,8 +119,8 @@ type Director struct {
 	endpointCandidates    contracts.EndpointCandidates
 	requestControlPlugins Config
 	// We just need a pointer to an int32 variable since Priority is a pointer in InferenceObjective.
-	// No need to set this in the constructor, since the value we want is the default (0) and
-	// and value types cannot be nil
+	// No need to set this in the constructor, since the value we want is the default (0)
+	// and value types cannot be nil.
 	defaultPriority int32
 
 	// responseBodyQueues maps request IDs to their async processing channels.

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -147,7 +147,7 @@ func (m *InferenceObjectiveWrapper) PoolGroup(poolGroup string) *InferenceObject
 	return m
 }
 
-func (m *InferenceObjectiveWrapper) Priority(priority int) *InferenceObjectiveWrapper {
+func (m *InferenceObjectiveWrapper) Priority(priority int32) *InferenceObjectiveWrapper {
 	m.Spec.Priority = &priority
 	return m
 }

--- a/test/utils/igw/wrappers.go
+++ b/test/utils/igw/wrappers.go
@@ -45,7 +45,7 @@ func MakeModelWrapper(namespacedName types.NamespacedName) *InferenceObjectiveWr
 }
 
 // SetPriority sets the value of the InferenceObjective.spec.priority.
-func (m *InferenceObjectiveWrapper) SetPriority(level int) *InferenceObjectiveWrapper {
+func (m *InferenceObjectiveWrapper) SetPriority(level int32) *InferenceObjectiveWrapper {
 	m.Spec.Priority = &level
 	return m
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
This PR standardizes InferenceObjective.spec.priority to use an explicit-width integer type.
  - Updates the API field InferenceObjectiveSpec.Priority from *int to *int32. In Kubernetes APIs, int is platform-dependent (32/64-bit) and can lead to inconsistent schemas and generated clients; int32 is stable and matches 
    API conventions.
  - Regenerates dependent artifacts so everything stays in sync:
      - CRD schema (config/crd/bases/...inferenceobjectives.yaml) now reflects format: int32.
      - Apply-configuration client code (client-go/applyconfiguration/.../inferenceobjectivespec.go) now uses *int32 and WithPriority(int32).
      - Deepcopy output updated accordingly.
  - Fixes internal code/tests that assumed int for priority (e.g., director default priority handling and test wrappers), while keeping the scheduler/internal objective representation as int where needed via explicit
    conversion.

**Which issue(s) this PR fixes**:
Fixes #1036 

**Release note** _(write `NONE` if no user-facing change)_:
NONE
