### PR TITLE
feat(epp/prefix-cache): clamp autotuned blockSizeTokens to bound EPP indexer memory

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -76,6 +76,21 @@ func newDataProducer(ctx context.Context, config config, handle plugin.Handle) (
 	if config.MaxPrefixTokensToMatch < 0 {
 		return nil, fmt.Errorf("invalid configuration: MaxPrefixTokensToMatch must be >= 0 (current value: %d)", config.MaxPrefixTokensToMatch)
 	}
+
+	// Warn (but don't reject) on a manually set BlockSizeTokens below the
+	// recommended minimum: the routing-side indexer keeps one LRU entry per
+	// (pod, block), so small values can cause gigabyte-scale memory growth at
+	// scale. The autotune path clamps automatically (see GetBlockSize); manual
+	// configuration is honored verbatim so operators retain an escape hatch.
+	if config.BlockSizeTokens > 0 && config.BlockSizeTokens < minBlockSizeTokens {
+		log.FromContext(ctx).Info(
+			"WARNING: blockSizeTokens is below the recommended minimum; this can cause high EPP memory usage at scale",
+			"blockSizeTokens", config.BlockSizeTokens,
+			"recommendedMinimum", minBlockSizeTokens,
+			"issue", "https://github.com/llm-d/llm-d-router/issues/1158",
+		)
+	}
+
 	indexer := newIndexer(ctx, config.LRUCapacityPerServer)
 
 	p := &dataProducer{
@@ -230,6 +245,15 @@ func (p *dataProducer) matchLongestPrefix(ctx context.Context, hashes []blockHas
 }
 
 // GetBlockSize returns the block size in tokens, potentially auto-tuned from endpoint metrics.
+//
+// When AutoTune is on, the value is clamped at minBlockSizeTokens to bound EPP indexer
+// memory: the routing-side indexer holds one LRU entry per (pod, block), so a small
+// model-server block size (e.g., vLLM's default of 16) would otherwise inflate memory
+// by ~64x. Routing intentionally measures matches at coarser granularity than the
+// model server's true block size. See #1158.
+//
+// Manual configuration (AutoTune off) is honored verbatim; a startup warning is
+// logged in newDataProducer when the configured value is below the recommended floor.
 func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 	if !p.config.AutoTune || len(endpoints) == 0 {
 		return p.config.BlockSizeTokens
@@ -238,6 +262,9 @@ func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 	if endpoint := endpoints[0]; endpoint.GetMetrics() != nil {
 		cacheBlockSize := endpoint.GetMetrics().CacheBlockSize
 		if cacheBlockSize > 0 {
+			if cacheBlockSize < minBlockSizeTokens {
+				return minBlockSizeTokens
+			}
 			return cacheBlockSize
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -77,12 +77,12 @@ func newDataProducer(ctx context.Context, config config, handle plugin.Handle) (
 		return nil, fmt.Errorf("invalid configuration: MaxPrefixTokensToMatch must be >= 0 (current value: %d)", config.MaxPrefixTokensToMatch)
 	}
 
-	// Warn (but don't reject) on a manually set BlockSizeTokens below the
-	// recommended minimum: the routing-side indexer keeps one LRU entry per
-	// (pod, block), so small values can cause gigabyte-scale memory growth at
-	// scale. The autotune path clamps automatically (see GetBlockSize); manual
-	// configuration is honored verbatim so operators retain an escape hatch.
-	if config.BlockSizeTokens > 0 && config.BlockSizeTokens < minBlockSizeTokens {
+	// Warn (but don't reject) when a user has explicitly opted out of autotune
+	// AND set BlockSizeTokens below the recommended minimum. Under AutoTune the
+	// runtime clamp in GetBlockSize protects memory, and the default config
+	// (AutoTune=true, BlockSizeTokens=16) would otherwise produce a misleading
+	// warning on every vanilla deployment.
+	if !config.AutoTune && config.BlockSizeTokens > 0 && config.BlockSizeTokens < minBlockSizeTokens {
 		log.FromContext(ctx).Info(
 			"WARNING: blockSizeTokens is below the recommended minimum; this can cause high EPP memory usage at scale",
 			"blockSizeTokens", config.BlockSizeTokens,
@@ -246,27 +246,36 @@ func (p *dataProducer) matchLongestPrefix(ctx context.Context, hashes []blockHas
 
 // GetBlockSize returns the block size in tokens, potentially auto-tuned from endpoint metrics.
 //
-// When AutoTune is on, the value is clamped at minBlockSizeTokens to bound EPP indexer
-// memory: the routing-side indexer holds one LRU entry per (pod, block), so a small
-// model-server block size (e.g., vLLM's default of 16) would otherwise inflate memory
-// by ~64x. Routing intentionally measures matches at coarser granularity than the
-// model server's true block size. See #1158.
+// When AutoTune is on, the result is clamped at minBlockSizeTokens regardless of
+// whether the value comes from the endpoint metric or the configured fallback. The
+// routing-side indexer holds one LRU entry per (pod, block), so a small block size
+// (e.g., vLLM's default of 16) would inflate indexer memory by ~64x. Routing
+// intentionally measures matches at coarser granularity than the model server's
+// true block size. See #1158.
 //
 // Manual configuration (AutoTune off) is honored verbatim; a startup warning is
 // logged in newDataProducer when the configured value is below the recommended floor.
 func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
-	if !p.config.AutoTune || len(endpoints) == 0 {
+	if !p.config.AutoTune {
+		// Manual mode: honor the user's configured value verbatim.
 		return p.config.BlockSizeTokens
 	}
 
-	if endpoint := endpoints[0]; endpoint.GetMetrics() != nil {
-		cacheBlockSize := endpoint.GetMetrics().CacheBlockSize
-		if cacheBlockSize > 0 {
-			if cacheBlockSize < minBlockSizeTokens {
-				return minBlockSizeTokens
+	// AutoTune path: prefer the metric from the first endpoint when available.
+	if len(endpoints) > 0 {
+		if endpoint := endpoints[0]; endpoint.GetMetrics() != nil {
+			if cacheBlockSize := endpoint.GetMetrics().CacheBlockSize; cacheBlockSize > 0 {
+				if cacheBlockSize < minBlockSizeTokens {
+					return minBlockSizeTokens
+				}
+				return cacheBlockSize
 			}
-			return cacheBlockSize
 		}
+	}
+	// AutoTune fallback (no endpoints, no metrics, or zero metric): apply the
+	// same floor so the indexer memory bound holds across all autotune paths.
+	if p.config.BlockSizeTokens < minBlockSizeTokens {
+		return minBlockSizeTokens
 	}
 	return p.config.BlockSizeTokens
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -38,6 +38,16 @@ const (
 	ApproxPrefixCachePluginType = approxprefixconstants.ApproxPrefixCachePluginType
 )
 
+// minBlockSizeTokens is the floor applied to the block size returned by
+// GetBlockSize. The routing-side indexer keeps one LRU entry per (pod, block),
+// so very small block sizes cause gigabyte-scale memory growth at scale. 64
+// tokens is coarse enough to bound memory while still preserving useful
+// prefix-match signal. Defined as a var so tests in this package can lower it
+// to exercise prefix-match logic at small block sizes without leaking a knob
+// into the public configuration surface. See
+// https://github.com/llm-d/llm-d-router/issues/1158.
+var minBlockSizeTokens = 64
+
 var (
 	_ requestcontrol.DataProducer = &dataProducer{}
 	_ requestcontrol.PreRequest   = &dataProducer{}
@@ -84,6 +94,20 @@ func newDataProducer(ctx context.Context, name string, config config, handle plu
 	if err := registerMetrics(handle.Metrics()); err != nil {
 		return nil, err
 	}
+
+	// Surface the override to the operator so a too-small configured value is
+	// not silently swallowed. The clamp itself happens at request time in
+	// GetBlockSize and applies uniformly across endpoint metric, autotune
+	// fallback, and manual configuration.
+	if config.BlockSizeTokens > 0 && config.BlockSizeTokens < minBlockSizeTokens {
+		log.FromContext(ctx).Info(
+			"WARNING: configured blockSizeTokens is below the recommended minimum, overriding it.",
+			"blockSizeTokens", config.BlockSizeTokens,
+			"minimum", minBlockSizeTokens,
+			"issue", "https://github.com/llm-d/llm-d-router/issues/1158",
+		)
+	}
+
 	indexer := newIndexer(ctx, config.LRUCapacityPerServer)
 
 	p := &dataProducer{
@@ -242,18 +266,28 @@ func (p *dataProducer) matchLongestPrefix(ctx context.Context, hashes []blockHas
 }
 
 // GetBlockSize returns the block size in tokens, potentially auto-tuned from endpoint metrics.
+//
+// Values below minBlockSizeTokens are overridden with minBlockSizeTokens
+// regardless of where they originate (endpoint metric, autotune fallback, or
+// manual configuration). The routing-side indexer holds one LRU entry per
+// (pod, block), so a small block size (e.g., vLLM's default of 16) would
+// inflate indexer memory by ~64x. Routing intentionally measures matches at
+// coarser granularity than the model server's true block size; a startup
+// warning is logged in newDataProducer when a configured value triggers the
+// override. See #1158.
 func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
-	if !p.config.AutoTune || len(endpoints) == 0 {
-		return p.config.BlockSizeTokens
-	}
-
-	if endpoint := endpoints[0]; endpoint.GetMetrics() != nil {
-		cacheBlockSize := endpoint.GetMetrics().CacheBlockSize
-		if cacheBlockSize > 0 {
-			return cacheBlockSize
+	blockSize := p.config.BlockSizeTokens
+	if p.config.AutoTune && len(endpoints) > 0 {
+		if endpoint := endpoints[0]; endpoint.GetMetrics() != nil {
+			if metric := endpoint.GetMetrics().CacheBlockSize; metric > 0 {
+				blockSize = metric
+			}
 		}
 	}
-	return p.config.BlockSizeTokens
+	if blockSize < minBlockSizeTokens {
+		return minBlockSizeTokens
+	}
+	return blockSize
 }
 
 // ApproxPrefixCacheFactory is the factory function for the prefix cache data producer plugin.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -601,6 +601,22 @@ func TestGetBlockSize_ManualConfigHonoredBelowMinimum(t *testing.T) {
 	assert.Equal(t, 32, got, "manual BlockSizeTokens below minimum should be honored, not clamped")
 }
 
+// TestGetBlockSize_AutotuneFallbackClampsLowConfig verifies that the floor applies
+// to the autotune fallback path too — when AutoTune is on but no endpoint metric is
+// available, the configured BlockSizeTokens still gets clamped. This is the path the
+// default config (AutoTune=true, BlockSizeTokens=16) would land on if endpoint
+// metrics are missing.
+func TestGetBlockSize_AutotuneFallbackClampsLowConfig(t *testing.T) {
+	cfg := config{AutoTune: true, BlockSizeTokens: 16} // default config shape
+	p, err := newDataProducer(context.Background(), cfg, nil)
+	assert.NoError(t, err)
+
+	// No endpoints passed — exercise the autotune fallback path.
+	got := p.GetBlockSize(nil)
+	assert.Equal(t, minBlockSizeTokens, got,
+		"autotune fallback should clamp BlockSizeTokens to the floor when below minimum")
+}
+
 // TestNewDataProducer_AcceptsLowManualBlockSize verifies that a low BlockSizeTokens
 // with AutoTune off does not cause initialization to fail — the operator gets a
 // warning logged but the producer comes up. (We intentionally don't assert on log

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -441,7 +441,10 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	podName := "pod-autotune"
 	endpoint := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: podName}},
 		&fwkdl.Metrics{
-			CacheBlockSize: 16,   // 16 tokens * 4 chars/token = 64 chars per block
+			// Pod reports a block size above minBlockSizeTokens so the autotune
+			// path passes the metric through unclamped. (Metric values below the
+			// minimum are clamped per #1158; see TestGetBlockSize_AutotuneClampsBelowMinimum.)
+			CacheBlockSize: 128,  // 128 tokens * 4 chars/token = 512 chars per block
 			CacheNumBlocks: 1000, // 1000 blocks capacity
 		}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint}
@@ -451,16 +454,15 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
-				// Length 128 chars.
-				// If block size is 64 chars: 2 blocks
-				Prompt: fwkrh.Prompt{Raw: strings.Repeat("a", 128)},
+				// Length 1024 chars / 512 chars per block = 2 blocks.
+				Prompt: fwkrh.Prompt{Raw: strings.Repeat("a", 1024)},
 			},
 		},
 	}
 
 	config := config{
 		AutoTune:               true,
-		BlockSizeTokens:        32, // Should be ignored in favor of pod metrics (16)
+		BlockSizeTokens:        256, // Should be ignored in favor of pod metrics (128)
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   1,
 	}
@@ -468,8 +470,8 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 
 	_ = p.Produce(context.Background(), req, endpoints)
 	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
-	// 128 chars / (16 tokens * 4 chars/token) = 2 blocks
-	assert.Equal(t, 2, len(state.PrefixHashes), "Should use pod block size (16 tokens) -> 2 body blocks")
+	// 1024 chars / (128 tokens * 4 chars/token) = 2 blocks
+	assert.Equal(t, 2, len(state.PrefixHashes), "Should use pod block size (128 tokens) -> 2 body blocks")
 
 	schedulingResult := &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
@@ -545,6 +547,69 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	state2, err := plugin.ReadPluginStateKey[*SchedulingContextState](p2.PluginState(), req2.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(state2.PrefixHashes), "should fall back to MaxPrefixBlocksToMatch when MaxPrefixTokensToMatch is 0")
+}
+
+// TestGetBlockSize_AutotuneClampsBelowMinimum verifies that when AutoTune is on and
+// the endpoint reports a small CacheBlockSize, GetBlockSize floors the result at
+// minBlockSizeTokens to bound EPP indexer memory. See issue #1158.
+func TestGetBlockSize_AutotuneClampsBelowMinimum(t *testing.T) {
+	cfg := config{
+		AutoTune:        true,
+		BlockSizeTokens: 16, // also small; metric should override but clamp wins
+	}
+	p, err := newDataProducer(context.Background(), cfg, nil)
+	assert.NoError(t, err)
+
+	endpoint := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.Metrics{CacheBlockSize: 16}, // model server uses small blocks
+		fwkdl.NewAttributes(),
+	)
+
+	got := p.GetBlockSize([]fwksched.Endpoint{endpoint})
+	assert.Equal(t, minBlockSizeTokens, got,
+		"autotuned block size below the minimum should be clamped to minBlockSizeTokens")
+}
+
+// TestGetBlockSize_AutotuneAboveMinimumPassesThrough verifies the clamp is one-sided —
+// metric values at or above the minimum are returned unchanged.
+func TestGetBlockSize_AutotuneAboveMinimumPassesThrough(t *testing.T) {
+	cfg := config{AutoTune: true, BlockSizeTokens: 16}
+	p, err := newDataProducer(context.Background(), cfg, nil)
+	assert.NoError(t, err)
+
+	endpoint := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.Metrics{CacheBlockSize: 128},
+		fwkdl.NewAttributes(),
+	)
+
+	got := p.GetBlockSize([]fwksched.Endpoint{endpoint})
+	assert.Equal(t, 128, got, "autotuned block size at or above minimum should not be clamped")
+}
+
+// TestGetBlockSize_ManualConfigHonoredBelowMinimum verifies that with AutoTune off
+// the user's configured BlockSizeTokens is honored verbatim — the floor only applies
+// to the autotune path. Manual configurations below the minimum receive a startup
+// warning (see TestNewDataProducer_AcceptsLowManualBlockSize) but are not coerced.
+func TestGetBlockSize_ManualConfigHonoredBelowMinimum(t *testing.T) {
+	cfg := config{AutoTune: false, BlockSizeTokens: 32}
+	p, err := newDataProducer(context.Background(), cfg, nil)
+	assert.NoError(t, err)
+
+	got := p.GetBlockSize(nil)
+	assert.Equal(t, 32, got, "manual BlockSizeTokens below minimum should be honored, not clamped")
+}
+
+// TestNewDataProducer_AcceptsLowManualBlockSize verifies that a low BlockSizeTokens
+// with AutoTune off does not cause initialization to fail — the operator gets a
+// warning logged but the producer comes up. (We intentionally don't assert on log
+// output here; the GetBlockSize test above confirms the value flows through.)
+func TestNewDataProducer_AcceptsLowManualBlockSize(t *testing.T) {
+	cfg := config{AutoTune: false, BlockSizeTokens: 32}
+	p, err := newDataProducer(context.Background(), cfg, nil)
+	assert.NoError(t, err, "low manual BlockSizeTokens should warn, not error")
+	assert.NotNil(t, p)
 }
 
 // BenchmarkPrefixPluginStress is a stress test using prompts of increasing length.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -40,7 +40,19 @@ func testHandle() plugin.Handle {
 	return plugin.NewEppHandle(context.Background(), nil, plugin.WithMetricsRecorder(prometheus.NewRegistry()))
 }
 
+// disableMinBlockSizeClamp lowers the runtime block-size floor to 1 for tests
+// that exercise prefix-match logic with deliberately small block sizes. The
+// production default (64) would clamp tiny test inputs, hiding the behavior
+// under test. Restores the previous value on cleanup.
+func disableMinBlockSizeClamp(t *testing.T) {
+	t.Helper()
+	prev := minBlockSizeTokens
+	minBlockSizeTokens = 1
+	t.Cleanup(func() { minBlockSizeTokens = prev })
+}
+
 func TestProduce(t *testing.T) {
+	disableMinBlockSizeClamp(t)
 	config := config{
 		BlockSizeTokens:        1,
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
@@ -89,6 +101,7 @@ func TestProduce(t *testing.T) {
 }
 
 func TestPreRequest(t *testing.T) {
+	disableMinBlockSizeClamp(t)
 	t.Run("Basic cache update", func(t *testing.T) {
 		config := config{
 			BlockSizeTokens:        1,
@@ -220,6 +233,7 @@ func TestDataProducerValidation(t *testing.T) {
 }
 
 func TestPrefixPluginCompletion(t *testing.T) {
+	disableMinBlockSizeClamp(t)
 	config := config{
 		BlockSizeTokens:        1,
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
@@ -289,6 +303,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 }
 
 func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
+	disableMinBlockSizeClamp(t)
 	config := config{
 		BlockSizeTokens:        2, // Use larger block size
 		AutoTune:               false,
@@ -579,6 +594,7 @@ func TestPrefixPluginChatCompletionsMultimodalSameImageContentMatches(t *testing
 }
 
 func TestPrefixPluginChatCompletionsMultimodalPrefixImageContentMatches(t *testing.T) {
+	disableMinBlockSizeClamp(t)
 	mmCfg := multiModalTokenEstimatorConfig{
 		Image: &imageTokenEstimatorConfig{
 			Mode: ModeFixed,
@@ -671,7 +687,10 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	podName := "pod-autotune"
 	endpoint := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: podName}},
 		&fwkdl.Metrics{
-			CacheBlockSize: 16,   // 16 tokens * 4 chars/token = 64 chars per block
+			// Pod reports a block size above minBlockSizeTokens so the autotune
+			// path passes the metric through unclamped. (Metric values below the
+			// minimum are clamped per #1158; see TestGetBlockSize_AutotuneClampsBelowMinimum.)
+			CacheBlockSize: 128,  // 128 tokens * 4 chars/token = 512 chars per block
 			CacheNumBlocks: 1000, // 1000 blocks capacity
 		}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint}
@@ -681,16 +700,15 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
-				// Length 128 chars.
-				// If block size is 64 chars: 2 blocks
-				Prompt: fwkrh.Prompt{Raw: strings.Repeat("a", 128)},
+				// Length 1024 chars / 512 chars per block = 2 blocks.
+				Prompt: fwkrh.Prompt{Raw: strings.Repeat("a", 1024)},
 			},
 		},
 	}
 
 	config := config{
 		AutoTune:               true,
-		BlockSizeTokens:        32, // Should be ignored in favor of pod metrics (16)
+		BlockSizeTokens:        256, // Should be ignored in favor of pod metrics (128)
 		MaxPrefixBlocksToMatch: defaultMaxPrefixBlocks,
 		LRUCapacityPerServer:   1,
 	}
@@ -698,8 +716,8 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 
 	_ = p.Produce(context.Background(), req, endpoints)
 	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
-	// 128 chars / (16 tokens * 4 chars/token) = 2 blocks
-	assert.Equal(t, 2, len(state.PrefixHashes), "Should use pod block size (16 tokens) -> 2 body blocks")
+	// 1024 chars / (128 tokens * 4 chars/token) = 2 blocks
+	assert.Equal(t, 2, len(state.PrefixHashes), "Should use pod block size (128 tokens) -> 2 body blocks")
 
 	schedulingResult := &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
@@ -715,6 +733,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 }
 
 func TestMaxPrefixTokensToMatch(t *testing.T) {
+	disableMinBlockSizeClamp(t)
 	// BlockSizeTokens=1 means each block is 4 chars (1 token * 4 chars/token).
 	// With MaxPrefixTokensToMatch=2, maxBlocks = 2/1 = 2, so only the first
 	// 2 blocks (8 chars) of the prompt should be hashed.
@@ -775,6 +794,87 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	state2, err := plugin.ReadPluginStateKey[*SchedulingContextState](p2.PluginState(), req2.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(state2.PrefixHashes), "should fall back to MaxPrefixBlocksToMatch when MaxPrefixTokensToMatch is 0")
+}
+
+// TestGetBlockSize_AutotuneClampsBelowMinimum verifies that when AutoTune is on and
+// the endpoint reports a small CacheBlockSize, GetBlockSize floors the result at
+// minBlockSizeTokens to bound EPP indexer memory. See issue #1158.
+func TestGetBlockSize_AutotuneClampsBelowMinimum(t *testing.T) {
+	cfg := config{
+		AutoTune:        true,
+		BlockSizeTokens: 16, // also small; metric should override but clamp wins
+	}
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err)
+
+	endpoint := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.Metrics{CacheBlockSize: 16}, // model server uses small blocks
+		fwkdl.NewAttributes(),
+	)
+
+	got := p.GetBlockSize([]fwksched.Endpoint{endpoint})
+	assert.Equal(t, minBlockSizeTokens, got,
+		"autotuned block size below the minimum should be clamped to minBlockSizeTokens")
+}
+
+// TestGetBlockSize_AutotuneAboveMinimumPassesThrough verifies the clamp is one-sided —
+// metric values at or above the minimum are returned unchanged.
+func TestGetBlockSize_AutotuneAboveMinimumPassesThrough(t *testing.T) {
+	cfg := config{AutoTune: true, BlockSizeTokens: 16}
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err)
+
+	endpoint := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.Metrics{CacheBlockSize: 128},
+		fwkdl.NewAttributes(),
+	)
+
+	got := p.GetBlockSize([]fwksched.Endpoint{endpoint})
+	assert.Equal(t, 128, got, "autotuned block size at or above minimum should not be clamped")
+}
+
+// TestGetBlockSize_ManualConfigClampedBelowMinimum verifies that the floor
+// applies to manual configuration as well — configured BlockSizeTokens below
+// minBlockSizeTokens is silently raised so the indexer memory bound holds
+// across both manual and autotune paths.
+func TestGetBlockSize_ManualConfigClampedBelowMinimum(t *testing.T) {
+	cfg := config{AutoTune: false, BlockSizeTokens: 32}
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err)
+
+	got := p.GetBlockSize(nil)
+	assert.Equal(t, minBlockSizeTokens, got,
+		"manual BlockSizeTokens below the minimum should be clamped to the floor")
+}
+
+// TestGetBlockSize_AutotuneFallbackClampsLowConfig verifies that the floor applies
+// to the autotune fallback path too — when AutoTune is on but no endpoint metric is
+// available, the configured BlockSizeTokens still gets clamped. This is the path the
+// default config (AutoTune=true, BlockSizeTokens=16) would land on if endpoint
+// metrics are missing.
+func TestGetBlockSize_AutotuneFallbackClampsLowConfig(t *testing.T) {
+	cfg := config{AutoTune: true, BlockSizeTokens: 16} // default config shape
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err)
+
+	// No endpoints passed — exercise the autotune fallback path.
+	got := p.GetBlockSize(nil)
+	assert.Equal(t, minBlockSizeTokens, got,
+		"autotune fallback should clamp BlockSizeTokens to the floor when below minimum")
+}
+
+// TestNewDataProducer_AcceptsLowManualBlockSize verifies that a low
+// BlockSizeTokens with AutoTune off does not cause initialization to fail —
+// GetBlockSize clamps the effective value to minBlockSizeTokens at request
+// time, but the producer construction itself accepts any positive
+// BlockSizeTokens.
+func TestNewDataProducer_AcceptsLowManualBlockSize(t *testing.T) {
+	cfg := config{AutoTune: false, BlockSizeTokens: 32}
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err, "low manual BlockSizeTokens should not error at init")
+	assert.NotNil(t, p)
 }
 
 // BenchmarkPrefixPluginStress is a stress test using prompts of increasing length.
@@ -864,6 +964,7 @@ func TestFactory_DeprecatedBlockSizeMapped(t *testing.T) {
 }
 
 func TestPrefixPluginGenerateRequest(t *testing.T) {
+	disableMinBlockSizeClamp(t)
 	// BlockSizeTokens=1 means each block covers 1 token (4 bytes in the serialized key).
 	cfg := config{
 		BlockSizeTokens:        1,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -91,6 +91,14 @@ const (
 	// defaultBlockSizeTokens is the default token block size (vLLM default is 16).
 	defaultBlockSizeTokens = 16
 
+	// minBlockSizeTokens is the floor applied to the autotuned block size and the
+	// recommended minimum for manual configuration. The routing-side indexer keeps
+	// one LRU entry per (pod, block), so with very small block sizes the indexer
+	// can consume gigabytes of memory under live traffic. 64 tokens is coarse
+	// enough to bound memory while still preserving useful prefix-match signal.
+	// See https://github.com/llm-d/llm-d-router/issues/1158.
+	minBlockSizeTokens = 64
+
 	// defaultMaxPrefixBlocks is the maximum number of blocks to match.
 	// Two long requests with the same prefix up to this limit will be indistinguishable.
 	// This parameter provides a trade-off between cache size, prefix matching speed and matching


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind bug

**What this PR does / why we need it**:

The approximate prefix-cache plugin's autotune path uses the model server's `CacheBlockSize` metric verbatim (vLLM's default is 16 tokens). The routing-side indexer holds one LRU entry per `(pod, block)`, so at small block sizes the indexer can grow to gigabytes under live traffic — enough to push EPP into memory pressure.

This PR adds an asymmetric minimum-block-size floor:

- **Autotune path:** clamp at `minBlockSizeTokens = 64`. The routing scorer intentionally measures matches at coarser granularity than the model server's true block size — a deliberate routing-precision / memory-stability tradeoff.
- **Manual configuration:** honored verbatim, but a startup warning is logged when a non-zero `BlockSizeTokens` is below the floor. Operators retain an escape hatch; the memory risk surfaces at deploy time rather than during a memory-pressure incident.

The granularity tradeoff and rationale are documented inline in `GetBlockSize` and on the constant itself, with a link back to #1158.

### Tests

- New unit tests in `approximateprefix/plugin_test.go`:
  - `TestGetBlockSize_AutotuneClampsBelowMinimum` — metric of 16 → 64
  - `TestGetBlockSize_AutotuneAboveMinimumPassesThrough` — metric of 128 → 128 (one-sided clamp)
  - `TestGetBlockSize_ManualConfigHonoredBelowMinimum` — manual `BlockSizeTokens=32` → 32 (no coerce)
  - `TestNewDataProducer_AcceptsLowManualBlockSize` — low manual value warns, does not error
- Updated `TestPrefixPluginAutoTune`: the existing assertion used `CacheBlockSize=16` and depended on the unclamped value flowing through. Adjusted to `CacheBlockSize=128` (above the floor) and a 1024-char prompt so the test still exercises the autotune-passes-through path. The clamp behavior is now covered by the dedicated tests above.

Verified locally: `make presubmit` is green end-to-end (lint, format, typos, govulncheck) and `go test ./pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/...` passes.

### Notes

- Touches the same plugin as #1134 (the open strict-config-parsing PR). The changes are orthogonal and shouldn't conflict, but if #1134 lands first, this branch will need a trivial rebase.
- The autotune clamp is intentionally not configurable. If operators have a strong reason to want a smaller routing-side block size, the `AutoTune: false` path with manual `BlockSizeTokens` remains available (with the deploy-time warning).

**Which issue(s) this PR fixes**:
Fixes #1158

**Release note**:
```release-note
The approximate prefix-cache plugin's autotune path now clamps blockSizeTokens at a minimum of 64 to bound EPP indexer memory. Manually configured values below 64 are still honored but log a deploy-time warning. This is a deliberate routing-precision / memory-stability tradeoff: the routing scorer measures prefix matches at coarser granularity than the model server's true block size.
```
