### PR TITLE
fix: EPP crashes - response body queue race

### DIFF
--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -99,8 +99,10 @@ type responseBodyWork struct {
 // It ensures chunks are processed in order via a channel while keeping plugin execution
 // off the critical streaming path.
 type responseBodyQueue struct {
-	ch   chan responseBodyWork
-	done chan struct{} // closed when the processing goroutine exits
+	mu     sync.Mutex
+	closed bool
+	ch     chan responseBodyWork
+	done   chan struct{} // closed when the processing goroutine exits
 }
 
 // Director orchestrates the request handling flow after initial parsing by the handler.
@@ -397,7 +399,10 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 		// processing all previously queued chunks before running the final chunk synchronously.
 		if val, ok := d.responseBodyQueues.LoadAndDelete(requestID); ok {
 			q := val.(*responseBodyQueue)
+			q.mu.Lock()
+			q.closed = true
 			close(q.ch)
+			q.mu.Unlock()
 			<-q.done // wait for all queued chunks to be processed
 		}
 		// Run the final chunk synchronously so DynamicMetadata is available for the response.
@@ -411,17 +416,21 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 			response:       response,
 			targetEndpoint: reqCtx.TargetPod,
 		}
-		if val, ok := d.responseBodyQueues.Load(requestID); ok {
-			val.(*responseBodyQueue).ch <- work
+		q := &responseBodyQueue{
+			ch:   make(chan responseBodyWork, 100),
+			done: make(chan struct{}),
+		}
+		val, loaded := d.responseBodyQueues.LoadOrStore(requestID, q)
+		if loaded {
+			q = val.(*responseBodyQueue)
 		} else {
-			q := &responseBodyQueue{
-				ch:   make(chan responseBodyWork, 100),
-				done: make(chan struct{}),
-			}
-			d.responseBodyQueues.Store(requestID, q)
 			go d.processResponseBodyQueue(q)
+		}
+		q.mu.Lock()
+		if !q.closed {
 			q.ch <- work
 		}
+		q.mu.Unlock()
 	}
 	logger.V(logutil.TRACE).Info("Exiting HandleResponseBodyChunk")
 	return reqCtx

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1328,6 +1328,68 @@ func TestDirector_HandleResponseBody_ChunkOrdering(t *testing.T) {
 	}
 }
 
+func TestDirector_HandleResponseBody_ConcurrentSendAndClose(t *testing.T) {
+	// Regression test for the "send on closed channel" panic.
+	// Multiple goroutines send intermediate chunks while a final-chunk goroutine
+	// concurrently closes the queue. Without mutex protection, this TOCTOU race
+	// would panic. Run with -race and -count to increase detection probability.
+	plugin := &panicDetectPlugin{
+		typedName: fwkplugin.TypedName{Type: "panic-detect", Name: "panic-detect"},
+	}
+
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	ds := datastore.NewDatastore(t.Context(), nil, 0)
+	director := NewDirectorWithConfig(ds, &mockScheduler{}, nil, nil, NewConfig().WithResponseStreamingPlugins(plugin))
+
+	const numSenders = 30
+	const numRounds = 200
+
+	for round := range numRounds {
+		requestID := fmt.Sprintf("concurrent-test-%d", round)
+		var wg sync.WaitGroup
+
+		// Fire intermediate chunks concurrently.
+		for range numSenders {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				reqCtx := &handlers.RequestContext{
+					Request: &handlers.Request{
+						Headers: map[string]string{reqcommon.RequestIDHeaderKey: requestID},
+					},
+					Response:  &handlers.Response{Headers: map[string]string{}},
+					TargetPod: &fwkdl.EndpointMetadata{},
+				}
+				director.HandleResponseBody(ctx, reqCtx, false)
+			}()
+		}
+
+		// Let goroutines queue up so the race window is wide open.
+		time.Sleep(time.Microsecond)
+
+		// Final chunk — this is the close side of the race.
+		finalReqCtx := &handlers.RequestContext{
+			Request: &handlers.Request{
+				Headers: map[string]string{reqcommon.RequestIDHeaderKey: requestID},
+			},
+			Response:  &handlers.Response{Headers: map[string]string{}},
+			TargetPod: &fwkdl.EndpointMetadata{},
+		}
+		director.HandleResponseBody(ctx, finalReqCtx, true)
+
+		wg.Wait()
+	}
+}
+
+// panicDetectPlugin is a minimal ResponseStreaming plugin used in the concurrent race test.
+type panicDetectPlugin struct {
+	typedName fwkplugin.TypedName
+}
+
+func (p *panicDetectPlugin) TypedName() fwkplugin.TypedName { return p.typedName }
+func (p *panicDetectPlugin) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, _ *fwkrc.Response, _ *fwkdl.EndpointMetadata) {
+}
+
 // orderTrackingPlugin records the CompletionTokens from each ResponseBody call to verify ordering.
 type orderTrackingPlugin struct {
 	mu                  sync.Mutex


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Trigger Scenario
  Two gRPC stream goroutines process the same requestID concurrently — one handling an intermediate response body chunk (endOfStream=false), the other handling either the final chunkor a  cleanup path (endOfStream=true). Both goroutines share the same Director.responseBodyQueues sync.Map.

  It leads to panic: send on closed channel

  EPP process crashes at director.go. Low frequency, but each occurrence kills the entire service instance, dropping all in-flight requests.



Root Cause
  sync.Map only protects the atomicity of map operations (Load, LoadAndDelete), not the lifecycle of the values stored inside it. A TOCTOU window exists between Load and q.ch <- work in the intermediate-chunk path: the final-chunk path can slip in with LoadAndDelete + close(q.ch) between those two steps.


Fix
  Add a sync.Mutex and closed flag to responseBodyQueue. The close path sets closed=true under the lock before closing the channel; the send path checks closed under the same lock before sending. Replace the Load-then-Store pattern with LoadOrStore to eliminate a secondary race where two goroutines each create and store separate queues for the same request ID.

**Which issue(s) this PR fixes**:

issue https://github.com/llm-d/llm-d-router/issues/1140

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
