### PR TITLE
   fix: validate ZMQ port range to prevent KV-events subscriber startup failures on multi-rank pods

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -659,6 +659,10 @@ func (s *Scorer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMetad
 	// the legacy single-port-per-pod behaviour; multi-rank wide-EP / DP
 	// pods get one subscriber per rank automatically.
 	port := s.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid KV-events ZMQ port %d for endpoint %s (socketPort=%d, rankIndex=%d)",
+			port, endpointKey, s.kvEventsConfig.PodDiscoveryConfig.SocketPort, meta.GetRankIndex())
+	}
 	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
 
 	logger := log.FromContext(ctx).WithName(s.typedName.String())

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_extractor_test.go
@@ -159,6 +159,27 @@ func TestScorer_EnsureSubscriber_SurvivesRequestCtxCancel(t *testing.T) {
 		"subscriber must outlive the caller's request-scoped context")
 }
 
+func TestScorer_EnsureSubscriber_RejectsPortOutOfRange(t *testing.T) {
+	s := newExtractorScorer(true)
+	defer s.subscribersManager.Shutdown(context.Background())
+
+	s.kvEventsConfig.PodDiscoveryConfig.SocketPort = 65535
+
+	err := s.ensureSubscriber(discardCtx(t), &fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a-rank-1"},
+		Address:        "10.0.0.1",
+		Port:           "8080",
+		RankIndex:      1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid KV-events ZMQ port 65536")
+	assert.Contains(t, err.Error(), "socketPort=65535")
+	assert.Contains(t, err.Error(), "rankIndex=1")
+
+	ids, _ := s.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids, "invalid port must not register a subscriber")
+}
+
 // Backwards-compat: configs that don't wire the endpoint-notification-source
 // rely on Score()-time subscriber discovery. Verify the legacy path still
 // installs a subscriber for each endpoint Score() sees.


### PR DESCRIPTION
…res on multi-rank pods

**What type of PR is this?**
 
/kind bug
 

**What this PR does / why we need it**:

issue:
when precise-prefix-cache-scorer runs in pod discovery mode (kvEventsConfig.discoverPods: true with podDiscoveryConfig).  The deployment has multiple ranks per pod (multi-TargetPorts / wide-EP / DP), so EndpointMetadata.RankIndex is ≥ 1 for some endpoints.
The operator sets the base ZMQ socketPort high enough that socketPort + rankIndex exceeds 65535 (e.g. socketPort=65535 and rankIndex=1 → port 65536).


Failure symptoms
  • ensureSubscriber builds an invalid endpoint such as tcp://<pod-ip>:65536.
  • EnsureSubscriber still succeeds; the ZMQ goroutine fails to dial and retries every ~5s.
  • No KV events are indexed for that rank → prefix-cache scoring is wrong or degraded for that rank.
  • No clear startup/config error today; the failure is silent until you inspect logs


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
