### PR TITLE
FileDiscovery plugin (4/4) - wiring into the runner

### DIFF
--- a/cmd/epp/runner/health.go
+++ b/cmd/epp/runner/health.go
@@ -117,12 +117,15 @@ func (s *healthServer) checkProtocolSupport(isLive bool) bool {
 	if len(supported) == 0 {
 		return true
 	}
-	appProtocol := pool.AppProtocol
-	if appProtocol == "" {
-		appProtocol = v1.AppProtocolHTTP
+	// An unset AppProtocol means the operator did not declare a protocol on the
+	// pool. Treat that as "no protocol constraint" rather than silently
+	// defaulting to HTTP, which would lock out file-discovery deployments and
+	// any K8s pool that uses a non-HTTP parser without setting AppProtocol.
+	if pool.AppProtocol == "" {
+		return true
 	}
 	for _, p := range supported {
-		if p == appProtocol {
+		if p == pool.AppProtocol {
 			return true
 		}
 	}

--- a/cmd/epp/runner/health_test.go
+++ b/cmd/epp/runner/health_test.go
@@ -89,6 +89,17 @@ func TestHealthServer_Check(t *testing.T) {
 			wantStatus:            healthPb.HealthCheckResponse_NOT_SERVING,
 		},
 		{
+			// File-discovery pools and K8s pools without an explicit AppProtocol
+			// must not be constrained to HTTP -- a non-HTTP parser would otherwise
+			// lock the EPP out of SERVING permanently.
+			name:                  "LeaderElectionDisabled_EmptyAppProtocol_NoConstraint",
+			leaderElectionEnabled: false,
+			hasSynced:             true,
+			pool:                  &datalayer.EndpointPool{},
+			supporter:             &mockSupporter{protocols: []v1.AppProtocol{v1.AppProtocolH2C}},
+			wantStatus:            healthPb.HealthCheckResponse_SERVING,
+		},
+		{
 			name:                  "LeaderElectionEnabled_Liveness_AlwaysServing",
 			leaderElectionEnabled: true,
 			service:               LivenessCheckService,

--- a/cmd/epp/runner/resolve_discovery_test.go
+++ b/cmd/epp/runner/resolve_discovery_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configapi "github.com/llm-d/llm-d-inference-scheduler/apix/config/v1alpha1"
+	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+	discoveryfile "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/discovery/file"
+)
+
+func init() {
+	fwkplugin.Register(discoveryfile.PluginType, discoveryfile.Factory)
+}
+
+func makeConfig(pluginName, pluginType string, params json.RawMessage, discoveryRef string) *configapi.EndpointPickerConfig {
+	return &configapi.EndpointPickerConfig{
+		Plugins: []configapi.PluginSpec{
+			{Name: pluginName, Type: pluginType, Parameters: params},
+		},
+		DataLayer: &configapi.DataLayerConfig{
+			Discovery: &configapi.DiscoveryConfig{PluginRef: discoveryRef},
+		},
+	}
+}
+
+func TestResolveDiscovery_FileDiscovery(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "endpoints-*.yaml")
+	require.NoError(t, err)
+	_, _ = f.WriteString("endpoints: []\n")
+	require.NoError(t, f.Close())
+
+	params, _ := json.Marshal(map[string]any{"path": f.Name()})
+	cfg := makeConfig("my-disc", discoveryfile.PluginType, params, "my-disc")
+
+	r := &Runner{}
+	disc, err := r.resolveDiscovery(cfg)
+	require.NoError(t, err)
+	assert.IsType(t, &discoveryfile.FileDiscovery{}, disc)
+	assert.Equal(t, discoveryfile.PluginType, disc.TypedName().Type)
+	assert.Equal(t, "my-disc", disc.TypedName().Name)
+}
+
+func TestResolveDiscovery_PluginRefNotFound(t *testing.T) {
+	cfg := &configapi.EndpointPickerConfig{
+		Plugins: []configapi.PluginSpec{
+			{Name: "other", Type: discoveryfile.PluginType},
+		},
+		DataLayer: &configapi.DataLayerConfig{
+			Discovery: &configapi.DiscoveryConfig{PluginRef: "nonexistent"},
+		},
+	}
+	r := &Runner{}
+	_, err := r.resolveDiscovery(cfg)
+	assert.ErrorContains(t, err, "no plugin found with name")
+}
+
+func TestResolveDiscovery_UnknownType(t *testing.T) {
+	cfg := makeConfig("my-disc", "unknown-type", nil, "my-disc")
+	r := &Runner{}
+	_, err := r.resolveDiscovery(cfg)
+	assert.ErrorContains(t, err, "unknown plugin type")
+}
+
+func TestResolveDiscovery_NotEndpointDiscovery(t *testing.T) {
+	const notDiscType = "not-a-discovery"
+	fwkplugin.Register(notDiscType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+		return &notDiscoveryPlugin{}, nil
+	})
+	cfg := makeConfig("not-disc", notDiscType, nil, "not-disc")
+	r := &Runner{}
+	_, err := r.resolveDiscovery(cfg)
+	assert.ErrorContains(t, err, "does not implement EndpointDiscovery")
+}
+
+type notDiscoveryPlugin struct{}
+
+func (p *notDiscoveryPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "not-a-discovery", Name: "not-a-discovery"}
+}
+
+var _ fwkplugin.Plugin = (*notDiscoveryPlugin)(nil)

