### PR TITLE
refactor: rename run*Protocal to handler*

### DIFF
--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -149,7 +149,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 			}
 		}
 
-		if len(allowedEncoders) > 0 && s.runEPDConnectorProtocol != nil {
+		if len(allowedEncoders) > 0 && s.handleEPDConnector != nil {
 			s.logger.V(4).Info("encoder headers detected, using EPD protocol",
 				"encoderCount", len(allowedEncoders),
 				"encoderCandidates", len(encoderHostPorts),
@@ -159,7 +159,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 				attribute.Int("llm_d.epd_proxy.encoder_count", len(allowedEncoders)),
 				attribute.Int("llm_d.epd_proxy.encoder_candidates", len(encoderHostPorts)),
 			)
-			s.runEPDConnectorProtocol(w, r, prefillHostPort, allowedEncoders)
+			s.handleEPDConnector(w, r, prefillHostPort, allowedEncoders)
 			return
 		}
 
@@ -174,7 +174,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 
 		if len(prefillHostPort) > 0 {
 			s.logger.V(4).Info("using P/D protocol")
-			s.runPDConnectorProtocol(w, r, prefillHostPort, apiType)
+			s.handlePDConnector(w, r, prefillHostPort, apiType)
 			return
 		}
 

--- a/pkg/sidecar/proxy/chat_completions_test.go
+++ b/pkg/sidecar/proxy/chat_completions_test.go
@@ -126,7 +126,7 @@ func testPrefillHeaderRouting(t *testing.T, apiType APIType) {
 				s.prefillSamplerFn = func(n int) int { return i % n }
 				var hostPort string
 				var capturedReq *http.Request
-				s.runPDConnectorProtocol = func(_ http.ResponseWriter, r *http.Request, selectedHostPort string, _ APIType) {
+				s.handlePDConnector = func(_ http.ResponseWriter, r *http.Request, selectedHostPort string, _ APIType) {
 					hostPort = selectedHostPort
 					capturedReq = r
 				}
@@ -312,7 +312,7 @@ func TestServer_encoderEndpointRouting(t *testing.T) {
 			var epdEncoders []string
 			var capturedReq *http.Request
 			if tt.epdConfigured {
-				s.runEPDConnectorProtocol = func(_ http.ResponseWriter, r *http.Request, prefillHost string, encoders []string) {
+				s.handleEPDConnector = func(_ http.ResponseWriter, r *http.Request, prefillHost string, encoders []string) {
 					epdCalled = true
 					epdPrefill = prefillHost
 					epdEncoders = encoders
@@ -322,7 +322,7 @@ func TestServer_encoderEndpointRouting(t *testing.T) {
 
 			var pdCalled bool
 			var pdHost string
-			s.runPDConnectorProtocol = func(_ http.ResponseWriter, r *http.Request, host string, _ APIType) {
+			s.handlePDConnector = func(_ http.ResponseWriter, r *http.Request, host string, _ APIType) {
 				pdCalled = true
 				pdHost = host
 				capturedReq = r

--- a/pkg/sidecar/proxy/connector_epd_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_epd_shared_storage.go
@@ -207,8 +207,8 @@ func (s *Server) fanoutEncoderPrimer(originalRequest map[string]any, encoderHost
 	return nil
 }
 
-// runEPDProtocol implements the Encoder-Prefiller-Decoder disaggregation protocol
-func (s *Server) runEPDProtocol(w http.ResponseWriter, r *http.Request, prefillEndPoint string, encodeEndPoints []string) {
+// handleEPD handles an Encoder-Prefiller-Decoder disaggregation request
+func (s *Server) handleEPD(w http.ResponseWriter, r *http.Request, prefillEndPoint string, encodeEndPoints []string) {
 	s.logger.V(4).Info("running EPD protocol", "prefiller", prefillEndPoint, "encoderCount", len(encodeEndPoints))
 
 	// Read request body
@@ -273,7 +273,7 @@ func (s *Server) runEPDProtocol(w http.ResponseWriter, r *http.Request, prefillE
 		s.logger.V(4).Info("using P/D protocol after encoder", "prefiller", prefillEndPoint)
 		// Run the configured P/D protocol (prefill + decode)
 		// This will use whichever protocol is configured: shared-storage, nixlv2, or sglang
-		s.runPDConnectorProtocol(w, pdRequest, prefillEndPoint, APITypeChatCompletions)
+		s.handlePDConnector(w, pdRequest, prefillEndPoint, APITypeChatCompletions)
 	} else {
 		s.logger.V(4).Info("no prefiller configured, going directly to decoder after encoder")
 		// No prefiller, go directly to decoder (Encoder-Decoder mode)

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -32,7 +32,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/telemetry"
 )
 
-func (s *Server) runNIXLProtocolV2(w http.ResponseWriter, r *http.Request, prefillPodHostPort string, apiType APIType) {
+func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPodHostPort string, apiType APIType) {
 	tokenLimitFields := tokenLimitFieldsForAPIType(apiType)
 	s.logger.V(4).Info("running NIXL protocol V2", "url", prefillPodHostPort, "tokenLimitFields", tokenLimitFields)
 

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -52,7 +52,7 @@ func init() {
 	}
 }
 
-func (s *Server) runSGLangProtocol(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
+func (s *Server) handleSGLang(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
 	s.logger.V(4).Info("running SGLang protocol", "url", prefillPodHostPort)
 
 	// Make Request
@@ -79,10 +79,10 @@ func (s *Server) runSGLangProtocol(w http.ResponseWriter, r *http.Request, prefi
 	}
 
 	// Send concurrent prefill and decode requests
-	s.sendSGLangConcurrentRequests(w, r, body, prefillPodHostPort)
+	s.handleSGLangConcurrentRequests(w, r, body, prefillPodHostPort)
 }
 
-func (s *Server) sendSGLangConcurrentRequests(w http.ResponseWriter, r *http.Request, body []byte, prefillHost string) {
+func (s *Server) handleSGLangConcurrentRequests(w http.ResponseWriter, r *http.Request, body []byte, prefillHost string) {
 	tracer := telemetry.Tracer()
 	ctx := r.Context()
 

--- a/pkg/sidecar/proxy/connector_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_shared_storage.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 )
 
-func (s *Server) runSharedStorageProtocol(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
+func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
 	s.logger.V(4).Info("running Shared Storage protocol", "url", prefillPodHostPort)
 
 	// Read and parse request body

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -207,23 +207,23 @@ func (c Config) String() string {
 	return string(b)
 }
 
-// pdConnectorRunner runs the configured P/D KV connector. The APIType lets each
+// pdConnectorHandler handles a P/D KV connector request. The APIType lets each
 // connector decide internally which JSON fields (if any) need special handling.
-type pdConnectorRunner func(http.ResponseWriter, *http.Request, string, APIType)
+type pdConnectorHandler func(http.ResponseWriter, *http.Request, string, APIType)
 
-type epdProtocolRunner func(http.ResponseWriter, *http.Request, string, []string)
+type epdConnectorHandler func(http.ResponseWriter, *http.Request, string, []string)
 
 // Server is the reverse proxy server
 type Server struct {
-	logger                  logr.Logger
-	addr                    net.Addr      // the proxy TCP address
-	readyCh                 chan struct{} // closed once addr is set and server is listening
-	handler                 http.Handler  // the handler function. either a Mux or a proxy
-	allowlistValidator      *AllowlistValidator
-	runPDConnectorProtocol  pdConnectorRunner // the handler for running the Prefiller-Decoder protocol
-	runEPDConnectorProtocol epdProtocolRunner // the handler for running the Encoder-Prefiller-Decoder protocol
-	prefillerURLPrefix      string
-	encoderURLPrefix        string
+	logger             logr.Logger
+	addr               net.Addr      // the proxy TCP address
+	readyCh            chan struct{} // closed once addr is set and server is listening
+	handler            http.Handler  // the handler function. either a Mux or a proxy
+	allowlistValidator *AllowlistValidator
+	handlePDConnector  pdConnectorHandler  // handles the Prefiller-Decoder connector request
+	handleEPDConnector epdConnectorHandler // handles the Encoder-Prefiller-Decoder connector request
+	prefillerURLPrefix string
+	encoderURLPrefix   string
 
 	decoderProxy        http.Handler                     // decoder proxy handler
 	prefillerProxies    *lru.Cache[string, http.Handler] // cached prefiller proxy handlers
@@ -306,20 +306,20 @@ func (s *Server) Start(ctx context.Context) error {
 // always set them explicitly after cloning.
 func (s *Server) Clone() *Server {
 	return &Server{
-		addr:                    s.addr,
-		readyCh:                 make(chan struct{}),
-		handler:                 s.handler,
-		allowlistValidator:      s.allowlistValidator,
-		runPDConnectorProtocol:  s.runPDConnectorProtocol,
-		runEPDConnectorProtocol: s.runEPDConnectorProtocol,
-		prefillerURLPrefix:      s.prefillerURLPrefix,
-		encoderURLPrefix:        s.encoderURLPrefix,
-		prefillerProxies:        s.prefillerProxies,
-		encoderProxies:          s.encoderProxies,
-		dataParallelProxies:     s.dataParallelProxies,
-		forwardDataParallel:     s.forwardDataParallel,
-		prefillSamplerFn:        s.prefillSamplerFn,
-		config:                  s.config,
+		addr:                s.addr,
+		readyCh:             make(chan struct{}),
+		handler:             s.handler,
+		allowlistValidator:  s.allowlistValidator,
+		handlePDConnector:   s.handlePDConnector,
+		handleEPDConnector:  s.handleEPDConnector,
+		prefillerURLPrefix:  s.prefillerURLPrefix,
+		encoderURLPrefix:    s.encoderURLPrefix,
+		prefillerProxies:    s.prefillerProxies,
+		encoderProxies:      s.encoderProxies,
+		dataParallelProxies: s.dataParallelProxies,
+		forwardDataParallel: s.forwardDataParallel,
+		prefillSamplerFn:    s.prefillSamplerFn,
+		config:              s.config,
 	}
 }
 
@@ -357,17 +357,17 @@ func (s *Server) setKVConnector() {
 
 	switch s.config.KVConnector {
 	case KVConnectorSharedStorage:
-		s.runPDConnectorProtocol = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
-			s.runSharedStorageProtocol(w, r, host)
+		s.handlePDConnector = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
+			s.handleSharedStorage(w, r, host)
 		}
 	case KVConnectorSGLang:
-		s.runPDConnectorProtocol = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
-			s.runSGLangProtocol(w, r, host)
+		s.handlePDConnector = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
+			s.handleSGLang(w, r, host)
 		}
 	case KVConnectorNIXLV2:
 		fallthrough
 	default:
-		s.runPDConnectorProtocol = s.runNIXLProtocolV2
+		s.handlePDConnector = s.handleNIXLV2
 	}
 }
 
@@ -381,7 +381,7 @@ func (s *Server) setECConnector() {
 
 	switch ecConnector {
 	case ECExampleConnector:
-		s.runEPDConnectorProtocol = s.runEPDProtocol
+		s.handleEPDConnector = s.handleEPD
 	default:
 		// Unknown EC connector value, skip encoder stage
 		return


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
- http handlers should be properly named not using run*Protocal7send*ConcurrentRequests

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1198

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
