### PR TITLE
ci: trigger check workflows on pull_request_target for bot-created PRs

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -8,17 +8,22 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
+    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: read
   actions: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   check-changes:
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -23,6 +23,11 @@ concurrency:
 
 jobs:
   check-changes:
+    # pull_request_target fires even when GITHUB_TOKEN creates the PR (e.g. the
+    # release-notes bot). pull_request does not. We register pull_request_target
+    # so bot-created PRs get a "skipped" conclusion that satisfies branch
+    # protection, but we skip all real work: pull_request already covers human
+    # PRs, and running twice would cause the concurrency group to cancel one run.
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -5,18 +5,22 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  pull_request_target:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   lychee:
     name: Check Markdown Links
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -20,6 +20,11 @@ concurrency:
 jobs:
   lychee:
     name: Check Markdown Links
+    # pull_request_target fires even when GITHUB_TOKEN creates the PR (e.g. the
+    # release-notes bot). pull_request does not. We register pull_request_target
+    # so bot-created PRs get a "skipped" conclusion that satisfies branch
+    # protection, but we skip all real work: pull_request already covers human
+    # PRs, and running twice would cause the concurrency group to cancel one run.
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add `pull_request_target` trigger to `md-link-check.yml` and `ci-pr-checks.yaml`, with a job-level skip condition and an updated concurrency key.

GitHub suppresses `pull_request` events when `GITHUB_TOKEN` is the actor creating the PR. The `release-notes-update.yaml` workflow uses `github.token` to open its PRs, so the `pull_request`-triggered workflows never fire and their required checks stay pending indefinitely.

`ci-signed-commits.yaml` was already correct (uses `pull_request_target` + skip condition) and is unchanged.

- `pull_request_target` is added alongside `pull_request` so the workflow is triggered for bot-created PRs.
- Each gated job has `if: github.event_name != 'pull_request_target'`, so the job is **skipped** (not run) when triggered this way. GitHub treats a skipped conclusion as satisfying branch protection.
- The concurrency group key now includes `${{ github.event_name }}` to prevent the `pull_request_target` run from cancelling an in-flight `pull_request` run for human PRs (which also receive both events).

See for example #1117 and #1129

```release-note
NONE
```