--- a/cmd/epp/runner/resolve_discovery_test.go
+++ b/cmd/epp/runner/resolve_discovery_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	configapi "github.com/llm-d/llm-d-inference-scheduler/apix/config/v1alpha1"
-	fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
-	discoveryfile "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/plugins/datalayer/discovery/file"
+	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	discoveryfile "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/discovery/file"
 )
 
 func init() {

--- a/cmd/epp/runner/resolve_discovery_test.go
+++ b/cmd/epp/runner/resolve_discovery_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -52,7 +53,7 @@ func TestResolveDiscovery_FileDiscovery(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	params, _ := json.Marshal(map[string]any{"path": f.Name()})
-	p, err := discoveryfile.Factory("my-disc", params, nil)
+	p, err := discoveryfile.Factory("my-disc", json.NewDecoder(bytes.NewReader(params)), nil)
 	require.NoError(t, err)
 
 	r := &Runner{PluginHandle: newHandleWithPlugin(t, "my-disc", p)}

--- a/cmd/epp/runner/resolve_discovery_test.go
+++ b/cmd/epp/runner/resolve_discovery_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runner
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -29,17 +30,17 @@ import (
 	discoveryfile "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/discovery/file"
 )
 
-func init() {
-	fwkplugin.Register(discoveryfile.PluginType, discoveryfile.Factory)
+func newHandleWithPlugin(t *testing.T, name string, p fwkplugin.Plugin) fwkplugin.Handle {
+	t.Helper()
+	h := fwkplugin.NewEppHandle(context.Background(), nil)
+	h.AddPlugin(name, p)
+	return h
 }
 
-func makeConfig(pluginName, pluginType string, params json.RawMessage, discoveryRef string) *configapi.EndpointPickerConfig {
+func discoveryConfigRef(ref string) *configapi.EndpointPickerConfig {
 	return &configapi.EndpointPickerConfig{
-		Plugins: []configapi.PluginSpec{
-			{Name: pluginName, Type: pluginType, Parameters: params},
-		},
 		DataLayer: &configapi.DataLayerConfig{
-			Discovery: &configapi.DiscoveryConfig{PluginRef: discoveryRef},
+			Discovery: &configapi.DiscoveryConfig{PluginRef: ref},
 		},
 	}
 }
@@ -51,10 +52,11 @@ func TestResolveDiscovery_FileDiscovery(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	params, _ := json.Marshal(map[string]any{"path": f.Name()})
-	cfg := makeConfig("my-disc", discoveryfile.PluginType, params, "my-disc")
+	p, err := discoveryfile.Factory("my-disc", params, nil)
+	require.NoError(t, err)
 
-	r := &Runner{}
-	disc, err := r.resolveDiscovery(cfg)
+	r := &Runner{PluginHandle: newHandleWithPlugin(t, "my-disc", p)}
+	disc, err := r.resolveDiscovery(discoveryConfigRef("my-disc"))
 	require.NoError(t, err)
 	assert.IsType(t, &discoveryfile.FileDiscovery{}, disc)
 	assert.Equal(t, discoveryfile.PluginType, disc.TypedName().Type)
@@ -62,35 +64,16 @@ func TestResolveDiscovery_FileDiscovery(t *testing.T) {
 }
 
 func TestResolveDiscovery_PluginRefNotFound(t *testing.T) {
-	cfg := &configapi.EndpointPickerConfig{
-		Plugins: []configapi.PluginSpec{
-			{Name: "other", Type: discoveryfile.PluginType},
-		},
-		DataLayer: &configapi.DataLayerConfig{
-			Discovery: &configapi.DiscoveryConfig{PluginRef: "nonexistent"},
-		},
-	}
-	r := &Runner{}
-	_, err := r.resolveDiscovery(cfg)
-	assert.ErrorContains(t, err, "no plugin found with name")
-}
-
-func TestResolveDiscovery_UnknownType(t *testing.T) {
-	cfg := makeConfig("my-disc", "unknown-type", nil, "my-disc")
-	r := &Runner{}
-	_, err := r.resolveDiscovery(cfg)
-	assert.ErrorContains(t, err, "unknown plugin type")
+	r := &Runner{PluginHandle: fwkplugin.NewEppHandle(context.Background(), nil)}
+	_, err := r.resolveDiscovery(discoveryConfigRef("nonexistent"))
+	assert.ErrorContains(t, err, "nonexistent")
 }
 
 func TestResolveDiscovery_NotEndpointDiscovery(t *testing.T) {
-	const notDiscType = "not-a-discovery"
-	fwkplugin.Register(notDiscType, func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
-		return &notDiscoveryPlugin{}, nil
-	})
-	cfg := makeConfig("not-disc", notDiscType, nil, "not-disc")
-	r := &Runner{}
-	_, err := r.resolveDiscovery(cfg)
-	assert.ErrorContains(t, err, "does not implement EndpointDiscovery")
+	r := &Runner{PluginHandle: newHandleWithPlugin(t, "not-disc", &notDiscoveryPlugin{})}
+	_, err := r.resolveDiscovery(discoveryConfigRef("not-disc"))
+	assert.ErrorContains(t, err, "not-disc")
+	assert.ErrorContains(t, err, "EndpointDiscovery")
 }
 
 type notDiscoveryPlugin struct{}

--- a/cmd/epp/runner/run_with_file_discovery_test.go
+++ b/cmd/epp/runner/run_with_file_discovery_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthPb "google.golang.org/grpc/health/grpc_health_v1"
+
+	runserver "github.com/llm-d/llm-d-router/pkg/epp/server"
+)
+
+// TestRunWithFileDiscovery_Smoke is a wiring test for the file-discovery path.
+// It does not exercise ext_proc routing; that lives in the integration test.
+// The asserts here guard against regressions in: (a) phaseTwo + resolveDiscovery
+// agreeing on a single plugin instance (the bug elevran caught), (b) the
+// RunnableGroup's Ready() gate firing once the plugin loads its initial file,
+// and (c) the health and ext_proc gRPC servers binding their ports.
+func TestRunWithFileDiscovery_Smoke(t *testing.T) {
+	dir := t.TempDir()
+	endpointsPath := filepath.Join(dir, "endpoints.yaml")
+	require.NoError(t, os.WriteFile(endpointsPath, []byte(
+		"endpoints:\n"+
+			"  - name: stub\n"+
+			"    address: 127.0.0.1\n"+
+			"    port: \"19999\"\n"), 0o644))
+
+	configText := fmt.Sprintf(`apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - name: file-discovery
+    type: file-discovery
+    parameters:
+      path: %q
+      watchFile: false
+  - name: random-picker
+    type: random-picker
+  - name: single-profile-handler
+    type: single-profile-handler
+  - name: metrics-source
+    type: metrics-data-source
+  - name: metrics-extractor
+    type: core-metrics-extractor
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: random-picker
+dataLayer:
+  injectDefaults: false
+  discovery:
+    pluginRef: file-discovery
+  sources:
+    - pluginRef: metrics-source
+      extractors:
+        - pluginRef: metrics-extractor
+`, endpointsPath)
+
+	grpcPort := freeTCPPort(t)
+	healthPort := freeTCPPort(t)
+	metricsPort := freeTCPPort(t)
+
+	opts := runserver.NewOptions()
+	opts.GRPCPort = grpcPort
+	opts.GRPCHealthPort = healthPort
+	opts.MetricsPort = metricsPort
+	opts.SecureServing = false
+	opts.HealthChecking = true
+	opts.EnablePprof = false
+	opts.PoolName = "test-pool"
+	opts.PoolNamespace = "test-ns"
+	opts.ConfigText = configText
+
+	r := NewRunner()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
+	require.NoError(t, err)
+	require.NotNil(t, rawConfig.DataLayer)
+	require.NotNil(t, rawConfig.DataLayer.Discovery)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- r.runWithFileDiscovery(ctx, opts, rawConfig) }()
+
+	// Health gRPC is gated on the discovery plugin's Ready() channel. Reaching
+	// SERVING proves: the plugin loaded ./endpoints.yaml, fired Ready, and the
+	// runnable group started both the health server and (separately) the ext_proc
+	// server. If phaseTwo and resolveDiscovery disagreed on the plugin instance,
+	// Start() would never run and this would time out.
+	healthAddr := fmt.Sprintf("127.0.0.1:%d", healthPort)
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case err := <-runErr:
+			t.Fatalf("runWithFileDiscovery exited before health came up: %v", err)
+		case <-deadline:
+			t.Fatal("timeout waiting for health gRPC to reach SERVING")
+		default:
+		}
+		if checkHealthServing(healthAddr) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// ext_proc port is bound (also gated on Ready).
+	extProcConn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", grpcPort), time.Second)
+	require.NoError(t, err, "ext_proc port should accept TCP connections")
+	_ = extProcConn.Close()
+
+	// Confirm the resolved discovery plugin matches the one the loader registered.
+	disc, err := r.resolveDiscovery(rawConfig)
+	require.NoError(t, err)
+	assert.Equal(t, "file-discovery", disc.TypedName().Type)
+	assert.Equal(t, "file-discovery", disc.TypedName().Name)
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("runWithFileDiscovery returned unexpected error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("runWithFileDiscovery did not return after context cancel")
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func checkHealthServing(addr string) bool {
+	cc, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return false
+	}
+	defer cc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	resp, err := healthPb.NewHealthClient(cc).Check(ctx, &healthPb.HealthCheckRequest{})
+	return err == nil && resp.GetStatus() == healthPb.HealthCheckResponse_SERVING
+}

--- a/cmd/epp/runner/rungroup.go
+++ b/cmd/epp/runner/rungroup.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// RunnableGroup collects named goroutines and starts them together under a
+// shared context. The first non-nil error cancels the group; Run returns that
+// error wrapped with the runnable name.
+type RunnableGroup interface {
+	Add(name string, fn func(ctx context.Context) error)
+	Run(ctx context.Context) error
+}
+
+func newRunnableGroup() RunnableGroup {
+	return &groupRunner{}
+}
+
+type namedFn struct {
+	name string
+	fn   func(ctx context.Context) error
+}
+
+type groupRunner struct {
+	fns []namedFn
+}
+
+func (g *groupRunner) Add(name string, fn func(ctx context.Context) error) {
+	g.fns = append(g.fns, namedFn{name: name, fn: fn})
+}
+
+func (g *groupRunner) Run(ctx context.Context) error {
+	eg, ectx := errgroup.WithContext(ctx)
+	for _, nf := range g.fns {
+		eg.Go(func() error {
+			if err := nf.fn(ectx); err != nil {
+				return fmt.Errorf("%s: %w", nf.name, err)
+			}
+			return nil
+		})
+	}
+	return eg.Wait()
+}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -158,6 +158,11 @@ type Runner struct {
 	parser               fwkrh.Parser
 	dlRuntime            *datalayer.Runtime
 	PluginHandle         fwkplugin.Handle
+	// rawConfig caches the result of parseConfigurationPhaseOne. Run() peeks at
+	// it to decide between K8s and file-discovery paths; setup() also parses
+	// the same config. Caching avoids re-reading the file, re-registering
+	// plugins/feature gates, and re-emitting the data-layer setup logs.
+	rawConfig *configapi.EndpointPickerConfig
 }
 
 // WithExecutableName sets the name of the executable containing the runner.
@@ -589,6 +594,10 @@ func (r *Runner) registerInTreePlugins() {
 }
 
 func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver.Options) (*configapi.EndpointPickerConfig, error) {
+	if r.rawConfig != nil {
+		return r.rawConfig, nil
+	}
+
 	logger := log.FromContext(ctx)
 
 	var configBytes []byte
@@ -627,6 +636,7 @@ func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver
 		setupLog.Info("Data layer: ENABLED (default)")
 	}
 
+	r.rawConfig = rawConfig
 	return rawConfig, nil
 }
 

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -158,10 +158,7 @@ type Runner struct {
 	parser               fwkrh.Parser
 	dlRuntime            *datalayer.Runtime
 	PluginHandle         fwkplugin.Handle
-	// rawConfig caches the result of parseConfigurationPhaseOne. Run() peeks at
-	// it to decide between K8s and file-discovery paths; setup() also parses
-	// the same config. Caching avoids re-reading the file, re-registering
-	// plugins/feature gates, and re-emitting the data-layer setup logs.
+	// rawConfig caches the result of parseConfigurationPhaseOne.
 	rawConfig *configapi.EndpointPickerConfig
 }
 
