### PR TITLE
fix(epp/parsers/openai): degrade gracefully on malformed usage fields

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
@@ -244,6 +245,25 @@ func validateChatCompletionsMessages(messages []fwkrh.Message) error {
 	return nil
 }
 
+// toInt coerces a JSON-decoded number-ish value into an int. JSON numbers
+// land as float64 after json.Unmarshal into map[string]any; some
+// non-conforming providers emit strings. Anything else is ignored so that
+// usage extraction stays best-effort rather than panicking.
+func toInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	case string:
+		if f, err := strconv.ParseFloat(n, 64); err == nil {
+			return int(f)
+		}
+	}
+	return 0
+}
+
 func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 	var responseErr error
 	var responseBody map[string]any
@@ -253,14 +273,19 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 	}
 
 	if responseBody["usage"] != nil {
-		usg := responseBody["usage"].(map[string]any)
+		usg, ok := responseBody["usage"].(map[string]any)
+		if !ok {
+			// Malformed upstream response: "usage" present but not a JSON object.
+			return nil, nil //nolint:nilnil
+		}
 		objectType, _ := responseBody["object"].(string)
 		usage := extractUsageByAPIType(usg, objectType)
 		if usg["prompt_token_details"] != nil {
-			detailsMap := usg["prompt_token_details"].(map[string]any)
-			if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
-				usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
-					CachedTokens: int(cachedTokens.(float64)),
+			if detailsMap, ok := usg["prompt_token_details"].(map[string]any); ok {
+				if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
+					usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
+						CachedTokens: toInt(cachedTokens),
+					}
 				}
 			}
 		}
