### PR TITLE
Rename EPP-managed headers to x-llm-d

### DIFF
--- a/pkg/epp/framework/common/request/headers_test.go
+++ b/pkg/epp/framework/common/request/headers_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func TestGetHeader(t *testing.T) {
-	headers := map[string]string{"X-SLO-TTFT-MS": "42", "Other": "x"}
-	assert.Equal(t, "42", GetHeader(headers, "X-SLO-TTFT-MS"))
-	assert.Equal(t, "42", GetHeader(headers, "x-slo-ttft-ms"))
+	headers := map[string]string{"X-LLM-D-SLO-TTFT-MS": "42", "Other": "x"}
+	assert.Equal(t, "42", GetHeader(headers, "X-LLM-D-SLO-TTFT-MS"))
+	assert.Equal(t, "42", GetHeader(headers, "x-llm-d-slo-ttft-ms"))
 	assert.Equal(t, "", GetHeader(headers, "missing"))
 	assert.Equal(t, "", GetHeader(nil, "k"))
 }

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/doc.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/doc.go
@@ -53,7 +53,7 @@ limitations under the License.
 //     This maximizes the number of requests served before their deadlines expire.
 //
 //   - SLO Deadline ("slo-deadline-ordering-policy"): Orders requests by an SLO-based (service level objective) deadline
-//     computed as ReceivedTimestamp + x-slo-ttft-ms header (interpreted as milliseconds).
+//     computed as ReceivedTimestamp + x-llm-d-slo-ttft-ms header (interpreted as milliseconds).
 //     Requests without a valid header are scheduled after SLO-bound requests.
 //     This maximizes the number of requests served before the deadlines computed on the defined SLO expire.
 package ordering

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/README.md
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/README.md
@@ -14,21 +14,21 @@ The SLO Deadline ordering policy selects requests based on a deadline derived fr
 ## What It Does
 
 The policy computes a deadline for each request as:
-`Deadline = ReceivedTimestamp + x-slo-ttft-ms`
+`Deadline = ReceivedTimestamp + x-llm-d-slo-ttft-ms`
 
 - **`ReceivedTimestamp`**: The time the request was received by the gateway.
-- **`x-slo-ttft-ms`**: A request header specifying the target Time-To-First-Token in milliseconds.
+- **`x-llm-d-slo-ttft-ms`**: A request header specifying the target Time-To-First-Token in milliseconds. The deprecated `x-slo-ttft-ms` alias is still accepted for compatibility.
 
 ## Inputs consumed
 
 This policy inspects the following attributes of the request:
 - **ReceivedTimestamp**: The time the request was received by the gateway.
-- **`x-slo-ttft-ms` Header**: A header specifying the target Time-To-First-Token in milliseconds.
+- **`x-llm-d-slo-ttft-ms` Header**: A header specifying the target Time-To-First-Token in milliseconds.
 
 Requests are prioritized as follows:
 1. Requests with **earlier absolute deadlines** are dispatched first.
 2. If two requests have the same deadline, or if both lack a valid deadline, they are ordered by `ReceivedTimestamp` (FCFS).
-3. Requests without a valid `x-slo-ttft-ms` header (missing, empty, or invalid integer) are assigned a far-future deadline, placing them behind all SLO-bound requests.
+3. Requests without a valid `x-llm-d-slo-ttft-ms` header (missing, empty, or invalid integer) are assigned a far-future deadline, placing them behind all SLO-bound requests.
 
 ## Behavior and Queue Pairing
 
@@ -39,7 +39,7 @@ This policy **requires** specific queue capabilities to function correctly.
 
 ## Configuration
 