@@ -594,6 +591,11 @@ func (r *Runner) registerInTreePlugins() {
 }
 
 func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver.Options) (*configapi.EndpointPickerConfig, error) {
+	// parseConfigurationPhaseOne is idempotent: Run() calls it to decide
+	// between the K8s and file-discovery paths, and the K8s path's setup()
+	// then calls it a second time. Cache the parsed config so we don't
+	// re-read the file, re-register plugins/feature gates, or re-emit the
+	// data-layer setup logs.
 	if r.rawConfig != nil {
 		return r.rawConfig, nil
 	}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -975,10 +975,19 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	return g.Run(ctx)
 }
 
+// metricsShutdownTimeout bounds graceful shutdown of the metrics server so a
+// scraper holding a connection at process exit cannot block termination.
+const metricsShutdownTimeout = 5 * time.Second
+
 // serveMetrics starts a standalone Prometheus metrics HTTP server.
+//
+// EPP metrics are registered with controller-runtime's registry (see
+// pkg/epp/metrics.Register), not the prometheus default registry. The handler
+// must serve ctrlmetrics.Registry directly; promhttp.Handler() would expose only
+// Go runtime/process metrics and silently omit every EPP metric.
 func serveMetrics(ctx context.Context, port int, enablePprof bool) error {
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{EnableOpenMetrics: true}))
 	if enablePprof {
 		mux.HandleFunc("/debug/pprof/", nhpprof.Index)
 		mux.HandleFunc("/debug/pprof/cmdline", nhpprof.Cmdline)
@@ -995,7 +1004,9 @@ func serveMetrics(ctx context.Context, port int, enablePprof bool) error {
 	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
 	go func() {
 		<-ctx.Done()
-		_ = srv.Shutdown(context.Background())
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
 	}()
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("metrics server: %w", err)

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -822,33 +822,23 @@ func resolvePoolNamespace(poolNamespace string) string {
 	return runserver.DefaultPoolNamespace
 }
 
-// resolveDiscovery finds the plugin named by rawConfig.DataLayer.Discovery.PluginRef,
-// instantiates it via the registered factory, and returns it as an EndpointDiscovery.
+// resolveDiscovery returns the discovery plugin identified by
+// rawConfig.DataLayer.Discovery.PluginRef. The plugin is expected to have
+// already been instantiated and registered in r.PluginHandle by
+// parseConfigurationPhaseTwo; this function only looks it up and verifies its
+// type, so the loader-created instance (with its real Handle wired in) is the
+// one the runner drives.
 func (r *Runner) resolveDiscovery(rawConfig *configapi.EndpointPickerConfig) (fwkdl.EndpointDiscovery, error) {
 	ref := rawConfig.DataLayer.Discovery.PluginRef
-	for _, spec := range rawConfig.Plugins {
-		name := spec.Name
-		if name == "" {
-			name = spec.Type
-		}
-		if name != ref {
-			continue
-		}
-		factory, ok := fwkplugin.Registry[spec.Type]
-		if !ok {
-			return nil, fmt.Errorf("discovery: unknown plugin type %q for plugin %q", spec.Type, ref)
-		}
-		p, err := factory(name, spec.Parameters, nil)
-		if err != nil {
-			return nil, fmt.Errorf("discovery: failed to create plugin %q: %w", ref, err)
-		}
-		disc, ok := p.(fwkdl.EndpointDiscovery)
-		if !ok {
-			return nil, fmt.Errorf("discovery: plugin %q (type %q) does not implement EndpointDiscovery", ref, spec.Type)
-		}
-		return disc, nil
+	p := r.PluginHandle.Plugin(ref)
+	if p == nil {
+		return nil, fmt.Errorf("discovery: no plugin found with name %q", ref)
 	}
-	return nil, fmt.Errorf("discovery: no plugin found with name %q", ref)
+	disc, ok := p.(fwkdl.EndpointDiscovery)
+	if !ok {
+		return nil, fmt.Errorf("discovery: plugin %q does not implement EndpointDiscovery", ref)
+	}
+	return disc, nil
 }
 
 // runWithFileDiscovery handles the execution path when a discovery plugin is configured.

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -21,10 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	nhpprof "net/http/pprof"
 	"os"
 	"regexp"
-	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -1015,17 +1013,9 @@ func serveMetrics(ctx context.Context, port int, enablePprof bool) error {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{EnableOpenMetrics: true}))
 	if enablePprof {
-		mux.HandleFunc("/debug/pprof/", nhpprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", nhpprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", nhpprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", nhpprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", nhpprof.Trace)
-		mux.Handle("/debug/pprof/goroutine", nhpprof.Handler("goroutine"))
-		mux.Handle("/debug/pprof/heap", nhpprof.Handler("heap"))
-		mux.Handle("/debug/pprof/allocs", nhpprof.Handler("allocs"))
-		mux.Handle("/debug/pprof/threadcreate", nhpprof.Handler("threadcreate"))
-		mux.Handle("/debug/pprof/block", nhpprof.Handler("block"))
-		runtime.SetBlockProfileRate(1)
+		for path, h := range profiling.PprofHandlers() {
+			mux.Handle(path, h)
+		}
 	}
 	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
 	go func() {

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -873,6 +873,20 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	pool := datalayer.NewEndpointPool(namespace, poolName)
 	ds := datastore.NewDatastore(ctx, epf, int32(opts.ModelServerMetricsPort)).WithEndpointPool(pool)
 
+	// On bare metal / Slurm / Ray (or any deployment without the K8s Downward
+	// API), neither --pool-namespace nor the NAMESPACE env var is set, so the
+	// pool ends up labeled with the literal "default" -- a Kubernetes-flavored
+	// string that is meaningless outside K8s. Behavior is unaffected; only
+	// metrics labels and log fields look wrong. Warn so operators set
+	// --pool-namespace explicitly for their environment.
+	if opts.PoolNamespace == "" && os.Getenv("NAMESPACE") == "" {
+		setupLog.Info("file-discovery mode: pool namespace defaulted to "+
+			runserver.DefaultPoolNamespace+"; pass --pool-namespace to label "+
+			"metrics and logs for your environment",
+			"namespace", runserver.DefaultPoolNamespace)
+	}
+
+
 	// File mode runs without a controller manager, so several Kubernetes-only
 	// features are inactive: the InferenceModelRewrite and InferenceObjective
 	// reconcilers never start, and any "k8s-notification-source" plugin in the

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -21,13 +21,16 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	nhpprof "net/http/pprof"
 	"os"
 	"regexp"
+	"runtime"
 	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
@@ -63,6 +66,7 @@ import (
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	discoveryfile "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/discovery/file"
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
@@ -212,6 +216,17 @@ func (r *Runner) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to init tracing %w", err)
 		}
+	}
+
+	// If the config specifies a discovery plugin, take the file discovery path which
+	// does not require a Kubernetes cluster. Otherwise fall through to the K8s path.
+	rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
+	if err != nil {
+		setupLog.Error(err, "Failed to parse configuration")
+		return err
+	}
+	if rawConfig.DataLayer != nil && rawConfig.DataLayer.Discovery != nil {
+		return r.runWithFileDiscovery(ctx, opts, rawConfig)
 	}
 
 	// --- Get Kubernetes Config ---
@@ -569,6 +584,8 @@ func (r *Runner) registerInTreePlugins() {
 	// register saturation detector plugins
 	fwkplugin.Register(concurrency.ConcurrencyDetectorType, concurrency.ConcurrencyDetectorFactory)
 	fwkplugin.Register(utilization.UtilizationDetectorType, utilization.UtilizationDetectorFactory)
+	// register discovery plugins
+	fwkplugin.Register(discoveryfile.PluginType, discoveryfile.Factory)
 }
 
 func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver.Options) (*configapi.EndpointPickerConfig, error) {
@@ -793,4 +810,182 @@ func resolvePoolNamespace(poolNamespace string) string {
 		return nsEnv
 	}
 	return runserver.DefaultPoolNamespace
+}
+
+// resolveDiscovery finds the plugin named by rawConfig.DataLayer.Discovery.PluginRef,
+// instantiates it via the registered factory, and returns it as an EndpointDiscovery.
+func (r *Runner) resolveDiscovery(rawConfig *configapi.EndpointPickerConfig) (fwkdl.EndpointDiscovery, error) {
+	ref := rawConfig.DataLayer.Discovery.PluginRef
+	for _, spec := range rawConfig.Plugins {
+		name := spec.Name
+		if name == "" {
+			name = spec.Type
+		}
+		if name != ref {
+			continue
+		}
+		factory, ok := fwkplugin.Registry[spec.Type]
+		if !ok {
+			return nil, fmt.Errorf("discovery: unknown plugin type %q for plugin %q", spec.Type, ref)
+		}
+		p, err := factory(name, spec.Parameters, nil)
+		if err != nil {
+			return nil, fmt.Errorf("discovery: failed to create plugin %q: %w", ref, err)
+		}
+		disc, ok := p.(fwkdl.EndpointDiscovery)
+		if !ok {
+			return nil, fmt.Errorf("discovery: plugin %q (type %q) does not implement EndpointDiscovery", ref, spec.Type)
+		}
+		return disc, nil
+	}
+	return nil, fmt.Errorf("discovery: no plugin found with name %q", ref)
+}
+
+// runWithFileDiscovery handles the execution path when a discovery plugin is configured.
+// It builds the EPP server stack without a Kubernetes cluster or controller manager.
+func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Options, rawConfig *configapi.EndpointPickerConfig) error {
+	useNewMetrics := !r.featureGates[datalayer.EnableLegacyMetricsFeatureGate]
+
+	var pmc backendmetrics.PodMetricsClient
+	if !useNewMetrics {
+		var err error
+		pmc, err = backendmetrics.NewPodMetricsClientImpl(setupLog, backendmetrics.Config{
+			ModelServerMetricsScheme:        opts.ModelServerMetricsScheme,
+			ModelServerMetricsHTTPSInsecure: opts.ModelServerMetricsHTTPSInsecure,
+			ModelServerMetricsPath:          opts.ModelServerMetricsPath,
+			TotalQueuedRequestsMetric:       opts.TotalQueuedRequestsMetric,
+			TotalRunningRequestsMetric:      opts.TotalRunningRequestsMetric,
+			KVCacheUsagePercentageMetric:    opts.KVCacheUsagePercentageMetric,
+			LoRAInfoMetric:                  opts.LoRAInfoMetric,
+			CacheInfoMetric:                 opts.CacheInfoMetric,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	epf := r.setupMetricsCollection(useNewMetrics, opts, pmc)
+
+	namespace := resolvePoolNamespace(opts.PoolNamespace)
+	poolName := opts.PoolName
+	if poolName == "" {
+		poolName = "epp"
+	}
+	pool := datalayer.NewEndpointPool(namespace, poolName)
+	ds := datastore.NewDatastore(ctx, epf, int32(opts.ModelServerMetricsPort)).WithEndpointPool(pool)
+
+	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+	if err != nil {
+		setupLog.Error(err, "Failed to parse configuration")
+		return err
+	}
+
+	disc, err := r.resolveDiscovery(rawConfig)
+	if err != nil {
+		setupLog.Error(err, "Failed to resolve discovery plugin")
+		return err
+	}
+
+	disallowedExtractorType := ""
+	if !useNewMetrics {
+		disallowedExtractorType = extractormetrics.MetricsExtractorType
+	}
+	if err := r.dlRuntime.Configure(eppConfig.DataConfig, useNewMetrics, disallowedExtractorType, setupLog); err != nil {
+		return fmt.Errorf("failed to configure datalayer: %w", err)
+	}
+
+	if r.schedulerConfig == nil {
+		return errors.New("scheduler config must be set either by config api or through code")
+	}
+	setupLog.Info("parsed config", "scheduler-config", r.schedulerConfig)
+
+	scheduler := scheduling.NewSchedulerWithConfig(r.schedulerConfig)
+	endpointCandidates := requestcontrol.NewDatastoreEndpointCandidates(ds,
+		requestcontrol.WithDisableEndpointSubsetFilter(opts.DisableEndpointSubsetFilter))
+	admissionController := requestcontrol.NewLegacyAdmissionController(eppConfig.SaturationDetector, endpointCandidates)
+	director := requestcontrol.NewDirectorWithConfig(ds, scheduler, admissionController, endpointCandidates, r.requestControlConfig)
+
+	gknn := common.GKNN{
+		NamespacedName: types.NamespacedName{Name: poolName, Namespace: namespace},
+	}
+	serverRunner := &runserver.ExtProcServerRunner{
+		GrpcPort:                         opts.GRPCPort,
+		GKNN:                             gknn,
+		Datastore:                        ds,
+		ControllerCfg:                    runserver.NewControllerConfig(false),
+		SecureServing:                    opts.SecureServing,
+		HealthChecking:                   opts.HealthChecking,
+		CertPath:                         opts.CertPath,
+		EnableCertReload:                 opts.EnableCertReload,
+		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
+		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
+		Director:                         director,
+		Parser:                           r.parser,
+		SaturationDetector:               eppConfig.SaturationDetector,
+		UseExperimentalDatalayerV2:       useNewMetrics,
+	}
+
+	r.customCollectors = append(r.customCollectors, collectors.NewInferencePoolMetricsCollector(ds))
+	metrics.Register(r.customCollectors...)
+	metrics.RecordInferenceExtensionInfo(version.CommitSHA, version.BuildRef)
+
+	setupLog.Info("EPP starting (file discovery mode)",
+		"grpcPort", opts.GRPCPort,
+		"pool", poolName,
+		"namespace", namespace,
+		"discoveryPlugin", disc.TypedName())
+
+	isLeader := &atomic.Bool{}
+	isLeader.Store(true)
+
+	healthSrv := grpc.NewServer()
+	healthPb.RegisterHealthServer(healthSrv, &healthServer{
+		logger:                ctrl.Log.WithName("health"),
+		datastore:             ds,
+		isLeader:              isLeader,
+		leaderElectionEnabled: false,
+		supporter:             r.parser,
+	})
+
+	g := newRunnableGroup()
+	g.Add("discovery", func(ctx context.Context) error {
+		return disc.Start(ctx, fwkdl.NewDiscoveryNotifier(ds))
+	})
+	g.Add("epp-server", func(ctx context.Context) error {
+		return serverRunner.AsRunnable(ctrl.Log.WithName("ext-proc")).Start(ctx)
+	})
+	g.Add("health", func(ctx context.Context) error {
+		return runnable.NoLeaderElection(runnable.GRPCServer("health", healthSrv, opts.GRPCHealthPort)).Start(ctx)
+	})
+	g.Add("metrics", func(ctx context.Context) error {
+		return serveMetrics(ctx, opts.MetricsPort, opts.EnablePprof)
+	})
+	return g.Run(ctx)
+}
+
+// serveMetrics starts a standalone Prometheus metrics HTTP server.
+func serveMetrics(ctx context.Context, port int, enablePprof bool) error {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	if enablePprof {
+		mux.HandleFunc("/debug/pprof/", nhpprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", nhpprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", nhpprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", nhpprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", nhpprof.Trace)
+		mux.Handle("/debug/pprof/goroutine", nhpprof.Handler("goroutine"))
+		mux.Handle("/debug/pprof/heap", nhpprof.Handler("heap"))
+		mux.Handle("/debug/pprof/allocs", nhpprof.Handler("allocs"))
+		mux.Handle("/debug/pprof/threadcreate", nhpprof.Handler("threadcreate"))
+		mux.Handle("/debug/pprof/block", nhpprof.Handler("block"))
+		runtime.SetBlockProfileRate(1)
+	}
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background())
+	}()
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("metrics server: %w", err)
+	}
+	return nil
 }

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -896,7 +896,6 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 			"namespace", runserver.DefaultPoolNamespace)
 	}
 
