### PR TITLE
fix: --inference-pool-namespace/--inference-pool-name silently ignored when YAML config present

### DIFF
--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -499,7 +499,8 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 		opts.decoderInsecureSkipVerify = *cfg.DecoderTLSInsecureSkipVerify
 	}
 
-	if cfg.InferencePool != "" && !opts.isFlagSet(inferencePool) {
+	if cfg.InferencePool != "" && !opts.isFlagSet(inferencePool) &&
+		!opts.isFlagSet(inferencePoolNamespace) && !opts.isFlagSet(inferencePoolName) {
 		opts.inferencePool = cfg.InferencePool
 	}
 	if cfg.PoolGroup != "" && !opts.isFlagSet(poolGroup) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Trigger Scenario: 
User sets InferencePool via deprecated CLI flags (--inference-pool-namespace myns --inference-pool-name mypool) while also mounting a YAML config that contains  inference-pool: yaml-ns/yaml-pool.

The YAML value (yaml-ns/yaml-pool) silently takes effect instead of the CLI value (myns/mypool). The user's explicit CLI intent is ignored with no warning.


 Expected Behavior: 
CLI flags always take precedence over YAML configuration, regardless of whether the user uses the new --inference-pool flag or the deprecated  --inference-pool-namespace / --inference-pool-name flags.

 Root Cause: 
mergeYAMLConfiguration()  only guards YAML merge with !opts.isFlagSet(inferencePool), omitting checks for the two deprecated flags. When YAML wins the merge,  Complete()  unconditionally parses opts.inferencePool back into Namespace/Name, overwriting the deprecated flags' values. The TLS deprecated fields have identical  protection (checking both old and new flags) — InferencePool simply missed it.



**Which issue(s) this PR fixes**:

strengthen https://github.com/llm-d/llm-d-router/pull/683
