### PR TITLE
fix: preserve assistant tool_calls through tokenizer render path

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -440,6 +440,8 @@ type Message struct {
 	Role string `json:"role,omitempty"`
 	// Content defines text of this message
 	Content Content `json:"content"`
+	// ToolCalls contains assistant tool calls for chat template rendering.
+	ToolCalls []any `json:"tool_calls,omitempty"`
 }
 
 type Content struct {

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -555,6 +555,8 @@ type Message struct {
 	Role string `json:"role,omitempty"`
 	// Content defines text of this message
 	Content Content `json:"content"`
+	// ToolCalls contains assistant tool calls for chat template rendering.
+	ToolCalls []any `json:"tool_calls,omitempty"`
 }
 
 type Content struct {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
@@ -212,6 +213,7 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 			Role:    msg.Role,
 			Content: tokenizerTypes.Content{Raw: msg.Content.Raw},
 		}
+		setToolCallsIfSupported(&conv, msg.ToolCalls)
 		for _, block := range msg.Content.Structured {
 			conv.Content.Structured = append(conv.Content.Structured, tokenizerTypes.ContentBlock{
 				Type:     block.Type,
@@ -231,6 +233,16 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 		ContinueFinalMessage:      chat.ContinueFinalMessage,
 		AddGenerationPrompt:       chat.AddGenerationPrompt,
 		ChatTemplateKWArgs:        chat.ChatTemplateKWArgs,
+	}
+}
+
+func setToolCallsIfSupported(conv *tokenizerTypes.Conversation, toolCalls []any) {
+	if len(toolCalls) == 0 {
+		return
+	}
+	field := reflect.ValueOf(conv).Elem().FieldByName("ToolCalls")
+	if field.IsValid() && field.CanSet() && field.Type() == reflect.TypeOf(toolCalls) {
+		field.Set(reflect.ValueOf(toolCalls))
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -245,8 +245,9 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 	conversation := make([]tokenizerTypes.Conversation, 0, len(chat.Messages))
 	for _, msg := range chat.Messages {
 		conv := tokenizerTypes.Conversation{
-			Role:    msg.Role,
-			Content: tokenizerTypes.Content{Raw: msg.Content.Raw},
+			Role:      msg.Role,
+			Content:   tokenizerTypes.Content{Raw: msg.Content.Raw},
+			ToolCalls: msg.ToolCalls,
 		}
 		for _, block := range msg.Content.Structured {
 			conv.Content.Structured = append(conv.Content.Structured, tokenizerTypes.ContentBlock{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -19,6 +19,7 @@ package tokenizer
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
@@ -212,10 +213,24 @@ func TestConvertMMFeaturesNil(t *testing.T) {
 }
 
 func TestChatCompletionsToRenderChatRequest(t *testing.T) {
+	toolCalls := []any{
+		map[string]any{
+			"id":   "chatcmpl-tool-1",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "bash",
+				"arguments": `{"command":"ls -la"}`,
+			},
+		},
+	}
 	chat := &fwkrh.ChatCompletionsRequest{
 		Messages: []fwkrh.Message{
 			{Role: "system", Content: fwkrh.Content{Raw: "You are a helpful assistant."}},
-			{Role: "user", Content: fwkrh.Content{Raw: "Hello!"}},
+			{
+				Role:      "assistant",
+				Content:   fwkrh.Content{Raw: "Reflection."},
+				ToolCalls: toolCalls,
+			},
 		},
 		ChatTemplate:              "template",
 		AddGenerationPrompt:       true,
@@ -228,12 +243,17 @@ func TestChatCompletionsToRenderChatRequest(t *testing.T) {
 	require.Len(t, result.Conversation, 2)
 	assert.Equal(t, "system", result.Conversation[0].Role)
 	assert.Equal(t, tokenizerTypes.Content{Raw: "You are a helpful assistant."}, result.Conversation[0].Content)
-	assert.Equal(t, "user", result.Conversation[1].Role)
-	assert.Equal(t, tokenizerTypes.Content{Raw: "Hello!"}, result.Conversation[1].Content)
+	assert.Equal(t, "assistant", result.Conversation[1].Role)
+	assert.Equal(t, tokenizerTypes.Content{Raw: "Reflection."}, result.Conversation[1].Content)
 	assert.Equal(t, "template", result.ChatTemplate)
 	assert.True(t, result.AddGenerationPrompt)
 	assert.False(t, result.ContinueFinalMessage)
 	assert.True(t, result.ReturnAssistantTokensMask)
+
+	field := reflect.ValueOf(result.Conversation[1]).FieldByName("ToolCalls")
+	if field.IsValid() {
+		assert.Equal(t, toolCalls, field.Interface())
+	}
 }
 
 func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -288,10 +288,24 @@ func TestConvertMMFeaturesNil(t *testing.T) {
 }
 
 func TestChatCompletionsToRenderChatRequest(t *testing.T) {
+	toolCalls := []any{
+		map[string]any{
+			"id":   "chatcmpl-tool-1",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "bash",
+				"arguments": `{"command":"ls -la"}`,
+			},
+		},
+	}
 	chat := &fwkrh.ChatCompletionsRequest{
 		Messages: []fwkrh.Message{
 			{Role: "system", Content: fwkrh.Content{Raw: "You are a helpful assistant."}},
-			{Role: "user", Content: fwkrh.Content{Raw: "Hello!"}},
+			{
+				Role:      "assistant",
+				Content:   fwkrh.Content{Raw: "Reflection."},
+				ToolCalls: toolCalls,
+			},
 		},
 		ChatTemplate:              "template",
 		AddGenerationPrompt:       true,
@@ -304,12 +318,14 @@ func TestChatCompletionsToRenderChatRequest(t *testing.T) {
 	require.Len(t, result.Conversation, 2)
 	assert.Equal(t, "system", result.Conversation[0].Role)
 	assert.Equal(t, tokenizerTypes.Content{Raw: "You are a helpful assistant."}, result.Conversation[0].Content)
-	assert.Equal(t, "user", result.Conversation[1].Role)
-	assert.Equal(t, tokenizerTypes.Content{Raw: "Hello!"}, result.Conversation[1].Content)
+	assert.Equal(t, "assistant", result.Conversation[1].Role)
+	assert.Equal(t, tokenizerTypes.Content{Raw: "Reflection."}, result.Conversation[1].Content)
 	assert.Equal(t, "template", result.ChatTemplate)
 	assert.True(t, result.AddGenerationPrompt)
 	assert.False(t, result.ContinueFinalMessage)
 	assert.True(t, result.ReturnAssistantTokensMask)
+
+	assert.Equal(t, toolCalls, result.Conversation[1].ToolCalls)
 }
 
 func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -173,8 +173,9 @@ type chatRenderRequest struct {
 // chatMessage is one OpenAI-shaped message. Content is either a plain string
 // or an array of parts; chatContent's MarshalJSON picks the right wire form.
 type chatMessage struct {
-	Role    string      `json:"role"`
-	Content chatContent `json:"content"`
+	Role      string      `json:"role"`
+	Content   chatContent `json:"content"`
+	ToolCalls []any       `json:"tool_calls,omitempty"`
 }
 
 // chatContent serializes either Raw (string) or Parts (array of typed parts).
@@ -208,7 +209,11 @@ type chatImageURL struct {
 func buildChatRenderRequest(model string, req *tokenizerTypes.RenderChatRequest) chatRenderRequest {
 	msgs := make([]chatMessage, len(req.Conversation))
 	for idx, c := range req.Conversation {
-		msgs[idx] = chatMessage{Role: c.Role, Content: toChatContent(c.Content)}
+		msgs[idx] = chatMessage{
+			Role:      c.Role,
+			Content:   toChatContent(c.Content),
+			ToolCalls: c.ToolCalls,
+		}
 	}
 	return chatRenderRequest{
 		Model:                model,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -126,6 +126,45 @@ func TestVLLMHTTPRenderer_RenderChat_Multimodal(t *testing.T) {
 	assert.Equal(t, "text", parts[1].(map[string]any)["type"])
 }
 
+func TestVLLMHTTPRenderer_RenderChat_ToolCalls(t *testing.T) {
+	srv, cap := httpFixture(t, nil, renderResponse{TokenIDs: []uint32{1, 2, 3}})
+	defer srv.Close()
+
+	toolCalls := []any{
+		map[string]any{
+			"id":   "chatcmpl-tool-1",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "bash",
+				"arguments": `{"command":"ls -la"}`,
+			},
+		},
+	}
+	r := newHTTPRenderer(t, srv)
+	req := &tokenizerTypes.RenderChatRequest{
+		Conversation: []tokenizerTypes.Conversation{
+			{Role: "user", Content: tokenizerTypes.Content{Raw: "list files"}},
+			{
+				Role:      "assistant",
+				Content:   tokenizerTypes.Content{Raw: ""},
+				ToolCalls: toolCalls,
+			},
+		},
+		AddGenerationPrompt: true,
+	}
+	_, _, err := r.RenderChat(context.Background(), req)
+	require.NoError(t, err)
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(cap.chat, &sent))
+	msgs, ok := sent["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, msgs, 2)
+	assistant, ok := msgs[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, toolCalls, assistant["tool_calls"])
+}
+
 func TestVLLMHTTPRenderer_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -163,6 +163,74 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
+			name:    "chat completions request body with assistant tool calls",
+			headers: map[string]string{":path": "/v1/chat/completions"},
+			body: map[string]any{
+				"model": "test",
+				"messages": []any{
+					map[string]any{
+						"role":    "user",
+						"content": "List files",
+					},
+					map[string]any{
+						"role":    "assistant",
+						"content": "Reflection.",
+						"tool_calls": []any{
+							map[string]any{
+								"id":   "chatcmpl-tool-1",
+								"type": "function",
+								"function": map[string]any{
+									"name":      "bash",
+									"arguments": `{"command":"ls -la"}`,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				ChatCompletions: &fwkrh.ChatCompletionsRequest{
+					Messages: []fwkrh.Message{
+						{Role: "user", Content: fwkrh.Content{Raw: "List files"}},
+						{
+							Role:    "assistant",
+							Content: fwkrh.Content{Raw: "Reflection."},
+							ToolCalls: []any{
+								map[string]any{
+									"id":   "chatcmpl-tool-1",
+									"type": "function",
+									"function": map[string]any{
+										"name":      "bash",
+										"arguments": `{"command":"ls -la"}`,
+									},
+								},
+							},
+						},
+					},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model": "test",
+					"messages": []any{
+						map[string]any{"role": "user", "content": "List files"},
+						map[string]any{
+							"role":    "assistant",
+							"content": "Reflection.",
+							"tool_calls": []any{
+								map[string]any{
+									"id":   "chatcmpl-tool-1",
+									"type": "function",
+									"function": map[string]any{
+										"name":      "bash",
+										"arguments": `{"command":"ls -la"}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:    "chat completions request body with multi-modal content",
 			headers: map[string]string{":path": "/v1/chat/completions"},
 			body: map[string]any{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Parse assistant `tool_calls` from chat-completions requests and forward them to the tokenizer's `RenderChatRequest`, then on to both rendering backends, so the rendered prompt used for KV-cache block indexing matches vLLM's rendering for tool-calling workloads.

Scheduler-side counterpart to the kv-cache fix in https://github.com/llm-d/llm-d-kv-cache/pull/577. Per the discussion there, the kv-cache change alone is not enough — the scheduler must also parse `tool_calls` and pass it through.

Paths covered:

- OpenAI request parser populates `Message.ToolCalls`.
- `ChatCompletionsToRenderChatRequest` writes it to `tokenizerTypes.Conversation.ToolCalls` (v0.8.1 of `llm-d-kv-cache` already exposes this field via https://github.com/llm-d/llm-d-kv-cache/pull/577).
- UDS path: `Conversation` is serialized as-is and consumed by the Python tokenizer service.
- vLLM HTTP path: `buildChatRenderRequest` now projects `ToolCalls` onto the outgoing `chatMessage`, so `/v1/chat/completions/render` receives the field.

Verified with the Qwen2.5 tokenizer that dropping `tool_calls` from the assistant message changes the rendered token stream (differs starting at token 32, 21-token delta), so the missing field would otherwise misalign KV-cache block hashes on tool-calling workloads.

**Which issue(s) this PR fixes**:

Fixes #1045

**Release note**:
```release-note
NONE
```