### PR TITLE
refactor:  a bunch of clean up and refactor in routing sidecar

### DIFF
--- a/pkg/sidecar/constants/constants.go
+++ b/pkg/sidecar/constants/constants.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	// KVConnectorNIXLV2 enables the P/D KV NIXL v2 protocol
+	KVConnectorNIXLV2 = "nixlv2"
+
+	// KVConnectorSharedStorage enables the P/D KV Shared Storage protocol
+	KVConnectorSharedStorage = "shared-storage"
+
+	// KVConnectorSGLang enables SGLang the P/D KV disaggregation protocol
+	KVConnectorSGLang = "sglang"
+
+	// ECExampleConnector enables the Encoder disaggregation protocol (E/PD, E/P/D)
+	ECExampleConnector = "ec-example"
+
+	// DefaultPoolGroup is the default pool group name
+	DefaultPoolGroup = "inference.networking.k8s.io"
+
+	// LegacyPoolGroup is the legacy pool group name
+	LegacyPoolGroup = "inference.networking.x-k8s.io"
+)

--- a/pkg/sidecar/proxy/allowlist.go
+++ b/pkg/sidecar/proxy/allowlist.go
@@ -19,7 +19,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
@@ -203,7 +202,7 @@ func (av *AllowlistValidator) IsAllowed(hostPort string) bool {
 	}
 
 	// Clean up the hostPort input
-	hostPort = av.normalizeHostPort(hostPort)
+	hostPort = normalizeHostPort(hostPort)
 
 	av.allowedTargetsMu.RLock()
 	defer av.allowedTargetsMu.RUnlock()
@@ -211,20 +210,6 @@ func (av *AllowlistValidator) IsAllowed(hostPort string) bool {
 	allowed := av.allowedTargets.Has(hostPort)
 	av.logger.V(4).Info("allowlist check", "hostPort", hostPort, "allowed", allowed)
 	return allowed
-}
-
-// normalizeHostPort extracts the host part from a host:port string
-func (av *AllowlistValidator) normalizeHostPort(hostPort string) string {
-	// Use net.SplitHostPort to handle IPv6 addresses and ports
-	host, _, err := net.SplitHostPort(hostPort)
-	if err != nil {
-		// If net.SplitHostPort fails, it's likely just a hostname without port
-		av.logger.V(5).Info("could not parse host:port, treating as hostname",
-			"input", hostPort,
-			"error", err.Error())
-		return hostPort
-	}
-	return host
 }
 
 // onInferencePoolAdd handles new InferencePool resources

--- a/pkg/sidecar/proxy/allowlist.go
+++ b/pkg/sidecar/proxy/allowlist.go
@@ -202,7 +202,7 @@ func (av *AllowlistValidator) IsAllowed(hostPort string) bool {
 	}
 
 	// Clean up the hostPort input
-	hostPort = normalizeHostPort(hostPort)
+	hostPort = extractHost(hostPort)
 
 	av.allowedTargetsMu.RLock()
 	defer av.allowedTargetsMu.RUnlock()

--- a/pkg/sidecar/proxy/allowlist_test.go
+++ b/pkg/sidecar/proxy/allowlist_test.go
@@ -70,14 +70,14 @@ var _ = Describe("AllowlistValidator", func() {
 
 		It("should parse host:port correctly", func() {
 			// Test host:port format parsing
-			Expect(normalizeHostPort("10.244.1.100:8000")).To(Equal("10.244.1.100"))
-			Expect(normalizeHostPort("valid-pod:8000")).To(Equal("valid-pod"))
+			Expect(extractHost("10.244.1.100:8000")).To(Equal("10.244.1.100"))
+			Expect(extractHost("valid-pod:8000")).To(Equal("valid-pod"))
 			// Just hostname (no port)
-			Expect(normalizeHostPort("valid-pod")).To(Equal("valid-pod"))
+			Expect(extractHost("valid-pod")).To(Equal("valid-pod"))
 			// IPv6 addresses (net.SplitHostPort handles these correctly
-			Expect(normalizeHostPort("[::1]:8000")).To(Equal("::1"))
+			Expect(extractHost("[::1]:8000")).To(Equal("::1"))
 			// IPv6 without port
-			Expect(normalizeHostPort("::1")).To(Equal("::1"))
+			Expect(extractHost("::1")).To(Equal("::1"))
 		})
 	})
 })

