### PR TITLE
[1/3] feat(precise-scorer): switch to absolute matched/total normalization

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -749,8 +749,23 @@ func (s *Scorer) getBlockSizeTokens() int {
 	return s.blockSizeTokens
 }
 
+// scoreBlockKeys computes per-pod scores from precomputed block keys, avoiding
+// re-tokenization in the legacy prompt/chat fallback paths. Empty input
+// returns an empty score map.
+func (s *Scorer) scoreBlockKeys(ctx context.Context, blockKeys []kvblock.BlockHash) (map[string]float64, error) {
+	if len(blockKeys) == 0 {
+		return map[string]float64{}, nil
+	}
+	keyToPods, err := s.kvCacheIndexer.KVBlockIndex().Lookup(ctx, blockKeys, nil)
+	if err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+	return s.kvBlockScorer.Score(ctx, blockKeys, keyToPods)
+}
+
 // getScores returns (scores, totalBlocks). Tokens path uses ScoreTokens;
-// prompt/chat fallback adds a ComputeBlockKeys to get totalBlocks.
+// prompt/chat fallback uses ComputeBlockKeys + scoreBlockKeys (single
+// tokenization).
 func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, request *scheduling.InferenceRequest) (map[string]float64, int, error) {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 	traceLogger := logger.V(logging.TRACE)
@@ -798,7 +813,6 @@ func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, reques
 			"toolsCount", len(renderReq.Tools),
 			"documentsCount", len(renderReq.Documents))
 
-		// Re-tokenizes alongside GetPodScores; acceptable in this legacy path.
 		//nolint:staticcheck // SA1019: legacy path retained for tokenizersPoolConfig configs.
 		blockKeys, err := s.kvCacheIndexer.ComputeBlockKeys(ctx, renderReq, "", request.TargetModel)
 		if err != nil {
@@ -807,14 +821,9 @@ func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, reques
 			}
 			return nil, 0, fmt.Errorf("failed to compute block keys for chat/completions: %w", err)
 		}
-
-		//nolint:staticcheck // SA1019: legacy path retained for tokenizersPoolConfig configs.
-		scores, err := s.kvCacheIndexer.GetPodScores(ctx, renderReq, "", request.TargetModel, nil)
+		scores, err := s.scoreBlockKeys(ctx, blockKeys)
 		if err != nil {
-			if errors.Is(err, kvcache.ErrInternalTokenizationDisabled) {
-				return map[string]float64{}, 0, nil
-			}
-			return nil, 0, fmt.Errorf("failed to get endpoint scores for chat/completions: %w", err)
+			return nil, 0, fmt.Errorf("failed to score block keys for chat/completions: %w", err)
 		}
 		return scores, len(blockKeys), nil
 	}
@@ -832,13 +841,9 @@ func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, reques
 			}
 			return nil, 0, fmt.Errorf("failed to compute block keys for completions: %w", err)
 		}
-		//nolint:staticcheck // SA1019: legacy path retained for tokenizersPoolConfig configs.
-		scores, err := s.kvCacheIndexer.GetPodScores(ctx, nil, prompt, request.TargetModel, nil)
+		scores, err := s.scoreBlockKeys(ctx, blockKeys)
 		if err != nil {
-			if errors.Is(err, kvcache.ErrInternalTokenizationDisabled) {
-				return map[string]float64{}, 0, nil
-			}
-			return nil, 0, fmt.Errorf("failed to get endpoint scores for completions: %w", err)
+			return nil, 0, fmt.Errorf("failed to score block keys for completions: %w", err)
 		}
 		return scores, len(blockKeys), nil
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -407,11 +407,8 @@ func (s *Scorer) Produce(ctx context.Context,
 
 // --- Scorer implementation ---
 
-// Score scores the provided endpoint based on the KVCache index state.
-// The returned scores are normalized to a range of 0-1.
-// If Produce was called beforehand, Score reuses the pre-computed
-// results from PluginState. Otherwise, it falls back to computing scores
-// directly via getScores (backward compatible).
+// Score returns score/totalBlocks per endpoint, clipped to [0, 1]. Reuses
+// Produce's cached blockKeys/scores when present; otherwise calls getScores.
 func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
 	// Start tracing span for scoring operation
 	tracer := telemetry.Tracer()
@@ -452,23 +449,27 @@ func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, r
 		span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
 	}
 
