### PR TITLE
Sidecar references old repo name

### DIFF
--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -26,10 +26,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/llm-d/llm-d-inference-scheduler/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/llm-d/llm-d-router/pkg/telemetry"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Sidecar PR #822 included a stale import reference to `llm-d-inference-schedule` instead of `llm-d-router`.
This fails `go.mod tidy`

**Which issue(s) this PR fixes**:
NA

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
