### PR TITLE
refactor(datalayer): typed Extractor[T] and source-as-dispatcher polling

### DIFF
--- a/pkg/epp/backend/metrics/podmetrics_parity_test.go
+++ b/pkg/epp/backend/metrics/podmetrics_parity_test.go
@@ -36,6 +36,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
+	sourcehttp "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
@@ -356,9 +357,9 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 		return nil, fmt.Errorf("failed to create data source: %w", err)
 	}
 
-	dataSource, ok := plugin.(fwkdl.PollingDataSource)
+	dataSource, ok := plugin.(*sourcehttp.HTTPDataSource[sourcemetrics.PrometheusMetricMap])
 	if !ok {
-		return nil, errors.New("plugin is not a PollingDataSource")
+		return nil, errors.New("plugin is not the expected HTTPDataSource[PrometheusMetricMap]")
 	}
 
 	metadata := &fwkdl.EndpointMetadata{
@@ -375,8 +376,7 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 		return endpoint.GetMetrics(), err
 	}
 	if data != nil {
-		err = extractor.Extract(ctx, data, endpoint)
-		if err != nil {
+		if err := extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: endpoint}); err != nil {
 			return endpoint.GetMetrics(), err
 		}
 	}

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -341,14 +341,14 @@ func buildDataLayerConfig(rawDataConfig *configapi.DataLayerConfig, handle fwkpl
 		if sourcePlugin, ok := handle.Plugin(source.PluginRef).(fwkdl.DataSource); ok {
 			sourceConfig := datalayer.DataSourceConfig{
 				Plugin:     sourcePlugin,
-				Extractors: []fwkdl.ExtractorBase{},
+				Extractors: []fwkplugin.Plugin{},
 			}
 			for _, extractor := range source.Extractors {
-				if extractorPlugin, ok := handle.Plugin(extractor.PluginRef).(fwkdl.ExtractorBase); ok {
-					sourceConfig.Extractors = append(sourceConfig.Extractors, extractorPlugin)
-				} else {
-					return nil, fmt.Errorf("the plugin %s is not a fwkdl.ExtractorBase", source.PluginRef)
+				extractorPlugin := handle.Plugin(extractor.PluginRef)
+				if extractorPlugin == nil {
+					return nil, fmt.Errorf("the plugin %s is not registered", extractor.PluginRef)
 				}
+				sourceConfig.Extractors = append(sourceConfig.Extractors, extractorPlugin)
 			}
 			cfg.Sources = append(cfg.Sources, sourceConfig)
 		} else {

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -832,11 +831,7 @@ func (m *mockSaturationDetector) Saturation(ctx context.Context, endpoints []fwk
 	return 0.5
 }
 
-func (m *mockSource) AddExtractor(_ fwkdl.Extractor) error {
-	return nil
-}
-
-func (m *mockSource) Collect(ctx context.Context, ep fwkdl.Endpoint) error {
+func (m *mockSource) Collect(_ context.Context, _ fwkdl.Endpoint) error {
 	return nil
 }
 
@@ -844,22 +839,10 @@ func (m *mockSource) Extractors() []string {
 	return []string{}
 }
 
-func (m *mockSource) OutputType() reflect.Type {
-	return fwkdl.NotificationEventType
-}
-
-func (m *mockSource) ExtractorType() reflect.Type {
-	return fwkdl.ExtractorType
-}
-
-// Mock Extractor
+// Mock Extractor: satisfies Extractor[NotificationEvent] for loader tests.
 type mockExtractor struct{ mockPlugin }
 
-func (m *mockExtractor) ExpectedInputType() reflect.Type {
-	return reflect.TypeFor[string]()
-}
-
-func (m *mockExtractor) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) error {
+func (m *mockExtractor) Extract(_ context.Context, _ fwkdl.NotificationEvent) error {
 	return nil
 }
 

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -22,20 +22,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/metrics"
 )
-
-// TODO:
-// currently the data store is expected to manage the state of multiple
-// Collectors (e.g., using sync.Map mapping pod to its Collector). Alternatively,
-// this can be encapsulated in this file, providing the data store with an interface
-// to only update on endpoint addition/change and deletion. This can also be used
-// to centrally track statistics such errors, active routines, etc.
 
 const (
 	defaultCollectionTimeout = time.Second
@@ -84,32 +76,19 @@ func NewCollector() *Collector {
 }
 
 // Start launches the collection goroutine.
-func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors *extractorMap) error {
-	if len(pollers) == 0 {
-		return errors.New("cannot start collector with empty sources")
+// Each PollingDispatcher owns its extractors; the Collector calls Dispatch per tick.
+func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, dispatchers []fwkdl.PollingDispatcher) error {
+	if len(dispatchers) == 0 {
+		return errors.New("cannot start collector with empty dispatchers")
 	}
-	for _, src := range pollers {
-		if src == nil {
-			return errors.New("cannot add nil data source")
+	for _, d := range dispatchers {
+		if d == nil {
+			return errors.New("cannot add nil dispatcher")
 		}
-	}
-	if extractors == nil {
-		extractors = newExtractorMap()
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-
-	// Filter to poll-capable extractors up front so the hot loop avoids per-tick type assertions.
-	pollingExtractors := make(map[string][]fwkdl.Extractor, extractors.Count())
-	extractors.Range(func(name string, exts []fwkdl.ExtractorBase) bool {
-		for _, ext := range exts {
-			if e, ok := ext.(fwkdl.Extractor); ok {
-				pollingExtractors[name] = append(pollingExtractors[name], e)
-			}
-		}
-		return true
-	})
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -118,7 +97,7 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
-	go c.run(ctx, ticker, ep, pollers, pollingExtractors)
+	go c.run(ctx, ticker, ep, dispatchers)
 	return nil
 }
 
@@ -133,7 +112,7 @@ func (c *Collector) Stop() {
 	}
 }
 
-func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, pollers []fwkdl.PollingDataSource, extractors map[string][]fwkdl.Extractor) {
+func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, dispatchers []fwkdl.PollingDispatcher) {
 	defer func() {
 		close(c.done)
 		ticker.Stop()
@@ -145,46 +124,20 @@ func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, p
 		case <-ctx.Done():
 			return
 		case <-ticker.Channel():
-			for _, src := range pollers {
+			for _, disp := range dispatchers {
 				if ctx.Err() != nil {
 					return
 				}
-				c.pollOne(ctx, src, ep, extractors, logger)
+				dispCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
+				if err := disp.Dispatch(dispCtx, ep); err != nil {
+					tn := disp.TypedName()
+					//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
+					metrics.DataLayerPollErrorsTotal.WithLabelValues(tn.Type).Inc()
+					metrics.LlmdDataLayerPollErrorsTotal.WithLabelValues(tn.Type).Inc()
+					logger.V(logging.DEBUG).Info("dispatch failed", "source", tn, "err", err)
+				}
+				cancel()
 			}
-		}
-	}
-}
-
-func (c *Collector) pollOne(ctx context.Context, src fwkdl.PollingDataSource, ep fwkdl.Endpoint, extractors map[string][]fwkdl.Extractor, logger logr.Logger) {
-	tn := src.TypedName()
-
-	pollCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
-	defer cancel()
-	data, err := src.Poll(pollCtx, ep)
-	if err != nil {
-		//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
-		metrics.DataLayerPollErrorsTotal.WithLabelValues(tn.Type).Inc()
-		metrics.LlmdDataLayerPollErrorsTotal.WithLabelValues(tn.Type).Inc()
-		logger.V(logging.DEBUG).Info("poll failed", "source", tn, "err", err)
-		return
-	}
-	if data == nil {
-		return
-	}
-
-	for _, ext := range extractors[tn.Name] {
-		if ctx.Err() != nil {
-			return
-		}
-		extCtx, cancel := context.WithTimeout(ctx, defaultCollectionTimeout)
-		err := ext.Extract(extCtx, data, ep)
-		cancel()
-		if err != nil {
-			extName := ext.TypedName()
-			//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
-			metrics.DataLayerExtractErrorsTotal.WithLabelValues(tn.Type, extName.Type).Inc()
-			metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(tn.Type, extName.Type).Inc()
-			logger.V(logging.DEBUG).Info("extract failed", "source", tn, "extractor", extName, "err", err)
 		}
 	}
 }

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -19,7 +19,6 @@ package datalayer
 import (
 	"context"
 	"errors"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -50,36 +49,62 @@ func defaultEndpoint() fwkdl.Endpoint {
 
 var (
 	endpoint = defaultEndpoint()
-	sources  = []fwkdl.PollingDataSource{&datasourcemocks.MetricsDataSource{}}
+	sources  = []fwkdl.PollingDispatcher{&datasourcemocks.MetricsDataSource{}}
 )
 
+// Mock PollingDispatchers for collector tests. Each tracks its own
+// invocation count and (for dataSource) runs bound extractors with metric
+// instrumentation. Same behavior the framework collector did before the
+// dispatcher pattern moved extractor handling into each dispatcher.
+
 type errSource struct {
-	datasourcemocks.MetricsDataSource
-	kind string
-	err  error
+	kind      string
+	err       error
+	CallCount int64
 }
 
 func (e *errSource) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: e.kind, Name: e.kind}
 }
-
-func (e *errSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
+func (e *errSource) Dispatch(_ context.Context, _ fwkdl.Endpoint) error {
 	atomic.AddInt64(&e.CallCount, 1)
-	return nil, e.err
+	return e.err
 }
+func (e *errSource) AppendExtractor(_ fwkplugin.Plugin) error { return nil }
 
 type dataSource struct {
-	datasourcemocks.MetricsDataSource
-	kind string
+	kind      string
+	CallCount int64
+	mu        sync.Mutex
+	exts      []*stubExtractor
 }
 
 func (d *dataSource) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: d.kind, Name: d.kind}
 }
-
-func (d *dataSource) Poll(_ context.Context, _ fwkdl.Endpoint) (any, error) {
+func (d *dataSource) Dispatch(ctx context.Context, ep fwkdl.Endpoint) error {
 	atomic.AddInt64(&d.CallCount, 1)
-	return struct{}{}, nil
+	d.mu.Lock()
+	exts := append([]*stubExtractor(nil), d.exts...)
+	d.mu.Unlock()
+	for _, ext := range exts {
+		if err := ext.Extract(ctx, fwkdl.PollInput[any]{Payload: struct{}{}, Endpoint: ep}); err != nil {
+			//nolint:staticcheck // SA1019: mock mirrors production's dual-record during deprecation window.
+			metrics.DataLayerExtractErrorsTotal.WithLabelValues(d.kind, ext.kind).Inc()
+			metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(d.kind, ext.kind).Inc()
+		}
+	}
+	return nil
+}
+func (d *dataSource) AppendExtractor(p fwkplugin.Plugin) error {
+	s, ok := p.(*stubExtractor)
+	if !ok {
+		return nil
+	}
+	d.mu.Lock()
+	d.exts = append(d.exts, s)
+	d.mu.Unlock()
+	return nil
 }
 
 type stubExtractor struct {
@@ -90,20 +115,19 @@ type stubExtractor struct {
 func (s *stubExtractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: s.kind, Name: s.kind}
 }
-func (s *stubExtractor) ExpectedInputType() reflect.Type                          { return reflect.TypeFor[any]() }
-func (s *stubExtractor) Extract(_ context.Context, _ any, _ fwkdl.Endpoint) error { return s.err }
+func (s *stubExtractor) Extract(_ context.Context, _ fwkdl.PollInput[any]) error { return s.err }
 
 func TestCollectorStartInputs(t *testing.T) {
 	tests := []struct {
 		name        string
 		ctxCanceled bool
-		sources     []fwkdl.PollingDataSource
+		sources     []fwkdl.PollingDispatcher
 		wantErr     bool
 		wantErrIs   error
 	}{
 		{name: "valid sources, live ctx", sources: sources},
-		{name: "empty sources", sources: []fwkdl.PollingDataSource{}, wantErr: true},
-		{name: "nil source", sources: []fwkdl.PollingDataSource{nil}, wantErr: true},
+		{name: "empty sources", sources: []fwkdl.PollingDispatcher{}, wantErr: true},
+		{name: "nil source", sources: []fwkdl.PollingDispatcher{nil}, wantErr: true},
 		{name: "cancelled parent ctx", ctxCanceled: true, sources: sources, wantErr: true, wantErrIs: context.Canceled},
 	}
 
@@ -117,13 +141,13 @@ func TestCollectorStartInputs(t *testing.T) {
 
 			c := NewCollector()
 			ticker := mocks.NewTicker()
-			err := c.Start(ctx, ticker, endpoint, tt.sources, newExtractorMap())
+			err := c.Start(ctx, ticker, endpoint, tt.sources)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantErrIs != nil {
 					assert.ErrorIs(t, err, tt.wantErrIs)
 				}
-				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, newExtractorMap()),
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources),
 					"retry after failed Start should succeed")
 			} else {
 				require.NoError(t, err)
@@ -138,8 +162,8 @@ func TestCollectorCanStartOnlyOnce(t *testing.T) {
 	ticker := mocks.NewTicker()
 	ctx := context.Background()
 
-	require.NoError(t, c.Start(ctx, ticker, endpoint, sources, newExtractorMap()))
-	assert.Error(t, c.Start(ctx, ticker, endpoint, sources, newExtractorMap()),
+	require.NoError(t, c.Start(ctx, ticker, endpoint, sources))
+	assert.Error(t, c.Start(ctx, ticker, endpoint, sources),
 		"second Start after success should error")
 	c.Stop()
 }
@@ -158,7 +182,7 @@ func TestCollectorStop(t *testing.T) {
 			setup: func(t *testing.T) *Collector {
 				c := NewCollector()
 				ticker := mocks.NewTicker()
-				_ = c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{}, newExtractorMap())
+				_ = c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{})
 				return c
 			},
 		},
@@ -167,7 +191,7 @@ func TestCollectorStop(t *testing.T) {
 			setup: func(t *testing.T) *Collector {
 				c := NewCollector()
 				ticker := mocks.NewTicker()
-				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, newExtractorMap()))
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources))
 				return c
 			},
 		},
@@ -189,7 +213,7 @@ func TestCollectorCollectsOnTicks(t *testing.T) {
 	c := NewCollector()
 	ticker := mocks.NewTicker()
 
-	require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{source}, newExtractorMap()))
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{source}))
 	defer c.Stop()
 
 	ticker.Tick()
@@ -241,30 +265,27 @@ func TestCollectorErrorMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var src fwkdl.PollingDataSource
+			var src fwkdl.PollingDispatcher
 			if tt.srcErr != nil {
 				src = &errSource{kind: tt.srcType, err: tt.srcErr}
 			} else {
 				src = &dataSource{kind: tt.srcType}
 			}
 
-			extractors := newExtractorMap()
 			if tt.extType != "" {
 				ext := &stubExtractor{kind: tt.extType, err: tt.extErr}
-				extractors.Append(src.TypedName().Name, ext)
+				require.NoError(t, src.AppendExtractor(ext))
 			}
 
-			//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
-			pollBefore := testutil.ToFloat64(metrics.DataLayerPollErrorsTotal.WithLabelValues(tt.srcType))
+			pollBefore := testutil.ToFloat64(metrics.LlmdDataLayerPollErrorsTotal.WithLabelValues(tt.srcType))
 			var extBefore float64
 			if tt.extType != "" {
-				//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
-				extBefore = testutil.ToFloat64(metrics.DataLayerExtractErrorsTotal.WithLabelValues(tt.srcType, tt.extType))
+				extBefore = testutil.ToFloat64(metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(tt.srcType, tt.extType))
 			}
 
 			c := NewCollector()
 			ticker := mocks.NewTicker()
-			require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{src}, extractors))
+			require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{src}))
 			defer c.Stop()
 
 			for i := 0; i < tt.ticks; i++ {
@@ -272,14 +293,12 @@ func TestCollectorErrorMetrics(t *testing.T) {
 			}
 
 			require.Eventually(t, func() bool {
-				//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
-				gotPoll := testutil.ToFloat64(metrics.DataLayerPollErrorsTotal.WithLabelValues(tt.srcType)) - pollBefore
+				gotPoll := testutil.ToFloat64(metrics.LlmdDataLayerPollErrorsTotal.WithLabelValues(tt.srcType)) - pollBefore
 				if gotPoll != tt.wantPollDelta {
 					return false
 				}
 				if tt.extType != "" {
-					//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
-					gotExt := testutil.ToFloat64(metrics.DataLayerExtractErrorsTotal.WithLabelValues(tt.srcType, tt.extType)) - extBefore
+					gotExt := testutil.ToFloat64(metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(tt.srcType, tt.extType)) - extBefore
 					if gotExt != tt.wantExtDelta {
 						return false
 					}
@@ -305,7 +324,7 @@ func TestCollectorRapidStartStopRaceFree(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		c := NewCollector()
 		ticker := mocks.NewTicker()
-		require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDataSource{src}, newExtractorMap()))
+		require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{src}))
 		ticker.Tick()
 		c.Stop()
 	}
