### PR TITLE
Update simulator version to v0.9

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,8 +82,8 @@ Creates a new `kind` cluster (or reuses an existing one) in the `default` namesp
 > [!NOTE]
 > You can pre-pull external images to avoid slow downloads:
 > ```
-> docker pull ghcr.io/llm-d/llm-d-inference-sim:v0.8.2
-> docker pull ghcr.io/llm-d/llm-d-uds-tokenizer:dev
+> docker pull ghcr.io/llm-d/llm-d-inference-sim:v0.9.0
+> docker pull vllm/vllm-openai-cpu:v0.19.1
 > ```
 
 ### Accessing the Gateway
@@ -443,7 +443,7 @@ The `deploy/components/` directory contains all reusable Kustomize components:
 - `vllm-decode/` — Decode pod with routing sidecar
 
 **Deployment overlays** — applied on top of the base components:
-- `overlays/simulator/` — adds `--mode=${VLLM_SIM_MODE}`, UDS tokenizer sidecar, KV cache args, and `--zmq-endpoint` on Decode. Included by default in all dev scenario overlays.
+- `overlays/simulator/` — adds `--mode=${VLLM_SIM_MODE}`, vllm renderer sidecar, KV cache args, and `--zmq-endpoint` on Decode. Included by default in all dev scenario overlays.
 - `overlays/real-vllm/` — adds `--kv-events-config` on Decode, `--ec-transfer-config` on Encode, and a shared PVC for encoder embeddings.
 
 **Infrastructure components** — shared cluster infrastructure:
@@ -519,12 +519,12 @@ a shared PVC (`ec-cache-pvc`) for encoder embeddings transfer.
 
 | Component | What it adds | When to use |
 |---|---|---|
-| `overlays/simulator/` | `--mode=${VLLM_SIM_MODE}`, UDS tokenizer, KV cache args, `--zmq-endpoint` on Decode | Dev/test with simulator image |
+| `overlays/simulator/` | `--mode=${VLLM_SIM_MODE}`, vLLM renderer, KV cache args, `--zmq-endpoint` on Decode | Dev/test with simulator image |
 | `overlays/real-vllm/` | `--kv-events-config` on Decode (per-pod ZMQ publisher), `--ec-transfer-config` on Encode, ec-cache PVC | Production with real vLLM image |
 
 | Variable | Default | Description |
 |---|---|---|
-| `VLLM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.8.2` | vLLM container image to deploy. Can be a simulator or a real vLLM image (e.g., `vllm/vllm-openai:v0.16.0`). Defaults to the simulator image. |
+| `VLLM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.9.0` | vLLM container image to deploy. Can be a simulator or a real vLLM image (e.g., `vllm/vllm-openai:v0.16.0`). Defaults to the simulator image. |
 | `VLLM_SIM_MODE` | `echo` | Simulator response mode. `echo` returns the input prompt as the response (useful for routing validation). `random` returns random sentences from a pre-defined bank. Only applies when using the simulator overlay. |
 
 ### Cleanup
@@ -618,10 +618,10 @@ kubectl --context kind-e2e-tests get pods
 | `VLLM_EXTRA_ARGS_E` | _(empty)_ | Additional flags for the Encoder vLLM container (e.g. `--mm-processor-kwargs={}`) |
 | `VLLM_EXTRA_ARGS_P` | _(empty)_ | Additional flags for the Prefill vLLM container (e.g. `--gpu-memory-utilization=0.9`) |
 | `VLLM_EXTRA_ARGS_D` | _(empty)_ | Additional flags for the Decode vLLM container (e.g. `--tensor-parallel-size=2`) |
-| `VLLM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.8.2` | vLLM container image to deploy. Can be a simulator or a real vLLM image (e.g., `vllm/vllm-openai:v0.16.0`) |
+| `VLLM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.9.0` | vLLM container image to deploy. Can be a simulator or a real vLLM image (e.g., `vllm/vllm-openai:v0.16.0`) |
 | `VLLM_SIM_MODE` | `echo` | Simulator response mode. Supported values: `echo` (returns the input prompt as the response), `random` (returns a random sentence from a pre-defined bank) |
 | `SIDECAR_IMAGE` | `ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev` | Routing sidecar image loaded into the Kind cluster |
-| `UDS_TOKENIZER_IMAGE` | `ghcr.io/llm-d/llm-d-uds-tokenizer:dev` | UDS tokenizer image loaded into the Kind cluster |
+| `VLLM_RENDER_IMAGE` | `vllm/vllm-openai-cpu:v0.19.1` | vLLM renderer image loaded into the Kind cluster |
 
 ### Coverage
 
@@ -659,36 +659,6 @@ If a worktree for the target ref already exists locally it is reused and not rem
 > CI runs the same comparison automatically on every PR: one report against `main`
 > and one against the most recent `release-*` branch. Both appear in the GitHub
 > Actions Job Summary for the run.