-	// Try to reuse pre-computed scores from Produce
+	// Try to reuse pre-computed scores from Produce. The cached blockKeys
+	// slice IS the request's block list, so its length is exactly the
+	// totalBlocks denominator the absolute normalizer needs.
 	var scores map[string]float64
+	var totalBlocks int
 	if pluginStateData, err := plugin.ReadPluginStateKey[*precisePluginState](
 		s.pluginState, request.RequestID, stateKey); err == nil {
 		scores = pluginStateData.scores
-		debugLogger.Info("Reusing pre-computed scores from Produce")
+		totalBlocks = len(pluginStateData.blockKeys)
+		debugLogger.Info("Reusing pre-computed scores from Produce", "totalBlocks", totalBlocks)
 	} else {
 		// Fallback: compute scores directly (backward compatible path).
 		var scoreErr error
-		scores, scoreErr = s.getScores(ctx, cycleState, request)
+		scores, totalBlocks, scoreErr = s.getScores(ctx, cycleState, request)
 		if scoreErr != nil {
 			logger.Error(scoreErr, "Failed to get endpoint scores")
 			span.SetStatus(codes.Error, scoreErr.Error())
 			return nil
 		}
 	}
-	debugLogger.Info("Got endpoint scores", "scores", scores)
+	debugLogger.Info("Got endpoint scores", "scores", scores, "totalBlocks", totalBlocks)
 
 	// Track scoring statistics
 	span.SetAttributes(
@@ -497,7 +498,7 @@ func (s *Scorer) Score(ctx context.Context, cycleState *scheduling.CycleState, r
 		endpoint.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(matchBlocks, 1, 1))
 	}
 
-	normalizedScores := indexedScoresToNormalizedScoredPods(endpoints, endpointToKey, scores)
+	normalizedScores := absoluteScoredPods(endpoints, endpointToKey, scores, totalBlocks)
 
 	// Calculate score distribution for observability
 	if len(normalizedScores) > 0 {
@@ -748,13 +749,9 @@ func (s *Scorer) getBlockSizeTokens() int {
 	return s.blockSizeTokens
 }
 
-// getScores retrieves the endpoint scores from the KV-cache indexer
-// based on the provided LLM request.
-// If tokenized prompt data is found on the request (written by the tokenizer
-// DataProducer plugin), it calls ScoreTokens directly, bypassing
-// prompt/chat tokenization. Otherwise, chat completions and regular
-// completions are tokenized internally by the kvcache indexer.
-func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, request *scheduling.InferenceRequest) (map[string]float64, error) {
+// getScores returns (scores, totalBlocks). Tokens path uses ScoreTokens;
+// prompt/chat fallback adds a ComputeBlockKeys to get totalBlocks.
+func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, request *scheduling.InferenceRequest) (map[string]float64, int, error) {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 	traceLogger := logger.V(logging.TRACE)
 
@@ -776,9 +773,14 @@ func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, reques
 
 			scores, err := s.kvCacheIndexer.ScoreTokens(ctx, tp.TokenIDs, request.TargetModel, nil, extraFeatures)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get endpoint scores for tokens: %w", err)
+				return nil, 0, fmt.Errorf("failed to get endpoint scores for tokens: %w", err)
 			}
-			return scores, nil
+			// floor(tokens/blockSize) — trailing partial block is dropped.
+			totalBlocks := 0
+			if s.blockSizeTokens > 0 {
+				totalBlocks = len(tp.TokenIDs) / s.blockSizeTokens
+			}
+			return scores, totalBlocks, nil
 		}
 	}
 
@@ -796,32 +798,50 @@ func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, reques
 			"toolsCount", len(renderReq.Tools),
 			"documentsCount", len(renderReq.Documents))
 
+		// Re-tokenizes alongside GetPodScores; acceptable in this legacy path.
+		//nolint:staticcheck // SA1019: legacy path retained for tokenizersPoolConfig configs.
+		blockKeys, err := s.kvCacheIndexer.ComputeBlockKeys(ctx, renderReq, "", request.TargetModel)
+		if err != nil {
+			if errors.Is(err, kvcache.ErrInternalTokenizationDisabled) {
+				return map[string]float64{}, 0, nil
+			}
+			return nil, 0, fmt.Errorf("failed to compute block keys for chat/completions: %w", err)
+		}
+
 		//nolint:staticcheck // SA1019: legacy path retained for tokenizersPoolConfig configs.
 		scores, err := s.kvCacheIndexer.GetPodScores(ctx, renderReq, "", request.TargetModel, nil)
 		if err != nil {
 			if errors.Is(err, kvcache.ErrInternalTokenizationDisabled) {
-				return map[string]float64{}, nil
+				return map[string]float64{}, 0, nil
 			}
-			return nil, fmt.Errorf("failed to get endpoint scores for chat/completions: %w", err)
+			return nil, 0, fmt.Errorf("failed to get endpoint scores for chat/completions: %w", err)
 		}
