### PR TITLE
feat(epp): prefix EPP-managed headers with x-llm-d-

### DIFF
--- a/config/charts/standalone/values.yaml
+++ b/config/charts/standalone/values.yaml
@@ -217,7 +217,7 @@ inferenceExtension:
                           max_requests: 40000
                     original_dst_lb_config:
                       use_http_header: true
-                      http_header_name: x-gateway-destination-endpoint
+                      http_header_name: x-llm-d-gateway-destination-endpoint
                   - name: ext_proc
                     type: STATIC
                     connect_timeout: 86400s

--- a/deploy/environments/dev/e2e-infra/envoy.yaml
+++ b/deploy/environments/dev/e2e-infra/envoy.yaml
@@ -159,7 +159,7 @@ data:
                 max_requests: 40000
           original_dst_lb_config:
             use_http_header: true
-            http_header_name: x-gateway-destination-endpoint
+            http_header_name: x-llm-d-gateway-destination-endpoint
         - name: ext_proc
           type: STRICT_DNS
           connect_timeout: 86400s

--- a/pkg/epp/framework/common/request/headers_test.go
+++ b/pkg/epp/framework/common/request/headers_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func TestGetHeader(t *testing.T) {
-	headers := map[string]string{"X-SLO-TTFT-MS": "42", "Other": "x"}
-	assert.Equal(t, "42", GetHeader(headers, "X-SLO-TTFT-MS"))
-	assert.Equal(t, "42", GetHeader(headers, "x-slo-ttft-ms"))
+	headers := map[string]string{"X-LLM-D-SLO-TTFT-MS": "42", "Other": "x"}
+	assert.Equal(t, "42", GetHeader(headers, "X-LLM-D-SLO-TTFT-MS"))
+	assert.Equal(t, "42", GetHeader(headers, "x-llm-d-slo-ttft-ms"))
 	assert.Equal(t, "", GetHeader(headers, "missing"))
 	assert.Equal(t, "", GetHeader(nil, "k"))
 }

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/doc.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/doc.go
@@ -53,7 +53,7 @@ limitations under the License.
 //     This maximizes the number of requests served before their deadlines expire.
 //
 //   - SLO Deadline ("slo-deadline-ordering-policy"): Orders requests by an SLO-based (service level objective) deadline
-//     computed as ReceivedTimestamp + x-slo-ttft-ms header (interpreted as milliseconds).
+//     computed as ReceivedTimestamp + x-llm-d-slo-ttft-ms header (interpreted as milliseconds).
 //     Requests without a valid header are scheduled after SLO-bound requests.
 //     This maximizes the number of requests served before the deadlines computed on the defined SLO expire.
 package ordering

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/README.md
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/README.md
@@ -14,21 +14,21 @@ The SLO Deadline ordering policy selects requests based on a deadline derived fr
 ## What It Does
 
 The policy computes a deadline for each request as:
-`Deadline = ReceivedTimestamp + x-slo-ttft-ms`
+`Deadline = ReceivedTimestamp + x-llm-d-slo-ttft-ms`
 
 - **`ReceivedTimestamp`**: The time the request was received by the gateway.
-- **`x-slo-ttft-ms`**: A request header specifying the target Time-To-First-Token in milliseconds.
+- **`x-llm-d-slo-ttft-ms`**: A request header specifying the target Time-To-First-Token in milliseconds.
 
 ## Inputs consumed
 
 This policy inspects the following attributes of the request:
 - **ReceivedTimestamp**: The time the request was received by the gateway.
-- **`x-slo-ttft-ms` Header**: A header specifying the target Time-To-First-Token in milliseconds.
+- **`x-llm-d-slo-ttft-ms` Header**: A header specifying the target Time-To-First-Token in milliseconds.
 
 Requests are prioritized as follows:
 1. Requests with **earlier absolute deadlines** are dispatched first.
 2. If two requests have the same deadline, or if both lack a valid deadline, they are ordered by `ReceivedTimestamp` (FCFS).
