### PR TITLE
deprecate UDS-backend in `token-producer` and suggest configuring the vllm render instead

### DIFF
--- a/deploy/config/epp-precise-prefix-cache-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-config.yaml
@@ -6,7 +6,7 @@ plugins:
     parameters:
       modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
       vllm:
-        http: http://localhost:8000
+        url: http://localhost:8000
   - type: endpoint-notification-source
   - type: metrics-data-source
   - type: core-metrics-extractor

--- a/deploy/config/sim-epp-kvcache-config.yaml
+++ b/deploy/config/sim-epp-kvcache-config.yaml
@@ -7,7 +7,7 @@ plugins:
   parameters:
     modelName: TinyLlama/TinyLlama-1.1B-Chat-v1.0  # replace to use a different model
     vllm:
-      http: http://localhost:8000
+      url: http://localhost:8000
 - type: precise-prefix-cache-scorer
   parameters:
     tokenProcessorConfig:

--- a/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml
+++ b/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml
@@ -9,7 +9,7 @@ plugins:
   parameters:
     modelName: "${MODEL_NAME}"
     vllm:
-      http: "http://localhost:8000"
+      url: "http://localhost:8000"
       # timeout: "5s"
       # mmTimeout: "30s"
 - type: precise-prefix-cache-scorer

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -24,6 +24,12 @@ The plugin calls vLLM's `/v1/completions/render` and
 to `vllm` with `http://localhost:8000`. Future protocol fields (e.g. `grpc`)
 can be added alongside `http` under the same `vllm` block.
 
