### PR TITLE
feat(precise-prefix-cache): DP support in discovery mode

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -326,6 +326,7 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 				Port:           strconv.Itoa(port),
 				MetricsHost:    net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(metricsPort)),
 				Labels:         labels,
+				RankIndex:      idx,
 			})
 	}
 

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -670,6 +670,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Port:        inferencePoolMultiTargetPort1,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},
+					RankIndex:   1,
 				},
 			},
 			op: func(ctx context.Context, ds Datastore) {
@@ -704,6 +705,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Port:        inferencePoolMultiTargetPort1,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},
+					RankIndex:   1,
 				},
 				{
 					NamespacedName: types.NamespacedName{
@@ -728,6 +730,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Port:        inferencePoolMultiTargetPort1,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},
+					RankIndex:   1,
 				},
 			},
 			op: func(ctx context.Context, ds Datastore) {
@@ -762,6 +765,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Port:        inferencePoolMultiTargetPort1,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},
+					RankIndex:   1,
 				},
 			},
 			op: func(ctx context.Context, ds Datastore) {

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -31,6 +31,9 @@ type EndpointMetadata struct {
 	Port           string
 	MetricsHost    string
 	Labels         map[string]string
+	// RankIndex is this endpoint's position in the pool's TargetPorts,
+	// identifying the pod-local rank in multi-port deployments.
+	RankIndex int
 }
 
 // String returns a string representation of the endpoint.
@@ -59,7 +62,17 @@ func (epm *EndpointMetadata) Clone() *EndpointMetadata {
 		Port:        epm.Port,
 		MetricsHost: epm.MetricsHost,
 		Labels:      clonedLabels,
+		RankIndex:   epm.RankIndex,
 	}
+}
+
+// GetRankIndex returns the rank index of this endpoint within the pool's
+// TargetPorts list.
+func (epm *EndpointMetadata) GetRankIndex() int {
+	if epm == nil {
+		return 0
+	}
+	return epm.RankIndex
 }
 
 // GetNamespacedName gets the namespace name of the Endpoint.

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -654,7 +654,12 @@ func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetad
 		return nil
 	}
 	endpointKey := meta.NamespacedName.String()
