### PR TITLE
refactor(datalayer): wrap sync.Maps in typed managers

### DIFF
--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -93,6 +93,9 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 			return errors.New("cannot add nil data source")
 		}
 	}
+	if extractors == nil {
+		extractors = newExtractorMap()
+	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -84,7 +84,7 @@ func NewCollector() *Collector {
 }
 
 // Start launches the collection goroutine.
-func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.ExtractorBase) error {
+func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors *extractorMap) error {
 	if len(pollers) == 0 {
 		return errors.New("cannot start collector with empty sources")
 	}
@@ -98,14 +98,15 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 	}
 
 	// Filter to poll-capable extractors up front so the hot loop avoids per-tick type assertions.
-	pollingExtractors := make(map[string][]fwkdl.Extractor, len(extractors))
-	for name, exts := range extractors {
+	pollingExtractors := make(map[string][]fwkdl.Extractor, extractors.Count())
+	extractors.Range(func(name string, exts []fwkdl.ExtractorBase) bool {
 		for _, ext := range exts {
 			if e, ok := ext.(fwkdl.Extractor); ok {
 				pollingExtractors[name] = append(pollingExtractors[name], e)
 			}
 		}
-	}
+		return true
+	})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -117,13 +117,13 @@ func TestCollectorStartInputs(t *testing.T) {
 
 			c := NewCollector()
 			ticker := mocks.NewTicker()
-			err := c.Start(ctx, ticker, endpoint, tt.sources, nil)
+			err := c.Start(ctx, ticker, endpoint, tt.sources, newExtractorMap())
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantErrIs != nil {
 					assert.ErrorIs(t, err, tt.wantErrIs)
 				}
-				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil),
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, newExtractorMap()),
 					"retry after failed Start should succeed")
 			} else {
 				require.NoError(t, err)
@@ -138,8 +138,8 @@ func TestCollectorCanStartOnlyOnce(t *testing.T) {
 	ticker := mocks.NewTicker()
 	ctx := context.Background()
 
-	require.NoError(t, c.Start(ctx, ticker, endpoint, sources, nil))
-	assert.Error(t, c.Start(ctx, ticker, endpoint, sources, nil),
+	require.NoError(t, c.Start(ctx, ticker, endpoint, sources, newExtractorMap()))
+	assert.Error(t, c.Start(ctx, ticker, endpoint, sources, newExtractorMap()),
 		"second Start after success should error")
 	c.Stop()
 }
@@ -158,7 +158,7 @@ func TestCollectorStop(t *testing.T) {
 			setup: func(t *testing.T) *Collector {
 				c := NewCollector()
 				ticker := mocks.NewTicker()
-				_ = c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{}, nil)
+				_ = c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{}, newExtractorMap())
 				return c
 			},
 		},
@@ -167,7 +167,7 @@ func TestCollectorStop(t *testing.T) {
 			setup: func(t *testing.T) *Collector {
 				c := NewCollector()
 				ticker := mocks.NewTicker()
-				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil))
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, newExtractorMap()))
 				return c
 			},
 		},
@@ -189,7 +189,7 @@ func TestCollectorCollectsOnTicks(t *testing.T) {
 	c := NewCollector()
 	ticker := mocks.NewTicker()
 
-	require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{source}, nil))
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{source}, newExtractorMap()))
 	defer c.Stop()
 
 	ticker.Tick()
@@ -248,10 +248,10 @@ func TestCollectorErrorMetrics(t *testing.T) {
 				src = &dataSource{kind: tt.srcType}
 			}
 
-			var extractors map[string][]fwkdl.ExtractorBase
+			extractors := newExtractorMap()
 			if tt.extType != "" {
 				ext := &stubExtractor{kind: tt.extType, err: tt.extErr}
-				extractors = map[string][]fwkdl.ExtractorBase{src.TypedName().Name: {ext}}
+				extractors.Set(src.TypedName().Name, []fwkdl.ExtractorBase{ext})
 			}
 
 			pollBefore := testutil.ToFloat64(metrics.DataLayerPollErrorsTotal.WithLabelValues(tt.srcType))
@@ -301,7 +301,7 @@ func TestCollectorRapidStartStopRaceFree(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		c := NewCollector()
 		ticker := mocks.NewTicker()
-		require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{src}, nil))
+		require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{src}, newExtractorMap()))
 		ticker.Tick()
 		c.Stop()
 	}
