### PR TITLE
feat(scheduling): emit OTel spans per plugin in scheduler profile

### DIFF
--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	errcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/error"
@@ -29,6 +31,7 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metrics"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 )
 
 // NewSchedulerProfile creates a new SchedulerProfile object and returns its pointer.
@@ -132,11 +135,23 @@ func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *fwksch
 	filteredEndpoints := endpoints
 	logger.V(logutil.DEBUG).Info("Before running filter plugins", "endpoints", filteredEndpoints)
 
+	tracer := telemetry.Tracer()
 	for _, filter := range p.filters {
 		logger.V(logutil.VERBOSE).Info("Running filter plugin", "plugin", filter.TypedName())
+		endpointsIn := len(filteredEndpoints)
+		spanCtx, span := tracer.Start(ctx, "gateway.scheduling.filter",
+			trace.WithAttributes(
+				attribute.String("plugin.extension_point", filterExtensionPoint),
+				attribute.String("plugin.type", filter.TypedName().Type),
+				attribute.String("plugin.name", filter.TypedName().Name),
+				attribute.Int("endpoints.in", endpointsIn),
+			),
+		)
 		before := time.Now()
-		filteredEndpoints = filter.Filter(ctx, cycleState, request, filteredEndpoints)
+		filteredEndpoints = filter.Filter(spanCtx, cycleState, request, filteredEndpoints)
 		metrics.RecordPluginProcessingLatency(filterExtensionPoint, filter.TypedName().Type, filter.TypedName().Name, time.Since(before))
+		span.SetAttributes(attribute.Int("endpoints.out", len(filteredEndpoints)))
+		span.End()
 		logger.V(logutil.DEBUG).Info("Completed running filter plugin successfully", "plugin", filter.TypedName(), "endpoints", filteredEndpoints)
 		if len(filteredEndpoints) == 0 {
 			logger.V(logutil.VERBOSE).Info("Filter eliminated all endpoints", "plugin", filter.TypedName(), "endpointsBefore", len(endpoints))
@@ -156,12 +171,23 @@ func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *fwksch
 	for _, endpoint := range endpoints {
 		weightedScorePerEndpoint[endpoint] = float64(0) // initialize weighted score per endpoint with 0 value
 	}
+	tracer := telemetry.Tracer()
 	// Iterate through each scorer in the chain and accumulate the weighted scores.
 	for _, scorer := range p.scorers {
 		logger.V(logutil.VERBOSE).Info("Running scorer plugin", "plugin", scorer.TypedName())
+		spanCtx, span := tracer.Start(ctx, "gateway.scheduling.scorer",
+			trace.WithAttributes(
+				attribute.String("plugin.extension_point", scorerExtensionPoint),
+				attribute.String("plugin.type", scorer.TypedName().Type),
+				attribute.String("plugin.name", scorer.TypedName().Name),
+				attribute.Float64("plugin.weight", scorer.Weight()),
+				attribute.Int("endpoints.scored", len(endpoints)),
+			),
+		)
 		before := time.Now()
-		scores := scorer.Score(ctx, cycleState, request, endpoints)
+		scores := scorer.Score(spanCtx, cycleState, request, endpoints)
 		metrics.RecordPluginProcessingLatency(scorerExtensionPoint, scorer.TypedName().Type, scorer.TypedName().Name, time.Since(before))
+		span.End()
 		for endpoint, score := range scores { // weight is relative to the sum of weights
 			logger.V(logutil.DEBUG).Info("Calculated score", "plugin", scorer.TypedName(), "endpoint", endpoint.GetMetadata().NamespacedName, "score", score)
 			weightedScorePerEndpoint[endpoint] += enforceScoreRange(score) * scorer.Weight()
@@ -183,9 +209,32 @@ func (p *SchedulerProfile) runPickerPlugin(ctx context.Context, cycleState *fwks
 	}
 	logger.V(logutil.VERBOSE).Info("Running picker plugin", "plugin", p.picker.TypedName())
 	logger.V(logutil.DEBUG).Info("Candidate pods for picking", "endpoints-weighted-score", scoredEndpoints)
+	tracer := telemetry.Tracer()
+	spanCtx, span := tracer.Start(ctx, "gateway.scheduling.picker",
+		trace.WithAttributes(
+			attribute.String("plugin.extension_point", pickerExtensionPoint),
+			attribute.String("plugin.type", p.picker.TypedName().Type),
+			attribute.String("plugin.name", p.picker.TypedName().Name),
+			attribute.Int("endpoints.scored", len(weightedScorePerEndpoint)),
+		),
+	)
+	defer span.End()
 	before := time.Now()
-	result := p.picker.Pick(ctx, cycleState, scoredEndpoints)
+	result := p.picker.Pick(spanCtx, cycleState, scoredEndpoints)
 	metrics.RecordPluginProcessingLatency(pickerExtensionPoint, p.picker.TypedName().Type, p.picker.TypedName().Name, time.Since(before))
+	if span.IsRecording() && result != nil {
+		switch n := len(result.TargetEndpoints); {
+		case n == 1:
+			span.SetAttributes(attribute.String("picker.selected.address",
+				result.TargetEndpoints[0].GetMetadata().Address))
+		case n > 1:
+			addrs := make([]string, n)
+			for i, ep := range result.TargetEndpoints {
+				addrs[i] = ep.GetMetadata().Address
+			}
+			span.SetAttributes(attribute.StringSlice("picker.selected.addresses", addrs))
+		}
+	}
 	logger.V(logutil.DEBUG).Info("Completed running picker plugin successfully", "plugin", p.picker.TypedName(), "result", result)
 
 	return result

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -21,9 +21,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
@@ -613,4 +617,56 @@ func findEndpoints(endpoints []fwksched.Endpoint, names ...k8stypes.NamespacedNa
 		}
 	}
 	return res
+}
+
+// BenchmarkSchedulerProfile_Run measures per-plugin span overhead.
+// NeverSample = no-exporter baseline; AlwaysSample = full-cost ceiling.
+func BenchmarkSchedulerProfile_Run(b *testing.B) {
+	crlog.SetLogger(logr.Discard()) // silence controller-runtime's log.SetLogger warning
+
+	pluginPool := []*testPlugin{
+		{TypeRes: "filter-1", FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}, {Name: "pod3"}}},
+		{TypeRes: "scorer-a", ScoreRes: 0.3},
+		{TypeRes: "scorer-b", ScoreRes: 0.5},
+		{TypeRes: "scorer-c", ScoreRes: 0.7},
+		{TypeRes: "picker-1", PickRes: k8stypes.NamespacedName{Name: "pod1"}},
+	}
+	profile := NewSchedulerProfile().
+		WithFilters(pluginPool[0]).
+		WithScorers(
+			NewWeightedScorer(pluginPool[1], 1),
+			NewWeightedScorer(pluginPool[2], 1),
+			NewWeightedScorer(pluginPool[3], 1),
+		).
+		WithPicker(pluginPool[4])
+
+	endpoints := []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
+	}
+	request := &fwksched.InferenceRequest{
+		TargetModel: "bench-model",
+		RequestID:   "bench-request",
+	}
+
+	benchProfileRun := func(b *testing.B, sampler sdktrace.Sampler) {
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sampler))
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(tp)
+		defer otel.SetTracerProvider(prev)
+		defer func() { _ = tp.Shutdown(context.Background()) }()
+
+		ctx := context.Background()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := profile.Run(ctx, request, fwksched.NewCycleState(), endpoints); err != nil {
+				b.Fatalf("Run failed: %v", err)
+			}
+		}
+	}
+
+	b.Run("AlwaysSample", func(b *testing.B) { benchProfileRun(b, sdktrace.AlwaysSample()) })
+	b.Run("NeverSample", func(b *testing.B) { benchProfileRun(b, sdktrace.NeverSample()) })
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Emits per-plugin OTel spans under `gateway.scheduling.{filter,scorer,picker}`, mirroring the existing per-plugin latency metric. Today only `gateway.request_orchestration` shows up individual Filter/Scorer/Picker work is invisible in traces.