-
 	// File mode runs without a controller manager, so several Kubernetes-only
 	// features are inactive: the InferenceModelRewrite and InferenceObjective
 	// reconcilers never start, and any "k8s-notification-source" plugin in the

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -873,6 +873,17 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	pool := datalayer.NewEndpointPool(namespace, poolName)
 	ds := datastore.NewDatastore(ctx, epf, int32(opts.ModelServerMetricsPort)).WithEndpointPool(pool)
 
+	// File mode runs without a controller manager, so several Kubernetes-only
+	// features are inactive: the InferenceModelRewrite and InferenceObjective
+	// reconcilers never start, and any "k8s-notification-source" plugin in the
+	// data layer config silently fails to bind (Runtime.Start, which wires
+	// notification sources into the manager, is intentionally skipped below).
+	// Surface this once at startup so operators porting a K8s config see why
+	// related behavior differs.
+	setupLog.Info("file-discovery mode: Kubernetes-only features are inactive " +
+		"(InferenceModelRewrite, InferenceObjective, and any " +
+		"k8s-notification-source data layer plugins); see docs/discovery.md")
+
 	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
 	if err != nil {
 		setupLog.Error(err, "Failed to parse configuration")

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -950,10 +950,23 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	g.Add("discovery", func(ctx context.Context) error {
 		return disc.Start(ctx, fwkdl.NewDiscoveryNotifier(ds))
 	})
+	// epp-server and health wait for the discovery plugin's initial sync before
+	// going live, so requests and probes never observe an empty datastore. See
+	// EndpointDiscovery.Ready contract.
 	g.Add("epp-server", func(ctx context.Context) error {
+		select {
+		case <-disc.Ready():
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 		return serverRunner.AsRunnable(ctrl.Log.WithName("ext-proc")).Start(ctx)
 	})
 	g.Add("health", func(ctx context.Context) error {
+		select {
+		case <-disc.Ready():
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 		return runnable.NoLeaderElection(runnable.GRPCServer("health", healthSrv, opts.GRPCHealthPort)).Start(ctx)
 	})
 	g.Add("metrics", func(ctx context.Context) error {

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -1,0 +1,543 @@
+# Endpoint Discovery
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [The EndpointDiscovery Interface](#the-endpointdiscovery-interface)
+  - [EndpointDiscovery](#endpointdiscovery)
+  - [DiscoveryNotifier](#discoverynotifier)
+  - [Ordering contract](#ordering-contract)
+  - [Wiring to the datastore](#wiring-to-the-datastore)
+- [Selecting a discovery plugin in the EPP config](#selecting-a-discovery-plugin-in-the-epp-config)
+- [File Discovery plugin](#file-discovery-plugin)
+  - [Parameters](#parameters)
+  - [Endpoints file format](#endpoints-file-format)
+  - [Live reload](#live-reload)
+  - [Validation rules](#validation-rules)
+- [Running EPP with file discovery (no Kubernetes)](#running-epp-with-file-discovery-no-kubernetes)
+  - [What you need](#what-you-need)
+  - [1. Endpoints file](#1-endpoints-file)
+  - [2. EPP config](#2-epp-config)
+  - [3. Start the EPP](#3-start-the-epp)
+  - [4. Envoy config](#4-envoy-config)
+  - [5. Start Envoy](#5-start-envoy)
+- [Writing a custom discovery plugin](#writing-a-custom-discovery-plugin)
+
+---
+
+## Overview
+
+By default the EPP discovers inference endpoints by watching a Kubernetes
+`InferencePool` object and the pods it selects.  The **discovery plugin
+interface** replaces that mechanism with a pluggable alternative so the EPP
+can run in environments where Kubernetes is not available -- for example bare
+metal inference clusters, Slurm jobs, or local development.
+
+When a discovery plugin is configured:
+
+- The EPP **does not** call `ctrl.GetConfig()` or start a controller manager.
+- The EPP **does not** require an `InferencePool` CRD or any K8s RBAC.
+- The discovery plugin is solely responsible for populating the endpoint
+  datastore via `DiscoveryNotifier`.
+- All scheduling, request control, and metrics collection behaviour is
+  unchanged.
+
+---
+
+## Architecture
+
+```
+  Client request
+       |
+       v
+  +--------+          +------------------------------+
+  |  Envoy |--ext_proc-->        EPP (port 9002)      |
+  +--------+  gRPC    |                              |
+       |               |  Scheduler  |  Datastore    |
+       |               |             |   endpoints   |
+       |               |          ^  |               |
+       |               +----------|--+               |
+       |                          |
+       |               +----------+----------+
+       |               |   EndpointDiscovery  |
+       |               |   plugin             |
+       |               |                      |
+       |               |  (file-discovery)    |
+       |               |  reads endpoints.yaml|
+       |               |  calls Upsert/Delete |
+       |               +---------------------+
+       |
+       | x-gateway-destination-endpoint header set by EPP
+       v
+  selected inference endpoint (e.g. 10.0.0.1:8000)
+```
+
+The EPP sets the `x-gateway-destination-endpoint` header on the response to
+`ext_proc`.  Envoy's `ORIGINAL_DST` cluster reads that header and forwards
+the request to the chosen endpoint.
+
+---
+
+## The EndpointDiscovery Interface
+
+### EndpointDiscovery
+
+```go
+// pkg/epp/framework/interface/datalayer/discovery.go
+
+type EndpointDiscovery interface {
+    plugin.Plugin   // provides TypedName() TypedName
+
+    // Start begins discovery and blocks until ctx is cancelled or a fatal
+    // error occurs. It must be called in a dedicated goroutine.
+    //
+    // Implementations SHOULD enumerate all currently known endpoints via
+    // notifier.Upsert before entering the watch loop to avoid serving an
+    // empty datastore at startup.
+    Start(ctx context.Context, notifier DiscoveryNotifier) error
+}
+```
+
+### DiscoveryNotifier
+
+```go
+type DiscoveryNotifier interface {
+    // Upsert adds or updates an endpoint in the datastore.
+    Upsert(endpoint *EndpointMetadata)
+    // Delete removes an endpoint by its namespaced name.
+    Delete(id types.NamespacedName)
+}
+```
+
+`EndpointMetadata` fields relevant to discovery:
+
+| Field | Type | Description |
+|---|---|---|
+| `NamespacedName` | `types.NamespacedName` | Unique identity of the endpoint. |
+| `PodName` | `string` | Logical name (used in metrics). |
+| `Address` | `string` | IP address of the inference server. |
+| `Port` | `string` | Port as a string (e.g. `"8000"`). |
+| `MetricsHost` | `string` | `host:port` for metrics scraping. Defaults to `address:port` if empty. |
+| `Labels` | `map[string]string` | Arbitrary labels available to scheduler plugins. |
+
+### Ordering contract
+
+`DiscoveryNotifier` is **not goroutine-safe**.  All `Upsert` and `Delete`
+calls must be made sequentially from a single goroutine and in causal order.
+An `Upsert` followed by a `Delete` for the same endpoint must arrive in that
+order or the endpoint will be incorrectly left in the datastore.
+
+### Wiring to the datastore
+
+The runner creates a `DiscoveryNotifier` backed by the datastore and passes
+it to `EndpointDiscovery.Start`:
+
+```go
+disc.Start(ctx, fwkdl.NewDiscoveryNotifier(ds))
+```
+
+`NewDiscoveryNotifier` accepts any value that implements
+`DiscoveryBackendStore` (i.e. has `BackendUpsert` and `BackendDelete`),
+which the production `Datastore` satisfies.
+
+---
+
+## Selecting a discovery plugin in the EPP config
+
+Add a `discovery` section inside `dataLayer` in the `EndpointPickerConfig`.
+The `pluginRef` field names a plugin instance defined in the top-level
+`plugins` list.
+
+```yaml
+plugins:
+  - name: my-endpoints          # the name referenced by pluginRef below
+    type: file-discovery        # plugin type registered in the runner
+    parameters:
+      path: /etc/epp/endpoints.yaml
+      watchFile: true
+
+# ... other plugins (scorers, filters, etc.) ...
+
+dataLayer:
+  discovery:
+    pluginRef: my-endpoints     # must match a name in plugins above
+```
+
+When `dataLayer.discovery` is present the EPP skips the Kubernetes setup
+entirely.  When it is absent the EPP uses the default Kubernetes-based
+discovery (backwards compatible).
+
+---
+
+## File Discovery plugin
+
+**Plugin type:** `file-discovery`
+
+Reads a static YAML or JSON file that lists inference endpoints, calls
+`DiscoveryNotifier.Upsert` for each entry, and optionally watches the file
+for changes using `fsnotify`.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | string | yes | -- | Absolute or relative path to the endpoints file. |
+| `watchFile` | bool | no | `false` | Re-read the file and reconcile the datastore whenever the file is written or replaced. |
+
+### Endpoints file format
+
+The file may be YAML or JSON.  YAML is recommended for readability.
+
+```yaml
+endpoints:
+  - name: <string>              # required -- unique within the file
+    namespace: <string>         # optional -- defaults to "default"
+    address: <IPv4 or IPv6>     # required -- must be a valid IP address
+    port: <string>              # required -- integer 1-65535 as a string
+    metricsHost: <string>       # optional -- host:port for metrics scraping
+                                #            defaults to address:port
+    labels:                     # optional -- arbitrary key/value labels
+      <key>: <value>
+```
+
+Example with two vLLM instances:
+
+```yaml
+endpoints:
+  - name: vllm-0
+    address: "10.0.0.1"
+    port: "8000"
+    labels:
+      model: llama-3-8b
+
+  - name: vllm-1
+    address: "10.0.0.2"
+    port: "8000"
+    metricsHost: "10.0.0.2:9090"   # scrape metrics from a different port
+    labels:
+      model: llama-3-8b
+```
+
+Example with multi-rank (tensor-parallel) setup where each rank is a
+separate endpoint:
+
+```yaml
+endpoints:
+  - name: tp-rank-0
+    namespace: inference
+    address: "192.168.1.10"
+    port: "8000"
+    labels:
+      rank: "0"
+      job: tp-job-42
+
+  - name: tp-rank-1
+    namespace: inference
+    address: "192.168.1.11"
+    port: "8000"
+    labels:
+      rank: "1"
+      job: tp-job-42
+```
+
+**Constraints:**
+
+- `address` must parse as a valid IP address (`net.ParseIP`).
+- `port` must be a decimal integer in the range 1-65535.
+- The file must not exceed 1 MiB.
+- Duplicate names within the same namespace result in the last `Upsert`
+  winning (the file is processed top-to-bottom).
+
+### Live reload
+
+When `watchFile: true` the plugin watches the file via `fsnotify`.  On a
+`Write` or `Create` event it re-reads the file, upserts all current
+endpoints, and deletes any endpoint that was present in the previous load
+but is absent from the new file.  Reload errors are logged but do not
+terminate the plugin -- the datastore retains its previous state.
+
+Atomic file replacement (write to a temp file then rename) triggers a
+`Create` event and is handled correctly.
+
+### Validation rules
+
+The plugin fails at startup (before `Start` returns an error) if:
+
+- `path` parameter is missing or empty.
+- The file cannot be opened.
+- The file exceeds 1 MiB.
+- The YAML/JSON cannot be parsed.
+- Any endpoint has an invalid `address` or `port`.
+
+---
+
+## Running EPP with file discovery (no Kubernetes)
+
+This example runs the EPP alongside Envoy on a single machine with two
+vLLM processes.  No Kubernetes, no `InferencePool` CRD.
+
+```
+localhost:8080  <-- Envoy (user-facing)
+localhost:9002  <-- EPP gRPC (ext_proc)
+localhost:9003  <-- EPP health (gRPC)
+localhost:9090  <-- EPP Prometheus metrics
+
+10.0.0.1:8000   <-- vLLM instance 0
+10.0.0.2:8000   <-- vLLM instance 1
+```
+
+### What you need
+
+- `llm-d-inference-scheduler` binary built from this repo.
+- Envoy v1.31+ binary or Docker image.
+- vLLM (or a compatible inference server) running on the target addresses.
+
+### 1. Endpoints file
+
+Save as `/etc/epp/endpoints.yaml`:
+
+```yaml
+endpoints:
+  - name: vllm-0
+    address: "10.0.0.1"
+    port: "8000"
+
+  - name: vllm-1
+    address: "10.0.0.2"
+    port: "8000"
+```
+
+### 2. EPP config
+
+Save as `/etc/epp/config.yaml`.  This example uses the default KV-cache
+utilization scorer and random picker -- adapt scheduling plugins as needed.
+
+```yaml
+plugins:
+  - name: file-disc
+    type: file-discovery
+    parameters:
+      path: /etc/epp/endpoints.yaml
+      watchFile: true
+
+  - name: kv-cache-scorer
+    type: kv-cache-utilization-scorer
+
+  - name: random-picker
+    type: random-picker
+
+  - name: single-profile
+    type: single-profile-handler
+    parameters:
+      scorer: kv-cache-scorer
+      picker: random-picker
+
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: single-profile
+
+dataLayer:
+  discovery:
+    pluginRef: file-disc
+```
+
+### 3. Start the EPP
+
+```bash
+llm-d-inference-scheduler \
+  --pool-name epp \
+  --config-file /etc/epp/config.yaml \
+  --grpc-port 9002 \
+  --grpc-health-port 9003 \
+  --metrics-port 9090
+```
+
+`--pool-name` is required even in file discovery mode; it is used as the
+internal pool identifier in the scheduler and metrics.  The value is
+arbitrary -- it does not need to match any Kubernetes object.
+
+The EPP logs `EPP starting (file discovery mode)` on startup and emits a
+log line for each endpoint loaded from the file.
+
+### 4. Envoy config
+
+Save as `/etc/envoy/envoy.yaml`.  The key pieces are:
+
+- A listener on `0.0.0.0:8080` that applies the `ext_proc` filter.
+- The `ext_proc` filter pointing at the EPP on `localhost:9002`.
+- An `ORIGINAL_DST` cluster that reads the `x-gateway-destination-endpoint`
+  header written by the EPP and forwards to the chosen endpoint.
+
+```yaml
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 19000
+
+static_resources:
+  listeners:
+    - name: inference
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: inference
+                route_config:
+                  name: inference
+                  virtual_hosts:
+                    - name: inference
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: original_destination_cluster
+                            timeout: 600s
+                            idle_timeout: 600s
+                http_filters:
+                  - name: envoy.filters.http.ext_proc
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: epp
+                          authority: localhost:9002
+                        timeout: 10s
+                      processing_mode:
+                        request_header_mode: SEND
+                        response_header_mode: SEND
+                        request_body_mode: FULL_DUPLEX_STREAMED
+                        response_body_mode: FULL_DUPLEX_STREAMED
+                        request_trailer_mode: SEND
+                        response_trailer_mode: SEND
+                      message_timeout: 600s
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: epp
+      type: STATIC
+      connect_timeout: 86400s
+      lb_policy: LEAST_REQUEST
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: epp
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 9002
+
+    - name: original_destination_cluster
+      type: ORIGINAL_DST
+      connect_timeout: 600s
+      lb_policy: CLUSTER_PROVIDED
+      circuit_breakers:
+        thresholds:
+          - max_connections: 10000
+            max_pending_requests: 10000
+            max_requests: 10000
+      original_dst_lb_config:
+        use_http_header: true
+        http_header_name: x-gateway-destination-endpoint
+```
+
+### 5. Start Envoy
+
+```bash
+envoy -c /etc/envoy/envoy.yaml
+```
+
+Requests to `http://localhost:8080/v1/completions` are now routed through
+the EPP to one of the two vLLM instances.
+
+---
+
+## Writing a custom discovery plugin
+
+Implement `fwkdl.EndpointDiscovery` and register the factory with the
+runner's plugin registry.
+
+```go
+package myplugin
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+
+    "k8s.io/apimachinery/pkg/types"
+
+    fwkdl    "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/datalayer"
+    fwkplugin "github.com/llm-d/llm-d-inference-scheduler/pkg/epp/framework/interface/plugin"
+)
+
+const PluginType = "my-discovery"
+
+type MyDiscovery struct {
+    typedName fwkplugin.TypedName
+    // ... plugin state ...
+}
+
+var _ fwkdl.EndpointDiscovery = (*MyDiscovery)(nil)
+
+func Factory(name string, params json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+    if name == "" {
+        name = PluginType
+    }
+    return &MyDiscovery{
+        typedName: fwkplugin.TypedName{Type: PluginType, Name: name},
+    }, nil
+}
+
+func (d *MyDiscovery) TypedName() fwkplugin.TypedName { return d.typedName }
+
+func (d *MyDiscovery) Start(ctx context.Context, notifier fwkdl.DiscoveryNotifier) error {
+    // 1. Enumerate existing endpoints.
+    notifier.Upsert(&fwkdl.EndpointMetadata{
+        NamespacedName: types.NamespacedName{Name: "ep0", Namespace: "default"},
+        Address:        "10.0.0.1",
+        Port:           "8000",
+        MetricsHost:    "10.0.0.1:8000",
+    })
+
+    // 2. Watch for changes and call Upsert/Delete as endpoints come and go.
+    //    All calls must be from this goroutine (DiscoveryNotifier is not goroutine-safe).
+    <-ctx.Done()
+    return nil
+}
+```
+
+Register the factory in the runner before calling `Run`:
+
+```go
+fwkplugin.Register(myplugin.PluginType, myplugin.Factory)
+```
+
+Then reference it in the EPP config:
+
+```yaml
+plugins:
+  - name: my-disc
+    type: my-discovery
+    parameters: {}
+
+dataLayer:
+  discovery:
+    pluginRef: my-disc
+```

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -290,6 +290,32 @@ If you copy a Kubernetes EPP config into a file-discovery deployment, expect
 behavior tied to these features to differ. The runner emits a one-time log
 at startup naming these inactive features.
 
+### Pool namespace
+
+The pool namespace ends up in metrics labels, log fields, and the pool's
+`{namespace}/{name}` identity. The runner resolves it in this order:
+
+1. `--pool-namespace` flag, if set.
+2. `NAMESPACE` environment variable, if set (Kubernetes injects this via the
+   Downward API).
+3. The literal string `default`, as a last-resort fallback.
+
+In Kubernetes the second source is always populated, so the fallback is
+effectively unreachable. On bare metal, in Slurm, in Ray, or in any
+container without the Downward API, neither source is set and the pool is
+labeled `default` -- a Kubernetes-flavored string that is meaningless
+outside K8s. Pass `--pool-namespace` explicitly so labels reflect your
+environment:
+
+```
+llm-d-inference-scheduler \
+  --pool-name slurm-job-42 \
+  --pool-namespace slurm \
+  --config-file /etc/epp/config.yaml
+```
+
+The runner emits a startup warning when neither `--pool-namespace` nor
+`NAMESPACE` is set, naming the value it fell back to.
 
 ---
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -193,10 +193,8 @@ The file may be YAML or JSON.  YAML is recommended for readability.
 endpoints:
   - name: <string>              # required -- unique within the file
     namespace: <string>         # optional -- defaults to "default"
-    address: <IPv4 or IPv6>     # required -- must be a valid IP address
+    address: <IPv4>             # required -- must be a valid IPv4 address
     port: <string>              # required -- integer 1-65535 as a string
-    metricsHost: <string>       # optional -- host:port for metrics scraping
-                                #            defaults to address:port
     labels:                     # optional -- arbitrary key/value labels
       <key>: <value>
 ```
@@ -214,7 +212,6 @@ endpoints:
   - name: vllm-1
     address: "10.0.0.2"
     port: "8000"
-    metricsHost: "10.0.0.2:9090"   # scrape metrics from a different port
     labels:
       model: llama-3-8b
 ```
@@ -243,7 +240,7 @@ endpoints:
 
 **Constraints:**
 
-- `address` must parse as a valid IP address (`net.ParseIP`).
+- `address` must be a literal IPv4 address (IPv6 is not supported).
 - `port` must be a decimal integer in the range 1-65535.
 - The file must not exceed 1 MiB.
 - Duplicate names within the same namespace result in the last `Upsert`

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -270,6 +270,27 @@ The plugin fails at startup (before `Start` returns an error) if:
 - The YAML/JSON cannot be parsed.
 - Any endpoint has an invalid `address` or `port`.
 
+### Kubernetes-only features that do not run in file discovery mode
+
+File discovery starts the EPP without a controller manager, so any feature
+that depends on a Kubernetes API server is inactive:
+
+- **`InferenceModelRewrite`** (model name rewriting for traffic split or
+  canary). The reconciler is not started; `ds.ModelRewriteGet` returns nil
+  for every request. There is no file-mode equivalent today.
+- **`InferenceObjective`** (per-request SLO objectives). The reconciler is
+  not started; objective lookups return nil. Plugins that depend on
+  per-request SLO data will see no objectives configured.
+- **`k8s-notification-source` data layer plugin** (and any other notification
+  source that needs the controller manager). The plugin loads from config
+  but is never bound to a manager, so it produces no events. Remove it from
+  `dataLayer.sources` when running in file discovery mode.
+
+If you copy a Kubernetes EPP config into a file-discovery deployment, expect
+behavior tied to these features to differ. The runner emits a one-time log
+at startup naming these inactive features.
+
+
 ---
 
 ## Running EPP with file discovery (no Kubernetes)

--- a/pkg/common/observability/profiling/pprof.go
+++ b/pkg/common/observability/profiling/pprof.go
@@ -24,38 +24,35 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// setupPprofHandlers only implements the pre-defined profiles:
-// https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/runtime/pprof/pprof.go;l=108
-func SetupPprofHandlers(mgr ctrl.Manager) error {
-	profiles := []string{
-		"heap",
-		"goroutine",
-		"allocs",
-		"threadcreate",
-		"block",
-		"mutex",
-	}
-	for _, p := range profiles {
-		if err := mgr.AddMetricsServerExtraHandler("/debug/pprof/"+p, pprof.Handler(p)); err != nil {
-			return err
-		}
-	}
-
-	handlerFuncs := map[string]http.HandlerFunc{
-		"/debug/pprof/":        pprof.Index,
-		"/debug/pprof/cmdline": pprof.Cmdline,
-		"/debug/pprof/profile": pprof.Profile,
-		"/debug/pprof/symbol":  pprof.Symbol,
-		"/debug/pprof/trace":   pprof.Trace,
-	}
-	for path, handler := range handlerFuncs {
-		if err := mgr.AddMetricsServerExtraHandler(path, handler); err != nil {
-			return err
-		}
-	}
-
+// PprofHandlers returns the pprof endpoints to mount on a metrics server,
+// keyed by URL path. The runtime block/mutex profile rates are turned on as a
+// side effect so the corresponding handlers return non-empty data; safe to
+// call once per process.
+func PprofHandlers() map[string]http.Handler {
 	runtime.SetMutexProfileFraction(1)
 	runtime.SetBlockProfileRate(1)
+	return map[string]http.Handler{
+		"/debug/pprof/":             http.HandlerFunc(pprof.Index),
+		"/debug/pprof/cmdline":      http.HandlerFunc(pprof.Cmdline),
+		"/debug/pprof/profile":      http.HandlerFunc(pprof.Profile),
+		"/debug/pprof/symbol":       http.HandlerFunc(pprof.Symbol),
+		"/debug/pprof/trace":        http.HandlerFunc(pprof.Trace),
+		"/debug/pprof/heap":         pprof.Handler("heap"),
+		"/debug/pprof/goroutine":    pprof.Handler("goroutine"),
+		"/debug/pprof/allocs":       pprof.Handler("allocs"),
+		"/debug/pprof/threadcreate": pprof.Handler("threadcreate"),
+		"/debug/pprof/block":        pprof.Handler("block"),
+		"/debug/pprof/mutex":        pprof.Handler("mutex"),
+	}
+}
 
+// SetupPprofHandlers registers the pprof endpoints on the controller-runtime
+// manager's metrics server.
+func SetupPprofHandlers(mgr ctrl.Manager) error {
+	for path, h := range PprofHandlers() {
+		if err := mgr.AddMetricsServerExtraHandler(path, h); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/epp/framework/interface/datalayer/discovery.go
+++ b/pkg/epp/framework/interface/datalayer/discovery.go
@@ -64,6 +64,21 @@ type EndpointDiscovery interface {
 	// through their watch mechanism (e.g. a Kubernetes list+watch) may fold the
 	// initial enumeration into the watch sequence instead.
 	Start(ctx context.Context, notifier DiscoveryNotifier) error
+
+	// Ready returns a channel that is closed once after the plugin has completed
+	// its initial reconciliation with the underlying source, regardless of how
+	// many endpoints that produced. Callers use it to gate request-serving
+	// components until the datastore has been populated for the first time.
+	//
+	// Contract:
+	//   - The channel is closed at most once per Start invocation.
+	//   - It is closed only after a successful initial sync. If Start returns
+	//     an error before that point, the channel remains open and callers
+	//     waiting on it should also observe ctx cancellation.
+	//   - "Initial sync" means whatever the plugin considers a complete first
+	//     pass (e.g. file load for FileDiscovery; first list+watch reconcile
+	//     for a Kubernetes plugin). Zero endpoints is a valid outcome.
+	Ready() <-chan struct{}
 }
 
 // DiscoveryNotifier is the callback through which EndpointDiscovery communicates

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"sync"
 
 	"github.com/fsnotify/fsnotify"
 	"k8s.io/apimachinery/pkg/types"
@@ -75,6 +76,9 @@ type FileDiscovery struct {
 	// zero-byte structs. Compared against the entries parsed during a
 	// reload to compute which endpoints to delete from the datastore.
 	endpoints map[types.NamespacedName]struct{}
+
+	ready     chan struct{}
+	readyOnce sync.Once
 }
 
 var _ fwkdl.EndpointDiscovery = (*FileDiscovery)(nil)
@@ -98,10 +102,15 @@ func Factory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplug
 		path:      p.Path,
 		watchFile: p.WatchFile,
 		endpoints: make(map[types.NamespacedName]struct{}),
+		ready:     make(chan struct{}),
 	}, nil
 }
 
 func (f *FileDiscovery) TypedName() fwkplugin.TypedName { return f.typedName }
+
+// Ready returns a channel closed after the first successful load of the
+// endpoints file. See EndpointDiscovery.Ready for the contract.
+func (f *FileDiscovery) Ready() <-chan struct{} { return f.ready }
 
 // Start loads the endpoints file, notifies the datastore, then optionally watches
 // for changes. Blocks until ctx is cancelled or a fatal error occurs.
@@ -111,6 +120,7 @@ func (f *FileDiscovery) Start(ctx context.Context, notifier fwkdl.DiscoveryNotif
 	if err := f.load(notifier); err != nil {
 		return fmt.Errorf("file-discovery: initial load failed: %w", err)
 	}
+	f.readyOnce.Do(func() { close(f.ready) })
 
 	if !f.watchFile {
 		<-ctx.Done()

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
@@ -73,7 +73,12 @@ func writeTemp(t *testing.T, content string) string {
 }
 
 func newFD(path string, watch bool) *FileDiscovery {
-	return &FileDiscovery{path: path, watchFile: watch, endpoints: make(map[types.NamespacedName]struct{})}
+	return &FileDiscovery{
+		path:      path,
+		watchFile: watch,
+		endpoints: make(map[types.NamespacedName]struct{}),
+		ready:     make(chan struct{}),
+	}
 }
 
 const validYAML = `
@@ -118,10 +123,32 @@ func TestStart_LoadsEndpoints(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	fd := newFD(path, false)
+	require.NoError(t, fd.Start(ctx, notifier))
 
 	assert.ElementsMatch(t, []string{"ns1/ep1", "default/ep2"}, notifier.upsertedNames())
 	assert.Empty(t, notifier.deleted)
+
+	select {
+	case <-fd.Ready():
+	default:
+		t.Fatal("Ready() channel should be closed after a successful initial load")
+	}
+}
+
+func TestReady_StaysOpenWhenInitialLoadFails(t *testing.T) {
+	fd := newFD("/nonexistent/endpoints.yaml", false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := fd.Start(ctx, &recordingNotifier{})
+	require.Error(t, err)
+
+	select {
+	case <-fd.Ready():
+		t.Fatal("Ready() must not be closed when initial load fails")
+	default:
+	}
 }
 
 func TestStart_DefaultNamespace(t *testing.T) {


### PR DESCRIPTION
 ## Summary
This is the last PR to enable FileDIscovery plugin in EPP, once merged this will **allow users to run EPP (and llm-d) without Kubernetes.** 

Wire the file-discovery plugin (#1135) into the runner so the EPP can run without a Kubernetes cluster. When dataLayer.discovery.pluginRef` is set, the runner skips controller-manager setup, runs discovery + servers under a `RunnableGroup`, gates request-serving on `EndpointDiscovery.Ready()`, and warns about K8s-only features that are inactive in this mode.

The K8s path is unchanged behavior-wise (one cleanup commit avoids a double-parse of the EPP config).

### Changes to the discoveryEndpoint interface 
One function   `EndpointDiscovery.Ready()` was added to the interface.

In K8s mode the controller-runtime manager waits for cache sync before the first reconcile; in file-discovery mode there is no manager. Without a synchronization point the runner would start the ext_proc server while discovery is still inside the initial file load, and early requests  would land on an empty datastore (503 / "no candidates").

`Ready()` returns a channel closed once after the plugin's first successful sync. The runner gates `epp-server` and `health` on it
(metrics is not gated, so `/metrics` is observable during a slow startup). On initial-load failure the channel stays open and the runnable group cancels via `ctx.Done()`.