@@ -312,7 +312,7 @@ func TestCollectorRapidStartStopRaceFree(t *testing.T) {
 func TestCollectorConcurrentStopRaceFree(t *testing.T) {
 	c := NewCollector()
 	ticker := mocks.NewTicker()
-	require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil))
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, newExtractorMap()))
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -251,7 +251,7 @@ func TestCollectorErrorMetrics(t *testing.T) {
 			extractors := newExtractorMap()
 			if tt.extType != "" {
 				ext := &stubExtractor{kind: tt.extType, err: tt.extErr}
-				extractors.Set(src.TypedName().Name, []fwkdl.ExtractorBase{ext})
+				extractors.Append(src.TypedName().Name, ext)
 			}
 
 			pollBefore := testutil.ToFloat64(metrics.DataLayerPollErrorsTotal.WithLabelValues(tt.srcType))

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+)
+
+// sourceHit identifies a matched source by its variant, registered name, and value.
+type sourceHit struct {
+	variant sourceVariant
+	name    string
+	src     fwkdl.DataSource
+}
+
+// variantSourceMap stores DataSources of one variant, keyed by TypedName.Name.
+// sync.Map: registrations happen during Configure; reads run concurrently from
+// NewEndpoint, dispatch, and Collector goroutines (godoc case 1).
+type variantSourceMap[T fwkdl.DataSource] struct {
+	v sourceVariant
+	m sync.Map
+}
+
+func newVariantSourceMap[T fwkdl.DataSource](v sourceVariant) *variantSourceMap[T] {
+	return &variantSourceMap[T]{v: v}
+}
+
+// Set stores src under its TypedName.Name, overwriting any prior entry.
+func (m *variantSourceMap[T]) Set(src T) {
+	m.m.Store(src.TypedName().Name, src)
+}
+
+// Get returns the source stored under name, if any.
+func (m *variantSourceMap[T]) Get(name string) (T, bool) {
+	raw, ok := m.m.Load(name)
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	return raw.(T), true
+}
+
+// Sources returns a snapshot slice of every stored source. Order is unspecified.
+func (m *variantSourceMap[T]) Sources() []T {
+	var out []T
+	m.m.Range(func(_, raw any) bool {
+		out = append(out, raw.(T))
+		return true
+	})
+	return out
+}
+
+// Count returns the number of stored entries.
+func (m *variantSourceMap[T]) Count() int {
+	n := 0
+	m.m.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+// IsEmpty reports whether no entries are stored.
+func (m *variantSourceMap[T]) IsEmpty() bool {
+	empty := true
+	m.m.Range(func(_, _ any) bool {
+		empty = false
+		return false
+	})
+	return empty
+}
+
+// Range invokes f for every entry. f returning false stops iteration.
+func (m *variantSourceMap[T]) Range(f func(name string, src T) bool) {
+	m.m.Range(func(k, raw any) bool {
+		return f(k.(string), raw.(T))
+	})
+}
+
+// ForEach calls f for every entry. The first error from f stops iteration
+// and is returned to the caller.
+func (m *variantSourceMap[T]) ForEach(f func(name string, src T) error) error {
+	var firstErr error
+	m.m.Range(func(k, raw any) bool {
+		if err := f(k.(string), raw.(T)); err != nil {
+			firstErr = err
+			return false
+		}
+		return true
+	})
+	return firstErr
+}
+
+// findFirst returns the first source for which matches returns true.
+func (m *variantSourceMap[T]) findFirst(matches func(fwkdl.DataSource) bool) sourceHit {
+	var found sourceHit
+	m.m.Range(func(k, raw any) bool {
+		src := raw.(T)
+		if !matches(src) {
+			return true
+		}
+		found = sourceHit{variant: m.v, name: k.(string), src: src}
+		return false
+	})
+	return found
+}
+
+// pollingManager owns the registered PollingDataSources.
+type pollingManager struct {
+	*variantSourceMap[fwkdl.PollingDataSource]
+}
+
+func newPollingManager() *pollingManager {
+	return &pollingManager{variantSourceMap: newVariantSourceMap[fwkdl.PollingDataSource](variantPolling)}
+}
+
+// notificationManager owns the registered NotificationSources.
+// GVK uniqueness is enforced per-Configure-call by a caller-owned gvk tracker
+// (see runtime.go); the manager itself is pure typed storage.
+type notificationManager struct {
+	*variantSourceMap[fwkdl.NotificationSource]
+}
+
+func newNotificationManager() *notificationManager {
+	return &notificationManager{variantSourceMap: newVariantSourceMap[fwkdl.NotificationSource](variantNotification)}
+}
+
+// endpointManager owns the registered EndpointSources.
+type endpointManager struct {
+	*variantSourceMap[fwkdl.EndpointSource]
+}
+
+func newEndpointManager() *endpointManager {
+	return &endpointManager{variantSourceMap: newVariantSourceMap[fwkdl.EndpointSource](variantEndpoint)}
+}
+
+// collectorManager tracks per-endpoint Collectors keyed by namespaced name.
+type collectorManager struct {
+	// sync.Map: per-pod reconcilers concurrently add and remove
+	// collectors on disjoint keys.
+	m sync.Map
+}
+
+func newCollectorManager() *collectorManager {
+	return &collectorManager{}
+}
+
+// Register stores c under key if absent. Returns true if c was stored, false
+// if a collector was already registered for key.
+func (cm *collectorManager) Register(key types.NamespacedName, c *Collector) bool {
+	_, loaded := cm.m.LoadOrStore(key, c)
+	return !loaded
+}
+
+// Remove deletes and returns the collector for key.
+func (cm *collectorManager) Remove(key types.NamespacedName) (*Collector, bool) {
+	v, ok := cm.m.LoadAndDelete(key)
+	if !ok {
+		return nil, false
+	}
+	c, _ := v.(*Collector)
+	return c, c != nil
+}
+
+// StopAll calls Stop on every registered collector.
+func (cm *collectorManager) StopAll() {
+	cm.m.Range(func(_, v any) bool {
+		if c, ok := v.(*Collector); ok {
+			c.Stop()
+		}
+		return true
+	})
+}
+
+// extractorMap is a name-keyed map of extractor slices used to associate
+// extractors with their source by name. Extractors arrive as ExtractorBase;
+// callers type-assert per variant at use.
+// sync.Map: written during Configure; read concurrently afterwards.
+type extractorMap struct {
+	m sync.Map
+}
+
+func newExtractorMap() *extractorMap {
+	return &extractorMap{}
+}
+
+// Set stores exts under srcName, overwriting any prior entry.
+func (e *extractorMap) Set(srcName string, exts []fwkdl.ExtractorBase) {
+	e.m.Store(srcName, exts)
+}
+
+// Get returns the extractors stored under srcName, if any.
+func (e *extractorMap) Get(srcName string) ([]fwkdl.ExtractorBase, bool) {
+	raw, ok := e.m.Load(srcName)
+	if !ok {
+		return nil, false
+	}
+	return raw.([]fwkdl.ExtractorBase), true
+}
+
+// Count returns the number of stored entries.
+func (e *extractorMap) Count() int {
+	n := 0
+	e.m.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+// Range invokes f for every entry. f returning false stops iteration.
+func (e *extractorMap) Range(f func(name string, exts []fwkdl.ExtractorBase) bool) {
+	e.m.Range(func(k, raw any) bool {
+		return f(k.(string), raw.([]fwkdl.ExtractorBase))
+	})
+}
+
+// Append adds ext to srcName's extractor slice, deduping by extractor type so
+// code-registered extractors are a no-op when an equivalent type is already
+// wired via config.
+func (e *extractorMap) Append(srcName string, ext fwkdl.ExtractorBase) {
+	existing, _ := e.Get(srcName)
+	extType := ext.TypedName().Type
+	for _, p := range existing {
+		if p.TypedName().Type == extType {
+			return
+		}
+	}
+	e.Set(srcName, append(existing, ext))
+}

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 )
 
 // sourceHit identifies a matched source by its variant, registered name, and value.
@@ -190,59 +190,54 @@ func (cm *collectorManager) StopAll() {
 	})
 }
 