-
-## Tokenization Architecture
-
-> [!NOTE]
-> **Python is NOT required**. Previous EPP versions (before v0.5.1) used embedded Python
-> tokenizers.
-
-The project uses **UDS (Unix Domain Socket)** tokenization. A separate UDS tokenizer
-sidecar container handles tokenization; the EPP itself does not. Previous approaches
-(daulet/tokenizers, direct Python/vLLM linking) are deprecated and no longer used.
-
-The UDS tokenizer image is built and published by the
-[llm-d-kv-cache](https://github.com/llm-d/llm-d-kv-cache) repository.
-Published images are available at `ghcr.io/llm-d/llm-d-uds-tokenizer:<tag>`
-
-- The `:dev` tag tracks the kv-cache `main` branch.
-- To pin a specific release, set `UDS_TOKENIZER_TAG` (or `UDS_TOKENIZER_IMAGE` for a
-  fully custom reference):
-
-  ```bash
-  UDS_TOKENIZER_TAG=v0.7.0 make env-dev-kind
-  ```
-
-- To use a different registry, set `IMAGE_REGISTRY` (shared with all other images):
-
-  ```bash
-  IMAGE_REGISTRY=quay.io/my-org make env-dev-kind
-  ```
-
-- To build the image from source, run `make image-build-uds` in the `llm-d-kv-cache` repo.
 
 ## Kubernetes Development Environment
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ PROJECT_NAME ?= llm-d-router
 EPP_IMAGE_NAME ?= llm-d-router-endpoint-picker
 SIDECAR_IMAGE_NAME ?= llm-d-router-disagg-sidecar
 VLLM_SIMULATOR_IMAGE_NAME ?= llm-d-inference-sim
-UDS_TOKENIZER_IMAGE_NAME ?= llm-d-uds-tokenizer
 SIDECAR_NAME ?= pd-sidecar
 BUILDER_IMAGE_NAME ?= llm-d-builder
 IMAGE_REGISTRY ?= ghcr.io/llm-d
@@ -34,13 +33,9 @@ SIDECAR_IMAGE_TAG_BASE ?= $(IMAGE_REGISTRY)/$(SIDECAR_IMAGE_NAME)
 SIDECAR_TAG ?= dev
 export SIDECAR_IMAGE ?= $(SIDECAR_IMAGE_TAG_BASE):$(SIDECAR_TAG)
 
-VLLM_SIMULATOR_TAG ?= v0.8.2
+VLLM_SIMULATOR_TAG ?= v0.9.0
 VLLM_SIMULATOR_TAG_BASE ?= $(IMAGE_REGISTRY)/$(VLLM_SIMULATOR_IMAGE_NAME)
 export VLLM_IMAGE ?= $(VLLM_SIMULATOR_TAG_BASE):$(VLLM_SIMULATOR_TAG)
-
-UDS_TOKENIZER_TAG ?= dev
-UDS_TOKENIZER_TAG_BASE ?= $(IMAGE_REGISTRY)/$(UDS_TOKENIZER_IMAGE_NAME)
-export UDS_TOKENIZER_IMAGE ?= $(UDS_TOKENIZER_TAG_BASE):$(UDS_TOKENIZER_TAG)
 
 # CPU-only vLLM image that exposes `vllm launch render` for the token-producer
 # plugin's HTTP backend.
@@ -119,7 +114,7 @@ endif
 # Env vars forwarded into the e2e test container.
 # Add new image vars here so they are automatically passed through.
 # Should we pass ALL env vars here?
-E2E_ENV_VARS = EPP_IMAGE VLLM_IMAGE SIDECAR_IMAGE UDS_TOKENIZER_IMAGE VLLM_RENDER_IMAGE \
+E2E_ENV_VARS = EPP_IMAGE VLLM_IMAGE SIDECAR_IMAGE VLLM_RENDER_IMAGE \
                E2E_KEEP_CLUSTER_ON_FAILURE E2E_PORT E2E_METRICS_PORT K8S_CONTEXT READY_TIMEOUT
 BUILDER_E2E_ENV_FLAGS = $(foreach v,$(E2E_ENV_VARS),$(if $($(v)),-e $(v)=$($(v))))
 ifneq ($(filter command line environment,$(origin NAMESPACE)),)
@@ -468,8 +463,6 @@ env: ## Print environment variables
 	@echo "SIDECAR_IMAGE=$(SIDECAR_IMAGE)"
 	@echo "VLLM_SIMULATOR_TAG=$(VLLM_SIMULATOR_TAG)"
 	@echo "VLLM_IMAGE=$(VLLM_IMAGE)"
-	@echo "UDS_TOKENIZER_TAG=$(UDS_TOKENIZER_TAG)"
-	@echo "UDS_TOKENIZER_IMAGE=$(UDS_TOKENIZER_IMAGE)"
 	@echo "VLLM_RENDER_IMAGE=$(VLLM_RENDER_IMAGE)"
 	@echo "BUILDER_IMAGE=$(BUILDER_IMAGE)"
 

--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:latest
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.9.0
         imagePullPolicy: Always
         args:
         - --model

--- a/config/manifests/vllm/sim-grpc-deployment.yaml
+++ b/config/manifests/vllm/sim-grpc-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:latest
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.9.0
         imagePullPolicy: Always
         args:
         - --model

--- a/deploy/components/overlays/simulator/kustomization.yaml
+++ b/deploy/components/overlays/simulator/kustomization.yaml
@@ -5,7 +5,7 @@
 #   - --mode=${VLLM_SIM_MODE} arg on Decode (vllm-d) only — controls simulator
 #     response mode (echo: returns input, random: returns random sentences)
 #   - --zmq-endpoint on Decode only — publishes KV cache events to the EPP
-#   - UDS tokenizer sidecar on all deployments (Decode, Prefill, Encode)
+#   - vLLM Render sidecar on all deployments (Decode, Prefill, Encode)
 #   - KV cache args on Decode for cache-aware scheduling tests
 #
 # Uses JSON patches (op: add) to INSERT into args arrays without replacing
@@ -43,46 +43,38 @@ patches:
     - op: add
       path: /spec/template/spec/initContainers/0
       value:
-        name: uds-tokenizer
-        image: ${UDS_TOKENIZER_IMAGE}
+        name: vllm-render
+        image: ${VLLM_RENDER_IMAGE}
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
+        command: ["vllm"]
+        args: ["launch", "render", "${MODEL_NAME}", "--port=8082"]
         env:
-        - name: LOG_LEVEL
-          value: "DEBUG"
-        - name: PROBE_PORT
-          value: "8082"
         - name: HF_TOKEN
           value: "${HF_TOKEN}"
         ports:
-        - name: health
+        - name: http
           containerPort: 8082
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /health
             port: 8082
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /health
             port: 8082
           initialDelaySeconds: 5
           periodSeconds: 5
         volumeMounts:
-        - name: uds-socket
-          mountPath: /tmp/tokenizer
+        - name: model-cache
+          mountPath: /root/.cache/huggingface
     - op: add
-      path: /spec/template/spec/containers/0/volumeMounts
+      path: /spec/template/spec/volumes/-
       value:
-      - name: uds-socket
-        mountPath: /tmp/tokenizer
-    - op: add
-      path: /spec/template/spec/volumes
-      value:
-      - name: uds-socket
+        name: model-cache
         emptyDir: {}
-
 # --- Prefill and Encode deployments (vllm-p, vllm-e) ---
 # No initContainers in base, so create the array
 - target:
@@ -92,42 +84,35 @@ patches:
     - op: add
       path: /spec/template/spec/initContainers
       value:
-      - name: uds-tokenizer
-        image: ${UDS_TOKENIZER_IMAGE}
+        name: vllm-render
+        image: ${VLLM_RENDER_IMAGE}
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
+        command: ["vllm"]
+        args: ["launch", "render", "${MODEL_NAME}", "--port=8082"]
         env:
-        - name: LOG_LEVEL
-          value: "DEBUG"
-        - name: PROBE_PORT
-          value: "8082"
         - name: HF_TOKEN
           value: "${HF_TOKEN}"
         ports:
-        - name: health
+        - name: http
           containerPort: 8082
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /health
             port: 8082
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /health
             port: 8082
           initialDelaySeconds: 5
           periodSeconds: 5
         volumeMounts:
-        - name: uds-socket
-          mountPath: /tmp/tokenizer
+        - name: model-cache
+          mountPath: /root/.cache/huggingface
     - op: add
-      path: /spec/template/spec/containers/0/volumeMounts
+      path: /spec/template/spec/volumes/-
       value:
-      - name: uds-socket
-        mountPath: /tmp/tokenizer
-    - op: add
-      path: /spec/template/spec/volumes
-      value:
-      - name: uds-socket
+        name: model-cache
         emptyDir: {}

--- a/deploy/components/overlays/simulator/kustomization.yaml
+++ b/deploy/components/overlays/simulator/kustomization.yaml
@@ -76,13 +76,13 @@ patches:
         name: model-cache
         emptyDir: {}
 # --- Prefill and Encode deployments (vllm-p, vllm-e) ---
-# No initContainers in base, so create the array
+# initContainers: [] in base, so append with /-
 - target:
     kind: Deployment
     name: "vllm-[pe]"
   patch: |
     - op: add
-      path: /spec/template/spec/initContainers
+      path: /spec/template/spec/initContainers/-
       value:
         name: vllm-render
         image: ${VLLM_RENDER_IMAGE}

--- a/deploy/components/vllm-decode/deployment.yaml
+++ b/deploy/components/vllm-decode/deployment.yaml
@@ -140,3 +140,4 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+      volumes: []

--- a/deploy/components/vllm-encode/deployment.yaml
+++ b/deploy/components/vllm-encode/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         llm-d.ai/component: encode
         llm-d.ai/role: encode
     spec:
+      initContainers: []
       containers:
       - name: vllm
         # VLLM_IMAGE can be a simulator (e.g. llm-d-inference-sim) or a real

--- a/deploy/components/vllm-encode/deployment.yaml
+++ b/deploy/components/vllm-encode/deployment.yaml
@@ -97,3 +97,4 @@ spec:
               fieldPath: metadata.namespace
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+      volumes: []

--- a/deploy/components/vllm-prefill/deployment.yaml
+++ b/deploy/components/vllm-prefill/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         llm-d.ai/component: prefill
         llm-d.ai/role: prefill
     spec:
+      initContainers: []
       containers:
       - name: vllm
         # VLLM_IMAGE can be a simulator (e.g. llm-d-inference-sim) or a real

--- a/deploy/components/vllm-prefill/deployment.yaml
+++ b/deploy/components/vllm-prefill/deployment.yaml
@@ -95,3 +95,4 @@ spec:
               fieldPath: metadata.namespace
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+      volumes: []

--- a/deploy/environments/dev/README.md
+++ b/deploy/environments/dev/README.md
@@ -9,7 +9,7 @@ scenario-specific patches. The atomic components live in `deploy/components/`:
 | `vllm-decode/` | Decode pod — always deployed, includes routing sidecar (removed in EPD scenario) |
 | `vllm-prefill/` | Prefill pod — deployed when `DISAGG_P=true` |
 | `vllm-encode/` | Encoder pod — deployed when `DISAGG_E=true` |
-| `overlays/simulator/` | Adds `--mode=${VLLM_SIM_MODE}`, UDS tokenizer, KV cache and ZMQ args (included by all scenario overlays) |
+| `overlays/simulator/` | Adds `--mode=${VLLM_SIM_MODE}`, vLLM render, KV cache and ZMQ args (included by all scenario overlays) |
 
 These overlays are used by both `scripts/kind-dev-env.sh` (for local KIND clusters)
 and e2e tests (via `kustomize build` + env var substitution).
@@ -67,9 +67,9 @@ Variables substituted at deploy time via `envsubst` or Go test `substituteMany`:
 | `DISAGG_E` | Deploy a separate Encoder pod (`true`/`false`) | `false` |
 | `DISAGG_P` | Deploy a separate Prefill pod (`true`/`false`) | `false` |
 | `VLLM_SIM_MODE` | Simulator response mode: `echo` (returns input) or `random` (random sentences) | `echo` |
-| `VLLM_IMAGE` | vLLM container image (simulator or real) | `ghcr.io/llm-d/llm-d-inference-sim:v0.8.2` |
+| `VLLM_IMAGE` | vLLM container image (simulator or real) | `ghcr.io/llm-d/llm-d-inference-sim:v0.9.0` |
 | `SIDECAR_IMAGE` | Routing sidecar image | `ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev` |
-| `UDS_TOKENIZER_IMAGE` | UDS tokenizer sidecar image | `ghcr.io/llm-d/llm-d-uds-tokenizer:dev` |
+| `VLLM_RENDER_IMAGE` | vLLM render sidecar image | `vllm/vllm-openai-cpu:v0.19.1` |
 | `MODEL_NAME` | Model name passed to vLLM. Can be a real HuggingFace model (e.g. `TinyLlama/TinyLlama-1.1B-Chat-v1.0`, `Qwen/Qwen3-VL-2B-Instruct`) or an arbitrary name when using the simulator (e.g. `food-review`) | `food-review` |
 | `POOL_NAME` | InferencePool name | `food-review-inference-pool` |
 | `VLLM_REPLICA_COUNT_E` | Encode deployment replicas | `1` |

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.5
 	k8s.io/apiextensions-apiserver v0.35.5
 	k8s.io/apimachinery v0.35.5
@@ -141,6 +140,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.35.5 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.5
 	k8s.io/apiextensions-apiserver v0.35.5
 	k8s.io/apimachinery v0.35.5
@@ -140,7 +141,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.35.5 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -19,7 +19,7 @@ set -euox pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 EPP_IMAGE="${EPP_IMAGE:-ghcr.io/llm-d/llm-d-router-endpoint-picker:dev}"
-SIM_IMAGE="${VLLM_IMAGE:-ghcr.io/llm-d/llm-d-inference-sim:v0.8.2}"
+SIM_IMAGE="${VLLM_IMAGE:-ghcr.io/llm-d/llm-d-inference-sim:v0.9.0}"
 MANIFEST_PATH="${MANIFEST_PATH:-${DIR}/../test/testdata/sim-deployment.yaml}"
 USE_KIND="${USE_KIND:-true}"
 

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -23,7 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${IMAGE_REGISTRY:=ghcr.io/llm-d}"
 
 # Set a default VLLM_SIMULATOR_TAG if not provided
-export VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-v0.8.2}"
+export VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-v0.9.0}"
 
 # VLLM_IMAGE: the vLLM container image to deploy. Can be a simulator or real vLLM image
 # (e.g., vllm/vllm-openai:v0.16.0 for production). Defaults to the simulator image.
