### PR TITLE
rename BackendUpsert/Delete and DiscoveryBackendStore to us…

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -87,10 +87,10 @@ type Datastore interface {
 	PodUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.Pod) bool
 	PodDelete(podName string)
 
-	// BackendUpsert adds or updates an endpoint from a non-Kubernetes discovery source.
-	BackendUpsert(ctx context.Context, meta *fwkdl.EndpointMetadata)
-	// BackendDelete removes the endpoint with the given namespaced name.
-	BackendDelete(id types.NamespacedName)
+	// EndpointUpsert adds or updates an endpoint from a non-Kubernetes discovery source.
+	EndpointUpsert(ctx context.Context, meta *fwkdl.EndpointMetadata)
+	// EndpointDelete removes the endpoint with the given namespaced name.
+	EndpointDelete(id types.NamespacedName)
 
 	// Clears the store state, happens when the pool gets deleted.
 	Clear()
@@ -371,11 +371,11 @@ func (ds *datastore) PodDelete(podName string) {
 	})
 }
 
-func (ds *datastore) BackendUpsert(_ context.Context, meta *fwkdl.EndpointMetadata) {
+func (ds *datastore) EndpointUpsert(_ context.Context, meta *fwkdl.EndpointMetadata) {
 	ds.upsertEndpoint(meta)
 }
 
-func (ds *datastore) BackendDelete(id types.NamespacedName) {
+func (ds *datastore) EndpointDelete(id types.NamespacedName) {
 	if v, ok := ds.pods.LoadAndDelete(id); ok {
 		ds.epf.ReleaseEndpoint(v.(fwkdl.Endpoint))
 	}
@@ -384,7 +384,7 @@ func (ds *datastore) BackendDelete(id types.NamespacedName) {
 // upsertEndpoint stores or updates a single endpoint in the pods map.
 // Returns true if the endpoint was newly created, false if it already existed
 // or if NewEndpoint returned nil (duplicate-start race).
-// Shared by BackendUpsert and podUpdateOrAddIfNotExist.
+// Shared by EndpointUpsert and podUpdateOrAddIfNotExist.
 func (ds *datastore) upsertEndpoint(meta *fwkdl.EndpointMetadata) bool {
 	existing, ok := ds.pods.Load(meta.NamespacedName)
 	if !ok {

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -47,7 +47,7 @@ import (
 	testutil "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/util/testing"
 )
 
-// mockEndpointFactory is a minimal EndpointFactory for BackendUpsert/Delete tests.
+// mockEndpointFactory is a minimal EndpointFactory for EndpointUpsert/Delete tests.
 // When returnNil is true, NewEndpoint returns nil (simulating a duplicate-start race).
 type mockEndpointFactory struct {
 	returnNil bool
@@ -1346,61 +1346,61 @@ func TestExtractActivePorts(t *testing.T) {
 	}
 }
 
-// ---- BackendUpsert / BackendDelete tests -----------------------------------
+// ---- EndpointUpsert / EndpointDelete tests -----------------------------------
 
-func TestBackendUpsert_NewEndpoint(t *testing.T) {
+func TestEndpointUpsert_NewEndpoint(t *testing.T) {
 	const addr, port = "10.0.0.1", "8000"
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr, Port: port})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr, Port: port})
 
 	eps := ds.PodList(AllPodsPredicate)
 	assert.Len(t, eps, 1)
 	assert.Equal(t, addr, eps[0].GetMetadata().Address)
 }
 
-func TestBackendUpsert_UpdateExisting(t *testing.T) {
+func TestEndpointUpsert_UpdateExisting(t *testing.T) {
 	const addr1, addr2 = "10.0.0.1", "10.0.0.2"
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr1})
-	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr2})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr1})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr2})
 
 	eps := ds.PodList(AllPodsPredicate)
 	assert.Len(t, eps, 1)
 	assert.Equal(t, addr2, eps[0].GetMetadata().Address)
 }
 
-func TestBackendUpsert_NewEndpointFactoryReturnsNil(t *testing.T) {
+func TestEndpointUpsert_NewEndpointFactoryReturnsNil(t *testing.T) {
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{returnNil: true}, 0)
 	meta := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Name: "ep1", Namespace: "default"}}
 
