### PR TITLE
fix(mocks): give mock extractors distinct Types

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
@@ -58,7 +58,7 @@ func (m *NotificationExtractor) WithExtractError(err error) *NotificationExtract
 }
 
 func (m *NotificationExtractor) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: "mock-extractor", Name: m.name}
+	return fwkplugin.TypedName{Type: m.name, Name: m.name}
 }
 
 func (m *NotificationExtractor) ExpectedInputType() reflect.Type {
@@ -132,7 +132,7 @@ func (m *Extractor) WithMetricsUpdate(metrics *fwkdl.Metrics) *Extractor {
 }
 
 func (m *Extractor) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: "mock-extractor", Name: m.name}
+	return fwkplugin.TypedName{Type: m.name, Name: m.name}
 }
 
 func (m *Extractor) ExpectedInputType() reflect.Type {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Framework dedups by TypedName().Type; both mocks returned the same Type, silently dropping any second binding. Use m.name as Type to match stubExtractor.
Unblocks flakey tests:
  - `TestRuntimePollingMultipleExtractors`
  - `TestRuntimeNotificationDispatch/extractor_error_doesn't_stop_other_extractors`


Failure log: https://github.com/llm-d/llm-d-router/actions/runs/25877524202/job/76048619268?pr=1057

**Which issue(s) this PR fixes**: 
Fixes #1142 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
