### PR TITLE
chore(GHA): rename internal variable for workflow

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -16,7 +16,7 @@ jobs:
   set-params:
     runs-on: ubuntu-latest
     outputs:
-      project_name: ${{ steps.version.outputs.project_name }}
+      epp_name: ${{ steps.version.outputs.epp_name }}
       sidecar_name: ${{ steps.version.outputs.sidecar_name }}
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -24,7 +24,7 @@ jobs:
         id: version
         run: |
           repo="${GITHUB_REPOSITORY##*/}"
-          echo "project_name=${repo}-dev" >> "$GITHUB_OUTPUT"
+          echo "epp_name=${repo}-dev" >> "$GITHUB_OUTPUT"
           echo "sidecar_name=llm-d-routing-sidecar-dev" >> "$GITHUB_OUTPUT"
 
       - name: Set branch name as tag
@@ -36,7 +36,7 @@ jobs:
     needs: set-params
     uses: ./.github/workflows/ci-build-images.yaml
     with:
-      epp-image-name: ${{ needs.set-params.outputs.project_name }}
+      epp-image-name: ${{ needs.set-params.outputs.epp_name }}
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: "true"

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -16,7 +16,7 @@ jobs:
   set-params:
     runs-on: ubuntu-latest
     outputs:
-      project_name: ${{ steps.version.outputs.project_name }}
+      epp_name: ${{ steps.version.outputs.epp_name }}
       sidecar_name: ${{ steps.version.outputs.sidecar_name }}
       tag: ${{ steps.tag.outputs.tag }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
@@ -25,7 +25,7 @@ jobs:
         id: version
         run: |
           repo="${GITHUB_REPOSITORY##*/}"
-          echo "project_name=$repo" >> "$GITHUB_OUTPUT"
+          echo "epp_name=$repo" >> "$GITHUB_OUTPUT"
           echo "sidecar_name=llm-d-routing-sidecar" >> "$GITHUB_OUTPUT"
 
       - name: Determine tag name
@@ -46,7 +46,7 @@ jobs:
     needs: set-params
     uses: ./.github/workflows/ci-build-images.yaml
     with:
-      epp-image-name: ${{ needs.set-params.outputs.project_name }}
+      epp-image-name: ${{ needs.set-params.outputs.epp_name }}
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: ${{ needs.set-params.outputs.prerelease }}


### PR DESCRIPTION


**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
- better reflect renaming from llm-d-inference-scheduler to llm-d-router
- relate to ongoing work in https://github.com/llm-d/llm-d-router/pull/1098

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
