### PR TITLE
ci: add PR smoke test against llm-d-kv-cache main

### DIFF
--- a/.github/workflows/ci-kvcache-upstream-smoke.yaml
+++ b/.github/workflows/ci-kvcache-upstream-smoke.yaml
@@ -1,0 +1,29 @@
+name: CI - kv-cache Upstream Smoke
+
+# Non-blocking smoke test that pins llm-d-kv-cache to its latest main and
+# runs the preciseprefixcache unit tests. See issue #1056.
+
+on:
+  push:
+    branches: [main]
+    paths: ['**/*.go', 'go.mod', 'Makefile', '.github/workflows/ci-kvcache-upstream-smoke.yaml']
+  pull_request:
+    branches: [main]
+    paths: ['**/*.go', 'go.mod', 'Makefile', '.github/workflows/ci-kvcache-upstream-smoke.yaml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true  # informational only; never blocks merges
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make test-kvcache-upstream-smoke

--- a/Makefile
+++ b/Makefile
@@ -257,17 +257,22 @@ test-unit-%: image-build-builder
 
 # Smoke test against llm-d-kv-cache main (or any ref via KVCACHE_UPSTREAM_REF).
 # Pins the dep in a temp worktree so the developer's go.mod is not mutated.
-# See issue #1056.
+# Auto-discovers every package that imports llm-d-kv-cache so new consumers
+# are covered without touching this target. See issue #1056.
 .PHONY: test-kvcache-upstream-smoke
-test-kvcache-upstream-smoke: ## Run preciseprefixcache tests against llm-d-kv-cache main
-	@ref="$${KVCACHE_UPSTREAM_REF:-main}"; \
-	wt=$$(mktemp -d) && trap "rm -rf $$wt" EXIT && \
-	tar --exclude=.git -C . -cf - . | tar -C $$wt -xf - && \
-	cd $$wt && \
-	go mod edit -replace github.com/llm-d/llm-d-kv-cache=github.com/llm-d/llm-d-kv-cache@$$ref && \
-	go mod tidy && \
-	go list -m github.com/llm-d/llm-d-kv-cache && \
-	go test -count=1 -timeout 10m ./pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/...
+test-kvcache-upstream-smoke: ## Run all kv-cache-consuming tests against llm-d-kv-cache main
+	@set -e; \
+	ref="$${KVCACHE_UPSTREAM_REF:-main}"; \
+	wt=$$(mktemp -d -t kvcache-smoke.XXXXXX); trap "rm -rf $$wt" EXIT; \
+	tar --exclude=.git -C . -cf - . | tar -C $$wt -xf -; \
+	cd $$wt; \
+	go mod edit -replace github.com/llm-d/llm-d-kv-cache=github.com/llm-d/llm-d-kv-cache@$$ref; \
+	go mod tidy; \
+	go list -m github.com/llm-d/llm-d-kv-cache; \
+	pkgs=$$(go list -f '{{.ImportPath}} {{join .Imports " "}} {{join .TestImports " "}} {{join .XTestImports " "}}' ./... \
+	  | awk '/github.com\/llm-d\/llm-d-kv-cache/ {print $$1}'); \
+	echo "Testing packages:"; printf '  %s\n' $$pkgs; \
+	go test -count=1 -timeout 10m $$pkgs
 
 .PHONY: test-filter
 test-filter: image-build-builder ## Run filtered unit tests (usage: make test-filter PATTERN=TestName TYPE=epp)

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,20 @@ test-unit-%: image-build-builder
 	$(BUILDER_RUN) "go test -v -race -coverprofile=$(COVERAGE_DIR)/$*.out -covermode=atomic $($*_TEST_PACKAGES)"
 	$(BUILDER_RUN) 'go tool cover -func=$(COVERAGE_DIR)/$*.out | tail -1'
 
+# Smoke test against llm-d-kv-cache main (or any ref via KVCACHE_UPSTREAM_REF).
+# Pins the dep in a temp worktree so the developer's go.mod is not mutated.
+# See issue #1056.
+.PHONY: test-kvcache-upstream-smoke
+test-kvcache-upstream-smoke: ## Run preciseprefixcache tests against llm-d-kv-cache main
+	@ref="$${KVCACHE_UPSTREAM_REF:-main}"; \
+	wt=$$(mktemp -d) && trap "rm -rf $$wt" EXIT && \
+	tar --exclude=.git -C . -cf - . | tar -C $$wt -xf - && \
+	cd $$wt && \
+	go mod edit -replace github.com/llm-d/llm-d-kv-cache=github.com/llm-d/llm-d-kv-cache@$$ref && \
+	go mod tidy && \
+	go list -m github.com/llm-d/llm-d-kv-cache && \
+	go test -count=1 -timeout 10m ./pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/...
+
 .PHONY: test-filter
 test-filter: image-build-builder ## Run filtered unit tests (usage: make test-filter PATTERN=TestName TYPE=epp)
 	@if [ -z "$(PATTERN)" ]; then \


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Adds a non-blocking CI job (`CI - kv-cache Upstream Smoke`) that pins `github.com/llm-d/llm-d-kv-cache` to its latest `main` via a `go.mod` `replace` in a temp worktree and runs the kv-cache-consuming unit tests on every PR. Also exposed as `make test-kvcache-upstream-smoke` for local repro.

`continue-on-error: true` — informational only, never blocks merges.

Per the discussion in llm-d/llm-d-kv-cache#548 and llm-d/llm-d-kv-cache#557, breaking changes in kv-cache `main` land silently and only surface when we bump `go.mod` — typically during release week. This gives us an early signal without imposing any obligation on the upstream repo.

The target packages to test are auto-discovered via `go list` by scanning imports, so new kv-cache consumers are covered without touching this workflow.

**Relationship to [#1060](https://github.com/llm-d/llm-d-inference-scheduler/pull/1060)**

This PR adds the *signal*; [#1060](https://github.com/llm-d/llm-d-inference-scheduler/pull/1060) is the *fix* for the first breakage that signal exposes (kv-cache `main` removed `pkg/preprocessing/chat_completions`, which `preciseprefixcache` still imports).

The two PRs are independent — neither blocks the other — but the recommended merge order is **#1060 first, then this one**, so the smoke job lands green on `main` instead of red-on-arrival. Merging this one first is also acceptable since the job is non-blocking; it would simply show red until #1060 lands.

**Testing**

- `KVCACHE_UPSTREAM_REF=v0.7.1 make test-kvcache-upstream-smoke` → PASS (covers both `preciseprefixcache` and `dataproducer/tokenizer`).
- `KVCACHE_UPSTREAM_REF=main make test-kvcache-upstream-smoke` → FAIL, catching a real silent breakage: kv-cache `main` no longer ships `pkg/preprocessing/chat_completions`, which `preciseprefixcache` still imports. Fixed by #1060.

**Which issue(s) this PR fixes**:

Fixes #1056

**Release note**:
```release-note
NONE
```