### PR TITLE
Cleanup migrated GAIE imports

### DIFF
--- a/docs/create_new_filter.md
+++ b/docs/create_new_filter.md
@@ -46,8 +46,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/scheduling/plugins"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/scheduling/types"
 )
 ```
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/coalescer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/coalescer.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 	"time"
 
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 )
 
 // batchSubmission represents a single caller's request to PredictBulkStrict

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/metrics.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 )
 
 // GetMetrics fetches & parses metrics from the training server (for Bayesian Ridge).

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 	"time"
 
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 )
 
 // Predict uses cached coefficients (Bayesian Ridge) or HTTP calls (XGBoost/LightGBM) for prediction.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"time"
 
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	logutil "github.com/llm-d/llm-d-inference-scheduler/pkg/common/observability/logging"
 )
 
 // AddTrainingDataBulk buffers entries for periodic flush.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -33,9 +33,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	infextv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 
 	"github.com/llm-d/llm-d-inference-scheduler/apix/v1alpha2"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/env"
 	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 

--- a/test/e2e/epp/utils_test.go
+++ b/test/e2e/epp/utils_test.go
@@ -34,9 +34,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 
 	"github.com/llm-d/llm-d-inference-scheduler/apix/v1alpha2"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/metadata"
 	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Rewrites migrated GAIE package imports to use local llm-d-router packages.

This keeps GAIE usage limited to API types, including the existing InferencePool API surface, and moves the InferencePoolImport API root used by CRD generation into the local module.

**Which issue(s) this PR fixes**:

Fixes #1118

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```