### PR TITLE
Fix precise-scorer to use tokenProcessor.BlockSize() instead of depre…

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -244,17 +244,18 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 	}
 
 	return &Scorer{
-		typedName:          plugin.TypedName{Type: PrecisePrefixCachePluginType},
-		kvCacheIndexer:     kvCacheIndexer,
-		kvBlockScorer:      kvBlockScorer,
-		subscribersManager: subscribersManager,
-		kvEventsConfig:     config.KVEventsConfig,
-		pluginState:        plugin.NewPluginState(ctx),
-		speculativeCache:   speculativeCache,
-		speculativeTTL:     speculativeTTL,
-		blockSizeTokens:    config.TokenProcessorConfig.BlockSize,
-		speculativeEnabled: config.SpeculativeIndexing,
-		subscriberCtx:      ctx,
+		typedName:            plugin.TypedName{Type: PrecisePrefixCachePluginType},
+		kvCacheIndexer:       kvCacheIndexer,
+		tokenProcessor:       tokenProcessor,
+		kvBlockScorer:        kvBlockScorer,
+		subscribersManager:   subscribersManager,
+		kvEventsConfig:       config.KVEventsConfig,
+		pluginState:          plugin.NewPluginState(ctx),
+		speculativeCache:     speculativeCache,
+		speculativeTTL:       speculativeTTL,
+		tokenProcessorConfig: config.TokenProcessorConfig,
+		speculativeEnabled:   config.SpeculativeIndexing,
+		subscriberCtx:        ctx,
 	}, nil
 }
 
@@ -275,6 +276,7 @@ func New(ctx context.Context, config PluginConfig) (*Scorer, error) {
 type Scorer struct {
 	typedName      plugin.TypedName
 	kvCacheIndexer kvCacheIndexer
+	tokenProcessor kvblock.TokenProcessor
 
 	subscribersManager *kvevents.SubscriberManager
 	kvEventsConfig     *kvevents.Config
@@ -291,9 +293,9 @@ type Scorer struct {
 	// kvBlockScorer scores pods based on block hits with device-backend weights.
 	kvBlockScorer kvcache.KVBlockScorer
 
-	// blockSizeTokens is the number of tokens per KV-block, used for
-	// constructing PrefixCacheMatchInfo in Produce.
-	blockSizeTokens int
+	// tokenProcessorConfig is the config used to construct the token processor.
+	// Guaranteed non-nil by New() (defaults are filled in there).
+	tokenProcessorConfig *kvblock.TokenProcessorConfig
 
 	// speculativeEnabled controls whether speculative indexing is active.
 	speculativeEnabled bool
@@ -707,7 +709,7 @@ func (s *Scorer) computeBlockKeys(ctx context.Context,
 		if len(tp.MultiModalFeatures) > 0 {
 			mmHashes, mmPlaceholders := tokenizer.ConvertMMFeaturesFromUpstream(tp.MultiModalFeatures)
 			extraFeatures = kvblock.ComputeBlockExtraFeatures(
-				mmHashes, mmPlaceholders, s.blockSizeTokens, len(tp.TokenIDs))
+				mmHashes, mmPlaceholders, s.getBlockSizeTokens(), len(tp.TokenIDs))
 		}
 		return s.kvCacheIndexer.ComputeBlockKeysFromTokens(ctx, tp.TokenIDs, request.TargetModel, extraFeatures)
 	}
@@ -744,9 +746,9 @@ func extractPodSet(endpoints []scheduling.Endpoint) sets.Set[string] {
 	return podSet
 }
 
-// getBlockSizeTokens returns the block size in tokens from the token processor config.
+// getBlockSizeTokens returns the block size in tokens from the token processor.
 func (s *Scorer) getBlockSizeTokens() int {
-	return s.blockSizeTokens
+	return s.tokenProcessor.BlockSize()
 }
 
 // scoreBlockKeys computes per-pod scores from precomputed block keys, avoiding
@@ -783,7 +785,7 @@ func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, reques
 			if len(tp.MultiModalFeatures) > 0 {
 				mmHashes, mmPlaceholders := tokenizer.ConvertMMFeaturesFromUpstream(tp.MultiModalFeatures)
 				extraFeatures = kvblock.ComputeBlockExtraFeatures(
-					mmHashes, mmPlaceholders, s.blockSizeTokens, len(tp.TokenIDs))
+					mmHashes, mmPlaceholders, s.getBlockSizeTokens(), len(tp.TokenIDs))
 			}
 
 			scores, err := s.kvCacheIndexer.ScoreTokens(ctx, tp.TokenIDs, request.TargetModel, nil, extraFeatures)
@@ -792,8 +794,8 @@ func (s *Scorer) getScores(ctx context.Context, _ *scheduling.CycleState, reques
 			}
 			// floor(tokens/blockSize) — trailing partial block is dropped.
 			totalBlocks := 0
-			if s.blockSizeTokens > 0 {
-				totalBlocks = len(tp.TokenIDs) / s.blockSizeTokens
+			if s.getBlockSizeTokens() > 0 {
+				totalBlocks = len(tp.TokenIDs) / s.getBlockSizeTokens()
 			}
 			return scores, totalBlocks, nil
 		}


### PR DESCRIPTION
…cated BlockSize field

The Scorer struct stored blockSizeTokens initialized from config.TokenProcessorConfig.BlockSize, which is deprecated in llm-d-kv-cache. Change to use the tokenProcessor.BlockSize() method to correctly resolves the block size.

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
The Scorer struct in precise prefix cache stored blockSizeTokens initialized from config.TokenProcessorConfig.BlockSize, which is deprecated in llm-d-kv-cache. As a result, it doesn't read values of BlockSizeTokens by user configuration. 

**Which issue(s) this PR fixes**:
https://github.com/llm-d/llm-d-router/issues/1157
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