-This policy does not require any custom parameters in the flow control configuration itself, but it relies on the presence of the `x-slo-ttft-ms` header in incoming requests.
+This policy does not require any custom parameters in the flow control configuration itself, but it relies on the presence of the `x-llm-d-slo-ttft-ms` header in incoming requests.
 
 ```yaml
 orderingPolicyRef: slo-deadline-ordering-policy
@@ -47,10 +47,9 @@ orderingPolicyRef: slo-deadline-ordering-policy
 
 ## Trade-offs
 
-- **Header Dependency:** Requires clients or upstream components to correctly set the `x-slo-ttft-ms` header.
+- **Header Dependency:** Requires clients or upstream components to correctly set the `x-llm-d-slo-ttft-ms` header.
 - **Starvation Risk:** Non-SLO requests or requests with very loose SLOs may be starved if there is a constant influx of tight-SLO requests.
 - **Computational Overhead:** Similar to EDF, maintaining a priority heap incurs higher CPU overhead ($O(\log n)$) than a simple FIFO list.
 
 ## Related Documentation
 *   [Ordering Overview](../README.md)
-

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 const (
@@ -39,7 +39,7 @@ const (
 	SLODeadlineOrderingPolicyType = "slo-deadline-ordering-policy"
 
 	// sloTtftHeader is the request header name for SLO time-to-first-token in milliseconds.
-	sloTtftHeader = "x-slo-ttft-ms"
+	sloTtftHeader = metadata.TTFTSLOHeaderKey
 )
 
 func SLODeadlineOrderingPolicyFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
@@ -83,7 +83,7 @@ func (p *sloDeadlinePolicy) TypedName() plugin.TypedName {
 
 var sloMaxDeadlineTime = time.Unix(0, 1<<63-1)
 
-// calculateSLODeadline computes the SLO-based deadline for a request: ReceivedTimestamp + x-slo-ttft-ms (ms).
+// calculateSLODeadline computes the SLO-based deadline for a request: ReceivedTimestamp + SLO TTFT header (ms).
 // The header is read from the InferenceRequest()'s headers. If the header is missing, empty, or invalid,
 // the request is assigned a far-future deadline so it sorts after SLO-bound requests.
 func calculateSLODeadline(item flowcontrol.QueueItemAccessor) time.Time {
@@ -95,7 +95,7 @@ func calculateSLODeadline(item flowcontrol.QueueItemAccessor) time.Time {
 	if infReq == nil || infReq.Headers == nil {
 		return sloMaxDeadlineTime
 	}
-	sloTtft := request.GetHeader(infReq.Headers, sloTtftHeader)
+	sloTtft, _ := metadata.GetLowerCaseHeaderValue(infReq.Headers, sloTtftHeader)
 	if sloTtft == "" {
 		return sloMaxDeadlineTime
 	}

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 var testFlowKey = flowcontrol.FlowKey{ID: "test-flow", Priority: 0}
@@ -119,6 +120,23 @@ func TestCalculateSLODeadline(t *testing.T) {
 	accValid := &mocks.MockQueueItemAccessor{OriginalRequestV: reqValid}
 	deadline := calculateSLODeadline(accValid)
 	assert.Equal(t, now.Add(200*time.Millisecond), deadline)
+
+	// Old alias
+	reqOldAlias := mocks.NewMockFlowControlRequest(1, "old-alias", testFlowKey)
+	reqOldAlias.ReceivedTimestampV = now
+	reqOldAlias.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{metadata.OldTTFTSLOHeaderKey: "150"}}
+	accOldAlias := &mocks.MockQueueItemAccessor{OriginalRequestV: reqOldAlias}
+	assert.Equal(t, now.Add(150*time.Millisecond), calculateSLODeadline(accOldAlias))
+
+	// New header takes precedence over old alias
+	reqBoth := mocks.NewMockFlowControlRequest(1, "both", testFlowKey)
+	reqBoth.ReceivedTimestampV = now
+	reqBoth.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{
+		sloTtftHeader:                "200",
+		metadata.OldTTFTSLOHeaderKey: "50",
+	}}
+	accBoth := &mocks.MockQueueItemAccessor{OriginalRequestV: reqBoth}
+	assert.Equal(t, now.Add(200*time.Millisecond), calculateSLODeadline(accBoth))
 
 	// Missing header
 	reqNoHeader := mocks.NewMockFlowControlRequest(2, "no", testFlowKey)

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -30,13 +30,14 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 const (
 	LatencyAdmissionPluginType = "latency-slo-admitter"
 
-	ttftSLOHeaderKey = "x-slo-ttft-ms"
-	tpotSLOHeaderKey = "x-slo-tpot-ms"
+	ttftSLOHeaderKey = metadata.TTFTSLOHeaderKey
+	tpotSLOHeaderKey = metadata.TPOTSLOHeaderKey
 )
 
 // compile-time validation
@@ -112,8 +113,10 @@ func (p *LatencyAdmission) AdmitRequest(ctx context.Context, request *fwksched.I
 	}
 
 	// Check if SLOs are set — if not, we can't determine validity, so admit.
-	ttftSLO := parseFloatHeaderValue(request.Headers[ttftSLOHeaderKey])
-	tpotSLO := parseFloatHeaderValue(request.Headers[tpotSLOHeaderKey])
+	ttftSLOHeader, _ := metadata.GetLowerCaseHeaderValue(request.Headers, ttftSLOHeaderKey)
+	tpotSLOHeader, _ := metadata.GetLowerCaseHeaderValue(request.Headers, tpotSLOHeaderKey)
+	ttftSLO := parseFloatHeaderValue(ttftSLOHeader)
+	tpotSLO := parseFloatHeaderValue(tpotSLOHeader)
 	hasSLO := ttftSLO > 0 || tpotSLO > 0
 	if !hasSLO {
 		return nil

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
@@ -25,6 +25,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 func makeLatencyAdmissionEndpoint(name string, kvCache float64, runningRequests int) fwksched.Endpoint {
@@ -108,6 +109,44 @@ func TestAdmitRequest(t *testing.T) {
 					attrlatency.NewLatencyPredictionInfo(false, false, -30, -5, 130, 35, 0))
 			},
 			wantErr: true,
+		},
+		{
+			name: "sheddable, old SLO aliases — reject",
+			request: &fwksched.InferenceRequest{
+				Headers: map[string]string{
+					metadata.OldTTFTSLOHeaderKey: "100",
+					metadata.OldTPOTSLOHeaderKey: "30",
+				},
+				Objectives: fwksched.RequestObjectives{Priority: -1},
+			},
+			endpoints: []fwksched.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+			},
+			setupFn: func(endpoints []fwksched.Endpoint) {
+				endpoints[0].Put(attrlatency.LatencyPredictionInfoDataKey.String(),
+					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
+			},
+			wantErr: true,
+		},
+		{
+			name: "new SLO headers take precedence over old aliases",
+			request: &fwksched.InferenceRequest{
+				Headers: map[string]string{
+					metadata.TTFTSLOHeaderKey:    "0",
+					metadata.OldTTFTSLOHeaderKey: "100",
+					metadata.TPOTSLOHeaderKey:    "0",
+					metadata.OldTPOTSLOHeaderKey: "30",
+				},
+				Objectives: fwksched.RequestObjectives{Priority: -1},
+			},
+			endpoints: []fwksched.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+			},
+			setupFn: func(endpoints []fwksched.Endpoint) {
+				endpoints[0].Put(attrlatency.LatencyPredictionInfoDataKey.String(),
+					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40, 0))
+			},
+			wantErr: false,
 		},
 		{
 			name:    "sheddable, all invalid, but one pod idle — admit",

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -42,6 +42,7 @@ import (
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	latencyproducerconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/constants"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 const (
@@ -50,9 +51,9 @@ const (
 	LatencyDataProviderPluginType = latencyproducerconstants.LatencyDataProviderPluginType
 
 	// TTFTSLOHeaderKey is the header key for the TTFT SLO.
-	TTFTSLOHeaderKey = "x-slo-ttft-ms"
+	TTFTSLOHeaderKey = metadata.TTFTSLOHeaderKey
 	// TPOTSLOHeaderKey is the header key for the TPOT SLO.
-	TPOTSLOHeaderKey = "x-slo-tpot-ms"
+	TPOTSLOHeaderKey = metadata.TPOTSLOHeaderKey
 
 	// ExperimentalDefaultPrefillProfile is the default profile name for prefill endpoints in disaggregated serving.
 	ExperimentalDefaultPrefillProfile = "prefill"
@@ -315,7 +316,7 @@ func (pl *PredictedLatency) deletePredictedLatencyContextForRequest(request *fwk
 // parseFloatHeader retrieves a header by name, parses it as a float64,
 // and returns the value or an error if the header is missing or invalid.
 func parseFloatHeader(request fwksched.InferenceRequest, headerName string) (float64, error) {
-	headerValue, ok := request.Headers[headerName]
+	headerValue, ok := metadata.GetLowerCaseHeaderValue(request.Headers, headerName)
 	if !ok {
 		return 0, nil
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -31,6 +31,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
 )
 
@@ -137,15 +138,70 @@ func createTestInferenceRequestWithBody(reqID string, ttftSLO, tpotSLO float64, 
 	headers := make(map[string]string)
 	headers[reqcommon.RequestIDHeaderKey] = reqID
 	if ttftSLO > 0 {
-		headers["x-ttft-slo"] = fmt.Sprintf("%f", ttftSLO)
+		headers[metadata.TTFTSLOHeaderKey] = fmt.Sprintf("%f", ttftSLO)
 	}
 	if tpotSLO > 0 {
-		headers["x-avg-tpot-slo"] = fmt.Sprintf("%f", tpotSLO)
+		headers[metadata.TPOTSLOHeaderKey] = fmt.Sprintf("%f", tpotSLO)
 	}
 
 	return &fwksched.InferenceRequest{
 		Headers: headers,
 		Body:    body,
+	}
+}
+
+func TestParseSLOHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		wantTTFT float64
+		wantTPOT float64
+	}{
+		{
+			name: "SLO headers",
+			headers: map[string]string{
+				metadata.TTFTSLOHeaderKey: "100",
+				metadata.TPOTSLOHeaderKey: "50",
+			},
+			wantTTFT: 100,
+			wantTPOT: 50,
+		},
+		{
+			name: "old aliases",
+			headers: map[string]string{
+				metadata.OldTTFTSLOHeaderKey: "101",
+				metadata.OldTPOTSLOHeaderKey: "51",
+			},
+			wantTTFT: 101,
+			wantTPOT: 51,
+		},
+		{
+			name: "new headers take precedence",
+			headers: map[string]string{
+				metadata.TTFTSLOHeaderKey:    "102",
+				metadata.OldTTFTSLOHeaderKey: "999",
+				metadata.TPOTSLOHeaderKey:    "52",
+				metadata.OldTPOTSLOHeaderKey: "999",
+			},
+			wantTTFT: 102,
+			wantTPOT: 52,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pl := &PredictedLatency{}
+			req := &fwksched.InferenceRequest{Headers: tt.headers}
+			plCtx := &predictedLatencyCtx{}
+
+			pl.parseSLOHeaders(context.Background(), req, plCtx)
+
+			assert.Equal(t, tt.wantTTFT, plCtx.ttftSLO)
+			assert.Equal(t, tt.wantTPOT, plCtx.avgTPOTSLO)
+		})
 	}
 }
 

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"maps"
 	"strconv"
+	"strings"
 	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -47,16 +48,12 @@ func (s *StreamingServer) HandleRequestHeaders(ctx context.Context, reqCtx *Requ
 	}
 
 	for _, header := range req.RequestHeaders.Headers.Headers {
-		reqCtx.Request.Headers[header.Key] = envoy.GetHeaderValue(header)
-		switch header.Key {
-		case metadata.FlowFairnessIDKey:
-			reqCtx.FairnessID = reqCtx.Request.Headers[header.Key]
-		case metadata.ObjectiveKey:
-			reqCtx.ObjectiveKey = reqCtx.Request.Headers[header.Key]
-		case metadata.ModelNameRewriteKey:
-			reqCtx.TargetModelName = reqCtx.Request.Headers[header.Key]
-		}
+		reqCtx.Request.Headers[strings.ToLower(header.Key)] = envoy.GetHeaderValue(header)
 	}
+
+	reqCtx.FairnessID, _ = metadata.GetLowerCaseHeaderValue(reqCtx.Request.Headers, metadata.FlowFairnessIDKey)
+	reqCtx.ObjectiveKey, _ = metadata.GetLowerCaseHeaderValue(reqCtx.Request.Headers, metadata.ObjectiveKey)
+	reqCtx.TargetModelName, _ = metadata.GetLowerCaseHeaderValue(reqCtx.Request.Headers, metadata.ModelNameRewriteKey)
 
 	if reqCtx.FairnessID == "" {
 		reqCtx.FairnessID = metadata.DefaultFairnessID

--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -37,12 +37,14 @@ func TestHandleRequestHeaders(t *testing.T) {
 		headers        []*configPb.HeaderValue
 		wantHeaders    map[string]string
 		wantFairnessID string
+		wantObjective  string
+		wantTarget     string
 	}{
 		{
-			name: "Extracts Fairness ID and Removes Header",
+			name: "Extracts old Fairness ID alias",
 			headers: []*configPb.HeaderValue{
-				{Key: "x-test", Value: "val"},
-				{Key: metadata.FlowFairnessIDKey, Value: "user-123"},
+				{Key: "X-Test", Value: "val"},
+				{Key: "X-Gateway-Inference-Fairness-Id", Value: "user-123"},
 			},
 			wantHeaders:    map[string]string{"x-test": "val"},
 			wantFairnessID: "user-123",
@@ -53,6 +55,20 @@ func TestHandleRequestHeaders(t *testing.T) {
 				{Key: metadata.FlowFairnessIDKey, RawValue: []byte("binary-id"), Value: "wrong-id"},
 			},
 			wantFairnessID: "binary-id",
+		},
+		{
+			name: "Prefers new control headers over old aliases",
+			headers: []*configPb.HeaderValue{
+				{Key: metadata.OldFlowFairnessIDKey, Value: "old-user"},
+				{Key: metadata.FlowFairnessIDKey, Value: "new-user"},
+				{Key: metadata.OldObjectiveKey, Value: "old-objective"},
+				{Key: metadata.ObjectiveKey, Value: "new-objective"},
+				{Key: metadata.OldModelNameRewriteKey, Value: "old-model"},
+				{Key: metadata.ModelNameRewriteKey, Value: "new-model"},
+			},
+			wantFairnessID: "new-user",
+			wantObjective:  "new-objective",
+			wantTarget:     "new-model",
 		},
 	}
 
@@ -72,6 +88,8 @@ func TestHandleRequestHeaders(t *testing.T) {
 			assert.NoError(t, err, "HandleRequestHeaders should not return an error")
 
 			assert.Equal(t, tc.wantFairnessID, reqCtx.FairnessID, "FairnessID should match expected value")
+			assert.Equal(t, tc.wantObjective, reqCtx.ObjectiveKey, "ObjectiveKey should match expected value")
+			assert.Equal(t, tc.wantTarget, reqCtx.TargetModelName, "TargetModelName should match expected value")
 
 			if tc.wantHeaders != nil {
 				for k, v := range tc.wantHeaders {
@@ -89,10 +107,11 @@ func TestGenerateHeaders_Sanitization(t *testing.T) {
 		RequestSize:    123,
 		Request: &Request{
 			Headers: map[string]string{
-				"x-user-data":                   "important",              // should passthrough
-				metadata.ObjectiveKey:           "sensitive-objective-id", // should be stripped
-				metadata.DestinationEndpointKey: "1.1.1.1:666",            // should be stripped
-				"content-length":                "99999",                  // should be stripped (re-added by logic)
+				"x-user-data":                   "important",                  // should passthrough
+				metadata.ObjectiveKey:           "sensitive-objective-id",     // should be stripped
+				metadata.OldObjectiveKey:        "old-sensitive-objective-id", // should be stripped
+				metadata.DestinationEndpointKey: "1.1.1.1:666",                // should be stripped
+				"content-length":                "99999",                      // should be stripped (re-added by logic)
 			},
 		},
 	}
@@ -106,6 +125,7 @@ func TestGenerateHeaders_Sanitization(t *testing.T) {
 
 	assert.Contains(t, gotHeaders, "x-user-data")
 	assert.NotContains(t, gotHeaders, metadata.ObjectiveKey)
+	assert.NotContains(t, gotHeaders, metadata.OldObjectiveKey)
 	assert.Equal(t, "1.2.3.4:8080", gotHeaders[metadata.DestinationEndpointKey])
 	assert.Equal(t, "123", gotHeaders["Content-Length"])
 }

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -341,10 +341,11 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	reqCtx := &RequestContext{
 		Response: &Response{
 			Headers: map[string]string{
-				"x-backend-server":              "vllm-v0.6.3",            // should passthrough
-				metadata.ObjectiveKey:           "sensitive-objective-id", // should be stripped
-				metadata.DestinationEndpointKey: "10.2.0.5:8080",          // should be stripped
-				"content-length":                "500",                    // should be stripped
+				"x-backend-server":              "vllm-v0.6.3",                // should passthrough
+				metadata.ObjectiveKey:           "sensitive-objective-id",     // should be stripped
+				metadata.OldObjectiveKey:        "old-sensitive-objective-id", // should be stripped
+				metadata.DestinationEndpointKey: "10.2.0.5:8080",              // should be stripped
+				"content-length":                "500",                        // should be stripped
 			},
 		},
 	}
@@ -359,6 +360,7 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	assert.Contains(t, gotHeaders, "x-backend-server")
 	assert.Contains(t, gotHeaders, "x-went-into-resp-headers")
 	assert.NotContains(t, gotHeaders, metadata.ObjectiveKey)
+	assert.NotContains(t, gotHeaders, metadata.OldObjectiveKey)
 	assert.NotContains(t, gotHeaders, metadata.DestinationEndpointKey)
 	assert.NotContains(t, gotHeaders, "content-length")
 }

--- a/pkg/epp/handlers/server_abort_test.go
+++ b/pkg/epp/handlers/server_abort_test.go
@@ -95,8 +95,11 @@ func TestUpdateStateAndSendIfNeeded_Evicted(t *testing.T) {
 			if tt.wantHeader {
 				require.NotNil(t, ir.Headers, "Should have HeaderMutation when eviction reason is set")
 				require.Len(t, ir.Headers.SetHeaders, 1)
-				assert.Equal(t, "x-llm-d-request-dropped-reason", ir.Headers.SetHeaders[0].Header.Key)
-				assert.Equal(t, []byte(tt.requestDroppedReason), ir.Headers.SetHeaders[0].Header.RawValue)
+				gotHeaders := make(map[string]string, len(ir.Headers.SetHeaders))
+				for _, header := range ir.Headers.SetHeaders {
+					gotHeaders[header.Header.Key] = string(header.Header.RawValue)
+				}
+				assert.Equal(t, map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(tt.requestDroppedReason)}, gotHeaders)
 			} else {
 				assert.Nil(t, ir.Headers, "Should not have HeaderMutation when eviction reason is empty")
 			}

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package metadata
 
+import "strings"
+
 const (
 	// SubsetFilterNamespace is the key for the outer namespace struct in the metadata field of the extproc request that is used to wrap the subset filter.
 	SubsetFilterNamespace = "envoy.lb.subset_hint"
@@ -29,14 +31,61 @@ const (
 	// DestinationEndpointServedKey is the metadata key used by Envoy to specify the endpoint that served the request.
 	DestinationEndpointServedKey = "x-gateway-destination-endpoint-served"
 	// FlowFairnessIDKey is the header key used to pass the fairness ID to be used in Flow Control.
-	FlowFairnessIDKey = "x-gateway-inference-fairness-id"
+	FlowFairnessIDKey = "x-llm-d-inference-fairness-id"
+	// OldFlowFairnessIDKey is the deprecated alias for FlowFairnessIDKey.
+	OldFlowFairnessIDKey = "x-gateway-inference-fairness-id"
 	// ObjectiveKey is the header key used to specify the objective of an incoming request.
-	ObjectiveKey = "x-gateway-inference-objective"
+	ObjectiveKey = "x-llm-d-inference-objective"
+	// OldObjectiveKey is the deprecated alias for ObjectiveKey.
+	OldObjectiveKey = "x-gateway-inference-objective"
 	// ModelNameRewriteKey is the header key used to specify the model name to be used when the request is forwarded to the model server.
-	ModelNameRewriteKey = "x-gateway-model-name-rewrite"
+	ModelNameRewriteKey = "x-llm-d-model-name-rewrite"
+	// OldModelNameRewriteKey is the deprecated alias for ModelNameRewriteKey.
+	OldModelNameRewriteKey = "x-gateway-model-name-rewrite"
+	// TTFTSLOHeaderKey is the header key used to specify the time-to-first-token SLO in milliseconds.
+	TTFTSLOHeaderKey = "x-llm-d-slo-ttft-ms"
+	// OldTTFTSLOHeaderKey is the deprecated alias for TTFTSLOHeaderKey.
+	OldTTFTSLOHeaderKey = "x-slo-ttft-ms"
+	// TPOTSLOHeaderKey is the header key used to specify the time-per-output-token SLO in milliseconds.
+	TPOTSLOHeaderKey = "x-llm-d-slo-tpot-ms"
+	// OldTPOTSLOHeaderKey is the deprecated alias for TPOTSLOHeaderKey.
+	OldTPOTSLOHeaderKey = "x-slo-tpot-ms"
 
 	// DefaultFairnessID is the default fairness ID used when no ID is provided in the request.
 	// This ensures that requests without explicit fairness identifiers are still grouped and managed by the Flow Control
 	// system.
 	DefaultFairnessID = "default-flow"
 )
+
+// All headerAliases keys and values must be lower case.
+var headerAliases = map[string][]string{
+	FlowFairnessIDKey:   {FlowFairnessIDKey, OldFlowFairnessIDKey},
+	ObjectiveKey:        {ObjectiveKey, OldObjectiveKey},
+	ModelNameRewriteKey: {ModelNameRewriteKey, OldModelNameRewriteKey},
+	TTFTSLOHeaderKey:    {TTFTSLOHeaderKey, OldTTFTSLOHeaderKey},
+	TPOTSLOHeaderKey:    {TPOTSLOHeaderKey, OldTPOTSLOHeaderKey},
+}
+
+// HeaderNames returns the current header name followed by deprecated aliases.
+func HeaderNames(key string) []string {
+	key = strings.ToLower(key)
+	if names, ok := headerAliases[key]; ok {
+		return names
+	}
+	return []string{key}
+}
+
+// GetLowerCaseHeaderValue returns a header value from a lower-case header map using the current name first, then deprecated aliases.
+func GetLowerCaseHeaderValue(headers map[string]string, key string) (string, bool) {
+	key = strings.ToLower(key)
+	if aliases, ok := headerAliases[key]; ok {
+		for _, alias := range aliases {
+			if value, ok := headers[alias]; ok {
+				return value, true
+			}
+		}
+		return "", false
+	}
+	value, ok := headers[key]
+	return value, ok
+}

--- a/pkg/epp/metadata/consts_test.go
+++ b/pkg/epp/metadata/consts_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderAliases(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{ObjectiveKey, OldObjectiveKey}, HeaderNames(ObjectiveKey))
+	assert.Equal(t, []string{ObjectiveKey, OldObjectiveKey}, HeaderNames("X-LLM-D-Inference-Objective"))
+	assert.Equal(t, []string{TTFTSLOHeaderKey, OldTTFTSLOHeaderKey}, HeaderNames(TTFTSLOHeaderKey))
+	assert.Equal(t, []string{DestinationEndpointKey}, HeaderNames(DestinationEndpointKey))
+	assert.Equal(t, []string{"x-user-header"}, HeaderNames("X-User-Header"))
+}
+
+func TestGetLowerCaseHeaderValuePrefersCurrentName(t *testing.T) {
+	t.Parallel()
+
+	headers := map[string]string{
+		OldObjectiveKey: "old-objective",
+		ObjectiveKey:    "new-objective",
+	}
+	got, ok := GetLowerCaseHeaderValue(headers, ObjectiveKey)
+	assert.True(t, ok)
+	assert.Equal(t, "new-objective", got)
+
+	headers = map[string]string{
+		OldObjectiveKey: "old-objective",
+	}
+	got, ok = GetLowerCaseHeaderValue(headers, ObjectiveKey)
+	assert.True(t, ok)
+	assert.Equal(t, "old-objective", got)
+
+	headers = map[string]string{
+		"x-user-header": "user-value",
+	}
+	got, ok = GetLowerCaseHeaderValue(headers, "X-User-Header")
+	assert.True(t, ok)
+	assert.Equal(t, "user-value", got)
+}

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -66,7 +66,7 @@ type Options struct {
 	//
 	EndpointSelector            string // Selector to filter model server pods on, only 'key=value' pairs are supported. (TODO: k8s.Selector, pflag.StringSlice?)
 	EndpointTargetPorts         []int  // Target ports of model server pods.
-	DisableEndpointSubsetFilter bool   // Disables respecting x-gateway-destination-endpoint-subset in EPP.
+	DisableEndpointSubsetFilter bool   // Disables respecting destination endpoint subset metadata in EPP.
 	//
 	// MSP metrics scraping.
 	//
@@ -153,7 +153,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntSliceVar(&opts.EndpointTargetPorts, "endpoint-target-ports", opts.EndpointTargetPorts, "Target ports of model server pods. "+
 		"Format: a comma-separated list of numbers without whitespace (e.g., '3000,3001,3002').")
 	fs.BoolVar(&opts.DisableEndpointSubsetFilter, "disable-endpoint-subset-filter", opts.DisableEndpointSubsetFilter,
-		"Disables respecting the x-gateway-destination-endpoint-subset metadata for dispatching requests in EPP.")
+		"Disables respecting the destination endpoint subset metadata for dispatching requests in EPP.")
 	fs.StringVar(&opts.ModelServerMetricsScheme, "model-server-metrics-scheme", opts.ModelServerMetricsScheme,
 		"Protocol scheme used in scraping metrics from endpoints.")
 	_ = fs.MarkDeprecated("model-server-metrics-scheme", "This flag is deprecated. Configure via EndpointPickerConfig data layer plugin parameters instead.")

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -119,8 +119,13 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 	expectedMutatedBodyBytes, _ := json.Marshal(expectedMutatedBodyMap)
 	contentLength := strconv.Itoa(len(expectedMutatedBodyBytes))
 	expectedBody := string(expectedMutatedBodyBytes)
-	expectedRequestHeaders := map[string]string{metadata.DestinationEndpointKey: fmt.Sprintf("%s:%d", podAddress, poolPort),
-		"Content-Length": contentLength, ":method": "POST", "x-test": "body", "x-request-id": "test-request-id"}
+	expectedRequestHeaders := map[string]string{
+		metadata.DestinationEndpointKey: fmt.Sprintf("%s:%d", podAddress, poolPort),
+		"Content-Length":                contentLength,
+		":method":                       "POST",
+		"x-test":                        "body",
+		"x-request-id":                  "test-request-id",
+	}
 	expectedResponseHeaders := map[string]string{"x-went-into-resp-headers": "true", ":method": "POST", "x-test": "body"}
 	expectedSchedulerHeaders := map[string]string{":method": "POST", "x-test": "body", "x-request-id": "test-request-id"}
 

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -21,24 +21,30 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 var (
 	// InputControlHeaders are sent by the Gateway/User to control EPP behavior.
 	// We must extract these, then strip them so they don't leak to the backend.
-	InputControlHeaders = sets.New(
-		strings.ToLower(metadata.FlowFairnessIDKey),
-		strings.ToLower(metadata.ObjectiveKey),
-		strings.ToLower(metadata.ModelNameRewriteKey),
-		strings.ToLower(metadata.SubsetFilterKey),
+	InputControlHeaders = lowerHeaderNames(
+		metadata.FlowFairnessIDKey,
+		metadata.ObjectiveKey,
+		metadata.ModelNameRewriteKey,
+		metadata.SubsetFilterKey,
+		metadata.TTFTSLOHeaderKey,
+		metadata.TPOTSLOHeaderKey,
 	)
 
 	// OutputInjectionHeaders are headers EPP injects for the backend.
 	// If the user sends these, they must be stripped to prevent ambiguity.
-	OutputInjectionHeaders = sets.New(
-		strings.ToLower(metadata.DestinationEndpointKey),
-		strings.ToLower(metadata.DestinationEndpointServedKey),
+	OutputInjectionHeaders = addLowerHeaders(
+		lowerHeaderNames(
+			metadata.DestinationEndpointKey,
+			metadata.DestinationEndpointServedKey,
+		),
+		errcommon.RequestDroppedReasonHeaderKey,
 	)
 
 	// ProtocolHeaders are managed by the proxy layer (Envoy/EPP).
@@ -48,4 +54,21 @@ var (
 func IsSystemOwnedHeader(key string) bool {
 	k := strings.ToLower(key)
 	return InputControlHeaders.Has(k) || OutputInjectionHeaders.Has(k) || ProtocolHeaders.Has(k)
+}
+
+func lowerHeaderNames(keys ...string) sets.Set[string] {
+	headers := sets.New[string]()
+	for _, key := range keys {
+		for _, name := range metadata.HeaderNames(key) {
+			headers.Insert(strings.ToLower(name))
+		}
+	}
+	return headers
+}
+
+func addLowerHeaders(headers sets.Set[string], keys ...string) sets.Set[string] {
+	for _, key := range keys {
+		headers.Insert(strings.ToLower(key))
+	}
+	return headers
 }

--- a/pkg/epp/util/request/headers_test.go
+++ b/pkg/epp/util/request/headers_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
+)
+
+func TestIsSystemOwnedHeaderIncludesAliases(t *testing.T) {
+	t.Parallel()
+
+	systemHeaders := []string{
+		metadata.FlowFairnessIDKey,
+		metadata.OldFlowFairnessIDKey,
+		metadata.ObjectiveKey,
+		metadata.OldObjectiveKey,
+		metadata.ModelNameRewriteKey,
+		metadata.OldModelNameRewriteKey,
+		metadata.SubsetFilterKey,
+		metadata.TTFTSLOHeaderKey,
+		metadata.OldTTFTSLOHeaderKey,
+		metadata.TPOTSLOHeaderKey,
+		metadata.OldTPOTSLOHeaderKey,
+		metadata.DestinationEndpointKey,
+		metadata.DestinationEndpointServedKey,
+		errcommon.RequestDroppedReasonHeaderKey,
+		"Content-Length",
+	}
+
+	for _, header := range systemHeaders {
+		assert.True(t, IsSystemOwnedHeader(header), "header %q should be system-owned", header)
+	}
+	assert.False(t, IsSystemOwnedHeader("x-user-data"))
+}

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -269,7 +269,7 @@ func GenerateStreamedRequestSet(
 func GenerateStreamedGRPCRequestSet(
 	logger logr.Logger,
 	prompt string,
-	inferenceObjective string, // Set to non-empty to set x-gateway-inference-objective value
+	inferenceObjective string, // Set to non-empty to set x-llm-d-inference-objective value
 	filterMetadata []string,
 	methodName string,
 ) []*extProcPb.ProcessingRequest {


### PR DESCRIPTION
## Summary

Fixes #1152.

This migrates llm-d-managed EPP headers to canonical `x-llm-d-*` names while preserving old names as backward-compatible aliases for reads.

Canonical mappings:

| Old header | New header |
| --- | --- |
| `x-gateway-inference-fairness-id` | `x-llm-d-inference-fairness-id` |
| `x-gateway-inference-objective` | `x-llm-d-inference-objective` |
| `x-gateway-model-name-rewrite` | `x-llm-d-model-name-rewrite` |
| `x-slo-ttft-ms` | `x-llm-d-slo-ttft-ms` |
| `x-slo-tpot-ms` | `x-llm-d-slo-tpot-ms` |

Compatibility behavior:

- read paths accept both new and old names for migrated headers
- if both are present, the new canonical name wins deterministically
- EPP strips/ignores both new and old migrated system/control headers where system headers are already stripped
- SLO headers are treated as EPP input-control headers after this migration, so both new and old SLO names are consumed by EPP and stripped from backend-forwarded request headers

## Notes for review

Per maintainer feedback, the GAIE endpoint picker protocol headers remain unchanged and are not aliased or re-emitted under `x-llm-d-*`:

- `x-gateway-destination-endpoint-subset`
- `x-gateway-destination-endpoint`
- `x-gateway-destination-endpoint-served`

The existing dropped-reason response header also remains unchanged as `x-llm-d-request-dropped-reason` and does not emit an extra compatibility alias because it has not been released yet.

## Tests

- `git diff --check`
- `go test ./pkg/common/error ./pkg/epp/...`
- `golangci-lint run --config=./.golangci.yml` for touched packages