@@ -61,13 +61,6 @@ export SIDECAR_TAG="${SIDECAR_TAG:-dev}"
 # Set a default SIDECAR_IMAGE if not provided
 SIDECAR_IMAGE="${SIDECAR_IMAGE:-${IMAGE_REGISTRY}/llm-d-router-disagg-sidecar:${SIDECAR_TAG}}"
 export SIDECAR_IMAGE
-
-# Set the default UDS tokenizer image tag
-export UDS_TOKENIZER_TAG="${UDS_TOKENIZER_TAG:-dev}"
-
-# Set a default UDS_TOKENIZER_IMAGE if not provided
-UDS_TOKENIZER_IMAGE="${UDS_TOKENIZER_IMAGE:-${IMAGE_REGISTRY}/llm-d-uds-tokenizer:${UDS_TOKENIZER_TAG}}"
-export UDS_TOKENIZER_IMAGE
 
 # Set a default VLLM_RENDER_IMAGE if not provided (CPU-only vLLM image that
 # runs `vllm launch render` for the token-producer plugin's HTTP backend).
@@ -330,7 +323,7 @@ load_image() {
     fi
 }
 
-for IMAGE in "${VLLM_IMAGE}" "${EPP_IMAGE}" "${SIDECAR_IMAGE}" "${UDS_TOKENIZER_IMAGE}"; do
+for IMAGE in "${VLLM_IMAGE}" "${EPP_IMAGE}" "${SIDECAR_IMAGE}" "${VLLM_RENDER_IMAGE}"; do
     pull_image "${IMAGE}"
     load_image "${IMAGE}"
 done