-		return scores, nil
+		return scores, len(blockKeys), nil
 	}
 
-	// For regular completions, use the prompt directly
+	// For regular completions, use the prompt directly.
 	if request.Body != nil && request.Body.Completions != nil {
 		prompt := request.Body.Completions.Prompt.Raw
 		traceLogger.Info("Using completion prompt directly", "promptLength", len(prompt))
 
 		//nolint:staticcheck // SA1019: legacy path retained for tokenizersPoolConfig configs.
+		blockKeys, err := s.kvCacheIndexer.ComputeBlockKeys(ctx, nil, prompt, request.TargetModel)
+		if err != nil {
+			if errors.Is(err, kvcache.ErrInternalTokenizationDisabled) {
+				return map[string]float64{}, 0, nil
+			}
+			return nil, 0, fmt.Errorf("failed to compute block keys for completions: %w", err)
+		}
+		//nolint:staticcheck // SA1019: legacy path retained for tokenizersPoolConfig configs.
 		scores, err := s.kvCacheIndexer.GetPodScores(ctx, nil, prompt, request.TargetModel, nil)
 		if err != nil {
 			if errors.Is(err, kvcache.ErrInternalTokenizationDisabled) {
-				return map[string]float64{}, nil
+				return map[string]float64{}, 0, nil
 			}
-			return nil, fmt.Errorf("failed to get endpoint scores for completions: %w", err)
+			return nil, 0, fmt.Errorf("failed to get endpoint scores for completions: %w", err)
 		}
-		return scores, nil
+		return scores, len(blockKeys), nil
 	}
 
-	return nil, errors.New("no valid input found in request")
+	return nil, 0, errors.New("no valid input found in request")
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_uds_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_uds_test.go
@@ -3,11 +3,11 @@ package preciseprefixcache
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
@@ -39,8 +39,14 @@ func createUDSTokenizer(t *testing.T, model string) *tokenization.UdsTokenizer {
 	return udsTokenizer
 }
 
-// TestPrefixCacheTracking_Score_UDS tests the prefix cache scoring with UDS tokenizer.
-// This test requires a running UDS tokenizer sidecar.
+// TestPrefixCacheTracking_Score_UDS exercises the full precise scorer end-to-end
+// against a real UDS tokenizer: tokenize a prompt, populate the kvblock.Index
+// with synthetic per-pod cache entries, then verify Score() emits absolute
+// `matched_blocks / total_blocks` per pod. Skipped without a UDS socket.
+//
+// Per-subcase expected values are computed dynamically from the matched chunk
+// counts and the actual chunk count produced by the tokenizer, so the test
+// stays correct if tokenization output changes.
 func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 	skipIfNoUDSTokenizer(t)
 
@@ -49,12 +55,18 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 		"He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, " +
 		"slightly domed and divided by arches into stiff sections."
 
+	// kvBlockData populates the index for the request and reports the total
+	// chunk count, which is the absolute-normalization denominator.
+	type populateFn func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) (
+		blockData map[kvblock.BlockHash][]kvblock.PodEntry, totalChunks int)
+
 	testcases := []struct {
-		name                string
-		endpoints           []scheduling.Endpoint
-		request             *scheduling.InferenceRequest
-		kvBlockData         func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) map[kvblock.BlockHash][]kvblock.PodEntry
-		wantScoresByAddress map[string]float64
+		name        string
+		endpoints   []scheduling.Endpoint
+		request     *scheduling.InferenceRequest
+		populate    populateFn
+		wantEmpty   bool           // Score returned no entries (nil or empty body)
+		wantMatched map[string]int // matched chunks per pod under longest-prefix; expected = matched / totalChunks
 	}{
 		{
 			name: "nil request",
@@ -64,12 +76,10 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 			},
-			wantScoresByAddress: map[string]float64{}, // empty map
+			wantEmpty: true,
 		},
 		{
 			name: "empty request body",
@@ -79,9 +89,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 			},
 			request: &scheduling.InferenceRequest{
@@ -89,7 +97,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				TargetModel: "test-model",
 				Body:        nil,
 			},
