### PR TITLE
file-discovery-1: add BackendUpsert/Delete interface methods and extract upertEndpoint helper

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -87,6 +87,11 @@ type Datastore interface {
 	PodUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.Pod) bool
 	PodDelete(podName string)
 
+	// BackendUpsert adds or updates an endpoint from a non-Kubernetes discovery source.
+	BackendUpsert(ctx context.Context, meta *fwkdl.EndpointMetadata)
+	// BackendDelete removes the endpoint with the given namespaced name.
+	BackendDelete(id types.NamespacedName)
+
 	// Clears the store state, happens when the pool gets deleted.
 	Clear()
 }
@@ -334,23 +339,9 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 	existingEpSet := sets.Set[types.NamespacedName]{}
 	for _, endpointMetadata := range pods {
 		existingEpSet.Insert(endpointMetadata.NamespacedName)
-		var ep fwkdl.Endpoint
-		existing, ok := ds.pods.Load(endpointMetadata.NamespacedName)
-		if !ok {
-			ep = ds.epf.NewEndpoint(ds.parentCtx, endpointMetadata, ds)
-			if ep == nil {
-				// NewEndpoint returns nil when a collector is already running for this
-				// endpoint (duplicate reconcile race). The existing entry in ds.pods
-				// is still valid; skip re-registering it.
-				continue
-			}
-			ds.pods.Store(endpointMetadata.NamespacedName, ep)
+		if ds.upsertEndpoint(endpointMetadata) {
 			result = false
-		} else {
-			ep = existing.(fwkdl.Endpoint)
 		}
-		// Update endpoint properties if anything changed.
-		ep.UpdateMetadata(endpointMetadata)
 	}
 
 	// remove endpoints that are no longer active in the pool
@@ -378,6 +369,37 @@ func (ds *datastore) PodDelete(podName string) {
 		}
 		return true
 	})
+}
+
+func (ds *datastore) BackendUpsert(_ context.Context, meta *fwkdl.EndpointMetadata) {
+	ds.upsertEndpoint(meta)
+}
+
+func (ds *datastore) BackendDelete(id types.NamespacedName) {
+	if v, ok := ds.pods.LoadAndDelete(id); ok {
+		ds.epf.ReleaseEndpoint(v.(fwkdl.Endpoint))
+	}
+}
+
+// upsertEndpoint stores or updates a single endpoint in the pods map.
+// Returns true if the endpoint was newly created, false if it already existed
+// or if NewEndpoint returned nil (duplicate-start race).
+// Shared by BackendUpsert and podUpdateOrAddIfNotExist.
+func (ds *datastore) upsertEndpoint(meta *fwkdl.EndpointMetadata) bool {
+	existing, ok := ds.pods.Load(meta.NamespacedName)
+	if !ok {
+		ep := ds.epf.NewEndpoint(ds.parentCtx, meta, ds)
+		if ep == nil {
+			// NewEndpoint returns nil when a collector is already running for this
+			// endpoint (duplicate reconcile race). The existing entry in ds.pods
+			// is still valid; skip re-registering it.
+			return false
+		}
+		ds.pods.Store(meta.NamespacedName, ep)
+		return true
+	}
+	existing.(fwkdl.Endpoint).UpdateMetadata(meta)
+	return false
 }
 
 func (ds *datastore) podResyncAll(ctx context.Context, reader client.Reader) error {

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -1349,28 +1349,30 @@ func TestExtractActivePorts(t *testing.T) {
 // ---- BackendUpsert / BackendDelete tests -----------------------------------
 
 func TestBackendUpsert_NewEndpoint(t *testing.T) {
+	const addr, port = "10.0.0.1", "8000"
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.1", Port: "8000"})
+	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr, Port: port})
 
 	eps := ds.PodList(AllPodsPredicate)
 	assert.Len(t, eps, 1)
-	assert.Equal(t, "10.0.0.1", eps[0].GetMetadata().Address)
+	assert.Equal(t, addr, eps[0].GetMetadata().Address)
 }
 
 func TestBackendUpsert_UpdateExisting(t *testing.T) {
+	const addr1, addr2 = "10.0.0.1", "10.0.0.2"
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.1"})
-	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.2"})
+	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr1})
+	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr2})
 
 	eps := ds.PodList(AllPodsPredicate)
 	assert.Len(t, eps, 1)
