### PR TITLE
[docs] reference llm-d CONTRIBUTING.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -935,6 +935,8 @@ If using coding agents, please ensure that the agent uses the PR template format
 The template contains a `release-notes` section which must be filled for any change that has
 user facing impact.
 
+For additional information and context, please refer to the [llm-d contributing guide](https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md)
+
 ### Presubmit
 
 Before opening a PR, run:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Refer to llm-d CONTRIBUTING.md from router's DEVELOPMENT.md

**Which issue(s) this PR fixes**:
NONE

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
