### PR TITLE
docs: rename `inference scheduler` to `llm-d Router` and fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ assignees: ''
 
 **Environment**:
 - Kubernetes version (use `kubectl version`):
-- llm-d-scheduler version (use `git describe --tags --dirty --always` if you built from source, or specify the tag if you used a tagged version or image):
+- llm-d-router version (use `git describe --tags --dirty --always` if you built from source, or specify the tag if you used a tagged version or image):
 - Cloud provider or hardware configuration:
 - Install tools:
 - Others:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-Documentation for developing the inference scheduler.
+Documentation for developing the llm-d Router.
 
 ## Table of Contents
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# llm-d Inference Scheduler Architecture
+# llm-d Router Architecture
 
 ## Table of Contents
 
@@ -75,7 +75,7 @@ The design enables:
 
 ## Configuration
 
-The inference scheduler relies on a YAML-based configuration—provided either as a file or an in-line parameter—to determine which lifecycle hooks (plugins) are active.
+The llm-d EPP relies on a YAML-based configuration—provided either as a file or an in-line parameter—to determine which lifecycle hooks (plugins) are active.
 
 Specifically, this configuration establishes the following components:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ The design enables:
 
 ## Configuration
 
-The llm-d EPP relies on a YAML-based configuration—provided either as a file or an in-line parameter—to determine which lifecycle hooks (plugins) are active.
+The llm-d Endpoint Picker relies on a YAML-based configuration—provided either as a file or an in-line parameter—to determine which lifecycle hooks (plugins) are active.
 
 Specifically, this configuration establishes the following components:
 

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -215,7 +215,7 @@ sequenceDiagram
 
 ## Future Considerations
 
-- Cache coordinate (we can talk about 3 different types of cache: KV-cache, embeddings, and multimedia content)
+- Cache coordination (we can talk about 3 different types of cache: KV-cache, embeddings, and multimedia content)
 - Pre-allocation of kv blocks in the decode node, push cache from the prefill to the decode worker during calculation
 - More sophisticated encode worker selection (e.g., load-aware scheduling, cache content, locality-aware placement)
 

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the architecture and request lifecycle for enabling **disaggregated inference execution** in the llm-d router. llm-d supports multiple disaggregation topologies:
+This document describes the architecture and request lifecycle for enabling **disaggregated inference execution** in the llm-d Router. llm-d supports multiple disaggregation topologies:
 
 - **EPD** (no disaggregation) – a single node handles all three functions (encode, prefill, and decode). This is the default mode when no disaggregation is configured.
 - **P/D** (Prefill/Decode) – separates the prefill and decode stages onto different workers. This is functionally equivalent to EP/D, since prefill workers also handle encoding (multimodal processing) as part of the prefill stage.
@@ -215,7 +215,7 @@ sequenceDiagram
 
 ## Future Considerations
 
-- Cache coordinate (we can talk about 3 different types of cache: KV-cache, embeddings, and mumtimedia content)
+- Cache coordinate (we can talk about 3 different types of cache: KV-cache, embeddings, and multimedia content)
 - Pre-allocation of kv blocks in the decode node, push cache from the prefill to the decode worker during calculation
 - More sophisticated encode worker selection (e.g., load-aware scheduling, cache content, locality-aware placement)
 
@@ -223,7 +223,7 @@ sequenceDiagram
 
 ## Integrating External Prefill/Decode Workloads
 
-The llm-d inference scheduler supports integration with external disaggregated encode/prefill/decode (E/P/D) workloads or other inference frameworks that follow the same E/P/D separation pattern but use **different Kubernetes Pod labeling conventions**.
+The llm-d Router supports integration with external disaggregated encode/prefill/decode (E/P/D) workloads or other inference frameworks that follow the same E/P/D separation pattern but use **different Kubernetes Pod labeling conventions**.
 
 ### Labeling Convention Flexibility
 
@@ -519,6 +519,5 @@ Custom profile names (if your scheduling profiles are not named `decode`/`prefil
 - vLLM: [Disaggregated Prefill](https://docs.vllm.ai/en/latest/features/disagg_prefill/)
 - vLLM: [Encode Prefill Decode Disaggregation Design](https://docs.google.com/document/d/1aed8KtC6XkXtdoV87pWT0a8OJlZ-CpnuLLzmR8l9BAE/edit?tab=t.0#heading=h.9xkkijtnbbje)
 - vLLM: [Disaggregated Encoder](https://docs.vllm.ai/en/latest/features/disagg_encoder/)
-- vLLM: [[RFC]: Prototype Separating Vision Encoder to Its Own Worker](https://github.com/vllm-project/vllm/issues/20799)}
+- vLLM: [[RFC]: Prototype Separating Vision Encoder to Its Own Worker](https://github.com/vllm-project/vllm/issues/20799)
 - vLLM: [Encoder Disaggregation for Scalable Multimodal Model Serving](https://vllm.ai/blog/vllm-epd)
-

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,7 +6,7 @@ All metrics are in the `llm_d_inference_scheduler` subsystem.
 
 ## Scrape and see the metric
 
-Metrics defined in llm-d-scheduler are in addition to Inference Gateway metrics. For more details of seeing metrics, see the [metrics and observability section](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics-and-observability.md).
+Metrics defined by llm-d Router are in addition to Inference Gateway metrics. For more details of seeing metrics, see the [metrics and observability section](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics-and-observability.md).
 
 ## Metrics Details
 

--- a/docs/plugins-vs-builtins.md
+++ b/docs/plugins-vs-builtins.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 This document defines the distinction between **plugins** and **builtins** in the
-llm-d inference scheduler framework. Following these guidelines ensures a
+llm-d Router framework. Following these guidelines ensures a
 consistent architecture where users have clear control over what they can
 configure, and core runtime machinery remains reliable and non-optional.
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind cleanup
**What this PR does / why we need it**:
Rename all "inference scheduler" / "llm-d-scheduler" references to "llm-d Router" in bug report template and documentation
> Terminology Change: The Inference Scheduler has been renamed to llm-d Router; see [Terminology](https://github.com/llm-d/llm-d-router/blob/main/README.md#terminology).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