@@ -278,38 +303,38 @@ func extractUsageByAPIType(usg map[string]any, objectType string) fwkrh.Usage {
 	switch {
 	case strings.HasPrefix(objectType, objectTypeResponse) || strings.HasPrefix(objectType, objectTypeConversation):
 		// Responses/Conversations APIs use input_tokens/output_tokens
-		if usg["input_tokens"] != nil {
-			usage.PromptTokens = int(usg["input_tokens"].(float64))
+		if v, ok := usg["input_tokens"]; ok && v != nil {
+			usage.PromptTokens = toInt(v)
 		}
-		if usg["output_tokens"] != nil {
-			usage.CompletionTokens = int(usg["output_tokens"].(float64))
+		if v, ok := usg["output_tokens"]; ok && v != nil {
+			usage.CompletionTokens = toInt(v)
 		}
 	case objectType == objectTypeChatCompletion || objectType == objectTypeChatCompletionChunk || objectType == objectTypeTextCompletion:
 		// Traditional APIs use prompt_tokens/completion_tokens
-		if usg["prompt_tokens"] != nil {
-			usage.PromptTokens = int(usg["prompt_tokens"].(float64))
+		if v, ok := usg["prompt_tokens"]; ok && v != nil {
+			usage.PromptTokens = toInt(v)
 		}
-		if usg["completion_tokens"] != nil {
-			usage.CompletionTokens = int(usg["completion_tokens"].(float64))
+		if v, ok := usg["completion_tokens"]; ok && v != nil {
+			usage.CompletionTokens = toInt(v)
 		}
 	default:
 		// Fallback: try both field naming conventions
-		if usg["input_tokens"] != nil {
-			usage.PromptTokens = int(usg["input_tokens"].(float64))
-		} else if usg["prompt_tokens"] != nil {
-			usage.PromptTokens = int(usg["prompt_tokens"].(float64))
+		if v, ok := usg["input_tokens"]; ok && v != nil {
+			usage.PromptTokens = toInt(v)
+		} else if v, ok := usg["prompt_tokens"]; ok && v != nil {
+			usage.PromptTokens = toInt(v)
 		}
 
-		if usg["output_tokens"] != nil {
-			usage.CompletionTokens = int(usg["output_tokens"].(float64))
-		} else if usg["completion_tokens"] != nil {
-			usage.CompletionTokens = int(usg["completion_tokens"].(float64))
+		if v, ok := usg["output_tokens"]; ok && v != nil {
+			usage.CompletionTokens = toInt(v)
+		} else if v, ok := usg["completion_tokens"]; ok && v != nil {
+			usage.CompletionTokens = toInt(v)
 		}
 	}
 
 	// total_tokens field name is consistent across all API types
-	if usg["total_tokens"] != nil {
-		usage.TotalTokens = int(usg["total_tokens"].(float64))
+	if v, ok := usg["total_tokens"]; ok && v != nil {
+		usage.TotalTokens = toInt(v)
 	}
 
 	return usage

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package openai
+
+import (
+	"testing"
+)
+
+// Regression test for #981: extractUsage must not panic when an upstream
+// response uses non-conforming types for usage fields. Before the fix,
+// each vector below crashed the goroutine processing the response via an
+// unchecked type assertion.
+func TestExtractUsage_MalformedFields_NoPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "usage_field_is_string",
+			body: `{"object":"chat.completion","usage":"oops"}`,
+		},
+		{
+			name: "prompt_token_details_is_number",
+			body: `{"object":"chat.completion","usage":{"prompt_token_details":0,"prompt_tokens":7}}`,
+		},
+		{
+			name: "prompt_tokens_is_string",
+			body: `{"object":"chat.completion","usage":{"prompt_tokens":"1024"}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("extractUsage panicked on %q: %v", tc.body, r)
+				}
+			}()
+			_, _ = extractUsage([]byte(tc.body))
+		})
+	}
+}
+
+// Some non-conforming providers emit numeric usage fields as JSON strings;
+// toInt coerces these rather than panicking.
+func TestExtractUsage_StringCoercion(t *testing.T) {
+	body := `{"object":"chat.completion","usage":{"prompt_tokens":"1024","completion_tokens":"7","total_tokens":"1031"}}`
+	u, err := extractUsage([]byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u == nil {
+		t.Fatal("usage is nil")
+	}
+	if u.PromptTokens != 1024 {
+		t.Errorf("PromptTokens = %d, want 1024", u.PromptTokens)
+	}
+	if u.CompletionTokens != 7 {
+		t.Errorf("CompletionTokens = %d, want 7", u.CompletionTokens)
+	}
+	if u.TotalTokens != 1031 {
+		t.Errorf("TotalTokens = %d, want 1031", u.TotalTokens)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #981. `extractUsage` and `extractUsageByAPIType` in `pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go` performed unchecked type assertions on every usage field after `json.Unmarshal` into `map[string]any`. A non-conforming upstream response whose `"usage"` is a string, whose `"prompt_token_details"` is a number, or whose token-count fields (`prompt_tokens`, `completion_tokens`, `input_tokens`, `output_tokens`, `total_tokens`, `prompt_token_details.cached_tokens`) are strings panics the goroutine processing the response and takes the EPP request offline.

Switched the two map casts in `extractUsage` to comma-ok form and routed every numeric usage field through a new `toInt` helper that handles `float64`, `json.Number`, and string-encoded numbers. Unknown shapes fall through to zero so usage extraction stays best-effort rather than crashing.

## Verified locally

Before the fix, all three vectors from the issue panic at the documented lines:

| Vector | Body | Panic |
|---|---|---|
| `usage` is string | `{"object":"chat.completion","usage":"oops"}` | `interface conversion: interface {} is string, not map[string]interface {}` |
| `prompt_token_details` is number | `{"object":"chat.completion","usage":{"prompt_token_details":0}}` | `interface conversion: interface {} is float64, not map[string]interface {}` |
| `prompt_tokens` is string | `{"object":"chat.completion","usage":{"prompt_tokens":"1024"}}` | `interface conversion: interface {} is string, not float64` |

After the fix:
- all three vectors return cleanly
- `prompt_tokens: "1024"` now coerces to `1024` instead of crashing
- existing `TestOpenAIParser_ParseResponse` (6 subtests) and `TestOpenAIParser_ParseResponse_Streaming` (8 subtests) still pass
- `make test-unit-epp` and `make presubmit` are green

## Test plan
- [x] `go test ./pkg/epp/framework/plugins/requesthandling/parsers/openai/...`
- [x] `make test-unit-epp`
- [x] `make presubmit` (DCO, signed commits, go-mod-check, format, lint, govulncheck)
- [ ] Reviewer to confirm the broader graceful-degrade behavior (`toInt` returning `0` on unknown shapes) is acceptable vs. surfacing an error