### PR TITLE
support mooncake conenctor in sidecar

### DIFF
--- a/pkg/sidecar/proxy/connector_mooncake.go
+++ b/pkg/sidecar/proxy/connector_mooncake.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/llm-d/llm-d-router/pkg/telemetry"
+)
+
+var mooncakeBootstrapPort int
+
+func init() {
+	mooncakeBootstrapPort = 8998
+
+	if portStr := os.Getenv("VLLM_MOONCAKE_BOOTSTRAP_PORT"); portStr != "" {
+		if port, err := strconv.Atoi(portStr); err == nil {
+			mooncakeBootstrapPort = port
+		}
+	}
+}
+
+func (s *Server) runMooncakeProtocol(w http.ResponseWriter, r *http.Request, prefillPodHostPort string, apiType APIType) {
+	tokenLimitFields := tokenLimitFieldsForAPIType(apiType)
+	s.logger.V(4).Info("running Mooncake protocol", "url", prefillPodHostPort, "tokenLimitFields", tokenLimitFields)
+
+	defer r.Body.Close() //nolint:errcheck
+	original, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error())) //nolint:errcheck
+		return
+	}
+
+	var completionRequest map[string]any
+	if err := json.Unmarshal(original, &completionRequest); err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	requestUUID, err := uuid.NewUUID()
+	if err != nil {
+		if err := errorBadGateway(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+	uuidStr := requestUUID.String()
+	transferID := "xfer-" + uuidStr
+
+	// Prefill Stage
+	tracer := telemetry.Tracer()
+	ctx := r.Context()
+
+	ctx, prefillSpan := tracer.Start(ctx, "llm_d.pd_proxy.prefill",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	prefillSpan.SetAttributes(
+		attribute.String("llm_d.pd_proxy.request_id", uuidStr),
+		attribute.String("llm_d.pd_proxy.prefill_target", prefillPodHostPort),
+		attribute.String("llm_d.pd_proxy.connector", "mooncake"),
+	)
+	prefillStart := time.Now()
+
+	preq := r.Clone(ctx)
+	preq.Header.Add(requestHeaderRequestID, uuidStr)
+
+	streamValue, streamOk := completionRequest[requestFieldStream]
+	streamOptionsValue, streamOptionsOk := completionRequest[requestFieldStreamOptions]
+
+	type savedField struct {
+		field   string
+		val     any
+		present bool
+	}
+	var savedTokenValues [2]savedField
+	for i, field := range tokenLimitFields {
+		if v, ok := completionRequest[field]; ok {
+			savedTokenValues[i] = savedField{field: field, val: v, present: true}
+		} else {
+			savedTokenValues[i] = savedField{field: field}
+		}
+	}
+
+	originalRequest := maps.Clone(completionRequest)
+
+	completionRequest[requestFieldKVTransferParams] = map[string]any{
+		requestFieldDoRemoteDecode:  true,
+		requestFieldDoRemotePrefill: false,
+		requestFieldTransferID:      transferID,
+	}
+
+	completionRequest[requestFieldStream] = false
+	delete(completionRequest, requestFieldStreamOptions)
+
+	for _, field := range tokenLimitFields {
+		completionRequest[field] = 1
+	}
+
+	pbody, err := json.Marshal(completionRequest)
+	if err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+	preq.Body = io.NopCloser(bytes.NewReader(pbody))
+	preq.ContentLength = int64(len(pbody))
+
+	prefillHandler, err := s.prefillerProxyHandler(prefillPodHostPort)
+	if err != nil {
+		if err := errorBadGateway(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	s.logger.V(4).Info("sending prefill request", "to", prefillPodHostPort)
+	s.logger.V(5).Info("Prefill request", "body", string(pbody))
+	pw := &bufferedResponseWriter{}
+	prefillHandler.ServeHTTP(pw, preq)
+
+	prefillDuration := time.Since(prefillStart)
+	prefillSpan.SetAttributes(
+		attribute.Int("llm_d.pd_proxy.prefill.status_code", pw.statusCode),
+		attribute.Float64("llm_d.pd_proxy.prefill.duration_ms", float64(prefillDuration.Milliseconds())),
+	)
+
+	if isHTTPError(pw.statusCode) {
+		s.logger.Error(err, "request failed", "code", pw.statusCode, "body", pw.buffer.String())
+		prefillSpan.SetStatus(codes.Error, "prefill request failed")
+		prefillSpan.End()
+
+		if shouldFallbackToDecode(pw) {
+			s.logger.Info("fallback to decode", "request_id", uuidStr)
+			fallbackReq := cloneRequestWithBody(r, original)
+			s.dispatchDecode(w, fallbackReq, originalRequest)
+		} else {
+			for key, values := range pw.Header() {
+				for _, v := range values {
+					w.Header().Add(key, v)
+				}
+			}
+			w.WriteHeader(pw.statusCode)
+			_, err := w.Write(pw.bodyBytes())
+			if err != nil {
+				s.logger.Error(err, "failed to send error response to client")
+			}
+		}
+		return
+	}
+	prefillSpan.End()
+
+	var prefillerResponse map[string]any
+	if err := json.Unmarshal(pw.bodyBytes(), &prefillerResponse); err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	pCachedTokens, hasPCachedTokens := extractCachedTokens(prefillerResponse)
+	if !hasPCachedTokens {
+		pCachedTokens = 0
+	}
+
+	// Bootstrap discovery: get engine_id for this prefiller
+	prefillHost := s.getBootstrapHost(prefillPodHostPort)
+	bootstrapAddr := fmt.Sprintf("http://%s:%d", prefillHost, mooncakeBootstrapPort)
+
+	engineID, err := s.getMooncakeEngineID(prefillHost, bootstrapAddr)
+	if err != nil {
+		s.logger.Error(err, "failed to discover mooncake engine_id", "bootstrapAddr", bootstrapAddr)
+		if err := errorBadGateway(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	s.logger.V(5).Info("mooncake bootstrap discovery complete",
+		"engineID", engineID,
+		"bootstrapAddr", bootstrapAddr,
+		"transferID", transferID,
+	)
+
+	// Decode Stage
+	ctx, decodeSpan := tracer.Start(ctx, "llm_d.pd_proxy.decode",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer decodeSpan.End()
+
+	decodeSpan.SetAttributes(
+		attribute.String("llm_d.pd_proxy.request_id", uuidStr),
+		attribute.String("llm_d.pd_proxy.connector", "mooncake"),
+	)
+	decodeStart := time.Now()
+
+	dreq := r.Clone(ctx)
+	dreq.Header.Add(requestHeaderRequestID, uuidStr)
+
+	delete(completionRequest, requestFieldStream)
+	streamingEnabled := false
+	if streamOk {
+		completionRequest[requestFieldStream] = streamValue
+		if streamBool, ok := streamValue.(bool); ok {
+			streamingEnabled = streamBool
+		}
+	}
+	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.streaming", streamingEnabled))
+	if streamOptionsOk {
+		completionRequest[requestFieldStreamOptions] = streamOptionsValue
+	}
+
+	for i := range savedTokenValues[:len(tokenLimitFields)] {
+		sv := &savedTokenValues[i]
+		delete(completionRequest, sv.field)
+		if sv.present {
+			completionRequest[sv.field] = sv.val
+		}
+	}
+
+	// Construct kv_transfer_params for decode (Mooncake does NOT pass through from prefill)
+	completionRequest[requestFieldKVTransferParams] = map[string]any{
+		requestFieldDoRemotePrefill:     true,
+		requestFieldDoRemoteDecode:      false,
+		requestFieldRemoteBootstrapAddr: bootstrapAddr,
+		requestFieldRemoteEngineID:      engineID,
+		requestFieldTransferID:          transferID,
+	}
+
+	dbody, err := json.Marshal(completionRequest)
+	if err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+	dreq.Body = io.NopCloser(bytes.NewReader(dbody))
+	dreq.ContentLength = int64(len(dbody))
+
+	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
+	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens)
+	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeWriter, dreq)
+	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
+
+	if !dataParallelUsed {
+		s.logger.V(4).Info("sending request to decoder", "to", s.config.DecoderURL.Host)
+		decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host))
+		s.dispatchDecode(decodeWriter, dreq, completionRequest)
+	}
+	if err := finalizeDecodeWriter(); err != nil {
+		s.logger.Error(err, "failed to flush cached token response writer")
+		decodeSpan.SetStatus(codes.Error, "failed to flush cached token response writer")
+		return
+	}
+
+	decodeDuration := time.Since(decodeStart)
+	decodeSpan.SetAttributes(attribute.Float64("llm_d.pd_proxy.decode.duration_ms", float64(decodeDuration.Milliseconds())))
+
+	if currentSpan := trace.SpanFromContext(ctx); currentSpan.SpanContext().IsValid() {
+		var totalDuration time.Duration
+		var trueTTFT time.Duration
+		if requestStartValue := ctx.Value(requestStartTimeKey); requestStartValue != nil {
+			if requestStart, ok := requestStartValue.(time.Time); ok {
+				totalDuration = time.Since(requestStart)
+				trueTTFT = decodeStart.Sub(requestStart)
+			}
+		}
+
+		coordinatorOverhead := decodeStart.Sub(prefillStart.Add(prefillDuration))
+
+		currentSpan.SetAttributes(
+			attribute.Float64("llm_d.pd_proxy.total_duration_ms", float64(totalDuration.Milliseconds())),
+			attribute.Float64("llm_d.pd_proxy.true_ttft_ms", float64(trueTTFT.Milliseconds())),
+			attribute.Float64("llm_d.pd_proxy.prefill_duration_ms", float64(prefillDuration.Milliseconds())),
+			attribute.Float64("llm_d.pd_proxy.decode_duration_ms", float64(decodeDuration.Milliseconds())),
+			attribute.Float64("llm_d.pd_proxy.coordinator_overhead_ms", float64(coordinatorOverhead.Milliseconds())),
+		)
+	}
+}
+
+// getMooncakeEngineID returns the engine_id for the given prefiller host,
+// querying the bootstrap server if not already cached.
+func (s *Server) getMooncakeEngineID(prefillHost, bootstrapAddr string) (string, error) {
+	if engineID, ok := s.mooncakeBootstrapCache.Get(prefillHost); ok {
+		return engineID, nil
+	}
+
+	queryURL := bootstrapAddr + "/query"
+	s.logger.V(4).Info("querying mooncake bootstrap server", "url", queryURL)
+
+	resp, err := http.Get(queryURL) //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("failed to query mooncake bootstrap server at %s: %w", queryURL, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("mooncake bootstrap server returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read bootstrap response: %w", err)
+	}
+
+	// Response format: {"0": {"engine_id": "...", "worker_addr": {...}}, ...}
+	var bootstrapResponse map[string]map[string]any
+	if err := json.Unmarshal(body, &bootstrapResponse); err != nil {
+		return "", fmt.Errorf("failed to parse bootstrap response: %w", err)
+	}
+
+	for _, dpEntry := range bootstrapResponse {
+		engineID, ok := dpEntry["engine_id"].(string)
+		if !ok || engineID == "" {
+			continue
+		}
+		s.mooncakeBootstrapCache.Add(prefillHost, engineID)
+		return engineID, nil
+	}
+
+	return "", fmt.Errorf("no engine_id found in bootstrap response from %s", queryURL)
+}

--- a/pkg/sidecar/proxy/connector_mooncake_test.go
+++ b/pkg/sidecar/proxy/connector_mooncake_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2" // nolint:revive
+	. "github.com/onsi/gomega"    // nolint:revive
+
+	"github.com/llm-d/llm-d-router/pkg/common/routing"
+	"github.com/llm-d/llm-d-router/test/sidecar/mock"
+)
+
+type mooncakeTestInfo struct {
+	sidecarTestInfo
+	bootstrapHandler *mock.MooncakeBootstrapHandler
+}
+
+func mooncakeTestSetup() *mooncakeTestInfo {
+	testInfo := &mooncakeTestInfo{}
+
+	testInfo.ctx = newTestContext()
+	testInfo.ctx, testInfo.cancelFn = context.WithCancel(testInfo.ctx)
+	testInfo.stoppedCh = make(chan struct{})
+
+	// Decoder
+	testInfo.decodeHandler = &mock.ChatCompletionHandler{
+		Connector: KVConnectorMooncake,
+		Role:      mock.RoleDecode,
+	}
+	testInfo.decodeBackend = httptest.NewServer(testInfo.decodeHandler)
+	DeferCleanup(testInfo.decodeBackend.Close)
+
+	// Prefiller with bootstrap /query endpoint
+	testInfo.prefillHandler = &mock.ChatCompletionHandler{
+		Connector: KVConnectorMooncake,
+		Role:      mock.RolePrefill,
+	}
+	testInfo.bootstrapHandler = &mock.MooncakeBootstrapHandler{}
+	mux := mock.NewMooncakePrefillMux(testInfo.prefillHandler, testInfo.bootstrapHandler)
+	testInfo.prefillBackend = httptest.NewServer(mux)
+	DeferCleanup(testInfo.prefillBackend.Close)
+
+	// Set bootstrap port to match the test server's port
+	prefillURL, err := url.Parse(testInfo.prefillBackend.URL)
+	Expect(err).ToNot(HaveOccurred())
+	mooncakeBootstrapPort, err = parsePort(prefillURL.Port())
+	Expect(err).ToNot(HaveOccurred())
+
+	// Proxy
+	decodeURL, err := url.Parse(testInfo.decodeBackend.URL)
+	Expect(err).ToNot(HaveOccurred())
+	testInfo.decodeURL = decodeURL
+	cfg := Config{Port: "0", DecoderURL: testInfo.decodeURL, KVConnector: KVConnectorMooncake}
+	testInfo.proxy = NewProxy(cfg)
+
+	return testInfo
+}
+
+func parsePort(portStr string) (int, error) {
+	i, err := json.Number(portStr).Int64()
+	if err != nil {
+		return 0, err
+	}
+	return int(i), nil
+}
+
+var _ = Describe("Mooncake Connector", func() {
+
+	var testInfo *mooncakeTestInfo
+
+	BeforeEach(func() {
+		testInfo = mooncakeTestSetup()
+	})
+
+	startProxy := func() string {
+		go func() {
+			defer GinkgoRecover()
+
+			testInfo.proxy.allowlistValidator = &AllowlistValidator{enabled: false}
+			err := testInfo.proxy.Start(testInfo.ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			testInfo.stoppedCh <- struct{}{}
+		}()
+
+		<-testInfo.proxy.readyCh
+		DeferCleanup(func() {
+			testInfo.cancelFn()
+			<-testInfo.stoppedCh
+		})
+
+		return "http://" + testInfo.proxy.addr.String()
+	}
+
+	sendChatCompletionsRequest := func(proxyBaseAddr string) map[string]any {
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(chatCompletionsRequestBody)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+
+		responseBody, err := io.ReadAll(rp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rp.StatusCode).To(Equal(http.StatusOK), string(responseBody))
+
+		var response map[string]any
+		Expect(json.Unmarshal(responseBody, &response)).To(Succeed())
+		return response
+	}
+
+	sendStreamingChatCompletionsRequest := func(proxyBaseAddr string) string {
+		body := `{
+				"model": "Qwen/Qwen2-0.5B",
+				"messages": [
+				  {"role": "user", "content": "Hello"}
+				],
+				"max_tokens": 50,
+				"stream": true,
+				"stream_options": {"include_usage": true}
+			}`
+
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+
+		responseBody, err := io.ReadAll(rp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rp.StatusCode).To(Equal(http.StatusOK), string(responseBody))
+		Expect(rp.Header.Get("Content-Type")).To(ContainSubstring(eventStreamContentType))
+		return string(responseBody)
+	}
+
+	cachedTokensFromResponse := func(response map[string]any) float64 {
+		usage, ok := response["usage"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		details, ok := usage["prompt_tokens_details"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		cachedTokens, ok := details["cached_tokens"].(float64)
+		Expect(ok).To(BeTrue())
+		return cachedTokens
+	}
+
+	It("should send prefill with transfer_id and construct decode kv_transfer_params", func() {
+		proxyBaseAddr := startProxy()
+
+		By("sending a /v1/chat/completions request with prefill header")
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(chatCompletionsRequestBody)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if rp.StatusCode != 200 {
+			bp, _ := io.ReadAll(rp.Body) //nolint:errcheck
+			Fail(string(bp))
+		}
+
+		By("verifying prefill request has correct kv_transfer_params")
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		Expect(testInfo.prefillHandler.CompletionRequests).To(HaveLen(1))
+		prefillReq := testInfo.prefillHandler.CompletionRequests[0]
+
+		Expect(prefillReq).To(HaveKey(requestFieldKVTransferParams))
+		kvTransferParams, ok := prefillReq[requestFieldKVTransferParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+
+		Expect(kvTransferParams).To(HaveKeyWithValue(requestFieldDoRemoteDecode, true))
+		Expect(kvTransferParams).To(HaveKeyWithValue(requestFieldDoRemotePrefill, false))
+		Expect(kvTransferParams).To(HaveKey(requestFieldTransferID))
+		transferID, ok := kvTransferParams[requestFieldTransferID].(string)
+		Expect(ok).To(BeTrue())
+		Expect(transferID).To(HavePrefix("xfer-"))
+
+		// Mooncake prefill should NOT have remote_block_ids, remote_host, remote_port
+		Expect(kvTransferParams).ToNot(HaveKey(requestFieldRemoteBlockIDs))
+		Expect(kvTransferParams).ToNot(HaveKey(requestFieldRemoteHost))
+		Expect(kvTransferParams).ToNot(HaveKey(requestFieldRemotePort))
+
+		Expect(prefillReq).To(HaveKeyWithValue("max_tokens", BeNumerically("==", 1)))
+		Expect(prefillReq).To(HaveKeyWithValue("stream", false))
+		Expect(prefillReq).ToNot(HaveKey("stream_options"))
+
+		By("verifying decode request has sidecar-constructed kv_transfer_params")
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		Expect(testInfo.decodeHandler.CompletionRequests).To(HaveLen(1))
+		decodeReq := testInfo.decodeHandler.CompletionRequests[0]
+
+		Expect(decodeReq).To(HaveKey(requestFieldKVTransferParams))
+		decodeKVParams, ok := decodeReq[requestFieldKVTransferParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+
+		Expect(decodeKVParams).To(HaveKeyWithValue(requestFieldDoRemotePrefill, true))
+		Expect(decodeKVParams).To(HaveKeyWithValue(requestFieldDoRemoteDecode, false))
+		Expect(decodeKVParams).To(HaveKeyWithValue(requestFieldRemoteEngineID, mock.TestMooncakeEngineID))
+		Expect(decodeKVParams).To(HaveKey(requestFieldRemoteBootstrapAddr))
+		Expect(decodeKVParams).To(HaveKeyWithValue(requestFieldTransferID, transferID))
+
+		// Verify bootstrap addr format
+		bootstrapAddr, ok := decodeKVParams[requestFieldRemoteBootstrapAddr].(string)
+		Expect(ok).To(BeTrue())
+		Expect(bootstrapAddr).To(HavePrefix("http://"))
+
+		By("verifying bootstrap server was queried")
+		Expect(testInfo.bootstrapHandler.QueryCount.Load()).To(BeNumerically("==", 1))
+	})
+
+	It("should propagate prefiller cached tokens to decode response", func() {
+		proxyBaseAddr := startProxy()
+
+		response := sendChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 7))
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+	})
+
+	It("should add prefiller cached tokens when decoder usage details omit cached_tokens", func() {
+		testInfo.decodeHandler.RawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{}}}`
+		proxyBaseAddr := startProxy()
+
+		response := sendChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(cachedTokensFromResponse(response)).To(BeNumerically("==", 7))
+	})
+
+	It("should cache bootstrap engine_id and query only once per prefiller host", func() {
+		proxyBaseAddr := startProxy()
+
+		By("sending first request")
+		sendChatCompletionsRequest(proxyBaseAddr)
+		Expect(testInfo.bootstrapHandler.QueryCount.Load()).To(BeNumerically("==", 1))
+
+		By("sending second request to same prefiller")
+		sendChatCompletionsRequest(proxyBaseAddr)
+		Expect(testInfo.bootstrapHandler.QueryCount.Load()).To(BeNumerically("==", 1))
+
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 2))
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 2))
+	})
+
+	It("should replace cached tokens in streamed usage chunks", func() {
+		testInfo.decodeHandler.RawResponseType = eventStreamContentType
+		testInfo.decodeHandler.RawResponse = "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":64,\"completion_tokens\":1,\"total_tokens\":65,\"prompt_tokens_details\":{\"cached_tokens\":49}}}\n\ndata: [DONE]\n"
+		proxyBaseAddr := startProxy()
+
+		responseBody := sendStreamingChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(responseBody).To(ContainSubstring(`"content":"hello"`))
+		Expect(responseBody).To(ContainSubstring(`"cached_tokens":7`))
+		Expect(responseBody).ToNot(ContainSubstring(`"cached_tokens":49`))
+		Expect(responseBody).To(ContainSubstring("data: [DONE]"))
+	})
+
+	It("should restore original max_tokens in decode request", func() {
+		proxyBaseAddr := startProxy()
+
+		sendChatCompletionsRequest(proxyBaseAddr)
+
+		Expect(testInfo.prefillHandler.CompletionRequests).To(HaveLen(1))
+		prefillReq := testInfo.prefillHandler.CompletionRequests[0]
+		Expect(prefillReq).To(HaveKeyWithValue("max_tokens", BeNumerically("==", 1)))
+
+		Expect(testInfo.decodeHandler.CompletionRequests).To(HaveLen(1))
+		decodeReq := testInfo.decodeHandler.CompletionRequests[0]
+		Expect(decodeReq).To(HaveKeyWithValue("max_tokens", BeNumerically("==", 50)))
+	})
+
+	// Responses API tests
+
+	It("should handle responses API request with mooncake connector", func() {
+		proxyBaseAddr := startProxy()
+
+		By("sending a /v1/responses request with prefill header")
+		//nolint:goconst
+		body := `{
+				"model": "gpt-4o",
+				"input": "Hello, how are you?",
+				"max_output_tokens": 50
+			}`
+
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ResponsesPath, strings.NewReader(body))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if rp.StatusCode != 200 {
+			bp, _ := io.ReadAll(rp.Body) //nolint:all
+			Fail(string(bp))
+		}
+
+		By("verifying prefill request has max_output_tokens=1")
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		prefillReq := testInfo.prefillHandler.CompletionRequests[0]
+		Expect(prefillReq).To(HaveKeyWithValue("max_output_tokens", BeNumerically("==", 1)))
+
+		By("verifying decode request has original max_output_tokens=50")
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		decodeReq := testInfo.decodeHandler.CompletionRequests[0]
+		Expect(decodeReq).To(HaveKeyWithValue("max_output_tokens", BeNumerically("==", 50)))
+
+		By("verifying decode has mooncake kv_transfer_params")
+		decodeKVParams, ok := decodeReq[requestFieldKVTransferParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(decodeKVParams).To(HaveKeyWithValue(requestFieldRemoteEngineID, mock.TestMooncakeEngineID))
+		Expect(decodeKVParams).To(HaveKey(requestFieldTransferID))
+		Expect(decodeKVParams).To(HaveKey(requestFieldRemoteBootstrapAddr))
+	})
+
+	It("should pass through responses API request when no prefill header is set", func() {
+		proxyBaseAddr := startProxy()
+
+		body := `{
+				"model": "gpt-4o",
+				"input": "Hello, how are you?",
+				"max_output_tokens": 50
+			}`
+
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ResponsesPath, strings.NewReader(body))
+		Expect(err).ToNot(HaveOccurred())
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if rp.StatusCode != 200 {
+			bp, _ := io.ReadAll(rp.Body) //nolint:all
+			Fail(string(bp))
+		}
+
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 0))
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+	})
+})

--- a/pkg/sidecar/proxy/connector_test.go
+++ b/pkg/sidecar/proxy/connector_test.go
@@ -44,7 +44,7 @@ type sidecarTestInfo struct {
 	proxy          *Server
 }
 
-var connectors = []string{KVConnectorSharedStorage, KVConnectorNIXLV2}
+var connectors = []string{KVConnectorSharedStorage, KVConnectorNIXLV2, KVConnectorMooncake}
 
 var _ = Describe("Common Connector tests", func() {
 
@@ -194,8 +194,23 @@ func sidecarConnectionTestSetup(connector string) *sidecarTestInfo {
 		Connector: connector,
 		Role:      mock.RolePrefill,
 	}
-	testInfo.prefillBackend = httptest.NewServer(testInfo.prefillHandler)
+
+	if connector == KVConnectorMooncake {
+		bootstrapHandler := &mock.MooncakeBootstrapHandler{}
+		mux := mock.NewMooncakePrefillMux(testInfo.prefillHandler, bootstrapHandler)
+		testInfo.prefillBackend = httptest.NewServer(mux)
+	} else {
+		testInfo.prefillBackend = httptest.NewServer(testInfo.prefillHandler)
+	}
 	DeferCleanup(testInfo.prefillBackend.Close)
+
+	if connector == KVConnectorMooncake {
+		prefillURL, err := url.Parse(testInfo.prefillBackend.URL)
+		Expect(err).ToNot(HaveOccurred())
+		port, err := parsePort(prefillURL.Port())
+		Expect(err).ToNot(HaveOccurred())
+		mooncakeBootstrapPort = port
+	}
 
 	// Proxy
 	url, err := url.Parse(testInfo.decodeBackend.URL)

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -144,6 +144,7 @@ var (
 		KVConnectorNIXLV2:        {},
 		KVConnectorSharedStorage: {},
 		KVConnectorSGLang:        {},
+		KVConnectorMooncake:      {},
 	}
 
 	// supportedECConnectors defines all valid E/P EC connector types
@@ -158,7 +159,7 @@ var (
 		encodeStage:  {},
 	}
 
-	supportedKVConnectorNamesStr = strings.Join([]string{KVConnectorNIXLV2, KVConnectorSharedStorage, KVConnectorSGLang}, ", ")
+	supportedKVConnectorNamesStr = strings.Join([]string{KVConnectorNIXLV2, KVConnectorSharedStorage, KVConnectorSGLang, KVConnectorMooncake}, ", ")
 	supportedECConnectorNamesStr = strings.Join([]string{ECExampleConnector}, ", ")
 	supportedTLSStageNamesStr    = strings.Join([]string{prefillStage, decodeStage, encodeStage}, ", ")
 )

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -68,6 +68,10 @@ const (
 	requestFieldBootstrapPort = "bootstrap_port"
 	requestFieldBootstrapRoom = "bootstrap_room"
 
+	// Mooncake fields
+	requestFieldTransferID          = "transfer_id"
+	requestFieldRemoteBootstrapAddr = "remote_bootstrap_addr"
+
 	// KVConnectorNIXLV2 enables the P/D KV NIXL v2 protocol
 	KVConnectorNIXLV2 = "nixlv2"
 
@@ -76,6 +80,9 @@ const (
 
 	// KVConnectorSGLang enables SGLang the P/D KV disaggregation protocol
 	KVConnectorSGLang = "sglang"
+
+	// KVConnectorMooncake enables the Mooncake P2P KV transfer protocol
+	KVConnectorMooncake = "mooncake"
 
 	// ECExampleConnector enables the Encoder disaggregation protocol (E/PD, E/P/D)
 	ECExampleConnector = "ec-example"
@@ -225,11 +232,12 @@ type Server struct {
 	prefillerURLPrefix      string
 	encoderURLPrefix        string
 
-	decoderProxy        http.Handler                     // decoder proxy handler
-	prefillerProxies    *lru.Cache[string, http.Handler] // cached prefiller proxy handlers
-	encoderProxies      *lru.Cache[string, http.Handler] // cached encoder proxy handlers
-	dataParallelProxies map[string]http.Handler          // Proxies to other vLLM servers
-	forwardDataParallel bool                             // Use special Data Parallel work around
+	decoderProxy           http.Handler                     // decoder proxy handler
+	prefillerProxies       *lru.Cache[string, http.Handler] // cached prefiller proxy handlers
+	encoderProxies         *lru.Cache[string, http.Handler] // cached encoder proxy handlers
+	mooncakeBootstrapCache *lru.Cache[string, string]       // cached prefiller host → engine_id
+	dataParallelProxies    map[string]http.Handler          // Proxies to other vLLM servers
+	forwardDataParallel    bool                             // Use special Data Parallel work around
 
 	prefillSamplerFn func(n int) int // allow test override
 
@@ -240,17 +248,19 @@ type Server struct {
 func NewProxy(config Config) *Server {
 	prefillerCache, _ := lru.New[string, http.Handler](1024) // nolint:errcheck
 	encoderCache, _ := lru.New[string, http.Handler](1024)   // nolint:errcheck
+	bootstrapCache, _ := lru.New[string, string](1024)       // nolint:errcheck
 
 	server := &Server{
-		readyCh:             make(chan struct{}),
-		prefillerProxies:    prefillerCache,
-		encoderProxies:      encoderCache,
-		prefillerURLPrefix:  "http://",
-		encoderURLPrefix:    "http://",
-		config:              config,
-		dataParallelProxies: map[string]http.Handler{},
-		forwardDataParallel: true,
-		prefillSamplerFn:    rand.IntN,
+		readyCh:                make(chan struct{}),
+		prefillerProxies:       prefillerCache,
+		encoderProxies:         encoderCache,
+		mooncakeBootstrapCache: bootstrapCache,
+		prefillerURLPrefix:     "http://",
+		encoderURLPrefix:       "http://",
+		config:                 config,
+		dataParallelProxies:    map[string]http.Handler{},
+		forwardDataParallel:    true,
+		prefillSamplerFn:       rand.IntN,
 	}
 
 	server.setKVConnector()
@@ -316,6 +326,7 @@ func (s *Server) Clone() *Server {
 		encoderURLPrefix:        s.encoderURLPrefix,
 		prefillerProxies:        s.prefillerProxies,
 		encoderProxies:          s.encoderProxies,
+		mooncakeBootstrapCache:  s.mooncakeBootstrapCache,
 		dataParallelProxies:     s.dataParallelProxies,
 		forwardDataParallel:     s.forwardDataParallel,
 		prefillSamplerFn:        s.prefillSamplerFn,
@@ -364,6 +375,8 @@ func (s *Server) setKVConnector() {
 		s.runPDConnectorProtocol = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
 			s.runSGLangProtocol(w, r, host)
 		}
+	case KVConnectorMooncake:
+		s.runPDConnectorProtocol = s.runMooncakeProtocol
 	case KVConnectorNIXLV2:
 		fallthrough
 	default:

--- a/test/sidecar/mock/chat_completions_handler.go
+++ b/test/sidecar/mock/chat_completions_handler.go
@@ -143,6 +143,43 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 		}
 
+	case "mooncake":
+		switch cc.Role {
+		case RoleDecode:
+			rawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":49}}}`
+		case RolePrefill:
+			kvTransferParams, ok := completionRequest["kv_transfer_params"]
+			if !ok || kvTransferParams == nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("expected kv_transfer_params:{...}")) //nolint:all
+				return
+			}
+			kvTransferParamsMap, ok := kvTransferParams.(map[string]any)
+			if !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("expected kv_transfer_params:{...}")) //nolint:all
+				return
+			}
+			if v, ok := kvTransferParamsMap["do_remote_decode"]; !ok || !v.(bool) {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("expected do_remote_decode:true")) //nolint:all
+				return
+			}
+			if v, ok := kvTransferParamsMap["do_remote_prefill"]; !ok || v.(bool) {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("expected do_remote_prefill:false")) //nolint:all
+				return
+			}
+			if _, ok := kvTransferParamsMap["transfer_id"]; !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("expected transfer_id to be present")) //nolint:all
+				return
+			}
+
+			// Mooncake prefiller does NOT return kv_transfer_params (returns None in vLLM)
+			rawResponse = `{"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{"cached_tokens":7}}}`
+		}
+
 	case "shared-storage":
 		// Shared Storage protocol just returns empty response
 		rawResponse = `{}`

