### PR TITLE
docs: link out llm-d org CONTRIBUTING.md from README and DEVELOPMENT

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -909,6 +909,11 @@ For more details, see the Gateway API Inference Extension
 
 ## Submitting Changes
 
+Read the [llm-d organization contributing guide](https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md)
+first — it covers project-wide guidelines, code of conduct, and community resources that apply across
+all llm-d repositories. The sections below describe router-repo-specific expectations on top of that
+baseline.
+
 ### Scope
 
 Scoped changes and localized bug fixes can be submitted directly as a PR. 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ To ensure clarity across the project, we use the following standard terminology:
 
 ## Contributing
 
+Start with the [llm-d organization contributing guide][org-contributing] for project-wide guidelines, code of conduct, and community resources.
+
 Our community meeting is bi-weekly at Wednesday 10AM PDT ([Google Meet], [Meeting Notes]).
 
 We currently utilize the [#sig-router] channel in llm-d Slack workspace for communications.
@@ -80,6 +82,7 @@ maintainers can do an assessment, and work on the details with you. See
 
 Contributions are welcome!
 
+[org-contributing]:https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md
 [create an issue]:https://github.com/llm-d/llm-d-inference-scheduler/issues/new
 [discussion]:https://github.com/llm-d/llm-d-inference-scheduler/discussions/new?category=q-a
 [Slack]:https://llm-d.slack.com/


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Point contributors at the llm-d organization-wide contributing guide for project-wide guidelines, code of conduct, and community resources. repo-specific contribution expectations (DEVELOPMENT.md, PR template, deprecation policy) stay as the layer above.

**Which issue(s) this PR fixes**:
Fixes #

Followup to #1114.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