-			wantScoresByAddress: map[string]float64{}, // empty map
+			wantEmpty: true,
 		},
 		{
 			name: "longest prefix scorer (default scorer)",
@@ -99,33 +107,21 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 0,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 0}, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
 						Address:        "10.0.0.2",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 1,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 1}, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-c"},
 						Address:        "10.0.0.3",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 2,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 2}, nil,
 				),
 			},
 			request: &scheduling.InferenceRequest{
@@ -137,13 +133,13 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					},
 				},
 			},
-			kvBlockData: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) map[kvblock.BlockHash][]kvblock.PodEntry {
+			populate: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) (
+				map[kvblock.BlockHash][]kvblock.PodEntry, int) {
 				require.NotNil(t, req.Completions, "req expected to use Completions API")
 
 				udsTokenizer := createUDSTokenizer(t, model)
 				defer func() {
-					err := udsTokenizer.Close()
-					require.NoError(t, err)
+					require.NoError(t, udsTokenizer.Close())
 				}()
 
 				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.Raw)
@@ -153,7 +149,6 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				require.NoError(t, err)
 				chunkKeys, err := tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, model, nil)
 				require.NoError(t, err)
-
 				require.GreaterOrEqual(t, len(chunkKeys), 3, "Need at least 3 chunks for test")
 
 				return map[kvblock.BlockHash][]kvblock.PodEntry{
@@ -169,12 +164,14 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					chunkKeys[2]: {
 						{PodIdentifier: "10.0.0.1:8080"},
 					},
-				}
+				}, len(chunkKeys)
 			},
-			wantScoresByAddress: map[string]float64{
-				"10.0.0.1:8080": 1.0, // 3 chunks -> (3-1)/(3-1) = 1.0
-				"10.0.0.2:8080": 0.5, // 2 chunks -> (2-1)/(3-1) = 0.5
-				"10.0.0.3:8080": 0.0, // 1 chunk -> (1-1)/(3-1) = 0.0
+			// pod-a has all 3 leading chunks; pod-b 2; pod-c 1. Absolute norm
+			// scales each by 1/totalChunks (computed at assert time).
+			wantMatched: map[string]int{
+				"10.0.0.1:8080": 3,
+				"10.0.0.2:8080": 2,
+				"10.0.0.3:8080": 1,
 			},
 		},
 		{
@@ -185,22 +182,14 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 0,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 0}, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
 						Address:        "10.0.0.2",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 1,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 1}, nil,
 				),
 			},
 			request: &scheduling.InferenceRequest{
@@ -211,26 +200,17 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						ChatTemplate: `{% for message in messages %}{{ message.role }}: {{ message.content }}
 		{% endfor %}`,
 						Messages: []fwkrh.Message{
-							{
-								Role:    "user",
-								Content: fwkrh.Content{Raw: "Hello, how are you?"},
-							},
-							{
-								Role:    "assistant",
-								Content: fwkrh.Content{Raw: "I'm doing well, thank you for asking!"},
-							},
-							{
-								Role:    "user",
-								Content: fwkrh.Content{Raw: "Can you help me with a question about prefix caching in LLM inference?"},
-							},
+							{Role: "user", Content: fwkrh.Content{Raw: "Hello, how are you?"}},
+							{Role: "assistant", Content: fwkrh.Content{Raw: "I'm doing well, thank you for asking!"}},
+							{Role: "user", Content: fwkrh.Content{Raw: "Can you help me with a question about prefix caching in LLM inference?"}},
 						},
 					},
 				},
 			},