-// extractorMap is a name-keyed map of extractor slices used to associate
-// extractors with their source by name. Extractors arrive as ExtractorBase;
-// callers type-assert per variant at use.
-// sync.Map: written during Configure; read concurrently afterwards.
+// extractorMap is a name-keyed map of extractor slices.
 type extractorMap struct {
-	m sync.Map
+	// RWMutex (not sync.Map) so Append's read-then-write is atomic.
+	mu sync.RWMutex
+	m  map[string][]fwkdl.ExtractorBase
 }
 
 func newExtractorMap() *extractorMap {
-	return &extractorMap{}
-}
-
-// Set stores exts under srcName, overwriting any prior entry.
-func (e *extractorMap) Set(srcName string, exts []fwkdl.ExtractorBase) {
-	e.m.Store(srcName, exts)
+	return &extractorMap{m: make(map[string][]fwkdl.ExtractorBase)}
 }
 
 // Get returns the extractors stored under srcName, if any.
 func (e *extractorMap) Get(srcName string) ([]fwkdl.ExtractorBase, bool) {
-	raw, ok := e.m.Load(srcName)
-	if !ok {
-		return nil, false
-	}
-	return raw.([]fwkdl.ExtractorBase), true
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	exts, ok := e.m[srcName]
+	return exts, ok
 }
 
 // Count returns the number of stored entries.
 func (e *extractorMap) Count() int {
-	n := 0
-	e.m.Range(func(_, _ any) bool {
-		n++
-		return true
-	})
-	return n
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return len(e.m)
 }
 
-// Range invokes f for every entry. f returning false stops iteration.
+// Range invokes f for every entry; f returning false stops iteration.
+// f runs under RLock — must not block or call back into write methods.
 func (e *extractorMap) Range(f func(name string, exts []fwkdl.ExtractorBase) bool) {
-	e.m.Range(func(k, raw any) bool {
-		return f(k.(string), raw.([]fwkdl.ExtractorBase))
-	})
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for k, v := range e.m {
+		if !f(k, v) {
+			return
+		}
+	}
 }
 
-// Append adds ext to srcName's extractor slice, deduping by extractor type so
-// code-registered extractors are a no-op when an equivalent type is already
-// wired via config.
+// Append adds ext to srcName's slice, deduping by Type. Safe for concurrent use.
 func (e *extractorMap) Append(srcName string, ext fwkdl.ExtractorBase) {
-	existing, _ := e.Get(srcName)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	existing := e.m[srcName]
 	extType := ext.TypedName().Type
 	for _, p := range existing {
 		if p.TypedName().Type == extType {
 			return
 		}
 	}
-	e.Set(srcName, append(existing, ext))
+	e.m[srcName] = append(existing, ext)
 }

--- a/pkg/epp/datalayer/manager_test.go
+++ b/pkg/epp/datalayer/manager_test.go
@@ -1,0 +1,41 @@
+package datalayer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	srcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
+)
+
+// TestVariantSourceMap_ConcurrentReadsRaceFree verifies variantSourceMap's
+// sync.Map backing permits concurrent read access from many goroutines
+// without data races. Run under -race to catch regressions if the storage
+// switches to a primitive that requires explicit locking on reads.
+func TestVariantSourceMap_ConcurrentReadsRaceFree(t *testing.T) {
+	m := newVariantSourceMap[fwkdl.PollingDataSource](variantPolling)
+	for i := 0; i < 5; i++ {
+		m.Set(srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: fmt.Sprintf("src%d", i)}))
+	}
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = m.Get(fmt.Sprintf("src%d", i%5))
+			_ = m.Sources()
+			_ = m.Count()
+			_ = m.IsEmpty()
+			m.Range(func(string, fwkdl.PollingDataSource) bool { return true })
+			require.NoError(t, m.ForEach(func(string, fwkdl.PollingDataSource) error { return nil }))
+			_ = m.findFirst(func(fwkdl.DataSource) bool { return false })
+		}(i)
+	}
+	wg.Wait()
+}

--- a/pkg/epp/datalayer/manager_test.go
+++ b/pkg/epp/datalayer/manager_test.go
@@ -7,35 +7,87 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
-	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	srcmocks "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/mocks"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	extractormocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/mocks"
+	srcmocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/mocks"
 )
 
-// TestVariantSourceMap_ConcurrentReadsRaceFree verifies variantSourceMap's
-// sync.Map backing permits concurrent read access from many goroutines
-// without data races. Run under -race to catch regressions if the storage
-// switches to a primitive that requires explicit locking on reads.
-func TestVariantSourceMap_ConcurrentReadsRaceFree(t *testing.T) {
-	m := newVariantSourceMap[fwkdl.PollingDataSource](variantPolling)
-	for i := 0; i < 5; i++ {
-		m.Set(srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: fmt.Sprintf("src%d", i)}))
+// TestConcurrentAccessRaceFree pins concurrent safety on the manager maps.
+// Run under -race to catch regressions.
+func TestConcurrentAccessRaceFree(t *testing.T) {
+	const goroutines = 32
+
+	cases := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "variantSourceMap reads",
+			run: func(t *testing.T) {
+				m := newVariantSourceMap[fwkdl.PollingDataSource](variantPolling)
+				for i := 0; i < 5; i++ {
+					m.Set(srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: fmt.Sprintf("src%d", i)}))
+				}
+				var wg sync.WaitGroup
+				for i := 0; i < goroutines; i++ {
+					wg.Add(1)
+					go func(i int) {
+						defer wg.Done()
+						_, _ = m.Get(fmt.Sprintf("src%d", i%5))
+						_ = m.Sources()
+						_ = m.Count()
+						_ = m.IsEmpty()
+						m.Range(func(string, fwkdl.PollingDataSource) bool { return true })
+						require.NoError(t, m.ForEach(func(string, fwkdl.PollingDataSource) error { return nil }))
+						_ = m.findFirst(func(fwkdl.DataSource) bool { return false })
+					}(i)
+				}
+				wg.Wait()
+			},
+		},
+		{
+			name: "extractorMap reads",
+			run: func(t *testing.T) {
+				m := newExtractorMap()
+				for i := 0; i < 5; i++ {
+					m.Append(fmt.Sprintf("src%d", i),
+						extractormocks.NewEndpointExtractor(fmt.Sprintf("ext%d", i)))
+				}
+				var wg sync.WaitGroup
+				for i := 0; i < goroutines; i++ {
+					wg.Add(1)
+					go func(i int) {
+						defer wg.Done()
+						_, _ = m.Get(fmt.Sprintf("src%d", i%5))
+						_ = m.Count()
+						m.Range(func(string, []fwkdl.ExtractorBase) bool { return true })
+					}(i)
+				}
+				wg.Wait()
+			},
+		},
+		{
+			name: "extractorMap concurrent Append dedups",
+			run: func(t *testing.T) {
+				m := newExtractorMap()
+				const srcName = "shared"
+				var wg sync.WaitGroup
+				for i := 0; i < goroutines; i++ {
+					wg.Add(1)
+					go func(i int) {
+						defer wg.Done()
+						m.Append(srcName, extractormocks.NewEndpointExtractor(fmt.Sprintf("ext%d", i)))
+					}(i)
+				}
+				wg.Wait()
+				got, _ := m.Get(srcName)
+				require.Len(t, got, 1, "Append must dedup by Type under concurrent callers")
+			},
+		},
 	}
 