--- a/pkg/sidecar/proxy/allowlist_test.go
+++ b/pkg/sidecar/proxy/allowlist_test.go
@@ -70,23 +70,14 @@ var _ = Describe("AllowlistValidator", func() {
 
 		It("should parse host:port correctly", func() {
 			// Test host:port format parsing
-			normalized := validator.normalizeHostPort("10.244.1.100:8000")
-			Expect(normalized).To(Equal("10.244.1.100"))
-
-			normalized = validator.normalizeHostPort("valid-pod:8000")
-			Expect(normalized).To(Equal("valid-pod"))
-
+			Expect(normalizeHostPort("10.244.1.100:8000")).To(Equal("10.244.1.100"))
+			Expect(normalizeHostPort("valid-pod:8000")).To(Equal("valid-pod"))
 			// Just hostname (no port)
-			normalized = validator.normalizeHostPort("valid-pod")
-			Expect(normalized).To(Equal("valid-pod"))
-
-			// IPv6 addresses (net.SplitHostPort handles these correctly)
-			normalized = validator.normalizeHostPort("[::1]:8000")
-			Expect(normalized).To(Equal("::1"))
-
+			Expect(normalizeHostPort("valid-pod")).To(Equal("valid-pod"))
+			// IPv6 addresses (net.SplitHostPort handles these correctly
+			Expect(normalizeHostPort("[::1]:8000")).To(Equal("::1"))
 			// IPv6 without port
-			normalized = validator.normalizeHostPort("::1")
-			Expect(normalized).To(Equal("::1"))
+			Expect(normalizeHostPort("::1")).To(Equal("::1"))
 		})
 	})
 })

--- a/pkg/sidecar/proxy/connector_epd_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_epd_shared_storage.go
@@ -265,7 +265,7 @@ func (s *Server) handleEPD(w http.ResponseWriter, r *http.Request, prefillEndPoi
 	}
 
 	// Clone request with modified body and add request ID header
-	pdRequest := cloneRequestWithBody(r, modifiedBody)
+	pdRequest := cloneRequestWithBody(r.Context(), r, modifiedBody)
 	pdRequest.Header.Add(requestHeaderRequestID, requestID)
 
 	// If prefiller is configured, use P/D protocol; otherwise go directly to decoder

--- a/pkg/sidecar/proxy/connector_epd_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_epd_shared_storage.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 
@@ -211,21 +210,8 @@ func (s *Server) fanoutEncoderPrimer(originalRequest map[string]any, encoderHost
 func (s *Server) handleEPD(w http.ResponseWriter, r *http.Request, prefillEndPoint string, encodeEndPoints []string) {
 	s.logger.V(4).Info("running EPD protocol", "prefiller", prefillEndPoint, "encoderCount", len(encodeEndPoints))
 
-	// Read request body
-	defer func() { _ = r.Body.Close() }()
-	original, err := io.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(err.Error()))
-		return
-	}
-
-	// Parse completion request
-	var completionRequest map[string]any
-	if err := json.Unmarshal(original, &completionRequest); err != nil {
-		if err := errorJSONInvalid(err, w); err != nil {
-			s.logger.Error(err, "failed to send error response to client")
-		}
+	_, completionRequest, ok := s.readJSONBody(r, w)
+	if !ok {
 		return
 	}
 

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -61,7 +61,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	prefillSpan.SetAttributes(
 		attribute.String("llm_d.pd_proxy.request_id", uuidStr),
 		attribute.String("llm_d.pd_proxy.prefill_target", prefillPodHostPort),
-		attribute.String("llm_d.pd_proxy.connector", "nixlv2"),
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorNIXLV2),
 	)
 	prefillStart := time.Now()
 