+> [!WARNING]
+> The `udsTokenizerConfig` backend (gRPC-over-UDS sidecar) is **deprecated**
+> and will be removed in a future release. Existing configs continue to work
+> but emit a deprecation warning at startup. Migrate to `vllm.http`. See
+> [Migration](#migration-from-udstokenizerconfig) below.
+
 ## Config
 
 | Parameter        | Default                 | Description                                                       |
@@ -81,6 +87,36 @@ Plugin config — dedicated render Service:
 A complete sample config that pairs this with `precise-prefix-cache-scorer`
 is at
 [`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).
+
+## Migration from `udsTokenizerConfig`
+
+The legacy UDS backend ran a per-pod tokenizer sidecar and connected over a
+shared Unix domain socket. Replace it with the vLLM HTTP /render backend,
+which calls the same model-serving pods (or a co-located `vllm launch render`
+sidecar) and removes the dedicated tokenizer image.
+
+Before:
+
+```yaml
+- type: token-producer
+  parameters:
+    modelName: "${MODEL_NAME}"
+    udsTokenizerConfig:
+      socketFile: /tmp/tokenizer/tokenizer-uds.socket
+```
+
+After:
+
+```yaml
+- type: token-producer
+  parameters:
+    modelName: "${MODEL_NAME}"
+    vllm:
+      http: "http://localhost:8000"   # or a shared render Service
+```
+
+See the [Deployment](#deployment) section above for sidecar vs shared-Service
+options.
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -36,7 +36,7 @@ the same `vllm` block.
 | Parameter        | Default                 | Description                                                       |
 | ---------------- | ----------------------- | ----------------------------------------------------------------- |
 | `modelName`      | – (required)            | Model whose tokenizer should be loaded / sent in render requests. |
-| `vllm.url`       | `http://localhost:8000` | Base URL of the vLLM render endpoint, plain HTTP only (no TLS), no trailing slash. |
+| `vllm.url`       | `http://localhost:8000` | Base URL of the vLLM render endpoint (no trailing slash).         |
 | `vllm.timeout`   | `5s`                    | Per-request timeout for text-only requests.                       |
 | `vllm.mmTimeout` | `30s`                   | Per-request timeout for multimodal requests.                      |
 
@@ -113,7 +113,7 @@ After:
   parameters:
     modelName: "${MODEL_NAME}"
     vllm:
-      url: "http://localhost:8000"   # or a shared render Service; plain HTTP only
+      url: "http://localhost:8000"   # or a shared render Service
 ```
 
 See the [Deployment](#deployment) section above for sidecar vs shared-Service

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -20,14 +20,15 @@ upstream list shape, sorted by placeholder offset.
 ## Backend
 
 The plugin calls vLLM's `/v1/completions/render` and
-`/v1/chat/completions/render` over HTTP. An empty configuration falls back
-to `vllm` with `http://localhost:8000`. Future protocol fields (e.g. `grpc`)
-can be added alongside `http` under the same `vllm` block.
+`/v1/chat/completions/render` over plain HTTP (TLS is not supported). An
+empty configuration falls back to `vllm` with `http://localhost:8000`.
+Future protocol fields (e.g. `grpc`) can be added alongside `url` under
+the same `vllm` block.
 
 > [!WARNING]
 > The `udsTokenizerConfig` backend (gRPC-over-UDS sidecar) is **deprecated**
 > and will be removed in a future release. Existing configs continue to work
-> but emit a deprecation warning at startup. Migrate to `vllm.http`. See
+> but emit a deprecation warning at startup. Migrate to `vllm.url`. See
 > [Migration](#migration-from-udstokenizerconfig) below.
 
 ## Config
@@ -35,7 +36,7 @@ can be added alongside `http` under the same `vllm` block.
 | Parameter        | Default                 | Description                                                       |
 | ---------------- | ----------------------- | ----------------------------------------------------------------- |
 | `modelName`      | – (required)            | Model whose tokenizer should be loaded / sent in render requests. |
-| `vllm.http`      | `http://localhost:8000` | Base URL of the vLLM render endpoint (no trailing slash).         |
+| `vllm.url`       | `http://localhost:8000` | Base URL of the vLLM render endpoint, plain HTTP only (no TLS), no trailing slash. |
 | `vllm.timeout`   | `5s`                    | Per-request timeout for text-only requests.                       |
 | `vllm.mmTimeout` | `30s`                   | Per-request timeout for multimodal requests.                      |
 
@@ -71,7 +72,7 @@ Plugin config — sidecar (loopback):
   parameters:
     modelName: "${MODEL_NAME}"
     vllm:
-      http: "http://localhost:8000"       # optional; this is the default
+      url: "http://localhost:8000"       # optional; this is the default
 ```
 
 Plugin config — dedicated render Service:
@@ -81,7 +82,7 @@ Plugin config — dedicated render Service:
   parameters:
     modelName: "${MODEL_NAME}"
     vllm:
-      http: "http://vllm-render.default.svc.cluster.local:8000"
+      url: "http://vllm-render.default.svc.cluster.local:8000"
 ```
 
 A complete sample config that pairs this with `precise-prefix-cache-scorer`
@@ -112,7 +113,7 @@ After:
   parameters:
     modelName: "${MODEL_NAME}"
     vllm:
-      http: "http://localhost:8000"   # or a shared render Service
+      url: "http://localhost:8000"   # or a shared render Service; plain HTTP only
 ```
 
 See the [Deployment](#deployment) section above for sidecar vs shared-Service

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -61,10 +61,13 @@ var TokenizedPromptDataKey = plugin.NewDataKey(tokenizedPromptKeyID, PluginType)
 // tokenizerPluginConfig holds the configuration for the tokenizer plugin.
 //
 // The default backend is `vllm` (HTTP /render). `udsTokenizerConfig` is the
-// legacy gRPC-over-UDS backend, selected only when explicitly enabled. An
+// deprecated gRPC-over-UDS backend, selected only when explicitly enabled. An
 // empty configuration falls back to `vllm` with its default endpoint.
 type tokenizerPluginConfig struct {
-	// TokenizerConfig configures the legacy gRPC-over-UDS backend.
+	// TokenizerConfig configures the deprecated gRPC-over-UDS backend.
+	//
+	// Deprecated: the UDS tokenizer backend is deprecated and will be removed
+	// in a future release. Migrate to the `vllm` HTTP /render backend.
 	TokenizerConfig tokenization.UdsTokenizerConfig `json:"udsTokenizerConfig,omitempty"`
 	// VLLM configures the vLLM /render backend.
 	VLLM *vllmConfig `json:"vllm,omitempty"`
@@ -112,11 +115,15 @@ func LegacyPluginFactory(name string, rawParameters json.RawMessage, handle plug
 
 // NewPlugin creates a new tokenizer plugin instance and constructs the
 // configured backend. vllm is the default; udsTokenizerConfig is selected
-// only when explicitly enabled (its socketFile is set).
+// only when explicitly enabled (its socketFile is set) and is deprecated.
 func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) (*Plugin, error) {
 	var tk tokenizer
 	switch {
 	case config.TokenizerConfig.IsEnabled():
+		log.FromContext(ctx).Info(
+			"DEPRECATION: 'udsTokenizerConfig' backend is deprecated and will be removed in a future release; migrate to the 'vllm' HTTP /render backend",
+			"pluginType", PluginType,
+		)
 		uds, err := newUDSTokenizer(ctx, &config.TokenizerConfig, config.ModelName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize UDS tokenizer for '%s' plugin - %w", PluginType, err)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -121,7 +121,7 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 	switch {
 	case config.TokenizerConfig.IsEnabled():
 		log.FromContext(ctx).Info(
-			"DEPRECATION: 'udsTokenizerConfig' backend is deprecated and will be removed in a future release; migrate to the 'vllm' HTTP /render backend",
+			"DEPRECATION: the 'udsTokenizerConfig' parameter is deprecated and will be removed in a future release; set the 'vllm' parameter instead (see plugin README)",
 			"pluginType", PluginType,
 		)
 		uds, err := newUDSTokenizer(ctx, &config.TokenizerConfig, config.ModelName)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -47,9 +47,8 @@ const (
 	maxErrorBodySnippetBytes = 1024
 )
 
-// vllmConfig configures the vLLM /render backend. Only plain HTTP is
-// supported (no TLS). Future protocol fields (e.g., grpc) can be added
-// alongside url.
+// vllmConfig configures the vLLM /render backend. Future protocol fields
+// (e.g., grpc) can be added alongside url.
 type vllmConfig struct {
 	// URL is the base URL of the vLLM render endpoint (no trailing slash).
 	// Can be a loopback sidecar or a dedicated Service.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -47,13 +47,14 @@ const (
 	maxErrorBodySnippetBytes = 1024
 )
 
-// vllmConfig configures the vLLM /render backend. Future protocol fields
-// (e.g., grpc) can be added alongside http.
+// vllmConfig configures the vLLM /render backend. Only plain HTTP is
+// supported (no TLS). Future protocol fields (e.g., grpc) can be added
+// alongside url.
 type vllmConfig struct {
-	// HTTP is the base URL of the vLLM render endpoint (no trailing slash).
+	// URL is the base URL of the vLLM render endpoint (no trailing slash).
 	// Can be a loopback sidecar or a dedicated Service.
 	// Defaults to http://localhost:8000.
-	HTTP string `json:"http,omitempty"`
+	URL string `json:"url,omitempty"`
 	// Timeout is the per-request timeout for text-only requests
 	// (Go duration string, e.g. "5s"). Defaults to 5s.
 	Timeout string `json:"timeout,omitempty"`
@@ -73,7 +74,7 @@ type vllmHTTPRenderer struct {
 }
 
 func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, error) {
-	url := strings.TrimRight(cfg.HTTP, "/")
+	url := strings.TrimRight(cfg.URL, "/")
 	if url == "" {
 		url = defaultHTTPRenderURL
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -37,7 +37,7 @@ const testHTTPModel = "test-model"
 
 func newHTTPRenderer(t *testing.T, srv *httptest.Server) *vllmHTTPRenderer {
 	t.Helper()
-	r, err := newVLLMHTTPRenderer(&vllmConfig{HTTP: srv.URL}, testHTTPModel)
+	r, err := newVLLMHTTPRenderer(&vllmConfig{URL: srv.URL}, testHTTPModel)
 	require.NoError(t, err)
 	return r
 }
@@ -142,7 +142,7 @@ func TestPluginFactory_RejectsBothBackends(t *testing.T) {
 	params := `{
 		"modelName": "m",
 		"udsTokenizerConfig": {"socketFile": "/tmp/foo.sock"},
-		"vllm": {"http": "http://localhost:8000"}
+		"vllm": {"url": "http://localhost:8000"}
 	}`
 	handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
 	p, err := PluginFactory("test", json.RawMessage(params), handle)

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
@@ -57,7 +57,7 @@ plugins:
     parameters:
       modelName: meta-llama/Llama-3.1-8B-Instruct
       vllm:
-        http: http://localhost:8000
+        url: http://localhost:8000
   - type: context-length-aware
     parameters:
       label: llm-d.ai/context-length-range

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
@@ -31,7 +31,7 @@ plugins:
     parameters:
       modelName: hf-repo/model-name
       vllm:
-        http: http://localhost:8000
+        url: http://localhost:8000
   - type: precise-prefix-cache-scorer
     parameters:
       tokenProcessorConfig:
@@ -71,7 +71,7 @@ plugins:
     parameters:
       modelName: hf-repo/model-name
       vllm:
-        http: http://localhost:8000
+        url: http://localhost:8000
   - type: precise-prefix-cache-scorer
     parameters:
       tokenProcessorConfig:

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -183,7 +183,7 @@ plugins:
   parameters:
     modelName: Qwen/Qwen2.5-1.5B-Instruct
     vllm:
-      http: http://localhost:8000
+      url: http://localhost:8000
 - type: precise-prefix-cache-scorer
   parameters:
     tokenProcessorConfig:
@@ -215,7 +215,7 @@ plugins:
   parameters:
     modelName: Qwen/Qwen2.5-1.5B-Instruct
     vllm:
-      http: http://localhost:8000
+      url: http://localhost:8000
 - type: precise-prefix-cache-scorer
   parameters:
     tokenProcessorConfig:


### PR DESCRIPTION
Christmas came early

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
deprecated UDS-backend in `token-producer`
```