@@ -392,14 +385,14 @@ kubectl --context ${KUBE_CONTEXT} create configmap epp-config --from-file=epp-co
 # Deploy Istio base (shared infrastructure)
 kubectl kustomize --enable-helm deploy/environments/dev/base-kind-istio \
   | envsubst '${POOL_NAME} ${MODEL_NAME} ${MODEL_NAME_SAFE} ${EPP_NAME} ${EPP_IMAGE} ${VLLM_IMAGE} \
-  ${SIDECAR_IMAGE} ${UDS_TOKENIZER_IMAGE} ${VLLM_RENDER_IMAGE} ${TARGET_PORTS} ${NAMESPACE} ${METRICS_ENDPOINT_AUTH} \
+  ${SIDECAR_IMAGE} ${VLLM_RENDER_IMAGE} ${TARGET_PORTS} ${NAMESPACE} ${METRICS_ENDPOINT_AUTH} \
 ${VLLM_REPLICA_COUNT_E} ${VLLM_REPLICA_COUNT_P} ${VLLM_REPLICA_COUNT_D} ${VLLM_DATA_PARALLEL_SIZE}' \
   | kubectl --context ${KUBE_CONTEXT} apply -f -
 
 # Deploy scenario-specific vLLM components
 kubectl kustomize --enable-helm ${KUSTOMIZE_DIR} \
   | envsubst '${POOL_NAME} ${MODEL_NAME} ${MODEL_NAME_SAFE} ${EPP_NAME} ${EPP_IMAGE} ${VLLM_IMAGE} \
-  ${SIDECAR_IMAGE} ${UDS_TOKENIZER_IMAGE} ${TARGET_PORTS} ${NAMESPACE} \
+  ${SIDECAR_IMAGE} ${VLLM_RENDER_IMAGE} ${TARGET_PORTS} ${NAMESPACE} \
   ${VLLM_REPLICA_COUNT_E} ${VLLM_REPLICA_COUNT_P} ${VLLM_REPLICA_COUNT_D} ${VLLM_DATA_PARALLEL_SIZE} \
   ${KV_CONNECTOR_TYPE} ${EC_CONNECTOR_TYPE} ${CONNECTOR_TYPE} ${KV_CACHE_ENABLED} ${HF_TOKEN} ${VLLM_SIM_MODE} \
   ${DECODE_ROLE} ${VLLM_EXTRA_ARGS_E} ${VLLM_EXTRA_ARGS_P} ${VLLM_EXTRA_ARGS_D}' \

--- a/scripts/pull_images.sh
+++ b/scripts/pull_images.sh
@@ -7,16 +7,13 @@ echo "Using container tool: ${CONTAINER_RUNTIME}"
 # Set a default EPP_TAG if not provided
 EPP_TAG="${EPP_TAG:-dev}"
 # Set a default VLLM_SIMULATOR_TAG if not provided
-VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-latest}"
+VLLM_SIMULATOR_TAG="${VLLM_SIMULATOR_TAG:-v0.9.0}"
 # Set the default routing side car image tag
 SIDECAR_TAG="${SIDECAR_TAG:-dev}"
-# Set the default UDS tokenizer image tag
-UDS_TOKENIZER_TAG="${UDS_TOKENIZER_TAG:-dev}"
 
 export EPP_IMAGE="${EPP_IMAGE:-ghcr.io/llm-d/llm-d-router-endpoint-picker:${EPP_TAG}}"
 export VLLM_IMAGE="${VLLM_IMAGE:-ghcr.io/llm-d/llm-d-inference-sim:${VLLM_SIMULATOR_TAG}}"
 export SIDECAR_IMAGE="${SIDECAR_IMAGE:-ghcr.io/llm-d/llm-d-router-disagg-sidecar:${SIDECAR_TAG}}"
-export UDS_TOKENIZER_IMAGE="${UDS_TOKENIZER_IMAGE:-ghcr.io/llm-d/llm-d-uds-tokenizer:${UDS_TOKENIZER_TAG}}"
 export VLLM_RENDER_IMAGE="${VLLM_RENDER_IMAGE:-vllm/vllm-openai-cpu:v0.19.1}"
 
 TARGETOS="${TARGETOS:-linux}"