@@ -197,7 +197,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 
 	decodeSpan.SetAttributes(
 		attribute.String("llm_d.pd_proxy.request_id", uuidStr),
-		attribute.String("llm_d.pd_proxy.connector", "nixlv2"),
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorNIXLV2),
 	)
 	decodeStart := time.Now()
 

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -159,7 +159,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 
 		if shouldFallbackToDecode(pw) {
 			s.logger.Info("fallback to decode", "request_id", uuidStr)
-			fallbackReq := cloneRequestWithBody(r, original)
+			fallbackReq := cloneRequestWithBody(r.Context(), r, original)
 			s.dispatchDecode(w, fallbackReq, originalRequest)
 		} else {
 			for key, values := range pw.Header() {

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -36,21 +36,8 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	tokenLimitFields := tokenLimitFieldsForAPIType(apiType)
 	s.logger.V(4).Info("running NIXL protocol V2", "url", prefillPodHostPort, "tokenLimitFields", tokenLimitFields)
 
-	// Read request body
-	defer r.Body.Close() //nolint:errcheck
-	original, err := io.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest) // TODO: check FastAPI error code when failing to read body
-		w.Write([]byte(err.Error()))         //nolint:errcheck
-		return
-	}
-
-	// Parse completion request
-	var completionRequest map[string]any
-	if err := json.Unmarshal(original, &completionRequest); err != nil {
-		if err := errorJSONInvalid(err, w); err != nil {
-			s.logger.Error(err, "failed to send error response to client")
-		}
+	original, completionRequest, ok := s.readJSONBody(r, w)
+	if !ok {
 		return
 	}
 

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -184,7 +183,7 @@ func (s *Server) addSGLangBootstrapInfo(requestData map[string]interface{}, pref
 	}
 
 	// Generate bootstrap host from prefill host
-	bootstrapHost := s.getBootstrapHost(prefillHostPort)
+	bootstrapHost := normalizeHostPort(prefillHostPort)
 
 	// Add bootstrap information
 	modifiedRequest[requestFieldBootstrapHost] = bootstrapHost
@@ -215,10 +214,4 @@ func (s *Server) parseSGLangRequest(r *http.Request) (map[string]interface{}, er
 
 func (s *Server) generateSGLangRoomID() int64 {
 	return time.Now().UnixNano() + int64(rand.IntN(1000))
-}
-
-func (s *Server) getBootstrapHost(prefillHostPort string) string {
-	// Extract hostname from prefill host
-	parts := strings.Split(prefillHostPort, ":")
-	return parts[0]
 }

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -183,7 +183,7 @@ func (s *Server) addSGLangBootstrapInfo(requestData map[string]interface{}, pref
 	}
 
 	// Generate bootstrap host from prefill host
-	bootstrapHost := normalizeHostPort(prefillHostPort)
+	bootstrapHost := extractHost(prefillHostPort)
 
 	// Add bootstrap information
 	modifiedRequest[requestFieldBootstrapHost] = bootstrapHost

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -91,7 +91,7 @@ func (s *Server) handleSGLangConcurrentRequests(w http.ResponseWriter, r *http.R
 	)
 	prefillSpan.SetAttributes(
 		attribute.String("llm_d.pd_proxy.prefill_target", prefillHost),
-		attribute.String("llm_d.pd_proxy.connector", "sglang"),
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorSGLang),
 		attribute.Bool("llm_d.pd_proxy.prefill.async", true),
 	)
 	prefillStart := time.Now()
@@ -140,7 +140,7 @@ func (s *Server) handleSGLangConcurrentRequests(w http.ResponseWriter, r *http.R
 	defer decodeSpan.End()
 
 	decodeSpan.SetAttributes(
-		attribute.String("llm_d.pd_proxy.connector", "sglang"),
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorSGLang),
 		attribute.Bool("llm_d.pd_proxy.decode.concurrent_with_prefill", true),
 	)
 	decodeStart := time.Now()

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -17,7 +17,6 @@ limitations under the License.
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -100,8 +99,8 @@ func (s *Server) handleSGLangConcurrentRequests(w http.ResponseWriter, r *http.R
 	// Create separate requests for prefill and decode
 	// Use context.WithoutCancel for prefillReq to prevent it from being aborted
 	// if the main HTTP handler (which serves decodeReq) finishes first.
-	prefillReq := cloneWithJSONBody(context.WithoutCancel(r.Context()), r, body)
-	decodeReq := cloneWithJSONBody(r.Context(), r, body)
+	prefillReq := cloneRequestWithBody(context.WithoutCancel(r.Context()), r, body)
+	decodeReq := cloneRequestWithBody(r.Context(), r, body)
 
 	prefillHandler, err := s.prefillerProxyHandler(prefillHost)
 	if err != nil {
@@ -176,13 +175,6 @@ func (s *Server) handleSGLangConcurrentRequests(w http.ResponseWriter, r *http.R
 			attribute.Bool("llm_d.pd_proxy.concurrent_pd", true),
 		)
 	}
-}
-
-func cloneWithJSONBody(ctx context.Context, r *http.Request, body []byte) *http.Request {
-	req := r.Clone(ctx)
-	req.Body = io.NopCloser(bytes.NewReader(body))
-	req.ContentLength = int64(len(body))
-	return req
 }
 
 func (s *Server) addSGLangBootstrapInfo(requestData map[string]interface{}, prefillHostPort string, roomID int64) map[string]interface{} {

--- a/pkg/sidecar/proxy/connector_sglang_test.go
+++ b/pkg/sidecar/proxy/connector_sglang_test.go
@@ -98,7 +98,7 @@ var _ = Describe("SGLang Connector", func() {
 		Expect(prq1).To(HaveKey(requestFieldBootstrapPort))
 		Expect(prq1).To(HaveKey(requestFieldBootstrapRoom))
 
-		expectedHost := normalizeHostPort(prefillHostPort)
+		expectedHost := extractHost(prefillHostPort)
 		Expect(prq1[requestFieldBootstrapHost]).To(Equal(expectedHost))
 		Expect(prq1[requestFieldBootstrapPort]).To(Equal(float64(sglangBootstrapPort)))
 		Expect(prq1[requestFieldBootstrapRoom]).ToNot(BeNil())

--- a/pkg/sidecar/proxy/connector_sglang_test.go
+++ b/pkg/sidecar/proxy/connector_sglang_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -99,7 +98,7 @@ var _ = Describe("SGLang Connector", func() {
 		Expect(prq1).To(HaveKey(requestFieldBootstrapPort))
 		Expect(prq1).To(HaveKey(requestFieldBootstrapRoom))
 
-		expectedHost := strings.Split(prefillHostPort, ":")[0]
+		expectedHost := normalizeHostPort(prefillHostPort)
 		Expect(prq1[requestFieldBootstrapHost]).To(Equal(expectedHost))
 		Expect(prq1[requestFieldBootstrapPort]).To(Equal(float64(sglangBootstrapPort)))
 		Expect(prq1[requestFieldBootstrapRoom]).ToNot(BeNil())

--- a/pkg/sidecar/proxy/connector_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_shared_storage.go
@@ -17,7 +17,6 @@ limitations under the License.
 package proxy
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -54,7 +53,7 @@ func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, pre
 	// For more information refer to the RFC https://github.com/vllm-project/vllm/issues/24256
 	if cacheHitThreshold, hasCacheHitThreshold := completionRequest[requestFieldCacheHitThreshold]; hasCacheHitThreshold {
 		s.logger.V(4).Info("cache_hit_threshold field found in the request, trying to decode first", requestFieldCacheHitThreshold, cacheHitThreshold)
-		decodeReq := cloneRequestWithBody(r, original)
+		decodeReq := cloneRequestWithBody(r.Context(), r, original)
 		needsPrefill, err := s.tryDecode(w, decodeReq, completionRequest)
 		if err != nil {
 			return
@@ -83,7 +82,7 @@ func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, pre
 		return
 	}
 
-	decodeReq := cloneRequestWithBody(r, decodeRequestBody)
+	decodeReq := cloneRequestWithBody(r.Context(), r, decodeRequestBody)
 	s.decoderProxy.ServeHTTP(w, decodeReq)
 }
 
@@ -240,7 +239,7 @@ func (s *Server) prefill(w http.ResponseWriter, r *http.Request, prefillPodHostP
 		}
 		return err
 	}
-	preq := cloneRequestWithBody(r, pbody)
+	preq := cloneRequestWithBody(r.Context(), r, pbody)
 
 	prefillHandler, err := s.prefillerProxyHandler(prefillPodHostPort)
 	if err != nil {
@@ -266,11 +265,4 @@ func (s *Server) prefill(w http.ResponseWriter, r *http.Request, prefillPodHostP
 
 	s.logger.V(4).Info("prefill completed successfully")
 	return nil
-}
-
-func cloneRequestWithBody(r *http.Request, body []byte) *http.Request {
-	cloned := r.Clone(r.Context())
-	cloned.Body = io.NopCloser(bytes.NewReader(body))
-	cloned.ContentLength = int64(len(body))
-	return cloned
 }

--- a/pkg/sidecar/proxy/connector_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_shared_storage.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"strings"
@@ -29,21 +28,8 @@ import (
 func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
 	s.logger.V(4).Info("running Shared Storage protocol", "url", prefillPodHostPort)
 
-	// Read and parse request body
-	defer r.Body.Close() //nolint:errcheck
-	original, err := io.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest) // TODO: check FastAPI error code when failing to read body
-		w.Write([]byte(err.Error()))         //nolint:errcheck
-		return
-	}
-
-	// Parse completion request
-	var completionRequest map[string]any
-	if err := json.Unmarshal(original, &completionRequest); err != nil {
-		if err := errorJSONInvalid(err, w); err != nil {
-			s.logger.Error(err, "failed to send Invalid JSON error response to client")
-		}
+	original, completionRequest, ok := s.readJSONBody(r, w)
+	if !ok {
 		return
 	}
 

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -86,7 +86,7 @@ func (s *Server) runChunkedDecode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.runChunkedDecodeFromMap(w, cloneRequestWithBody(r, original), completionRequest)
+	s.runChunkedDecodeFromMap(w, cloneRequestWithBody(r.Context(), r, original), completionRequest)
 }
 
 // runChunkedDecodeFromMap executes chunked decode given an already-parsed completionRequest map.
@@ -181,7 +181,7 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 			"chunk", chunkIndex, "chunkBudget", chunkBudget, "totalTokensSoFar", totalTokens)
 
 		bw := &bufferedResponseWriter{}
-		s.decoderProxy.ServeHTTP(bw, cloneRequestWithBody(r.WithContext(ctx), chunkBody))
+		s.decoderProxy.ServeHTTP(bw, cloneRequestWithBody(ctx, r, chunkBody))
 
 		if isHTTPError(bw.statusCode) {
 			s.logger.Error(fmt.Errorf("chunk %d failed with status %d", chunkIndex, bw.statusCode),

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"strings"
@@ -70,19 +69,8 @@ func (s *Server) dispatchDecode(w http.ResponseWriter, r *http.Request, completi
 // runChunkedDecode reads and parses the body, then delegates to
 // runChunkedDecodeFromMap.
 func (s *Server) runChunkedDecode(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close() //nolint:errcheck
-	original, err := io.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error())) //nolint:errcheck
-		return
-	}
-
-	var completionRequest map[string]any
-	if err := json.Unmarshal(original, &completionRequest); err != nil {
-		if err := errorJSONInvalid(err, w); err != nil {
-			s.logger.Error(err, "failed to send error response to client")
-		}
+	original, completionRequest, ok := s.readJSONBody(r, w)
+	if !ok {
 		return
 	}
 

--- a/pkg/sidecar/proxy/errors.go
+++ b/pkg/sidecar/proxy/errors.go
@@ -18,8 +18,11 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 )
+
+var errInvalidJSON = errors.New("invalid JSON")
 
 // vLLM error response
 type errorResponse struct {

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -40,13 +40,13 @@ func writeTempYAML(t *testing.T, name, content string) string {
 
 func createConfigWithValidYAML(t *testing.T) string {
 	t.Helper()
-	return writeTempYAML(t, "valid.yaml", `
+	return writeTempYAML(t, "valid.yaml", fmt.Sprintf(`
 port: 8100
 vllm-port: 8200
 data-parallel-size: 5
-kv-connector: "sglang"
-connector: "nixlv2"
-ec-connector: "ec-example"
+kv-connector: %q
+connector: %q
+ec-connector: %q
 enable-ssrf-protection: true
 enable-prefiller-sampling: true
 enable-tls:
@@ -62,7 +62,7 @@ inference-pool: "file-ns/inference-pool-file"
 pool-group: "pool-group-file"
 max-idle-conns-per-host: 300
 decode-chunk-size: 128
-`)
+`, KVConnectorSGLang, KVConnectorNIXLV2, ECExampleConnector))
 }
 
 func createConfigWithUnknownKeys(t *testing.T) string {
@@ -84,14 +84,13 @@ invalid-yaml,
 
 func TestSidecarConfiguration(t *testing.T) {
 	// --- inline YAML for testing ---
-	inlineYAML :=
-		`{
+	inlineYAML := fmt.Sprintf(`{
 		port: 8011,
 		vllm-port: 8021,
 		data-parallel-size: 3,
-		kv-connector: sglang,
-		connector: nixlv2,
-		ec-connector: ec-example,
+		kv-connector: %s,
+		connector: %s,
+		ec-connector: %s,
 		enable-ssrf-protection: true,
 		enable-prefiller-sampling: true,
 		enable-tls: ['prefiller', 'decoder'],
@@ -105,7 +104,7 @@ func TestSidecarConfiguration(t *testing.T) {
 		pool-group: pool-group-inline,
 		max-idle-conns-per-host: 200,
 		decode-chunk-size: 256
-	}`
+	}`, KVConnectorSGLang, KVConnectorNIXLV2, ECExampleConnector)
 	invalidInlineYAML := "{port: 8200, invalid-yaml}"
 
 	// -- file YAML for testing ---

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -33,6 +33,8 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/sidecar/constants"
 )
 
 const (
@@ -68,23 +70,12 @@ const (
 	requestFieldBootstrapPort = "bootstrap_port"
 	requestFieldBootstrapRoom = "bootstrap_room"
 
-	// KVConnectorNIXLV2 enables the P/D KV NIXL v2 protocol
-	KVConnectorNIXLV2 = "nixlv2"
-
-	// KVConnectorSharedStorage enables the P/D KV Shared Storage protocol
-	KVConnectorSharedStorage = "shared-storage"
-
-	// KVConnectorSGLang enables SGLang the P/D KV disaggregation protocol
-	KVConnectorSGLang = "sglang"
-
-	// ECExampleConnector enables the Encoder disaggregation protocol (E/PD, E/P/D)
-	ECExampleConnector = "ec-example"
-
-	// DefaultPoolGroup is the default pool group name
-	DefaultPoolGroup = "inference.networking.k8s.io"
-
-	// LegacyPoolGroup is the legacy pool group name
-	LegacyPoolGroup = "inference.networking.x-k8s.io"
+	KVConnectorNIXLV2        = constants.KVConnectorNIXLV2
+	KVConnectorSharedStorage = constants.KVConnectorSharedStorage
+	KVConnectorSGLang        = constants.KVConnectorSGLang
+	ECExampleConnector       = constants.ECExampleConnector
+	DefaultPoolGroup         = constants.DefaultPoolGroup
+	LegacyPoolGroup          = constants.LegacyPoolGroup
 )
 
 // APIType represents the type of OpenAI API being used.

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -161,21 +161,27 @@ func (s *Server) createDecoderProxyHandler(decoderURL *url.URL, decoderInsecureS
 	return decoderProxy
 }
 
-// readJSONBody reads the request body, closes it, and unmarshals it into a
-// map. On failure it writes the appropriate HTTP error response and returns
-// ok=false so the caller can simply return.
-func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, map[string]any, bool) {
+func bodyAsJSON(r *http.Request) ([]byte, map[string]any, error) {
 	defer func() { _ = r.Body.Close() }()
 	raw, err := io.ReadAll(r.Body)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(err.Error()))
-		return nil, nil, false
+		return nil, nil, err
 	}
 	var parsed map[string]any
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		if err := errorJSONInvalid(err, w); err != nil {
-			s.logger.Error(err, "failed to send error response to client")
+		return nil, nil, fmt.Errorf("%w: %w", errInvalidJSON, err)
+	}
+	return raw, parsed, nil
+}
+
+func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, map[string]any, bool) {
+	raw, parsed, err := bodyAsJSON(r)
+	if err != nil {
+		if !errors.Is(err, errInvalidJSON) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(err.Error()))
+		} else if writeErr := errorJSONInvalid(err, w); writeErr != nil {
+			s.logger.Error(writeErr, "failed to send error response to client")
 		}
 		return nil, nil, false
 	}
@@ -189,13 +195,12 @@ func cloneRequestWithBody(ctx context.Context, r *http.Request, body []byte) *ht
 	return cloned
 }
 
-// normalizeHostPort returns the host part of a host:port string. If parsing
+// extractHost returns the host part of a host:port string. If parsing
 // fails (e.g. no port), the input is returned as-is.
-func normalizeHostPort(hostPort string) string {
-	host, _, err := net.SplitHostPort(hostPort)
+func extractHost(hostWithPort string) string {
+	host, _, err := net.SplitHostPort(hostWithPort)
 	if err != nil {
-		// If net.SplitHostPort fails, it's likely just a hostname without port
-		return hostPort
+		return hostWithPort
 	}
 	return host
 }

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -168,8 +168,8 @@ func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, m
 	defer func() { _ = r.Body.Close() }()
 	raw, err := io.ReadAll(r.Body)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest) // TODO: check FastAPI error code when failing to read body
-				_, _ = w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(err.Error()))
 		return nil, nil, false
 	}
 	var parsed map[string]any
@@ -181,6 +181,7 @@ func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, m
 	}
 	return raw, parsed, true
 }