-			kvBlockData: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) map[kvblock.BlockHash][]kvblock.PodEntry {
+			populate: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) (
+				map[kvblock.BlockHash][]kvblock.PodEntry, int) {
 				require.NotNil(t, req.ChatCompletions, "req expected to use ChatCompletions API")
 
-				// convert to types format
 				conversations := make([]types.Conversation, 0, len(req.ChatCompletions.Messages))
 				for _, msg := range req.ChatCompletions.Messages {
 					conversations = append(conversations, types.Conversation{
@@ -241,11 +221,9 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 
 				udsTokenizer := createUDSTokenizer(t, model)
 				defer func() {
-					err := udsTokenizer.Close()
-					require.NoError(t, err)
+					require.NoError(t, udsTokenizer.Close())
 				}()
 
-				// render the chat template using UDS tokenizer
 				renderReq := &types.RenderChatRequest{
 					Conversation: conversations,
 					ChatTemplate: req.ChatCompletions.ChatTemplate,
@@ -257,10 +235,8 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				require.NoError(t, err)
 				chunkKeys, err := tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, model, nil)
 				require.NoError(t, err)
-
 				require.GreaterOrEqual(t, len(chunkKeys), 2, "Need at least 2 chunks for test")
 
-				// pod-a has both chunks, pod-b has only the first
 				return map[kvblock.BlockHash][]kvblock.PodEntry{
 					chunkKeys[0]: {
 						{PodIdentifier: "10.0.0.1:8080"},
@@ -269,11 +245,11 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					chunkKeys[1]: {
 						{PodIdentifier: "10.0.0.1:8080"},
 					},
-				}
+				}, len(chunkKeys)
 			},
-			wantScoresByAddress: map[string]float64{
-				"10.0.0.1:8080": 1.0, // 2 chunks -> (2-1)/(2-1) = 1.0
-				"10.0.0.2:8080": 0.0, // 1 chunk -> (1-1)/(2-1) = 0.0
+			wantMatched: map[string]int{
+				"10.0.0.1:8080": 2,
+				"10.0.0.2:8080": 1,
 			},
 		},
 		{
@@ -284,33 +260,21 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 0,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 0}, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
 						Address:        "10.0.0.2",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 1,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 1}, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-c"},
 						Address:        "10.0.0.3",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 2,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 2}, nil,
 				),
 			},
 			request: &scheduling.InferenceRequest{
@@ -322,13 +286,13 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					},
 				},
 			},
-			kvBlockData: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) map[kvblock.BlockHash][]kvblock.PodEntry {
+			populate: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) (
+				map[kvblock.BlockHash][]kvblock.PodEntry, int) {
 				require.NotNil(t, req.Completions, "req expected to use Completions API")
 
 				udsTokenizer := createUDSTokenizer(t, model)
 				defer func() {
-					err := udsTokenizer.Close()
-					require.NoError(t, err)
+					require.NoError(t, udsTokenizer.Close())
 				}()
 
 				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.Raw)
@@ -338,13 +302,14 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				require.NoError(t, err)
 				chunkKeys, err := tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, model, nil)
 				require.NoError(t, err)
-
 				require.GreaterOrEqual(t, len(chunkKeys), 3, "Need at least 3 chunks for test")
 
-				// Test partial prefix cache scenario:
-				// - chunk0: all endpoints (common prefix start)
-				// - chunk1: only pod-a (creates a gap for pod-b and pod-c)
-				// - chunk2: pod-a and pod-b (pod-b has this but missing chunk1)
+				// Partial-prefix scenario:
+				//   chunk0: all three pods
+				//   chunk1: only pod-a (gap for pod-b and pod-c)
+				//   chunk2: pod-a and pod-b (pod-b has it but is missing chunk1)
+				// Longest contiguous prefix:
+				//   pod-a: 3, pod-b: 1 (stops at gap), pod-c: 1
 				return map[kvblock.BlockHash][]kvblock.PodEntry{
 					chunkKeys[0]: {
 						{PodIdentifier: "10.0.0.1:8080"},
@@ -352,21 +317,18 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						{PodIdentifier: "10.0.0.3:8080"},
 					},
 					chunkKeys[1]: {
-						{PodIdentifier: "10.0.0.1:8080"}, // only pod-a has chunk1
+						{PodIdentifier: "10.0.0.1:8080"},
 					},
 					chunkKeys[2]: {
 						{PodIdentifier: "10.0.0.1:8080"},
-						{PodIdentifier: "10.0.0.2:8080"}, // pod-b has chunk2 but missing chunk1
+						{PodIdentifier: "10.0.0.2:8080"},
 					},
-				}
+				}, len(chunkKeys)
 			},