-	const goroutines = 32
-	var wg sync.WaitGroup
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			_, _ = m.Get(fmt.Sprintf("src%d", i%5))
-			_ = m.Sources()
-			_ = m.Count()
-			_ = m.IsEmpty()
-			m.Range(func(string, fwkdl.PollingDataSource) bool { return true })
-			require.NoError(t, m.ForEach(func(string, fwkdl.PollingDataSource) error { return nil }))
-			_ = m.findFirst(func(fwkdl.DataSource) bool { return false })
-		}(i)
+	for _, tc := range cases {
+		t.Run(tc.name, tc.run)
 	}
-	wg.Wait()
 }

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -125,6 +125,10 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 		}
 	}
 
+	if err := r.validateNoCrossVariantCollisions(); err != nil {
+		return err
+	}
+
 	// Resolve code-registered pending registrations after processing user config.
 	for _, pending := range r.pendingRegistrations {
 		var gvkFilter *schema.GroupVersionKind
@@ -200,6 +204,58 @@ func (r *Runtime) registerSource(src fwkdl.DataSource, g *gvk) error {
 	default:
 		return fmt.Errorf("skipping unknown datasource plugin type %s", src.TypedName().String())
 	}
+}
+
+// validateNoCrossVariantCollisions errors if any SourceType is registered in
+// more than one variant manager. findSourceByType already catches this when
+// a pending extractor references the colliding type; this check fires
+// exhaustively at end of Configure for the no-pending case.
+func (r *Runtime) validateNoCrossVariantCollisions() error {
+	type seenSource struct {
+		variant sourceVariant
+		name    string
+	}
+	seen := make(map[string]seenSource)
+
+	check := func(name string, src fwkdl.DataSource, v sourceVariant) error {
+		t := src.TypedName().Type
+		if prior, ok := seen[t]; ok && prior.variant != v {
+			return fmt.Errorf("%w: %q in %s (%s) and %s (%s)",
+				ErrSourceTypeCollision, t, prior.variant, prior.name, v, name)
+		}
+		seen[t] = seenSource{variant: v, name: name}
+		return nil
+	}
+
+	var firstErr error
+	r.polling.Range(func(name string, src fwkdl.PollingDataSource) bool {
+		if err := check(name, src, variantPolling); err != nil {
+			firstErr = err
+			return false
+		}
+		return true
+	})
+	if firstErr != nil {
+		return firstErr
+	}
+	r.notification.Range(func(name string, src fwkdl.NotificationSource) bool {
+		if err := check(name, src, variantNotification); err != nil {
+			firstErr = err
+			return false
+		}
+		return true
+	})
+	if firstErr != nil {
+		return firstErr
+	}
+	r.endpoint.Range(func(name string, src fwkdl.EndpointSource) bool {
+		if err := check(name, src, variantEndpoint); err != nil {
+			firstErr = err
+			return false
+		}
+		return true
+	})
+	return firstErr
 }
 
 // findSourceByType walks every variant manager and returns the matching source.

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -113,8 +113,8 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 				return err
 			}
 
-			if len(srcCfg.Extractors) > 0 {
-				r.extractors.Set(srcName, srcCfg.Extractors)
+			for _, ext := range srcCfg.Extractors {
+				r.extractors.Append(srcName, ext)
 			}
 
 			extractorNames := make([]string, len(srcCfg.Extractors))
@@ -133,8 +133,8 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 	for _, pending := range r.pendingRegistrations {
 		var gvkFilter *schema.GroupVersionKind
 		if ns, ok := pending.DefaultSource.(fwkdl.NotificationSource); ok {
-			gvk := ns.GVK()
-			gvkFilter = &gvk
+			sourceGVK := ns.GVK()
+			gvkFilter = &sourceGVK
 		}
 		srcName, matchedSrc, err := r.findSourceByType(pending.SourceType, gvkFilter)
 		if err != nil {

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -32,20 +32,30 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 )
 
+var ErrSourceTypeCollision = errors.New("source type registered across variants")
+
+type sourceVariant string
+
+const (
+	variantPolling      sourceVariant = "polling"
+	variantNotification sourceVariant = "notification"
+	variantEndpoint     sourceVariant = "endpoint"
+)
+
 // Runtime manages data sources, extractors, their mapping, and endpoint lifecycle.
 type Runtime struct {
 	pollingInterval time.Duration // used for polling sources
 
-	pollers          sync.Map // Map of polling sources (key=source name, value=PollingDataSource)
-	notifiers        sync.Map // Map of k8s notification sources (key=source name, value=NotificationSource)
-	endpointSources  sync.Map // Map of endpoint sources (key=source name, value=EndpointSource)
-	sourceExtractors sync.Map // Map sources to extractors (key=source name. value=[]Extractor)
+	polling      *pollingManager
+	notification *notificationManager
+	endpoint     *endpointManager
+	extractors   *extractorMap
 
 	pendingMu            sync.Mutex
 	pendingRegistrations []fwkdl.PendingRegistration // code-registered (source-type, extractor) pairs, resolved by Configure()
 
-	collectors sync.Map    // Per-endpoint poller (key=namespaced name, value=*Collector)
-	logger     logr.Logger // Set in Configure; used where no context is available (e.g. ReleaseEndpoint).
+	collectors *collectorManager // per-endpoint poller, keyed by namespaced name
+	logger     logr.Logger       // Set in Configure; used where no context is available (e.g. ReleaseEndpoint).
 }
 
 const (
@@ -61,6 +71,11 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 	}
 	return &Runtime{
 		pollingInterval: interval,
+		polling:         newPollingManager(),
+		notification:    newNotificationManager(),
+		endpoint:        newEndpointManager(),
+		extractors:      newExtractorMap(),
+		collectors:      newCollectorManager(),
 		logger:          logr.Discard(),
 	}
 }
@@ -83,11 +98,7 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 	}
 	logger.Info("Configuring datalayer runtime", "numSources", numSources)
 