-	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, s.kvEventsConfig.PodDiscoveryConfig.SocketPort)
+	// Mirror vLLM's `offset_endpoint_port` rule: rank N binds at
+	// SocketPort + N. For single-rank pods (RankIndex=0) this collapses to
+	// the legacy single-port-per-pod behaviour; multi-rank wide-EP / DP
+	// pods get one subscriber per rank automatically.
+	port := s.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.RankIndex
+	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
 
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 	if err := s.subscribersManager.EnsureSubscriber(s.subscriberCtx, endpointKey,

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -658,7 +658,7 @@ func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetad
 	// SocketPort + N. For single-rank pods (RankIndex=0) this collapses to
 	// the legacy single-port-per-pod behaviour; multi-rank wide-EP / DP
 	// pods get one subscriber per rank automatically.
-	port := s.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.RankIndex
+	port := s.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
 	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
 
 	logger := log.FromContext(ctx).WithName(s.typedName.String())

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -233,6 +233,75 @@ func TestScorer_LegacyInScoreDiscovery_DiscoverPodsDisabled(t *testing.T) {
 	assert.Empty(t, ids)
 }
 
+// In wide-EP / data-parallel deployments vLLM binds one ZMQ PUB socket per
+// DP rank at SocketPort + dp_rank (see offset_endpoint_port in
+// vllm/distributed/kv_events.py). The scorer mirrors that rule so multiple
+// ranks sharing a pod IP land on distinct subscribers instead of colliding
+// on the base SocketPort.
+func TestScorer_ExtractEndpoint_OffsetsZMQPortByRankIndex(t *testing.T) {
+	ctx := discardCtx(t)
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	endpoints := []struct {
+		name    string
+		address string
+		rank    int
+		wantZMQ string
+	}{
+		{name: "pod-a-rank-0", address: "10.0.0.1", rank: 0, wantZMQ: "tcp://10.0.0.1:5557"},
+		{name: "pod-a-rank-1", address: "10.0.0.1", rank: 1, wantZMQ: "tcp://10.0.0.1:5558"},
+		{name: "pod-a-rank-2", address: "10.0.0.1", rank: 2, wantZMQ: "tcp://10.0.0.1:5559"},
+	}
+
+	for _, ep := range endpoints {
+		require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+			Type: fwkdl.EventAddOrUpdate,
+			Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+				NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: ep.name},
+				Address:        ep.address,
+				Port:           "8080",
+				RankIndex:      ep.rank,
+			}, nil),
+		}))
+	}
+
+	ids, zmqEndpoints := s.subscribersManager.GetActiveSubscribers()
+	gotByID := make(map[string]string, len(ids))
+	for i, id := range ids {
+		gotByID[id] = zmqEndpoints[i]
+	}
+	for _, ep := range endpoints {
+		key := "ns/" + ep.name
+		assert.Equal(t, ep.wantZMQ, gotByID[key],
+			"rank %d must subscribe at SocketPort + rank", ep.rank)
+	}
+}
+
+// Single-rank pods (the legacy precise-prefix-cache-aware deployment shape)
+// carry RankIndex=0 and must dial the base SocketPort unchanged. This is the
+// backwards-compatibility guard that lets existing one-port-per-pod
+// deployments keep working without any operator-side change.
+func TestScorer_ExtractEndpoint_SingleRankUsesBaseSocketPort(t *testing.T) {
+	ctx := discardCtx(t)
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(ctx)
+
+	require.NoError(t, s.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type: fwkdl.EventAddOrUpdate,
+		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+			Address:        "10.0.0.1",
+			Port:           "8080",
+			// RankIndex stays at its zero value.
+		}, nil),
+	}))
+
+	_, zmqEndpoints := s.subscribersManager.GetActiveSubscribers()
+	assert.Equal(t, []string{"tcp://10.0.0.1:5557"}, zmqEndpoints,
+		"single-rank pod (RankIndex=0) must dial the base SocketPort")
+}
+
 // Delete events from the data layer may omit address fields. The subscriber
 // is keyed by NamespacedName, so delete must succeed regardless of address
 // presence — otherwise stale subscribers leak when pods disappear.

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -194,6 +194,7 @@ func (r *flowControlRequest) ID() string {
 }
 func (r *flowControlRequest) InitialEffectiveTTL() time.Duration { return 0 } // Use controller default.
 func (r *flowControlRequest) ByteSize() uint64                   { return r.requestByteSize }
+
 func (r *flowControlRequest) InferenceRequest() *scheduling.InferenceRequest {
 	return r.inferenceRequest
 }
@@ -207,6 +208,7 @@ func (r *flowControlRequest) TargetModelName() string {
 	}
 	return r.inferenceRequest.TargetModel
 }
+
 func (r *flowControlRequest) FlowKey() flowcontrol.FlowKey {
 	return flowcontrol.FlowKey{ID: r.fairnessID, Priority: r.priority}
 }


### PR DESCRIPTION
## Summary

Carry the rank index through endpoint metadata so multi-port pod deployments (one `TargetPort` per rank) can be distinguished downstream.

- `EndpointMetadata.RankIndex` = position in `pool.TargetPorts`, populated in the datastore.
- `precise-prefix-cache-scorer` consumes it: KV-events ZMQ subscriber now dials `SocketPort + RankIndex`, matching vLLM's [`offset_endpoint_port`](https://github.com/vllm-project/vllm/blob/main/vllm/distributed/kv_events.py) (`base + dp_rank`).
- Single-rank pods (`RankIndex=0`) hit the base port unchanged — no operator-side change required.

## Test plan

- [x] Unit: `go test ./...` green, `go vet` clean.
- [x] Cluster: 1 pod, DP=2, TP=2. EPP logs show two subscribers at distinct ports against the same pod IP:

  ```
  Ensured KV-events subscriber  endpoint=.../-rank-0  zmq=tcp://10.129.7.198:5556
  Ensured KV-events subscriber  endpoint=.../-rank-1  zmq=tcp://10.129.7.198:5557
  ```

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