-			wantScoresByAddress: map[string]float64{
-				// pod-a: 3 chunks contiguously -> (3-1)/(3-1) = 1.0
-				// pod-b: prefix breaks at chunk1 (has 0,2 but not 1) -> only 1 chunk counted -> (1-1)/(3-1) = 0.0
-				// pod-c: only chunk 0 -> (1-1)/(3-1) = 0.0
-				"10.0.0.1:8080": 1.0,
-				"10.0.0.2:8080": 0.0,
-				"10.0.0.3:8080": 0.0,
+			wantMatched: map[string]int{
+				"10.0.0.1:8080": 3,
+				"10.0.0.2:8080": 1,
+				"10.0.0.3:8080": 1,
 			},
 		},
 		{
@@ -377,11 +339,7 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					&fwkdl.Metrics{
-						WaitingQueueSize: 0,
-					},
-					nil,
+					}, &fwkdl.Metrics{WaitingQueueSize: 0}, nil,
 				),
 			},
 			request: &scheduling.InferenceRequest{
@@ -393,13 +351,13 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					},
 				},
 			},
-			kvBlockData: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) map[kvblock.BlockHash][]kvblock.PodEntry {
+			populate: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) (
+				map[kvblock.BlockHash][]kvblock.PodEntry, int) {
 				require.NotNil(t, req.Completions, "req expected to use Completions API")
 
 				udsTokenizer := createUDSTokenizer(t, model)
 				defer func() {
-					err := udsTokenizer.Close()
-					require.NoError(t, err)
+					require.NoError(t, udsTokenizer.Close())
 				}()
 
 				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.Raw)
@@ -409,22 +367,19 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				require.NoError(t, err)
 				chunkKeys, err := tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, model, nil)
 				require.NoError(t, err)
-
 				require.GreaterOrEqual(t, len(chunkKeys), 2, "Need at least 2 chunks for test")
 
-				// Single endpoint has 2 chunks cached
+				// pod-a has the leading 2 chunks cached.
 				return map[kvblock.BlockHash][]kvblock.PodEntry{
-					chunkKeys[0]: {
-						{PodIdentifier: "10.0.0.1:8080"},
-					},
-					chunkKeys[1]: {
-						{PodIdentifier: "10.0.0.1:8080"},
-					},
-				}
+					chunkKeys[0]: {{PodIdentifier: "10.0.0.1:8080"}},
+					chunkKeys[1]: {{PodIdentifier: "10.0.0.1:8080"}},
+				}, len(chunkKeys)
 			},
-			wantScoresByAddress: map[string]float64{
-				// with only one endpoint, minScore == maxScore, so normalization returns 1.0
-				"10.0.0.1:8080": 1.0,
+			// Note: under absolute normalization, a single endpoint with 2/N
+			// matched chunks scores 2/N — not 1.0 (the previous min-max default
+			// when min==max).
+			wantMatched: map[string]int{
+				"10.0.0.1:8080": 2,
 			},
 		},
 		{
@@ -435,27 +390,21 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
 						Address:        "10.0.0.2",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-c"},
 						Address:        "10.0.0.3",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 			},
 			request: &scheduling.InferenceRequest{
@@ -467,12 +416,12 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					},
 				},
 			},
-			kvBlockData: nil, // no cached data
-			wantScoresByAddress: map[string]float64{
-				// when no endpoints have any cache hits, all should get equal scores (0.0)
-				"10.0.0.1:8080": 0.0,
-				"10.0.0.2:8080": 0.0,
-				"10.0.0.3:8080": 0.0,
+			// nil populate: no kvBlockData written, all pods score 0.0 under
+			// absolute normalization (cold-cluster behavior).
+			wantMatched: map[string]int{
+				"10.0.0.1:8080": 0,
+				"10.0.0.2:8080": 0,
+				"10.0.0.3:8080": 0,
 			},
 		},
 		{
@@ -483,27 +432,21 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
 						Address:        "10.0.0.1",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
 						Address:        "10.0.0.2",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 				scheduling.NewEndpoint(
 					&fwkdl.EndpointMetadata{
 						NamespacedName: k8stypes.NamespacedName{Name: "pod-c"},
 						Address:        "10.0.0.3",
 						Port:           "8080",
-					},
-					nil,
-					nil,
+					}, nil, nil,
 				),
 			},
 			request: &scheduling.InferenceRequest{
@@ -515,13 +458,13 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 					},
 				},
 			},
