### PR TITLE
feat(epp/plugins): strict plugin-config parsing via *json.Decoder

### DIFF
--- a/cmd/epp/runner/test_runner.go
+++ b/cmd/epp/runner/test_runner.go
@@ -39,7 +39,7 @@ func NewTestRunnerSetup(ctx context.Context, cfg *rest.Config, opts *runserver.O
 
 	if mockDataSource != nil {
 		mockType := mockDataSource.TypedName().Type
-		fwkplugin.Register(mockType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+		fwkplugin.Register(mockType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 			return mockDataSource, nil
 		})
 		defer delete(fwkplugin.Registry, mockType)

--- a/deploy/config/pd-epp-config.yaml
+++ b/deploy/config/pd-epp-config.yaml
@@ -2,10 +2,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 31250
+- type: prefix-cache-scorer
 - type: queue-scorer
 - type: prefill-filter
 - type: decode-filter

--- a/deploy/config/sim-epp-config.yaml
+++ b/deploy/config/sim-epp-config.yaml
@@ -3,10 +3,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 31250
+- type: prefix-cache-scorer
 - type: decode-filter
 - type: max-score-picker
 - type: single-profile-handler

--- a/deploy/config/sim-pd-epp-config.yaml
+++ b/deploy/config/sim-pd-epp-config.yaml
@@ -3,12 +3,13 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
     blockSizeTokens: 16
     autoTune: false
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 31250
+- type: prefix-cache-scorer
 - type: queue-scorer
 - type: prefill-filter
 - type: decode-filter

--- a/pkg/epp/README.md
+++ b/pkg/epp/README.md
@@ -1,7 +1,7 @@
 # The EndPoint Picker (EPP)
-This package provides the reference implementation for the Endpoint Picker (EPP). As demonstrated in the diagram below, it implements the [extension protocol](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v1.5.0/docs/proposals/004-endpoint-picker-protocol), enabling a proxy or gateway to request endpoint hints from an extension, and interacts with the model servers through the defined [model server protocol](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v1.5.0/docs/proposals/003-model-server-protocol).
+This package provides the reference implementation for the Endpoint Picker (EPP). As demonstrated in the diagram below, it implements the [extension protocol](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/proposals/004-endpoint-picker-protocol.md), enabling a proxy or gateway to request endpoint hints from an extension, and interacts with the model servers through the defined [model server protocol](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/proposals/003-model-server-protocol.md).
 
-![Architecture Diagram](https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/v1.5.0/docs/endpoint-picker.svg)
+![Architecture Diagram](https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/docs/endpoint-picker.svg)
 
 
 ## Core Functions
@@ -10,12 +10,12 @@ An EPP instance handles a single `InferencePool` (and so for each `InferencePool
 
 - Endpoint Selection
   - The EPP determines the appropriate Pod endpoint for the load balancer (LB) to route requests.
-  - It selects from the pool of ready Pods designated by the assigned InferencePool's [Selector](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v1.5.0/api/v1/inferencepool_types.go) field.
+  - It selects from the pool of ready Pods designated by the assigned InferencePool's [Selector](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/api/v1alpha1/inferencepool_types.go) field.
   - Endpoint selection is contingent on the request's ModelName matching an `InferenceObjective` that references the `InferencePool`.
   - Requests with unmatched ModelName values trigger an error response to the proxy.
 - Traffic Splitting and ModelName Rewriting
   - The EPP facilitates controlled rollouts of new adapter versions by implementing traffic splitting between adapters within the same `InferencePool`, as defined by the `InferenceObjective`.
-  - EPP rewrites the model name in the request to the [target model name](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v1.5.0/api/v1/inferencemodel_types.go) as defined on the `InferenceObjective` object.
+  - EPP rewrites the model name in the request to the [target model name](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/api/v1alpha1/inferencemodel_types.go) as defined on the `InferenceObjective` object.
 - Observability
   - The EPP generates metrics to enhance observability.
   - It reports InferenceObjective-level metrics, further broken down by target model.

--- a/pkg/epp/backend/metrics/podmetrics_parity_test.go
+++ b/pkg/epp/backend/metrics/podmetrics_parity_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	extractormetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
@@ -348,8 +349,8 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 
 	plugin, err := sourcemetrics.MetricsDataSourceFactory(
 		"test-metrics-source",
-		params, // configure scheme and path via parameters
-		nil,    // no plugin handle needed for test
+		fwkplugin.StrictDecoder(params), // configure scheme and path via parameters
+		nil,                             // no plugin handle needed for test
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create data source: %w", err)

--- a/pkg/epp/backend/metrics/podmetrics_parity_test.go
+++ b/pkg/epp/backend/metrics/podmetrics_parity_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
@@ -348,8 +349,8 @@ func parseWithDatalayerMetrics(ctx context.Context, t *testing.T, urlStr string)
 
 	plugin, err := sourcemetrics.MetricsDataSourceFactory(
 		"test-metrics-source",
-		params, // configure scheme and path via parameters
-		nil,    // no plugin handle needed for test
+		fwkplugin.StrictDecoder(params), // configure scheme and path via parameters
+		nil,                             // no plugin handle needed for test
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create data source: %w", err)

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -203,7 +203,7 @@ func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle fwkplug
 		if !ok {
 			return fmt.Errorf("plugin type '%s' is not registered", spec.Type)
 		}
-		plugin, err := factory(spec.Name, spec.Parameters, handle)
+		plugin, err := factory(spec.Name, fwkplugin.StrictDecoder(spec.Parameters), handle)
 		if err != nil {
 			return fmt.Errorf("failed to create plugin '%s' (type: %s): %w", spec.Name, spec.Type, err)
 		}

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -786,7 +786,7 @@ func registerTestPlugins(t *testing.T) {
 	}
 
 	mockFactory := func(tType string) fwkplugin.FactoryFunc {
-		return func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+		return func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 			return &mockPlugin{t: fwkplugin.TypedName{Name: name, Type: tType}}, nil
 		}
 	}
@@ -794,45 +794,45 @@ func registerTestPlugins(t *testing.T) {
 	// Register standard test mocks.
 	register(testPluginType, mockFactory(testPluginType))
 
-	fwkplugin.Register(testScorerType, func(name string, params json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testScorerType, func(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		// Attempt to unmarshal to trigger errors for invalid JSON in tests.
-		if len(params) > 0 {
+		if params != nil {
 			var p struct {
 				BlockSize int `json:"blockSize"`
 			}
-			if err := json.Unmarshal(params, &p); err != nil {
+			if err := params.Decode(&p); err != nil {
 				return nil, err
 			}
 		}
 		return &mockScorer{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testScorerType}}}, nil
 	})
 
-	fwkplugin.Register("utilization-detector", func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register("utilization-detector", func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockSaturationDetector{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: "utilization-detector"}}}, nil
 	})
 
-	fwkplugin.Register(testPickerType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testPickerType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockPicker{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testPickerType}}}, nil
 	})
 
-	fwkplugin.Register(testProfileHandler, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testProfileHandler, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockHandler{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testProfileHandler}}}, nil
 	})
 
-	fwkplugin.Register(testSourceType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testSourceType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockSource{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testSourceType}}}, nil
 	})
 
-	fwkplugin.Register(testExtractorType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testExtractorType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockExtractor{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testExtractorType}}}, nil
 	})
 
-	fwkplugin.Register(globalstrict.GlobalStrictFairnessPolicyType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(globalstrict.GlobalStrictFairnessPolicyType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &fwkfcmocks.MockFairnessPolicy{
 			TypedNameV: fwkplugin.TypedName{Name: name, Type: globalstrict.GlobalStrictFairnessPolicyType},
 		}, nil
 	})
-	fwkplugin.Register(fcfs.FCFSOrderingPolicyType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(fcfs.FCFSOrderingPolicyType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &fwkfcmocks.MockOrderingPolicy{
 			TypedNameV: fwkplugin.TypedName{Name: name, Type: fcfs.FCFSOrderingPolicyType},
 		}, nil

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -782,7 +782,7 @@ func registerTestPlugins(t *testing.T) {
 	}
 
 	mockFactory := func(tType string) fwkplugin.FactoryFunc {
-		return func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+		return func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 			return &mockPlugin{t: fwkplugin.TypedName{Name: name, Type: tType}}, nil
 		}
 	}
@@ -790,45 +790,45 @@ func registerTestPlugins(t *testing.T) {
 	// Register standard test mocks.
 	register(testPluginType, mockFactory(testPluginType))
 
-	fwkplugin.Register(testScorerType, func(name string, params json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testScorerType, func(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		// Attempt to unmarshal to trigger errors for invalid JSON in tests.
-		if len(params) > 0 {
+		if params != nil {
 			var p struct {
 				BlockSize int `json:"blockSize"`
 			}
-			if err := json.Unmarshal(params, &p); err != nil {
+			if err := params.Decode(&p); err != nil {
 				return nil, err
 			}
 		}
 		return &mockScorer{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testScorerType}}}, nil
 	})
 
-	fwkplugin.Register("utilization-detector", func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register("utilization-detector", func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockSaturationDetector{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: "utilization-detector"}}}, nil
 	})
 
-	fwkplugin.Register(testPickerType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testPickerType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockPicker{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testPickerType}}}, nil
 	})
 
-	fwkplugin.Register(testProfileHandler, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testProfileHandler, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockHandler{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testProfileHandler}}}, nil
 	})
 
-	fwkplugin.Register(testSourceType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testSourceType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockSource{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testSourceType}}}, nil
 	})
 
-	fwkplugin.Register(testExtractorType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(testExtractorType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockExtractor{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testExtractorType}}}, nil
 	})
 
-	fwkplugin.Register(globalstrict.GlobalStrictFairnessPolicyType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(globalstrict.GlobalStrictFairnessPolicyType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &fwkfcmocks.MockFairnessPolicy{
 			TypedNameV: fwkplugin.TypedName{Name: name, Type: globalstrict.GlobalStrictFairnessPolicyType},
 		}, nil
 	})
-	fwkplugin.Register(fcfs.FCFSOrderingPolicyType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fwkplugin.Register(fcfs.FCFSOrderingPolicyType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &fwkfcmocks.MockOrderingPolicy{
 			TypedNameV: fwkplugin.TypedName{Name: name, Type: fcfs.FCFSOrderingPolicyType},
 		}, nil

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -348,7 +348,7 @@ func registerDefaultPlugin(
 		return fmt.Errorf("plugin type '%s' not found in registry", pluginType)
 	}
 
-	plugin, err := factory(name, nil, handle)
+	plugin, err := factory(name, nil, handle) // default plugins have no parameters
 	if err != nil {
 		return fmt.Errorf("failed to instantiate default plugin '%s': %w", name, err)
 	}

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -288,25 +288,25 @@ func TestCreateMissingDataProducers(t *testing.T) {
 
 	// A DataProducer that produces keyA.
 	producerTypeA := "producer-a"
-	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockDataProducerP{name: name, produces: map[string]any{keyA: nil}}, nil
 	})
 
 	// A DataProducer that produces keyB.
 	producerTypeB := "producer-b"
-	producerBFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	producerBFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockDataProducerP{name: name, produces: map[string]any{keyB: nil}}, nil
 	})
 
 	// A non-ProducerPlugin registry entry (e.g. a scheduling scorer).
 	nonProducerType := "non-producer"
-	nonProducerFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	nonProducerFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &MockSchedulingPlugin{consumes: map[string]any{keyA: nil}}, nil
 	})
 
 	// A factory that always fails.
 	failingType := "failing"
-	failingFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	failingFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return nil, errors.New("requires params")
 	})
 

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -300,22 +300,22 @@ func TestCreateMissingDataProducers(t *testing.T) {
 	keyANonProducer := fwkplugin.NewDataKey("keyA", nonProducerType)
 
 	// A DataProducer that produces keyA.
-	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockDataProducerP{name: name, produces: map[fwkplugin.DataKey]any{keyA: nil}}, nil
 	})
 
 	// A DataProducer that produces keyB.
-	producerBFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	producerBFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockDataProducerP{name: name, produces: map[fwkplugin.DataKey]any{keyB: nil}}, nil
 	})
 
 	// A non-ProducerPlugin registry entry (e.g. a scheduling scorer).
-	nonProducerFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	nonProducerFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &MockSchedulingPlugin{consumes: map[fwkplugin.DataKey]any{keyA: nil}}, nil
 	})
 
 	// A factory that always fails.
-	failingFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	failingFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return nil, errors.New("requires params")
 	})
 

--- a/pkg/epp/framework/interface/plugin/registry.go
+++ b/pkg/epp/framework/interface/plugin/registry.go
@@ -17,12 +17,29 @@ limitations under the License.
 package plugin
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
 // Factory is the definition of the factory functions that are used to instantiate plugins
-// specified in a configuration.
-type FactoryFunc func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)
+// specified in a configuration. The framework provides a strict decoder
+// (DisallowUnknownFields) over the plugin's raw parameters, or nil when the plugin was
+// instantiated without parameters (e.g., as a default producer). Factories that ignore
+// parameters can take the decoder as `_ *json.Decoder`.
+type FactoryFunc func(name string, parameters *json.Decoder, handle Handle) (Plugin, error)
+
+// StrictDecoder returns a *json.Decoder configured with DisallowUnknownFields over the
+// given raw plugin parameters, or nil when raw is empty. The framework uses this when
+// invoking factories so each plugin gets uniform strict parsing; tests use it to
+// construct factory arguments without duplicating the decoder boilerplate.
+func StrictDecoder(raw json.RawMessage) *json.Decoder {
+	if len(raw) == 0 {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	return dec
+}
 
 // Register is a static function that can be called to register plugin factory functions.
 func Register(pluginType string, factory FactoryFunc) {

--- a/pkg/epp/framework/interface/plugin/registry_test.go
+++ b/pkg/epp/framework/interface/plugin/registry_test.go
@@ -41,7 +41,7 @@ func snapshotRegistries(t *testing.T) {
 	})
 }
 
-func dummyFactory(name string, parameters json.RawMessage, handle Handle) (Plugin, error) {
+func dummyFactory(name string, parameters *json.Decoder, handle Handle) (Plugin, error) {
 	return &basePlugin{name: TypedName{Type: "dummy", Name: name}}, nil
 }
 
@@ -65,7 +65,7 @@ func TestRegister_Overwrites(t *testing.T) {
 	Register("dup-type", dummyFactory)
 
 	var sentinel Plugin = &basePlugin{name: TypedName{Type: "sentinel", Name: "sentinel"}}
-	Register("dup-type", func(name string, parameters json.RawMessage, handle Handle) (Plugin, error) {
+	Register("dup-type", func(name string, parameters *json.Decoder, handle Handle) (Plugin, error) {
 		return sentinel, nil
 	})
 

--- a/pkg/epp/framework/plugins/README.md
+++ b/pkg/epp/framework/plugins/README.md
@@ -4,5 +4,5 @@ This directory contains the available plugins. For detailed information on indiv
 
 ## Related Documentation
 
-- [Architecture Overview](/docs/architecture.md)
-- [Creating a new Filter guide](/docs/create_new_filter.md)
+- [Architecture Overview](../../../../docs/architecture.md)
+- [Creating a new Filter guide](../../../../docs/create_new_filter.md)

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -80,10 +80,10 @@ type FileDiscovery struct {
 var _ fwkdl.EndpointDiscovery = (*FileDiscovery)(nil)
 
 // Factory is the plugin factory for file-discovery.
-func Factory(name string, parameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	p := &params{WatchFile: false}
-	if len(parameters) > 0 {
-		if err := json.Unmarshal(parameters, p); err != nil {
+	if parameters != nil {
+		if err := parameters.Decode(p); err != nil {
 			return nil, fmt.Errorf("file-discovery: failed to parse parameters: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
 // recordingNotifier captures Upsert and Delete calls for assertions.
@@ -87,18 +88,18 @@ endpoints:
 `
 
 func TestFactory_MissingPath(t *testing.T) {
-	_, err := Factory("", json.RawMessage(`{}`), nil)
+	_, err := Factory("", fwkplugin.StrictDecoder(json.RawMessage(`{}`)), nil)
 	assert.ErrorContains(t, err, "'path' parameter is required")
 }
 
 func TestFactory_InvalidJSON(t *testing.T) {
-	_, err := Factory("", json.RawMessage(`{bad json`), nil)
+	_, err := Factory("", fwkplugin.StrictDecoder(json.RawMessage(`{bad json`)), nil)
 	assert.ErrorContains(t, err, "failed to parse parameters")
 }
 
 func TestFactory_ValidParams(t *testing.T) {
 	path := writeTemp(t, validYAML)
-	plugin, err := Factory("my-discovery", json.RawMessage(`{"path":"`+path+`"}`), nil)
+	plugin, err := Factory("my-discovery", fwkplugin.StrictDecoder(json.RawMessage(`{"path":"`+path+`"}`)), nil)
 	require.NoError(t, err)
 	assert.Equal(t, PluginType, plugin.TypedName().Type)
 	assert.Equal(t, "my-discovery", plugin.TypedName().Name)
@@ -106,7 +107,7 @@ func TestFactory_ValidParams(t *testing.T) {
 
 func TestFactory_DefaultName(t *testing.T) {
 	path := writeTemp(t, validYAML)
-	plugin, err := Factory("", json.RawMessage(`{"path":"`+path+`"}`), nil)
+	plugin, err := Factory("", fwkplugin.StrictDecoder(json.RawMessage(`{"path":"`+path+`"}`)), nil)
 	require.NoError(t, err)
 	assert.Equal(t, PluginType, plugin.TypedName().Name)
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	sourcemetrics "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
@@ -615,7 +616,7 @@ func TestCoreMetricsExtractorFactoryDefaultEngine(t *testing.T) {
 				}
 			}
 
-			plugin, err := CoreMetricsExtractorFactory("test", params, nil)
+			plugin, err := CoreMetricsExtractorFactory("test", fwkplugin.StrictDecoder(params), nil)
 
 			if tt.wantErr {
 				if err == nil {

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
@@ -623,7 +624,7 @@ func TestCoreMetricsExtractorFactoryDefaultEngine(t *testing.T) {
 				}
 			}
 
-			plugin, err := CoreMetricsExtractorFactory("test", params, nil)
+			plugin, err := CoreMetricsExtractorFactory("test", fwkplugin.StrictDecoder(params), nil)
 
 			if tt.wantErr {
 				if err == nil {

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -123,11 +123,11 @@ const defaultEngineName = "vllm"
 
 // CoreMetricsExtractorFactory is a factory function used to instantiate data layer's metrics
 // Extractor plugins specified in a configuration.
-func CoreMetricsExtractorFactory(name string, parameters json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func CoreMetricsExtractorFactory(name string, parameters *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	params := defaultExtractorParams()
 
 	if parameters != nil { // overlay the defaults with configured values
-		if err := json.Unmarshal(parameters, params); err != nil {
+		if err := parameters.Decode(params); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -141,11 +141,11 @@ const defaultEngineName = "vllm"
 
 // CoreMetricsExtractorFactory is a factory function used to instantiate data layer's metrics
 // Extractor plugins specified in a configuration.
-func CoreMetricsExtractorFactory(name string, parameters json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func CoreMetricsExtractorFactory(name string, parameters *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	params := defaultExtractorParams()
 
 	if parameters != nil { // overlay the defaults with configured values
-		if err := json.Unmarshal(parameters, params); err != nil {
+		if err := parameters.Decode(params); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
@@ -89,7 +89,7 @@ func (me *ModelExtractor) ExpectedInputType() reflect.Type {
 
 // ModelServerExtractorFactory is a factory function used to instantiate data layer's
 // models extractor plugins specified in a configuration.
-func ModelServerExtractorFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func ModelServerExtractorFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	extractor := NewModelExtractor()
 	extractor.typedName.Name = name
 	return extractor, nil

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -60,14 +60,14 @@ func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource, 
 
 // MetricsDataSourceFactory is a factory function used to instantiate data layer's
 // metrics data source plugins specified in a configuration.
-func MetricsDataSourceFactory(name string, parameters json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	cfg, err := defaultDataSourceConfigParams()
 	if err != nil {
 		return nil, err
 	}
 
 	if parameters != nil { // overlay the defaults with configured values
-		if err := json.Unmarshal(parameters, cfg); err != nil {
+		if err := parameters.Decode(cfg); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
@@ -40,10 +40,10 @@ func NewHTTPModelsDataSource(scheme, path, name string) (*http.HTTPDataSource, e
 
 // ModelDataSourceFactory is a factory function used to instantiate data layer's
 // models data source plugins specified in a configuration.
-func ModelDataSourceFactory(name string, parameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func ModelDataSourceFactory(name string, parameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	cfg := defaultDataSourceConfigParams()
 	if parameters != nil { // overlay the defaults with configured values
-		if err := json.Unmarshal(parameters, cfg); err != nil {
+		if err := parameters.Decode(cfg); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -13,12 +13,13 @@ import (
 
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	extmodels "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/extractor/models"
 )
 
 func TestDatasource(t *testing.T) {
 	srcPlugin, err := ModelDataSourceFactory("models-data-source",
-		json.RawMessage(`{"scheme":"https","path":"/models","insecureSkipVerify":true}`), nil)
+		plugin.StrictDecoder(json.RawMessage(`{"scheme":"https","path":"/models","insecureSkipVerify":true}`)), nil)
 	assert.Nil(t, err, "failed to create http datasource")
 	source := srcPlugin.(fwkdl.PollingDataSource)
 

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -13,12 +13,13 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
 )
 
 func TestDatasource(t *testing.T) {
 	srcPlugin, err := ModelDataSourceFactory("models-data-source",
-		json.RawMessage(`{"scheme":"https","path":"/models","insecureSkipVerify":true}`), nil)
+		fwkplugin.StrictDecoder(json.RawMessage(`{"scheme":"https","path":"/models","insecureSkipVerify":true}`)), nil)
 	assert.Nil(t, err, "failed to create http datasource")
 	source := srcPlugin.(fwkdl.PollingDataSource)
 

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/factory.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/factory.go
@@ -40,13 +40,13 @@ type notificationSourceParams struct {
 }
 
 // NotificationSourceFactory is the factory function for k8s notification source plugins.
-func NotificationSourceFactory(name string, parameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func NotificationSourceFactory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	if parameters == nil {
 		return nil, errors.New("k8s-notification-source requires parameters (group, version, kind)")
 	}
 
 	var params notificationSourceParams
-	if err := json.Unmarshal(parameters, &params); err != nil {
+	if err := parameters.Decode(&params); err != nil {
 		return nil, fmt.Errorf("failed to parse notification source parameters: %w", err)
 	}
 
@@ -69,7 +69,7 @@ func NotificationSourceFactory(name string, parameters json.RawMessage, _ fwkplu
 }
 
 // EndpointSourceFactory is the factory function for endpoint notification source plugins.
-func EndpointSourceFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func EndpointSourceFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	if name == "" {
 		name = EndpointNotificationSourceType
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource_test.go
@@ -178,7 +178,7 @@ func TestNotificationSourceFactory(t *testing.T) {
 			t.Parallel()
 
 			rawParams := marshalParams(t, tt.params)
-			plugin, err := NotificationSourceFactory(tt.pluginName, rawParams, nil)
+			plugin, err := NotificationSourceFactory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)

--- a/pkg/epp/framework/plugins/flowcontrol/eviction/filtering/sheddable.go
+++ b/pkg/epp/framework/plugins/flowcontrol/eviction/filtering/sheddable.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 // SheddableFilterFactory creates a SheddableFilter plugin.
-func SheddableFilterFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func SheddableFilterFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	f := &SheddableFilter{name: SheddableFilterType}
 	if name != "" {
 		f.name = name

--- a/pkg/epp/framework/plugins/flowcontrol/eviction/ordering/priority_time.go
+++ b/pkg/epp/framework/plugins/flowcontrol/eviction/ordering/priority_time.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 // PriorityThenTimeOrderingFactory creates a PriorityThenTimeOrdering plugin.
-func PriorityThenTimeOrderingFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func PriorityThenTimeOrderingFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	p := &PriorityThenTimeOrdering{name: PriorityThenTimeOrderingType}
 	if name != "" {
 		p.name = name

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
@@ -18,7 +18,6 @@ package fairness
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +46,7 @@ func TestFairnessPolicyConformance(t *testing.T) {
 			t.Parallel()
 
 			// We pass nil for the handle as our core policies (RoundRobin, GlobalStrict) do not depend on it.
-			plugin, err := f(name, json.RawMessage{}, nil)
+			plugin, err := f(name, fwkplugin.StrictDecoder(nil), nil)
 			require.NoError(t, err, "Factory failed for plugin %s", name)
 			require.NotNil(t, plugin, "Factory returned nil for plugin %s", name)
 

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict.go
@@ -33,7 +33,7 @@ import (
 const GlobalStrictFairnessPolicyType = "global-strict-fairness-policy"
 
 // GlobalStrictFairnessPolicyFactory is the factory function for the global strict fairness policy.
-func GlobalStrictFairnessPolicyFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func GlobalStrictFairnessPolicyFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return newGlobalStrict(name), nil
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
@@ -36,7 +36,7 @@ import (
 const RoundRobinFairnessPolicyType = "round-robin-fairness-policy"
 
 // RoundRobinFairnessPolicyFactory is the factory function for the round-robin fairness policy.
-func RoundRobinFairnessPolicyFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func RoundRobinFairnessPolicyFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return newRoundRobin(name), nil
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/edf/edf.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/edf/edf.go
@@ -34,7 +34,7 @@ import (
 // For detailed documentation, see README.md.
 const EDFOrderingPolicyType = "edf-ordering-policy"
 
-func EDFOrderingPolicyFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func EDFOrderingPolicyFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return newEDFPolicy().withName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs/fcfs.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs/fcfs.go
@@ -33,7 +33,7 @@ import (
 // For detailed documentation on behavior and queue pairing, see README.md.
 const FCFSOrderingPolicyType = "fcfs-ordering-policy"
 
-func FCFSOrderingPolicyFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func FCFSOrderingPolicyFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return newFCFS().withName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
@@ -42,7 +42,7 @@ const (
 	sloTtftHeader = "x-slo-ttft-ms"
 )
 
-func SLODeadlineOrderingPolicyFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func SLODeadlineOrderingPolicyFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return newSLODeadlinePolicy().withName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
@@ -42,7 +42,7 @@ const (
 	sloTtftHeader = metadata.TTFTSLOHeaderKey
 )
 
-func SLODeadlineOrderingPolicyFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func SLODeadlineOrderingPolicyFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return newSLODeadlinePolicy().withName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -43,12 +43,12 @@ const (
 // ConcurrencyDetectorFactory instantiates the detector plugin using the provided JSON parameters.
 func ConcurrencyDetectorFactory(
 	name string,
-	params json.RawMessage,
+	params *json.Decoder,
 	handle fwkplugin.Handle,
 ) (fwkplugin.Plugin, error) {
 	var apiCfg apiConfig
-	if len(params) > 0 {
-		if err := json.Unmarshal(params, &apiCfg); err != nil {
+	if params != nil {
+		if err := params.Decode(&apiCfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal concurrency detector config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -82,7 +82,7 @@ func TestConcurrencyDetectorFactory(t *testing.T) {
 	}{
 		{
 			name:       "valid configuration",
-			configJSON: []byte(`{"mode": "requests", "maxConcurrency": 50, "headroom": 0.2}`),
+			configJSON: []byte(`{"maxConcurrency": 50, "headroom": 0.2}`),
 			wantError:  false,
 		},
 		{
@@ -127,7 +127,7 @@ func TestConcurrencyDetectorFactory(t *testing.T) {
 			t.Parallel()
 
 			plugin, err := ConcurrencyDetectorFactory("test-concurrency-detector",
-				tc.configJSON, fwkplugin.NewEppHandle(t.Context(), func() []types.NamespacedName { return nil }))
+				fwkplugin.StrictDecoder(tc.configJSON), fwkplugin.NewEppHandle(t.Context(), func() []types.NamespacedName { return nil }))
 			if tc.wantError {
 				require.Error(t, err, "Expected initialization to fail on invalid configuration")
 				require.Nil(t, plugin, "Plugin must be nil when initialization fails")
@@ -202,7 +202,7 @@ func TestDetector_Configuration(t *testing.T) {
 // TestDetector_TypedName verifies that the runtime type identification of the plugin is populated
 func TestDetector_TypedName(t *testing.T) {
 	t.Parallel()
-	plugin, err := ConcurrencyDetectorFactory("test-plugin", []byte(`{}`), fwkplugin.NewEppHandle(
+	plugin, err := ConcurrencyDetectorFactory("test-plugin", fwkplugin.StrictDecoder([]byte(`{}`)), fwkplugin.NewEppHandle(
 		t.Context(), func() []types.NamespacedName { return nil }))
 	require.NoError(t, err, "Plugin initialization should succeed")
 	require.Equal(t, "test-plugin", plugin.TypedName().Name)

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
@@ -44,12 +44,12 @@ const (
 // UtilizationDetectorFactory instantiates the detector plugin using the provided JSON parameters.
 func UtilizationDetectorFactory(
 	name string,
-	params json.RawMessage,
+	params *json.Decoder,
 	handle fwkplugin.Handle,
 ) (fwkplugin.Plugin, error) {
 	var apiCfg apiConfig
-	if len(params) > 0 {
-		if err := json.Unmarshal(params, &apiCfg); err != nil {
+	if params != nil {
+		if err := params.Decode(&apiCfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal utilization detector config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -118,7 +118,7 @@ func TestUtilizationDetectorFactory(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			plugin, err := UtilizationDetectorFactory("test-util-detector", tc.configJSON, fwkplugin.NewEppHandle(t.Context(), func() []types.NamespacedName { return nil }))
+			plugin, err := UtilizationDetectorFactory("test-util-detector", fwkplugin.StrictDecoder(tc.configJSON), fwkplugin.NewEppHandle(t.Context(), func() []types.NamespacedName { return nil }))
 			if tc.wantError {
 				require.Error(t, err, "Expected initialization to fail on invalid configuration")
 				require.Nil(t, plugin, "Plugin must be nil when initialization fails")
@@ -133,7 +133,7 @@ func TestUtilizationDetectorFactory(t *testing.T) {
 // TestDetector_TypedName provides structural assurance that initialization assigns proper types.
 func TestDetector_TypedName(t *testing.T) {
 	t.Parallel()
-	plugin, err := UtilizationDetectorFactory("test-plugin", []byte(`{}`), fwkplugin.NewEppHandle(
+	plugin, err := UtilizationDetectorFactory("test-plugin", fwkplugin.StrictDecoder([]byte(`{}`)), fwkplugin.NewEppHandle(
 		t.Context(), func() []types.NamespacedName { return nil }))
 	require.NoError(t, err, "Plugin initialization should succeed")
 	require.Equal(t, "test-plugin", plugin.TypedName().Name,

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/usagelimitpolicy.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/usagelimitpolicy.go
@@ -36,11 +36,11 @@ type staticPolicyConfig struct {
 
 // StaticPolicyFactory creates a StaticUsageLimitPolicy from JSON config.
 // If no threshold is specified, it defaults to 1.0 (no gating).
-func StaticPolicyFactory(name string, rawConfig json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func StaticPolicyFactory(name string, rawConfig *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	threshold := 1.0
-	if len(rawConfig) > 0 {
+	if rawConfig != nil {
 		var cfg staticPolicyConfig
-		if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+		if err := rawConfig.Decode(&cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse static usage limit policy config: %w", err)
 		}
 		if cfg.Threshold != nil {

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -56,10 +56,10 @@ type LatencyAdmission struct {
 }
 
 // LatencyAdmissionFactory creates a new LatencyAdmission plugin instance.
-func LatencyAdmissionFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func LatencyAdmissionFactory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := LatencyAdmissionDefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config for LatencyAdmission: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -60,10 +60,10 @@ type LatencyAdmission struct {
 }
 
 // LatencyAdmissionFactory creates a new LatencyAdmission plugin instance.
-func LatencyAdmissionFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func LatencyAdmissionFactory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := LatencyAdmissionDefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config for LatencyAdmission: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/README.md
@@ -59,7 +59,7 @@ saturation ≈ 0.34. This creates a dead zone at low load with a steep ramp at m
 
 ### Example Configuration
 
-See [`deploy/config/probabilistic-admitter-epp-config.yaml`](/deploy/config/probabilistic-admitter-epp-config.yaml) for the full EPP config. The
+See [`deploy/config/probabilistic-admitter-epp-config.yaml`](../../../../../../../deploy/config/probabilistic-admitter-epp-config.yaml) for the full EPP config. The
 key snippet:
 
 ```yaml

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin.go
@@ -64,7 +64,7 @@ type ProbabilisticAdmitter struct {
 }
 
 // Factory creates a ProbabilisticAdmitter from plugin configuration.
-func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	params := Parameters{
 		QueueDepthThreshold:  defaultQueueDepthThreshold,
 		KVCacheUtilThreshold: defaultKVCacheUtilThreshold,
@@ -72,7 +72,7 @@ func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fw
 		K:                    defaultK,
 	}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &params); err != nil {
+		if err := rawParameters.Decode(&params); err != nil {
 			return nil, fmt.Errorf("failed to parse parameters for '%s' plugin: %w", Type, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
@@ -25,6 +25,7 @@ import (
 
 	errcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/error"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
@@ -51,7 +52,7 @@ func defaultParams() Parameters {
 
 func TestFactory(t *testing.T) {
 	raw := json.RawMessage(`{"queueDepthThreshold":10,"kvCacheUtilThreshold":0.9,"power":3,"k":100}`)
-	p, err := Factory("test-admitter", raw, nil)
+	p, err := Factory("test-admitter", fwkplugin.StrictDecoder(raw), nil)
 	if err != nil {
 		t.Fatalf("Factory returned error: %v", err)
 	}
@@ -65,7 +66,7 @@ func TestFactory(t *testing.T) {
 }
 
 func TestFactory_Defaults(t *testing.T) {
-	p, err := Factory("test", nil, nil)
+	p, err := Factory("test", fwkplugin.StrictDecoder(nil), nil)
 	if err != nil {
 		t.Fatalf("Factory returned error: %v", err)
 	}
@@ -75,49 +76,49 @@ func TestFactory_Defaults(t *testing.T) {
 }
 
 func TestFactory_InvalidJSON(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{invalid}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{invalid}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
 }
 
 func TestFactory_ZeroQueueDepthThreshold(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"queueDepthThreshold":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"queueDepthThreshold":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for queueDepthThreshold=0")
 	}
 }
 
 func TestFactory_ZeroKVCacheUtilThreshold(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"kvCacheUtilThreshold":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"kvCacheUtilThreshold":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for kvCacheUtilThreshold=0")
 	}
 }
 
 func TestFactory_NegativePower(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"power":-1}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"power":-1}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for negative power")
 	}
 }
 
 func TestFactory_ZeroPower(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"power":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"power":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for zero power")
 	}
 }
 
 func TestFactory_NegativeK(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"k":-1}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"k":-1}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for negative k")
 	}
 }
 
 func TestFactory_ZeroK(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"k":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"k":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for zero k")
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
@@ -25,6 +25,7 @@ import (
 
 	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
@@ -51,7 +52,7 @@ func defaultParams() Parameters {
 
 func TestFactory(t *testing.T) {
 	raw := json.RawMessage(`{"queueDepthThreshold":10,"kvCacheUtilThreshold":0.9,"power":3,"k":100}`)
-	p, err := Factory("test-admitter", raw, nil)
+	p, err := Factory("test-admitter", fwkplugin.StrictDecoder(raw), nil)
 	if err != nil {
 		t.Fatalf("Factory returned error: %v", err)
 	}
@@ -65,7 +66,7 @@ func TestFactory(t *testing.T) {
 }
 
 func TestFactory_Defaults(t *testing.T) {
-	p, err := Factory("test", nil, nil)
+	p, err := Factory("test", fwkplugin.StrictDecoder(nil), nil)
 	if err != nil {
 		t.Fatalf("Factory returned error: %v", err)
 	}
@@ -75,49 +76,49 @@ func TestFactory_Defaults(t *testing.T) {
 }
 
 func TestFactory_InvalidJSON(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{invalid}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{invalid}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
 }
 
 func TestFactory_ZeroQueueDepthThreshold(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"queueDepthThreshold":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"queueDepthThreshold":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for queueDepthThreshold=0")
 	}
 }
 
 func TestFactory_ZeroKVCacheUtilThreshold(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"kvCacheUtilThreshold":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"kvCacheUtilThreshold":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for kvCacheUtilThreshold=0")
 	}
 }
 
 func TestFactory_NegativePower(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"power":-1}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"power":-1}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for negative power")
 	}
 }
 
 func TestFactory_ZeroPower(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"power":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"power":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for zero power")
 	}
 }
 
 func TestFactory_NegativeK(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"k":-1}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"k":-1}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for negative k")
 	}
 }
 
 func TestFactory_ZeroK(t *testing.T) {
-	_, err := Factory("test", json.RawMessage(`{"k":0}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"k":0}`)), nil)
 	if err == nil {
 		t.Fatal("expected error for zero k")
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -65,10 +65,9 @@ func (p *dataProducer) Produces() map[string]any {
 func newDataProducer(ctx context.Context, config config, handle plugin.Handle) (*dataProducer, error) {
 	log.FromContext(ctx).V(logutil.DEFAULT).Info("Prefix DataProducer initialized", "config", config)
 
-	//nolint:staticcheck // BlockSize is deprecated, but we check it here to provide a migration path for users.
-	if config.BlockSize > 0 && config.BlockSizeTokens <= 0 {
-		return nil, fmt.Errorf("invalid configuration: BlockSize (%d) is deprecated; please use BlockSizeTokens instead to define the cache block size in tokens", config.BlockSize)
-	}
+	// Note: 'blockSize' deprecation handling lives in ApproxPrefixCacheFactory so it
+	// applies to JSON-decoded configs uniformly with the strict-parsing policy (#1068).
+	// Direct callers of newDataProducer are expected to populate BlockSizeTokens.
 
 	if !config.AutoTune && config.BlockSizeTokens <= 0 {
 		return nil, fmt.Errorf("invalid configuration: BlockSizeTokens must be > 0 when AutoTune is disabled (current value: %d)", config.BlockSizeTokens)
@@ -245,12 +244,27 @@ func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 }
 
 // ApproxPrefixCacheFactory is the factory function for the prefix cache data producer plugin.
-func ApproxPrefixCacheFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func ApproxPrefixCacheFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := defaultConfig
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal prefix cache parameters: %w", err)
 		}
+	}
+
+	// Deprecated 'blockSize' is accepted with a warning and mapped to
+	// 'blockSizeTokens'. Removed (truly unknown) fields are rejected by the
+	// strict decoder above. See #1068.
+	if parameters.BlockSize > 0 {
+		log.FromContext(handle.Context()).V(logutil.DEFAULT).Info(
+			"'blockSize' is deprecated; use 'blockSizeTokens' instead",
+			"blockSize", parameters.BlockSize,
+		)
+		if parameters.BlockSizeTokens == defaultBlockSizeTokens {
+			// BlockSizeTokens left at its default — map the deprecated value into it.
+			parameters.BlockSizeTokens = parameters.BlockSize
+		}
+		parameters.BlockSize = 0
 	}
 
 	// pluginState will be initialized by newDataProducer as we pass nil here.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -68,10 +68,9 @@ func (p *dataProducer) Produces() map[plugin.DataKey]any {
 func newDataProducer(ctx context.Context, name string, config config, handle plugin.Handle) (*dataProducer, error) {
 	log.FromContext(ctx).V(logutil.DEFAULT).Info("Prefix DataProducer initialized", "config", config)
 
-	//nolint:staticcheck // BlockSize is deprecated, but we check it here to provide a migration path for users.
-	if config.BlockSize > 0 && config.BlockSizeTokens <= 0 {
-		return nil, fmt.Errorf("invalid configuration: BlockSize (%d) is deprecated; please use BlockSizeTokens instead to define the cache block size in tokens", config.BlockSize)
-	}
+	// Note: 'blockSize' deprecation handling lives in ApproxPrefixCacheFactory so it
+	// applies to JSON-decoded configs uniformly with the strict-parsing policy (#1068).
+	// Direct callers of newDataProducer are expected to populate BlockSizeTokens.
 
 	if !config.AutoTune && config.BlockSizeTokens <= 0 {
 		return nil, fmt.Errorf("invalid configuration: BlockSizeTokens must be > 0 when AutoTune is disabled (current value: %d)", config.BlockSizeTokens)
@@ -256,12 +255,27 @@ func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 }
 
 // ApproxPrefixCacheFactory is the factory function for the prefix cache data producer plugin.
-func ApproxPrefixCacheFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func ApproxPrefixCacheFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := defaultConfig
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal prefix cache parameters: %w", err)
 		}
+	}
+
+	// Deprecated 'blockSize' is accepted with a warning and mapped to
+	// 'blockSizeTokens'. Removed (truly unknown) fields are rejected by the
+	// strict decoder above. See #1068.
+	if parameters.BlockSize > 0 {
+		log.FromContext(handle.Context()).V(logutil.DEFAULT).Info(
+			"'blockSize' is deprecated; use 'blockSizeTokens' instead",
+			"blockSize", parameters.BlockSize,
+		)
+		if parameters.BlockSizeTokens == defaultBlockSizeTokens {
+			// BlockSizeTokens left at its default — map the deprecated value into it.
+			parameters.BlockSizeTokens = parameters.BlockSize
+		}
+		parameters.BlockSize = 0
 	}
 
 	// pluginState will be initialized by newDataProducer as we pass nil here.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -18,6 +18,7 @@ package approximateprefix
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -582,6 +583,54 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 			}
 		})
 	}
+}
+
+// TestFactory_RejectsUnknownField verifies that strict JSON parsing rejects
+// unknown fields in the plugin config. Encodes the strict-parsing policy
+// from issue #1068.
+func TestFactory_RejectsUnknownField(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := plugin.NewEppHandle(ctx, func() []k8stypes.NamespacedName { return nil })
+
+	dec := plugin.StrictDecoder(json.RawMessage(`{"unknownField": "value"}`))
+	_, err := ApproxPrefixCacheFactory("test", dec, handle)
+
+	assert.Error(t, err, "factory must reject unknown config fields")
+	if err != nil {
+		assert.Contains(t, err.Error(), "unknownField",
+			"error message should name the offending field")
+	}
+}
+
+// TestFactory_DeprecatedBlockSizeMapped verifies that the deprecated
+// 'blockSize' field is accepted (with a warning) and maps to
+// 'blockSizeTokens'. Encodes the two-pass deprecation policy from #1068:
+// deprecated fields are valid configuration, not errors.
+func TestFactory_DeprecatedBlockSizeMapped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := plugin.NewEppHandle(ctx, func() []k8stypes.NamespacedName { return nil })
+
+	// User supplies only the deprecated field. AutoTune=false forces
+	// BlockSizeTokens to be a meaningful value (no auto-tune fallback).
+	dec := plugin.StrictDecoder(json.RawMessage(`{"autoTune": false, "blockSize": 24}`))
+	p, err := ApproxPrefixCacheFactory("test", dec, handle)
+
+	assert.NoError(t, err, "deprecated blockSize should be accepted, not rejected")
+	if err != nil {
+		return
+	}
+
+	dp, ok := p.(*dataProducer)
+	if !ok {
+		t.Fatalf("expected *dataProducer, got %T", p)
+	}
+
+	assert.Equal(t, 24, dp.config.BlockSizeTokens,
+		"deprecated 'blockSize' should map to BlockSizeTokens")
+	assert.Equal(t, 0, dp.config.BlockSize,
+		"deprecated 'blockSize' should be cleared after mapping")
 }
 
 func randomPrompt(n int) string {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -18,6 +18,7 @@ package approximateprefix
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -758,6 +759,54 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 			}
 		})
 	}
+}
+
+// TestFactory_RejectsUnknownField verifies that strict JSON parsing rejects
+// unknown fields in the plugin config. Encodes the strict-parsing policy
+// from issue #1068.
+func TestFactory_RejectsUnknownField(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := plugin.NewEppHandle(ctx, func() []k8stypes.NamespacedName { return nil }, plugin.WithMetricsRecorder(prometheus.NewRegistry()))
+
+	dec := plugin.StrictDecoder(json.RawMessage(`{"unknownField": "value"}`))
+	_, err := ApproxPrefixCacheFactory("test", dec, handle)
+
+	assert.Error(t, err, "factory must reject unknown config fields")
+	if err != nil {
+		assert.Contains(t, err.Error(), "unknownField",
+			"error message should name the offending field")
+	}
+}
+
+// TestFactory_DeprecatedBlockSizeMapped verifies that the deprecated
+// 'blockSize' field is accepted (with a warning) and maps to
+// 'blockSizeTokens'. Encodes the two-pass deprecation policy from #1068:
+// deprecated fields are valid configuration, not errors.
+func TestFactory_DeprecatedBlockSizeMapped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := plugin.NewEppHandle(ctx, func() []k8stypes.NamespacedName { return nil }, plugin.WithMetricsRecorder(prometheus.NewRegistry()))
+
+	// User supplies only the deprecated field. AutoTune=false forces
+	// BlockSizeTokens to be a meaningful value (no auto-tune fallback).
+	dec := plugin.StrictDecoder(json.RawMessage(`{"autoTune": false, "blockSize": 24}`))
+	p, err := ApproxPrefixCacheFactory("test", dec, handle)
+
+	assert.NoError(t, err, "deprecated blockSize should be accepted, not rejected")
+	if err != nil {
+		return
+	}
+
+	dp, ok := p.(*dataProducer)
+	if !ok {
+		t.Fatalf("expected *dataProducer, got %T", p)
+	}
+
+	assert.Equal(t, 24, dp.config.BlockSizeTokens,
+		"deprecated 'blockSize' should map to BlockSizeTokens")
+	assert.Equal(t, 0, dp.config.BlockSize,
+		"deprecated 'blockSize' should be cleared after mapping")
 }
 
 func randomPrompt(n int) string {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -39,7 +39,7 @@ const (
 	profilePrefill           = "prefill"
 )
 
-func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func InFlightLoadProducerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return &InFlightLoadProducer{
 		typedName:      fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
 		requestTracker: newConcurrencyTracker(),

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -53,11 +53,11 @@ func defaultConfig() Config {
 	return Config{AddEstimatedOutputTokens: false}
 }
 
-func InFlightLoadProducerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func InFlightLoadProducerFactory(name string, decoder *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	cfg := defaultConfig()
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal inflight-load-producer parameters: %w", err)
+	if decoder != nil {
+		if err := decoder.Decode(&cfg); err != nil {
+			return nil, fmt.Errorf("failed to decode inflight-load-producer parameters: %w", err)
 		}
 	}
 	return &InFlightLoadProducer{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -66,10 +66,10 @@ type Parameters struct {
 }
 
 // Factory creates a multimodal encoder-cache data producer.
-func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := Parameters{}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' plugin - %w", ProducerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -37,13 +37,13 @@ func TestFactory(t *testing.T) {
 	raw, err := json.Marshal(map[string]any{"cacheSize": 4})
 	require.NoError(t, err)
 
-	created, err := Factory("mm-producer", raw, &testHandle{ctx: context.Background()})
+	created, err := Factory("mm-producer", plugin.StrictDecoder(raw), &testHandle{ctx: context.Background()})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 	assert.Equal(t, "mm-producer", created.TypedName().Name)
 	assert.Equal(t, ProducerType, created.TypedName().Type)
 
-	_, err = Factory("bad", json.RawMessage(`{"cacheSize":"bad"}`), &testHandle{ctx: context.Background()})
+	_, err = Factory("bad", plugin.StrictDecoder(json.RawMessage(`{"cacheSize":"bad"}`)), &testHandle{ctx: context.Background()})
 	require.Error(t, err)
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -100,7 +100,7 @@ type Producer struct {
 // PluginFactory parses the raw plugin configuration and returns a configured
 // Producer. Rejects configs with indexerConfig.tokenizersPoolConfig set, since
 // this producer is tokens-only and requires an upstream token-producer.
-func PluginFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	indexerConfig, err := kvcache.NewDefaultConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize indexer config: %w", err)
@@ -112,7 +112,7 @@ func PluginFactory(name string, rawParameters json.RawMessage, handle plugin.Han
 	}
 
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse %s plugin config: %w", PluginType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -286,7 +286,7 @@ func TestPluginFactory_RejectsTokenizersPoolConfig(t *testing.T) {
 	handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
 	raw := json.RawMessage(`{"indexerConfig":{"tokenizersPoolConfig":{"modelName":"x"}}}`)
 
-	_, err := PluginFactory("test", raw, handle)
+	_, err := PluginFactory("test", plugin.StrictDecoder(raw), handle)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "tokenizersPoolConfig is not supported")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -134,10 +134,10 @@ var DefaultConfig = Config{
 	PredictInProduce:                   true,
 }
 
-func PredictedLatencyFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PredictedLatencyFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config for PredictedLatency: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -141,10 +141,10 @@ var DefaultConfig = Config{
 	PredictInProduce:                   true,
 }
 
-func PredictedLatencyFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PredictedLatencyFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config for PredictedLatency: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -29,6 +29,7 @@ import (
 
 	reqcommon "github.com/llm-d/llm-d-inference-scheduler/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	igwtestutils "github.com/llm-d/llm-d-inference-scheduler/test/utils/igw"
@@ -331,7 +332,7 @@ func TestPredictedLatencyFactory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handle := igwtestutils.NewTestHandle(context.Background())
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := PredictedLatencyFactory(tt.pluginName, rawParams, handle)
+			plugin, err := PredictedLatencyFactory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), handle)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -367,7 +368,7 @@ func TestPredictedLatencyFactoryInvalidJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handle := igwtestutils.NewTestHandle(context.Background())
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := PredictedLatencyFactory("test", rawParams, handle)
+			plugin, err := PredictedLatencyFactory("test", fwkplugin.StrictDecoder(rawParams), handle)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -29,6 +29,7 @@ import (
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
@@ -385,7 +386,7 @@ func TestPredictedLatencyFactory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handle := igwtestutils.NewTestHandle(context.Background())
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := PredictedLatencyFactory(tt.pluginName, rawParams, handle)
+			plugin, err := PredictedLatencyFactory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), handle)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -421,7 +422,7 @@ func TestPredictedLatencyFactoryInvalidJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handle := igwtestutils.NewTestHandle(context.Background())
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := PredictedLatencyFactory("test", rawParams, handle)
+			plugin, err := PredictedLatencyFactory("test", fwkplugin.StrictDecoder(rawParams), handle)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -80,7 +80,7 @@ Plugin config — dedicated render Service:
 
 A complete sample config that pairs this with `precise-prefix-cache-scorer`
 is at
-[`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).
+[`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](../../../../../../../deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -73,11 +73,11 @@ type tokenizerPluginConfig struct {
 }
 
 // PluginFactory is the factory function for the tokenizer plugin.
-func PluginFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	config := tokenizerPluginConfig{}
 
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' plugin - %w", PluginType, err)
 		}
 	}
@@ -102,7 +102,7 @@ func PluginFactory(name string, rawParameters json.RawMessage, handle plugin.Han
 // to PluginFactory. Will be removed when LegacyPluginType is removed.
 //
 // Deprecated: register PluginType ("token-producer") instead.
-func LegacyPluginFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func LegacyPluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	log.FromContext(handle.Context()).Info(
 		"DEPRECATION: plugin type '"+LegacyPluginType+"' is deprecated; use '"+PluginType+"' instead",
 		"pluginName", name,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -90,7 +90,7 @@ func TestPluginFactory_Validation(t *testing.T) {
 				rawParams = json.RawMessage(tt.params)
 			}
 
-			p, err := PluginFactory("test-tokenizer", rawParams, handle)
+			p, err := PluginFactory("test-tokenizer", plugin.StrictDecoder(rawParams), handle)
 			if tt.expectErr {
 				require.Error(t, err)
 				assert.Nil(t, p)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -145,7 +145,7 @@ func TestPluginFactory_RejectsBothBackends(t *testing.T) {
 		"vllm": {"http": "http://localhost:8000"}
 	}`
 	handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
-	p, err := PluginFactory("test", json.RawMessage(params), handle)
+	p, err := PluginFactory("test", plugin.StrictDecoder(json.RawMessage(params)), handle)
 	require.Error(t, err)
 	assert.Nil(t, p)
 	assert.Contains(t, err.Error(), "only one of")
@@ -157,7 +157,7 @@ func TestPluginFactory_HTTPBackend_BadTimeout(t *testing.T) {
 		"vllm": {"timeout": "nope"}
 	}`
 	handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
-	p, err := PluginFactory("test", json.RawMessage(params), handle)
+	p, err := PluginFactory("test", plugin.StrictDecoder(json.RawMessage(params)), handle)
 	require.Error(t, err)
 	assert.Nil(t, p)
 	assert.Contains(t, err.Error(), "invalid 'timeout'")

--- a/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
@@ -74,9 +74,9 @@ type AttributeKey struct {
 	Name string `json:"name"`
 }
 
-func RequestAttributeReporterPluginFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func RequestAttributeReporterPluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	pluginConfig := Config{}
-	if err := json.Unmarshal(rawParameters, &pluginConfig); err != nil {
+	if err := rawParameters.Decode(&pluginConfig); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
@@ -62,7 +62,7 @@ func (desv *DestinationEndpointServedVerifier) WithName(name string) *Destinatio
 }
 
 // DestinationEndpointServedVerifierFactory defines the factory function for DestinationEndpointServedVerifier.
-func DestinationEndpointServedVerifierFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func DestinationEndpointServedVerifierFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewDestinationEndpointServedVerifier().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -83,7 +83,7 @@ func (p *OpenAIParser) SupportedAppProtocols() []v1.AppProtocol {
 	return []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP}
 }
 
-func OpenAIParserPluginFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func OpenAIParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewOpenAIParser().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -84,7 +84,7 @@ func (p *OpenAIParser) SupportedAppProtocols() []v1.AppProtocol {
 	return []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP}
 }
 
-func OpenAIParserPluginFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func OpenAIParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewOpenAIParser().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -57,7 +57,7 @@ func (p *PassthroughParser) SupportedAppProtocols() []v1.AppProtocol {
 	return []v1.AppProtocol{}
 }
 
-func PassthroughParserPluginFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func PassthroughParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewPassthroughParser().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -71,7 +71,7 @@ func (p *VertexAIParser) SupportedAppProtocols() []v1.AppProtocol {
 	return []v1.AppProtocol{v1.AppProtocolH2C}
 }
 
-func VertexAIParserPluginFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func VertexAIParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewVertexAIParser().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -59,7 +59,7 @@ func NewVllmGRPCParser() *VllmGRPCParser {
 	}
 }
 
-func VllmGRPCParserPluginFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func VllmGRPCParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewVllmGRPCParser().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/README.md
@@ -173,5 +173,5 @@ None.
 ---
 
 ## Related Documentation
-- [Creating a Custom Filter](/docs/create_new_filter.md)
-- [Disaggregated Inference Serving in llm-d](/docs/disaggregation.md)
+- [Creating a Custom Filter](../../../../../../../docs/create_new_filter.md)
+- [Disaggregated Inference Serving in llm-d](../../../../../../../docs/disaggregation.md)

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter.go
@@ -31,7 +31,7 @@ var _ scheduling.Filter = &ByLabel{} // validate interface conformance
 //
 // Deprecated: Use SelectorFactory for generic label-based filtering,
 // or the role-specific filters (decode-filter, prefill-filter, encode-filter) for role-based filtering.
-func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	if handle != nil {
 		log.FromContext(handle.Context()).Info("Deprecated: plugin type 'by-label' is deprecated, " +
 			"use 'label-selector-filter' for generic label filtering or " +
@@ -39,7 +39,7 @@ func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (
 	}
 	parameters := byLabelParameters{}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", ByLabelType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
@@ -10,6 +10,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
 )
@@ -94,7 +95,7 @@ func TestFactory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := Factory(tt.pluginName, rawParams, nil)
+			plugin, err := Factory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -129,7 +130,7 @@ func TestFactoryInvalidJSON(t *testing.T) {
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := Factory("test", rawParams, nil)
+			plugin, err := Factory("test", fwkplugin.StrictDecoder(rawParams), nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)
@@ -238,7 +239,7 @@ func TestByLabelFiltering(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			plugin, err := Factory("test-label", rawParams, nil)
+			plugin, err := Factory("test-label", fwkplugin.StrictDecoder(rawParams), nil)
 			require.NoError(t, err)
 			require.NotNil(t, plugin)
 

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
@@ -10,6 +10,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
@@ -94,7 +95,7 @@ func TestFactory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := Factory(tt.pluginName, rawParams, nil)
+			plugin, err := Factory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -129,7 +130,7 @@ func TestFactoryInvalidJSON(t *testing.T) {
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := Factory("test", rawParams, nil)
+			plugin, err := Factory("test", fwkplugin.StrictDecoder(rawParams), nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)
@@ -238,7 +239,7 @@ func TestByLabelFiltering(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			plugin, err := Factory("test-label", rawParams, nil)
+			plugin, err := Factory("test-label", fwkplugin.StrictDecoder(rawParams), nil)
 			require.NoError(t, err)
 			require.NotNil(t, plugin)
 

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles.go
@@ -38,7 +38,7 @@ const (
 )
 
 // DecodeRoleFactory defines the factory function for the Decode filter.
-func DecodeRoleFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func DecodeRoleFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewDecodeRole().WithName(name), nil
 }
 
@@ -48,7 +48,7 @@ func NewDecodeRole() *ByLabel {
 }
 
 // PrefillRoleFactory defines the factory function for the Prefill filter.
-func PrefillRoleFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func PrefillRoleFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewPrefillRole().WithName(name), nil
 }
 
@@ -58,7 +58,7 @@ func NewPrefillRole() *ByLabel {
 }
 
 // EncodeRoleFactory defines the factory function for the Encode filter.
-func EncodeRoleFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func EncodeRoleFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewEncodeRole().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector.go
@@ -31,10 +31,10 @@ var _ scheduling.Filter = &Selector{}
 var LabelSelectorFilterFactory = SelectorFactory
 
 // SelectorFactory defines the factory function for the Selector filter.
-func SelectorFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func SelectorFactory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	parameters := metav1.LabelSelector{}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LabelSelectorFilterType, err)
 		}
 	}
@@ -46,7 +46,7 @@ func SelectorFactory(name string, rawParameters json.RawMessage, _ plugin.Handle
 // rather than the canonical "label-selector-filter". It also logs a deprecation warning.
 //
 // Deprecated: Use SelectorFactory instead.
-func DeprecatedSelectorFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func DeprecatedSelectorFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	if handle != nil {
 		log.FromContext(handle.Context()).Info("Deprecated: plugin type 'by-label-selector' is deprecated, use 'label-selector-filter' instead")
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
@@ -11,6 +11,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
@@ -94,7 +95,7 @@ func TestLabelSelectorFilterFactoryWithJSON(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
 
-			plugin, err := bylabel.SelectorFactory(tt.pluginName, rawParams, nil)
+			plugin, err := bylabel.SelectorFactory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -137,7 +138,7 @@ func TestLabelSelectorFilterFactoryWithInvalidJSON(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
 
-			plugin, err := bylabel.SelectorFactory(tt.pluginName, rawParams, nil)
+			plugin, err := bylabel.SelectorFactory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)
@@ -291,7 +292,7 @@ func TestLabelSelectorFilterFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.selectorJSON)
-			plugin, err := bylabel.SelectorFactory("test-selector", rawParams, nil)
+			plugin, err := bylabel.SelectorFactory("test-selector", fwkplugin.StrictDecoder(rawParams), nil)
 			require.NoError(t, err)
 			require.NotNil(t, plugin)
 
@@ -317,7 +318,7 @@ func TestLabelSelectorFilterFiltering(t *testing.T) {
 
 func TestLabelSelectorFilterEdgeCases(t *testing.T) {
 	rawParams := json.RawMessage(`{"matchLabels": {"app": "test"}}`)
-	plugin, err := bylabel.SelectorFactory("test-selector", rawParams, nil)
+	plugin, err := bylabel.SelectorFactory("test-selector", fwkplugin.StrictDecoder(rawParams), nil)
 	require.NoError(t, err)
 
 	blf, ok := plugin.(*bylabel.Selector)
@@ -352,7 +353,7 @@ func TestLabelSelectorFilterEdgeCases(t *testing.T) {
 // Definition of labels is based on https://github.com/llm-d/llm-d-inference-scheduler/issues/220.
 func ExamplePrefillDecodeRolesInLWS() {
 	decodeLeaderJSON := json.RawMessage(`{ "matchLabels": { "leaderworkerset.sigs.k8s.io/worker-index": "0" } }`)
-	plugin, _ := bylabel.SelectorFactory("decode-role", decodeLeaderJSON, nil)
+	plugin, _ := bylabel.SelectorFactory("decode-role", fwkplugin.StrictDecoder(decodeLeaderJSON), nil)
 	decodeLeader, _ := plugin.(*bylabel.Selector)
 
 	decodeFollowerJSON := json.RawMessage(`{"matchExpressions": [{ 
@@ -360,14 +361,14 @@ func ExamplePrefillDecodeRolesInLWS() {
       	"operator": "NotIn",
       	"values": ["0"]
     }]}`)
-	plugin, _ = bylabel.SelectorFactory("ignore-decode-workers", decodeFollowerJSON, nil)
+	plugin, _ = bylabel.SelectorFactory("ignore-decode-workers", fwkplugin.StrictDecoder(decodeFollowerJSON), nil)
 	decodeFollower, _ := plugin.(*bylabel.Selector)
 
 	prefillWorkerJSON := json.RawMessage(`{"matchExpressions": [{
     	"key": "leaderworkerset.sigs.k8s.io/worker-index",
       	"operator": "DoesNotExist"
     }]}`)
-	plugin, _ = bylabel.SelectorFactory("prefill-role", prefillWorkerJSON, nil)
+	plugin, _ = bylabel.SelectorFactory("prefill-role", fwkplugin.StrictDecoder(prefillWorkerJSON), nil)
 	prefillworker, _ := plugin.(*bylabel.Selector)
 
 	endpoints := []scheduling.Endpoint{createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "vllm"},
@@ -415,7 +416,7 @@ func PrefillDecodeRolesInLWS(blf *bylabel.Selector, endpoints []scheduling.Endpo
 func TestDeprecatedSelectorFactoryBackwardCompat(t *testing.T) {
 	rawParams := json.RawMessage(`{"matchLabels": {"app": "nginx"}}`)
 
-	plugin, err := bylabel.DeprecatedSelectorFactory("compat-test", rawParams, nil) //nolint:staticcheck // testing deprecated function
+	plugin, err := bylabel.DeprecatedSelectorFactory("compat-test", fwkplugin.StrictDecoder(rawParams), nil) //nolint:staticcheck // testing deprecated function
 	require.NoError(t, err)
 	require.NotNil(t, plugin)
 

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
@@ -11,6 +11,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	"github.com/llm-d/llm-d-router/test/utils"
@@ -94,7 +95,7 @@ func TestLabelSelectorFilterFactoryWithJSON(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
 
-			plugin, err := bylabel.SelectorFactory(tt.pluginName, rawParams, nil)
+			plugin, err := bylabel.SelectorFactory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -137,7 +138,7 @@ func TestLabelSelectorFilterFactoryWithInvalidJSON(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
 
-			plugin, err := bylabel.SelectorFactory(tt.pluginName, rawParams, nil)
+			plugin, err := bylabel.SelectorFactory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)
@@ -291,7 +292,7 @@ func TestLabelSelectorFilterFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.selectorJSON)
-			plugin, err := bylabel.SelectorFactory("test-selector", rawParams, nil)
+			plugin, err := bylabel.SelectorFactory("test-selector", fwkplugin.StrictDecoder(rawParams), nil)
 			require.NoError(t, err)
 			require.NotNil(t, plugin)
 
@@ -317,7 +318,7 @@ func TestLabelSelectorFilterFiltering(t *testing.T) {
 
 func TestLabelSelectorFilterEdgeCases(t *testing.T) {
 	rawParams := json.RawMessage(`{"matchLabels": {"app": "test"}}`)
-	plugin, err := bylabel.SelectorFactory("test-selector", rawParams, nil)
+	plugin, err := bylabel.SelectorFactory("test-selector", fwkplugin.StrictDecoder(rawParams), nil)
 	require.NoError(t, err)
 
 	blf, ok := plugin.(*bylabel.Selector)
@@ -352,7 +353,7 @@ func TestLabelSelectorFilterEdgeCases(t *testing.T) {
 // Definition of labels is based on https://github.com/llm-d/llm-d-router/issues/220.
 func ExamplePrefillDecodeRolesInLWS() {
 	decodeLeaderJSON := json.RawMessage(`{ "matchLabels": { "leaderworkerset.sigs.k8s.io/worker-index": "0" } }`)
-	plugin, _ := bylabel.SelectorFactory("decode-role", decodeLeaderJSON, nil)
+	plugin, _ := bylabel.SelectorFactory("decode-role", fwkplugin.StrictDecoder(decodeLeaderJSON), nil)
 	decodeLeader, _ := plugin.(*bylabel.Selector)
 
 	decodeFollowerJSON := json.RawMessage(`{"matchExpressions": [{ 
@@ -360,14 +361,14 @@ func ExamplePrefillDecodeRolesInLWS() {
       	"operator": "NotIn",
       	"values": ["0"]
     }]}`)
-	plugin, _ = bylabel.SelectorFactory("ignore-decode-workers", decodeFollowerJSON, nil)
+	plugin, _ = bylabel.SelectorFactory("ignore-decode-workers", fwkplugin.StrictDecoder(decodeFollowerJSON), nil)
 	decodeFollower, _ := plugin.(*bylabel.Selector)
 
 	prefillWorkerJSON := json.RawMessage(`{"matchExpressions": [{
     	"key": "leaderworkerset.sigs.k8s.io/worker-index",
       	"operator": "DoesNotExist"
     }]}`)
-	plugin, _ = bylabel.SelectorFactory("prefill-role", prefillWorkerJSON, nil)
+	plugin, _ = bylabel.SelectorFactory("prefill-role", fwkplugin.StrictDecoder(prefillWorkerJSON), nil)
 	prefillworker, _ := plugin.(*bylabel.Selector)
 
 	endpoints := []scheduling.Endpoint{createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "vllm"},
@@ -415,7 +416,7 @@ func PrefillDecodeRolesInLWS(blf *bylabel.Selector, endpoints []scheduling.Endpo
 func TestDeprecatedSelectorFactoryBackwardCompat(t *testing.T) {
 	rawParams := json.RawMessage(`{"matchLabels": {"app": "nginx"}}`)
 
-	plugin, err := bylabel.DeprecatedSelectorFactory("compat-test", rawParams, nil) //nolint:staticcheck // testing deprecated function
+	plugin, err := bylabel.DeprecatedSelectorFactory("compat-test", fwkplugin.StrictDecoder(rawParams), nil) //nolint:staticcheck // testing deprecated function
 	require.NoError(t, err)
 	require.NotNil(t, plugin)
 

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -69,10 +69,10 @@ type Plugin struct {
 	config    Config
 }
 
-func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -83,10 +83,10 @@ type Plugin struct {
 	inFlightLoadDataKey          fwkplugin.DataKey
 }
 
-func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
@@ -105,7 +106,7 @@ func TestFilter_ExplorationProbability(t *testing.T) {
 }
 
 func TestFactory_ValidConfig(t *testing.T) {
-	plugin, err := Factory("test", nil, nil)
+	plugin, err := Factory("test", fwkplugin.StrictDecoder(nil), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, plugin)
 	assert.Equal(t, PluginType, plugin.TypedName().Type)
@@ -113,7 +114,7 @@ func TestFactory_ValidConfig(t *testing.T) {
 
 func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	// Setting only affinityThreshold should preserve defaults for other params.
-	plugin, err := Factory("test", []byte(`{"affinityThreshold": 0.95}`), nil)
+	plugin, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"affinityThreshold": 0.95}`)), nil)
 	assert.NoError(t, err)
 	p := plugin.(*Plugin)
 	assert.Equal(t, 0.95, p.config.AffinityThreshold)
@@ -121,7 +122,7 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfig.MaxTTFTPenaltyMs, p.config.MaxTTFTPenaltyMs)
 
 	// Setting only explorationProbability should preserve defaults for other params.
-	plugin, err = Factory("test", []byte(`{"explorationProbability": 0.05}`), nil)
+	plugin, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"explorationProbability": 0.05}`)), nil)
 	assert.NoError(t, err)
 	p = plugin.(*Plugin)
 	assert.Equal(t, DefaultConfig.AffinityThreshold, p.config.AffinityThreshold)
@@ -129,7 +130,7 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfig.MaxTTFTPenaltyMs, p.config.MaxTTFTPenaltyMs)
 
 	// Setting only maxTTFTPenaltyMs should preserve defaults for other params.
-	plugin, err = Factory("test", []byte(`{"maxTTFTPenaltyMs": 10000}`), nil)
+	plugin, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"maxTTFTPenaltyMs": 10000}`)), nil)
 	assert.NoError(t, err)
 	p = plugin.(*Plugin)
 	assert.Equal(t, DefaultConfig.AffinityThreshold, p.config.AffinityThreshold)
@@ -138,13 +139,13 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 }
 
 func TestFactory_InvalidAffinityThreshold(t *testing.T) {
-	_, err := Factory("test", []byte(`{"affinityThreshold": 1.5}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"affinityThreshold": 1.5}`)), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "affinityThreshold must be <= 1.0")
 }
 
 func TestFactory_InvalidExplorationProbability(t *testing.T) {
-	_, err := Factory("test", []byte(`{"explorationProbability": -0.1}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"explorationProbability": -0.1}`)), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "explorationProbability must be in [0, 1]")
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -186,7 +186,7 @@ func TestConsumes_ConditionalAttributes(t *testing.T) {
 }
 
 func TestFactory_ValidConfig(t *testing.T) {
-	plugin, err := Factory("test", nil, nil)
+	plugin, err := Factory("test", fwkplugin.StrictDecoder(nil), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, plugin)
 	assert.Equal(t, PluginType, plugin.TypedName().Type)
@@ -194,7 +194,7 @@ func TestFactory_ValidConfig(t *testing.T) {
 
 func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	// Setting only affinityThreshold should preserve defaults for other params.
-	plugin, err := Factory("test", []byte(`{"affinityThreshold": 0.95}`), nil)
+	plugin, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"affinityThreshold": 0.95}`)), nil)
 	assert.NoError(t, err)
 	p := plugin.(*Plugin)
 	assert.Equal(t, 0.95, p.config.AffinityThreshold)
@@ -202,7 +202,7 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfig.MaxTTFTPenaltyMs, p.config.MaxTTFTPenaltyMs)
 
 	// Setting only explorationProbability should preserve defaults for other params.
-	plugin, err = Factory("test", []byte(`{"explorationProbability": 0.05}`), nil)
+	plugin, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"explorationProbability": 0.05}`)), nil)
 	assert.NoError(t, err)
 	p = plugin.(*Plugin)
 	assert.Equal(t, DefaultConfig.AffinityThreshold, p.config.AffinityThreshold)
@@ -210,7 +210,7 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfig.MaxTTFTPenaltyMs, p.config.MaxTTFTPenaltyMs)
 
 	// Setting only maxTTFTPenaltyMs should preserve defaults for other params.
-	plugin, err = Factory("test", []byte(`{"maxTTFTPenaltyMs": 10000}`), nil)
+	plugin, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"maxTTFTPenaltyMs": 10000}`)), nil)
 	assert.NoError(t, err)
 	p = plugin.(*Plugin)
 	assert.Equal(t, DefaultConfig.AffinityThreshold, p.config.AffinityThreshold)
@@ -219,13 +219,13 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 }
 
 func TestFactory_InvalidAffinityThreshold(t *testing.T) {
-	_, err := Factory("test", []byte(`{"affinityThreshold": 1.5}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"affinityThreshold": 1.5}`)), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "affinityThreshold must be <= 1.0")
 }
 
 func TestFactory_InvalidExplorationProbability(t *testing.T) {
-	_, err := Factory("test", []byte(`{"explorationProbability": -0.1}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"explorationProbability": -0.1}`)), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "explorationProbability must be in [0, 1]")
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -56,10 +56,10 @@ type Plugin struct {
 	config    Config
 }
 
-func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -59,10 +59,10 @@ type Plugin struct {
 	latencyPredictionInfoDataKey fwkplugin.DataKey
 }
 
-func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/latency"
 )
@@ -115,13 +116,13 @@ func TestFilter_NoPredictionGoesToNegative(t *testing.T) {
 // Note: Deficit bucketing tests are in the slo-deficit-bucket-filter package.
 
 func TestFactory_ValidConfig(t *testing.T) {
-	plugin, err := Factory("test", nil, nil)
+	plugin, err := Factory("test", fwkplugin.StrictDecoder(nil), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, plugin)
 }
 
 func TestFactory_InvalidEpsilon(t *testing.T) {
-	_, err := Factory("test", []byte(`{"epsilonExploreNeg": 1.5}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"epsilonExploreNeg": 1.5}`)), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "epsilonExploreNeg must be in [0, 1]")
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
@@ -124,13 +124,13 @@ func TestFilter_NoPredictionGoesToNegative(t *testing.T) {
 // Note: Deficit bucketing tests are in the slo-deficit-bucket-filter package.
 
 func TestFactory_ValidConfig(t *testing.T) {
-	plugin, err := Factory("test", nil, nil)
+	plugin, err := Factory("test", fwkplugin.StrictDecoder(nil), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, plugin)
 }
 
 func TestFactory_InvalidEpsilon(t *testing.T) {
-	_, err := Factory("test", []byte(`{"epsilonExploreNeg": 1.5}`), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"epsilonExploreNeg": 1.5}`)), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "epsilonExploreNeg must be in [0, 1]")
 }

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
@@ -43,10 +43,10 @@ const (
 var _ fwksched.Picker = &MaxScorePicker{}
 
 // MaxScorePickerFactory defines the factory function for MaxScorePicker.
-func MaxScorePickerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func MaxScorePickerFactory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	parameters := picker.PickerParameters{MaxNumOfEndpoints: picker.DefaultMaxNumOfEndpoints}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' picker - %w", MaxScorePickerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/picker/random/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/random/picker.go
@@ -42,10 +42,10 @@ const (
 var _ fwksched.Picker = &RandomPicker{}
 
 // RandomPickerFactory defines the factory function for RandomPicker.
-func RandomPickerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func RandomPickerFactory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	parameters := picker.PickerParameters{MaxNumOfEndpoints: picker.DefaultMaxNumOfEndpoints}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' picker - %w", RandomPickerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
@@ -52,10 +52,10 @@ type weightedScoredEndpoint struct {
 var _ fwksched.Picker = &WeightedRandomPicker{}
 
 // WeightedRandomPickerFactory defines the factory function for WeightedRandomPicker.
-func WeightedRandomPickerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func WeightedRandomPickerFactory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	parameters := picker.PickerParameters{MaxNumOfEndpoints: picker.DefaultMaxNumOfEndpoints}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' picker - %w", WeightedRandomPickerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
@@ -29,13 +29,13 @@ type dataParallelProfileHandlerParameters struct {
 var _ scheduling.ProfileHandler = &ProfileHandler{}
 
 // ProfileHandlerFactory defines the factory function for the ProfileHandler
-func ProfileHandlerFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func ProfileHandlerFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	log.FromContext(handle.Context()).Info("Deprecated: Use simple-profile-handler with Istio >= 1.28.1")
 	parameters := dataParallelProfileHandlerParameters{
 		PrimaryPort: 8000,
 	}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' profile handler - %w", DataParallelProfileHandlerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
@@ -123,7 +123,7 @@ func TestProfileHandlerFactory(t *testing.T) {
 				rawParams = json.RawMessage(tt.jsonParams)
 			}
 			handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
-			plugin, err := ProfileHandlerFactory(tt.pluginName, rawParams, handle)
+			plugin, err := ProfileHandlerFactory(tt.pluginName, plugin.StrictDecoder(rawParams), handle)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -160,7 +160,7 @@ func TestProfileHandlerFactoryInvalidJSON(t *testing.T) {
 
 			rawParams := json.RawMessage(tt.jsonParams)
 			handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
-			plugin, err := ProfileHandlerFactory("test", rawParams, handle)
+			plugin, err := ProfileHandlerFactory("test", plugin.StrictDecoder(rawParams), handle)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
@@ -263,4 +263,4 @@ None.
 
 ## Related Documentation
 
-- [Disaggregation Architecture](/docs/disaggregation.md)
+- [Disaggregation Architecture](../../../../../../../docs/disaggregation.md)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_mm_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_mm_decider.go
@@ -23,7 +23,7 @@ type AlwaysDisaggMultimodalDecider struct {
 
 // AlwaysDisaggMulimodalDeciderPluginFactory defines the factory function for creating
 // a new instance of the AlwaysDisaggEncodeDecider.
-func AlwaysDisaggMulimodalDeciderPluginFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func AlwaysDisaggMulimodalDeciderPluginFactory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return newAlwaysDisaggEncodeDecider().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_pd_decider.go
@@ -23,7 +23,7 @@ type AlwaysDisaggPDDecider struct {
 
 // AlwaysDisaggPDDeciderPluginFactory defines the factory function for creating
 // a new instance of the AlwaysDisaggPDDecider.
-func AlwaysDisaggPDDeciderPluginFactory(name string, _ json.RawMessage,
+func AlwaysDisaggPDDeciderPluginFactory(name string, _ *json.Decoder,
 	_ plugin.Handle) (plugin.Plugin, error) {
 	return newAlwaysDisaggPDDecider().WithName(name), nil
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
@@ -41,13 +41,13 @@ type disaggHeadersHandlerParameters struct {
 // HeadersHandlerFactory defines the factory function for the HeadersHandler.
 //
 // Deprecated: Use HandlerFactory instead, disagg-profile-handler now implements PreRequest natively.
-func HeadersHandlerFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func HeadersHandlerFactory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	parameters := disaggHeadersHandlerParameters{
 		PrefillProfile: defaultPrefillProfile,
 		EncodeProfile:  defaultEncodeProfile,
 	}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' pre-request plugin - %w", DisaggHeadersHandlerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
@@ -106,7 +106,7 @@ func TestHeadersHandlerFactory(t *testing.T) {
 				raw = json.RawMessage(tt.rawParams)
 			}
 
-			p, err := HeadersHandlerFactory(tt.pluginName, raw, nil)
+			p, err := HeadersHandlerFactory(tt.pluginName, fwkplugin.StrictDecoder(raw), nil)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, p)
@@ -161,7 +161,7 @@ func TestPrefillHeaderHandlerBackwardCompat(t *testing.T) {
 	require.True(t, ok, "prefill-header-handler must be in the registry")
 
 	raw := json.RawMessage(`{"prefillProfile": "prefill"}`)
-	p, err := factory("compat-handler", raw, nil)
+	p, err := factory("compat-handler", fwkplugin.StrictDecoder(raw), nil)
 	require.NoError(t, err)
 	require.NotNil(t, p)
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -102,29 +102,36 @@ func (l *legacyDisaggProfileHandlerParameters) toDisaggParams(logger logr.Logger
 //
 //	if parameters.deciders.prefill is set - P disaggregation will be supported
 //	if parameters.deciders.encode is set - E disaggregation will be supported
-func HandlerFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func HandlerFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	logger := log.FromContext(handle.Context())
 
 	parameters := disaggProfileHandlerParameters{}
 	if rawParameters != nil {
-		legacy := legacyDisaggProfileHandlerParameters{}
-
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		// Capture raw bytes once so we can try each schema independently with
+		// strict decoding. The decoder passed in is one-shot, so we re-read
+		// from these bytes for the second attempt.
+		var raw json.RawMessage
+		if err := rawParameters.Decode(&raw); err != nil {
 			return nil, fmt.Errorf("failed to parse parameters of the disagg-profile-handler - %w", err)
 		}
-		if err := json.Unmarshal(rawParameters, &legacy); err != nil {
-			return nil, fmt.Errorf("failed to parse parameters of the disagg-profile-handler - %w", err)
-		}
 
-		if parameters.Profiles != (disaggProfilesParameters{}) ||
-			parameters.Deciders != (disaggDecidersParameters{}) {
-			// Make sure the legacy parameters were not used
-			if legacy != (legacyDisaggProfileHandlerParameters{}) {
-				return nil, errors.New("cannot mix deprecated flat parameters (decodeProfile, prefillProfile, encodeProfile, " +
-					"deciderPluginName, prefillDeciderPluginName, encodeDeciderPluginName) " +
-					"with nested parameters (profiles, deciders): use one format or the other")
+		// Try the new (nested) schema strictly first. If the user supplied
+		// only new-format fields, this succeeds. Per #1068, deprecated
+		// (legacy flat) fields are not in the new struct, so they would
+		// produce "unknown field" errors here — that's the signal to fall
+		// back to the legacy schema.
+		errNew := plugin.StrictDecoder(raw).Decode(&parameters)
+		if errNew != nil {
+			legacy := legacyDisaggProfileHandlerParameters{}
+			if errLegacy := plugin.StrictDecoder(raw).Decode(&legacy); errLegacy != nil {
+				// Neither schema parses cleanly: either mixed schemas or a
+				// genuinely unknown field. Surface both errors so callers can
+				// tell which they meant.
+				return nil, fmt.Errorf("failed to parse parameters of the disagg-profile-handler: "+
+					"nested schema error: %w; legacy schema error: %v "+
+					"(use one format exclusively: either nested profiles/deciders or the deprecated flat fields)",
+					errNew, errLegacy)
 			}
-		} else {
 			logger.Info("Deprecated: using flat parameter format, migrate to nested profiles/deciders format")
 			parameters = legacy.toDisaggParams(logger)
 		}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -226,7 +226,7 @@ func TestHandlerFactory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b, _ := json.Marshal(tt.params)
-			p, err := HandlerFactory("h", b, handle)
+			p, err := HandlerFactory("h", plugin.StrictDecoder(b), handle)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, p)
@@ -259,10 +259,10 @@ func TestHandlerFactory_DeprecatedFlatParams(t *testing.T) {
 			"encodeProfile":            "my-encode",
 			"prefillDeciderPluginName": PrefixBasedPDDeciderPluginType,
 		}, false},
-		{"nested format with unknown extra fields is accepted", map[string]any{
+		{"nested format with unknown extra fields is rejected", map[string]any{
 			"profiles":     map[string]any{"decode": "decode"},
 			"unknownField": "ignored",
-		}, false},
+		}, true},
 		{"mixing deprecated and nested fields is an error", map[string]any{
 			"decodeProfile": "my-decode",
 			"profiles":      map[string]any{"decode": "other-decode"},
@@ -275,7 +275,7 @@ func TestHandlerFactory_DeprecatedFlatParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b, _ := json.Marshal(tt.params)
-			p, err := HandlerFactory("h", b, handle)
+			p, err := HandlerFactory("h", plugin.StrictDecoder(b), handle)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, p)
@@ -305,14 +305,14 @@ func TestHandlerFactory_PdProfileHandlerParams(t *testing.T) {
 			"prefillProfile":    "prefill",
 			"deciderPluginName": PrefixBasedPDDeciderPluginType,
 		}, false},
-		{"pd-profile-handler with all params including ignored fields", map[string]any{
+		{"pd-profile-handler with unknown fields is rejected", map[string]any{
 			"decodeProfile":     "decode",
 			"prefillProfile":    "prefill",
 			"deciderPluginName": PrefixBasedPDDeciderPluginType,
-			"prefixPluginType":  "prefix-cache-scorer", // ignored by Handler
-			"prefixPluginName":  "prefix-cache-scorer", // ignored by Handler
-			"primaryPort":       8080,                  // ignored by Handler
-		}, false},
+			"prefixPluginType":  "prefix-cache-scorer", // unknown to both schemas (#1068)
+			"prefixPluginName":  "prefix-cache-scorer",
+			"primaryPort":       8080,
+		}, true},
 		{"pd-profile-handler unknown deciderPluginName", map[string]any{
 			"deciderPluginName": "INVALID",
 		}, true},
@@ -320,7 +320,7 @@ func TestHandlerFactory_PdProfileHandlerParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b, _ := json.Marshal(tt.params)
-			p, err := HandlerFactory("h", b, handle)
+			p, err := HandlerFactory("h", plugin.StrictDecoder(b), handle)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, p)
@@ -336,7 +336,7 @@ func TestHandlerFactory_InvalidJSON(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := handleWithDeciders(ctx)
 	for _, raw := range []string{`{"deciders": `} {
-		p, err := HandlerFactory("h", json.RawMessage(raw), handle)
+		p, err := HandlerFactory("h", plugin.StrictDecoder(json.RawMessage(raw)), handle)
 		assert.Error(t, err)
 		assert.Nil(t, p)
 	}
@@ -1281,7 +1281,7 @@ func TestHandler_Factory_NilDeciders(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b, _ := json.Marshal(tt.params)
-			p, err := HandlerFactory("h", b, handle)
+			p, err := HandlerFactory("h", plugin.StrictDecoder(b), handle)
 			if tt.expectErr {
 				assert.Error(t, err, tt.description)
 				assert.Nil(t, p)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -46,7 +46,7 @@ var _ scheduling.ProfileHandler = &PdProfileHandler{}
 // PdProfileHandlerFactory defines the factory function for the PdProfileHandler.
 //
 // Deprecated: Use HandlerFactory instead.
-func PdProfileHandlerFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PdProfileHandlerFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	log.FromContext(handle.Context()).Info("Deprecated: pd-profile-handler is deprecated, use disagg-profile-handler instead")
 	parameters := pdProfileHandlerParameters{
 		DecodeProfile:     defaultDecodeProfile,
@@ -56,7 +56,7 @@ func PdProfileHandlerFactory(name string, rawParameters json.RawMessage, handle 
 		DeciderPluginName: defaultDeciderPluginName,
 	}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' profile handler - %w", PdProfileHandlerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -47,7 +47,7 @@ var _ scheduling.ProfileHandler = &PdProfileHandler{}
 // PdProfileHandlerFactory defines the factory function for the PdProfileHandler.
 //
 // Deprecated: Use HandlerFactory instead.
-func PdProfileHandlerFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PdProfileHandlerFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	log.FromContext(handle.Context()).Info("Deprecated: pd-profile-handler is deprecated, use disagg-profile-handler instead")
 	parameters := pdProfileHandlerParameters{
 		DecodeProfile:     defaultDecodeProfile,
@@ -56,7 +56,7 @@ func PdProfileHandlerFactory(name string, rawParameters json.RawMessage, handle 
 		DeciderPluginName: defaultDeciderPluginName,
 	}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' profile handler - %w", PdProfileHandlerType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
@@ -122,7 +122,7 @@ func TestPdProfileHandlerFactory(t *testing.T) {
 				assert.NoError(t, err)
 				rawParams = json.RawMessage(bytes)
 			}
-			plugin, err := PdProfileHandlerFactory(tt.pluginName, rawParams, handle)
+			plugin, err := PdProfileHandlerFactory(tt.pluginName, plugin.StrictDecoder(rawParams), handle)
 
 			if tt.expectErr {
 				assert.Error(t, err)
@@ -162,7 +162,7 @@ func TestPdProfileHandlerFactoryInvalidJSON(t *testing.T) {
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
 			rawParams := json.RawMessage(tt.jsonParams)
-			plugin, err := PdProfileHandlerFactory("test", rawParams, handle)
+			plugin, err := PdProfileHandlerFactory("test", plugin.StrictDecoder(rawParams), handle)
 
 			assert.Error(t, err)
 			assert.Nil(t, plugin)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
@@ -48,14 +48,14 @@ type PrefixBasedPDDecider struct {
 
 // PrefixBasedPDDeciderPluginFactory defines the factory function for creating
 // a new instance of the prefixBasedPDDecider.
-func PrefixBasedPDDeciderPluginFactory(name string, rawParameters json.RawMessage,
+func PrefixBasedPDDeciderPluginFactory(name string, rawParameters *json.Decoder,
 	handle plugin.Handle) (plugin.Plugin, error) {
 	config := PrefixBasedPDDeciderConfig{
 		NonCachedTokens: 0,
 	}
 
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to parse %s plugin config: %w", PrefixBasedPDDeciderPluginType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -10,6 +10,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
@@ -172,7 +173,7 @@ func TestPrefixBasedPDDeciderFactory(t *testing.T) {
 				raw = json.RawMessage(tt.rawParams)
 			}
 
-			p, err := PrefixBasedPDDeciderPluginFactory(tt.pluginName, raw, nil)
+			p, err := PrefixBasedPDDeciderPluginFactory(tt.pluginName, plugin.StrictDecoder(raw), nil)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, p)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -10,6 +10,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-router/test/utils"
@@ -172,7 +173,7 @@ func TestPrefixBasedPDDeciderFactory(t *testing.T) {
 				raw = json.RawMessage(tt.rawParams)
 			}
 
-			p, err := PrefixBasedPDDeciderPluginFactory(tt.pluginName, raw, nil)
+			p, err := PrefixBasedPDDeciderPluginFactory(tt.pluginName, fwkplugin.StrictDecoder(raw), nil)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, p)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler.go
@@ -34,7 +34,7 @@ const (
 var _ fwksched.ProfileHandler = &SingleProfileHandler{}
 
 // SingleProfileHandlerFactory defines the factory function for SingleProfileHandler.
-func SingleProfileHandlerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func SingleProfileHandlerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewSingleProfileHandler().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -56,10 +56,10 @@ var _ scheduling.Scorer = &ActiveRequest{}
 var _ plugin.ConsumerPlugin = &ActiveRequest{}
 
 // Factory defines the factory function for the ActiveRequest scorer.
-func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := Parameters{}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", ActiveRequestType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -58,10 +58,10 @@ var _ scheduling.Scorer = &ActiveRequest{}
 var _ plugin.ConsumerPlugin = &ActiveRequest{}
 
 // Factory defines the factory function for the ActiveRequest scorer.
-func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := Parameters{}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", ActiveRequestType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
@@ -50,14 +50,14 @@ var _ scheduling.Filter = &ContextLengthAware{} // validate interface conformanc
 var _ scheduling.Scorer = &ContextLengthAware{} // validate interface conformance
 
 // Factory defines the factory function for the ContextLengthAware plugin.
-func Factory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	parameters := &contextLengthAwareParameters{
 		Label:           DefaultContextLengthLabel,
 		EnableFiltering: false,
 	}
 
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, parameters); err != nil {
+		if err := rawParameters.Decode(parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' plugin - %w", ContextLengthAwareType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -10,6 +10,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-inference-scheduler/test/utils"
@@ -68,7 +69,7 @@ func TestFactory(t *testing.T) {
 			if tt.jsonParams != "" {
 				rawParams = json.RawMessage(tt.jsonParams)
 			}
-			plugin, err := Factory(tt.pluginName, rawParams, nil)
+			plugin, err := Factory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			if tt.expectErr {
 				assert.Error(t, err)

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -10,6 +10,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/test/utils"
@@ -68,7 +69,7 @@ func TestFactory(t *testing.T) {
 			if tt.jsonParams != "" {
 				rawParams = json.RawMessage(tt.jsonParams)
 			}
-			plugin, err := Factory(tt.pluginName, rawParams, nil)
+			plugin, err := Factory(tt.pluginName, fwkplugin.StrictDecoder(rawParams), nil)
 
 			if tt.expectErr {
 				assert.Error(t, err)

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
@@ -33,7 +33,7 @@ const (
 var _ fwksched.Scorer = &KVCacheUtilizationScorer{}
 
 // KvCacheUtilizationScorerFactory defines the factory function for KVCacheUtilizationScorer.
-func KvCacheUtilizationScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func KvCacheUtilizationScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewKVCacheUtilizationScorer().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -111,10 +111,10 @@ func NewPlugin(config Config) *Plugin {
 	}
 }
 
-func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -118,10 +118,10 @@ func NewPlugin(config Config) *Plugin {
 	}
 }
 
-func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := DefaultConfig
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware.go
@@ -28,10 +28,10 @@ type loadAwareParameters struct {
 var _ scheduling.Scorer = &LoadAware{}
 
 // Factory defines the factory function for the LoadAware
-func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := loadAwareParameters{Threshold: QueueThresholdDefault}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", LoadAwareType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
@@ -33,7 +33,7 @@ const (
 var _ fwksched.Scorer = &LoraAffinityScorer{}
 
 // LoraAffinityScorerFactory defines the factory function for LoraAffinityScorer.
-func LoraAffinityScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func LoraAffinityScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewLoraAffinityScorer().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
@@ -49,10 +49,10 @@ type Config struct {
 }
 
 // Factory creates a multimodal encoder-cache affinity scorer.
-func Factory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	var cfg Config
-	if len(rawParameters) > 0 {
-		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse parameters for %q scorer: %w", Type, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -59,10 +59,10 @@ func (c *coldRequestState) Clone() plugin.StateData {
 }
 
 // Factory defines the factory function for the NoHitLRU
-func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := Parameters{}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", NoHitLRUType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -60,10 +60,10 @@ func (c *coldRequestState) Clone() plugin.StateData {
 }
 
 // Factory defines the factory function for the NoHitLRU
-func Factory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	parameters := Parameters{}
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", NoHitLRUType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -125,7 +125,7 @@ func TestNoHitLRUFactoryDependencyValidation(t *testing.T) {
 			raw = bytes
 		}
 
-		plugin, err := nohitlru.Factory("test", raw, tt.handle)
+		plugin, err := nohitlru.Factory("test", plugin.StrictDecoder(raw), tt.handle)
 		if tt.expectError {
 			if err == nil {
 				t.Fatalf("expected error for case %q, got none", tt.name)

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -129,7 +129,7 @@ func TestNoHitLRUFactoryDependencyValidation(t *testing.T) {
 			raw = bytes
 		}
 
-		plugin, err := nohitlru.Factory("test", raw, tt.handle)
+		plugin, err := nohitlru.Factory("test", plugin.StrictDecoder(raw), tt.handle)
 		if tt.expectError {
 			if err == nil {
 				t.Fatalf("expected error for case %q, got none", tt.name)

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -121,7 +121,7 @@ func (s *precisePluginState) Clone() plugin.StateData {
 
 // PluginFactory defines the factory function for creating
 // a new instance of the PrefixCacheTrackingPlugin.
-func PluginFactory(name string, rawParameters json.RawMessage,
+func PluginFactory(name string, rawParameters *json.Decoder,
 	handle plugin.Handle,
 ) (plugin.Plugin, error) {
 	indexerConfig, err := kvcache.NewDefaultConfig()
@@ -135,7 +135,7 @@ func PluginFactory(name string, rawParameters json.RawMessage,
 	}
 
 	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse %s plugin config: %w", PrecisePrefixCachePluginType, err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -44,7 +44,7 @@ const (
 )
 
 // PrefixCachePluginFactory defines the factory function for the Prefix plugin.
-func PrefixCachePluginFactory(name string, _ json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PrefixCachePluginFactory(name string, _ *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	p, err := New(handle.Context())
 	if err != nil {
 		return nil, err

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -52,11 +52,11 @@ const (
 )
 
 // PrefixCachePluginFactory defines the factory function for the Prefix plugin.
-func PrefixCachePluginFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+func PrefixCachePluginFactory(name string, decoder *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
 	var cfg Config
-	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &cfg); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal prefix cache scorer parameters: %w", err)
+	if decoder != nil {
+		if err := decoder.Decode(&cfg); err != nil {
+			return nil, fmt.Errorf("failed to decode prefix cache scorer parameters: %w", err)
 		}
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
@@ -34,7 +34,7 @@ const (
 var _ fwksched.Scorer = &QueueScorer{}
 
 // QueueScorerFactory defines the factory function for QueueScorer.
-func QueueScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func QueueScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewQueueScorer().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
@@ -34,7 +34,7 @@ const (
 var _ fwksched.Scorer = &RunningRequestsSizeScorer{}
 
 // RunningRequestsSizeScorerFactory defines the factory function for RunningRequestsSizeScorer.
-func RunningRequestsSizeScorerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func RunningRequestsSizeScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewRunningRequestsSizeScorer().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -26,7 +26,7 @@ var _ scheduling.Scorer = &SessionAffinity{}
 var _ requestcontrol.ResponseBodyProcessor = &SessionAffinity{}
 
 // Factory defines the factory function for SessionAffinity scorer.
-func Factory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func Factory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewSessionAffinity().WithName(name), nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -48,12 +48,12 @@ type TokenLoadScorer struct {
 	queueThresholdTokens float64
 }
 
-func TokenLoadScorerFactory(name string, params json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	cfg := Config{
 		QueueThresholdTokens: tokenQueueThresholdDefault,
 	}
-	if len(params) > 0 {
-		if err := json.Unmarshal(params, &cfg); err != nil {
+	if params != nil {
+		if err := params.Decode(&cfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal token load scorer config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -50,12 +50,12 @@ type TokenLoadScorer struct {
 	inFlightLoadDataKey  fwkplugin.DataKey
 }
 
-func TokenLoadScorerFactory(name string, params json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	cfg := Config{
 		QueueThresholdTokens: tokenQueueThresholdDefault,
 	}
-	if len(params) > 0 {
-		if err := json.Unmarshal(params, &cfg); err != nil {
+	if params != nil {
+		if err := params.Decode(&cfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal token load scorer config: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
+++ b/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
@@ -36,7 +36,7 @@ const (
 var _ fwksched.Filter = &HeaderBasedTestingFilter{}
 
 // HeaderBasedTestingFilterFactory defines the factory function for HeaderBasedTestingFilter.
-func HeaderBasedTestingFilterFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func HeaderBasedTestingFilterFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return NewHeaderBasedTestingFilter().WithName(name), nil
 }
 

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -4,10 +4,11 @@ package e2e
 const simpleConfig = `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 256
+- type: prefix-cache-scorer
 - type: decode-filter
 - type: max-score-picker
 - type: single-profile-handler
@@ -26,11 +27,12 @@ const deprecatedPdConfig = `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: prefill-header-handler
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
     blockSizeTokens: 16
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 256
+- type: prefix-cache-scorer
 - type: prefill-filter
 - type: decode-filter
 - type: max-score-picker
@@ -85,11 +87,12 @@ plugins:
 - type: encode-filter
 - type: prefill-filter
 - type: decode-filter
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
     blockSizeTokens: 16
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 256
+- type: prefix-cache-scorer
 - type: max-score-picker
 - type: always-disagg-multimodal-decider
 - type: prefix-based-pd-decider
@@ -122,11 +125,12 @@ schedulingProfiles:
 const pdConfig = `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
     blockSizeTokens: 16
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 256
+- type: prefix-cache-scorer
 - type: prefill-filter
 - type: decode-filter
 - type: max-score-picker
@@ -156,11 +160,11 @@ schedulingProfiles:
 const decodeOnlyConfig = `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefix-cache-scorer
+- type: approx-prefix-cache-producer
   parameters:
-    hashBlockSize: 10
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 256
+- type: prefix-cache-scorer
 - type: encode-filter
 - type: prefill-filter
 - type: decode-filter

--- a/test/integration/epp/e2e_config_smoke_test.go
+++ b/test/integration/epp/e2e_config_smoke_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package epp
+
+import "testing"
+
+// e2eConfigsForSmoke mirrors the YAML strings in test/e2e/configs_test.go so
+// the hermetic harness validates that the e2e fixtures actually parse +
+// instantiate plugins. Required because the real e2e suite only runs in CI
+// with a kind cluster, and an EPP-startup parse error there manifests as an
+// opaque pod CrashLoopBackOff + Ginkgo timeout (#1134 review feedback). This
+// keeps the same orphan-field-mismatch loop short.
+//
+// When the fixtures in test/e2e/configs_test.go are updated, mirror them here.
+var e2eConfigsForSmoke = map[string]string{
+	"simpleConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: approx-prefix-cache-producer
+  parameters:
+    maxPrefixBlocksToMatch: 256
+    lruCapacityPerServer: 256
+- type: prefix-cache-scorer
+- type: decode-filter
+- type: max-score-picker
+- type: single-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+`,
+	"deprecatedPdConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-header-handler
+- type: approx-prefix-cache-producer
+  parameters:
+    blockSizeTokens: 16
+    maxPrefixBlocksToMatch: 256
+    lruCapacityPerServer: 256
+- type: prefix-cache-scorer
+- type: prefill-filter
+- type: decode-filter
+- type: max-score-picker
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: prefix-based-pd-decider
+schedulingProfiles:
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+`,
+	"pdConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: approx-prefix-cache-producer
+  parameters:
+    blockSizeTokens: 16
+    maxPrefixBlocksToMatch: 256
+    lruCapacityPerServer: 256
+- type: prefix-cache-scorer
+- type: prefill-filter
+- type: decode-filter
+- type: max-score-picker
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      prefill: prefix-based-pd-decider
+schedulingProfiles:
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+`,
+	"epdConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: encode-filter
+- type: prefill-filter
+- type: decode-filter
+- type: approx-prefix-cache-producer
+  parameters:
+    blockSizeTokens: 16
+    maxPrefixBlocksToMatch: 256
+    lruCapacityPerServer: 256
+- type: prefix-cache-scorer
+- type: max-score-picker
+- type: always-disagg-multimodal-decider
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      encode: always-disagg-multimodal-decider
+      prefill: prefix-based-pd-decider
+schedulingProfiles:
+- name: encode
+  plugins:
+  - pluginRef: encode-filter
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+`,
+	"decodeOnlyConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: approx-prefix-cache-producer
+  parameters:
+    maxPrefixBlocksToMatch: 256
+    lruCapacityPerServer: 256
+- type: prefix-cache-scorer
+- type: encode-filter
+- type: prefill-filter
+- type: decode-filter
+- type: max-score-picker
+- type: disagg-profile-handler
+schedulingProfiles:
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+`,
+}
+
+func TestE2EConfigs_StartupParseSmoke(t *testing.T) {
+	for name, yaml := range e2eConfigsForSmoke {
+		t.Run(name, func(t *testing.T) {
+			// NewTestHarness fails the test if config-parse / plugin-init
+			// errors — exactly what we want to catch before pushing.
+			_ = NewTestHarness(t.Context(), t, WithConfigText(yaml))
+		})
+	}
+}

--- a/test/integration/epp/wellknown_configs_test.go
+++ b/test/integration/epp/wellknown_configs_test.go
@@ -76,7 +76,7 @@ plugins:
 - type: prefix-cache-scorer
   name: cpu-prefix-cache-scorer
   parameters:
-    producer: cpu-prefix-cache-producer
+    prefixMatchInfoProducerName: cpu-prefix-cache-producer
 schedulingProfiles:
 - name: default
   plugins:
@@ -214,9 +214,6 @@ plugins:
 - type: active-request-scorer
 - type: queue-scorer
 - type: pd-profile-handler
-  parameters:
-    threshold: 0
-    hashBlockSize: 5
 schedulingProfiles:
 - name: prefill
   plugins:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Implements #1068. EPP previously accepted plugin configs with unknown fields, silently dropping typos and stale-doc references — notably the recent `BlockSize` → `BlockSizeTokens` rename in the approximate prefix cache plugin, which left tiered-prefix-cache guides pointing at a non-functional field.

Changes `FactoryFunc` so the framework owns strict decoding:

```go
// Before:
type FactoryFunc func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)

// After:
type FactoryFunc func(name string, parameters *json.Decoder, handle Handle) (Plugin, error)
```

The framework wraps raw plugin parameters in a `json.Decoder` with `DisallowUnknownFields()` before invoking each factory (or passes nil when no parameters were supplied). A new `plugin.StrictDecoder` helper centralizes decoder construction so production code and tests share one path.

All ~30 factories migrated to the new signature; bodies that consumed parameters now call `decoder.Decode(&cfg)` in place of `json.Unmarshal`.

**Reference deprecation pattern (approximate prefix cache):**
- `BlockSize` remains on the config struct so strict decode accepts it.
- Factory post-processes: if `BlockSize` is set, log a deprecation warning and map to `BlockSizeTokens` when the latter is at its default.
- The now-redundant runtime `BlockSize` check in `newDataProducer` is removed; deprecation handling is consolidated at the factory boundary.

**Disagg profile handler refactor:**
The factory previously relied on `json.Unmarshal`'s re-readable bytes to try both new and legacy schemas in succession. With the one-shot `Decoder` this no longer works (second `Decode` returns EOF). Refactored to capture raw bytes once and strict-decode each schema independently — surfaces a clear error when neither matches (mixed format or unknown field).

**Tests:**
- Two new tests on `approximateprefix` capture the desired behavior: `TestFactory_RejectsUnknownField` and `TestFactory_DeprecatedBlockSizeMapped`.
- Tests that previously asserted "unknown fields silently accepted" were updated to assert rejection (the behavior #1068 reverses).
- All existing tests constructing factory arguments via `json.RawMessage` now wrap with `plugin.StrictDecoder`.
- `make test-unit-epp` passes locally; lint/format/typos all clean. (`make vulncheck` hits the pre-existing local-only issue tracked by #1122 / fixed by #1132 — unrelated to this change.)

**Notes:**
- Single atomic PR per [shmuelk's feedback](https://github.com/llm-d/llm-d-router/issues/1068#issuecomment-4452389806) — Go static typing requires the signature change and all factory migrations to land together.
- Per [elevran's guidance](https://github.com/llm-d/llm-d-router/issues/1068#issuecomment-4451660760), deprecated fields are accepted with a warning, not rejected; only *removed* (truly unknown) fields fail strict parsing.

**Which issue(s) this PR fixes**:
Fixes #1068

**Release note**:
```release-note
EPP now strictly parses plugin configurations — unknown fields cause plugin initialization to fail with a clear error rather than being silently ignored. Deprecated fields continue to be accepted with a warning until they are removed.
```
