### PR TITLE
fix: allow standalone sidecar resources to be configured

### DIFF
--- a/config/charts/standalone/values.yaml
+++ b/config/charts/standalone/values.yaml
@@ -29,6 +29,12 @@ inferenceExtension:
   sidecar:
     enabled: true
     proxyType: envoy
+    resources:
+      requests:
+        cpu: "4"
+        memory: 8Gi
+      limits:
+        memory: 16Gi
 
     # Agentgateway-specific settings used by the built-in preset when
     # proxyType=agentgateway. service.name is required.
@@ -275,10 +281,6 @@ inferenceExtension:
             name: http-8081
           - containerPort: 19001
             name: metrics-19001
-        resources:
-          requests:
-            cpu: 100m
-            memory: 512Mi
         readinessProbe:
           failureThreshold: 1
           httpGet:
@@ -315,10 +317,6 @@ inferenceExtension:
             name: metrics-15020
           - containerPort: 15021
             name: readiness-15021
-        resources:
-          requests:
-            cpu: 100m
-            memory: 256Mi
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/config/charts/standalone/values.yaml
+++ b/config/charts/standalone/values.yaml
@@ -13,6 +13,15 @@ inferenceExtension:
       targetPort: 8081
   env: []
   pluginsConfigFile: "default-plugins.yaml"
+  # Resource requests and limits for the EPP container.
+  # These defaults are sized for a standard EPP deployment with built-in scheduling plugins.
+  # CPU limits are intentionally unset to allow bursting to all available node CPUs during scheduling spikes.
+  resources:
+    requests:
+      cpu: "4"
+      memory: 8Gi
+    limits:
+      memory: 16Gi
 
   endpointsServer:
     # set it to false when you want to deploy EPP with inferencepool
@@ -24,6 +33,8 @@ inferenceExtension:
       - 8000
     # unused when createInferencePool is true
     modelServerType: vllm # vllm, sglang, triton-tensorrt-llm, trtllm-serve
+    # unused when createInferencePool is true
+    modelServerProtocol: http # http, grpc
 
 
   sidecar:
@@ -346,9 +357,17 @@ inferenceExtension:
       auth:
         # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
         enabled: true
+        # Service account token secret for authentication
+        secretName: inference-gateway-sa-metrics-reader-secret
+      # additional labels for the ServiceMonitor
+      extraLabels: {}
 
   tracing:
     enabled: false
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"
 
   latencyPredictor:
     # common latencyPredictor setting exists in config/charts/inference-extension/values.yaml
@@ -379,6 +398,7 @@ inferencePool:
   targetPorts:
     - number: 8000
   modelServerType: vllm # vllm, sglang, triton-tensorrt-llm, trtllm-serve
+  modelServerProtocol: http # http, grpc
   apiVersion: inference.networking.k8s.io/v1
   # modelServers: # REQUIRED
   #   matchLabels:


### PR DESCRIPTION
**What type of PR is this?**
  /kind bug                                                                                                                                                                                                                   
  /kind cleanup 

**What this PR does / why we need it**:
  This PR makes standalone proxy sidecar resources configurable via inferenceExtension.sidecar.resources and increases the default values.                                                                                    
                                                                                                                                                                                                                              
  Previously, the standalone chart hardcoded very small resource requests inside the built-in envoy and agentgateway presets, which made the proxy sidecar difficult to tune and too undersized for traffic spikes. This      
  change moves resource configuration to the top-level standalone sidecar settings so users can override it consistently regardless of proxy type, while also raising the defaults to more practical values.                  
                                                                                                                                                                                                                              
  The deployment template already renders sidecar.resources, so this change is limited to chart values cleanup and default sizing.       


**Which issue(s) this PR fixes**:
Fixes #1038 

**Release note** _(write `NONE` if no user-facing change)_:
NONE