-	assert.NotPanics(t, func() { ds.BackendUpsert(ctx, meta) })
+	assert.NotPanics(t, func() { ds.EndpointUpsert(ctx, meta) })
 	assert.Empty(t, ds.PodList(AllPodsPredicate))
 }
 
-func TestBackendDelete_Existing(t *testing.T) {
+func TestEndpointDelete_Existing(t *testing.T) {
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.BackendUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id})
 	assert.Len(t, ds.PodList(AllPodsPredicate), 1)
 
-	ds.BackendDelete(id)
+	ds.EndpointDelete(id)
 	assert.Empty(t, ds.PodList(AllPodsPredicate))
 }
 
-func TestBackendDelete_Missing(t *testing.T) {
+func TestEndpointDelete_Missing(t *testing.T) {
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{}, 0)
 
 	assert.NotPanics(t, func() {
-		ds.BackendDelete(types.NamespacedName{Name: "nonexistent", Namespace: "default"})
+		ds.EndpointDelete(types.NamespacedName{Name: "nonexistent", Namespace: "default"})
 	})
 }

--- a/pkg/epp/framework/interface/datalayer/discovery.go
+++ b/pkg/epp/framework/interface/datalayer/discovery.go
@@ -24,28 +24,28 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
 )
 
-// DiscoveryBackendStore is the narrow interface required by NewDiscoveryNotifier.
-// Any store that implements BackendUpsert and BackendDelete satisfies it.
-type DiscoveryBackendStore interface {
-	BackendUpsert(ctx context.Context, meta *EndpointMetadata)
-	BackendDelete(id types.NamespacedName)
+// DiscoveryEndpointStore is the narrow interface required by NewDiscoveryNotifier.
+// Any store that implements EndpointUpsert and EndpointDelete satisfies it.
+type DiscoveryEndpointStore interface {
+	EndpointUpsert(ctx context.Context, meta *EndpointMetadata)
+	EndpointDelete(id types.NamespacedName)
 }
 
-// NewDiscoveryNotifier wraps a DiscoveryBackendStore as a DiscoveryNotifier.
-func NewDiscoveryNotifier(store DiscoveryBackendStore) DiscoveryNotifier {
+// NewDiscoveryNotifier wraps a DiscoveryEndpointStore as a DiscoveryNotifier.
+func NewDiscoveryNotifier(store DiscoveryEndpointStore) DiscoveryNotifier {
 	return &discoveryNotifier{store: store}
 }
 
 type discoveryNotifier struct {
-	store DiscoveryBackendStore
+	store DiscoveryEndpointStore
 }
 
 func (n *discoveryNotifier) Upsert(endpoint *EndpointMetadata) {
-	n.store.BackendUpsert(context.Background(), endpoint)
+	n.store.EndpointUpsert(context.Background(), endpoint)
 }
 
 func (n *discoveryNotifier) Delete(id types.NamespacedName) {
-	n.store.BackendDelete(id)
+	n.store.EndpointDelete(id)
 }
 
 // EndpointDiscovery discovers inference endpoints and drives their lifecycle in the datastore.

--- a/pkg/epp/framework/interface/datalayer/discovery_test.go
+++ b/pkg/epp/framework/interface/datalayer/discovery_test.go
@@ -24,17 +24,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// fakeStore records calls to BackendUpsert and BackendDelete for assertion.
+// fakeStore records calls to EndpointUpsert and EndpointDelete for assertion.
 type fakeStore struct {
 	upserted []*EndpointMetadata
 	deleted  []types.NamespacedName
 }
 
-func (f *fakeStore) BackendUpsert(_ context.Context, meta *EndpointMetadata) {
+func (f *fakeStore) EndpointUpsert(_ context.Context, meta *EndpointMetadata) {
 	f.upserted = append(f.upserted, meta)
 }
 
-func (f *fakeStore) BackendDelete(id types.NamespacedName) {
+func (f *fakeStore) EndpointDelete(id types.NamespacedName) {
 	f.deleted = append(f.deleted, id)
 }
 


### PR DESCRIPTION
No behavior change. 4 files affected: the datastore interface and  implementation, and the discovery interface and its test.