-			kvBlockData: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) map[kvblock.BlockHash][]kvblock.PodEntry {
+			populate: func(t *testing.T, req *fwkrh.InferenceRequestBody, model string) (
+				map[kvblock.BlockHash][]kvblock.PodEntry, int) {
 				require.NotNil(t, req.Completions, "req expected to use Completions API")
 
 				udsTokenizer := createUDSTokenizer(t, model)
 				defer func() {
-					err := udsTokenizer.Close()
-					require.NoError(t, err)
+					require.NoError(t, udsTokenizer.Close())
 				}()
 
 				tokens, _, err := udsTokenizer.Render(req.Completions.Prompt.Raw)
@@ -531,10 +474,8 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 				require.NoError(t, err)
 				chunkKeys, err := tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, model, nil)
 				require.NoError(t, err)
-
 				require.GreaterOrEqual(t, len(chunkKeys), 2, "Need at least 2 chunks for test")
 
-				// all endpoints have the same 2 chunks cached
 				return map[kvblock.BlockHash][]kvblock.PodEntry{
 					chunkKeys[0]: {
 						{PodIdentifier: "10.0.0.1:8080"},
@@ -546,14 +487,15 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 						{PodIdentifier: "10.0.0.2:8080"},
 						{PodIdentifier: "10.0.0.3:8080"},
 					},
-				}
+				}, len(chunkKeys)
 			},
-			wantScoresByAddress: map[string]float64{
-				// when all endpoints have equal cache (minScore == maxScore), the implementation
-				// returns 1.0 for all endpoints to avoid division by zero
-				"10.0.0.1:8080": 1.0,
-				"10.0.0.2:8080": 1.0,
-				"10.0.0.3:8080": 1.0,
+			// Note: under absolute normalization, all-equal coverage no longer
+			// returns 1.0 for everyone (the prior min==max default). It returns
+			// 2/N for everyone — the actual coverage fraction.
+			wantMatched: map[string]int{
+				"10.0.0.1:8080": 2,
+				"10.0.0.2:8080": 2,
+				"10.0.0.3:8080": 2,
 			},
 		},
 	}
@@ -564,7 +506,6 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 
 			kvcacheConfig, err := kvcache.NewDefaultConfig()
 			require.NoError(t, err)
-
 			// Configure UDS tokenizer
 			//nolint:staticcheck // SA1019: exercising the legacy in-indexer tokenization path.
 			kvcacheConfig.TokenizersPoolConfig = &tokenization.Config{
@@ -582,13 +523,17 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, prefixCacheScorer)
 
