### PR TITLE
Reject unknown approximate prefix config fields

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -17,6 +17,7 @@ limitations under the License.
 package approximateprefix
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -248,7 +249,9 @@ func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 func ApproxPrefixCacheFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := defaultConfig
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(rawParameters))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal prefix cache parameters: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -34,6 +34,11 @@ import (
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
+func TestApproxPrefixCacheFactoryRejectsUnknownFields(t *testing.T) {
+	_, err := ApproxPrefixCacheFactory("test", []byte(`{"blockSizeCharacters": 16}`), plugin.NewEppHandle(t.Context(), nil))
+	assert.ErrorContains(t, err, "unknown field \"blockSizeCharacters\"")
+}
+
 func TestProduce(t *testing.T) {
 	config := config{
 		BlockSizeTokens:        1,


### PR DESCRIPTION
This updates the approximate prefix cache data producer to decode its plugin parameters with unknown-field rejection, so misspelled or removed configuration keys fail during plugin initialization instead of being silently ignored. I added a focused regression test that exercises an invalid approximate prefix configuration field and verified the targeted package with `go test ./pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix`.

Closes #1068