@@ -316,7 +335,7 @@ func TestCollectorRapidStartStopRaceFree(t *testing.T) {
 func TestCollectorConcurrentStopRaceFree(t *testing.T) {
 	c := NewCollector()
 	ticker := mocks.NewTicker()
-	require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, newExtractorMap()))
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources))
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package datalayer
 
 import (
-	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
 // Config defines the configuration of EPP data layer, as the set of DataSources
@@ -28,8 +28,12 @@ type Config struct {
 	Sources []DataSourceConfig // the data sources configured in the data layer
 }
 
-// DataSourceConfig defines the configuration of a specific DataSource
+// DataSourceConfig defines the configuration of a specific DataSource.
+// Plugin may be a DataSource (notification, endpoint) or a PollingDispatcher;
+// the framework type-asserts to the right variant at Configure time.
+// Extractors are stored as plugin.Plugin and type-asserted to the source's
+// variant; PollingDispatchers consume them via AppendExtractor.
 type DataSourceConfig struct {
-	Plugin     fwkdl.DataSource      // the data source plugin instance
-	Extractors []fwkdl.ExtractorBase // extractors defined for the data source
+	Plugin     plugin.Plugin   // the source plugin instance (DataSource or PollingDispatcher)
+	Extractors []plugin.Plugin // extractors defined for the data source
 }

--- a/pkg/epp/datalayer/k8s_bind.go
+++ b/pkg/epp/datalayer/k8s_bind.go
@@ -115,7 +115,7 @@ func (rn *notificationReconciler) dispatch(ctx context.Context, log logr.Logger,
 	}
 
 	for _, ext := range rn.extractors {
-		if err := ext.ExtractNotification(ctx, *processed); err != nil {
+		if err := ext.Extract(ctx, *processed); err != nil {
 			log.Error(err, "extractor failed", "extractor", ext.TypedName())
 		}
 	}

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -17,18 +17,21 @@ limitations under the License.
 package datalayer
 
 import (
+	"fmt"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
 // sourceHit identifies a matched source by its variant, registered name, and value.
+// src is plugin.Plugin because PollingDispatcher is not a DataSource.
 type sourceHit struct {
 	variant sourceVariant
 	name    string
-	src     fwkdl.DataSource
+	src     fwkplugin.Plugin
 }
 
 // variantSourceMap stores DataSources of one variant, keyed by TypedName.Name.
@@ -110,7 +113,9 @@ func (m *variantSourceMap[T]) ForEach(f func(name string, src T) error) error {
 }
 
 // findFirst returns the first source for which matches returns true.
-func (m *variantSourceMap[T]) findFirst(matches func(fwkdl.DataSource) bool) sourceHit {
+// matches takes plugin.Plugin so the same predicate works across all variants
+// (including PollingDispatcher, which is not a DataSource).
+func (m *variantSourceMap[T]) findFirst(matches func(fwkplugin.Plugin) bool) sourceHit {
 	var found sourceHit
 	m.m.Range(func(k, raw any) bool {
 		src := raw.(T)
@@ -123,14 +128,52 @@ func (m *variantSourceMap[T]) findFirst(matches func(fwkdl.DataSource) bool) sou
 	return found
 }
 
-// pollingManager owns the registered PollingDataSources.
-type pollingManager struct {
-	*variantSourceMap[fwkdl.PollingDataSource]
+// pollingDispatchers stores PollingDispatchers keyed by source name. Each
+// dispatcher owns its own extractors internally; the framework treats them
+// as opaque dispatch units.
+type pollingDispatchers struct {
+	mu sync.RWMutex
+	m  map[string]fwkdl.PollingDispatcher
 }
 
-func newPollingManager() *pollingManager {
-	return &pollingManager{variantSourceMap: newVariantSourceMap[fwkdl.PollingDataSource](variantPolling)}
+func newPollingDispatchers() *pollingDispatchers {
+	return &pollingDispatchers{m: make(map[string]fwkdl.PollingDispatcher)}
 }
+
+// Register installs disp under its TypedName.Name. Duplicate names fail loudly
+// so a config error surfaces at startup instead of silently shadowing telemetry.
+func (p *pollingDispatchers) Register(disp fwkdl.PollingDispatcher) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	name := disp.TypedName().Name
+	if _, exists := p.m[name]; exists {
+		return fmt.Errorf("duplicate %s source name %q", variantPolling, name)
+	}
+	p.m[name] = disp
+	return nil
+}
+
+// Get returns the dispatcher registered under name, if any.
+func (p *pollingDispatchers) Get(name string) (fwkdl.PollingDispatcher, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	d, ok := p.m[name]
+	return d, ok
+}
+
+// Dispatchers returns a snapshot of all dispatchers.
+func (p *pollingDispatchers) Dispatchers() map[string]fwkdl.PollingDispatcher {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make(map[string]fwkdl.PollingDispatcher, len(p.m))
+	for k, v := range p.m {
+		out[k] = v
+	}
+	return out
+}
+
+func (p *pollingDispatchers) Count() int    { p.mu.RLock(); defer p.mu.RUnlock(); return len(p.m) }
+func (p *pollingDispatchers) IsEmpty() bool { return p.Count() == 0 }
 
 // notificationManager owns the registered NotificationSources.
 // GVK uniqueness is enforced per-Configure-call by a caller-owned gvk tracker
@@ -190,37 +233,31 @@ func (cm *collectorManager) StopAll() {
 	})
 }
 
-// extractorMap is a name-keyed map of extractor slices.
+// extractorMap is a name-keyed map of extractor slices. Populated by Runtime.Configure
+// (single-threaded) and read-only thereafter; mutations after Configure returns are
+// not supported. Duplicate-Type detection is the caller's responsibility (see
+// runtime.Configure).
 type extractorMap struct {
-	// RWMutex (not sync.Map) so Append's read-then-write is atomic.
-	mu sync.RWMutex
-	m  map[string][]fwkdl.ExtractorBase
+	m map[string][]fwkplugin.Plugin
 }
 
 func newExtractorMap() *extractorMap {
-	return &extractorMap{m: make(map[string][]fwkdl.ExtractorBase)}
+	return &extractorMap{m: make(map[string][]fwkplugin.Plugin)}
 }
 
 // Get returns the extractors stored under srcName, if any.
-func (e *extractorMap) Get(srcName string) ([]fwkdl.ExtractorBase, bool) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+func (e *extractorMap) Get(srcName string) ([]fwkplugin.Plugin, bool) {
 	exts, ok := e.m[srcName]
 	return exts, ok
 }
 
 // Count returns the number of stored entries.
 func (e *extractorMap) Count() int {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
 	return len(e.m)
 }
 
 // Range invokes f for every entry; f returning false stops iteration.
-// f runs under RLock — must not block or call back into write methods.
-func (e *extractorMap) Range(f func(name string, exts []fwkdl.ExtractorBase) bool) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+func (e *extractorMap) Range(f func(name string, exts []fwkplugin.Plugin) bool) {
 	for k, v := range e.m {
 		if !f(k, v) {
 			return
@@ -228,16 +265,7 @@ func (e *extractorMap) Range(f func(name string, exts []fwkdl.ExtractorBase) boo
 	}
 }
 
-// Append adds ext to srcName's slice, deduping by Type. Safe for concurrent use.
-func (e *extractorMap) Append(srcName string, ext fwkdl.ExtractorBase) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	existing := e.m[srcName]
-	extType := ext.TypedName().Type
-	for _, p := range existing {
-		if p.TypedName().Type == extType {
-			return
-		}
-	}
-	e.m[srcName] = append(existing, ext)
+// Append adds ext to srcName's slice. Pure append; callers must dedup upstream.
+func (e *extractorMap) Append(srcName string, ext fwkplugin.Plugin) {
+	e.m[srcName] = append(e.m[srcName], ext)
 }

--- a/pkg/epp/datalayer/manager_test.go
+++ b/pkg/epp/datalayer/manager_test.go
@@ -6,88 +6,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
-	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
-	extractormocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/mocks"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	srcmocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/mocks"
 )
 
-// TestConcurrentAccessRaceFree pins concurrent safety on the manager maps.
-// Run under -race to catch regressions.
-func TestConcurrentAccessRaceFree(t *testing.T) {
+// TestVariantSourceMap_ConcurrentReadsRaceFree verifies variantSourceMap's
+// sync.Map backing permits concurrent read access from many goroutines
+// without data races. Run under -race to catch regressions if the storage
+// switches to a primitive that requires explicit locking on reads.
+func TestVariantSourceMap_ConcurrentReadsRaceFree(t *testing.T) {
+	m := newVariantSourceMap[fwkdl.NotificationSource](variantPolling)
+	for i := 0; i < 5; i++ {
+		m.Set(srcmocks.NewNotificationSource("polling", fmt.Sprintf("src%d", i), schema.GroupVersionKind{Group: "g", Version: "v", Kind: "k"}))
+	}
+
 	const goroutines = 32
-
-	cases := []struct {
-		name string
-		run  func(t *testing.T)
-	}{
-		{
-			name: "variantSourceMap reads",
-			run: func(t *testing.T) {
-				m := newVariantSourceMap[fwkdl.PollingDataSource](variantPolling)
-				for i := 0; i < 5; i++ {
-					m.Set(srcmocks.NewDataSource(fwkplugin.TypedName{Type: "polling", Name: fmt.Sprintf("src%d", i)}))
-				}
-				var wg sync.WaitGroup
-				for i := 0; i < goroutines; i++ {
-					wg.Add(1)
-					go func(i int) {
-						defer wg.Done()
-						_, _ = m.Get(fmt.Sprintf("src%d", i%5))
-						_ = m.Sources()
-						_ = m.Count()
-						_ = m.IsEmpty()
-						m.Range(func(string, fwkdl.PollingDataSource) bool { return true })
-						require.NoError(t, m.ForEach(func(string, fwkdl.PollingDataSource) error { return nil }))
-						_ = m.findFirst(func(fwkdl.DataSource) bool { return false })
-					}(i)
-				}
-				wg.Wait()
-			},
-		},
-		{
-			name: "extractorMap reads",
-			run: func(t *testing.T) {
-				m := newExtractorMap()
-				for i := 0; i < 5; i++ {
-					m.Append(fmt.Sprintf("src%d", i),
-						extractormocks.NewEndpointExtractor(fmt.Sprintf("ext%d", i)))
-				}
-				var wg sync.WaitGroup
-				for i := 0; i < goroutines; i++ {
-					wg.Add(1)
-					go func(i int) {
-						defer wg.Done()
-						_, _ = m.Get(fmt.Sprintf("src%d", i%5))
-						_ = m.Count()
-						m.Range(func(string, []fwkdl.ExtractorBase) bool { return true })
-					}(i)
-				}
-				wg.Wait()
-			},
-		},
-		{
-			name: "extractorMap concurrent Append dedups",
-			run: func(t *testing.T) {
-				m := newExtractorMap()
-				const srcName = "shared"
-				var wg sync.WaitGroup
-				for i := 0; i < goroutines; i++ {
-					wg.Add(1)
-					go func(i int) {
-						defer wg.Done()
-						m.Append(srcName, extractormocks.NewEndpointExtractor(fmt.Sprintf("ext%d", i)))
-					}(i)
-				}
-				wg.Wait()
-				got, _ := m.Get(srcName)
-				require.Len(t, got, 1, "Append must dedup by Type under concurrent callers")
-			},
-		},
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = m.Get(fmt.Sprintf("src%d", i%5))
+			_ = m.Sources()
+			_ = m.Count()
+			_ = m.IsEmpty()
+			m.Range(func(string, fwkdl.NotificationSource) bool { return true })
+			require.NoError(t, m.ForEach(func(string, fwkdl.NotificationSource) error { return nil }))
+			_ = m.findFirst(func(plugin.Plugin) bool { return false })
+		}(i)
 	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, tc.run)
-	}
+	wg.Wait()
 }

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
 var (
@@ -49,7 +49,7 @@ const (
 type Runtime struct {
 	pollingInterval time.Duration // used for polling sources
 
-	polling      *pollingManager
+	dispatchers  *pollingDispatchers
 	notification *notificationManager
 	endpoint     *endpointManager
 	extractors   *extractorMap
@@ -74,7 +74,7 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 	}
 	return &Runtime{
 		pollingInterval: interval,
-		polling:         newPollingManager(),
+		dispatchers:     newPollingDispatchers(),
 		notification:    newNotificationManager(),
 		endpoint:        newEndpointManager(),
 		extractors:      newExtractorMap(),
@@ -101,6 +101,17 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 	}
 	logger.Info("Configuring datalayer runtime", "numSources", numSources)
 
+	// boundTypes tracks (srcName, extractor type) pairs that already have a bound
+	// extractor. Pending registrations consult this so code-registered defaults
+	// yield to user-config extractors of the same Type.
+	boundTypes := make(map[string]map[string]struct{})
+	markBound := func(srcName, extType string) {
+		if boundTypes[srcName] == nil {
+			boundTypes[srcName] = make(map[string]struct{})
+		}
+		boundTypes[srcName][extType] = struct{}{}
+	}
+
 	gvk := newGvk()
 	if cfg != nil {
 		for _, srcCfg := range cfg.Sources {
@@ -116,8 +127,20 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 				return err
 			}
 
-			for _, ext := range srcCfg.Extractors {
-				r.extractors.Append(srcName, ext)
+			// PollingDispatchers own their extractors; notification/endpoint use extractorMap.
+			if disp, ok := src.(fwkdl.PollingDispatcher); ok {
+				for _, ext := range srcCfg.Extractors {
+					if err := disp.AppendExtractor(ext); err != nil {
+						return fmt.Errorf("dispatcher %s rejected extractor %s: %w",
+							src.TypedName(), ext.TypedName(), err)
+					}
+					markBound(srcName, ext.TypedName().Type)
+				}
+			} else {
+				for _, ext := range srcCfg.Extractors {
+					r.extractors.Append(srcName, ext)
+					markBound(srcName, ext.TypedName().Type)
+				}
 			}
 
 			extractorNames := make([]string, len(srcCfg.Extractors))
@@ -161,16 +184,30 @@ func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtrac
 			matchedSrc = pending.DefaultSource
 		}
 
-		if err := r.validateSourceExtractors(matchedSrc, []fwkdl.ExtractorBase{pending.Extractor}, disallowedExtractorType); err != nil {
+		if err := r.validateSourceExtractors(matchedSrc, []fwkplugin.Plugin{pending.Extractor}, disallowedExtractorType); err != nil {
 			return fmt.Errorf("code-registered extractor %s incompatible with source %s: %w",
 				pending.Extractor.TypedName(), srcName, err)
 		}
 
-		r.extractors.Append(srcName, pending.Extractor)
+		// Yield to user-config extractor of the same Type on this source.
+		extType := pending.Extractor.TypedName().Type
+		if _, alreadyBound := boundTypes[srcName][extType]; alreadyBound {
+			continue
+		}
+
+		if disp, ok := matchedSrc.(fwkdl.PollingDispatcher); ok {
+			if err := disp.AppendExtractor(pending.Extractor); err != nil {
+				return fmt.Errorf("dispatcher %s rejected pending extractor %s: %w",
+					matchedSrc.TypedName(), pending.Extractor.TypedName(), err)
+			}
+		} else {
+			r.extractors.Append(srcName, pending.Extractor)
+		}
+		markBound(srcName, extType)
 	}
 
 	logger.Info("Datalayer runtime configured",
-		"pollers", r.polling.Count(),
+		"pollers", r.dispatchers.Count(),
 		"notifiers", r.notification.Count(),
 		"endpointSources", r.endpoint.Count())
 	return nil
@@ -189,12 +226,31 @@ func (r *Runtime) Register(reg fwkdl.PendingRegistration) error {
 }
 
 // registerSource dispatches src to the matching variant manager. g enforces
-// per-Configure-call GVK uniqueness for NotificationSources.
-func (r *Runtime) registerSource(src fwkdl.DataSource, g *gvk) error {
+// per-Configure-call GVK uniqueness for NotificationSources. src may be a
+// PollingDispatcher (not a DataSource), so the parameter is plugin.Plugin.
+//
+// A source that implements more than one variant interface is rejected: type-
+// switch order would otherwise silently bind it to the first match, hiding the
+// ambiguity until a notification or endpoint event mismatched its handler.
+func (r *Runtime) registerSource(src fwkplugin.Plugin, g *gvk) error {
+	var variants []string
+	if _, ok := src.(fwkdl.PollingDispatcher); ok {
+		variants = append(variants, string(variantPolling))
+	}
+	if _, ok := src.(fwkdl.NotificationSource); ok {
+		variants = append(variants, string(variantNotification))
+	}
+	if _, ok := src.(fwkdl.EndpointSource); ok {
+		variants = append(variants, string(variantEndpoint))
+	}
+	if len(variants) > 1 {
+		return fmt.Errorf("source %s implements multiple variant interfaces (%v); a source must implement exactly one of PollingDispatcher, NotificationSource, EndpointSource",
+			src.TypedName().String(), variants)
+	}
+
 	switch s := src.(type) {
-	case fwkdl.PollingDataSource:
-		r.polling.Set(s)
-		return nil
+	case fwkdl.PollingDispatcher:
+		return r.dispatchers.Register(s)
 	case fwkdl.NotificationSource:
 		if err := g.Check(s); err != nil {
 			return err
@@ -220,7 +276,7 @@ func (r *Runtime) validateNoCrossVariantCollisions() error {
 	}
 	seen := make(map[string]seenSource)
 
-	check := func(name string, src fwkdl.DataSource, v sourceVariant) error {
+	check := func(name string, src fwkplugin.Plugin, v sourceVariant) error {
 		t := src.TypedName().Type
 		if prior, ok := seen[t]; ok && prior.variant != v {
 			return fmt.Errorf("%w: %q in %s (%s) and %s (%s)",
@@ -230,17 +286,13 @@ func (r *Runtime) validateNoCrossVariantCollisions() error {
 		return nil
 	}
 
-	var firstErr error
-	r.polling.Range(func(name string, src fwkdl.PollingDataSource) bool {
-		if err := check(name, src, variantPolling); err != nil {
-			firstErr = err
-			return false
+	for name, disp := range r.dispatchers.Dispatchers() {
+		if err := check(name, disp, variantPolling); err != nil {
+			return err
 		}
-		return true
-	})
-	if firstErr != nil {
-		return firstErr
 	}
+
+	var firstErr error
 	r.notification.Range(func(name string, src fwkdl.NotificationSource) bool {
 		if err := check(name, src, variantNotification); err != nil {
 			firstErr = err
@@ -263,8 +315,9 @@ func (r *Runtime) validateNoCrossVariantCollisions() error {
 
 // findSourceByType walks every variant manager and returns the matching source.
 // Returns ErrSourceTypeCollision if sourceType is registered in more than one variant.
-func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkdl.DataSource, error) {
-	matches := func(src fwkdl.DataSource) bool {
+// Return type is plugin.Plugin because PollingDispatcher is not a DataSource.
+func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVersionKind) (string, fwkplugin.Plugin, error) {
+	matches := func(src fwkplugin.Plugin) bool {
 		if src.TypedName().Type != sourceType {
 			return false
 		}
@@ -278,8 +331,17 @@ func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVer
 		return true
 	}
 
+	// Polling dispatchers searched first; one-pass scan.
+	var pollingHit sourceHit
+	for name, disp := range r.dispatchers.Dispatchers() {
+		if matches(disp) {
+			pollingHit = sourceHit{variant: variantPolling, name: name, src: disp}
+			break
+		}
+	}
+
 	matched, err := findUnique(sourceType,
-		r.polling.findFirst(matches),
+		pollingHit,
 		r.notification.findFirst(matches),
 		r.endpoint.findFirst(matches),
 	)
@@ -312,8 +374,11 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 	logger, _ := logr.FromContext(ctx)
 	logger = logger.WithValues("endpoint", endpointMetadata.GetNamespacedName())
 
-	pollers := r.polling.Sources()
-	if len(pollers) == 0 {
+	dispatchers := make([]fwkdl.PollingDispatcher, 0, r.dispatchers.Count())
+	for _, d := range r.dispatchers.Dispatchers() {
+		dispatchers = append(dispatchers, d)
+	}
+	if len(dispatchers) == 0 {
 		logger.Info("No polling sources configured, creating endpoint without collector")
 		endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
 		r.dispatchEndpointEvent(ctx, logger, fwkdl.EndpointEvent{Type: fwkdl.EventAddOrUpdate, Endpoint: endpoint})
@@ -330,7 +395,7 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 	}
 
 	ticker := NewTimeTicker(r.pollingInterval)
-	if err := collector.Start(ctx, ticker, endpoint, pollers, r.extractors); err != nil {
+	if err := collector.Start(ctx, ticker, endpoint, dispatchers); err != nil {
 		logger.Error(err, "failed to start collector for endpoint", "endpoint", key)
 		r.collectors.Remove(key)
 		return nil
@@ -372,7 +437,7 @@ func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger,
 		}
 		for _, ext := range exts {
 			if epExt, ok := ext.(fwkdl.EndpointExtractor); ok {
-				if err := epExt.ExtractEndpoint(ctx, *processed); err != nil {
+				if err := epExt.Extract(ctx, *processed); err != nil {
 					logger.Error(err, "endpoint extractor failed", "extractor", ext.TypedName())
 				}
 			}
@@ -381,10 +446,15 @@ func (r *Runtime) dispatchEndpointEvent(ctx context.Context, logger logr.Logger,
 	})
 }
 
-// validates the compatibility of data source and configured extractors. This includes
-// expected Extractor type, source output and extractor input type compatibility and
-// optionally source specific validation.
-func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fwkdl.ExtractorBase, disallowedExtractorType string) error {
+// validateSourceExtractors enforces config-time invariants on the extractors
+// declared for a source: duplicate Type detection, disallowed-type rejection,
+// and variant-specific contracts (NotificationExtractor + GVK match for
+// NotificationSources; EndpointExtractor for EndpointSources). Compile-time
+// Extractor[T] dispatch replaces the prior reflect-based input/output checks.
+//
+// src is plugin.Plugin to accommodate PollingDispatcher (not a DataSource);
+// dispatcher.AppendExtractor enforces its own typed contract.
+func (r *Runtime) validateSourceExtractors(src fwkplugin.Plugin, extractors []fwkplugin.Plugin, disallowedExtractorType string) error {
 	seenTypes := make(map[string]struct{}, len(extractors))
 	for _, ext := range extractors {
 		extType := ext.TypedName().Type
@@ -396,38 +466,26 @@ func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fw
 	}
 
 	for _, ext := range extractors {
-		// check if disallowed extractor type
 		if disallowedExtractorType != "" && ext.TypedName().Type == disallowedExtractorType {
 			return fmt.Errorf("disallowed Extractor %s is configured for source %s",
 				ext.TypedName().String(), src.TypedName().String())
 		}
 
-		// validate extractor type
-		extractorType := reflect.TypeOf(ext)
-		if err := validateExtractorCompatible(extractorType, src.ExtractorType()); err != nil {
-			return fmt.Errorf("extractor %s type incompatible with datasource %s: %w",
-				ext.TypedName(), src.TypedName(), err)
-		}
-
-		// validate input/output types match
-		if err := validateInputTypeCompatible(src.OutputType(), ext.ExpectedInputType()); err != nil {
-			return fmt.Errorf("extractor %s input type incompatible with datasource %s: %w",
-				ext.TypedName(), src.TypedName(), err)
-		}
 		if notifySrc, ok := src.(fwkdl.NotificationSource); ok {
-			if notifyExt, ok := ext.(fwkdl.NotificationExtractor); ok {
-				if notifySrc.GVK().String() != notifyExt.GVK().String() {
-					return fmt.Errorf("extractor %s GVK %s does not match source %s GVK %s",
-						ext.TypedName(), notifyExt.GVK().String(), src.TypedName(), notifySrc.GVK().String())
-				}
+			notifyExt, ok := ext.(fwkdl.NotificationExtractor)
+			if !ok {
+				return fmt.Errorf("notification source %s requires a NotificationExtractor; extractor %s does not implement it",
+					src.TypedName(), ext.TypedName())
+			}
+			if notifySrc.GVK().String() != notifyExt.GVK().String() {
+				return fmt.Errorf("extractor %s GVK %s does not match source %s GVK %s",
+					ext.TypedName(), notifyExt.GVK(), src.TypedName(), notifySrc.GVK())
 			}
 		}
-
-		// allow datasource custom validation
-		if validator, ok := src.(fwkdl.ValidatingDataSource); ok {
-			if err := validator.ValidateExtractor(ext); err != nil {
-				return fmt.Errorf("extractor %s failed custom validation for datasource %s: %w",
-					ext.TypedName(), src.TypedName(), err)
+		if _, ok := src.(fwkdl.EndpointSource); ok {
+			if _, ok := ext.(fwkdl.EndpointExtractor); !ok {
+				return fmt.Errorf("endpoint source %s requires an EndpointExtractor; extractor %s does not implement it",
+					src.TypedName(), ext.TypedName())
 			}
 		}
 	}
@@ -454,20 +512,6 @@ func (g *gvk) Check(src fwkdl.NotificationSource) error {
 	return nil
 }
 
-// validate input/output type compatibility.
-func validateInputTypeCompatible(dataSourceOutput, extractorInput reflect.Type) error {
-	if dataSourceOutput == nil || extractorInput == nil {
-		return errors.New("data source output type or extractor input type can't be nil")
-	}
-	if dataSourceOutput == extractorInput ||
-		(extractorInput.Kind() == reflect.Interface && extractorInput.NumMethod() == 0) ||
-		(extractorInput.Kind() == reflect.Interface && dataSourceOutput.Implements(extractorInput)) {
-		return nil
-	}
-	return fmt.Errorf("extractor input type %v is not compatible with data source output type %v",
-		extractorInput, dataSourceOutput)
-}
-
 // findUnique returns the single matching source across hits.
 // Returns ErrSourceTypeCollision if more than one hit is present.
 func findUnique(sourceType string, hits ...sourceHit) (sourceHit, error) {
@@ -485,21 +529,6 @@ func findUnique(sourceType string, hits ...sourceHit) (sourceHit, error) {
 		matched = h
 	}
 	return matched, nil
-}
-
-// validate extractor compatibility.
-func validateExtractorCompatible(extractorType reflect.Type, expectedInterfaceType reflect.Type) error {
-	if extractorType == nil || expectedInterfaceType == nil {
-		return errors.New("extractor type or expected interface type can't be nil")
-	}
-	if expectedInterfaceType.Kind() != reflect.Interface {
-		return fmt.Errorf("expected type must be an interface, got %v", expectedInterfaceType.Kind())
-	}
-	if !extractorType.Implements(expectedInterfaceType) {
-		return fmt.Errorf("extractor type %v does not implement interface %v",
-			extractorType, expectedInterfaceType)
-	}
-	return nil
 }
 
 var _ EndpointFactory = (*Runtime)(nil)

--- a/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
+++ b/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	extmocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
@@ -43,7 +44,7 @@ func TestNewEndpointDispatchesEventWithNoPollers(t *testing.T) {
 		Sources: []DataSourceConfig{
 			{
 				Plugin:     epSrc,
-				Extractors: []fwkdl.ExtractorBase{extractor},
+				Extractors: []fwkplugin.Plugin{extractor},
 			},
 		},
 	}

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -146,37 +146,85 @@ func TestConfigure_WarnPolicyMissingSource(t *testing.T) {
 	require.NoError(t, err, "Warn policy should not return error when source is absent")
 }
 
-func TestConfigure_DedupByExtractorType(t *testing.T) {
-	// (g) dedup: extractor type already wired via config → code registration is a no-op
+func TestConfigure_PendingRegistrationYieldsToConfigByType(t *testing.T) {
+	cases := []struct {
+		name       string
+		configExt  *extractormocks.EndpointExtractor
+		pendingExt *extractormocks.EndpointExtractor
+		wantNames  []string // expected bound extractor names, in order
+	}{
+		{
+			name:       "same type → pending yields to config",
+			configExt:  extractormocks.NewEndpointExtractor("config-ext"),
+			pendingExt: extractormocks.NewEndpointExtractor("code-ext"),
+			wantNames:  []string{"config-ext"},
+		},
+		{
+			name:       "different type → both bound (no yield)",
+			configExt:  extractormocks.NewEndpointExtractor("config-ext"),
+			pendingExt: extractormocks.NewEndpointExtractor("code-ext").WithType("other-extractor-type"),
+			wantNames:  []string{"config-ext", "code-ext"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRuntime(0)
+			logger := newTestLogger(t)
+			src := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, "ep-src")
+
+			cfg := &Config{
+				Sources: []DataSourceConfig{{
+					Plugin:     src,
+					Extractors: []fwkplugin.Plugin{tc.configExt},
+				}},
+			}
+
+			require.NoError(t, r.Register(fwkdl.PendingRegistration{
+				Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+				SourceType: notifications.EndpointNotificationSourceType,
+				Extractor:  tc.pendingExt,
+			}))
+
+			require.NoError(t, r.Configure(cfg, false, "", logger))
+
+			exts, ok := r.extractors.Get("ep-src")
+			require.True(t, ok)
+			gotNames := make([]string, len(exts))
+			for i, e := range exts {
+				gotNames[i] = e.TypedName().Name
+			}
+			assert.Equal(t, tc.wantNames, gotNames)
+		})
+	}
+}
+
+func TestConfigure_PendingVsPending_FirstWinsOnSameType(t *testing.T) {
 	r := NewRuntime(0)
 	logger := newTestLogger(t)
 
-	src := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, "ep-src")
-	extFromConfig := extractormocks.NewEndpointExtractor("config-ext")
-	extFromCode := extractormocks.NewEndpointExtractor("code-ext")
+	defaultSrc := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, notifications.EndpointNotificationSourceType)
+	first := extractormocks.NewEndpointExtractor("first-pending")
+	second := extractormocks.NewEndpointExtractor("second-pending")
 
-	// User config wires extFromConfig to src.
-	cfg := &Config{
-		Sources: []DataSourceConfig{{
-			Plugin:     src,
-			Extractors: []fwkdl.ExtractorBase{extFromConfig},
-		}},
-	}
-
-	// Code registers extFromCode — same type as extFromConfig ("mock-endpoint-extractor").
 	require.NoError(t, r.Register(fwkdl.PendingRegistration{
-		Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
+		Owner:         fwkplugin.TypedName{Type: "plugin-a", Name: "a"},
+		SourceType:    notifications.EndpointNotificationSourceType,
+		Extractor:     first,
+		DefaultSource: defaultSrc,
+	}))
+	require.NoError(t, r.Register(fwkdl.PendingRegistration{
+		Owner:      fwkplugin.TypedName{Type: "plugin-b", Name: "b"},
 		SourceType: notifications.EndpointNotificationSourceType,
-		Extractor:  extFromCode,
+		Extractor:  second,
 	}))
 
-	err := r.Configure(cfg, false, "", logger)
-	require.NoError(t, err)
+	require.NoError(t, r.Configure(nil, false, "", logger))
 
-	exts, ok := r.extractors.Get("ep-src")
+	exts, ok := r.extractors.Get(notifications.EndpointNotificationSourceType)
 	require.True(t, ok)
-	require.Len(t, exts, 1, "code registration should be deduped; only config extractor present")
-	assert.Equal(t, "config-ext", exts[0].TypedName().Name)
+	require.Len(t, exts, 1, "second pending must yield to first when Types collide")
+	assert.Equal(t, "first-pending", exts[0].TypedName().Name)
 }
 
 // Pins rejection of duplicate-Type extractors per source. Append dedups silently otherwise.
@@ -191,7 +239,7 @@ func TestConfigure_DuplicateExtractorTypePerSource(t *testing.T) {
 	cfg := &Config{
 		Sources: []DataSourceConfig{{
 			Plugin:     src,
-			Extractors: []fwkdl.ExtractorBase{ext1, ext2},
+			Extractors: []fwkplugin.Plugin{ext1, ext2},
 		}},
 	}
 

--- a/pkg/epp/datalayer/runtime_validate_test.go
+++ b/pkg/epp/datalayer/runtime_validate_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,115 +17,19 @@ limitations under the License.
 package datalayer
 
 import (
-	"reflect"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	extractormocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/mocks"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
-
-var (
-	extractorType             = reflect.TypeFor[fwkdl.Extractor]()
-	notificationextractorType = reflect.TypeFor[fwkdl.NotificationExtractor]()
-)
-
-func TestValidateInputTypeCompatible(t *testing.T) {
-	type rawStruct struct{}
-	type iface interface{ Foo() }
-
-	tests := []struct {
-		name   string
-		output reflect.Type
-		input  reflect.Type
-		valid  bool
-	}{
-		{"exact match", typeOfT(rawStruct{}), typeOfT(rawStruct{}), true},
-		{"input is interface{}", typeOfT(rawStruct{}), typeOfT((*any)(nil)), true},
-		{"nil types are not allowed", typeOfT(rawStruct{}), typeOfT(nil), false},
-		{"output does not implement input", typeOfT(rawStruct{}), typeOfT((*iface)(nil)), false},
-	}
-
-	for _, tt := range tests {
-		err := validateInputTypeCompatible(tt.output, tt.input)
-		if tt.valid {
-			assert.NoError(t, err, "%s: expected valid extractor type", tt.name)
-		} else {
-			assert.Error(t, err, "%s: expected invalid extractor type", tt.name)
-		}
-	}
-}
-
-func TestValidateExtractorCompatible(t *testing.T) {
-	type notExtractor struct{}
-
-	tests := []struct {
-		name         string
-		extType      reflect.Type
-		expectedType reflect.Type
-		valid        bool
-		errContains  string
-	}{
-		{
-			name:         "nil extractor type",
-			extType:      nil,
-			expectedType: extractorType,
-			valid:        false,
-			errContains:  "can't be nil",
-		},
-		{
-			name:         "nil expected type",
-			extType:      reflect.TypeFor[*notExtractor](),
-			expectedType: nil,
-			valid:        false,
-			errContains:  "can't be nil",
-		},
-		{
-			name:         "expected type not interface",
-			extType:      reflect.TypeFor[*notExtractor](),
-			expectedType: reflect.TypeFor[string](),
-			valid:        false,
-			errContains:  "must be an interface",
-		},
-		{
-			name:         "does not implement interface",
-			extType:      reflect.TypeFor[*notExtractor](),
-			expectedType: extractorType,
-			valid:        false,
-			errContains:  "does not implement interface",
-		},
-	}
-
-	for _, tt := range tests {
-		err := validateExtractorCompatible(tt.extType, tt.expectedType)
-		if tt.valid {
-			assert.NoError(t, err, "%s: expected valid", tt.name)
-		} else {
-			assert.Error(t, err, "%s: expected error", tt.name)
-			if tt.errContains != "" {
-				assert.Contains(t, err.Error(), tt.errContains, "%s: error should contain", tt.name)
-			}
-		}
-	}
-}
-
-func TestTypeConstants(t *testing.T) {
-	assert.True(t, extractorType.Kind() == reflect.Interface, "extractorType should be an interface")
-	assert.True(t, notificationextractorType.Kind() == reflect.Interface, "notificationextractorType should be an interface")
-}
-
-func typeOfT(v any) reflect.Type {
-	t := reflect.TypeOf(v)
-	if t == nil {
-		return nil
-	}
-	if t.Kind() == reflect.Pointer {
-		return t.Elem()
-	}
-	return t
-}
 
 func TestRuntimeConfigureWithNilExtractor(t *testing.T) {
 	logger := newTestLogger(t)
@@ -148,7 +52,7 @@ func TestRuntimeConfigureDuplicateGVKFails(t *testing.T) {
 	logger := newTestLogger(t)
 	r := NewRuntime(1)
 
-	// Create two notification sources with the same GVK
+	// Two notification sources with the same GVK must fail at Configure.
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 	src1 := mocks.NewNotificationSource("test", "source1", gvk)
 	src2 := mocks.NewNotificationSource("test", "source2", gvk)
@@ -163,4 +67,82 @@ func TestRuntimeConfigureDuplicateGVKFails(t *testing.T) {
 	err := r.Configure(cfg, false, "", logger)
 	assert.Error(t, err, "Configure should fail with duplicate GVK")
 	assert.Contains(t, err.Error(), "duplicate", "Error should mention duplicate GVK")
+}
+
+// NotificationSource and EndpointSource dispatch sites type-assert the
+// extractor without checking ok. A mismatched extractor type would panic at
+// the first event or be silently ignored at dispatch. Configure must catch it.
+func TestRuntimeConfigure_NotificationSource_RequiresNotificationExtractor(t *testing.T) {
+	logger := newTestLogger(t)
+	r := NewRuntime(1)
+
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	src := mocks.NewNotificationSource("notif-src", "notif", gvk)
+	// A polling extractor is NOT a NotificationExtractor.
+	wrongExt := extractormocks.NewPollingExtractor("polling-ext")
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{
+			{Plugin: src, Extractors: []fwkplugin.Plugin{wrongExt}},
+		},
+	}
+
+	err := r.Configure(cfg, false, "", logger)
+	require.Error(t, err, "Configure must reject a non-NotificationExtractor for a notification source")
+	assert.Contains(t, err.Error(), "NotificationExtractor")
+}
+
+func TestRuntimeConfigure_EndpointSource_RequiresEndpointExtractor(t *testing.T) {
+	logger := newTestLogger(t)
+	r := NewRuntime(1)
+
+	src := notifications.NewEndpointDataSource("endpoint-src", "endpoint")
+	wrongExt := extractormocks.NewPollingExtractor("polling-ext")
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{
+			{Plugin: src, Extractors: []fwkplugin.Plugin{wrongExt}},
+		},
+	}
+
+	err := r.Configure(cfg, false, "", logger)
+	require.Error(t, err, "Configure must reject a non-EndpointExtractor for an endpoint source")
+	assert.Contains(t, err.Error(), "EndpointExtractor")
+}
+
+// multiVariantSource implements two variant interfaces. The registerSource
+// type-switch routes by first match; without an explicit guard the source
+// would silently land in whichever case comes first.
+type multiVariantSource struct {
+	typedName fwkplugin.TypedName
+	gvk       schema.GroupVersionKind
+}
+
+func (m *multiVariantSource) TypedName() fwkplugin.TypedName                     { return m.typedName }
+func (m *multiVariantSource) GVK() schema.GroupVersionKind                       { return m.gvk }
+func (m *multiVariantSource) Dispatch(_ context.Context, _ fwkdl.Endpoint) error { return nil }
+func (m *multiVariantSource) AppendExtractor(_ fwkplugin.Plugin) error           { return nil }
+func (m *multiVariantSource) Notify(_ context.Context, event fwkdl.NotificationEvent) (*fwkdl.NotificationEvent, error) {
+	// Body never runs in this test. Configure rejects the source for
+	// implementing multiple variants before any Notify call. Echo the
+	// event so the return satisfies nilnil.
+	return &event, nil
+}
+
+func TestRuntimeConfigure_SourceImplementingMultipleVariants_Rejected(t *testing.T) {
+	logger := newTestLogger(t)
+	r := NewRuntime(1)
+
+	src := &multiVariantSource{
+		typedName: fwkplugin.TypedName{Type: "ambiguous", Name: "ambiguous"},
+		gvk:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+	}
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{{Plugin: src}},
+	}
+
+	err := r.Configure(cfg, false, "", logger)
+	require.Error(t, err, "a source that implements multiple variant interfaces must be rejected")
+	assert.Contains(t, err.Error(), "multiple variant")
 }

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -18,7 +18,6 @@ package datalayer
 
 import (
 	"context"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,65 +25,62 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
-var (
-	ExtractorBaseType         = reflect.TypeFor[ExtractorBase]()
-	ExtractorType             = reflect.TypeFor[Extractor]()
-	NotificationExtractorType = reflect.TypeFor[NotificationExtractor]()
-	NotificationEventType     = reflect.TypeFor[NotificationEvent]()
-	EndpointExtractorType     = reflect.TypeFor[EndpointExtractor]()
-	EndpointEventReflectType  = reflect.TypeFor[EndpointEvent]()
-)
-
-// DataSource provides raw data to registered Extractors.
-// For poll-based sources, use PollingDataSource.
-// For event-driven sources, use NotificationSource.
+// DataSource provides raw data to registered Extractors. Concrete variants
+// are PollingDispatcher (poll-driven), NotificationSource (k8s-event-driven),
+// and EndpointSource (lifecycle-event-driven).
 type DataSource interface {
 	plugin.Plugin
-	// OutputType returns the type of data this DataSource produces.
-	// Used for validating extractor compatibility.
-	OutputType() reflect.Type
-	// ExtractorType returns the type of Extractor this DataSource expects.
-	// For poll-based sources, this is the base Extractor interface.
-	// For notification sources, this is the NotificationExtractor interface.
-	ExtractorType() reflect.Type
 }
 
-// PollingDataSource is a poll-based DataSource that fetches data at regular intervals.
-type PollingDataSource interface {
-	DataSource
-	// Poll fetches data for an endpoint and returns it.
-	// The Runtime handles calling extractors with the returned data.
-	Poll(ctx context.Context, ep Endpoint) (any, error)
-}
-
-// ExtractorBase is the common base for all extractor variants.
-// It provides identity and type-compatibility information without
-// prescribing how extraction is triggered.
-type ExtractorBase interface {
+// Extractor transforms typed input T into endpoint attributes. T pins the
+// dispatch payload:
+//
+//   - Polling extractors:      T = PollInput[D]      (paired with a PollingDispatcher)
+//   - Notification extractors: T = NotificationEvent (also implement NotificationExtractor for GVK)
+//   - Endpoint extractors:     T = EndpointEvent
+type Extractor[T any] interface {
 	plugin.Plugin
-	// ExpectedInputType defines the type expected by the extractor.
-	ExpectedInputType() reflect.Type
+	Extract(ctx context.Context, in T) error
 }
 
-// Extractor transforms raw data from a PollingDataSource into structured
-// attributes. Used only with poll-based sources; the Runtime calls Extract
-// on each tick with the data returned by the source's Poll method.
-type Extractor interface {
-	ExtractorBase
-	// Extract transforms the raw data source output into a concrete structured
-	// attribute, stored on the given endpoint.
-	Extract(ctx context.Context, data any, ep Endpoint) error
+// PollInput pairs the typed poll payload with the endpoint being polled.
+// Payload is the parser's result and is expected to be usable when Poll returns a nil error.
+type PollInput[D any] struct {
+	Payload  D
+	Endpoint Endpoint
 }
 
-// ValidatingDataSource is an optional interface that DataSources can implement
-// to perform additional custom validation when adding extractors.
-type ValidatingDataSource interface {
-	// ValidateExtractor allows the DataSource to perform additional validation
-	// beyond the standard type compatibility checks. Return an error if validation fails.
-	ValidateExtractor(extractor ExtractorBase) error
+// EndpointExtractor is the typed contract for endpoint-lifecycle extractors.
+type EndpointExtractor = Extractor[EndpointEvent]
+
+// PollingExtractor is the typed contract for poll-based extractors.
+type PollingExtractor[T any] = Extractor[PollInput[T]]
+
+// NotificationExtractor is the typed contract for k8s-event extractors.
+// GVK identifies the kind this extractor handles; it must match the paired
+// NotificationSource's GVK.
+type NotificationExtractor interface {
+	Extractor[NotificationEvent]
+	GVK() schema.GroupVersionKind
 }
 
-// EventType identifies the type of mutation that triggered the notification.
+// PollingDispatcher is the framework's contract for polling sources. The
+// source owns its extractors and runs them with typed input each tick.
+//
+// Contract:
+//   - Dispatch runs bound extractors in AppendExtractor-insertion order.
+//   - Each Poll and each Extract step runs under its own timeout.
+//   - Non-nil return = poll failure; per-extractor failures record
+//     DataLayerExtractErrorsTotal and do NOT surface as the return error.
+//   - AppendExtractor is a pure append; duplicate-Type detection is the caller's
+//     responsibility (see runtime.Configure).
+type PollingDispatcher interface {
+	plugin.Plugin
+	Dispatch(ctx context.Context, ep Endpoint) error
+	AppendExtractor(ext plugin.Plugin) error
+}
+
+// EventType identifies the type of mutation that triggered a notification.
 type EventType int
 
 const (
@@ -97,17 +93,11 @@ const (
 // NotificationEvent carries the event type and the affected object.
 // Object is deep-copied by the framework core before delivery.
 type NotificationEvent struct {
-	// Type is the mutation type.
-	Type EventType
-	// Object is the current state of the object (for add/update) or the
-	// last known state (for delete). Note that for delete notifications
-	// only the object's name and namespace can be relied on.
+	Type   EventType
 	Object *unstructured.Unstructured
 }
 
 // NotificationSource is an event-driven DataSource for a single k8s GVK.
-// The framework core owns the k8s notification mechanisms (e.g., watches,
-// caches, informers) and calls the source's Notify on events.
 type NotificationSource interface {
 	DataSource
 	// GVK returns the GroupVersionKind this source watches.
@@ -120,43 +110,16 @@ type NotificationSource interface {
 	Notify(ctx context.Context, event NotificationEvent) (*NotificationEvent, error)
 }
 
-// NotificationExtractor processes k8s object events pushed from a
-// NotificationSource. The Runtime calls ExtractNotification directly;
-// Extract from the base Extractor interface is never invoked on this type.
-type NotificationExtractor interface {
-	ExtractorBase
-	// GVK returns the GroupVersionKind this extractor handles.
-	GVK() schema.GroupVersionKind
-	// ExtractNotification processes a notification event. Called synchronously
-	// by the source in event order.
-	ExtractNotification(ctx context.Context, event NotificationEvent) error
-}
-
 // EndpointEvent carries an endpoint lifecycle event.
-// Reuses EventType: EventAddOrUpdate signals an endpoint was added to the
-// datastore; EventDelete signals an endpoint was removed.
 type EndpointEvent struct {
 	Type     EventType
 	Endpoint Endpoint
 }
 
-// EndpointSource is an event-driven DataSource driven by endpoint lifecycle
-// changes. The Runtime calls NotifyEndpoint when an endpoint is added to or
-// removed from the datastore, then dispatches the (possibly modified) event to
-// registered EndpointExtractors. Return nil to suppress extractor dispatch.
+// EndpointSource is an event-driven DataSource driven by endpoint lifecycle changes.
 type EndpointSource interface {
 	DataSource
 	// NotifyEndpoint is called by the Runtime on each endpoint lifecycle event.
-	// Returns the event (possibly modified) for the Runtime to dispatch to extractors.
-	// Returns nil event to signal Runtime to skip extractor dispatch.
+	// Returns nil event to skip extractor dispatch.
 	NotifyEndpoint(ctx context.Context, event EndpointEvent) (*EndpointEvent, error)
-}
-
-// EndpointExtractor processes endpoint lifecycle events pushed from an
-// EndpointSource. The Runtime calls ExtractEndpoint directly;
-// Extract from the base Extractor interface is never invoked on this type.
-type EndpointExtractor interface {
-	ExtractorBase
-	// ExtractEndpoint processes an endpoint lifecycle event.
-	ExtractEndpoint(ctx context.Context, event EndpointEvent) error
 }

--- a/pkg/epp/framework/interface/datalayer/registrar.go
+++ b/pkg/epp/framework/interface/datalayer/registrar.go
@@ -40,7 +40,7 @@ type Registrant interface {
 type PendingRegistration struct {
 	Owner         plugin.TypedName // registering plugin; used as map key + error context
 	SourceType    string           // TypedName.Type to match, e.g. "endpoint-notification-source"
-	Extractor     ExtractorBase    // required; extractor to wire to the matched source
+	Extractor     plugin.Plugin    // required; framework type-asserts to the matched source's variant
 	DefaultSource DataSource       // nil → no auto-create; non-nil → create if absent
 	IfMissing     MissingPolicy    // applies only when DefaultSource is nil
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -86,19 +85,10 @@ func (ext *Extractor) TypedName() fwkplugin.TypedName {
 	return ext.typedName
 }
 
-// ExpectedType defines the type expected by the metrics.Extractor - a
-// parsed output from a Prometheus metrics endpoint.
-func (ext *Extractor) ExpectedInputType() reflect.Type {
-	return sourcemetrics.PrometheusMetricType
-}
-
-// Extract transforms the data source output into a concrete attribute that
-// is stored on the given endpoint.
-func (ext *Extractor) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) error {
-	families, ok := data.(sourcemetrics.PrometheusMetricMap)
-	if !ok {
-		return fmt.Errorf("unexpected input in Extract: %T", data)
-	}
+// Extract transforms the typed metrics payload into endpoint attributes.
+func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]) error {
+	families := in.Payload
+	ep := in.Endpoint
 
 	engineType := getEngineTypeFromEndpoint(ep, ext.engineLabelKey)
 	mapping, ok := ext.registry.Get(engineType)

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -71,10 +71,6 @@ func TestExtractorExtract(t *testing.T) {
 		t.Error("empty extractor name")
 	}
 
-	if inputType := extractor.ExpectedInputType(); inputType != sourcemetrics.PrometheusMetricType {
-		t.Errorf("incorrect expected input type: %v", inputType)
-	}
-
 	ep := fwkdl.NewEndpoint(nil, nil)
 	if ep == nil {
 		t.Fatal("expected non-nil endpoint")
@@ -82,7 +78,7 @@ func TestExtractorExtract(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		data    any
+		data    sourcemetrics.PrometheusMetricMap
 		wantErr bool
 		updated bool // whether metrics are expected to change
 	}{
@@ -194,7 +190,7 @@ func TestExtractorExtract(t *testing.T) {
 			}()
 
 			before := ep.GetMetrics().Clone()
-			err := extractor.Extract(ctx, tt.data, ep)
+			err := extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: tt.data, Endpoint: ep})
 			after := ep.GetMetrics()
 
 			if tt.wantErr && err == nil {
@@ -254,7 +250,7 @@ func TestExtractorMultiEngine(t *testing.T) {
 	epVllm := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		Labels: map[string]string{DefaultEngineTypeLabelKey: "vllm"},
 	}, nil)
-	_ = extractor.Extract(ctx, data, epVllm)
+	_ = extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: epVllm})
 	if epVllm.GetMetrics().WaitingQueueSize != 10 {
 		t.Errorf("vllm: expected queue size 10, got %v", epVllm.GetMetrics().WaitingQueueSize)
 	}
@@ -263,7 +259,7 @@ func TestExtractorMultiEngine(t *testing.T) {
 	epSgl := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		Labels: map[string]string{DefaultEngineTypeLabelKey: "sglang"},
 	}, nil)
-	_ = extractor.Extract(ctx, data, epSgl)
+	_ = extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: epSgl})
 	if epSgl.GetMetrics().WaitingQueueSize != 20 {
 		t.Errorf("sglang: expected queue size 20, got %v", epSgl.GetMetrics().WaitingQueueSize)
 	}
@@ -292,7 +288,7 @@ func TestBackwardCompatibility(t *testing.T) {
 
 	// Case 1: No labels at all
 	epNone := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{Labels: nil}, nil)
-	_ = extractor.Extract(ctx, data, epNone)
+	_ = extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: epNone})
 	if epNone.GetMetrics().WaitingQueueSize != 100 {
 		t.Errorf("no labels: expected 100, got %v", epNone.GetMetrics().WaitingQueueSize)
 	}
@@ -301,7 +297,7 @@ func TestBackwardCompatibility(t *testing.T) {
 	epUnknown := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		Labels: map[string]string{DefaultEngineTypeLabelKey: "unknown-engine"},
 	}, nil)
-	_ = extractor.Extract(ctx, data, epUnknown)
+	_ = extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: epUnknown})
 	if epUnknown.GetMetrics().WaitingQueueSize != 100 {
 		t.Errorf("unknown label: expected 100, got %v", epUnknown.GetMetrics().WaitingQueueSize)
 	}
@@ -351,7 +347,7 @@ func TestCacheInfoLabelAliasing(t *testing.T) {
 	}
 
 	ep := fwkdl.NewEndpoint(nil, nil)
-	_ = extractor.Extract(ctx, data, ep)
+	_ = extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
 
 	if ep.GetMetrics().CacheBlockSize != 64 {
 		t.Errorf("expected CacheBlockSize 64, got %d", ep.GetMetrics().CacheBlockSize)
@@ -418,7 +414,7 @@ func TestDirectGaugeSpecExtraction(t *testing.T) {
 	}
 
 	ep := fwkdl.NewEndpoint(nil, nil)
-	_ = extractor.Extract(ctx, data, ep)
+	_ = extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
 
 	if ep.GetMetrics().CacheBlockSize != 64 {
 		t.Errorf("expected CacheBlockSize 64, got %d", ep.GetMetrics().CacheBlockSize)
@@ -506,7 +502,7 @@ func TestCoreMetricsExtractorFactoryDefaultEngine(t *testing.T) {
 			checkDefault: "custom",
 		},
 		{
-			name: "custom engineConfigs auto-appends vllm sglang trtllm-serve triton-tensorrt-llm and triton",
+			name: "custom engineConfigs auto-appends vllm sglang trtllm-serve and triton-tensorrt-llm",
 			params: map[string]any{
 				"engineConfigs": []map[string]any{
 					{
@@ -525,14 +521,6 @@ func TestCoreMetricsExtractorFactoryDefaultEngine(t *testing.T) {
 			},
 			wantErr:      false,
 			checkDefault: "triton-tensorrt-llm",
-		},
-		{
-			name: "defaultEngine triton",
-			params: map[string]any{
-				"defaultEngine": "triton",
-			},
-			wantErr:      false,
-			checkDefault: "triton",
 		},
 		{
 			name: "custom engineConfigs with custom vllm preserves user config",
@@ -725,39 +713,5 @@ func TestGetEngineTypeFromEndpoint(t *testing.T) {
 				t.Errorf("getEngineTypeFromEndpoint() = %q, want %q", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestDefaultEngineConfigsTritonValues(t *testing.T) {
-	var tritonConfig *engineConfigParams
-	for _, config := range defaultEngineConfigs {
-		if config.Name == "triton" {
-			// Create a local copy to point to
-			c := config
-			tritonConfig = &c
-			break
-		}
-	}
-
-	if tritonConfig == nil {
-		t.Fatalf("Expected to find 'triton' in defaultEngineConfigs, but it was not found")
-	}
-
-	expectedQueued := "nv_inference_pending_request_count"
-	if tritonConfig.QueuedRequestsSpec != expectedQueued {
-		t.Errorf("triton QueuedRequestsSpec = %q, want %q", tritonConfig.QueuedRequestsSpec, expectedQueued)
-	}
-
-	expectedRunning := "nv_inference_exec_count"
-	if tritonConfig.RunningRequestsSpec != expectedRunning {
-		t.Errorf("triton RunningRequestsSpec = %q, want %q", tritonConfig.RunningRequestsSpec, expectedRunning)
-	}
-
-	// Verify LLM-specific metrics are intentionally empty
-	if tritonConfig.KVUsageSpec != "" {
-		t.Errorf("triton KVUsageSpec = %q, want empty string", tritonConfig.KVUsageSpec)
-	}
-	if tritonConfig.LoRASpec != "" {
-		t.Errorf("triton LoRASpec = %q, want empty string", tritonConfig.LoRASpec)
 	}
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -42,31 +42,29 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	sourcehttp "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
-// pipeline wraps a PollingDataSource and an Extractor, calling both in sequence.
-// This replicates what the Collector does at runtime, allowing tests to exercise
-// the full fetch→extract path without a running Collector.
+// pipeline pairs a typed HTTPDataSource with its extractor. Tests assert
+// against the dispatcher contract via Poll (which fans extract errors out
+// through DataLayerExtractErrorsTotal, not the return value), and against
+// the extractor's error logic by reaching into source/ext directly.
 type pipeline struct {
-	source    fwkdl.PollingDataSource
-	extractor fwkdl.Extractor
+	source *sourcehttp.HTTPDataSource[sourcemetrics.PrometheusMetricMap]
+	ext    *Extractor
 }
 
-// Poll fetches raw data from the source then passes it to the extractor.
+// Poll dispatches the source: fetches data and runs every bound extractor.
+// Per the PollingDispatcher contract, per-extractor failures are recorded via
+// DataLayerExtractErrorsTotal and do NOT surface as a returned error here.
 func (p *pipeline) Poll(ctx context.Context, ep fwkdl.Endpoint) error {
-	data, err := p.source.Poll(ctx, ep)
-	if err != nil {
-		return err
-	}
-	if data == nil {
-		return nil
-	}
-	return p.extractor.Extract(ctx, data, ep)
+	return p.source.Dispatch(ctx, ep)
 }
 
-// buildSource creates a MetricsDataSource pointing at the given server URL.
-func buildSource(t *testing.T, serverURL string) fwkdl.PollingDataSource {
+// buildSource creates a typed HTTPDataSource[PrometheusMetricMap] pointing at
+// the given server URL.
+func buildSource(t *testing.T, serverURL string) *sourcehttp.HTTPDataSource[sourcemetrics.PrometheusMetricMap] {
 	t.Helper()
 
 	parsedURL, err := url.Parse(serverURL)
@@ -94,7 +92,10 @@ func buildPipeline(t *testing.T, serverURL string, params *modelServerExtractorP
 	if err != nil {
 		return nil, err
 	}
-	return &pipeline{source: source, extractor: ext}, nil
+	if err := source.AppendExtractor(ext); err != nil {
+		return nil, err
+	}
+	return &pipeline{source: source, ext: ext}, nil
 }
 
 // newEndpointAt creates a fwkdl.Endpoint with the given host (host:port) and optional labels.
@@ -262,7 +263,13 @@ func TestMetricsExtractionMissingMetricFamilyReturnsError(t *testing.T) {
 				DefaultEngineTypeLabelKey: "vllm",
 			})
 
-			pollErr := p.Poll(ctx, ep)
+			// Drive Poll + Extract directly so the extractor's error surfaces.
+			// The dispatcher contract intentionally swallows extractor errors
+			// into DataLayerExtractErrorsTotal; this test asserts on the error
+			// itself.
+			data, err := p.source.Poll(ctx, ep)
+			require.NoError(t, err, "fetch should succeed; we are testing the extractor's error path")
+			pollErr := p.ext.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
 
 			require.Error(t, pollErr, "expected error for missing metric family")
 			assert.True(t, strings.Contains(pollErr.Error(), tc.wantErrContain),
@@ -336,7 +343,10 @@ func TestMetricsExtractionJoinedErrors(t *testing.T) {
 		DefaultEngineTypeLabelKey: "vllm",
 	})
 
-	pollErr := p.Poll(ctx, ep)
+	// Drive Poll + Extract directly so the joined extractor errors surface.
+	data, err := p.source.Poll(ctx, ep)
+	require.NoError(t, err)
+	pollErr := p.ext.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
 	require.Error(t, pollErr)
 
 	errMsg := pollErr.Error()
@@ -365,7 +375,11 @@ func TestMetricsExtractionMultipleExtractors(t *testing.T) {
 	})
 	defer srv.Close()
 
-	source := buildSource(t, srv.URL)
+	// Each extractor gets its own source so Dispatch fires only its own extractor;
+	// they share the same backing URL but isolated dispatchers preserve the
+	// per-extractor test intent (no cross-firing).
+	sourceA := buildSource(t, srv.URL)
+	sourceB := buildSource(t, srv.URL)
 
 	// Extractor A: queue + running only
 	extA := buildExtractor(t, &modelServerExtractorParams{
@@ -401,8 +415,10 @@ func TestMetricsExtractionMultipleExtractors(t *testing.T) {
 	epA := newEndpointAt(mustHost(t, srv.URL), vllmLabels)
 	epB := newEndpointAt(mustHost(t, srv.URL), vllmLabels)
 
-	pipeA := &pipeline{source: source, extractor: extA}
-	pipeB := &pipeline{source: source, extractor: extB}
+	require.NoError(t, sourceA.AppendExtractor(extA))
+	require.NoError(t, sourceB.AppendExtractor(extB))
+	pipeA := &pipeline{source: sourceA}
+	pipeB := &pipeline{source: sourceB}
 
 	require.NoError(t, pipeA.Poll(ctx, epA))
 	require.NoError(t, pipeB.Poll(ctx, epB))

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
@@ -18,7 +18,6 @@ package mocks
 
 import (
 	"context"
-	"reflect"
 	"sync"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
@@ -41,7 +40,7 @@ func NewEndpointExtractor(name string) *EndpointExtractor {
 	return &EndpointExtractor{name: name}
 }
 
-// WithExtractError configures the extractor to return an error on ExtractEndpoint.
+// WithExtractError configures the extractor to return an error on Extract.
 func (m *EndpointExtractor) WithExtractError(err error) *EndpointExtractor {
 	m.extractErr = err
 	return m
@@ -51,12 +50,8 @@ func (m *EndpointExtractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock-endpoint-extractor", Name: m.name}
 }
 
-func (m *EndpointExtractor) ExpectedInputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractEndpoint records the event and returns any configured error.
-func (m *EndpointExtractor) ExtractEndpoint(_ context.Context, event fwkdl.EndpointEvent) error {
+// Extract records the event and returns any configured error.
+func (m *EndpointExtractor) Extract(_ context.Context, event fwkdl.EndpointEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.events = append(m.events, event)

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
@@ -30,6 +30,7 @@ var _ fwkdl.EndpointExtractor = (*EndpointExtractor)(nil)
 // It records all events it receives and provides helper methods for test assertions.
 type EndpointExtractor struct {
 	name       string
+	typeName   string
 	events     []fwkdl.EndpointEvent
 	mu         sync.Mutex
 	extractErr error
@@ -37,7 +38,7 @@ type EndpointExtractor struct {
 
 // NewEndpointExtractor creates a new mock EndpointExtractor with the given name.
 func NewEndpointExtractor(name string) *EndpointExtractor {
-	return &EndpointExtractor{name: name}
+	return &EndpointExtractor{name: name, typeName: "mock-endpoint-extractor"}
 }
 
 // WithExtractError configures the extractor to return an error on Extract.
@@ -46,8 +47,15 @@ func (m *EndpointExtractor) WithExtractError(err error) *EndpointExtractor {
 	return m
 }
 
+// WithType overrides the extractor's TypedName().Type for tests that need
+// distinct Types (e.g. covering yield-vs-bind branches in runtime.Configure).
+func (m *EndpointExtractor) WithType(typeName string) *EndpointExtractor {
+	m.typeName = typeName
+	return m
+}
+
 func (m *EndpointExtractor) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: "mock-endpoint-extractor", Name: m.name}
+	return fwkplugin.TypedName{Type: m.typeName, Name: m.name}
 }
 
 // Extract records the event and returns any configured error.

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
@@ -18,13 +18,17 @@ package mocks
 
 import (
 	"context"
-	"reflect"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+var (
+	_ fwkdl.NotificationExtractor           = (*NotificationExtractor)(nil)
+	_ fwkdl.PollingExtractor[fwkdl.Metrics] = (*Extractor)(nil)
 )
 
 // NotificationExtractor implements both Extractor and NotificationExtractor for testing.
@@ -51,7 +55,7 @@ func (m *NotificationExtractor) WithGVK(gvk schema.GroupVersionKind) *Notificati
 	return m
 }
 
-// WithExtractError configures the extractor to return an error on ExtractNotification.
+// WithExtractError configures the extractor to return an error on Extract.
 func (m *NotificationExtractor) WithExtractError(err error) *NotificationExtractor {
 	m.extractErr = err
 	return m
@@ -61,16 +65,12 @@ func (m *NotificationExtractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: m.name, Name: m.name}
 }
 
-func (m *NotificationExtractor) ExpectedInputType() reflect.Type {
-	return reflect.TypeFor[fwkdl.NotificationEvent]()
-}
-
 func (m *NotificationExtractor) GVK() schema.GroupVersionKind {
 	return m.gvk
 }
 
-// ExtractNotification is the NotificationExtractor method — records the event.
-func (m *NotificationExtractor) ExtractNotification(_ context.Context, event fwkdl.NotificationEvent) error {
+// Extract records the event and returns any configured error.
+func (m *NotificationExtractor) Extract(_ context.Context, event fwkdl.NotificationEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.events = append(m.events, event)
@@ -96,29 +96,23 @@ func (m *NotificationExtractor) Reset() {
 	m.events = nil
 }
 
-// Extractor is a generic mock for Extractor interface.
-// It records call counts and optionally updates endpoint metrics.
+// Extractor is a generic mock for the typed Extractor[PollInput[Metrics]]
+// interface used by polling tests. It records call counts and optionally
+// updates endpoint metrics on each Extract.
 type Extractor struct {
-	name            string
-	inputType       reflect.Type
-	callCount       int
-	mu              sync.Mutex
-	extractErr      error
-	updateMetrics   bool
-	metricsToUpdate *fwkdl.Metrics
+	name       string
+	callCount  int
+	mu         sync.Mutex
+	extractErr error
+	// metricsUpdate, when non-nil, is written to Endpoint on each Extract.
+	metricsUpdate *fwkdl.Metrics
 }
 
-// NewExtractor creates a new mock extractor with the given name and input type.
-func NewExtractor(name string, inputType reflect.Type) *Extractor {
-	return &Extractor{
-		name:      name,
-		inputType: inputType,
-	}
-}
-
-// NewPollingExtractor creates a mock extractor for polling data sources (Metrics type).
+// NewPollingExtractor creates a mock extractor for polling data sources.
+// The metrics-typed input matches the HTTPDataSource[Metrics] dispatcher
+// used by polling integration tests.
 func NewPollingExtractor(name string) *Extractor {
-	return NewExtractor(name, reflect.TypeFor[fwkdl.Metrics]())
+	return &Extractor{name: name}
 }
 
 // WithExtractError configures the extractor to return an error.
@@ -127,30 +121,26 @@ func (m *Extractor) WithExtractError(err error) *Extractor {
 	return m
 }
 
-// WithMetricsUpdate configures the extractor to update endpoint metrics.
+// WithMetricsUpdate configures the extractor to write metrics into the
+// endpoint on each Extract. Passing nil disables the update.
 func (m *Extractor) WithMetricsUpdate(metrics *fwkdl.Metrics) *Extractor {
-	m.updateMetrics = true
-	m.metricsToUpdate = metrics
+	m.metricsUpdate = metrics
 	return m
 }
 
+// Type uses m.name so instances look like distinct plugin types; HTTP source dedupes appends by Type.
 func (m *Extractor) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: m.name, Name: m.name}
 }
 
-func (m *Extractor) ExpectedInputType() reflect.Type {
-	return m.inputType
-}
-
-func (m *Extractor) Extract(_ context.Context, data any, ep fwkdl.Endpoint) error {
+func (m *Extractor) Extract(_ context.Context, in fwkdl.PollInput[fwkdl.Metrics]) error {
 	m.mu.Lock()
 	m.callCount++
 	m.mu.Unlock()
 
-	if m.updateMetrics && m.metricsToUpdate != nil {
-		ep.UpdateMetrics(m.metricsToUpdate)
+	if m.metricsUpdate != nil {
+		in.Endpoint.UpdateMetrics(m.metricsUpdate)
 	}
-
 	return m.extractErr
 }
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
@@ -3,8 +3,6 @@ package models
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"reflect"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
@@ -15,18 +13,13 @@ import (
 // asynchronously and not tied to incoming requests
 var _ fwkplugin.ProducerPlugin = &ModelExtractor{}
 
-var _ fwkdl.Extractor = &ModelExtractor{}
+var _ fwkdl.PollingExtractor[*ModelResponse] = &ModelExtractor{}
 
-// ModelResponse is the response from /v1/models API
+// ModelResponse is the response from /v1/models API.
 type ModelResponse struct {
 	Object string                 `json:"object"`
 	Data   []attrmodels.ModelData `json:"data"`
 }
-
-// ModelsResponseType is the type of models response
-var (
-	ModelsResponseType = reflect.TypeOf(ModelResponse{})
-)
 
 // ModelExtractor implements the models extraction.
 type ModelExtractor struct {
@@ -50,11 +43,6 @@ func (me *ModelExtractor) TypedName() fwkplugin.TypedName {
 	return me.typedName
 }
 
-// ExpectedInputType defines the type expected by ModelExtractor.
-func (me *ModelExtractor) ExpectedInputType() reflect.Type {
-	return ModelsResponseType
-}
-
 // ModelServerExtractorFactory is a factory function used to instantiate data layer's
 // models extractor plugins specified in a configuration.
 func ModelServerExtractorFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -63,21 +51,13 @@ func ModelServerExtractorFactory(name string, _ *json.Decoder, _ fwkplugin.Handl
 	return extractor, nil
 }
 
-// Extract transforms the data source output into a concrete attribute that
-// is stored on the given endpoint.
-func (me *ModelExtractor) Extract(_ context.Context, data any, ep fwkdl.Endpoint) error {
-	models, ok := data.(*ModelResponse)
-	if !ok {
-		return fmt.Errorf("unexpected input in Extract: %T", data)
-	}
-
-	ep.GetAttributes().Put(me.dk.String(), attrmodels.ModelDataCollection(models.Data))
+// Extract stores the model list as an endpoint attribute.
+func (me *ModelExtractor) Extract(_ context.Context, in fwkdl.PollInput[*ModelResponse]) error {
+	in.Endpoint.GetAttributes().Put(me.dk.String(), attrmodels.ModelDataCollection(in.Payload.Data))
 	return nil
 }
 
 // Produces returns data produced by the producer.
-// This is a map from data key (string) produced to
-// the data type of the key (represented as data with default value casted as any field).
 func (me *ModelExtractor) Produces() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{me.dk: attrmodels.ModelDataCollection{}}
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor_test.go
@@ -17,7 +17,7 @@ func TestExtractorExtract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create extractor: %v", err)
 	}
-	extractor := extPlugin.(fwkdl.Extractor)
+	extractor := extPlugin.(*ModelExtractor)
 
 	if exType := extPlugin.TypedName().Type; exType == "" {
 		t.Error("empty extractor type")
@@ -27,10 +27,6 @@ func TestExtractorExtract(t *testing.T) {
 		t.Error("empty extractor name")
 	}
 
-	if inputType := extractor.ExpectedInputType(); inputType != ModelsResponseType {
-		t.Errorf("incorrect expected input type: %v", inputType)
-	}
-
 	ep := fwkdl.NewEndpoint(nil, nil)
 	if ep == nil {
 		t.Fatal("expected non-nil endpoint")
@@ -38,18 +34,14 @@ func TestExtractorExtract(t *testing.T) {
 
 	model := "food-review"
 
+	// Note: nil Payload is the dispatcher's responsibility per the
+	// PollingDispatcher contract; Extract does not guard against it.
 	tests := []struct {
 		name    string
-		data    any
+		data    *ModelResponse
 		wantErr bool
 		updated bool // whether metrics are expected to change
 	}{
-		{
-			name:    "nil data",
-			data:    nil,
-			wantErr: true,
-			updated: false,
-		},
 		{
 			name:    "empty ModelsResponse",
 			data:    &ModelResponse{},
@@ -89,7 +81,7 @@ func TestExtractorExtract(t *testing.T) {
 			if ok && before != nil {
 				t.Error("expected empty attributes")
 			}
-			err := extractor.Extract(ctx, tt.data, ep)
+			err := extractor.Extract(ctx, fwkdl.PollInput[*ModelResponse]{Payload: tt.data, Endpoint: ep})
 			after, ok := attr.Get(key)
 			if !ok && tt.updated {
 				t.Error("expected updated attributes")

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -19,83 +19,153 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"reflect"
+	"runtime/debug"
+	"slices"
+	"sync"
+	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/metrics"
 )
 
-// HTTPDataSource is a data source that receives its data using HTTP client.
-type HTTPDataSource struct {
-	typedName fwkplugin.TypedName
-	scheme    string // scheme to use
-	path      string // path to use
+var ErrExtractorTypeMismatch = errors.New("extractor type mismatch")
 
-	client     Client // client (e.g. a wrapped http.Client) used to get data
-	parser     func(io.Reader) (any, error)
-	outputType reflect.Type
+// defaultStepTimeout bounds each Poll and each Extract independently so a slow
+// extractor cannot starve sibling extractors of their tick budget.
+const defaultStepTimeout = time.Second
+
+// HTTPDataSource is a typed polling dispatcher. T is the data type the source
+// produces; bound extractors must implement Extractor[PollInput[T]].
+type HTTPDataSource[T any] struct {
+	typedName fwkplugin.TypedName
+	scheme    string
+	path      string
+
+	client Client
+	// parser converts the response body to T. MUST NOT return (zero, nil) for nilable T;
+	// the dispatcher does not validate.
+	parser func(io.Reader) (T, error)
+
+	mu   sync.RWMutex
+	exts []fwkdl.PollingExtractor[T]
 }
 
-// NewHTTPDataSource returns a new data source, configured with
-// the provided scheme, path and certificate verification parameters.
-func NewHTTPDataSource(scheme string, path string, skipCertVerification bool, pluginType string,
-	pluginName string, parser func(io.Reader) (any, error), outputType reflect.Type) (*HTTPDataSource, error) {
+// NewHTTPDataSource constructs a typed polling dispatcher.
+func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
+	pluginType, pluginName string, parser func(io.Reader) (T, error)) (*HTTPDataSource[T], error) {
 	if scheme != "http" && scheme != "https" {
 		return nil, fmt.Errorf("unsupported scheme: %s", scheme)
 	}
 	if scheme == "https" {
 		httpsTransport := baseTransport.Clone()
-		httpsTransport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: skipCertVerification,
-		}
+		httpsTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipCertVerification}
 		defaultClient.Transport = httpsTransport
 	}
+	return &HTTPDataSource[T]{
+		typedName: fwkplugin.TypedName{Type: pluginType, Name: pluginName},
+		scheme:    scheme,
+		path:      path,
+		client:    defaultClient,
+		parser:    parser,
+	}, nil
+}
 
-	dataSrc := &HTTPDataSource{
-		typedName: fwkplugin.TypedName{
-			Type: pluginType,
-			Name: pluginName,
-		},
-		scheme:     scheme,
-		path:       path,
-		client:     defaultClient,
-		parser:     parser,
-		outputType: outputType,
+func (s *HTTPDataSource[T]) TypedName() fwkplugin.TypedName { return s.typedName }
+
+// Poll fetches and parses one tick. Exposed for tests; runtime uses Dispatch.
+func (s *HTTPDataSource[T]) Poll(ctx context.Context, ep fwkdl.Endpoint) (T, error) {
+	target := s.getEndpoint(ep.GetMetadata())
+	raw, err := s.client.Get(ctx, target, ep.GetMetadata(), func(r io.Reader) (any, error) {
+		return s.parser(r)
+	})
+	if err != nil {
+		var zero T
+		return zero, err
 	}
-	return dataSrc, nil
+	// Defensive: unreachable with the current Client (parser passthrough); remove with Client[T] refactor.
+	typed, ok := raw.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("HTTPDataSource %s: parser returned %T, expected %T", s.typedName, raw, zero)
+	}
+	return typed, nil
 }
 
-// TypedName returns the data source type and name.
-func (dataSrc *HTTPDataSource) TypedName() fwkplugin.TypedName {
-	return dataSrc.typedName
+// Dispatch polls the endpoint and fans the result out to every bound
+// extractor. Each step (Poll and each Extract) runs under its own
+// defaultStepTimeout so one slow extractor does not starve siblings.
+//
+// Return contract: a non-nil return indicates a poll-level failure (the
+// dispatcher could not produce data). Per-extractor failures are recorded
+// in DataLayerExtractErrorsTotal and do NOT surface as a returned error.
+// This keeps the collector's poll/extract counters cleanly separated.
+func (s *HTTPDataSource[T]) Dispatch(ctx context.Context, ep fwkdl.Endpoint) error {
+	pollCtx, cancelPoll := context.WithTimeout(ctx, defaultStepTimeout)
+	data, err := s.Poll(pollCtx, ep)
+	cancelPoll()
+	if err != nil {
+		return err
+	}
+	in := fwkdl.PollInput[T]{Payload: data, Endpoint: ep}
+	s.mu.RLock()
+	exts := slices.Clone(s.exts)
+	s.mu.RUnlock()
+	for _, ext := range exts {
+		if ctx.Err() != nil {
+			return nil
+		}
+		extCtx, cancelExt := context.WithTimeout(ctx, defaultStepTimeout)
+		s.runExtractor(extCtx, ext, in)
+		cancelExt()
+	}
+	return nil
 }
 
-// OutputType returns the type of data this DataSource produces.
-func (dataSrc *HTTPDataSource) OutputType() reflect.Type {
-	return dataSrc.outputType
-}
-
-// ExtractorType returns the type of Extractor this DataSource expects.
-func (dataSrc *HTTPDataSource) ExtractorType() reflect.Type {
-	return fwkdl.ExtractorType
-}
-
-// Poll fetches data for an endpoint and returns it.
-func (dataSrc *HTTPDataSource) Poll(ctx context.Context, ep fwkdl.Endpoint) (any, error) {
-	target := dataSrc.getEndpoint(ep.GetMetadata())
-	return dataSrc.client.Get(ctx, target, ep.GetMetadata(), dataSrc.parser)
-}
-
-func (dataSrc *HTTPDataSource) getEndpoint(ep Addressable) *url.URL {
-	return &url.URL{
-		Scheme: dataSrc.scheme,
-		Host:   ep.GetMetricsHost(),
-		Path:   dataSrc.path,
+// runExtractor invokes ext under panic recovery; both failures and panics increment DataLayerExtractErrorsTotal.
+func (s *HTTPDataSource[T]) runExtractor(ctx context.Context, ext fwkdl.PollingExtractor[T], in fwkdl.PollInput[T]) {
+	logger := log.FromContext(ctx)
+	srcType := s.typedName.Type
+	extType := ext.TypedName().Type
+	defer func() {
+		if r := recover(); r != nil {
+			//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
+			metrics.DataLayerExtractErrorsTotal.WithLabelValues(srcType, extType).Inc()
+			metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(srcType, extType).Inc()
+			logger.Error(fmt.Errorf("%v", r), "extractor panicked",
+				"source", s.typedName, "extractor", ext.TypedName(), "stack", string(debug.Stack()))
+		}
+	}()
+	if err := ext.Extract(ctx, in); err != nil {
+		//nolint:staticcheck // SA1019: Keep deprecated metric for backwards compatibility
+		metrics.DataLayerExtractErrorsTotal.WithLabelValues(srcType, extType).Inc()
+		metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(srcType, extType).Inc()
+		logger.V(logging.DEBUG).Info("extract failed", "source", s.typedName, "extractor", ext.TypedName(), "err", err)
 	}
 }
 
-var _ fwkdl.DataSource = (*HTTPDataSource)(nil)
-var _ fwkdl.PollingDataSource = (*HTTPDataSource)(nil)
+// AppendExtractor binds ext as a typed PollingExtractor[T]. Duplicate-Type detection
+// is the caller's responsibility (see runtime.Configure); this is a pure append.
+func (s *HTTPDataSource[T]) AppendExtractor(ext fwkplugin.Plugin) error {
+	typed, ok := ext.(fwkdl.PollingExtractor[T])
+	if !ok {
+		return fmt.Errorf("%w: extractor %s: expected %s, got %T",
+			ErrExtractorTypeMismatch, ext.TypedName(), reflect.TypeFor[fwkdl.PollingExtractor[T]](), ext)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.exts = append(s.exts, typed)
+	return nil
+}
+
+func (s *HTTPDataSource[T]) getEndpoint(ep Addressable) *url.URL {
+	return &url.URL{Scheme: s.scheme, Host: ep.GetMetricsHost(), Path: s.path}
+}

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
@@ -1,0 +1,291 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/metrics"
+)
+
+type fakeClient struct {
+	value any
+	err   error
+}
+
+func (c *fakeClient) Get(_ context.Context, _ *url.URL, _ Addressable,
+	parser func(io.Reader) (any, error)) (any, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	if c.value != nil {
+		return c.value, nil
+	}
+	return parser(nil)
+}
+
+type stubExtractor struct {
+	extType string
+	err     error
+	block   time.Duration
+
+	mu        sync.Mutex
+	callCount int
+	lastCtx   context.Context
+}
+
+func newStubExtractor(extType string) *stubExtractor {
+	return &stubExtractor{extType: extType}
+}
+
+func (e *stubExtractor) withError(err error) *stubExtractor { e.err = err; return e }
+func (e *stubExtractor) withBlock(d time.Duration) *stubExtractor {
+	e.block = d
+	return e
+}
+
+func (e *stubExtractor) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: e.extType, Name: e.extType}
+}
+
+func (e *stubExtractor) Extract(ctx context.Context, _ fwkdl.PollInput[int]) error {
+	e.mu.Lock()
+	e.callCount++
+	e.lastCtx = ctx
+	e.mu.Unlock()
+	if e.block > 0 {
+		select {
+		case <-time.After(e.block):
+		case <-ctx.Done():
+		}
+	}
+	return e.err
+}
+
+func (e *stubExtractor) calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.callCount
+}
+
+// wrongTypedExtractor satisfies plugin.Plugin but not Extractor[PollInput[int]].
+type wrongTypedExtractor struct{}
+
+func (wrongTypedExtractor) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "wrong", Name: "wrong"}
+}
+
+func newDS(t *testing.T, srcType string, fc *fakeClient) *HTTPDataSource[int] {
+	t.Helper()
+	return &HTTPDataSource[int]{
+		typedName: fwkplugin.TypedName{Type: srcType, Name: srcType},
+		scheme:    "http",
+		path:      "/test",
+		client:    fc,
+		parser:    func(_ io.Reader) (int, error) { return 0, nil },
+	}
+}
+
+func newTestEndpoint() fwkdl.Endpoint {
+	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{MetricsHost: "10.0.0.1:8000"}, fwkdl.NewMetrics())
+}
+
+func extDelta(t *testing.T, srcType, extType string, before float64) float64 {
+	t.Helper()
+	return testutil.ToFloat64(metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(srcType, extType)) - before
+}
+
+func extBefore(t *testing.T, srcType, extType string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(srcType, extType))
+}
+
+func TestDispatch_PollFailure_ReturnsError(t *testing.T) {
+	wantErr := errors.New("upstream offline")
+	s := newDS(t, "src-poll-fail", &fakeClient{err: wantErr})
+	require.NoError(t, s.AppendExtractor(newStubExtractor("ext")))
+
+	err := s.Dispatch(context.Background(), newTestEndpoint())
+	require.ErrorIs(t, err, wantErr, "poll-level failure must surface as the returned error")
+}
+
+func TestDispatch_ExtractorFailure_ReturnsNil(t *testing.T) {
+	const src, ext = "src-ext-fail", "ext-fail"
+	s := newDS(t, src, &fakeClient{value: 42})
+	require.NoError(t, s.AppendExtractor(newStubExtractor(ext).withError(errors.New("bad data"))))
+
+	before := extBefore(t, src, ext)
+	require.NoError(t, s.Dispatch(context.Background(), newTestEndpoint()),
+		"extractor failure must not surface as a returned error")
+	assert.Equal(t, float64(1), extDelta(t, src, ext, before),
+		"extractor failure must record one DataLayerExtractErrorsTotal increment")
+}
+
+func TestDispatch_ExtractorFailure_LabelsBothSrcAndExt(t *testing.T) {
+	const src, ext = "src-label", "ext-label"
+	s := newDS(t, src, &fakeClient{value: 1})
+	require.NoError(t, s.AppendExtractor(newStubExtractor(ext).withError(errors.New("x"))))
+
+	before := extBefore(t, src, ext)
+	require.NoError(t, s.Dispatch(context.Background(), newTestEndpoint()))
+	assert.Equal(t, float64(1), extDelta(t, src, ext, before),
+		"counter must be incremented under (src=%q, ext=%q); any other label tuple is a regression",
+		src, ext)
+	assert.Zero(t, testutil.ToFloat64(metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(src, src)),
+		"counter must not appear under (src, src)")
+	assert.Zero(t, testutil.ToFloat64(metrics.LlmdDataLayerExtractErrorsTotal.WithLabelValues(ext, ext)),
+		"counter must not appear under (ext, ext)")
+}
+
+func TestDispatch_MultipleExtractorFailures_BothRecorded(t *testing.T) {
+	const src, extA, extB = "src-multi", "ext-a", "ext-b"
+	s := newDS(t, src, &fakeClient{value: 1})
+	require.NoError(t, s.AppendExtractor(newStubExtractor(extA).withError(errors.New("a"))))
+	require.NoError(t, s.AppendExtractor(newStubExtractor(extB).withError(errors.New("b"))))
+
+	beforeA := extBefore(t, src, extA)
+	beforeB := extBefore(t, src, extB)
+	require.NoError(t, s.Dispatch(context.Background(), newTestEndpoint()))
+
+	assert.Equal(t, float64(1), extDelta(t, src, extA, beforeA),
+		"each failing extractor must record its own increment")
+	assert.Equal(t, float64(1), extDelta(t, src, extB, beforeB))
+}
+
+func TestDispatch_SlowExtractor_DoesNotStarveNext(t *testing.T) {
+	slow := newStubExtractor("ext-slow").
+		withBlock(2 * defaultStepTimeout).
+		withError(context.DeadlineExceeded)
+	fast := newStubExtractor("ext-fast")
+
+	s := newDS(t, "src-isolation", &fakeClient{value: 1})
+	require.NoError(t, s.AppendExtractor(slow))
+	require.NoError(t, s.AppendExtractor(fast))
+
+	start := time.Now()
+	require.NoError(t, s.Dispatch(context.Background(), newTestEndpoint()))
+	elapsed := time.Since(start)
+
+	assert.Equal(t, 1, fast.calls(), "fast extractor must still run after slow extractor timed out")
+	assert.Less(t, elapsed, 2*defaultStepTimeout+500*time.Millisecond,
+		"total Dispatch time must be ~one step-timeout (slow) + epsilon (fast); got %s", elapsed)
+}
+
+func TestDispatch_ParentCtxCancelled_StopsRemainingExtractors(t *testing.T) {
+	first := newStubExtractor("ext-first")
+	second := newStubExtractor("ext-second")
+	third := newStubExtractor("ext-third")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	firstWithSideEffect := &cancelOnExtract{stub: first, cancel: cancel}
+
+	s := newDS(t, "src-cancel", &fakeClient{value: 1})
+	require.NoError(t, s.AppendExtractor(firstWithSideEffect))
+	require.NoError(t, s.AppendExtractor(second))
+	require.NoError(t, s.AppendExtractor(third))
+
+	require.NoError(t, s.Dispatch(ctx, newTestEndpoint()))
+
+	assert.Equal(t, 1, firstWithSideEffect.stub.calls(), "first extractor runs before cancel observed")
+	assert.Equal(t, 0, second.calls(), "second extractor must be skipped once parent ctx is cancelled")
+	assert.Equal(t, 0, third.calls(), "third extractor must be skipped once parent ctx is cancelled")
+}
+
+type cancelOnExtract struct {
+	stub   *stubExtractor
+	cancel context.CancelFunc
+}
+
+func (c *cancelOnExtract) TypedName() fwkplugin.TypedName { return c.stub.TypedName() }
+func (c *cancelOnExtract) Extract(ctx context.Context, in fwkdl.PollInput[int]) error {
+	err := c.stub.Extract(ctx, in)
+	c.cancel()
+	return err
+}
+
+func TestAppendExtractor(t *testing.T) {
+	cases := []struct {
+		name      string
+		preBound  []fwkplugin.Plugin
+		appending fwkplugin.Plugin
+		wantErr   error
+		wantCount int
+	}{
+		{
+			name:      "valid first append",
+			appending: newStubExtractor("ext-a"),
+			wantCount: 1,
+		},
+		{
+			name:      "different type appends successfully",
+			preBound:  []fwkplugin.Plugin{newStubExtractor("ext-a")},
+			appending: newStubExtractor("ext-b"),
+			wantCount: 2,
+		},
+		{
+			name:      "wrong type returns error",
+			appending: wrongTypedExtractor{},
+			wantErr:   ErrExtractorTypeMismatch,
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newDS(t, "src", &fakeClient{value: 1})
+			for _, ext := range tc.preBound {
+				require.NoError(t, s.AppendExtractor(ext), "pre-bind setup must succeed")
+			}
+			err := s.AppendExtractor(tc.appending)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			s.mu.RLock()
+			defer s.mu.RUnlock()
+			assert.Len(t, s.exts, tc.wantCount)
+		})
+	}
+}
+
+func TestAppendExtractor_PreservesInsertionOrder(t *testing.T) {
+	s := newDS(t, "src-order", &fakeClient{value: 1})
+	calls := make([]string, 0, 3)
+	var mu sync.Mutex
+	for _, name := range []string{"a", "b", "c"} {
+		wrapped := &orderedStub{stub: newStubExtractor(name), name: name, log: &calls, mu: &mu}
+		require.NoError(t, s.AppendExtractor(wrapped))
+	}
+	require.NoError(t, s.Dispatch(context.Background(), newTestEndpoint()))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"a", "b", "c"}, calls,
+		"contract: extractors run in AppendExtractor-insertion order")
+}
+
+type orderedStub struct {
+	stub *stubExtractor
+	name string
+	log  *[]string
+	mu   *sync.Mutex
+}
+
+func (o *orderedStub) TypedName() fwkplugin.TypedName { return o.stub.TypedName() }
+func (o *orderedStub) Extract(ctx context.Context, in fwkdl.PollInput[int]) error {
+	o.mu.Lock()
+	*o.log = append(*o.log, o.name)
+	o.mu.Unlock()
+	return o.stub.Extract(ctx, in)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/http/httptest/parsercontract.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/httptest/parsercontract.go
@@ -1,0 +1,36 @@
+// Package httptest provides test helpers for HTTPDataSource parser
+// implementations.
+package httptest
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ParserContract asserts that parser satisfies the HTTPDataSource parser
+// contract: each goldenInput returns (meaningful T, nil error), and never
+// (nil, nil) for nilable T.
+func ParserContract[T any](t *testing.T, parser func(io.Reader) (T, error), goldenInputs ...[]byte) {
+	t.Helper()
+	nilable := isNilable(reflect.TypeFor[T]().Kind())
+	for i, input := range goldenInputs {
+		value, err := parser(bytes.NewReader(input))
+		require.NoErrorf(t, err, "golden input %d: parser returned error", i)
+		if nilable {
+			require.Falsef(t, reflect.ValueOf(value).IsNil(),
+				"golden input %d: parser returned nil for nilable T (contract violation)", i)
+		}
+	}
+}
+
+func isNilable(k reflect.Kind) bool {
+	switch k {
+	case reflect.Pointer, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return true
+	}
+	return false
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -53,9 +53,9 @@ type metricsDatasourceParams struct {
 // NewHTTPMetricsDataSource constructs a MetricsDataSource with the given scheme and path.
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
-func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource, error) {
+func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource[PrometheusMetricMap], error) {
 	return http.NewHTTPDataSource(scheme, path, defaultMetricsInsecureSkipVerify,
-		MetricsDataSourceType, name, parseMetrics, PrometheusMetricType)
+		MetricsDataSourceType, name, parseMetrics)
 }
 
 // MetricsDataSourceFactory is a factory function used to instantiate data layer's
@@ -72,8 +72,8 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		}
 	}
 
-	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify, MetricsDataSourceType,
-		name, parseMetrics, PrometheusMetricType)
+	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify,
+		MetricsDataSourceType, name, parseMetrics)
 }
 
 // These flags are registered in options.go (server package) and marked as deprecated there.
@@ -147,7 +147,7 @@ func fromBoolFlag(name string) (bool, bool, error) {
 	return b, true, nil
 }
 
-func parseMetrics(data io.Reader) (any, error) {
+func parseMetrics(data io.Reader) (PrometheusMetricMap, error) {
 	parser := expfmt.NewTextParser(model.LegacyValidation)
 	return parser.TextToMetricFamilies(data)
 }

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -29,11 +29,11 @@ import (
 
 func TestDatasource(t *testing.T) {
 	_, err := http.NewHTTPDataSource("invalid", "/metrics", true, MetricsDataSourceType,
-		"metrics-data-source", parseMetrics, PrometheusMetricType)
+		"metrics-data-source", parseMetrics)
 	assert.NotNil(t, err, "expected to fail with invalid scheme")
 
 	source, err := http.NewHTTPDataSource("https", "/metrics", true, MetricsDataSourceType,
-		"metrics-data-source", parseMetrics, PrometheusMetricType)
+		"metrics-data-source", parseMetrics)
 	assert.Nil(t, err, "failed to create HTTP datasource")
 
 	dsType := source.TypedName().Type

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/parsercontract_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/parsercontract_test.go
@@ -1,0 +1,15 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http/httptest"
+)
+
+func TestParseMetrics_Contract(t *testing.T) {
+	httptest.ParserContract(t, parseMetrics,
+		[]byte(""),
+		[]byte("# HELP foo_total counts foo\n# TYPE foo_total counter\nfoo_total 1\n"),
+		[]byte("# HELP queue depth gauge\n# TYPE queue gauge\nqueue 1\n# HELP active running gauge\n# TYPE active gauge\nactive 2\n"),
+	)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/types.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/types.go
@@ -17,13 +17,8 @@ limitations under the License.
 package metrics
 
 import (
-	"reflect"
-
 	dto "github.com/prometheus/client_model/go"
 )
 
+// PrometheusMetricMap is the parsed metric-families map produced by parseMetrics.
 type PrometheusMetricMap = map[string]*dto.MetricFamily
-
-var (
-	PrometheusMetricType = reflect.TypeFor[PrometheusMetricMap]()
-)

--- a/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
+++ b/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
@@ -19,7 +19,6 @@ package mocks
 import (
 	"context"
 	"errors"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,9 +30,15 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
-var _ fwkdl.DataSource = (*MetricsDataSource)(nil)
-var _ fwkdl.PollingDataSource = (*MetricsDataSource)(nil)
+var (
+	_ fwkdl.PollingDispatcher  = (*MetricsDataSource)(nil)
+	_ fwkdl.DataSource         = (*NotificationSource)(nil)
+	_ fwkdl.NotificationSource = (*NotificationSource)(nil)
+)
 
+// MetricsDataSource is a test PollingDispatcher: on Dispatch it writes the
+// preconfigured metrics into the endpoint and returns a sentinel error. The
+// sentinel signals "test dispatch ran" without producing real Poll data.
 type MetricsDataSource struct {
 	mu        sync.RWMutex
 	typedName plugin.TypedName
@@ -50,14 +55,6 @@ func (fds *MetricsDataSource) TypedName() plugin.TypedName {
 	return fds.typedName
 }
 
-func (fds *MetricsDataSource) OutputType() reflect.Type {
-	return reflect.TypeFor[fwkdl.Metrics]()
-}
-
-func (fds *MetricsDataSource) ExtractorType() reflect.Type {
-	return reflect.TypeFor[fwkdl.Extractor]()
-}
-
 // SetMetrics replaces the metrics map in a thread-safe manner.
 func (fds *MetricsDataSource) SetMetrics(metrics map[types.NamespacedName]*fwkdl.Metrics) {
 	fds.mu.Lock()
@@ -72,7 +69,10 @@ func (fds *MetricsDataSource) SetErrors(errors map[types.NamespacedName]error) {
 	fds.errors = errors
 }
 
-func (fds *MetricsDataSource) Poll(ctx context.Context, ep fwkdl.Endpoint) (any, error) {
+// Dispatch satisfies PollingDispatcher. Preserves the original mock side
+// effect (write metrics into the endpoint when keyed by NamespacedName) and
+// returns the sentinel error so tests can detect the dispatch ran.
+func (fds *MetricsDataSource) Dispatch(_ context.Context, ep fwkdl.Endpoint) error {
 	atomic.AddInt64(&fds.CallCount, 1)
 	fds.mu.RLock()
 	defer fds.mu.RUnlock()
@@ -84,10 +84,14 @@ func (fds *MetricsDataSource) Poll(ctx context.Context, ep fwkdl.Endpoint) (any,
 			ep.UpdateMetrics(clone)
 		}
 	}
-	return nil, errors.New("sentinel nothing polled")
+	return errors.New("sentinel nothing polled")
 }
 
-// NotificationSource implements both DataSource and NotificationSource for testing.
+// AppendExtractor is a no-op: this mock sets endpoint metrics directly in
+// Dispatch instead of running extractors.
+func (fds *MetricsDataSource) AppendExtractor(_ plugin.Plugin) error { return nil }
+
+// NotificationSource implements DataSource + NotificationSource for testing.
 type NotificationSource struct {
 	typedName plugin.TypedName
 	gvk       schema.GroupVersionKind
@@ -100,34 +104,13 @@ func NewNotificationSource(pluginType, name string, gvk schema.GroupVersionKind)
 	}
 }
 
-func (m *NotificationSource) TypedName() plugin.TypedName {
-	return m.typedName
-}
-
-func (m *NotificationSource) OutputType() reflect.Type {
-	return reflect.TypeFor[fwkdl.NotificationEvent]()
-}
-
-func (m *NotificationSource) ExtractorType() reflect.Type {
-	return reflect.TypeFor[fwkdl.NotificationExtractor]()
-}
-
-func (m *NotificationSource) GVK() schema.GroupVersionKind {
-	return m.gvk
+func (m *NotificationSource) TypedName() plugin.TypedName  { return m.typedName }
+func (m *NotificationSource) GVK() schema.GroupVersionKind { return m.gvk }
+func (m *NotificationSource) Extractors() []string         { return []string{} }
+func (m *NotificationSource) Collect(_ context.Context, _ fwkdl.Endpoint) error {
+	return nil
 }
 
 func (m *NotificationSource) Notify(_ context.Context, event fwkdl.NotificationEvent) (*fwkdl.NotificationEvent, error) {
 	return &event, nil
-}
-
-func (m *NotificationSource) Extractors() []string {
-	return []string{}
-}
-
-func (m *NotificationSource) AddExtractor(_ fwkdl.Extractor) error {
-	return nil
-}
-
-func (m *NotificationSource) Collect(_ context.Context, _ fwkdl.Endpoint) error {
-	return nil
 }

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
@@ -33,9 +33,9 @@ type modelsDatasourceParams struct {
 // NewHTTPModelsDataSource constructs a ModelsDataSource with the given scheme and path.
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
-func NewHTTPModelsDataSource(scheme, path, name string) (*http.HTTPDataSource, error) {
+func NewHTTPModelsDataSource(scheme, path, name string) (*http.HTTPDataSource[*extmodels.ModelResponse], error) {
 	return http.NewHTTPDataSource(scheme, path, defaultModelsInsecureSkipVerify,
-		ModelsDataSourceType, name, parseModels, extmodels.ModelsResponseType)
+		ModelsDataSourceType, name, parseModels)
 }
 
 // ModelDataSourceFactory is a factory function used to instantiate data layer's
@@ -51,8 +51,8 @@ func ModelDataSourceFactory(name string, parameters *json.Decoder, _ plugin.Hand
 		return nil, fmt.Errorf("unsupported scheme: %s", cfg.Scheme)
 	}
 
-	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify, ModelsDataSourceType,
-		name, parseModels, extmodels.ModelsResponseType)
+	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify,
+		ModelsDataSourceType, name, parseModels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP data source: %w", err)
 	}
@@ -67,12 +67,14 @@ func defaultDataSourceConfigParams() *modelsDatasourceParams {
 	}
 }
 
-func parseModels(data io.Reader) (any, error) {
+func parseModels(data io.Reader) (*extmodels.ModelResponse, error) {
 	body, err := io.ReadAll(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %v", err)
 	}
 	var modelsResponse extmodels.ModelResponse
-	err = json.Unmarshal(body, &modelsResponse)
-	return &modelsResponse, err
+	if err := json.Unmarshal(body, &modelsResponse); err != nil {
+		return nil, err
+	}
+	return &modelsResponse, nil
 }

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -21,17 +21,16 @@ func TestDatasource(t *testing.T) {
 	srcPlugin, err := ModelDataSourceFactory("models-data-source",
 		fwkplugin.StrictDecoder(json.RawMessage(`{"scheme":"https","path":"/models","insecureSkipVerify":true}`)), nil)
 	assert.Nil(t, err, "failed to create http datasource")
-	source := srcPlugin.(fwkdl.PollingDataSource)
+	source := srcPlugin.(fwkdl.PollingDispatcher)
 
 	extPlugin, err := extmodels.ModelServerExtractorFactory("models-data-extractor", nil, nil)
 	assert.Nil(t, err, "failed to create extractor")
-	extractor := extPlugin.(fwkdl.Extractor)
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
 			{
 				Plugin:     source,
-				Extractors: []fwkdl.ExtractorBase{extractor},
+				Extractors: []fwkplugin.Plugin{extPlugin},
 			},
 		},
 	}
@@ -54,7 +53,6 @@ func TestDatasource(t *testing.T) {
 	endpoint := runtime.NewEndpoint(ctx, pod, nil)
 	assert.NotNil(t, endpoint, "failed to create endpoint")
 
-	data, err := source.Poll(ctx, endpoint)
-	assert.NotNil(t, err, "expected to fail to collect metrics")
-	assert.Nil(t, data)
+	err = source.Dispatch(ctx, endpoint)
+	assert.NotNil(t, err, "expected dispatch to fail (no real HTTP target)")
 }

--- a/pkg/epp/framework/plugins/datalayer/source/models/parsercontract_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/parsercontract_test.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http/httptest"
+)
+
+func TestParseModels_Contract(t *testing.T) {
+	httptest.ParserContract(t, parseModels,
+		[]byte(`{"object":"list","data":[]}`),
+		[]byte(`{"object":"list","data":[{"id":"qwen2.5-7b"}]}`),
+		[]byte(`{"object":"list","data":[{"id":"a","parent":"a"},{"id":"b"}]}`),
+	)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource.go
@@ -18,7 +18,6 @@ package notifications
 
 import (
 	"context"
-	"reflect"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
@@ -48,16 +47,6 @@ func NewEndpointDataSource(pluginType, pluginName string) *EndpointDataSource {
 // TypedName returns the plugin type and name.
 func (s *EndpointDataSource) TypedName() fwkplugin.TypedName {
 	return s.typedName
-}
-
-// OutputType returns the type of data this DataSource produces (EndpointEvent).
-func (s *EndpointDataSource) OutputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractorType returns the type of Extractor this DataSource expects (EndpointExtractor).
-func (s *EndpointDataSource) ExtractorType() reflect.Type {
-	return fwkdl.EndpointExtractorType
 }
 
 // NotifyEndpoint passes the event through unchanged for the Runtime to dispatch to extractors.

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource_test.go
@@ -43,8 +43,6 @@ func TestNewEndpointDataSource(t *testing.T) {
 	src := NewEndpointDataSource("test-type", "test-name")
 	assert.Equal(t, "test-type", src.TypedName().Type)
 	assert.Equal(t, "test-name", src.TypedName().Name)
-	assert.Equal(t, fwkdl.EndpointEventReflectType, src.OutputType())
-	assert.Equal(t, fwkdl.EndpointExtractorType, src.ExtractorType())
 }
 
 func TestEndpointNotifyReturnsEvent(t *testing.T) {

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource.go
@@ -18,7 +18,6 @@ package notifications
 
 import (
 	"context"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -57,19 +56,8 @@ func (s *K8sNotificationSource) GVK() schema.GroupVersionKind {
 	return s.gvk
 }
 
-// OutputType returns the type of data this DataSource produces (NotificationEvent).
-func (s *K8sNotificationSource) OutputType() reflect.Type {
-	return fwkdl.NotificationEventType
-}
-
-// ExtractorType returns the type of Extractor this DataSource expects (NotificationExtractor).
-func (s *K8sNotificationSource) ExtractorType() reflect.Type {
-	return fwkdl.NotificationExtractorType
-}
-
-// Notify processes a notification event and returns it for Runtime to dispatch.
-// Returns the event (possibly modified) for Runtime to dispatch to extractors.
-// Returns nil event to signal Runtime to skip extractor dispatch.
-func (s *K8sNotificationSource) Notify(ctx context.Context, event fwkdl.NotificationEvent) (*fwkdl.NotificationEvent, error) {
+// Notify passes the event through for Runtime to dispatch to extractors.
+// Returns nil to skip extractor dispatch.
+func (s *K8sNotificationSource) Notify(_ context.Context, event fwkdl.NotificationEvent) (*fwkdl.NotificationEvent, error) {
 	return &event, nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"sync/atomic"
 
@@ -176,14 +175,9 @@ func (p *InFlightLoadProducer) RegisterDependencies(r datalayer.Registrar) error
 	})
 }
 
-// ExpectedInputType defines the type expected by the extractor.
-func (p *InFlightLoadProducer) ExpectedInputType() reflect.Type {
-	return datalayer.EndpointEventReflectType
-}
-
-// ExtractEndpoint handles endpoint deletion events to prune stateful trackers.
-func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datalayer.EndpointEvent) error {
-	if event.Type != datalayer.EventDelete || event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
+// Extract handles endpoint deletion events to prune stateful trackers.
+func (p *InFlightLoadProducer) Extract(ctx context.Context, event datalayer.EndpointEvent) error {
+	if event.Type != datalayer.EventDelete || event.Endpoint == nil {
 		return nil
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -177,7 +177,7 @@ func (p *InFlightLoadProducer) RegisterDependencies(r datalayer.Registrar) error
 
 // Extract handles endpoint deletion events to prune stateful trackers.
 func (p *InFlightLoadProducer) Extract(ctx context.Context, event datalayer.EndpointEvent) error {
-	if event.Type != datalayer.EventDelete || event.Endpoint == nil {
+	if event.Type != datalayer.EventDelete || event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
 		return nil
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -155,7 +155,7 @@ func TestInFlightLoadProducer_NotificationCleanup(t *testing.T) {
 		Endpoint: newStubSchedulingEndpoint(endpointName),
 	}
 
-	err := producer.ExtractEndpoint(ctx, eventEndpoint)
+	err := producer.Extract(ctx, eventEndpoint)
 	require.NoError(t, err)
 
 	// Verify Cleanup
@@ -597,14 +597,14 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 	t.Run("ExtractEndpoint", func(t *testing.T) {
 		// 1. Nil Endpoint
 		require.NotPanics(t, func() {
-			_ = producer.ExtractEndpoint(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: nil})
+			_ = producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: nil})
 		})
 
 		// 2. Nil Metadata
 		stub := newStubSchedulingEndpoint("nil-meta")
 		stub.metadata = nil
 		require.NotPanics(t, func() {
-			_ = producer.ExtractEndpoint(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: stub})
+			_ = producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: stub})
 		})
 	})
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -25,7 +25,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -300,14 +299,9 @@ func (p *Producer) removeStalePods() {
 	}
 }
 
-// ExpectedInputType declares the endpoint lifecycle event type this extractor consumes.
-func (p *Producer) ExpectedInputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractEndpoint removes deleted endpoints from the best-effort multimodal
+// Extract removes deleted endpoints from the best-effort multimodal
 // cache-affinity state when endpoint lifecycle events are wired through the data layer.
-func (p *Producer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
+func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error {
 	if event.Type != fwkdl.EventDelete || event.Endpoint == nil {
 		return nil
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -245,8 +245,6 @@ func TestStalePodCleanup(t *testing.T) {
 
 func TestProducerEndpointExtractorInterfaceContract(t *testing.T) {
 	producer := newTestProducer(t, nil, nil)
-
-	assert.Equal(t, fwkdl.EndpointEventReflectType, producer.ExpectedInputType())
 	var _ fwkdl.EndpointExtractor = producer
 	assert.True(t, reflect.TypeOf(producer).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
 }
@@ -257,7 +255,7 @@ func TestExtractEndpointRemovesDeletedPod(t *testing.T) {
 	producer := newTestProducer(t, nil, nil)
 	producer.putCacheEntry("hash-a", podA, podB)
 
-	err := producer.ExtractEndpoint(context.Background(), fwkdl.EndpointEvent{
+	err := producer.Extract(context.Background(), fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podB}, nil),
 	})

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -19,7 +19,6 @@ package preciseprefixcache
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -29,16 +28,11 @@ import (
 
 var _ fwkdl.EndpointExtractor = &Producer{}
 
-// ExpectedInputType reports the data-layer event type this extractor consumes.
-func (p *Producer) ExpectedInputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractEndpoint processes endpoint lifecycle events emitted by the
+// Extract processes endpoint lifecycle events emitted by the
 // endpoint-notification-source: add/update installs a per-pod ZMQ KV-events
 // subscriber, delete tears one down. No-op unless per-pod discovery is
 // enabled.
-func (p *Producer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
+func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error {
 	if !p.kvEventsConfig.DiscoverPods || p.kvEventsConfig.PodDiscoveryConfig == nil {
 		return nil
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
@@ -66,8 +66,6 @@ func TestProducer_EndpointExtractor_InterfaceContract(t *testing.T) {
 	p := newExtractorProducer(true)
 	defer p.subscribersManager.Shutdown(ctx)
 
-	assert.Equal(t, fwkdl.EndpointEventReflectType, p.ExpectedInputType())
-
 	var _ fwkdl.EndpointExtractor = p
 	assert.True(t, reflect.TypeOf(p).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
 }
@@ -81,7 +79,7 @@ func TestProducer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 	wantKey := "ns/pod-a"
 	wantEndpoint := "tcp://10.0.0.1:5557"
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
@@ -90,14 +88,14 @@ func TestProducer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 	require.Equal(t, []string{wantKey}, ids)
 	require.Equal(t, []string{wantEndpoint}, endpoints)
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
 	ids, _ = p.subscribersManager.GetActiveSubscribers()
 	assert.Len(t, ids, 1, "duplicate add must not create a second subscriber")
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: ep,
 	}))
@@ -111,7 +109,7 @@ func TestProducer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
 	p := newExtractorProducer(false)
 	defer p.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
@@ -129,7 +127,7 @@ func TestProducer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
 		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
@@ -174,7 +172,7 @@ func TestProducer_ExtractEndpoint_OffsetsZMQPortByRankIndex(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
-		require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 			Type: fwkdl.EventAddOrUpdate,
 			Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 				NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: ep.name},
@@ -203,7 +201,7 @@ func TestProducer_ExtractEndpoint_SingleRankUsesBaseSocketPort(t *testing.T) {
 	p := newExtractorProducer(true)
 	defer p.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type: fwkdl.EventAddOrUpdate,
 		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
@@ -224,7 +222,7 @@ func TestProducer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscri
 	p := newExtractorProducer(true)
 	defer p.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
@@ -236,7 +234,7 @@ func TestProducer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscri
 		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
-	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: deleteEndpoint,
 	}))

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync/atomic"
 	"time"
 
@@ -602,13 +601,7 @@ func (s *Scorer) PreRequest(ctx context.Context,
 
 // --- EndpointExtractor implementation ---
 
-// ExpectedInputType declares the data type this extractor consumes.
-// Required by the data layer's source/extractor type-compatibility check.
-func (s *Scorer) ExpectedInputType() reflect.Type {
-	return fwkdl.EndpointEventReflectType
-}
-
-// ExtractEndpoint reacts to endpoint lifecycle events from the data layer's
+// Extract reacts to endpoint lifecycle events from the data layer's
 // endpoint-notification-source: an add/update installs a per-pod ZMQ
 // subscriber so KV-cache events flow into the index; a delete tears it down.
 // No-op when DiscoverPods is disabled or the namespaced name is unavailable.
@@ -616,7 +609,7 @@ func (s *Scorer) ExpectedInputType() reflect.Type {
 // Being called at all is also the signal that the data layer is wired for
 // this scorer; the legacy in-Score discovery path turns itself off from
 // here on.
-func (s *Scorer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
+func (s *Scorer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error {
 	s.extractorActive.Store(true)
 	if !s.kvEventsConfig.DiscoverPods || s.kvEventsConfig.PodDiscoveryConfig == nil {
 		return nil

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -58,9 +58,6 @@ func TestScorer_EndpointExtractor_InterfaceContract(t *testing.T) {
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	assert.Equal(t, fwkdl.EndpointEventReflectType, s.ExpectedInputType(),
-		"ExpectedInputType must report EndpointEvent for data-layer compatibility checks")
-
 	var _ fwkdl.EndpointExtractor = s
 	assert.True(t, reflect.TypeOf(s).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
 }
@@ -74,7 +71,7 @@ func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 	wantKey := "ns/pod-a"
 	wantEndpoint := "tcp://10.0.0.1:5557"
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
@@ -84,14 +81,14 @@ func TestScorer_ExtractEndpoint_AddAndDelete(t *testing.T) {
 	require.Equal(t, []string{wantEndpoint}, endpoints, "ZMQ endpoint must derive from address + SocketPort")
 
 	// Re-add is idempotent (EnsureSubscriber dedups on identical endpoint).
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
 	ids, _ = s.subscribersManager.GetActiveSubscribers()
 	assert.Len(t, ids, 1, "duplicate add must not create a second subscriber")
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: ep,
 	}))
@@ -106,7 +103,7 @@ func TestScorer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
 	s := newExtractorScorer(false)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
@@ -125,7 +122,7 @@ func TestScorer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
 		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
@@ -216,7 +213,7 @@ func TestScorer_LegacyInScoreDiscovery_DisabledOnceExtractorObserved(t *testing.
 
 	// Simulate the data layer dispatching even an unrelated event — the call
 	// itself proves the source is wired.
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: newEndpoint("pod-x", "10.0.0.99"),
 	}))
@@ -276,7 +273,7 @@ func TestScorer_ExtractEndpoint_OffsetsZMQPortByRankIndex(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
-		require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 			Type: fwkdl.EventAddOrUpdate,
 			Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 				NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: ep.name},
@@ -308,7 +305,7 @@ func TestScorer_ExtractEndpoint_SingleRankUsesBaseSocketPort(t *testing.T) {
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type: fwkdl.EventAddOrUpdate,
 		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
@@ -331,7 +328,7 @@ func TestScorer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscribe
 	s := newExtractorScorer(true)
 	defer s.subscribersManager.Shutdown(ctx)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
 	}))
@@ -343,7 +340,7 @@ func TestScorer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscribe
 		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
-	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+	require.NoError(t, s.Extract(ctx, fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: deleteEndpoint,
 	}))

--- a/test/integration/epp/runtime_notification_test.go
+++ b/test/integration/epp/runtime_notification_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 )
@@ -45,7 +46,7 @@ func setupRuntimeWithExtractor(r *datalayer.Runtime, extractorName string) (*moc
 	ext := mocks.NewNotificationExtractor(extractorName)
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: src, Extractors: []fwkdl.ExtractorBase{ext}},
+			{Plugin: src, Extractors: []fwkplugin.Plugin{ext}},
 		},
 	}
 	return ext, r.Configure(cfg, false, "", logger)
@@ -153,7 +154,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 				ext2 := mocks.NewNotificationExtractor("extractor-2")
 				cfg := &datalayer.Config{
 					Sources: []datalayer.DataSourceConfig{
-						{Plugin: src, Extractors: []fwkdl.ExtractorBase{ext1, ext2}},
+						{Plugin: src, Extractors: []fwkplugin.Plugin{ext1, ext2}},
 					},
 				}
 				return ext1, r.Configure(cfg, false, "", logger)
@@ -176,7 +177,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 				workingExtractor := mocks.NewNotificationExtractor("working-extractor")
 				cfg := &datalayer.Config{
 					Sources: []datalayer.DataSourceConfig{
-						{Plugin: src, Extractors: []fwkdl.ExtractorBase{errExtractor, workingExtractor}},
+						{Plugin: src, Extractors: []fwkplugin.Plugin{errExtractor, workingExtractor}},
 					},
 				}
 				return workingExtractor, r.Configure(cfg, false, "", logger)
@@ -228,7 +229,7 @@ func TestRuntimeNotificationWithRuntime(t *testing.T) {
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: src, Extractors: []fwkdl.ExtractorBase{extractor}},
+			{Plugin: src, Extractors: []fwkplugin.Plugin{extractor}},
 		},
 	}
 	require.NoError(t, r.Configure(cfg, false, "", logger))
@@ -255,8 +256,8 @@ func TestRuntimeNotificationDifferentGVKs(t *testing.T) {
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: podSrc, Extractors: []fwkdl.ExtractorBase{podExtractor}},
-			{Plugin: svcSrc, Extractors: []fwkdl.ExtractorBase{svcExtractor}},
+			{Plugin: podSrc, Extractors: []fwkplugin.Plugin{podExtractor}},
+			{Plugin: svcSrc, Extractors: []fwkplugin.Plugin{svcExtractor}},
 		},
 	}
 

--- a/test/integration/epp/runtime_polling_test.go
+++ b/test/integration/epp/runtime_polling_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 	"time"
 
@@ -34,6 +33,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/mocks"
 	httpds "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 )
@@ -87,12 +87,12 @@ func TestRuntimePollingDispatch(t *testing.T) {
 			ext := mocks.NewPollingExtractor("test-extractor")
 
 			httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-				parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+				parsePrometheusMetrics)
 			require.NoError(t, err)
 
 			cfg := &datalayer.Config{
 				Sources: []datalayer.DataSourceConfig{
-					{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext}},
+					{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext}},
 				},
 			}
 
@@ -139,12 +139,12 @@ func TestRuntimePollingMultipleExtractors(t *testing.T) {
 	ext2 := mocks.NewPollingExtractor("extractor-2")
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext1, ext2}},
+			{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext1, ext2}},
 		},
 	}
 
@@ -188,12 +188,12 @@ func TestRuntimePollingEndpointLifecycle(t *testing.T) {
 	ext := mocks.NewPollingExtractor("lifecycle-extractor")
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext}},
+			{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext}},
 		},
 	}
 
@@ -242,7 +242,7 @@ func TestRuntimePollingWithoutExtractors(t *testing.T) {
 	r := datalayer.NewRuntime(50 * time.Millisecond)
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{
@@ -281,12 +281,12 @@ func TestRuntimePollingHTTPError(t *testing.T) {
 	ext := mocks.NewPollingExtractor("error-extractor")
 
 	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
-		parsePrometheusMetrics, reflect.TypeFor[fwkdl.Metrics]())
+		parsePrometheusMetrics)
 	require.NoError(t, err)
 
 	cfg := &datalayer.Config{
 		Sources: []datalayer.DataSourceConfig{
-			{Plugin: httpSrc, Extractors: []fwkdl.ExtractorBase{ext}},
+			{Plugin: httpSrc, Extractors: []fwkplugin.Plugin{ext}},
 		},
 	}
 
@@ -330,12 +330,12 @@ func createTestMetricsServer(t *testing.T, metrics map[string]float64) *httptest
 	return httptest.NewServer(handler)
 }
 
-func parsePrometheusMetrics(reader io.Reader) (any, error) {
-	metrics := &fwkdl.Metrics{}
+func parsePrometheusMetrics(reader io.Reader) (fwkdl.Metrics, error) {
+	var metrics fwkdl.Metrics
 	parser := expfmt.NewTextParser(model.LegacyValidation)
 	metricFamilies, err := parser.TextToMetricFamilies(reader)
 	if err != nil {
-		return nil, err
+		return metrics, err
 	}
 
 	for _, mf := range metricFamilies {


### PR DESCRIPTION
[Design doc](https://docs.google.com/document/d/1Ch78yADpIly3LTanH9Gv7BludwtqQrYrNQhvCQmh60w/edit?usp=sharing)

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Replaces the legacy `ExtractorBase` hierarchy with a generic `Extractor[T any]` interface and makes polling sources own their bound extractors via a `PollingDispatcher` contract. The runtime tick simplifies to `dispatcher.Dispatch(ctx, ep)`; per-call `any -> T` casts and reflect-based input-type checks are gone.

**Plugin before:**
```go
func (ext *Extractor) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) error {
  metrics, ok := data.(sourcemetrics.PrometheusMetricMap)
  if !ok {
    return fmt.Errorf("unexpected input in Extract: %T", data)
  }
  // ... business logic
}
```

**Plugin after:**
```go
func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]) error {
  metrics := in.Payload
  ep := in.Endpoint
  // ... business logic
}
```

**Behavior changes** (intentional; not behavior-preserving):

- **Pure-append at binding layer; dedup enforced at config-validation layer.** `HTTPDataSource.AppendExtractor` and `extractorMap.Append` are pure appends. Duplicate-Type detection lives in `runtime.Configure` (via `validateSourceExtractors` for user-config slices, plus an explicit `boundTypes` map that lets code-registered pending extractors yield to user-config of the same Type). Single enforcement layer, no per-binding-call defense.
- **Per-extractor panic recovery in `HTTPDataSource.Dispatch`.** A buggy extractor (e.g. nil-deref) no longer kills the EPP collector goroutine. Panics increment the same `*ExtractErrorsTotal` counters as regular failures and log with stack trace.
- **Multi-variant source rejection.** `registerSource` errors when a source implements more than one variant interface (`PollingDispatcher` + `NotificationSource`, etc.); previously the first match silently won.
- **Typed parser contract.** `HTTPDataSource[T]`'s `parser` field doc states "MUST NOT return (zero, nil) for nilable T; the dispatcher does not validate." Parsers signal failure with a non-nil error; the typed signature makes `(nil, nil)` an explicit programming bug rather than an accidental untyped fall-through.

**New plugin-author-visible surface**:

- `fwkdl.Extractor[T any]` interface (replaces `ExtractorBase` + reflect-based dispatch)
- `fwkdl.PollInput[T]`, `fwkdl.PollingExtractor[T]`, `fwkdl.PollingDispatcher`
- `http.ErrExtractorTypeMismatch` sentinel
- `httptest.ParserContract[T]` test helper for parser implementations to verify their non-nil-on-success contract against golden inputs
- `LlmdDataLayer{Poll,Extract}ErrorsTotal` increments added at the dispatch path for parity with the upstream metric-deprecation cycle

**Which issue(s) this PR fixes**:
Fixes https://github.com/llm-d/llm-d-router/issues/1053

**Release note**:
```release-note
The data layer's extractor API has been refactored to use Go generics. Out-of-tree plugin authors writing custom extractors must implement `Extract(ctx, fwkdl.PollInput[T]) error` (replacing the untyped `Extract(ctx, data any, ep Endpoint) error`); parsers passed to `NewHTTPDataSource[T]` must not return `(nil, nil)` for nilable T. A new `httptest.ParserContract[T]` helper validates parser implementations against this contract.
```
