### PR TITLE
refactor(requestcontrol): remove ConsumerPlugin from DataProducer

### DIFF
--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -79,7 +79,6 @@ func (m *typedMockPlugin) TypedName() fwkplugin.TypedName {
 }
 
 func (m *typedMockPlugin) Produces() map[string]any { return m.produces }
-func (m *typedMockPlugin) Consumes() map[string]any { return nil }
 func (m *typedMockPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	return nil
 }

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -68,7 +68,6 @@ type ResponseBodyProcessor interface {
 // PrepareRequestData is called by the director before scheduling requests.
 type DataProducer interface {
 	plugin.ProducerPlugin
-	plugin.ConsumerPlugin
 	PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -56,11 +56,6 @@ func (p *prepareData) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
-// Consumes returns the data consumed by the plugin.
-func (p *prepareData) Consumes() map[string]any {
-	return map[string]any{}
-}
-
 // Produces returns the data produced by the plugin.
 func (p *prepareData) Produces() map[string]any {
 	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -183,10 +183,6 @@ func (p *InFlightLoadProducer) Produces() map[string]any {
 	}
 }
 
-func (p *InFlightLoadProducer) Consumes() map[string]any {
-	return nil
-}
-
 // DeleteEndpoint removes an endpoint from the concurrency trackers to prevent memory leaks.
 // This matches the design of the previous saturation detector and is called by the
 // ExtractNotification hook to ensure deterministic cleanup of stateful data.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -140,11 +140,6 @@ func (p *Plugin) Produces() map[string]any {
 	return map[string]any{TokenizedPromptKey: fwkrh.TokenizedPrompt{}}
 }
 
-// Consumes returns the data keys this plugin requires.
-func (p *Plugin) Consumes() map[string]any {
-	return nil
-}
-
 // PrepareRequestData tokenizes the request prompt and stores the result on
 // InferenceRequestBody.TokenizedPrompt (TokenIDs + MultiModalFeatures in flat shape).
 // Returns an error when tokenization fails; the caller (Director) decides the

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -337,11 +337,6 @@ func (s *Scorer) Produces() map[string]any {
 	}
 }
 
-// Consumes declares the data keys this plugin requires from other plugins.
-func (s *Scorer) Consumes() map[string]any {
-	return map[string]any{}
-}
-
 // PrepareRequestData computes block keys, looks up the index, and stores
 // per-endpoint prefix match information. The computed block keys and scores
 // are saved to PluginState for reuse by Score() and PreRequest().

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -59,10 +59,6 @@ func (m *mockPrepareRequestDataPlugin) Produces() map[string]any {
 	return nil
 }
 
-func (m *mockPrepareRequestDataPlugin) Consumes() map[string]any {
-	return nil
-}
-
 // ctxObservingPlugin records the context it received so tests can verify the
 // timeout wrapper cancels the plugin's context when the deadline fires.
 type ctxObservingPlugin struct {
@@ -87,7 +83,6 @@ func (p *ctxObservingPlugin) PrepareRequestData(ctx context.Context, _ *fwksched
 }
 
 func (p *ctxObservingPlugin) Produces() map[string]any { return nil }
-func (p *ctxObservingPlugin) Consumes() map[string]any { return nil }
 
 // TestPrepareDataPluginsWithTimeout_CancelsPluginContext verifies that the
 // child context passed to plugins is cancelled with DeadlineExceeded when the


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes `ConsumerPlugin` from the `DataProducer` interface. DataProducers that don't consume data no longer need to implement an empty `Consumes()` method. Plugins that actually consume data can still implement `ConsumerPlugin` independently - the data dependency system detects consumers via runtime type assertion.

**Which issue(s) this PR fixes**:
Fixes #836

**Release note**:
```release-note
NONE