+
 
 func cloneRequestWithBody(ctx context.Context, r *http.Request, body []byte) *http.Request {
 	cloned := r.Clone(ctx)

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -165,7 +165,7 @@ func (s *Server) createDecoderProxyHandler(decoderURL *url.URL, decoderInsecureS
 // map. On failure it writes the appropriate HTTP error response and returns
 // ok=false so the caller can simply return.
 func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, map[string]any, bool) {
-	defer r.Body.Close() //nolint:errcheck
+	defer func() { _ = r.Body.Close() }()
 	raw, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest) // TODO: check FastAPI error code when failing to read body

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -189,6 +189,17 @@ func cloneRequestWithBody(ctx context.Context, r *http.Request, body []byte) *ht
 	return cloned
 }
 
+// normalizeHostPort returns the host part of a host:port string. If parsing
+// fails (e.g. no port), the input is returned as-is.
+func normalizeHostPort(hostPort string) string {
+	host, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		// If net.SplitHostPort fails, it's likely just a hostname without port
+		return hostPort
+	}
+	return host
+}
+
 // isHTTPError returns true if the status code indicates an error (not in the 2xx range).
 func isHTTPError(statusCode int) bool {
 	return statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -182,7 +182,6 @@ func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, m
 	return raw, parsed, true
 }
 
