### PR TITLE
fix: Add name as parameter to the approx prefix cache data producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -62,7 +62,7 @@ func (p *dataProducer) Produces() map[string]any {
 }
 
 // newDataProducer returns a new DataProducer plugin.
-func newDataProducer(ctx context.Context, config config, handle plugin.Handle) (*dataProducer, error) {
+func newDataProducer(ctx context.Context, config config, handle plugin.Handle, name string) (*dataProducer, error) {
 	log.FromContext(ctx).V(logutil.DEFAULT).Info("Prefix DataProducer initialized", "config", config)
 
 	//nolint:staticcheck // BlockSize is deprecated, but we check it here to provide a migration path for users.
@@ -77,11 +77,11 @@ func newDataProducer(ctx context.Context, config config, handle plugin.Handle) (
 		return nil, fmt.Errorf("invalid configuration: MaxPrefixTokensToMatch must be >= 0 (current value: %d)", config.MaxPrefixTokensToMatch)
 	}
 	indexer := newIndexer(ctx, config.LRUCapacityPerServer)
-
+	
 	p := &dataProducer{
 		typedName: plugin.TypedName{
 			Type: ApproxPrefixCachePluginType,
-			Name: ApproxPrefixCachePluginType,
+			Name: name,
 		},
 		config:      config,
 		indexerInst: indexer,
@@ -254,7 +254,7 @@ func ApproxPrefixCacheFactory(name string, rawParameters json.RawMessage, handle
 	}
 
 	// pluginState will be initialized by newDataProducer as we pass nil here.
-	p, err := newDataProducer(handle.Context(), parameters, handle)
+	p, err := newDataProducer(handle.Context(), parameters, handle, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -41,7 +41,7 @@ func TestProduce(t *testing.T) {
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
 	// Test the "initialize if nil" pattern
-	p, err := newDataProducer(context.Background(), config, nil)
+	p, err := newDataProducer(context.Background(), config, nil, "test-prefix")
 	assert.NoError(t, err)
 	assert.NotNil(t, p.PluginState())
 
@@ -87,7 +87,7 @@ func TestPreRequest(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newDataProducer(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil, "test-prefix")
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 	req1 := &fwksched.InferenceRequest{
@@ -148,12 +148,12 @@ func TestDataProducerValidation(t *testing.T) {
 	}}
 
 	for _, config := range validConfigs {
-		_, err := newDataProducer(context.Background(), config, nil)
+		_, err := newDataProducer(context.Background(), config, nil, "test-prefix")
 		assert.NoError(t, err)
 	}
 
 	for _, config := range invalidConfigs {
-		_, err := newDataProducer(context.Background(), config, nil)
+		_, err := newDataProducer(context.Background(), config, nil, "test-prefix")
 		assert.Error(t, err)
 	}
 }
@@ -164,7 +164,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newDataProducer(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil, "test-prefix")
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
@@ -233,7 +233,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newDataProducer(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil, "test-prefix")
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1}
@@ -299,7 +299,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameUrlMatches(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newDataProducer(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil, "test-prefix")
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1}
@@ -371,7 +371,7 @@ func TestPrefixPluginChatCompletionsMultimodalDifferentUrlPartialMatch(t *testin
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newDataProducer(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil, "test-prefix")
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1}
@@ -464,7 +464,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   1,
 	}
-	p, _ := newDataProducer(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil, "test-prefix")
 
 	_ = p.Produce(context.Background(), req, endpoints)
 	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
@@ -493,7 +493,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 		MaxPrefixTokensToMatch: 2,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, err := newDataProducer(context.Background(), cfg, nil)
+	p, err := newDataProducer(context.Background(), cfg, nil, "test-prefix")
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
@@ -526,7 +526,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 		MaxPrefixBlocksToMatch: 3,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p2, err := newDataProducer(context.Background(), cfg2, nil)
+	p2, err := newDataProducer(context.Background(), cfg2, nil, "test-prefix")
 	assert.NoError(t, err)
 
 	req2 := &fwksched.InferenceRequest{
@@ -554,7 +554,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 		MaxPrefixBlocksToMatch: 50000,
 		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
 	}
-	p, _ := newDataProducer(context.Background(), config, nil)
+	p, _ := newDataProducer(context.Background(), config, nil, "test-prefix")
 
 	promptLen := []int{1024, 4096, 10000, 50000}
 
@@ -591,4 +591,36 @@ func randomPrompt(n int) string {
 		sb.WriteRune(runes[rand.Intn(len(runes))])
 	}
 	return sb.String()
+}
+
+func TestPrefixPluginName(t *testing.T) {
+	config := config{
+		BlockSizeTokens:        1,
+		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
+		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
+	}
+	name := "custom-prefix-name"
+	p, err := newDataProducer(context.Background(), config, nil, name)
+	assert.NoError(t, err)
+	assert.Equal(t, name, p.TypedName().Name)
+	assert.Equal(t, ApproxPrefixCachePluginType, p.TypedName().Type)
+}
+
+func TestApproxPrefixCacheFactory(t *testing.T) {
+	name := "factory-test-name"
+	// Use a mock handle that returns context.Background()
+	handle := &mockHandle{ctx: context.Background()}
+	
+	p, err := ApproxPrefixCacheFactory(name, nil, handle)
+	assert.NoError(t, err)
+	assert.Equal(t, name, p.TypedName().Name)
+}
+
+type mockHandle struct {
+	plugin.Handle
+	ctx context.Context
+}
+
+func (h *mockHandle) Context() context.Context {
+	return h.ctx
 }


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind bug

**What this PR does / why we need it**:
Pass name field to the approx prefix cache data producer plugin

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partly addresses https://github.com/llm-d/llm-d-router/issues/1069

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