-	pollersCount := 0
-	notifiersCount := 0
-	endpointSourcesCount := 0
-	gvkToSource := make(map[string]string) // track GVK uniqueness for NotificationSources
-
+	gvk := newGvk()
 	if cfg != nil {
 		for _, srcCfg := range cfg.Sources {
 			src := srcCfg.Plugin
@@ -98,20 +109,12 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 				return err
 			}
 
-			if err := r.registerSource(src, gvkToSource); err != nil {
+			if err := r.registerSource(src, gvk); err != nil {
 				return err
 			}
-			switch src.(type) {
-			case fwkdl.PollingDataSource:
-				pollersCount++
-			case fwkdl.NotificationSource:
-				notifiersCount++
-			default:
-				endpointSourcesCount++
-			}
 
-			if len(srcCfg.Extractors) > 0 { // Store extractors mapped to source
-				r.sourceExtractors.Store(srcName, srcCfg.Extractors)
+			if len(srcCfg.Extractors) > 0 {
+				r.extractors.Set(srcName, srcCfg.Extractors)
 			}
 
 			extractorNames := make([]string, len(srcCfg.Extractors))
@@ -129,7 +132,10 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 			gvk := ns.GVK()
 			gvkFilter = &gvk
 		}
-		srcName, matchedSrc := r.findSourceByType(pending.SourceType, gvkFilter)
+		srcName, matchedSrc, err := r.findSourceByType(pending.SourceType, gvkFilter)
+		if err != nil {
+			return fmt.Errorf("resolve %s: %w", pending.Extractor.TypedName(), err)
+		}
 
 		if matchedSrc == nil {
 			if pending.DefaultSource == nil {
@@ -141,40 +147,25 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 				}
 				return errors.New(msg)
 			}
-			if regErr := r.registerSource(pending.DefaultSource, gvkToSource); regErr != nil {
-				return fmt.Errorf("auto-register default source for %s: %w",
-					pending.Extractor.TypedName(), regErr)
+			if err := r.registerSource(pending.DefaultSource, gvk); err != nil {
+				return fmt.Errorf("auto-register default source for %s: %w", pending.Extractor.TypedName(), err)
 			}
 			srcName = pending.DefaultSource.TypedName().Name
 			matchedSrc = pending.DefaultSource
 		}
 
-		if valErr := r.validateSourceExtractors(matchedSrc, []fwkdl.ExtractorBase{pending.Extractor}, disallowedExtractorType); valErr != nil {
+		if err := r.validateSourceExtractors(matchedSrc, []fwkdl.ExtractorBase{pending.Extractor}, disallowedExtractorType); err != nil {
 			return fmt.Errorf("code-registered extractor %s incompatible with source %s: %w",
-				pending.Extractor.TypedName(), srcName, valErr)
+				pending.Extractor.TypedName(), srcName, err)
 		}
 
-		existing, _ := r.sourceExtractors.Load(srcName)
-		var exts []fwkdl.ExtractorBase
-		if existing != nil {
-			exts = existing.([]fwkdl.ExtractorBase)
-		}
-
-		// Dedup by extractor type: code registration is a no-op if already wired via config.
-		pendingType := pending.Extractor.TypedName().Type
-		alreadyWired := false
-		for _, e := range exts {
-			if e.TypedName().Type == pendingType {
-				alreadyWired = true
-				break
-			}
-		}
-		if !alreadyWired {
-			r.sourceExtractors.Store(srcName, append(exts, pending.Extractor))
-		}
+		r.extractors.Append(srcName, pending.Extractor)
 	}
 
-	logger.Info("Datalayer runtime configured", "pollers", pollersCount, "notifiers", notifiersCount, "endpointSources", endpointSourcesCount)
+	logger.Info("Datalayer runtime configured",
+		"pollers", r.polling.Count(),
+		"notifiers", r.notification.Count(),
+		"endpointSources", r.endpoint.Count())
 	return nil
 }
 
@@ -190,30 +181,30 @@ func (r *Runtime) Register(reg fwkdl.PendingRegistration) error {
 	return nil
 }
 
