### PR TITLE
feat(epp/scheduling): support fallback scheduling profiles

### DIFF
--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -139,6 +139,13 @@ type SchedulingProfile struct {
 	// Plugins is the list of plugins for this SchedulingProfile. They are assigned
 	// to the appropriate "slots" based on their type.
 	Plugins []SchedulingPlugin `json:"plugins"`
+
+	// +optional
+	// FallbackProfile names another SchedulingProfile to run when this profile's
+	// scorers produce no usable signal (all weighted scores are zero). The
+	// referenced profile must exist in the same configuration and fallback chains
+	// must not cycle; both are validated at load time. See #1139.
+	FallbackProfile string `json:"fallbackProfile,omitempty"`
 }
 
 func (sp SchedulingProfile) String() string {

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -214,12 +214,59 @@ func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle fwkplug
 	return nil
 }
 
+// validateFallbackReferences validates that all FallbackProfile references on
+// the given configProfiles point to existing profile names and that no fallback
+// chain forms a cycle (including the degenerate one-node self-reference case).
+// Returns nil when the reference graph is acyclic and complete. See #1139.
+func validateFallbackReferences(configProfiles []configapi.SchedulingProfile) error {
+	nameSet := make(map[string]bool, len(configProfiles))
+	fallbackByName := make(map[string]string)
+	for _, p := range configProfiles {
+		nameSet[p.Name] = true
+		if p.FallbackProfile != "" {
+			fallbackByName[p.Name] = p.FallbackProfile
+		}
+	}
+
+	for primary, fb := range fallbackByName {
+		if primary == fb {
+			return fmt.Errorf("profile %q references itself as fallback", primary)
+		}
+		if !nameSet[fb] {
+			return fmt.Errorf("profile %q references unknown fallback profile %q", primary, fb)
+		}
+	}
+
+	// Cycle detection: from each profile, walk the fallback chain and fail if a
+	// node is revisited. Each node has at most one outgoing edge, so this is
+	// O(N) per starting profile and O(N^2) overall — fine for a startup-time
+	// validation over a handful of profiles.
+	for start := range fallbackByName {
+		visited := map[string]bool{start: true}
+		current := fallbackByName[start]
+		for current != "" {
+			if visited[current] {
+				return fmt.Errorf("fallback cycle detected involving profile %q", start)
+			}
+			visited[current] = true
+			current = fallbackByName[current]
+		}
+	}
+	return nil
+}
+
 func buildSchedulerConfig(
 	configProfiles []configapi.SchedulingProfile,
 	handle fwkplugin.Handle,
 ) (*scheduling.SchedulerConfig, error) {
 
-	profiles := make(map[string]fwksched.SchedulerProfile)
+	// Validate fallback references early so we surface configuration errors before
+	// instantiating plugins. See #1139.
+	if err := validateFallbackReferences(configProfiles); err != nil {
+		return nil, err
+	}
+
+	profiles := make(map[string]fwksched.SchedulerProfile, len(configProfiles))
 
 	for _, cfgProfile := range configProfiles {
 		fwProfile := scheduling.NewSchedulerProfile()
@@ -248,6 +295,16 @@ func buildSchedulerConfig(
 		profiles[cfgProfile.Name] = fwProfile
 	}
 
+	// Build the primary→fallback map (references already validated above). The
+	// scheduler consults this at run time when a primary's Run reports NoSignal=true.
+	fallbacks := make(map[string]fwksched.SchedulerProfile)
+	for _, cfgProfile := range configProfiles {
+		if cfgProfile.FallbackProfile == "" {
+			continue
+		}
+		fallbacks[cfgProfile.Name] = profiles[cfgProfile.FallbackProfile]
+	}
+
 	var profileHandler fwksched.ProfileHandler
 	for name, plugin := range handle.GetAllPluginsWithNames() {
 		if ph, ok := plugin.(fwksched.ProfileHandler); ok {
@@ -267,7 +324,7 @@ func buildSchedulerConfig(
 		return nil, errors.New("SingleProfileHandler cannot support multiple scheduling profiles")
 	}
 
-	return scheduling.NewSchedulerConfig(profileHandler, profiles), nil
+	return scheduling.NewSchedulerConfig(profileHandler, profiles).WithFallbacks(fallbacks), nil
 }
 
 func loadFeatureConfig(gates configapi.FeatureGates) map[string]bool {

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -975,3 +975,83 @@ func TestFilterExecutionOrderFromYAML(t *testing.T) {
 	require.Equal(t, []string{"filter-A", "filter-B", "filter-C", "scorer-X", "scorer-Y", "maxScorePicker"}, pluginRefs,
 		"Plugins slice must preserve YAML declaration order")
 }
+
+// TestValidateFallbackReferences covers the loader-level validation rules for
+// the fallbackProfile field on SchedulingProfile, per #1139:
+//   - dangling references → error,
+//   - self-references → error,
+//   - cycles in the fallback chain → error,
+//   - valid (acyclic) chains → no error.
+func TestValidateFallbackReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []configapi.SchedulingProfile
+		wantErr  string // substring expected in the error message; "" = no error
+	}{
+		{
+			name: "no fallbacks",
+			profiles: []configapi.SchedulingProfile{
+				{Name: "a"},
+				{Name: "b"},
+			},
+		},
+		{
+			name: "valid one-level fallback",
+			profiles: []configapi.SchedulingProfile{
+				{Name: "primary", FallbackProfile: "secondary"},
+				{Name: "secondary"},
+			},
+		},
+		{
+			name: "valid two-level chain",
+			profiles: []configapi.SchedulingProfile{
+				{Name: "a", FallbackProfile: "b"},
+				{Name: "b", FallbackProfile: "c"},
+				{Name: "c"},
+			},
+		},
+		{
+			name: "dangling reference",
+			profiles: []configapi.SchedulingProfile{
+				{Name: "primary", FallbackProfile: "does-not-exist"},
+			},
+			wantErr: "unknown fallback",
+		},
+		{
+			name: "self-reference",
+			profiles: []configapi.SchedulingProfile{
+				{Name: "loop", FallbackProfile: "loop"},
+			},
+			wantErr: "itself",
+		},
+		{
+			name: "two-node cycle",
+			profiles: []configapi.SchedulingProfile{
+				{Name: "a", FallbackProfile: "b"},
+				{Name: "b", FallbackProfile: "a"},
+			},
+			wantErr: "cycle",
+		},
+		{
+			name: "three-node cycle",
+			profiles: []configapi.SchedulingProfile{
+				{Name: "a", FallbackProfile: "b"},
+				{Name: "b", FallbackProfile: "c"},
+				{Name: "c", FallbackProfile: "a"},
+			},
+			wantErr: "cycle",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFallbackReferences(tt.profiles)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -157,6 +157,14 @@ type ScoredEndpoint struct {
 // ProfileRunResult captures the profile run result.
 type ProfileRunResult struct {
 	TargetEndpoints []Endpoint
+
+	// NoSignal is set by SchedulerProfile.Run when the profile's scorers
+	// produced no usable signal (all weighted scores were zero). The scheduler
+	// uses this to decide whether to fall through to a configured fallback
+	// profile before the ProfileHandler is involved. See #1139. Default false
+	// preserves pre-fallback behavior for any caller that constructs
+	// ProfileRunResult directly.
+	NoSignal bool
 }
 
 // SchedulingResult captures the result of the scheduling cycle.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
@@ -74,6 +74,10 @@ func TestPDSchedule(t *testing.T) {
 						Endpoint: endpoint1,
 					},
 				},
+				// Prefill has no scorers in this test, so all weighted scores
+				// are zero — Run flags this for the scheduler's fallback path (#1139).
+				// No fallback is configured here so the result passes through unchanged.
+				NoSignal: true,
 			},
 		},
 
@@ -205,6 +209,7 @@ func TestPDSchedule(t *testing.T) {
 								Endpoint: endpoint1,
 							},
 						},
+						NoSignal: true, // prefill has no scorers — see comment on prefillDecodeResult above
 					},
 				},
 				PrimaryProfileName: decode,

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -42,12 +42,16 @@ func NewSchedulerWithConfig(config *SchedulerConfig) *Scheduler {
 	return &Scheduler{
 		profileHandler: config.profileHandler,
 		profiles:       config.profiles,
+		fallbacks:      config.fallbacks,
 	}
 }
 
 type Scheduler struct {
 	profileHandler fwksched.ProfileHandler
 	profiles       map[string]fwksched.SchedulerProfile
+	// fallbacks maps a primary profile name to the SchedulerProfile that should run
+	// in its place when the primary's Run reports NoSignal=true. See #1139.
+	fallbacks map[string]fwksched.SchedulerProfile
 }
 
 // Schedule finds the target pod based on metrics and the requested lora adapter.
