### PR TITLE
build: pre-install govulncheck in builder image

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -12,6 +12,7 @@ ARG DOCKER_VERSION=29.3.0
 ARG DOCKER_BUILDX_VERSION=v0.32.1
 ARG ENVTEST_VERSION=release-0.19
 ARG ENVTEST_K8S_VERSION=1.31.0
+ARG GOVULNCHECK_VERSION=v1.3.0
 
 RUN dnf install -y podman gcc-toolset-12 && dnf clean all
 
@@ -63,6 +64,11 @@ RUN GOBIN=/usr/local/bin go install sigs.k8s.io/controller-runtime/tools/setup-e
     setup-envtest use ${ENVTEST_K8S_VERSION} --bin-dir ${ENVTEST_ASSETS_DIR} && \
     chmod -R a+rx ${ENVTEST_ASSETS_DIR}
 ENV ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION}
+
+# Install govulncheck. Build-time install ensures runtime invocations under
+# --userns=keep-id / -u <uid> can use the binary without writing to root-owned
+# /usr/local/bin.
+RUN GOBIN=/usr/local/bin go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
 # Go caches are mounted as volumes at runtime for persistence across image rebuilds.
 # Directories are created with open permissions so non-root users (docker -u) can write.

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ upgrade-deps: ## Upgrade all Go dependencies to latest minor/patch versions and 
 .PHONY: vulncheck
 vulncheck: image-build-builder ## Run govulncheck for known vulnerabilities
 	@printf "\033[33;1m==== Running govulncheck ====\033[0m\n"
-	$(BUILDER_RUN) 'go install golang.org/x/vuln/cmd/govulncheck@v1.3.0 && govulncheck ./...'
+	$(BUILDER_RUN) 'govulncheck ./...'
 
 .PHONY: presubmit
 presubmit: LINT_NEW_ONLY=true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The `make vulncheck` target installs `govulncheck` at runtime inside the builder container, but the base image bakes in `GOBIN=/usr/local/bin` (root-owned) while the container runs as the host user under both rootless podman (`--userns=keep-id`) and Docker (`-u $(id -u):$(id -g)`). As a result, `make presubmit` fails locally on those developer setups with `open /usr/local/bin/govulncheck: permission denied`.

This PR pre-installs `govulncheck` in `Dockerfile.builder`, matching the pattern used for every other tool (`setup-envtest`, `golangci-lint`, `typos`, `kubectl`, …). The Makefile target is simplified to call `govulncheck` directly, removing both the runtime install attempt and a runtime network dependency on `proxy.golang.org`.

Verified locally on macOS / rootless podman: `make presubmit` (lint, format, typos, vulncheck) now passes end-to-end on a clean branch. CI is unaffected because the existing GHA workflow runs `govulncheck` directly on the runner, not via `make vulncheck`.

**Which issue(s) this PR fixes**:
Fixes #1122

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
