### PR TITLE
ci: use GITHUB_TOKEN instead of PAT for GHCR authentication

### DIFF
--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -15,9 +15,6 @@ on:
       prerelease:
         required: true
         type: string
-    secrets:
-      GHCR_TOKEN:
-        required: true
 
 permissions:
   contents: read
@@ -38,7 +35,7 @@ jobs:
           tag: ${{ inputs.tag }}
           image-name: ${{ inputs.epp-image-name }}
           registry: ghcr.io/llm-d
-          github-token: ${{ secrets.GHCR_TOKEN }}
+          github-token: ${{ github.token }}
           prerelease: ${{ inputs.prerelease }}
 
       - name: Run Trivy scan on EPP image
@@ -59,7 +56,7 @@ jobs:
           tag: ${{ inputs.tag }}
           image-name: ${{ inputs.sidecar-image-name }}
           registry: ghcr.io/llm-d
-          github-token: ${{ secrets.GHCR_TOKEN }}
+          github-token: ${{ github.token }}
           prerelease: ${{ inputs.prerelease }}
 
       - name: Run Trivy scan on sidecar image

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -42,5 +42,3 @@ jobs:
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: "true"
-    secrets:
-      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -52,5 +52,3 @@ jobs:
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: ${{ needs.set-params.outputs.prerelease }}
-    secrets:
-      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Packages pushed to GHCR with a PAT (`GHCR_TOKEN`) are not automatically linked to the repository, but they are created as private, unlinked packages that do not appear in the repo's GH Packages page and cannot be pulled publicly.

Using the built-in `GITHUB_TOKEN` (with the already-declared `packages: write` permission) ensures pushed images are automatically linked to the repository and inherit its public visibility.

This was confirmed by inspecting a recent successful CI run: the image was pushed successfully but returned HTTP 401 on public `docker manifest inspect`, while older images pushed via `GITHUB_TOKEN` are publicly accessible.

The `GHCR_TOKEN` secret declaration is removed from `ci-build-images.yaml` and the `secrets:` blocks are removed from `ci-dev.yaml` and `ci-release.yaml`.

**Which issue(s) this PR fixes**:
NA

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

/cc @ahg-g
Confirming: image name changes in previous PRs included a `reelase-note` section?