### PR TITLE
Fix Triton Routing Failure in Legacy Metrics Mode

### DIFF
--- a/config/charts/epplib/templates/_deployment.yaml
+++ b/config/charts/epplib/templates/_deployment.yaml
@@ -145,6 +145,13 @@ spec:
               - --lora-info-metric
               - "" # LoRA metrics are not supported by trtllm-serve.
           {{- end }}
+          {{- if eq $modelServerType "triton" }}
+              - --total-queued-requests-metric="nv_inference_pending_request_count"
+              - --total-running-requests-metric="nv_inference_exec_count"
+              - --kv-cache-usage-percentage-metric=""
+              - --cache-info-metric=""
+              - --lora-info-metric=""
+          {{- end }}
           {{- end }}
               - --zap-encoder
               - "json"


### PR DESCRIPTION
**What type of PR is this?**
 
/kind bug
 
 
**What this PR does / why we need it**:
 
The issue is triggered when a user deploys the application using the legacy metrics collection mode (latencyPredictor.enabled = false or enableLegacyMetrics = true) while specifically configuring the inference pool to use the standard triton model server type.

The EPP  fails to collect accurate load metrics (such as queued requests and running requests) from the Triton backends. Without accurate load data, the queue-scorer makes incorrect routing decisions, which can lead to severe request queuing, load imbalances across the backends, and potential performance degradation (hotspotting).


 Root Cause: 
The Helm template (config/charts/epplib/templates/_deployment.yaml) responsible for rendering the legacy metrics CLI arguments explicitly handled other engine types (like vllm, sglang, triton-tensorrt-llm, and trtllm-serve) but completely omitted the conditional block for the standard  triton type. 
Consequently, EPP defaulted to using vLLM metric names, which do not exist on a Triton server.

   * Fix Method: Added a missing conditional block ({{- if eq $modelServerType "triton" }}) in the _deployment.yaml template to explicitly map the total-queued-requests-metric and total-running-requests-metric parameters to their correct Triton native Prometheus metric names, aligning them with the existing internal data layer definitions.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
