### PR TITLE
feat(flowcontrol): allow separate default band config for negative priorities

### DIFF
--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -345,6 +345,13 @@ type FlowControlConfig struct {
 	// priority levels. This template cascades to the standard `PriorityBandConfig` defaults.
 	DefaultPriorityBand *PriorityBandConfig `json:"defaultPriorityBand,omitempty"`
 
+	// +optional
+	// DefaultNegativePriorityBand allows you to define a separate template for priority levels
+	// strictly below zero. This enables designating negative-priority traffic as sheddable by
+	// setting lower capacity limits (e.g., maxBytes: "0" to drop immediately).
+	// If not specified, negative priorities fall back to DefaultPriorityBand.
+	DefaultNegativePriorityBand *PriorityBandConfig `json:"defaultNegativePriorityBand,omitempty"`
+
 	// PriorityBands allows you to explicitly define policies (like capacity limits) for specific
 	// priority levels. Traffic matching these priorities will be handled according to these rules.
 	// If a priority band is not specified, it uses specific defaults.
@@ -381,6 +388,10 @@ func (fcc *FlowControlConfig) String() string {
 
 	if fcc.DefaultPriorityBand != nil {
 		parts = append(parts, fmt.Sprintf("DefaultPriorityBand: %v", fcc.DefaultPriorityBand))
+	}
+
+	if fcc.DefaultNegativePriorityBand != nil {
+		parts = append(parts, fmt.Sprintf("DefaultNegativePriorityBand: %v", fcc.DefaultNegativePriorityBand))
 	}
 
 	if len(fcc.PriorityBands) > 0 {

--- a/apix/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apix/config/v1alpha1/zz_generated.deepcopy.go
@@ -197,6 +197,11 @@ func (in *FlowControlConfig) DeepCopyInto(out *FlowControlConfig) {
 		*out = new(PriorityBandConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DefaultNegativePriorityBand != nil {
+		in, out := &in.DefaultNegativePriorityBand, &out.DefaultNegativePriorityBand
+		*out = new(PriorityBandConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PriorityBands != nil {
 		in, out := &in.PriorityBands, &out.PriorityBands
 		*out = make([]PriorityBandConfig, len(*in))

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -129,6 +129,12 @@ type Config struct {
 	// If nil, it is automatically populated with system defaults during NewConfig.
 	DefaultPriorityBand *PriorityBandConfig
 
+	// DefaultNegativePriorityBand is an optional template for dynamically provisioning priority bands when a request
+	// arrives with a priority level strictly below zero. This allows setting lower capacity limits (or zero) for
+	// negative-priority traffic to designate it as sheddable.
+	// If nil, negative priorities fall back to DefaultPriorityBand.
+	DefaultNegativePriorityBand *PriorityBandConfig
+
 	// FlowGCTimeout defines the interval at which the registry scans for and garbage collects idle flows.
 	// A flow is collected if it has been observed to be Idle for at least one full scan interval.
 	// Optional: Defaults to `defaultFlowGCTimeout` (1 hour).
@@ -249,6 +255,15 @@ func WithPriorityBand(band *PriorityBandConfig) ConfigOption {
 func WithDefaultPriorityBand(band *PriorityBandConfig) ConfigOption {
 	return func(b *configBuilder) error {
 		b.config.DefaultPriorityBand = band
+		return nil
+	}
+}
+
+// WithDefaultNegativePriorityBand sets the template configuration used for dynamically provisioning priority bands
+// with priority levels strictly below zero.
+func WithDefaultNegativePriorityBand(band *PriorityBandConfig) ConfigOption {
+	return func(b *configBuilder) error {
+		b.config.DefaultNegativePriorityBand = band
 		return nil
 	}
 }
@@ -397,6 +412,14 @@ func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig, handle plugin.Hand
 		opts = append(opts, WithDefaultPriorityBand(templateBand))
 	}
 
+	if apiConfig.DefaultNegativePriorityBand != nil {
+		templateBand, err := buildDefaultPriorityBandTemplate(handle, apiConfig.DefaultNegativePriorityBand)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, WithDefaultNegativePriorityBand(templateBand))
+	}
+
 	for _, band := range apiConfig.PriorityBands {
 		pb, err := buildPriorityBand(handle, band)
 		if err != nil {
@@ -510,6 +533,13 @@ func NewConfig(handle plugin.Handle, opts ...ConfigOption) (*Config, error) {
 		}
 	}
 
+	// Apply defaults to DefaultNegativePriorityBand if set.
+	if builder.config.DefaultNegativePriorityBand != nil {
+		if err := builder.config.DefaultNegativePriorityBand.applyDefaults(handle); err != nil {
+			return nil, fmt.Errorf("failed to apply defaults to DefaultNegativePriorityBand: %w", err)
+		}
+	}
+
 	// Apply defaults to all explicitly configured bands.
 	for _, band := range builder.config.PriorityBands {
 		if err := band.applyDefaults(handle); err != nil {
@@ -618,6 +648,14 @@ func (c *Config) validate(checker capabilityChecker) error {
 		return fmt.Errorf("invalid DefaultPriorityBand configuration: %w", err)
 	}
 
+	if c.DefaultNegativePriorityBand != nil {
+		negTemplateCopy := *c.DefaultNegativePriorityBand
+		negTemplateCopy.Priority = -1
+		if err := negTemplateCopy.validate(checker); err != nil {
+			return fmt.Errorf("invalid DefaultNegativePriorityBand configuration: %w", err)
+		}
+	}
+
 	// Validate statically configured bands.
 	for _, band := range c.PriorityBands {
 		if err := band.validate(checker); err != nil {
@@ -690,6 +728,11 @@ func (c *Config) Clone() *Config {
 	if c.DefaultPriorityBand != nil {
 		val := *c.DefaultPriorityBand
 		clone.DefaultPriorityBand = &val
+	}
+
+	if c.DefaultNegativePriorityBand != nil {
+		val := *c.DefaultNegativePriorityBand
+		clone.DefaultNegativePriorityBand = &val
 	}
 
 	if c.PriorityBands != nil {

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -762,6 +762,46 @@ func TestNewConfigFromAPI(t *testing.T) {
 			},
 			expectedErr: "DefaultPriorityBand MaxRequests must be non-negative",
 		},
+
+		// --- DefaultNegativePriorityBand ---
+		{
+			name: "ShouldSucceed_WithDefaultNegativePriorityBand",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultNegativePriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("100")),
+				},
+			},
+			assertion: func(t *testing.T, cfg *Config) {
+				require.NotNil(t, cfg.DefaultNegativePriorityBand)
+				assert.Equal(t, uint64(100), cfg.DefaultNegativePriorityBand.MaxBytes,
+					"DefaultNegativePriorityBand MaxBytes should be translated")
+				assert.NotNil(t, cfg.DefaultNegativePriorityBand.OrderingPolicy,
+					"DefaultNegativePriorityBand should have defaults applied")
+			},
+		},
+		{
+			name: "ShouldFallBackToDefaultBand_WhenNegativeBandIsNil",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultPriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("500")),
+				},
+			},
+			assertion: func(t *testing.T, cfg *Config) {
+				assert.Nil(t, cfg.DefaultNegativePriorityBand,
+					"DefaultNegativePriorityBand should remain nil when not configured")
+				require.NotNil(t, cfg.DefaultPriorityBand)
+				assert.Equal(t, uint64(500), cfg.DefaultPriorityBand.MaxBytes)
+			},
+		},
+		{
+			name: "ShouldError_WithNegativeDefaultNegativePriorityBandMaxBytes",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultNegativePriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("-1")),
+				},
+			},
+			expectedErr: "DefaultPriorityBand MaxBytes must be non-negative",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -782,4 +822,60 @@ func TestNewConfigFromAPI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewConfig_DefaultNegativePriorityBand(t *testing.T) {
+	t.Parallel()
+	handle := newTestPluginsHandle(t)
+
+	t.Run("ShouldAcceptNegativeBandTemplate", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(handle,
+			WithDefaultNegativePriorityBand(&PriorityBandConfig{
+				MaxBytes: 500,
+			}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.DefaultNegativePriorityBand)
+		assert.Equal(t, uint64(500), cfg.DefaultNegativePriorityBand.MaxBytes)
+		assert.NotNil(t, cfg.DefaultNegativePriorityBand.OrderingPolicy,
+			"Defaults should be applied to DefaultNegativePriorityBand")
+	})
+
+	t.Run("ShouldAllowZeroMaxBytes_ForSheddableTraffic", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(handle,
+			WithDefaultNegativePriorityBand(&PriorityBandConfig{}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.DefaultNegativePriorityBand)
+		// MaxBytes=0 gets defaulted to 1GB via applyDefaults
+		assert.Equal(t, defaultPriorityBandMaxBytes, cfg.DefaultNegativePriorityBand.MaxBytes)
+	})
+
+	t.Run("ShouldValidateNegativeBandTemplate", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewConfig(handle,
+			WithDefaultNegativePriorityBand(&PriorityBandConfig{
+				Queue: "non-existent-queue",
+			}),
+		)
+		require.Error(t, err, "Should fail validation for invalid queue in negative band template")
+	})
+
+	t.Run("ShouldCloneNegativeBandTemplate", func(t *testing.T) {
+		t.Parallel()
+		original, err := NewConfig(handle,
+			WithDefaultNegativePriorityBand(&PriorityBandConfig{
+				MaxBytes: 200,
+			}),
+		)
+		require.NoError(t, err)
+
+		clone := original.Clone()
+		require.NotNil(t, clone.DefaultNegativePriorityBand)
+		require.NotSame(t, original.DefaultNegativePriorityBand, clone.DefaultNegativePriorityBand,
+			"Clone should have a distinct pointer for DefaultNegativePriorityBand")
+		assert.Equal(t, original.DefaultNegativePriorityBand.MaxBytes, clone.DefaultNegativePriorityBand.MaxBytes)
+	})
 }

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -278,7 +278,11 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 
 	fr.logger.V(logging.DEFAULT).Info("Dynamically provisioning new priority band", "priority", priority)
 
-	newBand := *fr.config.DefaultPriorityBand
+	template := fr.config.DefaultPriorityBand
+	if priority < 0 && fr.config.DefaultNegativePriorityBand != nil {
+		template = fr.config.DefaultNegativePriorityBand
+	}
+	newBand := *template
 	newBand.Priority = priority
 	fr.config.PriorityBands[priority] = &newBand
 

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -417,6 +417,91 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		require.NoError(t, err, "Existing flows should be auto-synced")
 		require.NotNil(t, mq)
 	})
+
+	t.Run("ShouldUseNegativeBandTemplate_WhenPriorityBelowZero", func(t *testing.T) {
+		t.Parallel()
+		handle := newTestPluginsHandle(t)
+
+		negativeMaxBytes := uint64(256)
+		cfg, err := NewConfig(handle,
+			WithDefaultNegativePriorityBand(&PriorityBandConfig{
+				MaxBytes: negativeMaxBytes,
+			}),
+		)
+		require.NoError(t, err)
+
+		h := newRegistryTestHarness(t, harnessOptions{config: cfg})
+
+		negativePrio := -5
+		key := flowcontrol.FlowKey{ID: "negative-flow", Priority: negativePrio}
+
+		err = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
+			return nil
+		})
+		require.NoError(t, err, "WithConnection should succeed for negative priority")
+
+		h.fr.mu.RLock()
+		band, exists := h.fr.config.PriorityBands[negativePrio]
+		h.fr.mu.RUnlock()
+		require.True(t, exists, "Negative priority band should be dynamically provisioned")
+		assert.Equal(t, negativeMaxBytes, band.MaxBytes,
+			"Negative priority band should use DefaultNegativePriorityBand template")
+	})
+
+	t.Run("ShouldFallBackToDefaultBand_WhenNegativeTemplateIsNil", func(t *testing.T) {
+		t.Parallel()
+		handle := newTestPluginsHandle(t)
+
+		cfg, err := NewConfig(handle)
+		require.NoError(t, err)
+
+		h := newRegistryTestHarness(t, harnessOptions{config: cfg})
+
+		negativePrio := -3
+		key := flowcontrol.FlowKey{ID: "fallback-flow", Priority: negativePrio}
+
+		err = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		h.fr.mu.RLock()
+		band, exists := h.fr.config.PriorityBands[negativePrio]
+		h.fr.mu.RUnlock()
+		require.True(t, exists, "Negative priority band should still be provisioned")
+		assert.Equal(t, defaultPriorityBandMaxBytes, band.MaxBytes,
+			"Without negative template, should fall back to default band's MaxBytes")
+	})
+
+	t.Run("ShouldUseDefaultBand_WhenPositivePriorityWithNegativeTemplate", func(t *testing.T) {
+		t.Parallel()
+		handle := newTestPluginsHandle(t)
+
+		negativeMaxBytes := uint64(100)
+		cfg, err := NewConfig(handle,
+			WithDefaultNegativePriorityBand(&PriorityBandConfig{
+				MaxBytes: negativeMaxBytes,
+			}),
+		)
+		require.NoError(t, err)
+
+		h := newRegistryTestHarness(t, harnessOptions{config: cfg})
+
+		positivePrio := 42
+		key := flowcontrol.FlowKey{ID: "positive-flow", Priority: positivePrio}
+
+		err = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		h.fr.mu.RLock()
+		band, exists := h.fr.config.PriorityBands[positivePrio]
+		h.fr.mu.RUnlock()
+		require.True(t, exists, "Positive priority band should be provisioned")
+		assert.Equal(t, defaultPriorityBandMaxBytes, band.MaxBytes,
+			"Positive priorities should use DefaultPriorityBand, not the negative template")
+	})
 }
 
 // --- Concurrency Tests ---


### PR DESCRIPTION
## Summary
- Add `DefaultNegativePriorityBand` config field for designating negative-priority traffic as sheddable
- `ensurePriorityBand` selects the negative band template when `priority < 0`, falls back to `DefaultPriorityBand` when nil
- Ported from kubernetes-sigs/gateway-api-inference-extension#2908 (closed per repo migration)

Fixes kubernetes-sigs/gateway-api-inference-extension#2452

## Test plan
- Unit tests for config creation, validation, cloning, and defaults
- Unit tests for dynamic provisioning with negative vs positive priorities
- `go test ./pkg/epp/flowcontrol/registry/ -run "Negative|negative" -v` -- all pass