### PR TITLE
generic read attribute function

### DIFF
--- a/pkg/epp/framework/interface/datalayer/attributemap.go
+++ b/pkg/epp/framework/interface/datalayer/attributemap.go
@@ -89,3 +89,21 @@ func (a *Attributes) Clone() AttributeMap {
 	})
 	return clone
 }
+
+// ReadAttribute retrieves attribute with the given key from AttributeMap and asserts it to type T.
+// Second return value is 'false' if the key is not found or the type assertion fails.
+func ReadAttribute[T Cloneable](attributeMap AttributeMap, key string) (T, bool) {
+	var zero T
+
+	raw, ok := attributeMap.Get(key)
+	if !ok {
+		return zero, false
+	}
+
+	val, ok := raw.(T)
+	if !ok {
+		return zero, false
+	}
+
+	return val, true
+}

--- a/pkg/epp/framework/interface/datalayer/attributemap_test.go
+++ b/pkg/epp/framework/interface/datalayer/attributemap_test.go
@@ -31,6 +31,14 @@ func (d *dummy) Clone() Cloneable {
 	return &dummy{Text: d.Text}
 }
 
+type anotherDummy struct {
+	Number int
+}
+
+func (d *anotherDummy) Clone() Cloneable {
+	return &anotherDummy{Number: d.Number}
+}
+
 func TestExpectPutThenGetToMatch(t *testing.T) {
 	attrs := NewAttributes()
 	original := &dummy{"foo"}
@@ -71,4 +79,26 @@ func TestCloneReturnsCopy(t *testing.T) {
 	if diff := cmp.Diff(kOrig, kClone); diff != "" {
 		t.Errorf("Unexpected output (-want +got): %v", diff)
 	}
+}
+
+func TestReadAttribute(t *testing.T) {
+	// successful retrieval
+	attrs := NewAttributes()
+	original := &dummy{"foo"}
+	attrs.Put("a", original)
+
+	got, ok := ReadAttribute[*dummy](attrs, "a")
+	assert.True(t, ok, "expected key to exist and value to be of type *dummy")
+	assert.NotSame(t, original, got, "expected Get to return a clone, not original")
+	assert.Equal(t, "foo", got.Text)
+
+	// missing key
+	_, ok = ReadAttribute[*dummy](attrs, "b")
+	assert.False(t, ok, "expected key not to exist")
+
+	// type mismatch
+	other, ok := ReadAttribute[*anotherDummy](attrs, "a")
+	assert.False(t, ok, "expected type mismatch")
+	assert.Nil(t, other) // zero value of pointer is nil
+
 }

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -108,12 +108,8 @@ func (d *detector) Consumes() map[string]any {
 }
 
 func (d *detector) getLoad(m datalayer.AttributeMap) *attrconcurrency.InFlightLoad {
-	if val, ok := m.Get(attrconcurrency.InFlightLoadKey); ok {
-		if load, ok := val.(*attrconcurrency.InFlightLoad); ok {
-			return load
-		}
-	}
-	return &attrconcurrency.InFlightLoad{}
+	val, _ := datalayer.ReadAttribute[*attrconcurrency.InFlightLoad](m, attrconcurrency.InFlightLoadKey)
+	return val
 }
 
 // Saturation calculates the saturation level of the pool.

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -108,7 +108,11 @@ func (d *detector) Consumes() map[string]any {
 }
 
 func (d *detector) getLoad(m datalayer.AttributeMap) *attrconcurrency.InFlightLoad {
-	val, _ := datalayer.ReadAttribute[*attrconcurrency.InFlightLoad](m, attrconcurrency.InFlightLoadKey)
+	val, ok := datalayer.ReadAttribute[*attrconcurrency.InFlightLoad](m, attrconcurrency.InFlightLoadKey)
+	if !ok {
+		return &attrconcurrency.InFlightLoad{}
+	}
+
 	return val
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -108,12 +108,11 @@ func (d *detector) Consumes() map[string]any {
 }
 
 func (d *detector) getLoad(m datalayer.AttributeMap) *attrconcurrency.InFlightLoad {
-	val, ok := datalayer.ReadAttribute[*attrconcurrency.InFlightLoad](m, attrconcurrency.InFlightLoadKey)
-	if !ok {
-		return &attrconcurrency.InFlightLoad{}
+	if val, ok := datalayer.ReadAttribute[*attrconcurrency.InFlightLoad](m, attrconcurrency.InFlightLoadKey); ok {
+		return val
 	}
 
-	return val
+	return &attrconcurrency.InFlightLoad{}
 }
 
 // Saturation calculates the saturation level of the pool.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
generic read attribute function. as the attributemap will start to get used across the code, each caller will have to do the same type conversion/assertion. This new function aims to do it once and reuse it across the code.
in current PR only one place was calling AttributesMap.Get, and that place was updated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
