### PR TITLE
[WIP]fix(epp): preallocate request body buffer from Content-Length

### DIFF
--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -209,5 +210,37 @@ func (m *mockDirectorRequest) GetRandomEndpoint() *datalayer.EndpointMetadata {
 	return &datalayer.EndpointMetadata{
 		Address: "1.2.3.4",
 		Port:    "80",
+	}
+}
+
+func TestRequestBodyCapacity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  int
+	}{
+		{name: "valid", value: "1024", want: 1024},
+		{name: "at cap", value: strconv.Itoa(maxRequestBodyPreallocBytes), want: maxRequestBodyPreallocBytes},
+		{name: "above cap clamped", value: strconv.Itoa(maxRequestBodyPreallocBytes + 1), want: maxRequestBodyPreallocBytes},
+		{name: "missing", value: "", want: 0},
+		{name: "malformed", value: "not-a-number", want: 0},
+		{name: "non-positive", value: "0", want: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var headers []*configPb.HeaderValue
+			if tc.value != "" {
+				headers = []*configPb.HeaderValue{{Key: "content-length", Value: tc.value}}
+			}
+			req := &extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{
+					Headers: &configPb.HeaderMap{Headers: headers},
+				},
+			}
+			assert.Equal(t, tc.want, requestBodyCapacity(req))
+		})
 	}
 }

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -164,6 +165,10 @@ type recvResult struct {
 	req *extProcPb.ProcessingRequest
 	err error
 }
+
+// maxRequestBodyPreallocBytes bounds Content-Length-driven body buffer
+// preallocation; sized for long-context (multi-MiB) JSON bodies.
+const maxRequestBodyPreallocBytes = 16 << 20 // 16 MiB
 
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	ctx := srv.Context()
@@ -311,6 +316,11 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			ctx = log.IntoContext(ctx, logger)
 
 			err = s.HandleRequestHeaders(ctx, reqCtx, v)
+			if err == nil && !v.RequestHeaders.EndOfStream {
+				if capacity := requestBodyCapacity(v); capacity > 0 {
+					body = make([]byte, 0, capacity)
+				}
+			}
 		case *extProcPb.ProcessingRequest_RequestBody:
 			loggerTrace.Info("Incoming body chunk", "EoS", v.RequestBody.EndOfStream)
 			// In the stream case, we can receive multiple request bodies.
@@ -442,6 +452,24 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			return nil
 		}
 	}
+}
+
+// requestBodyCapacity returns the body buffer preallocation size from
+// Content-Length, clamped to maxRequestBodyPreallocBytes. Returns 0 for
+// missing, malformed, or non-positive values.
+func requestBodyCapacity(req *extProcPb.ProcessingRequest_RequestHeaders) int {
+	contentLength := envoy.ExtractHeaderValue(req, "content-length")
+	if contentLength == "" {
+		return 0
+	}
+	bodyLength, err := strconv.Atoi(contentLength)
+	if err != nil || bodyLength <= 0 {
+		return 0
+	}
+	if bodyLength > maxRequestBodyPreallocBytes {
+		return maxRequestBodyPreallocBytes
+	}
+	return bodyLength
 }
 
 // finishResponse ensures all post-response logic, such as metric recording


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Large-input TTFT profiling on long-context workloads (~220 KB prompts, c=1200) shows that the EPP request body accumulation in `pkg/epp/handlers/server.go` is the largest single allocation site on the request path:

| hot path | alloc delta |
|---|---:|
| `StreamingServer.Process` | 2.54 GB flat / 5.75 GB cum |
| `body = append(body, v.RequestBody.Body...)` | 2.53 GB flat |

Without any size hint, the body slice doubles in capacity as ext_proc body chunks arrive, generating large amounts of short-lived garbage and pinning extra CPU on `growslice`/`memmove` on the request hot path.

This change uses the `Content-Length` header to preallocate the body buffer at request-headers time when more body chunks are still expected. The preallocation:

- Is bounded by a 1 MiB cap (`maxRequestBodyPreallocBytes`) so a hostile or malformed `Content-Length` cannot force unbounded reservation.
- Is skipped for missing, non-numeric, zero, negative, or oversized values — preserving behavior for chunked requests and requests without a length hint.
- Is only applied when the request-headers message is not already `EndOfStream`, so it does not allocate when there is no body to follow.

The end-to-end response/append path is unchanged; only the initial capacity of the slice that backs `body` is set, so the behavior of the existing `append` loop, `parser.ParseRequest`, and downstream `RawBody` consumers is preserved bit-for-bit.

Includes unit tests for the new `requestBodyCapacity` helper covering: missing header, valid value, case-insensitive lookup, `RawValue` preference, malformed value, zero, negative, value at the cap, and value above the cap.

The same fix was prototyped against the upstream Gateway API Inference Extension request path: https://github.com/yankay/gateway-api-inference-extension/tree/fix/epp-request-body-prealloc.

**Which issue(s) this PR fixes**:

Fixes #1110

Related parent issue: #1109

**Release note**:
```release-note
EPP now preallocates the request body buffer from the `Content-Length` header (capped at 1 MiB) to reduce allocations on the request hot path for long-context prompts.
```

---

## A/B benchmark (stable TTFT gate)

This section records a same-cluster before/after run using `bench/pure-router/stable-1s.sh` from the contributor `bench` branch (not yet on upstream `main`). EPP images were produced by compiling `cmd/epp` locally and packing the binary into a minimal `gcr.io/distroless/static:nonroot` image (`Dockerfile.epp`’s in-cluster `go mod download` timed out without a reachable module proxy), then `kind load docker-image` and `helm upgrade --reuse-values --set inferenceExtension.image.tag=...`.

**Workload:** `CONCURRENCY=1200`, `INPUT_CHARS=220000`, `WARMUP_REQS=300`, `ROUND_REQS=1500`, `ROUNDS=3`, `THRESHOLD_MS=1100` (script reports the median of the three per-round mean TTFTs).

| Variant | Commit | Image tag | Per-round mean TTFT (ms) | Median (ms) |
|:---|:---|:---|---:|---:|
| Baseline | `f6e6e18d` (`origin/main` at run time) | `bench-baseline` | 4314.56, 4598.05, 4394.66 | 4394.66 |
| This PR | `2dbe95b0` | `bench-fix` | 4310.88, 4382.00, 4460.55 | 4382.00 |

**TTFT:** The median improved by ~12.7 ms (~0.29%). Round 2 dropped ~4.7% while round 3 regressed slightly — overall this is **within noise** for a saturated single-replica EPP at c=1200, so **do not treat this as a promised user-visible TTFT reduction**. The optimization still targets real `growslice` / copy pressure when buffering large bodies.

**Alloc sample (this PR image, under load):** `go tool pprof -alloc_space -top` on `/debug/pprof/allocs` still shows `(*StreamingServer).Process` with large cumulative allocation, while the top **flat** bucket is dominated by `encoding/json.(*decodeState).literalStore` and protobuf byte decoding — consistent with JSON parse / framing dominating total `alloc_space` even after `Content-Length`-sized buffering.