-
 func cloneRequestWithBody(ctx context.Context, r *http.Request, body []byte) *http.Request {
 	cloned := r.Clone(ctx)
 	cloned.Body = io.NopCloser(bytes.NewReader(body))

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -158,6 +159,27 @@ func (s *Server) createDecoderProxyHandler(decoderURL *url.URL, decoderInsecureS
 		}
 	}
 	return decoderProxy
+}
+
+// readJSONBody reads the request body, closes it, and unmarshals it into a
+// map. On failure it writes the appropriate HTTP error response and returns
+// ok=false so the caller can simply return.
+func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, map[string]any, bool) {
+	defer r.Body.Close() //nolint:errcheck
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest) // TODO: check FastAPI error code when failing to read body
+		w.Write([]byte(err.Error()))         //nolint:errcheck
+		return nil, nil, false
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return nil, nil, false
+	}
+	return raw, parsed, true
 }
 
 func cloneRequestWithBody(ctx context.Context, r *http.Request, body []byte) *http.Request {

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -169,7 +169,7 @@ func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, m
 	raw, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest) // TODO: check FastAPI error code when failing to read body
-		w.Write([]byte(err.Error()))         //nolint:errcheck
+				_, _ = w.Write([]byte(err.Error()))
 		return nil, nil, false
 	}
 	var parsed map[string]any

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -1,10 +1,12 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -156,6 +158,13 @@ func (s *Server) createDecoderProxyHandler(decoderURL *url.URL, decoderInsecureS
 		}
 	}
 	return decoderProxy
