### PR TITLE
fix: prevent EPP response body queue panic

### DIFF
--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -451,6 +451,9 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 }
 
 func (d *Director) loadOrCreateResponseBodyQueue(reqCtx *handlers.RequestContext) *responseBodyQueue {
+	if val, ok := d.responseBodyQueues.Load(reqCtx); ok {
+		return val.(*responseBodyQueue)
+	}
 	q := newResponseBodyQueue()
 	val, loaded := d.responseBodyQueues.LoadOrStore(reqCtx, q)
 	if loaded {

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -52,7 +52,8 @@ const (
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2081):
 	// Make this timeout configurable per-plugin or globally via the Director configuration to support plugins with
 	// varying latency profiles.
-	dataProducerTimeout = 400 * time.Millisecond
+	dataProducerTimeout       = 400 * time.Millisecond
+	responseBodyQueueCapacity = 100
 )
 
 // Datastore defines the interface required by the Director.
@@ -99,8 +100,37 @@ type responseBodyWork struct {
 // It ensures chunks are processed in order via a channel while keeping plugin execution
 // off the critical streaming path.
 type responseBodyQueue struct {
-	ch   chan responseBodyWork
-	done chan struct{} // closed when the processing goroutine exits
+	ch     chan responseBodyWork
+	done   chan struct{} // closed when the processing goroutine exits
+	mu     sync.Mutex
+	closed bool
+}
+
+func newResponseBodyQueue() *responseBodyQueue {
+	return &responseBodyQueue{
+		ch:   make(chan responseBodyWork, responseBodyQueueCapacity),
+		done: make(chan struct{}),
+	}
+}
+
+func (q *responseBodyQueue) enqueue(work responseBodyWork) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return false
+	}
+	q.ch <- work
+	return true
+}
+
+func (q *responseBodyQueue) closeAndWait() {
+	q.mu.Lock()
+	if !q.closed {
+		q.closed = true
+		close(q.ch)
+	}
+	q.mu.Unlock()
+	<-q.done
 }
 
 // Director orchestrates the request handling flow after initial parsing by the handler.
@@ -123,9 +153,10 @@ type Director struct {
 	// and value types cannot be nil.
 	defaultPriority int32
 
-	// responseBodyQueues maps request IDs to their async processing channels.
-	// Each request gets a dedicated channel and goroutine to ensure chunks are
-	// processed in order while not blocking the streaming response path.
+	// responseBodyQueues maps request contexts to their async processing channels.
+	// Each request gets a dedicated channel and goroutine to ensure chunks are processed in order while not blocking the
+	// streaming response path. The request context key avoids coupling independent streams that reuse the same
+	// x-request-id header.
 	responseBodyQueues sync.Map
 }
 