@@ -81,6 +85,21 @@ func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceReq
 				loggerVerbose.Info("failed to run scheduler profile", "profile", name, "error", err.Error())
 			} else {
 				loggerVerbose.Info("Completed running scheduler profile succuessfully", "profile", name)
+			}
+
+			// Fallback chaining (#1139): if the profile reported no usable signal
+			// and a fallback is configured for it, run the fallback and substitute
+			// its result. ProfileHandler stays unaware that fallback was used.
+			if profileRunResult != nil && profileRunResult.NoSignal {
+				if fb, ok := s.fallbacks[name]; ok {
+					loggerVerbose.Info("Primary profile produced no usable signal; running fallback", "primary", name)
+					fbResult, fbErr := fb.Run(ctx, request, cycleState, candidateEndpoints)
+					if fbErr != nil {
+						loggerVerbose.Info("fallback profile failed to run", "primary", name, "error", fbErr.Error())
+					} else {
+						profileRunResult = fbResult
+					}
+				}
 			}
 
 			profileRunResults[name] = profileRunResult // if profile failed to run, the run result is nil

--- a/pkg/epp/scheduling/scheduler_config.go
+++ b/pkg/epp/scheduling/scheduler_config.go
@@ -30,10 +30,20 @@ func NewSchedulerConfig(profileHandler fwksched.ProfileHandler, profiles map[str
 	}
 }
 