+}
+
+func cloneRequestWithBody(ctx context.Context, r *http.Request, body []byte) *http.Request {
+	cloned := r.Clone(ctx)
+	cloned.Body = io.NopCloser(bytes.NewReader(body))
+	cloned.ContentLength = int64(len(body))
+	return cloned
 }
 
 // isHTTPError returns true if the status code indicates an error (not in the 2xx range).

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			prefillReplicas := 1
 			decodeReplicas := 4
-			modelServers := createModelServersPDNixl(prefillReplicas, decodeReplicas)
+			modelServers := createModelServersPDNixlV2(prefillReplicas, decodeReplicas)
 
 			epp := createEndPointPicker(deprecatedPdConfig)
 

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/llm-d/llm-d-router/pkg/sidecar/proxy"
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -81,17 +82,17 @@ func createModelServersPDWithConnector(prefillReplicas, decodeReplicas int, conn
 }
 
 func createModelServersPDNixlV2(prefillReplicas, decodeReplicas int) []string {
-	return createModelServersPDWithConnector(prefillReplicas, decodeReplicas, "nixlv2")
+	return createModelServersPDWithConnector(prefillReplicas, decodeReplicas, proxy.KVConnectorNIXLV2)
 }
 
 func createModelServersPDSharedStorage(decodeReplicas int) []string {
-	return createModelServersPDWithConnector(1, decodeReplicas, "shared-storage")
+	return createModelServersPDWithConnector(1, decodeReplicas, proxy.KVConnectorSharedStorage)
 }
 
 // createModelServersEpDDisagg creates model server resources for E/PD (encode + prefill/decode) testing.
 func createModelServersEpDDisagg(encodeReplicas, decodeReplicas int) []string {
 	return createModelServersFromKustomize(ePdDisaggDir, map[string]string{
-		"${EC_CONNECTOR_TYPE}":    "ec-example",
+		"${EC_CONNECTOR_TYPE}":    proxy.ECExampleConnector,
 		"${VLLM_REPLICA_COUNT_E}": strconv.Itoa(encodeReplicas),
 		"${VLLM_REPLICA_COUNT_D}": strconv.Itoa(decodeReplicas),
 	})
@@ -100,8 +101,8 @@ func createModelServersEpDDisagg(encodeReplicas, decodeReplicas int) []string {
 // createModelServersEPDDisagg creates model server resources for E/P/D (encode/prefill/decode) testing.
 func createModelServersEPDDisagg(encodeReplicas, prefillReplicas, decodeReplicas int) []string {
 	return createModelServersFromKustomize(ePDDisaggDir, map[string]string{
-		"${KV_CONNECTOR_TYPE}":    "shared-storage",
-		"${EC_CONNECTOR_TYPE}":    "ec-example",
+		"${KV_CONNECTOR_TYPE}":    proxy.KVConnectorSharedStorage,
+		"${EC_CONNECTOR_TYPE}":    proxy.ECExampleConnector,
 		"${VLLM_REPLICA_COUNT_E}": strconv.Itoa(encodeReplicas),
 		"${VLLM_REPLICA_COUNT_P}": strconv.Itoa(prefillReplicas),
 		"${VLLM_REPLICA_COUNT_D}": strconv.Itoa(decodeReplicas),

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -80,7 +80,7 @@ func createModelServersPDWithConnector(prefillReplicas, decodeReplicas int, conn
 	})
 }
 
-func createModelServersPDNixl(prefillReplicas, decodeReplicas int) []string {
+func createModelServersPDNixlV2(prefillReplicas, decodeReplicas int) []string {
 	return createModelServersPDWithConnector(prefillReplicas, decodeReplicas, "nixlv2")
 }
 

--- a/test/sidecar/mock/chat_completions_handler.go
+++ b/test/sidecar/mock/chat_completions_handler.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
+
+	"github.com/llm-d/llm-d-router/pkg/sidecar/constants"
 )
 
 // Role of the mocked handler
@@ -82,7 +84,7 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	var rawResponse string
 
 	switch cc.Connector {
-	case "nixlv2":
+	case constants.KVConnectorNIXLV2:
 		switch cc.Role {
 		case RoleDecode:
 			rawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":49}}}`
@@ -140,7 +142,7 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 		}
 
-	case "shared-storage":
+	case constants.KVConnectorSharedStorage:
 		// Shared Storage protocol just returns empty response
 		rawResponse = `{}`
 

--- a/test/sidecar/mock/chat_completions_handler.go
+++ b/test/sidecar/mock/chat_completions_handler.go
@@ -82,9 +82,6 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	var rawResponse string
 
 	switch cc.Connector {
-	case "nixl":
-		rawResponse = `{"remote_block_ids":[1, 2, 3], "remote_engine_id": "5b5fb28f-3f30-4bdd-9a36-958d52459200"}`
-
 	case "nixlv2":
 		switch cc.Role {
 		case RoleDecode:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
a bunch of chore/refactor not fix/feature change
- remove nixl case in test 
- rename function `createModelServersPDNixl` to `createModelServersPDNixlV2`
- refactor: cloneRequestWithBody replace old cloneWithBody and move to proxy_helpers.go
- refactor: move read json body unmarshal into a method to  reduce duplicated code in different kv-connectors
- refactor:  move sidecar const into a new package and refer hardcoded value by const
- refactor: move `normalizeHostPort()` in to helper , address [comments](https://github.com/llm-d/llm-d-router/pull/1193#discussion_r3259113017)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
