### PR TITLE
docs: update sig channel name and meeting links

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To ensure clarity across the project, we use the following standard terminology:
 
 Our community meeting is bi-weekly at Wednesday 10AM PDT ([Google Meet], [Meeting Notes]).
 
-We currently utilize the [#sig-inference-scheduler] channel in llm-d Slack workspace for communications.
+We currently utilize the [#sig-router] channel in llm-d Slack workspace for communications.
 
 For large changes please [create an issue] first describing the change so the
 maintainers can do an assessment, and work on the details with you. See
@@ -83,6 +83,6 @@ Contributions are welcome!
 [create an issue]:https://github.com/llm-d/llm-d-inference-scheduler/issues/new
 [discussion]:https://github.com/llm-d/llm-d-inference-scheduler/discussions/new?category=q-a
 [Slack]:https://llm-d.slack.com/
-[Google Meet]:https://meet.google.com/uin-yncz-rvg
+[Google Meet]:https://meet.google.com/zij-zekm-jvt
 [Meeting Notes]:https://docs.google.com/document/d/1Pf3x7ZM8nNpU56nt6CzePAOmFZ24NXDeXyaYb565Wq4
-[#sig-inference-scheduler]:https://llm-d.slack.com/?redir=%2Fmessages%2Fsig-inference-scheduler
+[#sig-router]:https://llm-d.slack.com/?redir=%2Fmessages%2Fsig-router


### PR DESCRIPTION
## Summary

- Rename Slack channel reference from `#sig-inference-scheduler` to `#sig-router` following the project rename
- Update Google Meet link to the new meeting URL
- Update Slack channel URL to match the new channel name

## Reason

The community channel was renamed from `sig-inference-scheduler` to `sig-router` to align with the project's rebranding from *Inference Scheduler* to *llm-d Router*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)