@@ -48,7 +45,6 @@ echo "--- Using the following images ---"
 echo "Scheduler Image:     ${EPP_IMAGE}"
 echo "Simulator Image:     ${VLLM_IMAGE}"
 echo "Sidecar Image:       ${SIDECAR_IMAGE}"
-echo "UDS Tokenizer Image: ${UDS_TOKENIZER_IMAGE}"
 echo "vLLM Render Image:   ${VLLM_RENDER_IMAGE}"
 echo "----------------------------------------------------"
 
@@ -56,6 +52,5 @@ echo "Pulling dependencies..."
 ensure_image "${EPP_IMAGE}"
 ensure_image "${VLLM_IMAGE}"
 ensure_image "${SIDECAR_IMAGE}"
-ensure_image "${UDS_TOKENIZER_IMAGE}"
 ensure_image "${VLLM_RENDER_IMAGE}"
 echo "Successfully pulled dependencies"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -62,12 +62,11 @@ var (
 	// Set E2E_KEEP_CLUSTER_ON_FAILURE=true to enable.
 	keepClusterOnFailure = env.GetEnvBool("E2E_KEEP_CLUSTER_ON_FAILURE", false, ginkgo.GinkgoLogr)
 
-	containerRuntime  = env.GetEnvString("CONTAINER_RUNTIME", "docker", ginkgo.GinkgoLogr)
-	eppImage          = env.GetEnvString("EPP_IMAGE", "ghcr.io/llm-d/llm-d-router-endpoint-picker:dev", ginkgo.GinkgoLogr)
-	vllmSimImage      = env.GetEnvString("VLLM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2", ginkgo.GinkgoLogr)
-	sideCarImage      = env.GetEnvString("SIDECAR_IMAGE", "ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev", ginkgo.GinkgoLogr)
-	udsTokenizerImage = env.GetEnvString("UDS_TOKENIZER_IMAGE", "ghcr.io/llm-d/llm-d-uds-tokenizer:dev", ginkgo.GinkgoLogr)
-	vllmRenderImage   = env.GetEnvString("VLLM_RENDER_IMAGE", "vllm/vllm-openai-cpu:v0.19.1", ginkgo.GinkgoLogr)
+	containerRuntime = env.GetEnvString("CONTAINER_RUNTIME", "docker", ginkgo.GinkgoLogr)
+	eppImage         = env.GetEnvString("EPP_IMAGE", "ghcr.io/llm-d/llm-d-router-endpoint-picker:dev", ginkgo.GinkgoLogr)
+	vllmSimImage     = env.GetEnvString("VLLM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.9.0", ginkgo.GinkgoLogr)
+	sideCarImage     = env.GetEnvString("SIDECAR_IMAGE", "ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev", ginkgo.GinkgoLogr)
+	vllmRenderImage  = env.GetEnvString("VLLM_RENDER_IMAGE", "vllm/vllm-openai-cpu:v0.19.1", ginkgo.GinkgoLogr)
 	// nsName is the namespace in which the K8S objects will be created
 	nsName = env.GetEnvString("NAMESPACE", "default", ginkgo.GinkgoLogr)
 
@@ -199,7 +198,6 @@ func setupK8sCluster() {
 	kindLoadImage(vllmSimImage)
 	kindLoadImage(eppImage)
 	kindLoadImage(sideCarImage)
-	kindLoadImage(udsTokenizerImage)
 	kindLoadImage(vllmRenderImage)
 }
 

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -45,7 +45,7 @@ func createModelServersFromKustomize(kustomizeDir string, extra map[string]strin
 	manifests = removeEmptyArgs(manifests)
 	// remove render sidecar if model is simulated
 	if !isModelReal(subs["${MODEL_NAME}"]) {
-		manifests = removeSidecarIfSimulated(manifests)
+		manifests = removeSidecarIfSimulatedModel(manifests)
 	}
 	objects := testutils.CreateObjsFromYaml(testConfig, manifests)
 	podsInDeploymentsReady(objects)

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -21,7 +21,6 @@ func createModelServersFromKustomize(kustomizeDir string, extra map[string]strin
 		"${MODEL_NAME}":              simModelName,
 		"${POOL_NAME}":               poolName,
 		"${VLLM_IMAGE}":              vllmSimImage,
-		"${UDS_TOKENIZER_IMAGE}":     udsTokenizerImage,
 		"${VLLM_RENDER_IMAGE}":       vllmRenderImage,
 		"${SIDECAR_IMAGE}":           sideCarImage,
 		"${VLLM_DATA_PARALLEL_SIZE}": "1",

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -37,11 +37,16 @@ func createModelServersFromKustomize(kustomizeDir string, extra map[string]strin
 	for k, v := range extra {
 		subs[k] = v
 	}
+
 	manifests := runKustomize(kustomizeDir)
 	manifests = substituteMany(manifests, subs)
 	// Remove labels with empty values (produced when ${DECODE_ROLE} is empty)
 	manifests = removeEmptyLabels(manifests)
 	manifests = removeEmptyArgs(manifests)
+	// remove render sidecar if model is simulated
+	if !isModelReal(subs["${MODEL_NAME}"]) {
+		manifests = removeSidecarIfSimulated(manifests)
+	}
 	objects := testutils.CreateObjsFromYaml(testConfig, manifests)
 	podsInDeploymentsReady(objects)
 	return objects

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -45,7 +45,7 @@ func createModelServersFromKustomize(kustomizeDir string, extra map[string]strin
 	manifests = removeEmptyArgs(manifests)
 	// remove render sidecar if model is simulated
 	if !isModelReal(subs["${MODEL_NAME}"]) {
-		manifests = removeSidecarIfSimulatedModel(manifests)
+		manifests = removeRenderSidecar(manifests)
 	}
 	objects := testutils.CreateObjsFromYaml(testConfig, manifests)
 	podsInDeploymentsReady(objects)

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -143,7 +143,8 @@ func runKustomize(kustomizeDir string) []string {
 	session, err := gexec.Start(command, nil, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
-	return strings.Split(string(session.Out.Contents()), "\n---")
+	res := strings.Split(string(session.Out.Contents()), "\n---")
+	return res
 }
 
 // removeEmptyArgs strips YAML list items that are empty strings after variable

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -143,8 +143,7 @@ func runKustomize(kustomizeDir string) []string {
 	session, err := gexec.Start(command, nil, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
-	res := strings.Split(string(session.Out.Contents()), "\n---")
-	return res
+	return strings.Split(string(session.Out.Contents()), "\n---")
 }
 
 // removeEmptyArgs strips YAML list items that are empty strings after variable
@@ -252,7 +251,7 @@ func removeListItemByName(lines []string, nameValue string) []string {
 				flush()
 			}
 			itemIndent = indent
-			buf = []string{line}
+			buf = append(make([]string, 0, 2), line)
 			// Inline name: "- name: <value>"
 			if strings.TrimSpace(strings.TrimPrefix(stripped, "- ")) == "name: "+nameValue {
 				isTarget = true

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -188,6 +188,98 @@ func removeEmptyLabels(inputs []string) []string {
 	return outputs
 }
 
+func isModelReal(modelName string) bool {
+	url := "https://huggingface.co/api/models/" + modelName
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK
+}
+
+// removeSidecarIfSimulated strips the vllm-render init container and the orphaned
+// model-cache volume from all manifests when running against a simulated (non-real) model.
+func removeSidecarIfSimulated(inputs []string) []string {
+	outputs := make([]string, len(inputs))
+	for idx, input := range inputs {
+		lines := strings.Split(input, "\n")
+		lines = removeListItemByName(lines, "vllm-render")
+		lines = removeListItemByName(lines, "model-cache")
+		outputs[idx] = strings.Join(lines, "\n")
+	}
+	return outputs
+}
+
+// removeListItemByName removes YAML list items whose direct `name:` field equals nameValue.
+// It buffers each item bounded by its leading "- " indent, then discards the buffer if the
+// name matches. The name check is limited to indent+2 (direct fields) to avoid matching
+// nested sub-items (e.g. volumeMount name inside a container block).
+func removeListItemByName(lines []string, nameValue string) []string {
+	result := make([]string, 0, len(lines))
+	var buf []string
+	itemIndent := -1
+	isTarget := false
+
+	flush := func() {
+		if !isTarget {
+			result = append(result, buf...)
+		}
+		buf = nil
+		isTarget = false
+		itemIndent = -1
+	}
+
+	for _, line := range lines {
+		stripped := strings.TrimLeft(line, " ")
+		if stripped == "" {
+			if itemIndent >= 0 {
+				buf = append(buf, line)
+			} else {
+				result = append(result, line)
+			}
+			continue
+		}
+		indent := len(line) - len(stripped)
+		isListStart := strings.HasPrefix(stripped, "- ")
+
+		switch {
+		case isListStart && (itemIndent < 0 || indent == itemIndent):
+			// First item or sibling at the same level.
+			if itemIndent >= 0 {
+				flush()
+			}
+			itemIndent = indent
+			buf = []string{line}
+			// Inline name: "- name: <value>"
+			if strings.TrimSpace(strings.TrimPrefix(stripped, "- ")) == "name: "+nameValue {
+				isTarget = true
+			}
+		case isListStart && itemIndent >= 0 && indent < itemIndent:
+			// List item at a shallower level — we've left the tracked list.
+			flush()
+			result = append(result, line)
+		case itemIndent >= 0 && indent <= itemIndent && !isListStart:
+			// Non-list line at or above item indent — end of list.
+			flush()
+			result = append(result, line)
+		case itemIndent >= 0:
+			// Content line inside the tracked item.
+			buf = append(buf, line)
+			// Own-line name field at exactly indent+2 (direct child, not nested).
+			if indent == itemIndent+2 && stripped == "name: "+nameValue {
+				isTarget = true
+			}
+		default:
+			result = append(result, line)
+		}
+	}
+	flush()
+	return result
+}
+
 func substituteMany(inputs []string, substitutions map[string]string) []string {
 	outputs := make([]string, len(inputs))
 	for idx, input := range inputs {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -11,17 +11,17 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apilabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -159,6 +159,9 @@ func removeEmptyArgs(inputs []string) []string {
 			if strings.TrimSpace(line) == `- ""` {
 				continue
 			}
+			if strings.TrimSpace(line) == `-` {
+				continue
+			}
 			filtered = append(filtered, line)
 		}
 		outputs[idx] = strings.Join(filtered, "\n")
@@ -201,130 +204,60 @@ func isModelReal(modelName string) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-// removeSidecarIfSimulatedModel strips the vllm-render init container and the orphaned
-// model-cache volume from all manifests when running against a simulated (non-real) model.
-func removeSidecarIfSimulatedModel(inputs []string) []string {
+// removeRenderSidecar takes a slice of YAML strings (each may contain multiple
+// objects separated by "---") and returns the same slice with the vllm-render
+// initContainer and the model-cache volume stripped from any Deployment.
+func removeRenderSidecar(inputs []string) []string {
 	outputs := make([]string, len(inputs))
-
 	for idx, input := range inputs {
-		output, err := processK8sManifests(input)
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-		outputs[idx] = output
+		docs := strings.Split(input, "\n---")
+		rendered := make([]string, 0, len(docs))
+		for _, doc := range docs {
+			if strings.TrimSpace(doc) == "" {
+				continue
+			}
+			rendered = append(rendered, filterDocument(doc))
+		}
+		outputs[idx] = strings.Join(rendered, "\n---\n")
 	}
-
 	return outputs
 }
 
-// processK8sManifests reads a multi-document YAML string, filters the specified
-// Deployment fields, and returns the modified YAML string.
-func processK8sManifests(yamlContent string) (string, error) {
-	decoder := yaml.NewDecoder(bytes.NewReader([]byte(yamlContent)))
-	var modifiedDocs []any
-
-	// Iterate through all YAML documents in the file
-	for {
-		var doc map[string]any
-		err := decoder.Decode(&doc)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return "", fmt.Errorf("error decoding yaml: %w", err)
-		}
-
-		// If the document is a Deployment, apply our cleanup logic
-		if kind, ok := doc["kind"].(string); ok && kind == "Deployment" {
-			podSpec := getPodSpec(doc)
-			if podSpec != nil {
-				removeNamedItem(podSpec, "initContainers", "vllm-render")
-				removeNamedItem(podSpec, "volumes", "model-cache")
-			}
-		}
-
-		// An empty YAML list entry (e.g. "- " left over from an unset variable
-		// substitution) decodes to a nil slice element and would re-encode as
-		// "- null". Drop those nil entries everywhere in the document.
-		stripNilFromLists(doc)
-
-		modifiedDocs = append(modifiedDocs, doc)
+func filterDocument(doc string) string {
+	obj := &unstructured.Unstructured{}
+	err := yaml.Unmarshal([]byte(doc), &obj.Object)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	if len(obj.Object) == 0 {
+		return doc
 	}
-
-	// Re-encode back to YAML string
-	var buf bytes.Buffer
-	encoder := yaml.NewEncoder(&buf)
-	encoder.SetIndent(2) // Standard Kubernetes YAML indentation
-
-	for _, doc := range modifiedDocs {
-		if err := encoder.Encode(doc); err != nil {
-			return "", fmt.Errorf("error encoding yaml: %w", err)
-		}
+	if obj.GetKind() == "Deployment" {
+		removePodSpecListItem(obj, "initContainers", "vllm-render")
+		removePodSpecListItem(obj, "volumes", "model-cache")
 	}
-	encoder.Close()
-
-	return buf.String(), nil
+	out, err := yaml.Marshal(obj.Object)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	return strings.TrimRight(string(out), "\n")
 }
 
-// stripNilFromLists recursively walks a decoded YAML value and drops nil entries
-// from any list it encounters. This prevents empty source list items (like "- ")
-// from being re-encoded as "- null".
-func stripNilFromLists(v any) any {
-	switch x := v.(type) {
-	case map[string]any:
-		for k, val := range x {
-			x[k] = stripNilFromLists(val)
-		}
-		return x
-	case []any:
-		filtered := make([]any, 0, len(x))
-		for _, item := range x {
-			if item == nil {
-				continue
-			}
-			filtered = append(filtered, stripNilFromLists(item))
-		}
-		return filtered
-	default:
-		return v
-	}
-}
-
-// getPodSpec safely navigates a Deployment document down to spec.template.spec
-// (the PodSpec). Returns the PodSpec map and true on success, or nil and false
-// if any level is missing or has an unexpected type.
-func getPodSpec(doc map[string]any) map[string]any {
-	if spec, ok := doc["spec"].(map[string]any); ok {
-		if template, ok := spec["template"].(map[string]any); ok {
-			if podSpec, ok := template["spec"].(map[string]any); ok {
-				return podSpec
-			}
-		}
-	}
-	return nil
-}
-
-// removeNamedItem removes the entry whose `name:` field equals nameValue from the
-// list at parent[fieldName]. If the list becomes empty, the field is deleted from
-// parent for cleaner YAML output.
-func removeNamedItem(parent map[string]any, fieldName, nameValue string) {
-	items, ok := parent[fieldName].([]any)
-	if !ok {
+func removePodSpecListItem(obj *unstructured.Unstructured, fieldName, itemName string) {
+	path := []string{"spec", "template", "spec", fieldName}
+	items, found, err := unstructured.NestedSlice(obj.Object, path...)
+	if err != nil || !found {
 		return
 	}
-
 	filtered := make([]any, 0, len(items))
 	for _, item := range items {
-		entry, ok := item.(map[string]any)
-		if ok && entry["name"] == nameValue {
+		if m, ok := item.(map[string]any); ok && m["name"] == itemName {
 			continue
 		}
 		filtered = append(filtered, item)
 	}
-
 	if len(filtered) == 0 {
-		delete(parent, fieldName)
-	} else {
-		parent[fieldName] = filtered
+		unstructured.RemoveNestedField(obj.Object, path...)
+		return
 	}
+	err = unstructured.SetNestedSlice(obj.Object, filtered, path...)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 }
 
 func substituteMany(inputs []string, substitutions map[string]string) []string {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -199,84 +201,130 @@ func isModelReal(modelName string) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-// removeSidecarIfSimulated strips the vllm-render init container and the orphaned
+// removeSidecarIfSimulatedModel strips the vllm-render init container and the orphaned
 // model-cache volume from all manifests when running against a simulated (non-real) model.
-func removeSidecarIfSimulated(inputs []string) []string {
+func removeSidecarIfSimulatedModel(inputs []string) []string {
 	outputs := make([]string, len(inputs))
+
 	for idx, input := range inputs {
-		lines := strings.Split(input, "\n")
-		lines = removeListItemByName(lines, "vllm-render")
-		lines = removeListItemByName(lines, "model-cache")
-		outputs[idx] = strings.Join(lines, "\n")
+		output, err := processK8sManifests(input)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		outputs[idx] = output
 	}
+
 	return outputs
 }
 
-// removeListItemByName removes YAML list items whose direct `name:` field equals nameValue.
-// It buffers each item bounded by its leading "- " indent, then discards the buffer if the
-// name matches. The name check is limited to indent+2 (direct fields) to avoid matching
-// nested sub-items (e.g. volumeMount name inside a container block).
-func removeListItemByName(lines []string, nameValue string) []string {
-	result := make([]string, 0, len(lines))
-	var buf []string
-	itemIndent := -1
-	isTarget := false
+// processK8sManifests reads a multi-document YAML string, filters the specified
+// Deployment fields, and returns the modified YAML string.
+func processK8sManifests(yamlContent string) (string, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader([]byte(yamlContent)))
+	var modifiedDocs []any
 
-	flush := func() {
-		if !isTarget {
-			result = append(result, buf...)
+	// Iterate through all YAML documents in the file
+	for {
+		var doc map[string]any
+		err := decoder.Decode(&doc)
+		if err == io.EOF {
+			break
 		}
-		buf = nil
-		isTarget = false
-		itemIndent = -1
+		if err != nil {
+			return "", fmt.Errorf("error decoding yaml: %w", err)
+		}
+
+		// If the document is a Deployment, apply our cleanup logic
+		if kind, ok := doc["kind"].(string); ok && kind == "Deployment" {
+			podSpec := getPodSpec(doc)
+			if podSpec != nil {
+				removeNamedItem(podSpec, "initContainers", "vllm-render")
+				removeNamedItem(podSpec, "volumes", "model-cache")
+			}
+		}
+
+		// An empty YAML list entry (e.g. "- " left over from an unset variable
+		// substitution) decodes to a nil slice element and would re-encode as
+		// "- null". Drop those nil entries everywhere in the document.
+		stripNilFromLists(doc)
+
+		modifiedDocs = append(modifiedDocs, doc)
 	}
 
-	for _, line := range lines {
-		stripped := strings.TrimLeft(line, " ")
-		if stripped == "" {
-			if itemIndent >= 0 {
-				buf = append(buf, line)
-			} else {
-				result = append(result, line)
+	// Re-encode back to YAML string
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2) // Standard Kubernetes YAML indentation
+
+	for _, doc := range modifiedDocs {
+		if err := encoder.Encode(doc); err != nil {
+			return "", fmt.Errorf("error encoding yaml: %w", err)
+		}
+	}
+	encoder.Close()
+
+	return buf.String(), nil
+}
+
+// stripNilFromLists recursively walks a decoded YAML value and drops nil entries
+// from any list it encounters. This prevents empty source list items (like "- ")
+// from being re-encoded as "- null".
+func stripNilFromLists(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, val := range x {
+			x[k] = stripNilFromLists(val)
+		}
+		return x
+	case []any:
+		filtered := make([]any, 0, len(x))
+		for _, item := range x {
+			if item == nil {
+				continue
 			}
+			filtered = append(filtered, stripNilFromLists(item))
+		}
+		return filtered
+	default:
+		return v
+	}
+}
+
+// getPodSpec safely navigates a Deployment document down to spec.template.spec
+// (the PodSpec). Returns the PodSpec map and true on success, or nil and false
+// if any level is missing or has an unexpected type.
+func getPodSpec(doc map[string]any) map[string]any {
+	if spec, ok := doc["spec"].(map[string]any); ok {
+		if template, ok := spec["template"].(map[string]any); ok {
+			if podSpec, ok := template["spec"].(map[string]any); ok {
+				return podSpec
+			}
+		}
+	}
+	return nil
+}
+
+// removeNamedItem removes the entry whose `name:` field equals nameValue from the
+// list at parent[fieldName]. If the list becomes empty, the field is deleted from
+// parent for cleaner YAML output.
+func removeNamedItem(parent map[string]any, fieldName, nameValue string) {
+	items, ok := parent[fieldName].([]any)
+	if !ok {
+		return
+	}
+
+	filtered := make([]any, 0, len(items))
+	for _, item := range items {
+		entry, ok := item.(map[string]any)
+		if ok && entry["name"] == nameValue {
 			continue
 		}
-		indent := len(line) - len(stripped)
-		isListStart := strings.HasPrefix(stripped, "- ")
-
-		switch {
-		case isListStart && (itemIndent < 0 || indent == itemIndent):
-			// First item or sibling at the same level.
-			if itemIndent >= 0 {
-				flush()
-			}
-			itemIndent = indent
-			buf = append(make([]string, 0, 2), line)
-			// Inline name: "- name: <value>"
-			if strings.TrimSpace(strings.TrimPrefix(stripped, "- ")) == "name: "+nameValue {
-				isTarget = true
-			}
-		case isListStart && itemIndent >= 0 && indent < itemIndent:
-			// List item at a shallower level — we've left the tracked list.
-			flush()
-			result = append(result, line)
-		case itemIndent >= 0 && indent <= itemIndent && !isListStart:
-			// Non-list line at or above item indent — end of list.
-			flush()
-			result = append(result, line)
-		case itemIndent >= 0:
-			// Content line inside the tracked item.
-			buf = append(buf, line)
-			// Own-line name field at exactly indent+2 (direct child, not nested).
-			if indent == itemIndent+2 && stripped == "name: "+nameValue {
-				isTarget = true
-			}
-		default:
-			result = append(result, line)
-		}
+		filtered = append(filtered, item)
 	}
-	flush()
-	return result
+
+	if len(filtered) == 0 {
+		delete(parent, fieldName)
+	} else {
+		parent[fieldName] = filtered
+	}
 }
 
 func substituteMany(inputs []string, substitutions map[string]string) []string {

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -13,9 +13,37 @@ spec:
         app: vllm-qwen3-32b
         inference.networking.k8s.io/engine-type: vllm
     spec:
+      initContainers:
+      - name: vllm-render
+        image: vllm/vllm-openai-cpu:v0.19.1
+        imagePullPolicy: IfNotPresent
+        restartPolicy: Always
+        command: ["vllm"]
+        args: ["launch", "render", "Qwen/Qwen3-32B", "--port=8082"]
+        ports:
+        - name: http
+          containerPort: 8082
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: model-cache
+          mountPath: /root/.cache/huggingface
+      volumes:
+      - name: model-cache
+        emptyDir: {}
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.2
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.9.0
         imagePullPolicy: IfNotPresent
         args:
         - --model

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-qwen3-32b
+  name: vllm-qwen3-06b
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vllm-qwen3-32b
+      app: vllm-qwen3-06b
   template:
     metadata:
       labels:
-        app: vllm-qwen3-32b
+        app: vllm-qwen3-06b
         inference.networking.k8s.io/engine-type: vllm
     spec:
       initContainers:
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]
-        args: ["launch", "render", "Qwen/Qwen3-32B", "--port=8082"]
+        args: ["launch", "render", "Qwen/Qwen3-0.6B", "--port=8082"]
         ports:
         - name: http
           containerPort: 8082
@@ -47,7 +47,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --model
-        - Qwen/Qwen3-32B
+        - Qwen/Qwen3-0.6B
         - --port
         - "8000"
         - --max-loras

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-qwen3-06b
+  name: vllm-qwen3-32b
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vllm-qwen3-06b
+      app: vllm-qwen3-32b
   template:
     metadata:
       labels:
-        app: vllm-qwen3-06b
+        app: vllm-qwen3-32b
         inference.networking.k8s.io/engine-type: vllm
     spec:
       initContainers:
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]
-        args: ["launch", "render", "Qwen/Qwen3-0.6B", "--port=8082"]
+        args: ["launch", "render", "Qwen/Qwen3-32B", "--port=8082"]
         ports:
         - name: http
           containerPort: 8082
@@ -47,7 +47,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --model
-        - Qwen/Qwen3-0.6B
+        - Qwen/Qwen3-32B
         - --port
         - "8000"
         - --max-loras


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use latest version of llm-d-inference-sim


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Update the default vLLM and simulator images, and remove the UDS Tokenizer and the `UDS_TOKENIZER_IMAGE` environment variable. Use `VLLM_RENDER_IMAGE` environment variable to define the render image name.
```