-// registerSource stores src in the appropriate typed sync.Map and enforces GVK uniqueness for NotificationSources.
-func (r *Runtime) registerSource(src fwkdl.DataSource, gvkToSource map[string]string) error {
-	srcName := src.TypedName().Name
-	if poller, ok := src.(fwkdl.PollingDataSource); ok {
-		r.pollers.Store(srcName, poller)
-	} else if notifier, ok := src.(fwkdl.NotificationSource); ok {
-		gvk := notifier.GVK().String()
-		if existingSource, exists := gvkToSource[gvk]; exists {
-			return fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
-				gvk, existingSource, src.TypedName().String())
+// registerSource dispatches src to the matching variant manager. g enforces
+// per-Configure-call GVK uniqueness for NotificationSources.
+func (r *Runtime) registerSource(src fwkdl.DataSource, g *gvk) error {
+	switch s := src.(type) {
+	case fwkdl.PollingDataSource:
+		r.polling.Set(s)
+		return nil
+	case fwkdl.NotificationSource:
+		if err := g.Check(s); err != nil {
+			return err
 		}
-		r.notifiers.Store(srcName, notifier)
-		gvkToSource[gvk] = srcName
-	} else if epSrc, ok := src.(fwkdl.EndpointSource); ok {
-		r.endpointSources.Store(srcName, epSrc)
-	} else {
+		r.notification.Set(s)
+		return nil
+	case fwkdl.EndpointSource:
+		r.endpoint.Set(s)
+		return nil
+	default:
 		return fmt.Errorf("skipping unknown datasource plugin type %s", src.TypedName().String())
 	}
-	return nil
 }
 
-// findSourceByType searches pollers, notifiers, and endpointSources for a source whose TypedName.Type
-// matches sourceType. For NotificationSources, also filters by GVK if gvkFilter is non-nil.
-func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource) {
+// findSourceByType walks every variant manager and returns the matching source.
+// Returns ErrSourceTypeCollision if sourceType is registered in more than one variant.
+func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource, error) {
 	matches := func(src fwkdl.DataSource) bool {
 		if src.TypedName().Type != sourceType {
 			return false
@@ -228,88 +219,41 @@ func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVer
 		return true
 	}
 
-	var foundName string
-	var foundSrc fwkdl.DataSource
-
-	r.pollers.Range(func(key, val any) bool {
-		src := val.(fwkdl.PollingDataSource)
-		if matches(src) {
-			foundName, foundSrc = key.(string), src
-			return false
-		}
-		return true
-	})
-	if foundSrc != nil {
-		return foundName, foundSrc
+	matched, err := findUnique(sourceType,
+		r.polling.findFirst(matches),
+		r.notification.findFirst(matches),
+		r.endpoint.findFirst(matches),
+	)
+	if err != nil {
+		return "", nil, err
 	}
-
-	r.notifiers.Range(func(key, val any) bool {
-		src := val.(fwkdl.NotificationSource)
-		if matches(src) {
-			foundName, foundSrc = key.(string), src
-			return false
-		}
-		return true
-	})
-	if foundSrc != nil {
-		return foundName, foundSrc
-	}
-
-	r.endpointSources.Range(func(key, val any) bool {
-		src := val.(fwkdl.EndpointSource)
-		if matches(src) {
-			foundName, foundSrc = key.(string), src
-			return false
-		}
-		return true
-	})
-
-	return foundName, foundSrc
+	return matched.name, matched.src, nil
 }
 
 // Start is called to enable the Runtime to start processing data collection. It wires
 // Kubernetes notifications into the manager.
 func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
-	var err error
-
-	r.notifiers.Range(func(key, val any) bool { // bind notification sources to the manager
-		ns := val.(fwkdl.NotificationSource)
-		srcName := ns.TypedName().Name
-
+	return r.notification.ForEach(func(srcName string, src fwkdl.NotificationSource) error {
 		var extractors []fwkdl.NotificationExtractor
-		if rawExts, ok := r.sourceExtractors.Load(srcName); ok {
-			raw := rawExts.([]fwkdl.ExtractorBase)
-			extractors = make([]fwkdl.NotificationExtractor, len(raw))
-			for i, e := range raw {
+		if rawExts, ok := r.extractors.Get(srcName); ok {
+			extractors = make([]fwkdl.NotificationExtractor, len(rawExts))
+			for i, e := range rawExts {
 				extractors[i] = e.(fwkdl.NotificationExtractor)
 			}
 		}
-
-		if bindErr := BindNotificationSource(ns, extractors, mgr); bindErr != nil {
-			err = fmt.Errorf("failed to bind notification source %s: %w", ns.TypedName(), bindErr)
-			return false
+		if err := BindNotificationSource(src, extractors, mgr); err != nil {
+			return fmt.Errorf("failed to bind notification source %s: %w", src.TypedName(), err)
 		}
-		return true
+		return nil
 	})
-	return err
 }
 
 // NewEndpoint sets up data polling on the provided endpoint.
 func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.EndpointMetadata, _ PoolInfo) fwkdl.Endpoint {
-	// TODO: should we cache the sources and map after Configure? Or just replace with maps and Mutex?
-	// The code could be simpler and also would benefit from using RLock mutex for concurrent access
-	// (no change expected) instead of using sync.Map (avoid use of Range just to count, more idiomatic code, etc.).
 	logger, _ := logr.FromContext(ctx)
 	logger = logger.WithValues("endpoint", endpointMetadata.GetNamespacedName())
 
-	var pollers []fwkdl.PollingDataSource
-	r.pollers.Range(func(_, val any) bool {
-		if poller, ok := val.(fwkdl.PollingDataSource); ok {
-			pollers = append(pollers, poller)
-		}
-		return true
-	})
-
+	pollers := r.polling.Sources()
 	if len(pollers) == 0 {
 		logger.Info("No polling sources configured, creating endpoint without collector")
 		endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
@@ -317,27 +261,19 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 		return endpoint
 	}
 
-	extractors := make(map[string][]fwkdl.ExtractorBase, len(pollers))
-	r.sourceExtractors.Range(func(key, val any) bool {
-		srcName := key.(string)
-		exts := val.([]fwkdl.ExtractorBase)
-		extractors[srcName] = exts
-		return true
-	})
-
 	endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
 	collector := NewCollector()
 
 	key := endpointMetadata.GetNamespacedName()
-	if _, loaded := r.collectors.LoadOrStore(key, collector); loaded {
+	if !r.collectors.Register(key, collector) {
 		logger.V(logging.DEFAULT).Info("collector already running for endpoint", "endpoint", key)
 		return nil
 	}
 
 	ticker := NewTimeTicker(r.pollingInterval)
-	if err := collector.Start(ctx, ticker, endpoint, pollers, extractors); err != nil {
+	if err := collector.Start(ctx, ticker, endpoint, pollers, r.extractors); err != nil {
 		logger.Error(err, "failed to start collector for endpoint", "endpoint", key)
-		r.collectors.Delete(key)
+		r.collectors.Remove(key)
 		return nil
 	}
 
@@ -350,8 +286,7 @@ func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 	r.dispatchEndpointEvent(context.Background(), r.logger, fwkdl.EndpointEvent{Type: fwkdl.EventDelete, Endpoint: ep})
 
 	key := ep.GetMetadata().GetNamespacedName()
-	if value, ok := r.collectors.LoadAndDelete(key); ok {
-		collector := value.(*Collector)
+	if collector, ok := r.collectors.Remove(key); ok {
 		collector.Stop()
 	}
 }
@@ -359,14 +294,11 @@ func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 // dispatchEndpointEvent routes an endpoint lifecycle event to all registered
 // EndpointSources and their extractors.
 func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger, event fwkdl.EndpointEvent) {
-	if isEmpty(&r.endpointSources) {
+	if r.endpoint.IsEmpty() {
 		return
 	}
-	r.endpointSources.Range(func(key, val any) bool {
-		srcName := key.(string)
-		epSrc := val.(fwkdl.EndpointSource)
-
-		processed, err := epSrc.NotifyEndpoint(ctx, event)
+	r.endpoint.Range(func(srcName string, src fwkdl.EndpointSource) bool {
+		processed, err := src.NotifyEndpoint(ctx, event)
 		if err != nil {
 			logger.Error(err, "endpoint source failed to process event", "source", srcName)
 			return true
@@ -375,11 +307,11 @@ func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger,
 			return true
 		}
 
-		rawExts, ok := r.sourceExtractors.Load(srcName)
+		exts, ok := r.extractors.Get(srcName)
 		if !ok {
 			return true
 		}
-		for _, ext := range rawExts.([]fwkdl.ExtractorBase) {
+		for _, ext := range exts {
 			if epExt, ok := ext.(fwkdl.EndpointExtractor); ok {
 				if err := epExt.ExtractEndpoint(ctx, *processed); err != nil {
 					logger.Error(err, "endpoint extractor failed", "extractor", ext.TypedName())
@@ -433,6 +365,26 @@ func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fw
 	return nil
 }
 
+// gvk enforces per-Configure-call GVK uniqueness for NotificationSources.
+type gvk struct {
+	seen map[string]string // gvk -> registered source name
+}
+
+func newGvk() *gvk {
+	return &gvk{seen: make(map[string]string)}
+}
+
+// Check rejects src if its GVK has already been seen by this tracker.
+func (g *gvk) Check(src fwkdl.NotificationSource) error {
+	key := src.GVK().String()
+	if existing, ok := g.seen[key]; ok {
+		return fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
+			key, existing, src.TypedName().String())
+	}
+	g.seen[key] = src.TypedName().Name
+	return nil
+}
+
 // validate input/output type compatibility.
 func validateInputTypeCompatible(dataSourceOutput, extractorInput reflect.Type) error {
 	if dataSourceOutput == nil || extractorInput == nil {
@@ -445,6 +397,25 @@ func validateInputTypeCompatible(dataSourceOutput, extractorInput reflect.Type) 
 	}
 	return fmt.Errorf("extractor input type %v is not compatible with data source output type %v",
 		extractorInput, dataSourceOutput)
+}
+
+// findUnique returns the single matching source across hits.
+// Returns ErrSourceTypeCollision if more than one hit is present.
+func findUnique(sourceType string, hits ...sourceHit) (sourceHit, error) {
+	var matched sourceHit
+	for _, h := range hits {
+		if h.src == nil {
+			continue
+		}
+		if matched.src != nil {
+			return sourceHit{}, fmt.Errorf("%w: %q in %s (%s) and %s (%s)",
+				ErrSourceTypeCollision, sourceType,
+				matched.variant, matched.name,
+				h.variant, h.name)
+		}
+		matched = h
+	}
+	return matched, nil
 }
 
 // validate extractor compatibility.
@@ -460,16 +431,6 @@ func validateExtractorCompatible(extractorType reflect.Type, expectedInterfaceTy
 			extractorType, expectedInterfaceType)
 	}
 	return nil
-}
-
-// isEmpty reports whether the sync.Map has no entries.
-func isEmpty(m *sync.Map) bool {
-	empty := true
-	m.Range(func(_, _ any) bool {
-		empty = false
-		return false // stop immediately
-	})
-	return empty
 }
 
 var _ EndpointFactory = (*Runtime)(nil)

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -32,7 +32,10 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 )
 
-var ErrSourceTypeCollision = errors.New("source type registered across variants")
+var (
+	ErrSourceTypeCollision    = errors.New("source type registered across variants")
+	ErrDuplicateExtractorType = errors.New("duplicate extractor type configured for the same source")
+)
 
 type sourceVariant string
 
@@ -382,6 +385,16 @@ func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger,
 // expected Extractor type, source output and extractor input type compatibility and
 // optionally source specific validation.
 func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fwkdl.ExtractorBase, disallowedExtractorType string) error {
+	seenTypes := make(map[string]struct{}, len(extractors))
+	for _, ext := range extractors {
+		extType := ext.TypedName().Type
+		if _, dup := seenTypes[extType]; dup {
+			return fmt.Errorf("%w: source=%s, extractor type=%s",
+				ErrDuplicateExtractorType, src.TypedName().String(), extType)
+		}
+		seenTypes[extType] = struct{}{}
+	}
+
 	for _, ext := range extractors {
 		// check if disallowed extractor type
 		if disallowedExtractorType != "" && ext.TypedName().Type == disallowedExtractorType {

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -179,6 +179,26 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 	assert.Equal(t, "config-ext", exts[0].TypedName().Name)
 }
 
+// Pins rejection of duplicate-Type extractors per source. Append dedups silently otherwise.
+func TestConfigure_DuplicateExtractorTypePerSource(t *testing.T) {
+	r := NewRuntime(0)
+	logger := newTestLogger(t)
+
+	src := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, "ep-src")
+	ext1 := extractormocks.NewEndpointExtractor("ext-1")
+	ext2 := extractormocks.NewEndpointExtractor("ext-2")
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{{
+			Plugin:     src,
+			Extractors: []fwkdl.ExtractorBase{ext1, ext2},
+		}},
+	}
+
+	err := r.Configure(cfg, false, "", logger)
+	require.ErrorIs(t, err, ErrDuplicateExtractorType)
+}
+
 // TestConfigure_CrossVariantCollisionNoPending pins the behavior added by
 // validateNoCrossVariantCollisions: two sources sharing a SourceType across
 // different variants must fail Configure even when no pending extractor

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -21,10 +21,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	extractormocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/mocks"
+	sourcemocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
 
@@ -74,9 +76,8 @@ func TestConfigure_ExtractorWiredToUserConfiguredSource(t *testing.T) {
 	err := r.Configure(cfg, false, "", logger)
 	require.NoError(t, err)
 
-	rawExts, ok := r.sourceExtractors.Load("ep-src")
-	require.True(t, ok, "sourceExtractors should have entry for ep-src")
-	exts := rawExts.([]fwkdl.ExtractorBase)
+	exts, ok := r.extractors.Get("ep-src")
+	require.True(t, ok, "extractors should have entry for ep-src")
 	require.Len(t, exts, 1)
 	assert.Equal(t, "ext-a", exts[0].TypedName().Name)
 }
@@ -100,15 +101,14 @@ func TestConfigure_DefaultSourceAutoRegisteredWhenAbsent(t *testing.T) {
 	err := r.Configure(nil, false, "", logger)
 	require.NoError(t, err)
 
-	// Source should be in endpointSources.
-	val, ok := r.endpointSources.Load(notifications.EndpointNotificationSourceType)
-	require.True(t, ok, "auto-registered source should appear in endpointSources")
-	assert.Equal(t, notifications.EndpointNotificationSourceType, val.(fwkdl.EndpointSource).TypedName().Name)
+	// Source should be in the endpoint manager.
+	src, ok := r.endpoint.Get(notifications.EndpointNotificationSourceType)
+	require.True(t, ok, "auto-registered source should appear in endpoint manager")
+	assert.Equal(t, notifications.EndpointNotificationSourceType, src.TypedName().Name)
 
 	// Extractor should be wired.
-	rawExts, ok := r.sourceExtractors.Load(notifications.EndpointNotificationSourceType)
+	exts, ok := r.extractors.Get(notifications.EndpointNotificationSourceType)
 	require.True(t, ok, "extractor should be wired to auto-registered source")
-	exts := rawExts.([]fwkdl.ExtractorBase)
 	require.Len(t, exts, 1)
 }
 
@@ -173,9 +173,54 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 	err := r.Configure(cfg, false, "", logger)
 	require.NoError(t, err)
 
-	rawExts, ok := r.sourceExtractors.Load("ep-src")
+	exts, ok := r.extractors.Get("ep-src")
 	require.True(t, ok)
-	exts := rawExts.([]fwkdl.ExtractorBase)
 	require.Len(t, exts, 1, "code registration should be deduped; only config extractor present")
 	assert.Equal(t, "config-ext", exts[0].TypedName().Name)
+}
+
+func TestConfigure_CrossVariantSourceTypeCollisionRejected(t *testing.T) {
+	const collidingType = "colliding-source-type"
+	gvk := schema.GroupVersionKind{Group: "test.io", Version: "v1", Kind: "Probe"}
+
+	polling := func() fwkdl.DataSource {
+		return sourcemocks.NewDataSource(fwkplugin.TypedName{Type: collidingType, Name: "polling-src"})
+	}
+	notification := func() fwkdl.DataSource {
+		return sourcemocks.NewNotificationSource(collidingType, "notif-src", gvk)
+	}
+	endpoint := func() fwkdl.DataSource {
+		return notifications.NewEndpointDataSource(collidingType, "endpoint-src")
+	}
+
+	cases := []struct {
+		name    string
+		sources []fwkdl.DataSource
+	}{
+		{"polling+endpoint", []fwkdl.DataSource{polling(), endpoint()}},
+		{"polling+notification", []fwkdl.DataSource{polling(), notification()}},
+		{"notification+endpoint", []fwkdl.DataSource{notification(), endpoint()}},
+		{"all three variants", []fwkdl.DataSource{polling(), notification(), endpoint()}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRuntime(0)
+			logger := newTestLogger(t)
+
+			require.NoError(t, r.Register(fwkdl.PendingRegistration{
+				Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+				SourceType: collidingType,
+				Extractor:  extractormocks.NewEndpointExtractor("ext"),
+			}))
+
+			srcCfgs := make([]DataSourceConfig, len(tc.sources))
+			for i, s := range tc.sources {
+				srcCfgs[i] = DataSourceConfig{Plugin: s}
+			}
+
+			err := r.Configure(&Config{Sources: srcCfgs}, false, "", logger)
+			require.ErrorIs(t, err, ErrSourceTypeCollision)
+		})
+	}
 }

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -179,6 +179,55 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 	assert.Equal(t, "config-ext", exts[0].TypedName().Name)
 }
 
+// TestConfigure_CrossVariantCollisionNoPending pins the behavior added by
+// validateNoCrossVariantCollisions: two sources sharing a SourceType across
+// different variants must fail Configure even when no pending extractor
+// references the colliding type. findSourceByType-driven detection only
+// fires on pending resolution; this fills the gap.
+func TestConfigure_CrossVariantCollisionNoPending(t *testing.T) {
+	const collidingType = "colliding-source-type"
+	gvk := schema.GroupVersionKind{Group: "test.io", Version: "v1", Kind: "Probe"}
+
+	cases := []struct {
+		name    string
+		sources []fwkdl.DataSource
+	}{
+		{
+			name: "polling+notification",
+			sources: []fwkdl.DataSource{
+				sourcemocks.NewDataSource(fwkplugin.TypedName{Type: collidingType, Name: "polling-src"}),
+				sourcemocks.NewNotificationSource(collidingType, "notif-src", gvk),
+			},
+		},
+		{
+			name: "polling+endpoint",
+			sources: []fwkdl.DataSource{
+				sourcemocks.NewDataSource(fwkplugin.TypedName{Type: collidingType, Name: "polling-src"}),
+				notifications.NewEndpointDataSource(collidingType, "endpoint-src"),
+			},
+		},
+		{
+			name: "notification+endpoint",
+			sources: []fwkdl.DataSource{
+				sourcemocks.NewNotificationSource(collidingType, "notif-src", gvk),
+				notifications.NewEndpointDataSource(collidingType, "endpoint-src"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRuntime(0)
+			srcCfgs := make([]DataSourceConfig, len(tc.sources))
+			for i, s := range tc.sources {
+				srcCfgs[i] = DataSourceConfig{Plugin: s}
+			}
+			err := r.Configure(&Config{Sources: srcCfgs}, false, "", newTestLogger(t))
+			require.ErrorIs(t, err, ErrSourceTypeCollision)
+		})
+	}
+}
+
 func TestConfigure_CrossVariantSourceTypeCollisionRejected(t *testing.T) {
 	const collidingType = "colliding-source-type"
 	gvk := schema.GroupVersionKind{Group: "test.io", Version: "v1", Kind: "Probe"}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

Configurations that register two sources with the same SourceType in different variants today silently first-match by variant iteration order (polling -> notification -> endpoint). This PR makes that case fail with ErrSourceTypeCollision at config time.

The detection is enabled by a small refactor: Runtime's four sync.Maps are wrapped in typed managers backed by a generic typedSyncMap[V]. Storage remains sync.Map the change is API shape. The commit body has the manager layout.

GVK uniqueness scope and all non-collision behavior are bit-for-bit identical, no external API changes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/llm-d/llm-d-router/issues/1131
Related To: https://github.com/llm-d/llm-d-inference-scheduler/issues/1051

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

Followup from # https://github.com/llm-d/llm-d-inference-scheduler/pull/883