--- a/test/sidecar/mock/mooncake_bootstrap_handler.go
+++ b/test/sidecar/mock/mooncake_bootstrap_handler.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mock
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+const (
+	// TestMooncakeEngineID is the engine_id returned by the mock bootstrap server.
+	TestMooncakeEngineID = "test-mooncake-engine-id-550e8400"
+)
+
+// MooncakeBootstrapHandler serves the /query endpoint that the Mooncake connector
+// uses to discover prefiller engine_ids.
+type MooncakeBootstrapHandler struct {
+	QueryCount atomic.Int32
+}
+
+func (h *MooncakeBootstrapHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	h.QueryCount.Add(1)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"0":{"engine_id":"` + TestMooncakeEngineID + `","worker_addr":{"0":{"0":"tcp://10.0.0.1:12345"}}}}`)) //nolint:all
+}
+
+// NewMooncakePrefillMux creates an http.ServeMux that routes /query to the
+// bootstrap handler and all other paths to the chat completion handler.
+func NewMooncakePrefillMux(completionHandler *ChatCompletionHandler, bootstrapHandler *MooncakeBootstrapHandler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/query", bootstrapHandler)
+	mux.Handle("/", completionHandler)
+	return mux
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Enable support for the mooncake connector.

Without the sidecar doing the P/D coordination, what happens is:

  1. The EPP picks a prefiller and a decoder, but the request goes directly to the decoder (port 8200) without any prefill stage and the sidecar just passes it through because there's no `x-prefiller-host-port` header it recognizes, or the old nixlv2 connector doesn't know how to construct mooncake's `kv_transfer_params`.
  2. So the decoder runs the both prefill and decode itself as if it were a standalone vLLM instance. You get a correct response, but you're not actually doing disaggregated P/D. The prefiller pods sit idle (or handle their own standalone requests).
  3. The kv_transfer_params: null in your curl response confirms this - no KV transfer happened. The decoder did all the work.

**Which issue(s) this PR fixes**:
Fixes #1220 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Adds alternative connector support for the routing sidecar mapping `MooncakeConenctor`'s KVTransferParams
```
cc @praveingk 