-	assert.Equal(t, "10.0.0.2", eps[0].GetMetadata().Address)
+	assert.Equal(t, addr2, eps[0].GetMetadata().Address)
 }
 
 func TestBackendUpsert_NewEndpointFactoryReturnsNil(t *testing.T) {

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -47,6 +47,21 @@ import (
 	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
+// simpleEndpointFactory is a minimal EndpointFactory for BackendUpsert/Delete tests.
+// When returnNil is true, NewEndpoint returns nil (simulating a duplicate-start race).
+type simpleEndpointFactory struct {
+	returnNil bool
+}
+
+func (f *simpleEndpointFactory) NewEndpoint(_ context.Context, meta *fwkdl.EndpointMetadata, _ datalayer.PoolInfo) fwkdl.Endpoint {
+	if f.returnNil {
+		return nil
+	}
+	return fwkdl.NewEndpoint(meta, fwkdl.NewMetrics())
+}
+
+func (f *simpleEndpointFactory) ReleaseEndpoint(_ fwkdl.Endpoint) {}
+
 func TestPoolGet_NoDeadlockWithConcurrentWrite(t *testing.T) {
 	pool := &datalayer.EndpointPool{
 		Namespace:   "default",
@@ -1329,4 +1344,61 @@ func TestExtractActivePorts(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---- BackendUpsert / BackendDelete tests -----------------------------------
+
+func TestBackendUpsert_NewEndpoint(t *testing.T) {
+	ctx := context.Background()
+	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
+
+	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.1", Port: "8000"})
+
+	eps := ds.PodList(AllPodsPredicate)
+	assert.Len(t, eps, 1)
+	assert.Equal(t, "10.0.0.1", eps[0].GetMetadata().Address)
+}
+
+func TestBackendUpsert_UpdateExisting(t *testing.T) {
+	ctx := context.Background()
+	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
+
+	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.1"})
+	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.2"})
+
+	eps := ds.PodList(AllPodsPredicate)
+	assert.Len(t, eps, 1)
+	assert.Equal(t, "10.0.0.2", eps[0].GetMetadata().Address)
+}
+
+func TestBackendUpsert_NewEndpointFactoryReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	ds := NewDatastore(ctx, &simpleEndpointFactory{returnNil: true}, 0)
+	meta := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Name: "ep1", Namespace: "default"}}
+
+	assert.NotPanics(t, func() { ds.BackendUpsert(ctx, meta) })
+	assert.Empty(t, ds.PodList(AllPodsPredicate))
+}
+
+func TestBackendDelete_Existing(t *testing.T) {
+	ctx := context.Background()
+	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
+
+	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id})
+	assert.Len(t, ds.PodList(AllPodsPredicate), 1)
+
+	ds.BackendDelete(id)
+	assert.Empty(t, ds.PodList(AllPodsPredicate))
+}
+
+func TestBackendDelete_Missing(t *testing.T) {
+	ctx := context.Background()
+	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+
+	assert.NotPanics(t, func() {
+		ds.BackendDelete(types.NamespacedName{Name: "nonexistent", Namespace: "default"})
+	})
 }

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -47,20 +47,20 @@ import (
 	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
-// simpleEndpointFactory is a minimal EndpointFactory for BackendUpsert/Delete tests.
+// mockEndpointFactory is a minimal EndpointFactory for BackendUpsert/Delete tests.
 // When returnNil is true, NewEndpoint returns nil (simulating a duplicate-start race).
-type simpleEndpointFactory struct {
+type mockEndpointFactory struct {
 	returnNil bool
 }
 
-func (f *simpleEndpointFactory) NewEndpoint(_ context.Context, meta *fwkdl.EndpointMetadata, _ datalayer.PoolInfo) fwkdl.Endpoint {
+func (f *mockEndpointFactory) NewEndpoint(_ context.Context, meta *fwkdl.EndpointMetadata, _ datalayer.PoolInfo) fwkdl.Endpoint {
 	if f.returnNil {
 		return nil
 	}
 	return fwkdl.NewEndpoint(meta, fwkdl.NewMetrics())
 }
 
-func (f *simpleEndpointFactory) ReleaseEndpoint(_ fwkdl.Endpoint) {}
+func (f *mockEndpointFactory) ReleaseEndpoint(_ fwkdl.Endpoint) {}
 
 func TestPoolGet_NoDeadlockWithConcurrentWrite(t *testing.T) {
 	pool := &datalayer.EndpointPool{
@@ -1350,7 +1350,7 @@ func TestExtractActivePorts(t *testing.T) {
 
 func TestBackendUpsert_NewEndpoint(t *testing.T) {
 	ctx := context.Background()
-	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
 	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.1", Port: "8000"})
@@ -1362,7 +1362,7 @@ func TestBackendUpsert_NewEndpoint(t *testing.T) {
 
 func TestBackendUpsert_UpdateExisting(t *testing.T) {
 	ctx := context.Background()
-	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
 	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.1"})
@@ -1375,7 +1375,7 @@ func TestBackendUpsert_UpdateExisting(t *testing.T) {
 
 func TestBackendUpsert_NewEndpointFactoryReturnsNil(t *testing.T) {
 	ctx := context.Background()
-	ds := NewDatastore(ctx, &simpleEndpointFactory{returnNil: true}, 0)
+	ds := NewDatastore(ctx, &mockEndpointFactory{returnNil: true}, 0)
 	meta := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Name: "ep1", Namespace: "default"}}
 
 	assert.NotPanics(t, func() { ds.BackendUpsert(ctx, meta) })
@@ -1384,7 +1384,7 @@ func TestBackendUpsert_NewEndpointFactoryReturnsNil(t *testing.T) {
 
 func TestBackendDelete_Existing(t *testing.T) {
 	ctx := context.Background()
-	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
 	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id})
@@ -1396,7 +1396,7 @@ func TestBackendDelete_Existing(t *testing.T) {
 
 func TestBackendDelete_Missing(t *testing.T) {
 	ctx := context.Background()
-	ds := NewDatastore(ctx, &simpleEndpointFactory{}, 0)
+	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 
 	assert.NotPanics(t, func() {
 		ds.BackendDelete(types.NamespacedName{Name: "nonexistent", Namespace: "default"})


### PR DESCRIPTION
This PR is the first of 4 PRs adding file based discovery allowing the epp to run without Kubernetes. The file based discovery is the first phase in re-creating the functionality of #1007 

Two methods are added to the Datastore interface to give non-Kubernetes discovery giving a direct route to push endpoints into the store:

- BackendUpsert(ctx context.Context, meta *fwkdl.EndpointMetadata)
- BackendDelete(id types.NamespacedName)

The store/update logic that was inline in podUpdateOrAddIfNotExist is extracted into a private upsertEndpoint helper, which both the K8s path and BackendUpsert now share. The K8s code path behavior is unchanged.