-3. Requests without a valid `x-slo-ttft-ms` header (missing, empty, or invalid integer) are assigned a far-future deadline, placing them behind all SLO-bound requests.
+3. Requests without a valid `x-llm-d-slo-ttft-ms` header (missing, empty, or invalid integer) are assigned a far-future deadline, placing them behind all SLO-bound requests.
 
 ## Behavior and Queue Pairing
 
@@ -39,7 +39,7 @@ This policy **requires** specific queue capabilities to function correctly.
 
 ## Configuration
 
-This policy does not require any custom parameters in the flow control configuration itself, but it relies on the presence of the `x-slo-ttft-ms` header in incoming requests.
+This policy does not require any custom parameters in the flow control configuration itself, but it relies on the presence of the `x-llm-d-slo-ttft-ms` header in incoming requests.
 
 ```yaml
 orderingPolicyRef: slo-deadline-ordering-policy
@@ -47,7 +47,7 @@ orderingPolicyRef: slo-deadline-ordering-policy
 
 ## Trade-offs
 
-- **Header Dependency:** Requires clients or upstream components to correctly set the `x-slo-ttft-ms` header.
+- **Header Dependency:** Requires clients or upstream components to correctly set the `x-llm-d-slo-ttft-ms` header.
 - **Starvation Risk:** Non-SLO requests or requests with very loose SLOs may be starved if there is a constant influx of tight-SLO requests.
 - **Computational Overhead:** Similar to EDF, maintaining a priority heap incurs higher CPU overhead ($O(\log n)$) than a simple FIFO list.
 

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
@@ -39,7 +39,7 @@ const (
 	SLODeadlineOrderingPolicyType = "slo-deadline-ordering-policy"
 
 	// sloTtftHeader is the request header name for SLO time-to-first-token in milliseconds.
-	sloTtftHeader = "x-slo-ttft-ms"
+	sloTtftHeader = "x-llm-d-slo-ttft-ms"
 )
 
 func SLODeadlineOrderingPolicyFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
@@ -83,7 +83,7 @@ func (p *sloDeadlinePolicy) TypedName() plugin.TypedName {
 
 var sloMaxDeadlineTime = time.Unix(0, 1<<63-1)
 
-// calculateSLODeadline computes the SLO-based deadline for a request: ReceivedTimestamp + x-slo-ttft-ms (ms).
+// calculateSLODeadline computes the SLO-based deadline for a request: ReceivedTimestamp + x-llm-d-slo-ttft-ms (ms).
 // The header is read from the InferenceRequest()'s headers. If the header is missing, empty, or invalid,
 // the request is assigned a far-future deadline so it sorts after SLO-bound requests.
 func calculateSLODeadline(item flowcontrol.QueueItemAccessor) time.Time {

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -35,8 +35,8 @@ import (
 const (
 	LatencyAdmissionPluginType = "latency-slo-admitter"
 
-	ttftSLOHeaderKey = "x-slo-ttft-ms"
-	tpotSLOHeaderKey = "x-slo-tpot-ms"
+	ttftSLOHeaderKey = "x-llm-d-slo-ttft-ms"
+	tpotSLOHeaderKey = "x-llm-d-slo-tpot-ms"
 )
 
 // compile-time validation

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -50,9 +50,9 @@ const (
 	LatencyDataProviderPluginType = latencyproducerconstants.LatencyDataProviderPluginType
 
 	// TTFTSLOHeaderKey is the header key for the TTFT SLO.
-	TTFTSLOHeaderKey = "x-slo-ttft-ms"
+	TTFTSLOHeaderKey = "x-llm-d-slo-ttft-ms"
 	// TPOTSLOHeaderKey is the header key for the TPOT SLO.
-	TPOTSLOHeaderKey = "x-slo-tpot-ms"
+	TPOTSLOHeaderKey = "x-llm-d-slo-tpot-ms"
 
 	// ExperimentalDefaultPrefillProfile is the default profile name for prefill endpoints in disaggregated serving.
 	ExperimentalDefaultPrefillProfile = "prefill"

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -21,19 +21,19 @@ const (
 	SubsetFilterNamespace = "envoy.lb.subset_hint"
 	// SubsetFilterKey is the metadata key used by Envoy to specify an array candidate pods for serving the request.
 	// If not specified, all the pods that are associated with the pool are candidates.
-	SubsetFilterKey = "x-gateway-destination-endpoint-subset"
+	SubsetFilterKey = "x-llm-d-gateway-destination-endpoint-subset"
 	// DestinationEndpointNamespace is the key for the outer namespace struct in the metadata field of the extproc response that is used to wrap the target endpoint.
 	DestinationEndpointNamespace = "envoy.lb"
 	// DestinationEndpointKey is the header and response metadata key used by Envoy to route to the appropriate pod.
-	DestinationEndpointKey = "x-gateway-destination-endpoint"
+	DestinationEndpointKey = "x-llm-d-gateway-destination-endpoint"
 	// DestinationEndpointServedKey is the metadata key used by Envoy to specify the endpoint that served the request.
-	DestinationEndpointServedKey = "x-gateway-destination-endpoint-served"
+	DestinationEndpointServedKey = "x-llm-d-gateway-destination-endpoint-served"
 	// FlowFairnessIDKey is the header key used to pass the fairness ID to be used in Flow Control.
-	FlowFairnessIDKey = "x-gateway-inference-fairness-id"
+	FlowFairnessIDKey = "x-llm-d-gateway-inference-fairness-id"
 	// ObjectiveKey is the header key used to specify the objective of an incoming request.
-	ObjectiveKey = "x-gateway-inference-objective"
+	ObjectiveKey = "x-llm-d-gateway-inference-objective"
 	// ModelNameRewriteKey is the header key used to specify the model name to be used when the request is forwarded to the model server.
-	ModelNameRewriteKey = "x-gateway-model-name-rewrite"
+	ModelNameRewriteKey = "x-llm-d-gateway-model-name-rewrite"
 
 	// DefaultFairnessID is the default fairness ID used when no ID is provided in the request.
 	// This ensures that requests without explicit fairness identifiers are still grouped and managed by the Flow Control

--- a/pkg/epp/requestcontrol/candidates.go
+++ b/pkg/epp/requestcontrol/candidates.go
@@ -94,7 +94,7 @@ func NewDatastoreEndpointCandidates(ds Datastore, opts ...EndpointCandidatesOpti
 //
 // It supports:
 // 1. Returning all endpoint candidates if no specific subset filter is present.
-// 2. Returning a filtered list of endpoint candidates if "x-gateway-destination-endpoint-subset" is present.
+// 2. Returning a filtered list of endpoint candidates if "x-llm-d-gateway-destination-endpoint-subset" is present.
 func (d *DatastoreEndpointCandidates) Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)
 
@@ -254,7 +254,7 @@ func (c *CachedEndpointCandidates) Locate(ctx context.Context, requestMetadata m
 }
 
 // generateCacheKey creates a deterministic string key representing the endpoint selection criteria.
-// It handles the "x-gateway-destination-endpoint-subset" structure specifically.
+// It handles the "x-llm-d-gateway-destination-endpoint-subset" structure specifically.
 func (c *CachedEndpointCandidates) generateCacheKey(reqMetadata map[string]any) string {
 	// No Metadata -> All Endpoints
 	if reqMetadata == nil {

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -66,7 +66,7 @@ type Options struct {
 	//
 	EndpointSelector            string // Selector to filter model server pods on, only 'key=value' pairs are supported. (TODO: k8s.Selector, pflag.StringSlice?)
 	EndpointTargetPorts         []int  // Target ports of model server pods.
-	DisableEndpointSubsetFilter bool   // Disables respecting x-gateway-destination-endpoint-subset in EPP.
+	DisableEndpointSubsetFilter bool   // Disables respecting x-llm-d-gateway-destination-endpoint-subset in EPP.
 	//
 	// MSP metrics scraping.
 	//
@@ -153,7 +153,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntSliceVar(&opts.EndpointTargetPorts, "endpoint-target-ports", opts.EndpointTargetPorts, "Target ports of model server pods. "+
 		"Format: a comma-separated list of numbers without whitespace (e.g., '3000,3001,3002').")
 	fs.BoolVar(&opts.DisableEndpointSubsetFilter, "disable-endpoint-subset-filter", opts.DisableEndpointSubsetFilter,
-		"Disables respecting the x-gateway-destination-endpoint-subset metadata for dispatching requests in EPP.")
+		"Disables respecting the x-llm-d-gateway-destination-endpoint-subset metadata for dispatching requests in EPP.")
 	fs.StringVar(&opts.ModelServerMetricsScheme, "model-server-metrics-scheme", opts.ModelServerMetricsScheme,
 		"Protocol scheme used in scraping metrics from endpoints.")
 	_ = fs.MarkDeprecated("model-server-metrics-scheme", "This flag is deprecated. Configure via EndpointPickerConfig data layer plugin parameters instead.")

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -269,7 +269,7 @@ func GenerateStreamedRequestSet(
 func GenerateStreamedGRPCRequestSet(
 	logger logr.Logger,
 	prompt string,
-	inferenceObjective string, // Set to non-empty to set x-gateway-inference-objective value
+	inferenceObjective string, // Set to non-empty to set x-llm-d-gateway-inference-objective value
 	filterMetadata []string,
 	methodName string,
 ) []*extProcPb.ProcessingRequest {

--- a/test/testdata/envoy.yaml
+++ b/test/testdata/envoy.yaml
@@ -159,7 +159,7 @@ data:
                 max_requests: 40000
           original_dst_lb_config:
             use_http_header: true
-            http_header_name: x-gateway-destination-endpoint
+            http_header_name: x-llm-d-gateway-destination-endpoint
         - name: ext_proc
           type: STRICT_DNS
           connect_timeout: 86400s


### PR DESCRIPTION
## Summary

Prefixes all EPP-managed HTTP headers with `x-llm-d-` as per [llm-d#1506](https://github.com/llm-d/llm-d/issues/1506) review feedback from @ahg-g.

**Gateway headers** (`pkg/epp/metadata/consts.go`):
- `x-gateway-destination-endpoint-subset` → `x-llm-d-gateway-destination-endpoint-subset`
- `x-gateway-destination-endpoint` → `x-llm-d-gateway-destination-endpoint`
- `x-gateway-destination-endpoint-served` → `x-llm-d-gateway-destination-endpoint-served`
- `x-gateway-inference-fairness-id` → `x-llm-d-gateway-inference-fairness-id`
- `x-gateway-inference-objective` → `x-llm-d-gateway-inference-objective`
- `x-gateway-model-name-rewrite` → `x-llm-d-gateway-model-name-rewrite`

**SLO headers** (predicted-latency, latency-slo-admitter, slo-deadline-ordering plugins):
- `x-slo-ttft-ms` → `x-llm-d-slo-ttft-ms`
- `x-slo-tpot-ms` → `x-llm-d-slo-tpot-ms`

Also updates Envoy `original_dst` `http_header_name` configs, CLI help text, doc comments, and unit tests to match.

Companion docs PR: [llm-d#1514](https://github.com/llm-d/llm-d/pull/1514)

## Breaking change

Clients, ingress gateways, and any Envoy/Gateway configs that set or read these headers must use the new names. Deploy router and downstream configs together.

## Not changed

`x-gateway-inference-request-cost` is user configurable and hasn't been changed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Unit tests for touched packages (`metadata`, `predictedlatency`, `latencyslo`, `slodeadline`, `common/request`)
- [ ] `make test-unit` (CI)
- [ ] `make test-integration-hermetic` (CI)

Fixes llm-d/llm-d#1506