+// WithFallbacks records the fallback profile for each primary profile name. The
+// scheduler consults this map when a profile's Run sets NoSignal=true; if a
+// matching fallback exists, it runs and its result replaces the primary's.
+// Mutates and returns the receiver for fluent construction. See #1139.
+func (c *SchedulerConfig) WithFallbacks(fallbacks map[string]fwksched.SchedulerProfile) *SchedulerConfig {
+	c.fallbacks = fallbacks
+	return c
+}
+
 // SchedulerConfig provides a configuration for the scheduler which influence routing decisions.
 type SchedulerConfig struct {
 	profileHandler fwksched.ProfileHandler
 	profiles       map[string]fwksched.SchedulerProfile
+	fallbacks      map[string]fwksched.SchedulerProfile
 }
 
 func (c *SchedulerConfig) String() string {

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -114,6 +114,11 @@ func (p *SchedulerProfile) String() string {
 
 // Run runs a SchedulerProfile. It invokes all the SchedulerProfile plugins for the given request in this
 // order - Filters, Scorers, Picker. After completing all, it returns the result.
+//
+// When the profile's scorers produce no usable signal (all weighted scores are
+// zero), Run sets ProfileRunResult.NoSignal on the returned result. The scheduler
+// uses this to chain to a configured fallback profile before the ProfileHandler
+// is involved. See #1139.
 func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.InferenceRequest, cycleState *fwksched.CycleState, candidateEndpoints []fwksched.Endpoint) (*fwksched.ProfileRunResult, error) {
 	endpoints := p.runFilterPlugins(ctx, request, cycleState, candidateEndpoints)
 	if len(endpoints) == 0 {
@@ -124,7 +129,22 @@ func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.InferenceR
 
 	result := p.runPickerPlugin(ctx, cycleState, weightedScorePerEndpoint)
 
+	if result != nil && allScoresZero(weightedScorePerEndpoint) {
+		result.NoSignal = true
+	}
+
 	return result, nil
+}
+
+// allScoresZero reports whether every weighted score in the map is exactly 0.
+// Empty maps are treated as "all zero" (no signal). See #1139.
+func allScoresZero(scores map[fwksched.Endpoint]float64) bool {
+	for _, s := range scores {
+		if s != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *fwksched.InferenceRequest, cycleState *fwksched.CycleState, endpoints []fwksched.Endpoint) []fwksched.Endpoint {

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -603,6 +603,79 @@ func (p *filterOnlyPlugin) Filter(_ context.Context, _ *fwksched.CycleState, _ *
 	return endpoints
 }
 
+// TestProfileRun_SetsNoSignalWhenScoresAllZero verifies that Run sets
+// ProfileRunResult.NoSignal when every weighted score is zero. The picker still
+// runs (it produces a fallback-eligible result); the scheduler then consults
+// NoSignal to decide whether to chain to a configured fallback. See #1139.
+func TestProfileRun_SetsNoSignalWhenScoresAllZero(t *testing.T) {
+	zeroScorer := &testPlugin{
+		TypeRes:   "zero-scorer",
+		ScoreRes:  0,
+		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
+	}
+	picker := &testPlugin{
+		TypeRes: "picker",
+		PickRes: k8stypes.NamespacedName{Name: "pod1"},
+	}
+
+	profile := NewSchedulerProfile().
+		WithFilters(zeroScorer).
+		WithScorers(NewWeightedScorer(zeroScorer, 1)).
+		WithPicker(picker)
+
+	input := []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+	}
+	req := &fwksched.InferenceRequest{TargetModel: "test", RequestID: uuid.NewString()}
+
+	result, err := profile.Run(context.Background(), req, fwksched.NewCycleState(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.NoSignal {
+		t.Error("expected result.NoSignal=true when every weighted score is zero")
+	}
+	if picker.PickCallCount != 1 {
+		t.Errorf("picker should still run when scores are zero; got %d calls", picker.PickCallCount)
+	}
+}
+
+// TestProfileRun_NoSignalFalseWhenScoresNonZero verifies the inverse: when at
+// least one weighted score is non-zero, NoSignal stays false.
+func TestProfileRun_NoSignalFalseWhenScoresNonZero(t *testing.T) {
+	nonZeroScorer := &testPlugin{
+		TypeRes:   "non-zero-scorer",
+		ScoreRes:  0.5,
+		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
+	}
+	picker := &testPlugin{
+		TypeRes: "picker",
+		PickRes: k8stypes.NamespacedName{Name: "pod1"},
+	}
+
+	profile := NewSchedulerProfile().
+		WithFilters(nonZeroScorer).
+		WithScorers(NewWeightedScorer(nonZeroScorer, 1)).
+		WithPicker(picker)
+
+	input := []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+	}
+	req := &fwksched.InferenceRequest{TargetModel: "test", RequestID: uuid.NewString()}
+
+	result, err := profile.Run(context.Background(), req, fwksched.NewCycleState(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.NoSignal {
+		t.Error("expected result.NoSignal=false when at least one score is non-zero")
+	}
+}
+
 func findEndpoints(endpoints []fwksched.Endpoint, names ...k8stypes.NamespacedName) []fwksched.Endpoint {
 	res := []fwksched.Endpoint{}
 	for _, endpoint := range endpoints {

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -155,3 +155,169 @@ func TestSchedule(t *testing.T) {
 		})
 	}
 }
+
+// TestSchedule_FallbackFiresWhenPrimaryHasNoSignal verifies that when a primary
+// profile's Run reports NoSignal=true, the scheduler runs the configured fallback
+// profile and substitutes its result before ProfileHandler.ProcessResults is
+// called. See #1139.
+func TestSchedule_FallbackFiresWhenPrimaryHasNoSignal(t *testing.T) {
+	zeroScorer := &testPlugin{
+		TypeRes:   "zero-scorer",
+		ScoreRes:  0,
+		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
+	}
+	primaryPicker := &testPlugin{
+		TypeRes: "primary-picker",
+		PickRes: k8stypes.NamespacedName{Name: "pod1"},
+	}
+	primary := NewSchedulerProfile().
+		WithFilters(zeroScorer).
+		WithScorers(NewWeightedScorer(zeroScorer, 1)).
+		WithPicker(primaryPicker)
+
+	fallbackScorer := &testPlugin{
+		TypeRes:   "fallback-scorer",
+		ScoreRes:  0.5,
+		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
+	}
+	fallbackPicker := &testPlugin{
+		TypeRes: "fallback-picker",
+		PickRes: k8stypes.NamespacedName{Name: "pod2"},
+	}
+	fallback := NewSchedulerProfile().
+		WithFilters(fallbackScorer).
+		WithScorers(NewWeightedScorer(fallbackScorer, 1)).
+		WithPicker(fallbackPicker)
+
+	cfg := NewSchedulerConfig(
+		single.NewSingleProfileHandler(),
+		map[string]fwksched.SchedulerProfile{"default": primary},
+	).WithFallbacks(map[string]fwksched.SchedulerProfile{
+		"default": fallback,
+	})
+	scheduler := NewSchedulerWithConfig(cfg)
+
+	input := []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+	}
+	req := &fwksched.InferenceRequest{TargetModel: "test", RequestID: uuid.NewString()}
+
+	result, err := scheduler.Schedule(context.Background(), req, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fallbackPicker.PickCallCount != 1 {
+		t.Errorf("fallback picker should run exactly once; got %d calls", fallbackPicker.PickCallCount)
+	}
+
+	got := result.ProfileResults["default"].TargetEndpoints[0].GetMetadata().NamespacedName.Name
+	if got != "pod2" {
+		t.Errorf("expected fallback's pick (pod2) under primary name, got %s", got)
+	}
+}
+
+// TestSchedule_FallbackDoesNotFireWhenPrimaryHasSignal verifies that the
+// fallback is not invoked when the primary profile produces non-zero scores,
+// even if a fallback is configured.
+func TestSchedule_FallbackDoesNotFireWhenPrimaryHasSignal(t *testing.T) {
+	primaryScorer := &testPlugin{
+		TypeRes:   "primary-scorer",
+		ScoreRes:  0.5,
+		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
+	}
+	primaryPicker := &testPlugin{
+		TypeRes: "primary-picker",
+		PickRes: k8stypes.NamespacedName{Name: "pod1"},
+	}
+	primary := NewSchedulerProfile().
+		WithFilters(primaryScorer).
+		WithScorers(NewWeightedScorer(primaryScorer, 1)).
+		WithPicker(primaryPicker)
+
+	fallbackPicker := &testPlugin{
+		TypeRes: "fallback-picker",
+		PickRes: k8stypes.NamespacedName{Name: "pod2"},
+	}
+	fallback := NewSchedulerProfile().
+		WithFilters(primaryScorer).
+		WithScorers(NewWeightedScorer(primaryScorer, 1)).
+		WithPicker(fallbackPicker)
+
+	cfg := NewSchedulerConfig(
+		single.NewSingleProfileHandler(),
+		map[string]fwksched.SchedulerProfile{"default": primary},
+	).WithFallbacks(map[string]fwksched.SchedulerProfile{
+		"default": fallback,
+	})
+	scheduler := NewSchedulerWithConfig(cfg)
+
+	input := []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+	}
+	req := &fwksched.InferenceRequest{TargetModel: "test", RequestID: uuid.NewString()}
+
+	result, err := scheduler.Schedule(context.Background(), req, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fallbackPicker.PickCallCount != 0 {
+		t.Errorf("fallback picker should NOT run when primary has signal; got %d calls", fallbackPicker.PickCallCount)
+	}
+	if primaryPicker.PickCallCount != 1 {
+		t.Errorf("primary picker should run; got %d calls", primaryPicker.PickCallCount)
+	}
+
+	got := result.ProfileResults["default"].TargetEndpoints[0].GetMetadata().NamespacedName.Name
+	if got != "pod1" {
+		t.Errorf("expected primary's pick (pod1), got %s", got)
+	}
+}
+
+// TestSchedule_NoFallbackConfigured verifies that when no fallback is registered
+// for a primary, the scheduler returns the primary's result even with NoSignal=true
+// (preserves pre-fallback behavior).
+func TestSchedule_NoFallbackConfigured(t *testing.T) {
+	zeroScorer := &testPlugin{
+		TypeRes:   "zero-scorer",
+		ScoreRes:  0,
+		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
+	}
+	primaryPicker := &testPlugin{
+		TypeRes: "primary-picker",
+		PickRes: k8stypes.NamespacedName{Name: "pod1"},
+	}
+	primary := NewSchedulerProfile().
+		WithFilters(zeroScorer).
+		WithScorers(NewWeightedScorer(zeroScorer, 1)).
+		WithPicker(primaryPicker)
+
+	cfg := NewSchedulerConfig(
+		single.NewSingleProfileHandler(),
+		map[string]fwksched.SchedulerProfile{"default": primary},
+	) // no WithFallbacks
+	scheduler := NewSchedulerWithConfig(cfg)
+
+	input := []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+	}
+	req := &fwksched.InferenceRequest{TargetModel: "test", RequestID: uuid.NewString()}
+
+	result, err := scheduler.Schedule(context.Background(), req, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if primaryPicker.PickCallCount != 1 {
+		t.Errorf("primary picker should run; got %d calls", primaryPicker.PickCallCount)
+	}
+
+	got := result.ProfileResults["default"].TargetEndpoints[0].GetMetadata().NamespacedName.Name
+	if got != "pod1" {
+		t.Errorf("expected primary's pick (pod1) when no fallback configured, got %s", got)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Implements #1139. Adds a **framework-level fallback mechanism** to the scheduler: when a primary scheduling profile's scorers produce no usable signal (every weighted score is zero), the scheduler chains to a configured fallback profile before `ProfileHandler` is involved.

This lets operators express the kind of strategy currently baked into the `latency-scorer` plugin (`compositeKVWeight`, `compositeQueueWeight`, `compositePrefixWeight`) as a separate, explicit fallback profile in YAML.

### Architecture

| Component | What it does |
|---|---|
| `apix/config/v1alpha1/SchedulingProfile.FallbackProfile string` (new) | Operator-facing field; names another profile to fall through to |
| `fwksched.ProfileRunResult.NoSignal bool` (new) | Set by `SchedulerProfile.Run` when all weighted scores are zero |
| `Scheduler` loop (modified) | After each profile's `Run`, checks `NoSignal`; if a fallback is registered for that primary, runs the fallback and substitutes its result under the primary's name |
| `validateFallbackReferences()` in loader (new) | Rejects dangling references, self-references, and cycles at config load time |

**ProfileHandler stays unaware** that fallback fired. The `profileRunResults` map passed to `ProcessResults` contains the actual result that should be used (fallback's, when fallback fired) stored under the primary profile's name — matching the issue's framework-level guarantee.

### Example config

```yaml
schedulingProfiles:
- name: latency-prediction
  fallbackProfile: composite-fallback
  plugins:
  - pluginRef: predicted-latency-producer
  - pluginRef: latency-scorer
    weight: 1
  - pluginRef: weighted-random-picker

- name: composite-fallback
  plugins:
  - pluginRef: kv-cache-utilization-scorer
    weight: 1
  - pluginRef: queue-depth-scorer
    weight: 1
  - pluginRef: prefix-cache-scorer
    weight: 1
  - pluginRef: weighted-random-picker
```

When `latency-prediction`'s scorers produce all-zero scores (predictions unavailable), `composite-fallback` runs in its place.

### Tests

12 new test cases:

- **Profile layer (2):** `NoSignal` flag is set when all weighted scores are zero; not set when at least one is non-zero.
- **Scheduler layer (3):** fallback fires when `NoSignal=true`; doesn't fire when primary has signal; primary result passes through when no fallback configured.
- **Loader validation (7 sub-cases):** valid one- and two-level chains, dangling reference, self-reference, two- and three-node cycles.

Updates the existing `TestPDSchedule` expected results to set `NoSignal=true` on the prefill profile (which has no scorers in that fixture and correctly reports no signal under the new behavior).

Verified locally: `make presubmit` green end-to-end (lint, format, typos, govulncheck). Full unit suite: 89 packages pass; the 6 remaining failures are pre-existing infra-dependent tests (`kind`/`etcd` required), unchanged from `main`.

### Out of scope (per the issue's own open questions)

- Removing `latency-scorer`'s composite-weight params (`compositeKVWeight`, etc.) — separate cleanup PR after this lands.
- P/D-disaggregated fallback selection — needs its own design pass; current implementation works correctly for non-disaggregated profiles and doesn't preclude future P/D work.
- Multi-level chain testing: recursion is bounded by cycle detection; tests cover one- and two-level chains.

**Which issue(s) this PR fixes**:
Fixes #1139

**Release note**:
```release-note
Scheduling profiles now support a `fallbackProfile` field. When a primary profile's scorers produce no usable signal (every weighted score is zero), the scheduler runs the named fallback profile in its place. Dangling references, self-references, and cycles in the fallback chain are rejected at config load time.
```