@@ -395,10 +426,9 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 	if endOfStream {
 		// Drain the async queue: close the channel and wait for the goroutine to finish
 		// processing all previously queued chunks before running the final chunk synchronously.
-		if val, ok := d.responseBodyQueues.LoadAndDelete(requestID); ok {
+		if val, ok := d.responseBodyQueues.LoadAndDelete(reqCtx); ok {
 			q := val.(*responseBodyQueue)
-			close(q.ch)
-			<-q.done // wait for all queued chunks to be processed
+			q.closeAndWait()
 		}
 		// Run the final chunk synchronously so DynamicMetadata is available for the response.
 		d.runResponseBodyPlugins(ctx, reqCtx.SchedulingRequest, response, reqCtx.TargetPod)
@@ -411,20 +441,23 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 			response:       response,
 			targetEndpoint: reqCtx.TargetPod,
 		}
-		if val, ok := d.responseBodyQueues.Load(requestID); ok {
-			val.(*responseBodyQueue).ch <- work
-		} else {
-			q := &responseBodyQueue{
-				ch:   make(chan responseBodyWork, 100),
-				done: make(chan struct{}),
-			}
-			d.responseBodyQueues.Store(requestID, q)
-			go d.processResponseBodyQueue(q)
-			q.ch <- work
+		q := d.loadOrCreateResponseBodyQueue(reqCtx)
+		if !q.enqueue(work) {
+			logger.V(logutil.DEBUG).Info("Skipping response body chunk because the async queue is closed", "requestID", requestID)
 		}
 	}
 	logger.V(logutil.TRACE).Info("Exiting HandleResponseBodyChunk")
 	return reqCtx
+}
+
+func (d *Director) loadOrCreateResponseBodyQueue(reqCtx *handlers.RequestContext) *responseBodyQueue {
+	q := newResponseBodyQueue()
+	val, loaded := d.responseBodyQueues.LoadOrStore(reqCtx, q)
+	if loaded {
+		return val.(*responseBodyQueue)
+	}
+	go d.processResponseBodyQueue(q)
+	return q
 }
 
 func (d *Director) GetRandomEndpoint() *fwkdl.EndpointMetadata {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1281,38 +1281,16 @@ func TestDirector_HandleResponseBody_ChunkOrdering(t *testing.T) {
 	director := NewDirectorWithConfig(ds, &mockScheduler{}, nil, nil, NewConfig().WithResponseStreamingPlugins(plugin))
 
 	const numChunks = 50
+	reqCtx := newResponseBodyTestRequestContext("ordering-test-request", 0)
 
 	for i := range numChunks {
-		reqCtx := &handlers.RequestContext{
-			Request: &handlers.Request{
-				Headers: map[string]string{
-					// All chunks share the same request ID so they go through the same queue.
-					reqcommon.RequestIDHeaderKey: "ordering-test-request",
-				},
-			},
-			Response: &handlers.Response{
-				Headers: map[string]string{},
-			},
-			TargetPod: &fwkdl.EndpointMetadata{},
-			Usage:     fwkrh.Usage{CompletionTokens: i},
-		}
+		reqCtx.Usage = fwkrh.Usage{CompletionTokens: i}
 		director.HandleResponseBody(ctx, reqCtx, false)
 	}
 
 	// Send final chunk to drain the queue.
-	finalReqCtx := &handlers.RequestContext{
-		Request: &handlers.Request{
-			Headers: map[string]string{
-				reqcommon.RequestIDHeaderKey: "ordering-test-request",
-			},
-		},
-		Response: &handlers.Response{
-			Headers: map[string]string{},
-		},
-		TargetPod: &fwkdl.EndpointMetadata{},
-		Usage:     fwkrh.Usage{CompletionTokens: numChunks},
-	}
-	director.HandleResponseBody(ctx, finalReqCtx, true)
+	reqCtx.Usage = fwkrh.Usage{CompletionTokens: numChunks}
+	director.HandleResponseBody(ctx, reqCtx, true)
 
 	// Total calls: numChunks async + 1 sync final.
 	plugin.mu.Lock()
@@ -1326,6 +1304,71 @@ func TestDirector_HandleResponseBody_ChunkOrdering(t *testing.T) {
 	for i, tokens := range tokenCounts {
 		assert.Equal(t, i, tokens, "chunk %d was processed out of order", i)
 	}
+}
+
+func TestDirector_HandleResponseBody_DuplicateRequestIDQueuesAreIndependent(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	plugin := newBlockingResponseStreamingPlugin()
+	director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil, NewConfig().WithResponseStreamingPlugins(plugin))
+
+	const requestID = "duplicate-request-id"
+	firstReqCtx := newResponseBodyTestRequestContext(requestID, 0)
+	secondReqCtx := newResponseBodyTestRequestContext(requestID, 0)
+
+	director.HandleResponseBody(ctx, firstReqCtx, false)
+	require.Eventually(t, func() bool {
+		return plugin.started()
+	}, time.Second, 10*time.Millisecond, "first request should start processing")
+
+	for i := range responseBodyQueueCapacity {
+		firstReqCtx.Usage = fwkrh.Usage{CompletionTokens: i + 1}
+		director.HandleResponseBody(ctx, firstReqCtx, false)
+	}
+
+	secondDone := make(chan any, 1)
+	go func() {
+		defer func() {
+			secondDone <- recover()
+		}()
+		director.HandleResponseBody(ctx, secondReqCtx, false)
+	}()
+
+	secondCompletedBeforeFinal := false
+	select {
+	case panicValue := <-secondDone:
+		require.Nil(t, panicValue, "second request with duplicate request ID should not panic")
+		secondCompletedBeforeFinal = true
+	case <-time.After(time.Second):
+	}
+
+	firstFinalDone := make(chan any, 1)
+	go func() {
+		defer func() {
+			firstFinalDone <- recover()
+		}()
+		director.HandleResponseBody(ctx, firstReqCtx, true)
+	}()
+
+	if !secondCompletedBeforeFinal {
+		select {
+		case panicValue := <-secondDone:
+			require.Nil(t, panicValue, "second request with duplicate request ID should not panic")
+		case <-time.After(time.Second):
+			t.Fatal("second request with duplicate request ID should not remain blocked")
+		}
+	}
+	require.True(t, secondCompletedBeforeFinal, "second request with duplicate request ID should not block behind the first request queue")
+
+	plugin.release()
+
+	select {
+	case panicValue := <-firstFinalDone:
+		require.Nil(t, panicValue, "first request final chunk should not panic")
+	case <-time.After(time.Second):
+		t.Fatal("first request final chunk should drain")
+	}
+
+	director.HandleResponseBody(ctx, secondReqCtx, true)
 }
 
 // orderTrackingPlugin records the CompletionTokens from each ResponseBody call to verify ordering.
@@ -1405,4 +1448,109 @@ func (p *testResponseStreaming) ResponseBody(_ context.Context, _ *fwksched.Infe
 	// Maintain legacy fields for compatibility
 	p.lastRespOnStreaming = response
 	p.lastTargetPodOnStreaming = targetPod.NamespacedName.String()
+}
+
+func TestResponseBodyQueue_CloseWaitsForBlockedEnqueue(t *testing.T) {
+	q := newResponseBodyQueue()
+	close(q.done)
+
+	for range responseBodyQueueCapacity {
+		require.True(t, q.enqueue(responseBodyWork{}))
+	}
+
+	enqueueDone := make(chan any, 1)
+	go func() {
+		defer func() {
+			enqueueDone <- recover()
+		}()
+		q.enqueue(responseBodyWork{})
+	}()
+
+	require.Eventually(t, func() bool {
+		if q.mu.TryLock() {
+			q.mu.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, 10*time.Millisecond, "enqueue should block while the queue is full")
+
+	closeDone := make(chan any, 1)
+	go func() {
+		defer func() {
+			closeDone <- recover()
+		}()
+		q.closeAndWait()
+	}()
+
+	<-q.ch
+
+	select {
+	case panicValue := <-enqueueDone:
+		require.Nil(t, panicValue, "enqueue should not panic when close waits")
+	case <-time.After(time.Second):
+		t.Fatal("enqueue should finish after queue space is available")
+	}
+
+	select {
+	case panicValue := <-closeDone:
+		require.Nil(t, panicValue, "close should not panic")
+	case <-time.After(time.Second):
+		t.Fatal("close should finish after enqueue completes")
+	}
+
+	require.False(t, q.enqueue(responseBodyWork{}), "enqueue should fail after the queue is closed")
+}
+
+type blockingResponseStreamingPlugin struct {
+	typedName fwkplugin.TypedName
+	once      sync.Once
+	startedCh chan struct{}
+	releaseCh chan struct{}
+}
+
+func newBlockingResponseStreamingPlugin() *blockingResponseStreamingPlugin {
+	return &blockingResponseStreamingPlugin{
+		typedName: fwkplugin.TypedName{Type: testPostStreamingType, Name: "blocking"},
+		startedCh: make(chan struct{}),
+		releaseCh: make(chan struct{}),
+	}
+}
+
+func (p *blockingResponseStreamingPlugin) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+func (p *blockingResponseStreamingPlugin) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, _ *fwkrc.Response, _ *fwkdl.EndpointMetadata) {
+	p.once.Do(func() {
+		close(p.startedCh)
+	})
+	<-p.releaseCh
+}
+
+func (p *blockingResponseStreamingPlugin) started() bool {
+	select {
+	case <-p.startedCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *blockingResponseStreamingPlugin) release() {
+	close(p.releaseCh)
+}
+
+func newResponseBodyTestRequestContext(requestID string, completionTokens int) *handlers.RequestContext {
+	return &handlers.RequestContext{
+		Request: &handlers.Request{
+			Headers: map[string]string{
+				reqcommon.RequestIDHeaderKey: requestID,
+			},
+		},
+		Response: &handlers.Response{
+			Headers: map[string]string{},
+		},
+		TargetPod: &fwkdl.EndpointMetadata{},
+		Usage:     fwkrh.Usage{CompletionTokens: completionTokens},
+	}
 }


### PR DESCRIPTION
## Summary
- prevent response body queues from being shared by independent streams that reuse the same `x-request-id`
- guard async response body queue enqueue/close lifecycle so a final chunk cannot close a channel while an intermediate chunk is sending
- add regression coverage for the reproduced `send on closed channel` failure and queue close/enqueue behavior

## Notes
- Fixes #1140
- Prior attempt #1146 by @weizhoublue was closed; this PR keeps the same crash scenario covered locally and adds request-context queue ownership so duplicate request IDs do not couple independent streams.

## Verification
- Reproduced locally before the fix: `go test ./pkg/epp/requestcontrol -run TestDirector_HandleResponseBody_DuplicateRequestIDQueuesAreIndependent -count=1` failed with `send on closed channel`
- `go test ./pkg/epp/requestcontrol -run 'Test(Director_HandleResponseBody_(DuplicateRequestIDQueuesAreIndependent|ChunkOrdering)|ResponseBodyQueue_CloseWaitsForBlockedEnqueue)$' -count=1`
- `go test -race ./pkg/epp/requestcontrol -count=1`
- `go test ./pkg/epp/... -count=1`