Plugins receive `spanCtx`, so any plugin-emitted span (`llm_d.epp.scorer.prefix_cache`) auto-reparents under the matching extension-point span. Picker attribute write is gated on `IsRecording()` with a single-string fast path. I also added a Benchmark, see results below.

Sibling of GIE [#2581](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2581).

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
```release-note
EPP scheduler emits per-plugin OTel spans with extension-point, plugin name/type, and endpoint-count attributes. Existing plugin spans auto-nest under the matching extension-point span.
```

<img width="945" height="459" alt="image" src="https://github.com/user-attachments/assets/112f02d0-7bb0-4bac-8809-12d556ea559d" />

```sh
go test -bench BenchmarkSchedulerProfile_Run -benchmem -cpu=1,2,4,8 ./pkg/epp/scheduling/
goos: linux
goarch: amd64
pkg: github.com/llm-d/llm-d-inference-scheduler/pkg/epp/scheduling
cpu: AMD Ryzen AI 9 HX 370 w/ Radeon 890M           
BenchmarkSchedulerProfile_Run/AlwaysSample                141228              8519 ns/op           12168 B/op        121 allocs/op
BenchmarkSchedulerProfile_Run/AlwaysSample-2              168046              6751 ns/op           12168 B/op        121 allocs/op
BenchmarkSchedulerProfile_Run/AlwaysSample-4              164931              7858 ns/op           12168 B/op        121 allocs/op
BenchmarkSchedulerProfile_Run/AlwaysSample-8              134767              8705 ns/op           12168 B/op        121 allocs/op
BenchmarkSchedulerProfile_Run/NeverSample                 185632              6356 ns/op            7688 B/op        113 allocs/op
BenchmarkSchedulerProfile_Run/NeverSample-2s  225676              5505 ns/op            7688 B/op            113 allocs/op
BenchmarkSchedulerProfile_Run/NeverSample-4                   205672              5159 ns/op        7688 B/op        113 allocs/op
BenchmarkSchedulerProfile_Run/NeverSample-8                   171789              6509 ns/op        7688 B/op        113 allocs/op
PASS
ok      github.com/llm-d/llm-d-inference-scheduler/pkg/epp/scheduling       10.975s
```