-			// populate the kvblock.Index with test data
-			if tt.kvBlockData != nil && tt.request != nil && tt.request.Body != nil {
+			// Populate the index and capture the chunk count for absolute-norm
+			// expected-value computation.
+			totalChunks := 0
+			if tt.populate != nil && tt.request != nil && tt.request.Body != nil {
 				kvBlockIndex := prefixCacheScorer.kvCacheIndexer.KVBlockIndex()
-				blockData := tt.kvBlockData(t, tt.request.Body, tt.request.TargetModel)
+				blockData, n := tt.populate(t, tt.request.Body, tt.request.TargetModel)
+				totalChunks = n
 				for key, entries := range blockData {
-					err := kvBlockIndex.Add(ctx, []kvblock.BlockHash{kvblock.EmptyBlockHash}, []kvblock.BlockHash{key}, entries)
-					require.NoError(t, err)
+					require.NoError(t, kvBlockIndex.Add(ctx,
+						[]kvblock.BlockHash{kvblock.EmptyBlockHash},
+						[]kvblock.BlockHash{key}, entries))
 				}
 			}
 
@@ -596,14 +541,38 @@ func TestPrefixCacheTracking_Score_UDS(t *testing.T) {
 
 			gotByAddress := make(map[string]float64)
 			for endpoint, score := range got {
-				if endpoint.GetMetadata() != nil {
-					m := endpoint.GetMetadata()
+				if m := endpoint.GetMetadata(); m != nil {
 					gotByAddress[fmt.Sprintf("%s:%s", m.Address, m.Port)] = score
 				}
 			}
 
-			if diff := cmp.Diff(tt.wantScoresByAddress, gotByAddress); diff != "" {
-				t.Errorf("Unexpected output (-want +got): %v", diff)
+			if tt.wantEmpty {
+				require.Empty(t, gotByAddress, "expected Score to return no entries")
+				return
+			}
+
+			// Build expected = matched / totalChunks (absolute normalization).
+			// totalChunks==0 means cold cluster — every pod scores 0.0.
+			wantByAddress := make(map[string]float64, len(tt.wantMatched))
+			for _, ep := range tt.endpoints {
+				m := ep.GetMetadata()
+				addr := fmt.Sprintf("%s:%s", m.Address, m.Port)
+				matched := tt.wantMatched[addr]
+				if totalChunks <= 0 || matched <= 0 {
+					wantByAddress[addr] = 0.0
+					continue
+				}
+				wantByAddress[addr] = float64(matched) / float64(totalChunks)
+			}
+
+			require.Equal(t, len(wantByAddress), len(gotByAddress),
+				"unexpected number of scored endpoints: want %v, got %v", wantByAddress, gotByAddress)
+			for addr, want := range wantByAddress {
+				got, ok := gotByAddress[addr]
+				require.True(t, ok, "no score for endpoint %s", addr)
+				require.Lessf(t, math.Abs(want-got), 1e-9,
+					"absolute-norm score mismatch for %s: want %f, got %f (totalChunks=%d, matched=%d)",
+					addr, want, got, totalChunks, tt.wantMatched[addr])
 			}
 		})
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/utils.go
@@ -2,7 +2,6 @@ package preciseprefixcache
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -10,37 +9,37 @@ import (
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 )
 
-// endpointToKey is a function type that converts a Pod to a string key.
-// It returns the key and a boolean indicating success.
 type endpointToKeyFunc func(endpoint scheduling.Endpoint) (string, bool)
 
-// indexedScoresToNormalizedScoredPods converts a map of pod scores to a map of
-// normalized scores. The function takes a list of pods, a function to convert
-// a pod to a key, and a map of scores indexed by those keys. It returns a map
-// of pods to their normalized scores.
-func indexedScoresToNormalizedScoredPods(endpoints []scheduling.Endpoint, endpointToKey endpointToKeyFunc,
-	scores map[string]float64) map[scheduling.Endpoint]float64 {
-	scoredEndpoints := make(map[scheduling.Endpoint]float64)
-	minScore, maxScore := getMinMax(scores)
+// absoluteScoredPods returns score/totalBlocks per endpoint, clipped to [0, 1].
+// totalBlocks <= 0 → all zeros.
+func absoluteScoredPods(endpoints []scheduling.Endpoint, endpointToKey endpointToKeyFunc,
+	scores map[string]float64, totalBlocks int) map[scheduling.Endpoint]float64 {
+	scoredEndpoints := make(map[scheduling.Endpoint]float64, len(endpoints))
+	if totalBlocks <= 0 {
+		for _, endpoint := range endpoints {
+			scoredEndpoints[endpoint] = 0.0
+		}
+		return scoredEndpoints
+	}
 
+	denom := float64(totalBlocks)
 	for _, endpoint := range endpoints {
 		key, ok := endpointToKey(endpoint)
 		if !ok {
 			continue
 		}
-
-		if score, ok := scores[key]; ok {
-			if minScore == maxScore {
-				scoredEndpoints[endpoint] = 1.0
-				continue
-			}
-
-			scoredEndpoints[endpoint] = (score - minScore) / (maxScore - minScore)
-		} else {
+		raw, ok := scores[key]
+		if !ok || raw <= 0 {
 			scoredEndpoints[endpoint] = 0.0
+			continue
 		}
+		ratio := raw / denom
+		if ratio > 1.0 {
+			ratio = 1.0
+		}
+		scoredEndpoints[endpoint] = ratio
 	}
-
 	return scoredEndpoints
 }
 
@@ -56,20 +55,4 @@ func cleanCachePeriodically[K comparable, V any](ctx context.Context, cache *ttl
 			cache.DeleteExpired()
 		}
 	}
-}
-
-func getMinMax(scores map[string]float64) (float64, float64) {
-	minScore := math.MaxFloat64
-	maxScore := math.Inf(-1)
-
-	for _, score := range scores {
-		if score < minScore {
-			minScore = score
-		}
-		if score > maxScore {
-			maxScore = score
-		}
-	}
-
-	return minScore, maxScore
 }


### PR DESCRIPTION
## Summary

Switch `precise-prefix-cache-scorer` from cross-endpoint min-max normalization to per-endpoint `matchBlocks / totalBlocks`, clipped to `[0, 1]`. Matches the approximate `prefix-cache-scorer` semantics.

## Tests
- [x] `go test -race ./pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/...`
- [x] `golangci-lint run` clean.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The precise-prefix-cache-scorer now emits absolute matched_blocks/total_blocks (clamped to [0,1]) instead of cross-endpoint min-max normalization. If you have tuned the scorer's weight for a specific workload, you may need to re-tune it.
```
