### PR TITLE
[2/3] feat(precise-prefix-cache): add precise-prefix-cache-producer

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -80,6 +80,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter"
 	reqdataprodprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload"
+	preciseproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache"
 	latencyproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
@@ -520,6 +521,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(nohitlru.NoHitLRUType, nohitlru.Factory)
 	fwkplugin.Register(activerequest.ActiveRequestType, activerequest.Factory)
 	fwkplugin.Register(preciseprefixcache.PrecisePrefixCachePluginType, preciseprefixcache.PluginFactory)
+	fwkplugin.Register(preciseproducer.PluginType, preciseproducer.PluginFactory)
 
 	// Flow Control plugins
 	fwkplugin.Register(globalstrict.GlobalStrictFairnessPolicyType, globalstrict.GlobalStrictFairnessPolicyFactory)

--- a/deploy/config/epp-precise-prefix-cache-split-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-split-config.yaml
@@ -1,0 +1,47 @@
+# Sample EPP config: split precise-prefix-cache pipeline
+#   token-producer -> precise-prefix-cache-producer -> prefix-cache-scorer
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: token-producer
+    parameters:
+      modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
+      vllm:
+        http: http://localhost:8000
+  - type: endpoint-notification-source
+  - type: metrics-data-source
+  - type: core-metrics-extractor
+  - type: single-profile-handler
+  - type: decode-filter
+  - type: precise-prefix-cache-producer
+    parameters:
+      tokenProcessorConfig:
+        blockSize: 64
+      indexerConfig:
+        kvBlockIndexConfig:
+          enableMetrics: true       # enable kv-block index metrics (prometheus)
+  - type: prefix-cache-scorer
+    parameters:
+      prefixMatchInfoProducerName: precise-prefix-cache-producer
+  - type: kv-cache-utilization-scorer
+  - type: queue-scorer
+  - type: max-score-picker
+dataLayer:
+  sources:
+    - pluginRef: metrics-data-source
+      extractors:
+        - pluginRef: core-metrics-extractor
+    - pluginRef: endpoint-notification-source
+      extractors:
+        - pluginRef: precise-prefix-cache-producer
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: decode-filter
+      - pluginRef: prefix-cache-scorer
+        weight: 2.0
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 1.0
+      - pluginRef: queue-scorer
+        weight: 1.0
+      - pluginRef: max-score-picker

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -117,6 +117,10 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 			return fmt.Errorf("auto-created default entry %q is not a ProducerPlugin, this is required by datakey: %v, which is consumed by: %v", defaultProducerNameOrType, key, consumerName)
 		}
 		handle.AddPlugin(plg.TypedName().Name, plg)
