### PR TITLE
ci: type prerelease workflow input as boolean

### DIFF
--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       prerelease:
         required: true
-        type: string
+        type: boolean
 
 permissions:
   contents: read

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -41,4 +41,4 @@ jobs:
       epp-image-name: ${{ needs.set-params.outputs.epp_name }}
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
       tag: ${{ needs.set-params.outputs.tag }}
-      prerelease: "true"
+      prerelease: true

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -51,4 +51,4 @@ jobs:
       epp-image-name: ${{ needs.set-params.outputs.epp_name }}
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
       tag: ${{ needs.set-params.outputs.tag }}
-      prerelease: ${{ needs.set-params.outputs.prerelease }}
+      prerelease: ${{ fromJSON(needs.set-params.outputs.prerelease) }}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`actionlint` flags the literal `prerelease: "true"` in `ci-dev.yaml:44` as a bool value being assigned to a string-typed input. The reusable workflow `ci-build-images.yaml` declared `prerelease` as `type: string`, but the value is semantically a boolean.
Aligning the declaration with intent fixes the lint and removes the type mismatch.

**Which issue(s) this PR fixes**:
NA

**Release note** _(write \`NONE\` if no user-facing change)_:
```release-note
NONE
```