### PR TITLE
Fix mock extractor type collision breaking multi-extractor tests

### DIFF
--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -152,8 +152,8 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 	logger := newTestLogger(t)
 
 	src := notifications.NewEndpointDataSource(notifications.EndpointNotificationSourceType, "ep-src")
-	extFromConfig := extractormocks.NewEndpointExtractor("config-ext")
-	extFromCode := extractormocks.NewEndpointExtractor("code-ext")
+	extFromConfig := extractormocks.NewEndpointExtractor("config-ext").WithType("shared-type")
+	extFromCode := extractormocks.NewEndpointExtractor("code-ext").WithType("shared-type")
 
 	// User config wires extFromConfig to src.
 	cfg := &Config{
@@ -163,7 +163,7 @@ func TestConfigure_DedupByExtractorType(t *testing.T) {
 		}},
 	}
 
-	// Code registers extFromCode — same type as extFromConfig ("mock-endpoint-extractor").
+	// Code registers extFromCode — same type as extFromConfig ("shared-type").
 	require.NoError(t, r.Register(fwkdl.PendingRegistration{
 		Owner:      fwkplugin.TypedName{Type: "test-plugin", Name: "test"},
 		SourceType: notifications.EndpointNotificationSourceType,

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
@@ -31,14 +31,16 @@ var _ fwkdl.EndpointExtractor = (*EndpointExtractor)(nil)
 // It records all events it receives and provides helper methods for test assertions.
 type EndpointExtractor struct {
 	name       string
+	typeName   string
 	events     []fwkdl.EndpointEvent
 	mu         sync.Mutex
 	extractErr error
 }
 
 // NewEndpointExtractor creates a new mock EndpointExtractor with the given name.
+// Type defaults to name so distinct instances have distinct types.
 func NewEndpointExtractor(name string) *EndpointExtractor {
-	return &EndpointExtractor{name: name}
+	return &EndpointExtractor{name: name, typeName: name}
 }
 
 // WithExtractError configures the extractor to return an error on ExtractEndpoint.
@@ -47,8 +49,15 @@ func (m *EndpointExtractor) WithExtractError(err error) *EndpointExtractor {
 	return m
 }
 
+// WithType overrides the Type field returned by TypedName. Use this when
+// multiple mock instances must share the same type (e.g., dedup tests).
+func (m *EndpointExtractor) WithType(t string) *EndpointExtractor {
+	m.typeName = t
+	return m
+}
+
 func (m *EndpointExtractor) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: "mock-endpoint-extractor", Name: m.name}
+	return fwkplugin.TypedName{Type: m.typeName, Name: m.name}
 }
 
 func (m *EndpointExtractor) ExpectedInputType() reflect.Type {

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
@@ -31,6 +31,7 @@ import (
 // It records all events it receives and provides helper methods for test assertions.
 type NotificationExtractor struct {
 	name       string
+	typeName   string
 	gvk        schema.GroupVersionKind
 	events     []fwkdl.NotificationEvent
 	mu         sync.Mutex
@@ -38,10 +39,12 @@ type NotificationExtractor struct {
 }
 
 // NewNotificationExtractor creates a new mock extractor with the given name.
+// Type defaults to name so distinct instances have distinct types.
 func NewNotificationExtractor(name string) *NotificationExtractor {
 	return &NotificationExtractor{
-		name: name,
-		gvk:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+		name:     name,
+		typeName: name,
+		gvk:      schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 	}
 }
 
@@ -57,8 +60,15 @@ func (m *NotificationExtractor) WithExtractError(err error) *NotificationExtract
 	return m
 }
 
+// WithType overrides the Type field returned by TypedName. Use this when
+// multiple mock instances must share the same type (e.g., dedup tests).
+func (m *NotificationExtractor) WithType(t string) *NotificationExtractor {
+	m.typeName = t
+	return m
+}
+
 func (m *NotificationExtractor) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: "mock-extractor", Name: m.name}
+	return fwkplugin.TypedName{Type: m.typeName, Name: m.name}
 }
 
 func (m *NotificationExtractor) ExpectedInputType() reflect.Type {
@@ -97,6 +107,7 @@ func (m *NotificationExtractor) Reset() {
 // It records call counts and optionally updates endpoint metrics.
 type Extractor struct {
 	name            string
+	typeName        string
 	inputType       reflect.Type
 	callCount       int
 	mu              sync.Mutex
@@ -106,9 +117,11 @@ type Extractor struct {
 }
 
 // NewExtractor creates a new mock extractor with the given name and input type.
+// Type defaults to name so distinct instances have distinct types.
 func NewExtractor(name string, inputType reflect.Type) *Extractor {
 	return &Extractor{
 		name:      name,
+		typeName:  name,
 		inputType: inputType,
 	}
 }
@@ -131,8 +144,15 @@ func (m *Extractor) WithMetricsUpdate(metrics *fwkdl.Metrics) *Extractor {
 	return m
 }
 
+// WithType overrides the Type field returned by TypedName. Use this when
+// multiple mock instances must share the same type (e.g., dedup tests).
+func (m *Extractor) WithType(t string) *Extractor {
+	m.typeName = t
+	return m
+}
+
 func (m *Extractor) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: "mock-extractor", Name: m.name}
+	return fwkplugin.TypedName{Type: m.typeName, Name: m.name}
 }
 
 func (m *Extractor) ExpectedInputType() reflect.Type {


### PR DESCRIPTION
## Summary

Fixes #1142

Mock extractors in `pkg/epp/framework/plugins/datalayer/extractor/mocks/` hardcoded `Type` to `"mock-extractor"` (or `"mock-endpoint-extractor"`) regardless of instance name. Since `Runtime.Configure()` dedups extractors by `TypedName().Type`, binding two mock extractors to the same source silently dropped the second one.

This caused deterministic CI failures in 9 runs across 7 unrelated branches over 5 days.

**Changes:**
- Default `Type` to the instance `name` so distinct mocks have distinct types
- Add `WithType()` builder method for tests that need explicit same-type dedup behavior
- Update the dedup test in `runtime_registrar_test.go` to use `WithType("shared-type")`

Affected mock types: `NotificationExtractor`, `Extractor`, `EndpointExtractor`

## Test plan

- [x] No remaining references to hardcoded `"mock-extractor"` or `"mock-endpoint-extractor"` strings
- [ ] CI lint-and-test passes (can't compile locally due to disk constraints on dev server)