+		logger.Info("auto-created default producer",
+			"producer", plg.TypedName().String(),
+			"dataKey", key,
+			"consumer", consumerName)
 	}
 
 	return nil

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
@@ -1,0 +1,40 @@
+# Precise Prefix Cache Producer
+
+**Type:** `precise-prefix-cache-producer`
+
+DataProducer that owns the precise KV-block index and publishes
+per-endpoint `PrefixCacheMatchInfo`. Pairs with the generic
+[`prefix-cache-scorer`](../../../scheduling/scorer/prefix/); the scorer
+must reference this producer by name:
+
+```yaml
+- type: prefix-cache-scorer
+  parameters:
+    prefixMatchInfoProducerName: precise-prefix-cache-producer
+```
+
+Without the `prefixMatchInfoProducerName` field, the scorer falls back
+to the auto-spawned approx producer.
+
+Pipeline per request:
+- Consume `TokenizedPrompt` from `token-producer`.
+- Hash tokens → KV-block keys → `kvblock.Index.Lookup`.
+- Write `PrefixCacheMatchInfo(matchBlocks, totalBlocks, blockSizeTokens)` per endpoint.
+- (`PreRequest`) Speculative-index the selected endpoint(s) with TTL eviction.
+- (`EndpointExtractor`) Per-pod ZMQ subscriber lifecycle on add/delete.
+
+Requires `TokenizedPrompt` on the request — set by a `token-producer`
+upstream. No-op otherwise.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tokenProcessorConfig` | object | `kvblock.DefaultTokenProcessorConfig()` | KV-block hashing (must match engine `blockSize`/`hashSeed`). |
+| `indexerConfig` | object | `kvcache.NewDefaultConfig()` | `kvcache.Indexer` config. |
+| `kvEventsConfig` | object | `kvevents.DefaultConfig()` | KV-events pool config. |
+| `speculativeIndexing` | bool | `false` | Seed predicted entries on routing decisions. |
+| `speculativeTTL` | duration | `2s` | TTL for speculative entries. |
+
+See [llm-d-kv-cache/docs/configuration.md](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/configuration.md)
+for nested parameter details.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
@@ -25,13 +25,19 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
-// Subset of kvcache.Indexer used by the producer. Tokens-only.
+// kvCacheIndexer is the subset of kvcache.Indexer that the producer relies on.
+// Intentionally narrow: only the tokens-based entry points, no prompt-string
+// fallback. Lets tests inject a fake without pulling the full indexer.
 type kvCacheIndexer interface {
 	ComputeBlockKeysFromTokens(ctx context.Context, tokens []uint32, modelName string, extraFeatures []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error)
 	KVBlockIndex() kvblock.Index
 }
 
-// Hashes TokenizedPrompt into KV-block keys. (nil, nil) when tokens absent.
+// computeBlockKeys hashes the request's TokenizedPrompt into KV-block keys,
+// passing any multimodal features into the block-extra-features computation
+// so MM tokens land in the right blocks. Returns (nil, nil) when the request
+// carries no tokens — callers needing a prompt-string fallback should run
+// a token-producer upstream.
 func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
 	request *scheduling.InferenceRequest, blockSizeTokens int,
 ) ([]kvblock.BlockHash, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
@@ -26,8 +26,6 @@ import (
 )
 
 // kvCacheIndexer is the subset of kvcache.Indexer that the producer relies on.
-// Intentionally narrow: only the tokens-based entry points, no prompt-string
-// fallback. Lets tests inject a fake without pulling the full indexer.
 type kvCacheIndexer interface {
 	ComputeBlockKeysFromTokens(ctx context.Context, tokens []uint32, modelName string, extraFeatures []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error)
 	KVBlockIndex() kvblock.Index
@@ -36,8 +34,7 @@ type kvCacheIndexer interface {
 // computeBlockKeys hashes the request's TokenizedPrompt into KV-block keys,
 // passing any multimodal features into the block-extra-features computation
 // so MM tokens land in the right blocks. Returns (nil, nil) when the request
-// carries no tokens — callers needing a prompt-string fallback should run
-// a token-producer upstream.
+// carries no tokens.
 func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
 	request *scheduling.InferenceRequest, blockSizeTokens int,
 ) ([]kvblock.BlockHash, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
+)
+
+// Subset of kvcache.Indexer used by the producer. Tokens-only.
+type kvCacheIndexer interface {
+	ComputeBlockKeysFromTokens(ctx context.Context, tokens []uint32, modelName string, extraFeatures []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error)
+	KVBlockIndex() kvblock.Index
+}
+
+// Hashes TokenizedPrompt into KV-block keys. (nil, nil) when tokens absent.
+func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
+	request *scheduling.InferenceRequest, blockSizeTokens int,
+) ([]kvblock.BlockHash, error) {
+	if request == nil || request.Body == nil {
+		return nil, nil
+	}
+	tp := request.Body.TokenizedPrompt
+	if tp == nil || len(tp.TokenIDs) == 0 {
+		return nil, nil
+	}
+	var extraFeatures []*kvblock.BlockExtraFeatures
+	if len(tp.MultiModalFeatures) > 0 {
+		mmHashes, mmPlaceholders := tokenizer.ConvertMMFeaturesFromUpstream(tp.MultiModalFeatures)
+		extraFeatures = kvblock.ComputeBlockExtraFeatures(
+			mmHashes, mmPlaceholders, blockSizeTokens, len(tp.TokenIDs))
+	}
+	return idx.ComputeBlockKeysFromTokens(ctx, tp.TokenIDs, request.TargetModel, extraFeatures)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/doc.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package preciseprefixcache hashes TokenizedPrompt into KV-block keys,
+// looks them up in the index, and writes per-endpoint PrefixCacheMatchInfo.
+package preciseprefixcache

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+)
+
+var _ fwkdl.EndpointExtractor = &Producer{}
+
+func (p *Producer) ExpectedInputType() reflect.Type {
+	return fwkdl.EndpointEventReflectType
+}
+
+// ExtractEndpoint: add/update installs a per-pod ZMQ subscriber, delete tears
+// it down. Sole per-pod discovery path; global socket mode is the alternative.
+func (p *Producer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
+	if !p.kvEventsConfig.DiscoverPods || p.kvEventsConfig.PodDiscoveryConfig == nil {
+		return nil
+	}
+	meta := event.Endpoint.GetMetadata()
+	if meta == nil || meta.NamespacedName.Name == "" {
+		return nil
+	}
+
+	logger := log.FromContext(ctx).WithName(p.typedName.String())
+	endpointKey := meta.NamespacedName.String()
+
+	switch event.Type {
+	case fwkdl.EventAddOrUpdate:
+		if err := p.ensureSubscriber(ctx, meta); err != nil {
+			return err
+		}
+		logger.V(logging.DEBUG).Info("Adding subscriber", "endpoint", endpointKey)
+	case fwkdl.EventDelete:
+		p.subscribersManager.RemoveSubscriber(ctx, endpointKey)
+		logger.V(logging.DEBUG).Info("Removed KV-events subscriber", "endpoint", endpointKey)
+	}
+	return nil
+}
+
+func (p *Producer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetadata) error {
+	if meta == nil || meta.Address == "" {
+		return nil
+	}
+	endpointKey := meta.NamespacedName.String()
+	// vLLM offset_endpoint_port: rank N binds at SocketPort + N.
+	port := p.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
+	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
+
+	logger := log.FromContext(ctx).WithName(p.typedName.String())
+	// Use subscriberCtx (plugin-lifetime), not the caller's ctx.
+	if err := p.subscribersManager.EnsureSubscriber(p.subscriberCtx, endpointKey,
+		zmqEndpoint, p.kvEventsConfig.TopicFilter, true); err != nil {
+		logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",
+			"endpoint", endpointKey, "address", meta.Address)
+		return fmt.Errorf("ensure subscriber for %s: %w", endpointKey, err)
+	}
+	logger.V(logging.DEBUG).Info("Ensured KV-events subscriber", "endpoint", endpointKey, "zmq", zmqEndpoint)
+	return nil
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -37,7 +37,7 @@ func (p *Producer) ExpectedInputType() reflect.Type {
 // ExtractEndpoint processes endpoint lifecycle events emitted by the
 // endpoint-notification-source: add/update installs a per-pod ZMQ KV-events
 // subscriber, delete tears one down. No-op unless per-pod discovery is
-// enabled; the alternative is global socket mode (KVEventsConfig.ZMQEndpoint).
+// enabled.
 func (p *Producer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
 	if !p.kvEventsConfig.DiscoverPods || p.kvEventsConfig.PodDiscoveryConfig == nil {
 		return nil
@@ -64,7 +64,7 @@ func (p *Producer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEven
 }
 
 // ensureSubscriber idempotently installs a KV-events subscriber for the given
-// endpoint, dialing SocketPort + RankIndex to match vLLM's offset_endpoint_port
+// endpoint, dialing SocketPort + RankIndex to match standard inference-engine port offsetting
 // (one ZMQ PUB socket per DP rank on the same pod IP).
 func (p *Producer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetadata) error {
 	if meta == nil || meta.Address == "" {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -29,12 +29,15 @@ import (
 
 var _ fwkdl.EndpointExtractor = &Producer{}
 
+// ExpectedInputType reports the data-layer event type this extractor consumes.
 func (p *Producer) ExpectedInputType() reflect.Type {
 	return fwkdl.EndpointEventReflectType
 }
 
-// ExtractEndpoint: add/update installs a per-pod ZMQ subscriber, delete tears
-// it down. Sole per-pod discovery path; global socket mode is the alternative.
+// ExtractEndpoint processes endpoint lifecycle events emitted by the
+// endpoint-notification-source: add/update installs a per-pod ZMQ KV-events
+// subscriber, delete tears one down. No-op unless per-pod discovery is
+// enabled; the alternative is global socket mode (KVEventsConfig.ZMQEndpoint).
 func (p *Producer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEvent) error {
 	if !p.kvEventsConfig.DiscoverPods || p.kvEventsConfig.PodDiscoveryConfig == nil {
 		return nil
@@ -60,17 +63,20 @@ func (p *Producer) ExtractEndpoint(ctx context.Context, event fwkdl.EndpointEven
 	return nil
 }
 
+// ensureSubscriber idempotently installs a KV-events subscriber for the given
+// endpoint, dialing SocketPort + RankIndex to match vLLM's offset_endpoint_port
+// (one ZMQ PUB socket per DP rank on the same pod IP).
 func (p *Producer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetadata) error {
 	if meta == nil || meta.Address == "" {
 		return nil
 	}
 	endpointKey := meta.NamespacedName.String()
-	// vLLM offset_endpoint_port: rank N binds at SocketPort + N.
 	port := p.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
 	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
 
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
-	// Use subscriberCtx (plugin-lifetime), not the caller's ctx.
+	// subscriberCtx is plugin-lifetime; caller ctx would tear subscribers
+	// down on request completion.
 	if err := p.subscribersManager.EnsureSubscriber(p.subscriberCtx, endpointKey,
 		zmqEndpoint, p.kvEventsConfig.TopicFilter, true); err != nil {
 		logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// Avoid a -race ding from subscriber goroutines writing through a t-bound
+// logger after t.Run cleanup.
+func discardCtx(t *testing.T) context.Context {
+	t.Helper()
+	return log.IntoContext(context.Background(), logr.Discard())
+}
+
+func newExtractorProducer(discoverPods bool) *Producer {
+	cfg := kvevents.DefaultConfig()
+	cfg.DiscoverPods = discoverPods
+	cfg.PodDiscoveryConfig = kvevents.DefaultPodReconcilerConfig()
+	cfg.PodDiscoveryConfig.SocketPort = 5557
+
+	return &Producer{
+		typedName:          plugin.TypedName{Type: PluginType, Name: PluginType},
+		subscribersManager: kvevents.NewSubscriberManager(kvevents.NewPool(cfg, nil, nil, nil)),
+		kvEventsConfig:     cfg,
+		subscriberCtx:      context.Background(),
+	}
+}
+
+func newEndpoint(name, addr string) fwkdl.Endpoint {
+	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: name},
+		Address:        addr,
+		Port:           "8080",
+	}, nil)
+}
+
+func TestProducer_EndpointExtractor_InterfaceContract(t *testing.T) {
+	ctx := discardCtx(t)
+	p := newExtractorProducer(true)
+	defer p.subscribersManager.Shutdown(ctx)
+
+	assert.Equal(t, fwkdl.EndpointEventReflectType, p.ExpectedInputType())
+
+	var _ fwkdl.EndpointExtractor = p
+	assert.True(t, reflect.TypeOf(p).Implements(reflect.TypeFor[fwkdl.EndpointExtractor]()))
+}
+
+func TestProducer_ExtractEndpoint_AddAndDelete(t *testing.T) {
+	ctx := discardCtx(t)
+	p := newExtractorProducer(true)
+	defer p.subscribersManager.Shutdown(ctx)
+
+	ep := newEndpoint("pod-a", "10.0.0.1")
+	wantKey := "ns/pod-a"
+	wantEndpoint := "tcp://10.0.0.1:5557"
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+
+	ids, endpoints := p.subscribersManager.GetActiveSubscribers()
+	require.Equal(t, []string{wantKey}, ids)
+	require.Equal(t, []string{wantEndpoint}, endpoints)
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+	ids, _ = p.subscribersManager.GetActiveSubscribers()
+	assert.Len(t, ids, 1, "duplicate add must not create a second subscriber")
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventDelete,
+		Endpoint: ep,
+	}))
+	ids, _ = p.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids)
+}
+
+// DiscoverPods=false → global-socket mode, per-pod discovery off.
+func TestProducer_ExtractEndpoint_DiscoverPodsDisabledIsNoOp(t *testing.T) {
+	ctx := discardCtx(t)
+	p := newExtractorProducer(false)
+	defer p.subscribersManager.Shutdown(ctx)
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
+	}))
+
+	ids, _ := p.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids)
+}
+
+func TestProducer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
+	ctx := discardCtx(t)
+	p := newExtractorProducer(true)
+	defer p.subscribersManager.Shutdown(ctx)
+
+	ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+	}, nil)
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+
+	ids, _ := p.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids)
+}
+
+// Regression: subscribers must survive request-ctx cancellation.
+func TestProducer_EnsureSubscriber_SurvivesRequestCtxCancel(t *testing.T) {
+	p := newExtractorProducer(true)
+	defer p.subscribersManager.Shutdown(context.Background())
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+
+	require.NoError(t, p.ensureSubscriber(reqCtx, &fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+		Address:        "10.0.0.1", Port: "8080",
+	}))
+
+	cancel()
+
+	ids, _ := p.subscribersManager.GetActiveSubscribers()
+	assert.ElementsMatch(t, []string{"ns/pod-a"}, ids)
+}
+
+// Per-rank subscribers at SocketPort + RankIndex (vLLM offset_endpoint_port).
+func TestProducer_ExtractEndpoint_OffsetsZMQPortByRankIndex(t *testing.T) {
+	ctx := discardCtx(t)
+	p := newExtractorProducer(true)
+	defer p.subscribersManager.Shutdown(ctx)
+
+	endpoints := []struct {
+		name    string
+		address string
+		rank    int
+		wantZMQ string
+	}{
+		{name: "pod-a-rank-0", address: "10.0.0.1", rank: 0, wantZMQ: "tcp://10.0.0.1:5557"},
+		{name: "pod-a-rank-1", address: "10.0.0.1", rank: 1, wantZMQ: "tcp://10.0.0.1:5558"},
+		{name: "pod-a-rank-2", address: "10.0.0.1", rank: 2, wantZMQ: "tcp://10.0.0.1:5559"},
+	}
+
+	for _, ep := range endpoints {
+		require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+			Type: fwkdl.EventAddOrUpdate,
+			Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+				NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: ep.name},
+				Address:        ep.address,
+				Port:           "8080",
+				RankIndex:      ep.rank,
+			}, nil),
+		}))
+	}
+
+	ids, zmqEndpoints := p.subscribersManager.GetActiveSubscribers()
+	gotByID := make(map[string]string, len(ids))
+	for i, id := range ids {
+		gotByID[id] = zmqEndpoints[i]
+	}
+	for _, ep := range endpoints {
+		key := "ns/" + ep.name
+		assert.Equal(t, ep.wantZMQ, gotByID[key],
+			"rank %d must subscribe at SocketPort + rank", ep.rank)
+	}
+}
+
+// RankIndex=0 must dial the base SocketPort unchanged.
+func TestProducer_ExtractEndpoint_SingleRankUsesBaseSocketPort(t *testing.T) {
+	ctx := discardCtx(t)
+	p := newExtractorProducer(true)
+	defer p.subscribersManager.Shutdown(ctx)
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type: fwkdl.EventAddOrUpdate,
+		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+			Address:        "10.0.0.1",
+			Port:           "8080",
+			// RankIndex stays at its zero value.
+		}, nil),
+	}))
+
+	_, zmqEndpoints := p.subscribersManager.GetActiveSubscribers()
+	assert.Equal(t, []string{"tcp://10.0.0.1:5557"}, zmqEndpoints,
+		"single-rank pod (RankIndex=0) must dial the base SocketPort")
+}
+
+// Delete by NamespacedName must work even when the event has no address.
+func TestProducer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscriber(t *testing.T) {
+	ctx := discardCtx(t)
+	p := newExtractorProducer(true)
+	defer p.subscribersManager.Shutdown(ctx)
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: newEndpoint("pod-a", "10.0.0.1"),
+	}))
+
+	ids, _ := p.subscribersManager.GetActiveSubscribers()
+	require.Len(t, ids, 1)
+
+	deleteEndpoint := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+	}, nil)
+
+	require.NoError(t, p.ExtractEndpoint(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventDelete,
+		Endpoint: deleteEndpoint,
+	}))
+
+	ids, _ = p.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	defaultSpeculativeTTL      = 2 * time.Second
+	experimentalPrefillProfile = "prefill"
+	blockKeysStateKey          = plugin.StateKey("precise-prefix-cache-producer.block-keys")
+)
+
+var _ requestcontrol.PreRequest = &Producer{}
+
+type speculativeEntries struct {
+	blockKeys  []kvblock.BlockHash
+	podEntries []kvblock.PodEntry
+}
+
+type blockKeysState struct {
+	blockKeys []kvblock.BlockHash
+}
+
+func (s *blockKeysState) Clone() plugin.StateData {
+	cp := make([]kvblock.BlockHash, len(s.blockKeys))
+	copy(cp, s.blockKeys)
+	return &blockKeysState{blockKeys: cp}
+}
+
+func buildSpeculativeCache(ctx context.Context, config PluginConfig,
+	index kvblock.Index,
+) (*ttlcache.Cache[string, *speculativeEntries], time.Duration, error) {
+	if !config.SpeculativeIndexing {
+		return nil, 0, nil
+	}
+
+	ttl := defaultSpeculativeTTL
+	if config.SpeculativeTTL != "" {
+		parsed, err := time.ParseDuration(config.SpeculativeTTL)
+		if err != nil {
+			return nil, 0, fmt.Errorf("invalid speculativeTTL %q: %w", config.SpeculativeTTL, err)
+		}
+		if parsed > 0 {
+			ttl = parsed
+		}
+	}
+
+	cache := ttlcache.New[string, *speculativeEntries](
+		ttlcache.WithTTL[string, *speculativeEntries](ttl),
+	)
+	cache.OnEviction(func(_ context.Context, reason ttlcache.EvictionReason,
+		item *ttlcache.Item[string, *speculativeEntries],
+	) {
+		if reason != ttlcache.EvictionReasonExpired {
+			return
+		}
+		entries := item.Value()
+		for _, reqKey := range entries.blockKeys {
+			// Speculative entries were added without engineKey mapping, so
+			// evict by RequestKey directly.
+			//nolint:errcheck // best-effort cleanup on TTL expiry
+			index.Evict(ctx, reqKey, kvblock.RequestKey, entries.podEntries)
+		}
+	})
+	go cache.Start()
+	go func() {
+		<-ctx.Done()
+		cache.Stop()
+	}()
+
+	return cache, ttl, nil
+}
+
+// Seeds speculative entries for the selected endpoint(s). No-op when disabled.
+func (p *Producer) PreRequest(ctx context.Context,
+	request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult,
+) {
+	if !p.speculativeEnabled {
+		return
+	}
+
+	logger := log.FromContext(ctx).WithName(p.typedName.String())
+
+	state, err := plugin.ReadPluginStateKey[*blockKeysState](
+		p.pluginState, request.RequestID, blockKeysStateKey)
+	if err != nil {
+		logger.V(logging.TRACE).Info("No plugin state for PreRequest, skipping speculative indexing",
+			"requestID", request.RequestID)
+		return
+	}
+	p.pluginState.Delete(request.RequestID)
+
+	if len(state.blockKeys) == 0 {
+		return
+	}
+
+	primary := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
+	if primary == nil || len(primary.TargetEndpoints) == 0 {
+		return
+	}
+	targetEndpoint := primary.TargetEndpoints[0]
+	targetMeta := targetEndpoint.GetMetadata()
+	if targetMeta == nil {
+		return
+	}
+	speculativePod := kvblock.PodEntry{
+		PodIdentifier: fmt.Sprintf("%s:%s", targetMeta.Address, targetMeta.Port),
+		Speculative:   true,
+	}
+
+	index := p.kvCacheIndexer.KVBlockIndex()
+	// nil engineKeys: confirmed KV events will fill them in.
+	if err := index.Add(ctx, nil, state.blockKeys, []kvblock.PodEntry{speculativePod}); err != nil {
+		logger.Error(err, "Failed to add speculative entries to index",
+			"pod", speculativePod.PodIdentifier)
+	}
+
+	allPodEntries := []kvblock.PodEntry{speculativePod}
+
+	// P/D disagg: seed the prefill endpoint too.
+	if pr, exists := schedulingResult.ProfileResults[experimentalPrefillProfile]; exists && len(pr.TargetEndpoints) > 0 {
+		if prefillMeta := pr.TargetEndpoints[0].GetMetadata(); prefillMeta != nil {
+			prefillPod := kvblock.PodEntry{
+				PodIdentifier: fmt.Sprintf("%s:%s", prefillMeta.Address, prefillMeta.Port),
+				Speculative:   true,
+			}
+			if err := index.Add(ctx, nil, state.blockKeys, []kvblock.PodEntry{prefillPod}); err != nil {
+				logger.Error(err, "Failed to add speculative entries for prefill endpoint",
+					"pod", prefillPod.PodIdentifier)
+			}
+			allPodEntries = append(allPodEntries, prefillPod)
+		}
+	}
+
+	p.speculativeCache.Set(request.RequestID, &speculativeEntries{
+		blockKeys:  state.blockKeys,
+		podEntries: allPodEntries,
+	}, p.speculativeTTL)
+
+	logger.V(logging.TRACE).Info("Added speculative entries",
+		"requestID", request.RequestID,
+		"pod", speculativePod.PodIdentifier,
+		"blockKeys", len(state.blockKeys),
+		"ttl", p.speculativeTTL)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest.go
@@ -39,21 +39,29 @@ const (
 
 var _ requestcontrol.PreRequest = &Producer{}
 
+// speculativeEntries records the speculative rows added on a routing decision
+// so the TTL-eviction callback can roll them back.
 type speculativeEntries struct {
 	blockKeys  []kvblock.BlockHash
 	podEntries []kvblock.PodEntry
 }
 
+// blockKeysState carries the block keys computed in Produce to PreRequest
+// via PluginState, avoiding a second hash on the same request.
 type blockKeysState struct {
 	blockKeys []kvblock.BlockHash
 }
 
+// Clone implements plugin.StateData.
 func (s *blockKeysState) Clone() plugin.StateData {
 	cp := make([]kvblock.BlockHash, len(s.blockKeys))
 	copy(cp, s.blockKeys)
 	return &blockKeysState{blockKeys: cp}
 }
 
+// buildSpeculativeCache constructs the TTL cache used to evict speculative
+// index entries. Returns (nil, 0, nil) when speculative indexing is disabled.
+// The cache and its background goroutine are bound to ctx.
 func buildSpeculativeCache(ctx context.Context, config PluginConfig,
 	index kvblock.Index,
 ) (*ttlcache.Cache[string, *speculativeEntries], time.Duration, error) {
@@ -98,7 +106,11 @@ func buildSpeculativeCache(ctx context.Context, config PluginConfig,
 	return cache, ttl, nil
 }
 
-// Seeds speculative entries for the selected endpoint(s). No-op when disabled.
+// PreRequest seeds speculative KV-block index entries for the endpoint(s)
+// selected by the scheduler, so the next same-prefix request hits without
+// waiting for confirmed KV-events from the engine. Entries are tracked in
+// a TTL cache and evicted automatically. No-op when speculativeIndexing
+// is disabled.
 func (p *Producer) PreRequest(ctx context.Context,
 	request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult,
 ) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/test/utils"
+)
+
+// addCall captures one fakeKVBlockIndex.Add invocation.
+type addCall struct {
+	keys    []kvblock.BlockHash
+	entries []kvblock.PodEntry
+}
+
+func newProducerForPreRequest(ctx context.Context, speculativeEnabled bool, idx *fakeKVBlockIndex) *Producer {
+	cache := ttlcache.New[string, *speculativeEntries](
+		ttlcache.WithTTL[string, *speculativeEntries](time.Minute),
+	)
+	return &Producer{
+		typedName:          plugin.TypedName{Type: PluginType, Name: "test"},
+		kvCacheIndexer:     &fakeKVCacheIndexer{index: idx},
+		speculativeCache:   cache,
+		speculativeTTL:     time.Minute,
+		speculativeEnabled: speculativeEnabled,
+		pluginState:        plugin.NewPluginState(ctx),
+	}
+}
+
+func primaryOnly(name string, endpoint scheduling.Endpoint) *scheduling.SchedulingResult {
+	return &scheduling.SchedulingResult{
+		PrimaryProfileName: name,
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			name: {TargetEndpoints: []scheduling.Endpoint{endpoint}},
+		},
+	}
+}
+
+// speculativeEnabled=true with populated block keys: index.Add called once
+// with the primary pod identifier, and a speculative cache entry is created.
+func TestPreRequest_SeedsSpeculativeForPrimary(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	var calls []addCall
+	idx := &fakeKVBlockIndex{
+		addFn: func(_ context.Context, _ []kvblock.BlockHash, keys []kvblock.BlockHash, entries []kvblock.PodEntry) error {
+			calls = append(calls, addCall{keys: keys, entries: entries})
+			return nil
+		},
+	}
+	p := newProducerForPreRequest(ctx, true, idx)
+
+	blockKeys := []kvblock.BlockHash{0xAA, 0xBB}
+	req := &scheduling.InferenceRequest{RequestID: "req-pre-1"}
+	p.pluginState.Write(req.RequestID, blockKeysStateKey, &blockKeysState{blockKeys: blockKeys})
+
+	p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, blockKeys, calls[0].keys)
+	require.Len(t, calls[0].entries, 1)
+	assert.Equal(t, "10.0.0.1:8080", calls[0].entries[0].PodIdentifier)
+	assert.True(t, calls[0].entries[0].Speculative)
+
+	cached := p.speculativeCache.Get(req.RequestID)
+	require.NotNil(t, cached)
+	assert.Equal(t, blockKeys, cached.Value().blockKeys)
+	require.Len(t, cached.Value().podEntries, 1)
+	assert.Equal(t, "10.0.0.1:8080", cached.Value().podEntries[0].PodIdentifier)
+}
+
+// speculativeEnabled=true with empty blockKeys: PreRequest must not call
+// index.Add and must not create a cache entry.
+func TestPreRequest_EmptyBlockKeys_NoAdd(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	idx := &fakeKVBlockIndex{
+		addFn: func(_ context.Context, _ []kvblock.BlockHash, _ []kvblock.BlockHash, _ []kvblock.PodEntry) error {
+			t.Fatalf("index.Add must not be called when blockKeys are empty")
+			return nil
+		},
+	}
+	p := newProducerForPreRequest(ctx, true, idx)
+
+	req := &scheduling.InferenceRequest{RequestID: "req-pre-empty"}
+	p.pluginState.Write(req.RequestID, blockKeysStateKey, &blockKeysState{blockKeys: nil})
+
+	p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
+
+	assert.Nil(t, p.speculativeCache.Get(req.RequestID))
+}
+
+// P/D prefill profile: index.Add called twice (primary + prefill), and the
+// cache entry tracks both pod identifiers.
+func TestPreRequest_PrefillProfile_SeedsBoth(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	var calls []addCall
+	idx := &fakeKVBlockIndex{
+		addFn: func(_ context.Context, _ []kvblock.BlockHash, keys []kvblock.BlockHash, entries []kvblock.PodEntry) error {
+			calls = append(calls, addCall{keys: keys, entries: entries})
+			return nil
+		},
+	}
+	p := newProducerForPreRequest(ctx, true, idx)
+
+	blockKeys := []kvblock.BlockHash{0xCC}
+	req := &scheduling.InferenceRequest{RequestID: "req-pre-pd"}
+	p.pluginState.Write(req.RequestID, blockKeysStateKey, &blockKeysState{blockKeys: blockKeys})
+
+	result := &scheduling.SchedulingResult{
+		PrimaryProfileName: "decode",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"decode":                   {TargetEndpoints: []scheduling.Endpoint{testEndpoints[0]}},
+			experimentalPrefillProfile: {TargetEndpoints: []scheduling.Endpoint{testEndpoints[1]}},
+		},
+	}
+	p.PreRequest(ctx, req, result)
+
+	require.Len(t, calls, 2)
+	assert.Equal(t, "10.0.0.1:8080", calls[0].entries[0].PodIdentifier)
+	assert.Equal(t, "10.0.0.2:8080", calls[1].entries[0].PodIdentifier)
+
+	cached := p.speculativeCache.Get(req.RequestID)
+	require.NotNil(t, cached)
+	require.Len(t, cached.Value().podEntries, 2)
+	assert.Equal(t, "10.0.0.1:8080", cached.Value().podEntries[0].PodIdentifier)
+	assert.Equal(t, "10.0.0.2:8080", cached.Value().podEntries[1].PodIdentifier)
+}
+
+// speculativeEnabled=false: early return — no index writes, no cache entry,
+// and PluginState is left untouched.
+func TestPreRequest_SpeculativeDisabled_NoOp(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	idx := &fakeKVBlockIndex{
+		addFn: func(_ context.Context, _ []kvblock.BlockHash, _ []kvblock.BlockHash, _ []kvblock.PodEntry) error {
+			t.Fatalf("index.Add must not be called when speculative indexing is disabled")
+			return nil
+		},
+	}
+	p := newProducerForPreRequest(ctx, false, idx)
+
+	req := &scheduling.InferenceRequest{RequestID: "req-pre-off"}
+	p.pluginState.Write(req.RequestID, blockKeysStateKey,
+		&blockKeysState{blockKeys: []kvblock.BlockHash{0xDD}})
+
+	p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
+
+	assert.Nil(t, p.speculativeCache.Get(req.RequestID))
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -42,24 +42,37 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/telemetry"
 )
 
+// PluginType is the registered type name of the precise-prefix-cache-producer.
 const PluginType = "precise-prefix-cache-producer"
 
-// Mirrors the legacy precise-prefix-cache-scorer config shape.
+// PluginConfig configures the precise-prefix-cache-producer. Nested fields
+// mirror the llm-d-kv-cache configuration shape (see that repo's
+// docs/configuration.md for details on TokenProcessorConfig, IndexerConfig,
+// and KVEventsConfig).
 type PluginConfig struct {
 	TokenProcessorConfig *kvblock.TokenProcessorConfig `json:"tokenProcessorConfig"`
 	IndexerConfig        *kvcache.Config               `json:"indexerConfig"`
 	KVEventsConfig       *kvevents.Config              `json:"kvEventsConfig"`
-	// Seed predicted cache entries post-routing so the next same-prefix
-	// request hits without waiting for engine confirmation.
+	// SpeculativeIndexing seeds predicted cache entries for the selected
+	// endpoint(s) immediately after a routing decision, so the next
+	// same-prefix request hits without waiting for engine confirmation.
 	SpeculativeIndexing bool `json:"speculativeIndexing"`
-	// Go duration string. Defaults to defaultSpeculativeTTL.
+	// SpeculativeTTL bounds how long speculative entries live before
+	// eviction. Go duration string; defaults to defaultSpeculativeTTL when
+	// empty.
 	SpeculativeTTL string `json:"speculativeTTL"`
 }
 
 var _ requestcontrol.DataProducer = &Producer{}
 
-// Owns the KV-block index and publishes per-endpoint PrefixCacheMatchInfo.
-// Speculative indexing in prerequest.go; subscriber lifecycle in extractor.go.
+// Producer is a DataProducer plugin that maintains a KV-block prefix-cache
+// index by subscribing to vLLM KV-events and writes per-endpoint
+// PrefixCacheMatchInfo for each request. Operators pair it with the
+// generic prefix-cache-scorer (set prefixMatchInfoProducerName to this
+// producer's instance name) to route requests by precise cache locality.
+//
+// Speculative-indexing logic lives in prerequest.go; per-pod ZMQ subscriber
+// lifecycle in extractor.go.
 type Producer struct {
 	typedName      plugin.TypedName
 	kvCacheIndexer kvCacheIndexer
@@ -84,6 +97,9 @@ type Producer struct {
 	subscriberCtx context.Context
 }
 
+// PluginFactory parses the raw plugin configuration and returns a configured
+// Producer. Rejects configs with indexerConfig.tokenizersPoolConfig set, since
+// this producer is tokens-only and requires an upstream token-producer.
 func PluginFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
 	indexerConfig, err := kvcache.NewDefaultConfig()
 	if err != nil {
@@ -110,16 +126,20 @@ func PluginFactory(name string, rawParameters json.RawMessage, handle plugin.Han
 		return nil, errors.New("tokenizersPoolConfig is not supported; configure a token-producer plugin instead")
 	}
 
-	p, err := New(handle.Context(), parameters)
+	p, err := New(handle.Context(), name, parameters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s plugin: %w", PluginType, err)
 	}
 
-	return p.WithName(name), nil
+	return p, nil
 }
 
-// Indexer and KV-events pool run in background goroutines bound to ctx.
-func New(ctx context.Context, config PluginConfig) (*Producer, error) {
+// New constructs a precise-prefix-cache-producer. The instance name becomes
+// the producer name on PrefixCacheMatchInfoDataKey, which downstream
+// consumers must match (see prefix-cache-scorer's prefixMatchInfoProducerName).
+// The kvcache indexer, KV-events pool, and any local ZMQ subscriber start
+// in background goroutines bound to ctx.
+func New(ctx context.Context, name string, config PluginConfig) (*Producer, error) {
 	if config.TokenProcessorConfig == nil {
 		config.TokenProcessorConfig = kvblock.DefaultTokenProcessorConfig()
 	}
@@ -161,12 +181,12 @@ func New(ctx context.Context, config PluginConfig) (*Producer, error) {
 	}
 
 	return &Producer{
-		typedName:          plugin.TypedName{Type: PluginType},
+		typedName:          plugin.TypedName{Type: PluginType, Name: name},
 		kvCacheIndexer:     indexer,
 		kvBlockScorer:      kvBlockScorer,
 		subscribersManager: subscribersManager,
 		kvEventsConfig:     config.KVEventsConfig,
-		dk:                 attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(PluginType),
+		dk:                 attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name),
 		pluginState:        plugin.NewPluginState(ctx),
 		speculativeCache:   speculativeCache,
 		speculativeTTL:     speculativeTTL,
@@ -176,25 +196,28 @@ func New(ctx context.Context, config PluginConfig) (*Producer, error) {
 	}, nil
 }
 
+// TypedName returns the plugin's registered type and name.
 func (p *Producer) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
-func (p *Producer) WithName(name string) *Producer {
-	p.typedName.Name = name
-	p.dk = attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name)
-	return p
-}
-
+// Produces declares the PrefixCacheMatchInfoDataKey published per endpoint,
+// name-bound to this producer instance.
 func (p *Producer) Produces() map[plugin.DataKey]any {
 	return map[plugin.DataKey]any{p.dk: attrprefix.PrefixCacheMatchInfo{}}
 }
 
-// Declares the TokenizedPrompt dep so the DAG orders token-producer first.
+// Consumes declares the TokenizedPrompt dependency from token-producer so
+// the data-layer DAG orders tokenization before this producer runs.
 func (p *Producer) Consumes() map[plugin.DataKey]any {
 	return map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedPrompt{}}
 }
 
+// Produce hashes the request's TokenizedPrompt into KV-block keys, looks
+// them up in the per-endpoint KV-block index, and writes PrefixCacheMatchInfo
+// to each candidate endpoint. No-op when the request carries no tokens.
+// With speculativeIndexing enabled, the computed block keys are stashed
+// for PreRequest to seed the index after a routing decision is made.
 func (p *Producer) Produce(ctx context.Context,
 	request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint,
 ) error {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents/engineadapter"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
+	"github.com/llm-d/llm-d-router/pkg/telemetry"
+)
+
+const PluginType = "precise-prefix-cache-producer"
+
+// Mirrors the legacy precise-prefix-cache-scorer config shape.
+type PluginConfig struct {
+	TokenProcessorConfig *kvblock.TokenProcessorConfig `json:"tokenProcessorConfig"`
+	IndexerConfig        *kvcache.Config               `json:"indexerConfig"`
+	KVEventsConfig       *kvevents.Config              `json:"kvEventsConfig"`
+	// Seed predicted cache entries post-routing so the next same-prefix
+	// request hits without waiting for engine confirmation.
+	SpeculativeIndexing bool `json:"speculativeIndexing"`
+	// Go duration string. Defaults to defaultSpeculativeTTL.
+	SpeculativeTTL string `json:"speculativeTTL"`
+}
+
+var _ requestcontrol.DataProducer = &Producer{}
+
+// Owns the KV-block index and publishes per-endpoint PrefixCacheMatchInfo.
+// Speculative indexing in prerequest.go; subscriber lifecycle in extractor.go.
+type Producer struct {
+	typedName      plugin.TypedName
+	kvCacheIndexer kvCacheIndexer
+
+	subscribersManager *kvevents.SubscriberManager
+	kvEventsConfig     *kvevents.Config
+
+	kvBlockScorer kvcache.KVBlockScorer
+
+	dk plugin.DataKey
+
+	pluginState *plugin.PluginState
+
+	speculativeCache   *ttlcache.Cache[string, *speculativeEntries]
+	speculativeTTL     time.Duration
+	speculativeEnabled bool
+
+	blockSizeTokens int
+
+	// Plugin-lifetime, not request-scoped: SubscriberManager binds each
+	// subscriber's goroutine to the ctx passed at registration.
+	subscriberCtx context.Context
+}
+
+func PluginFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+	indexerConfig, err := kvcache.NewDefaultConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize indexer config: %w", err)
+	}
+
+	parameters := PluginConfig{
+		IndexerConfig:  indexerConfig,
+		KVEventsConfig: kvevents.DefaultConfig(),
+	}
+
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse %s plugin config: %w", PluginType, err)
+		}
+	}
+
+	if parameters.IndexerConfig == nil {
+		return nil, errors.New("indexerConfig is required")
+	}
+	// Tokens-only: reject configs that rely on the indexer's internal tokenizer.
+	//nolint:staticcheck // SA1019
+	if parameters.IndexerConfig.TokenizersPoolConfig != nil {
+		return nil, errors.New("tokenizersPoolConfig is not supported; configure a token-producer plugin instead")
+	}
+
+	p, err := New(handle.Context(), parameters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create %s plugin: %w", PluginType, err)
+	}
+
+	return p.WithName(name), nil
+}
+
+// Indexer and KV-events pool run in background goroutines bound to ctx.
+func New(ctx context.Context, config PluginConfig) (*Producer, error) {
+	if config.TokenProcessorConfig == nil {
+		config.TokenProcessorConfig = kvblock.DefaultTokenProcessorConfig()
+	}
+
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(config.TokenProcessorConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token processor: %w", err)
+	}
+
+	indexer, err := kvcache.NewKVCacheIndexer(ctx, config.IndexerConfig, tokenProcessor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kvcache.Indexer: %w", err)
+	}
+	go indexer.Run(ctx)
+
+	scorerConfig := kvcache.DefaultKVBlockScorerConfig()
+	if config.IndexerConfig != nil && config.IndexerConfig.BackendConfigs != nil {
+		scorerConfig.BackendConfigs = config.IndexerConfig.BackendConfigs
+	}
+	kvBlockScorer, err := kvcache.NewKVBlockScorer(scorerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create KVBlockScorer: %w", err)
+	}
+
+	pool := kvevents.NewPool(config.KVEventsConfig, indexer.KVBlockIndex(), tokenProcessor, engineadapter.NewVLLMAdapter())
+	pool.Start(ctx)
+
+	subscribersManager := kvevents.NewSubscriberManager(pool)
+	if config.KVEventsConfig.ZMQEndpoint != "" {
+		if err := subscribersManager.EnsureSubscriber(ctx, "local-subscriber",
+			config.KVEventsConfig.ZMQEndpoint, config.KVEventsConfig.TopicFilter, false); err != nil {
+			return nil, fmt.Errorf("failed to create local subscriber for global socket mode: %w", err)
+		}
+	}
+
+	speculativeCache, speculativeTTL, err := buildSpeculativeCache(ctx, config, indexer.KVBlockIndex())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Producer{
+		typedName:          plugin.TypedName{Type: PluginType},
+		kvCacheIndexer:     indexer,
+		kvBlockScorer:      kvBlockScorer,
+		subscribersManager: subscribersManager,
+		kvEventsConfig:     config.KVEventsConfig,
+		dk:                 attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(PluginType),
+		pluginState:        plugin.NewPluginState(ctx),
+		speculativeCache:   speculativeCache,
+		speculativeTTL:     speculativeTTL,
+		speculativeEnabled: config.SpeculativeIndexing,
+		blockSizeTokens:    config.TokenProcessorConfig.BlockSize,
+		subscriberCtx:      ctx,
+	}, nil
+}
+
+func (p *Producer) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+func (p *Producer) WithName(name string) *Producer {
+	p.typedName.Name = name
+	p.dk = attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name)
+	return p
+}
+
+func (p *Producer) Produces() map[plugin.DataKey]any {
+	return map[plugin.DataKey]any{p.dk: attrprefix.PrefixCacheMatchInfo{}}
+}
+
+// Declares the TokenizedPrompt dep so the DAG orders token-producer first.
+func (p *Producer) Consumes() map[plugin.DataKey]any {
+	return map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedPrompt{}}
+}
+
+func (p *Producer) Produce(ctx context.Context,
+	request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint,
+) error {
+	ctx, span := telemetry.Tracer().Start(ctx, "llm_d.epp.producer.precise_prefix_cache",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	span.SetAttributes(attribute.Int("llm_d.producer.candidate_endpoints", len(endpoints)))
+	if request != nil {
+		if request.TargetModel != "" {
+			span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
+		}
+		if request.RequestID != "" {
+			span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
+		}
+	}
+
+	logger := log.FromContext(ctx).WithName(p.typedName.String())
+
+	blockKeys, err := computeBlockKeys(ctx, p.kvCacheIndexer, request, p.blockSizeTokens)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("failed to compute block keys: %w", err)
+	}
+	if len(blockKeys) == 0 {
+		span.SetAttributes(attribute.String("llm_d.producer.result", "skipped_no_tokens"))
+		return nil
+	}
+
+	endpointSet := extractEndpointSet(endpoints)
+
+	keyToPods, err := p.kvCacheIndexer.KVBlockIndex().Lookup(ctx, blockKeys, endpointSet)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("failed to lookup block keys: %w", err)
+	}
+
+	scores, err := p.kvBlockScorer.Score(ctx, blockKeys, keyToPods)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("failed to score block keys: %w", err)
+	}
+
+	totalBlocks := len(blockKeys)
+	maxMatch := 0
+	for _, ep := range endpoints {
+		md := ep.GetMetadata()
+		if md == nil {
+			continue
+		}
+		addr := fmt.Sprintf("%s:%s", md.Address, md.Port)
+		matchLen := int(scores[addr])
+		if matchLen > maxMatch {
+			maxMatch = matchLen
+		}
+		ep.Put(p.dk.String(),
+			attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens))
+	}
+
+	if p.speculativeEnabled {
+		p.pluginState.Write(request.RequestID, blockKeysStateKey,
+			&blockKeysState{blockKeys: blockKeys})
+	}
+
+	span.SetAttributes(
+		attribute.Int("llm_d.producer.total_blocks", totalBlocks),
+		attribute.Int("llm_d.producer.max_match_blocks", maxMatch),
+	)
+
+	logger.V(logging.TRACE).Info("Produce completed",
+		"blockKeys", totalBlocks, "scores", scores)
+	return nil
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"github.com/llm-d/llm-d-router/test/utils"
+)
+
+type fakeKVCacheIndexer struct {
+	computeFromTokens func(ctx context.Context, tokens []uint32, model string, extra []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error)
+	index             *fakeKVBlockIndex
+}
+
+func (f *fakeKVCacheIndexer) ComputeBlockKeysFromTokens(ctx context.Context, tokens []uint32, model string, extra []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+	if f.computeFromTokens != nil {
+		return f.computeFromTokens(ctx, tokens, model, extra)
+	}
+	return []kvblock.BlockHash{}, nil
+}
+
+func (f *fakeKVCacheIndexer) KVBlockIndex() kvblock.Index { return f.index }
+
+type fakeKVBlockIndex struct {
+	lookup func(ctx context.Context, keys []kvblock.BlockHash, podSet sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error)
+	addFn  func(ctx context.Context, prevKeys, keys []kvblock.BlockHash, entries []kvblock.PodEntry) error
+}
+
+func (f *fakeKVBlockIndex) Lookup(ctx context.Context, keys []kvblock.BlockHash, podSet sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
+	if f.lookup != nil {
+		return f.lookup(ctx, keys, podSet)
+	}
+	return map[kvblock.BlockHash][]kvblock.PodEntry{}, nil
+}
+
+func (f *fakeKVBlockIndex) Add(ctx context.Context, prevKeys, keys []kvblock.BlockHash, entries []kvblock.PodEntry) error {
+	if f.addFn != nil {
+		return f.addFn(ctx, prevKeys, keys, entries)
+	}
+	return nil
+}
+
+func (f *fakeKVBlockIndex) Evict(_ context.Context, _ kvblock.BlockHash, _ kvblock.KeyType, _ []kvblock.PodEntry) error {
+	return nil
+}
+
+func (f *fakeKVBlockIndex) GetRequestKey(_ context.Context, _ kvblock.BlockHash) (kvblock.BlockHash, error) {
+	return kvblock.EmptyBlockHash, nil
+}
+
+type fakeKVBlockScorer struct {
+	score func(ctx context.Context, keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error)
+}
+
+func (f *fakeKVBlockScorer) Strategy() kvcache.KVScoringStrategy {
+	return kvcache.LongestPrefixMatch
+}
+
+func (f *fakeKVBlockScorer) Score(ctx context.Context, keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error) {
+	if f.score != nil {
+		return f.score(ctx, keys, keyToPods)
+	}
+	return map[string]float64{}, nil
+}
+
+var testEndpoints = []scheduling.Endpoint{
+	scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
+			Address:        "10.0.0.1",
+			Port:           "8080",
+		}, nil, nil),
+	scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
+			Address:        "10.0.0.2",
+			Port:           "8080",
+		}, nil, nil),
+}
+
+const testBlockSize = 16
+
+func newProducerWithIndexer(ctx context.Context, idx kvCacheIndexer, scorer kvcache.KVBlockScorer) *Producer {
+	return &Producer{
+		typedName:       plugin.TypedName{Type: PluginType, Name: "test"},
+		kvCacheIndexer:  idx,
+		kvBlockScorer:   scorer,
+		kvEventsConfig:  &kvevents.Config{},
+		dk:              attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test"),
+		pluginState:     plugin.NewPluginState(ctx),
+		blockSizeTokens: testBlockSize,
+	}
+}
+
+// Tokens present → Produce hashes and writes per-endpoint match info.
+func TestProduce_UsesTokenizedPrompt(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	tokens := []uint32{10, 20, 30, 40, 50}
+	wantKey := kvblock.BlockHash(0xCAFE)
+
+	var capturedTokens []uint32
+
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, ts []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			capturedTokens = ts
+			return []kvblock.BlockHash{wantKey}, nil
+		},
+		index: &fakeKVBlockIndex{
+			lookup: func(_ context.Context, _ []kvblock.BlockHash, _ sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
+				return map[kvblock.BlockHash][]kvblock.PodEntry{
+					wantKey: {{PodIdentifier: "10.0.0.1:8080"}},
+				}, nil
+			},
+		},
+	}
+	scorer := &fakeKVBlockScorer{
+		score: func(_ context.Context, _ []kvblock.BlockHash, _ map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error) {
+			return map[string]float64{"10.0.0.1:8080": 1.0}, nil
+		},
+	}
+
+	p := newProducerWithIndexer(ctx, idx, scorer)
+
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-1",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{TokenIDs: tokens},
+		},
+	}
+
+	require.NoError(t, p.Produce(ctx, req, testEndpoints))
+	require.Equal(t, tokens, capturedTokens)
+
+	raw, ok := testEndpoints[0].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test").String())
+	require.True(t, ok)
+	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
+	require.True(t, ok)
+	assert.Equal(t, 1, info.MatchBlocks())
+	assert.Equal(t, 1, info.TotalBlocks())
+	assert.Equal(t, 16, info.BlockSizeTokens())
+
+	raw2, ok := testEndpoints[1].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test").String())
+	require.True(t, ok)
+	info2 := raw2.(*attrprefix.PrefixCacheMatchInfo)
+	assert.Equal(t, 0, info2.MatchBlocks())
+	assert.Equal(t, 1, info2.TotalBlocks())
+}
+
+// No tokens → no-op (no prompt-string fallback).
+func TestProduce_NoTokens_NoOp(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, _ []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			t.Fatalf("ComputeBlockKeysFromTokens must not be called when no tokens")
+			return nil, nil
+		},
+		index: &fakeKVBlockIndex{},
+	}
+	p := newProducerWithIndexer(ctx, idx, &fakeKVBlockScorer{})
+
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-2",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "no tokens here"}},
+		},
+	}
+	require.NoError(t, p.Produce(ctx, req, testEndpoints))
+}
+
+// Empty TokenIDs → no-op.
+func TestProduce_EmptyTokenizedPrompt_NoOp(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, _ []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			t.Fatalf("ComputeBlockKeysFromTokens must not be called for empty TokenIDs")
+			return nil, nil
+		},
+		index: &fakeKVBlockIndex{},
+	}
+	p := newProducerWithIndexer(ctx, idx, &fakeKVBlockScorer{})
+
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-3",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			Completions:     &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "p"}},
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{TokenIDs: []uint32{}},
+		},
+	}
+	require.NoError(t, p.Produce(ctx, req, testEndpoints))
+}
+
+// Multimodal features flow through to ComputeBlockKeysFromTokens.
+func TestProduce_PassesMMExtraFeatures(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	tokens := make([]uint32, 16)
+	for i := range tokens {
+		tokens[i] = uint32(i)
+	}
+	var captured []*kvblock.BlockExtraFeatures
+
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, _ []uint32, _ string, extra []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			captured = extra
+			return []kvblock.BlockHash{0xAA}, nil
+		},
+		index: &fakeKVBlockIndex{
+			lookup: func(_ context.Context, _ []kvblock.BlockHash, _ sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
+				return map[kvblock.BlockHash][]kvblock.PodEntry{}, nil
+			},
+		},
+	}
+	scorer := &fakeKVBlockScorer{}
+
+	p := newProducerWithIndexer(ctx, idx, scorer)
+
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-mm",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{
+				TokenIDs: tokens,
+				MultiModalFeatures: []fwkrh.MultiModalFeature{
+					{Modality: fwkrh.ModalityImage, Hash: "abc", Offset: 2, Length: 4},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, p.Produce(ctx, req, testEndpoints))
+	require.NotNil(t, captured)
+}
+
+// nil request / empty body → don't touch the indexer.
+func TestProduce_NoOpPaths(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, _ []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			t.Fatalf("ComputeBlockKeysFromTokens must not be called")
+			return nil, nil
+		},
+		index: &fakeKVBlockIndex{},
+	}
+	p := newProducerWithIndexer(ctx, idx, &fakeKVBlockScorer{})
+
+	require.NoError(t, p.Produce(ctx, &scheduling.InferenceRequest{RequestID: "x"}, testEndpoints))
+	require.NoError(t, p.Produce(ctx, &scheduling.InferenceRequest{RequestID: "x", Body: &fwkrh.InferenceRequestBody{}}, testEndpoints))
+}
+
+// Tokens-only: reject legacy tokenizersPoolConfig at factory time.
+func TestPluginFactory_RejectsTokenizersPoolConfig(t *testing.T) {
+	handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
+	raw := json.RawMessage(`{"indexerConfig":{"tokenizersPoolConfig":{"modelName":"x"}}}`)
+
+	_, err := PluginFactory("test", raw, handle)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tokenizersPoolConfig is not supported")
+}
+
+// Key built from string literals so an upstream rename trips the test.
+func TestProduces_DeclaresPrefixCacheMatchInfo(t *testing.T) {
+	p := &Producer{
+		typedName: plugin.TypedName{Type: PluginType, Name: "x"},
+		dk:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("x"),
+	}
+	expected := plugin.NewDataKey("PrefixCacheMatchInfoDataKey", "approx-prefix-cache-producer").
+		WithNonEmptyProducerName("x")
+	_, ok := p.Produces()[expected]
+	require.True(t, ok)
+}
+
+func TestConsumes_DeclaresTokenizedPrompt(t *testing.T) {
+	p := &Producer{typedName: plugin.TypedName{Type: PluginType, Name: "x"}}
+	expected := plugin.NewDataKey("TokenizedPrompt", "token-producer")
+	_, ok := p.Consumes()[expected]
+	require.True(t, ok)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
@@ -24,6 +24,9 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
+// extractEndpointSet builds the "address:port" identifier set used to filter
+// kvblock.Index lookups to candidate endpoints. Endpoints without metadata
+// are skipped.
 func extractEndpointSet(endpoints []scheduling.Endpoint) sets.Set[string] {
 	endpointSet := sets.New[string]()
 	for _, ep := range endpoints {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+func extractEndpointSet(endpoints []scheduling.Endpoint) sets.Set[string] {
+	endpointSet := sets.New[string]()
+	for _, ep := range endpoints {
+		if m := ep.GetMetadata(); m != nil {
+			endpointSet.Insert(fmt.Sprintf("%s:%s", m.Address, m.Port))
+		}
+	}
+	return endpointSet
+}


### PR DESCRIPTION
## Summary

New `precise-prefix-cache-producer` DataProducer plugin. Purely additive — existing `precise-prefix-cache-scorer` untouched.

Owns: KV-block index, KV-events pool, per-pod ZMQ subscriber lifecycle (`EndpointExtractor` on `endpoint-notification-source`), speculative TTL cache. Writes `PrefixCacheMatchInfo` per endpoint under its name-bound key, consuming `TokenizedPrompt` from `token-producer`. No internal tokenization fallback — `tokenizersPoolConfig` is rejected at the factory.

Pairs with the existing generic `prefix-cache-scorer` via explicit name reference:

```yaml
- type: prefix-cache-scorer
  parameters:
    prefixMatchInfoProducerName: precise-prefix-cache-producer
```

Without the field, the scorer keeps reading the auto-spawned approx producer as today.

## Test plan

- [x] `go test -race ./pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/...`
- [x] `golangci-lint run` clean.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Adds `precise-prefix-cache-producer` DataProducer plugin. Configure alongside `prefix-cache-scorer` with `prefixMatchInfoProducerName: precise-prefix-cache-producer` to opt into precise KV-block scoring; the existing monolithic `precise-prefix-cache-scorer` is unaffected.
```