### PR TITLE
add MayConsumePlugin interface for optional data key consumption

### DIFF
--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -81,10 +81,10 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 		}
 	}
 
-	// Warn about optional keys (MayConsume) with no producer — no error, just a warning.
+	// Warn about optional keys with no producer — no error, just a warning.
 	for _, p := range handle.GetAllPlugins() {
-		if mayConsumer, ok := p.(plugin.MayConsumePlugin); ok {
-			for key := range mayConsumer.MayConsume() {
+		if consumer, ok := p.(plugin.ConsumerPlugin); ok {
+			for key := range consumer.OptionalConsumes() {
 				if !producedKeys[key.String()] {
 					logger.Info("Warning: optional data key has no producer, plugin will use fallback",
 						"plugin", p.TypedName().Name, "dataKey", key.String())

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -81,6 +81,18 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 		}
 	}
 
+	// Warn about optional keys (MayConsume) with no producer — no error, just a warning.
+	for _, p := range handle.GetAllPlugins() {
+		if mayConsumer, ok := p.(plugin.MayConsumePlugin); ok {
+			for key := range mayConsumer.MayConsume() {
+				if !producedKeys[key.String()] {
+					logger.Info("Warning: optional data key has no producer, plugin will use fallback",
+						"plugin", p.TypedName().Name, "dataKey", key.String())
+				}
+			}
+		}
+	}
+
 	// Build the set of keys that are consumed but not yet produced.
 	missingKeys := make(map[string]string)
 	for _, p := range handle.GetAllPlugins() {

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -84,8 +84,8 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 	// Warn about optional keys with no producer — no error, just a warning.
 	for _, p := range handle.GetAllPlugins() {
 		if consumer, ok := p.(plugin.ConsumerPlugin); ok {
-			result := consumer.Consumes()
-			for key := range result.Optional {
+			dependencies := consumer.Consumes()
+			for key := range dependencies.Optional {
 				if !producedKeys[key.String()] {
 					logger.Info("Warning: optional data key has no producer, plugin will use fallback",
 						"plugin", p.TypedName().Name, "dataKey", key.String())
@@ -98,8 +98,8 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 	missingKeys := make(map[string]string)
 	for _, p := range handle.GetAllPlugins() {
 		if consumer, ok := p.(plugin.ConsumerPlugin); ok {
-			result := consumer.Consumes()
-			for key := range result.Required {
+			dependencies := consumer.Consumes()
+			for key := range dependencies.Required {
 				if !producedKeys[key.String()] {
 					missingKeys[key.String()] = consumer.TypedName().Name
 				}
@@ -205,10 +205,10 @@ func buildDAG(producers map[string]plugin.ProducerPlugin, consumers map[string]p
 			if pName == cName {
 				continue
 			}
-			consumed := consumer.Consumes()
-			if producer.Produces() != nil && consumed.Required != nil {
+			dependencies := consumer.Consumes()
+			if producer.Produces() != nil && dependencies.Required != nil {
 				for producedKey, producedData := range producer.Produces() {
-					if consumedData, ok := consumed.Required[producedKey]; ok {
+					if consumedData, ok := dependencies.Required[producedKey]; ok {
 						// Check types are same.
 						if reflect.TypeOf(producedData) != reflect.TypeOf(consumedData) {
 							return nil, errors.New("data type mismatch between produced and consumed data for key: " + producedKey.String())

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -84,7 +84,8 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 	// Warn about optional keys with no producer — no error, just a warning.
 	for _, p := range handle.GetAllPlugins() {
 		if consumer, ok := p.(plugin.ConsumerPlugin); ok {
-			for key := range consumer.OptionalConsumes() {
+			result := consumer.Consumes()
+			for key := range result.Optional {
 				if !producedKeys[key.String()] {
 					logger.Info("Warning: optional data key has no producer, plugin will use fallback",
 						"plugin", p.TypedName().Name, "dataKey", key.String())
@@ -97,7 +98,8 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 	missingKeys := make(map[string]string)
 	for _, p := range handle.GetAllPlugins() {
 		if consumer, ok := p.(plugin.ConsumerPlugin); ok {
-			for key := range consumer.Consumes() {
+			result := consumer.Consumes()
+			for key := range result.Required {
 				if !producedKeys[key.String()] {
 					missingKeys[key.String()] = consumer.TypedName().Name
 				}
@@ -203,9 +205,10 @@ func buildDAG(producers map[string]plugin.ProducerPlugin, consumers map[string]p
 			if pName == cName {
 				continue
 			}
-			if producer.Produces() != nil && consumer.Consumes() != nil {
+			consumed := consumer.Consumes()
+			if producer.Produces() != nil && consumed.Required != nil {
 				for producedKey, producedData := range producer.Produces() {
-					if consumedData, ok := consumer.Consumes()[producedKey]; ok {
+					if consumedData, ok := consumed.Required[producedKey]; ok {
 						// Check types are same.
 						if reflect.TypeOf(producedData) != reflect.TypeOf(consumedData) {
 							return nil, errors.New("data type mismatch between produced and consumed data for key: " + producedKey.String())

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -437,7 +437,7 @@ func TestCreateMissingDataProducers(t *testing.T) {
 
 // mockMayConsumerPlugin is a plugin that only optionally consumes certain data keys.
 type mockMayConsumerPlugin struct {
-	name            string
+	name             string
 	optionalConsumes map[fwkplugin.DataKey]any
 }
 
@@ -455,8 +455,8 @@ func (m *mockMayConsumerPlugin) OptionalConsumes() map[fwkplugin.DataKey]any {
 // This models a real plugin like prefix cache scorer — requires prefix-match data,
 // but optionally uses tokenized input and falls back to raw text if unavailable.
 type mockMixedConsumerPlugin struct {
-	name            string
-	consumes        map[fwkplugin.DataKey]any
+	name             string
+	consumes         map[fwkplugin.DataKey]any
 	optionalConsumes map[fwkplugin.DataKey]any
 }
 
@@ -490,7 +490,7 @@ func TestCreateMissingDataProducers_MayConsume(t *testing.T) {
 			name: "OptionalConsumes key with no producer — warning only, no error",
 			existingPlugins: []fwkplugin.Plugin{
 				&mockMayConsumerPlugin{
-					name:            "optional-consumer",
+					name:             "optional-consumer",
 					optionalConsumes: map[fwkplugin.DataKey]any{keyA: nil},
 				},
 			},
@@ -502,7 +502,7 @@ func TestCreateMissingDataProducers_MayConsume(t *testing.T) {
 			existingPlugins: []fwkplugin.Plugin{
 				&mockDataProducerP{name: "producer", produces: map[fwkplugin.DataKey]any{keyA: nil}},
 				&mockMayConsumerPlugin{
-					name:            "optional-consumer",
+					name:             "optional-consumer",
 					optionalConsumes: map[fwkplugin.DataKey]any{keyA: nil},
 				},
 			},
@@ -518,8 +518,8 @@ func TestCreateMissingDataProducers_MayConsume(t *testing.T) {
 			existingPlugins: []fwkplugin.Plugin{
 				&mockDataProducerP{name: "required-producer", produces: map[fwkplugin.DataKey]any{keyA: nil}},
 				&mockMixedConsumerPlugin{
-					name:            "prefix-cache-scorer",
-					consumes:        map[fwkplugin.DataKey]any{keyA: nil},
+					name:             "prefix-cache-scorer",
+					consumes:         map[fwkplugin.DataKey]any{keyA: nil},
 					optionalConsumes: map[fwkplugin.DataKey]any{fwkplugin.NewDataKey("tokenized-input", "tokenizer"): nil},
 				},
 			},

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -58,11 +58,9 @@ func (m *mockDataProducerP) Produces() map[fwkplugin.DataKey]any {
 	return m.produces
 }
 
-func (m *mockDataProducerP) Consumes() map[fwkplugin.DataKey]any {
-	return m.consumes
+func (m *mockDataProducerP) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{Required: m.consumes}
 }
-
-func (m *mockDataProducerP) OptionalConsumes() map[fwkplugin.DataKey]any { return nil }
 
 func (m *mockDataProducerP) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, &mockProducedDataType{value: 42})
@@ -90,11 +88,9 @@ type MockConsumerFairnessPolicy struct {
 	consumes map[fwkplugin.DataKey]any
 }
 
-func (m *MockConsumerFairnessPolicy) Consumes() map[fwkplugin.DataKey]any {
-	return m.consumes
+func (m *MockConsumerFairnessPolicy) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{Required: m.consumes}
 }
-
-func (m *MockConsumerFairnessPolicy) OptionalConsumes() map[fwkplugin.DataKey]any { return nil }
 
 type MockSchedulingPlugin struct {
 	fwksched.Scorer
@@ -105,11 +101,9 @@ func (m *MockSchedulingPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: "MockSchedulingPlugin", Type: "mock"}
 }
 
-func (m *MockSchedulingPlugin) Consumes() map[fwkplugin.DataKey]any {
-	return m.consumes
+func (m *MockSchedulingPlugin) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{Required: m.consumes}
 }
-
-func (m *MockSchedulingPlugin) OptionalConsumes() map[fwkplugin.DataKey]any { return nil }
 
 func TestValidatePluginExecutionOrder(t *testing.T) {
 	dkA := fwkplugin.NewDataKey("keyA", "mock")
@@ -445,10 +439,8 @@ func (m *mockMayConsumerPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockMayConsumerPlugin) Consumes() map[fwkplugin.DataKey]any { return nil }
-
-func (m *mockMayConsumerPlugin) OptionalConsumes() map[fwkplugin.DataKey]any {
-	return m.optionalConsumes
+func (m *mockMayConsumerPlugin) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{Optional: m.optionalConsumes}
 }
 
 // mockMixedConsumerPlugin is a plugin that has both required Consumes and optional OptionalConsumes.
@@ -464,12 +456,8 @@ func (m *mockMixedConsumerPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockMixedConsumerPlugin) Consumes() map[fwkplugin.DataKey]any {
-	return m.consumes
-}
-
-func (m *mockMixedConsumerPlugin) OptionalConsumes() map[fwkplugin.DataKey]any {
-	return m.optionalConsumes
+func (m *mockMixedConsumerPlugin) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{Required: m.consumes, Optional: m.optionalConsumes}
 }
 
 func TestCreateMissingDataProducers_MayConsume(t *testing.T) {

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -429,6 +429,115 @@ func TestCreateMissingDataProducers(t *testing.T) {
 	}
 }
 
+// mockMayConsumerPlugin is a plugin that optionally consumes certain data keys.
+type mockMayConsumerPlugin struct {
+	name       string
+	mayConsume map[fwkplugin.DataKey]any
+}
+
+func (m *mockMayConsumerPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
+}
+
+func (m *mockMayConsumerPlugin) MayConsume() map[fwkplugin.DataKey]any {
+	return m.mayConsume
+}
+
+// mockMixedConsumerPlugin is a plugin that has both required Consumes and optional MayConsume.
+// This models a real plugin like prefix cache scorer — requires prefix-match data,
+// but optionally uses tokenized input and falls back to raw text if unavailable.
+type mockMixedConsumerPlugin struct {
+	name       string
+	consumes   map[fwkplugin.DataKey]any
+	mayConsume map[fwkplugin.DataKey]any
+}
+
+func (m *mockMixedConsumerPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
+}
+
+func (m *mockMixedConsumerPlugin) Consumes() map[fwkplugin.DataKey]any {
+	return m.consumes
+}
+
+func (m *mockMixedConsumerPlugin) MayConsume() map[fwkplugin.DataKey]any {
+	return m.mayConsume
+}
+
+func TestCreateMissingDataProducers_MayConsume(t *testing.T) {
+	producerTypeA := "producer-a"
+	keyA := fwkplugin.NewDataKey("keyA", producerTypeA)
+
+	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+		return &mockDataProducerP{name: name, produces: map[fwkplugin.DataKey]any{keyA: nil}}, nil
+	})
+
+	testCases := []struct {
+		name            string
+		existingPlugins []fwkplugin.Plugin
+		factoryRegistry map[string]fwkplugin.FactoryFunc
+		wantErr         bool
+	}{
+		{
+			name: "MayConsume key with no producer — warning only, no error",
+			existingPlugins: []fwkplugin.Plugin{
+				&mockMayConsumerPlugin{
+					name:       "optional-consumer",
+					mayConsume: map[fwkplugin.DataKey]any{keyA: nil},
+				},
+			},
+			factoryRegistry: map[string]fwkplugin.FactoryFunc{},
+			wantErr:         false, // must NOT error
+		},
+		{
+			name: "MayConsume key with a producer present — no warning, no error",
+			existingPlugins: []fwkplugin.Plugin{
+				&mockDataProducerP{name: "producer", produces: map[fwkplugin.DataKey]any{keyA: nil}},
+				&mockMayConsumerPlugin{
+					name:       "optional-consumer",
+					mayConsume: map[fwkplugin.DataKey]any{keyA: nil},
+				},
+			},
+			factoryRegistry: map[string]fwkplugin.FactoryFunc{producerTypeA: producerAFactory},
+			wantErr:         false,
+		},
+		{
+			// Models the real prefix cache scorer — it requires prefix-match data (Consumes)
+			// but optionally uses tokenized input (MayConsume), falling back to raw text.
+			// The required key has a producer. The optional key does not.
+			// Result: no error. Warning logged for the missing optional key.
+			name: "plugin with both Consumes and MayConsume — required key has producer, optional does not",
+			existingPlugins: []fwkplugin.Plugin{
+				&mockDataProducerP{name: "required-producer", produces: map[fwkplugin.DataKey]any{keyA: nil}},
+				&mockMixedConsumerPlugin{
+					name:       "prefix-cache-scorer",
+					consumes:   map[fwkplugin.DataKey]any{keyA: nil},
+					mayConsume: map[fwkplugin.DataKey]any{fwkplugin.NewDataKey("tokenized-input", "tokenizer"): nil},
+				},
+			},
+			factoryRegistry: map[string]fwkplugin.FactoryFunc{},
+			wantErr:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handle := fwkplugin.NewEppHandle(context.Background(), func() []k8stypes.NamespacedName { return nil })
+			for _, p := range tc.existingPlugins {
+				handle.AddPlugin(p.TypedName().Name, p)
+			}
+
+			err := CreateMissingDataProducers(context.Background(), map[string]string{}, tc.factoryRegistry, handle)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func assertTopologicalOrder(t *testing.T, dag map[string][]string, ordered []string) {
 	t.Helper()
 	positions := make(map[string]int)

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -62,6 +62,8 @@ func (m *mockDataProducerP) Consumes() map[fwkplugin.DataKey]any {
 	return m.consumes
 }
 
+func (m *mockDataProducerP) OptionalConsumes() map[fwkplugin.DataKey]any { return nil }
+
 func (m *mockDataProducerP) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, &mockProducedDataType{value: 42})
 	return nil
@@ -92,6 +94,8 @@ func (m *MockConsumerFairnessPolicy) Consumes() map[fwkplugin.DataKey]any {
 	return m.consumes
 }
 
+func (m *MockConsumerFairnessPolicy) OptionalConsumes() map[fwkplugin.DataKey]any { return nil }
+
 type MockSchedulingPlugin struct {
 	fwksched.Scorer
 	consumes map[fwkplugin.DataKey]any
@@ -104,6 +108,8 @@ func (m *MockSchedulingPlugin) TypedName() fwkplugin.TypedName {
 func (m *MockSchedulingPlugin) Consumes() map[fwkplugin.DataKey]any {
 	return m.consumes
 }
+
+func (m *MockSchedulingPlugin) OptionalConsumes() map[fwkplugin.DataKey]any { return nil }
 
 func TestValidatePluginExecutionOrder(t *testing.T) {
 	dkA := fwkplugin.NewDataKey("keyA", "mock")
@@ -429,27 +435,29 @@ func TestCreateMissingDataProducers(t *testing.T) {
 	}
 }
 
-// mockMayConsumerPlugin is a plugin that optionally consumes certain data keys.
+// mockMayConsumerPlugin is a plugin that only optionally consumes certain data keys.
 type mockMayConsumerPlugin struct {
-	name       string
-	mayConsume map[fwkplugin.DataKey]any
+	name            string
+	optionalConsumes map[fwkplugin.DataKey]any
 }
 
 func (m *mockMayConsumerPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockMayConsumerPlugin) MayConsume() map[fwkplugin.DataKey]any {
-	return m.mayConsume
+func (m *mockMayConsumerPlugin) Consumes() map[fwkplugin.DataKey]any { return nil }
+
+func (m *mockMayConsumerPlugin) OptionalConsumes() map[fwkplugin.DataKey]any {
+	return m.optionalConsumes
 }
 
-// mockMixedConsumerPlugin is a plugin that has both required Consumes and optional MayConsume.
+// mockMixedConsumerPlugin is a plugin that has both required Consumes and optional OptionalConsumes.
 // This models a real plugin like prefix cache scorer — requires prefix-match data,
 // but optionally uses tokenized input and falls back to raw text if unavailable.
 type mockMixedConsumerPlugin struct {
-	name       string
-	consumes   map[fwkplugin.DataKey]any
-	mayConsume map[fwkplugin.DataKey]any
+	name            string
+	consumes        map[fwkplugin.DataKey]any
+	optionalConsumes map[fwkplugin.DataKey]any
 }
 
 func (m *mockMixedConsumerPlugin) TypedName() fwkplugin.TypedName {
@@ -460,15 +468,15 @@ func (m *mockMixedConsumerPlugin) Consumes() map[fwkplugin.DataKey]any {
 	return m.consumes
 }
 
-func (m *mockMixedConsumerPlugin) MayConsume() map[fwkplugin.DataKey]any {
-	return m.mayConsume
+func (m *mockMixedConsumerPlugin) OptionalConsumes() map[fwkplugin.DataKey]any {
+	return m.optionalConsumes
 }
 
 func TestCreateMissingDataProducers_MayConsume(t *testing.T) {
 	producerTypeA := "producer-a"
 	keyA := fwkplugin.NewDataKey("keyA", producerTypeA)
 
-	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	producerAFactory := fwkplugin.FactoryFunc(func(name string, _ *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockDataProducerP{name: name, produces: map[fwkplugin.DataKey]any{keyA: nil}}, nil
 	})
 
@@ -479,23 +487,23 @@ func TestCreateMissingDataProducers_MayConsume(t *testing.T) {
 		wantErr         bool
 	}{
 		{
-			name: "MayConsume key with no producer — warning only, no error",
+			name: "OptionalConsumes key with no producer — warning only, no error",
 			existingPlugins: []fwkplugin.Plugin{
 				&mockMayConsumerPlugin{
-					name:       "optional-consumer",
-					mayConsume: map[fwkplugin.DataKey]any{keyA: nil},
+					name:            "optional-consumer",
+					optionalConsumes: map[fwkplugin.DataKey]any{keyA: nil},
 				},
 			},
 			factoryRegistry: map[string]fwkplugin.FactoryFunc{},
 			wantErr:         false, // must NOT error
 		},
 		{
-			name: "MayConsume key with a producer present — no warning, no error",
+			name: "OptionalConsumes key with a producer present — no warning, no error",
 			existingPlugins: []fwkplugin.Plugin{
 				&mockDataProducerP{name: "producer", produces: map[fwkplugin.DataKey]any{keyA: nil}},
 				&mockMayConsumerPlugin{
-					name:       "optional-consumer",
-					mayConsume: map[fwkplugin.DataKey]any{keyA: nil},
+					name:            "optional-consumer",
+					optionalConsumes: map[fwkplugin.DataKey]any{keyA: nil},
 				},
 			},
 			factoryRegistry: map[string]fwkplugin.FactoryFunc{producerTypeA: producerAFactory},
@@ -503,16 +511,16 @@ func TestCreateMissingDataProducers_MayConsume(t *testing.T) {
 		},
 		{
 			// Models the real prefix cache scorer — it requires prefix-match data (Consumes)
-			// but optionally uses tokenized input (MayConsume), falling back to raw text.
+			// but optionally uses tokenized input (OptionalConsumes), falling back to raw text.
 			// The required key has a producer. The optional key does not.
 			// Result: no error. Warning logged for the missing optional key.
-			name: "plugin with both Consumes and MayConsume — required key has producer, optional does not",
+			name: "plugin with both Consumes and OptionalConsumes — required key has producer, optional does not",
 			existingPlugins: []fwkplugin.Plugin{
 				&mockDataProducerP{name: "required-producer", produces: map[fwkplugin.DataKey]any{keyA: nil}},
 				&mockMixedConsumerPlugin{
-					name:       "prefix-cache-scorer",
-					consumes:   map[fwkplugin.DataKey]any{keyA: nil},
-					mayConsume: map[fwkplugin.DataKey]any{fwkplugin.NewDataKey("tokenized-input", "tokenizer"): nil},
+					name:            "prefix-cache-scorer",
+					consumes:        map[fwkplugin.DataKey]any{keyA: nil},
+					optionalConsumes: map[fwkplugin.DataKey]any{fwkplugin.NewDataKey("tokenized-input", "tokenizer"): nil},
 				},
 			},
 			factoryRegistry: map[string]fwkplugin.FactoryFunc{},

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -58,8 +58,8 @@ func (m *mockDataProducerP) Produces() map[fwkplugin.DataKey]any {
 	return m.produces
 }
 
-func (m *mockDataProducerP) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{Required: m.consumes}
+func (m *mockDataProducerP) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{Required: m.consumes}
 }
 
 func (m *mockDataProducerP) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
@@ -88,8 +88,8 @@ type MockConsumerFairnessPolicy struct {
 	consumes map[fwkplugin.DataKey]any
 }
 
-func (m *MockConsumerFairnessPolicy) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{Required: m.consumes}
+func (m *MockConsumerFairnessPolicy) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{Required: m.consumes}
 }
 
 type MockSchedulingPlugin struct {
@@ -101,8 +101,8 @@ func (m *MockSchedulingPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: "MockSchedulingPlugin", Type: "mock"}
 }
 
-func (m *MockSchedulingPlugin) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{Required: m.consumes}
+func (m *MockSchedulingPlugin) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{Required: m.consumes}
 }
 
 func TestValidatePluginExecutionOrder(t *testing.T) {
@@ -439,8 +439,8 @@ func (m *mockMayConsumerPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockMayConsumerPlugin) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{Optional: m.optionalConsumes}
+func (m *mockMayConsumerPlugin) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{Optional: m.optionalConsumes}
 }
 
 // mockMixedConsumerPlugin is a plugin that has both required Consumes and optional OptionalConsumes.
@@ -456,8 +456,8 @@ func (m *mockMixedConsumerPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockMixedConsumerPlugin) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{Required: m.consumes, Optional: m.optionalConsumes}
+func (m *mockMixedConsumerPlugin) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{Required: m.consumes, Optional: m.optionalConsumes}
 }
 
 func TestCreateMissingDataProducers_MayConsume(t *testing.T) {

--- a/pkg/epp/framework/interface/plugin/plugins.go
+++ b/pkg/epp/framework/interface/plugin/plugins.go
@@ -30,16 +30,11 @@ type ConsumerPlugin interface {
 	// This is a map from DataKey produced to
 	// the data type of the key (represented as data with default value casted as any field).
 	Consumes() map[DataKey]any
-}
-
-// MayConsumePlugin defines the interface for a plugin that optionally consumes data.
-// Unlike ConsumerPlugin, the framework will NOT error if no producer exists for these keys.
-// Instead it logs a warning at init time. The plugin must handle the case where this data is absent.
-type MayConsumePlugin interface {
-	Plugin
-	// MayConsume returns data keys the plugin can optionally consume.
-	// The plugin must handle the case where this data is absent.
-	MayConsume() map[DataKey]any
+	// OptionalConsumes returns data keys the plugin can optionally consume.
+	// Unlike Consumes(), the framework will NOT error if no producer exists for these keys.
+	// Instead it logs a warning at init time. The plugin must handle the case where this data is absent.
+	// Return nil if there are no optional keys.
+	OptionalConsumes() map[DataKey]any
 }
 
 // ProducerPlugin defines the interface for a producer.

--- a/pkg/epp/framework/interface/plugin/plugins.go
+++ b/pkg/epp/framework/interface/plugin/plugins.go
@@ -23,10 +23,10 @@ type Plugin interface {
 	TypedName() TypedName
 }
 
-// ConsumesResult holds the data keys a plugin consumes, split by whether they
+// DataDependencies holds the data keys a plugin consumes, split by whether they
 // are required (framework errors if no producer exists) or optional (framework
 // logs a warning but continues if no producer exists).
-type ConsumesResult struct {
+type DataDependencies struct {
 	// Required keys — the framework will error at init time if no producer exists for any of these.
 	Required map[DataKey]any
 	// Optional keys — the framework logs a warning at init time but does NOT error if no producer exists.
@@ -40,7 +40,7 @@ type ConsumerPlugin interface {
 	// Consumes returns the data keys consumed by this plugin, split into Required and Optional.
 	// Required keys: the framework errors at init time if no producer exists.
 	// Optional keys: the framework logs a warning but does not error; the plugin must handle absence.
-	Consumes() ConsumesResult
+	Consumes() DataDependencies
 }
 
 // ProducerPlugin defines the interface for a producer.

--- a/pkg/epp/framework/interface/plugin/plugins.go
+++ b/pkg/epp/framework/interface/plugin/plugins.go
@@ -23,18 +23,24 @@ type Plugin interface {
 	TypedName() TypedName
 }
 
+// ConsumesResult holds the data keys a plugin consumes, split by whether they
+// are required (framework errors if no producer exists) or optional (framework
+// logs a warning but continues if no producer exists).
+type ConsumesResult struct {
+	// Required keys — the framework will error at init time if no producer exists for any of these.
+	Required map[DataKey]any
+	// Optional keys — the framework logs a warning at init time but does NOT error if no producer exists.
+	// The plugin must handle the case where this data is absent at runtime.
+	Optional map[DataKey]any
+}
+
 // ConsumerPlugin defines the interface for a consumer.
 type ConsumerPlugin interface {
 	Plugin
-	// Consumes returns data consumed by the plugin.
-	// This is a map from DataKey produced to
-	// the data type of the key (represented as data with default value casted as any field).
-	Consumes() map[DataKey]any
-	// OptionalConsumes returns data keys the plugin can optionally consume.
-	// Unlike Consumes(), the framework will NOT error if no producer exists for these keys.
-	// Instead it logs a warning at init time. The plugin must handle the case where this data is absent.
-	// Return nil if there are no optional keys.
-	OptionalConsumes() map[DataKey]any
+	// Consumes returns the data keys consumed by this plugin, split into Required and Optional.
+	// Required keys: the framework errors at init time if no producer exists.
+	// Optional keys: the framework logs a warning but does not error; the plugin must handle absence.
+	Consumes() ConsumesResult
 }
 
 // ProducerPlugin defines the interface for a producer.

--- a/pkg/epp/framework/interface/plugin/plugins.go
+++ b/pkg/epp/framework/interface/plugin/plugins.go
@@ -32,6 +32,16 @@ type ConsumerPlugin interface {
 	Consumes() map[DataKey]any
 }
 
+// MayConsumePlugin defines the interface for a plugin that optionally consumes data.
+// Unlike ConsumerPlugin, the framework will NOT error if no producer exists for these keys.
+// Instead it logs a warning at init time. The plugin must handle the case where this data is absent.
+type MayConsumePlugin interface {
+	Plugin
+	// MayConsume returns data keys the plugin can optionally consume.
+	// The plugin must handle the case where this data is absent.
+	MayConsume() map[DataKey]any
+}
+
 // ProducerPlugin defines the interface for a producer.
 type ProducerPlugin interface {
 	Plugin

--- a/pkg/epp/framework/interface/plugin/plugins_test.go
+++ b/pkg/epp/framework/interface/plugin/plugins_test.go
@@ -33,8 +33,7 @@ type consumerImpl struct {
 	consumes map[DataKey]any
 }
 
-func (c *consumerImpl) Consumes() map[DataKey]any         { return c.consumes }
-func (c *consumerImpl) OptionalConsumes() map[DataKey]any { return nil }
+func (c *consumerImpl) Consumes() ConsumesResult { return ConsumesResult{Required: c.consumes} }
 
 type producerImpl struct {
 	basePlugin
@@ -59,8 +58,8 @@ func TestConsumerPlugin_Contract(t *testing.T) {
 	var cp ConsumerPlugin = c
 
 	got := cp.Consumes()
-	assert.Len(t, got, 1)
-	_, ok := got[key]
+	assert.Len(t, got.Required, 1)
+	_, ok := got.Required[key]
 	assert.True(t, ok)
 	assert.Equal(t, "queue-filter/filter", cp.TypedName().String())
 }
@@ -87,7 +86,7 @@ func TestConsumerPlugin_EmptyConsumes(t *testing.T) {
 		basePlugin: basePlugin{name: TypedName{Type: "filter", Name: "noop"}},
 		consumes:   nil,
 	}
-	assert.Nil(t, c.Consumes())
+	assert.Nil(t, c.Consumes().Required)
 }
 
 func TestProducerPlugin_EmptyProduces(t *testing.T) {

--- a/pkg/epp/framework/interface/plugin/plugins_test.go
+++ b/pkg/epp/framework/interface/plugin/plugins_test.go
@@ -33,7 +33,8 @@ type consumerImpl struct {
 	consumes map[DataKey]any
 }
 
-func (c *consumerImpl) Consumes() map[DataKey]any { return c.consumes }
+func (c *consumerImpl) Consumes() map[DataKey]any         { return c.consumes }
+func (c *consumerImpl) OptionalConsumes() map[DataKey]any { return nil }
 
 type producerImpl struct {
 	basePlugin

--- a/pkg/epp/framework/interface/plugin/plugins_test.go
+++ b/pkg/epp/framework/interface/plugin/plugins_test.go
@@ -33,7 +33,7 @@ type consumerImpl struct {
 	consumes map[DataKey]any
 }
 
-func (c *consumerImpl) Consumes() ConsumesResult { return ConsumesResult{Required: c.consumes} }
+func (c *consumerImpl) Consumes() DataDependencies { return DataDependencies{Required: c.consumes} }
 
 type producerImpl struct {
 	basePlugin

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -103,9 +103,9 @@ func (d *detector) TypedName() fwkplugin.TypedName {
 	return d.typedName
 }
 
-func (d *detector) Consumes() map[fwkplugin.DataKey]any {
-	return map[fwkplugin.DataKey]any{
-		d.inFlightLoadDataKey: attrconcurrency.InFlightLoad{},
+func (d *detector) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{
+		Required: map[fwkplugin.DataKey]any{d.inFlightLoadDataKey: attrconcurrency.InFlightLoad{}},
 	}
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -103,8 +103,8 @@ func (d *detector) TypedName() fwkplugin.TypedName {
 	return d.typedName
 }
 
-func (d *detector) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{
+func (d *detector) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{d.inFlightLoadDataKey: attrconcurrency.InFlightLoad{}},
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -89,9 +89,9 @@ func (p *LatencyAdmission) TypedName() fwkplugin.TypedName {
 }
 
 // Consumes declares that this plugin reads latency prediction data from endpoints.
-func (p *LatencyAdmission) Consumes() map[fwkplugin.DataKey]any {
-	return map[fwkplugin.DataKey]any{
-		p.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{},
+func (p *LatencyAdmission) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{
+		Required: map[fwkplugin.DataKey]any{p.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{}},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -89,8 +89,8 @@ func (p *LatencyAdmission) TypedName() fwkplugin.TypedName {
 }
 
 // Consumes declares that this plugin reads latency prediction data from endpoints.
-func (p *LatencyAdmission) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{
+func (p *LatencyAdmission) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{p.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -209,8 +209,10 @@ func (p *Producer) Produces() map[plugin.DataKey]any {
 
 // Consumes declares the TokenizedPrompt dependency from token-producer so
 // the data-layer DAG orders tokenization before this producer runs.
-func (p *Producer) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedPrompt{}}
+func (p *Producer) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedPrompt{}},
+	}
 }
 
 // Produce hashes the request's TokenizedPrompt into KV-block keys, looks

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -209,8 +209,8 @@ func (p *Producer) Produces() map[plugin.DataKey]any {
 
 // Consumes declares the TokenizedPrompt dependency from token-producer so
 // the data-layer DAG orders tokenization before this producer runs.
-func (p *Producer) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (p *Producer) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedPrompt{}},
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -306,7 +306,7 @@ func TestProduces_DeclaresPrefixCacheMatchInfo(t *testing.T) {
 func TestConsumes_DeclaresTokenizedPrompt(t *testing.T) {
 	p := &Producer{typedName: plugin.TypedName{Type: PluginType, Name: "x"}}
 	expected := plugin.NewDataKey("TokenizedPrompt", "token-producer")
-	_, ok := p.Consumes()[expected]
+	_, ok := p.Consumes().Required[expected]
 	require.True(t, ok)
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
@@ -112,8 +112,8 @@ func (pl *PredictedLatency) Produces() map[plugin.DataKey]any {
 	}
 }
 
-func (pl *PredictedLatency) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (pl *PredictedLatency) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{pl.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
@@ -112,6 +112,8 @@ func (pl *PredictedLatency) Produces() map[plugin.DataKey]any {
 	}
 }
 
-func (pl *PredictedLatency) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{pl.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{}}
+func (pl *PredictedLatency) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{pl.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{}},
+	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks_test.go
@@ -35,7 +35,7 @@ func TestProducesConsumes(t *testing.T) {
 	assert.Contains(t, produces, expectedProduceKey)
 
 	consumes := pl.Consumes()
-	assert.Contains(t, consumes, attrprefix.PrefixCacheMatchInfoDataKey)
+	assert.Contains(t, consumes.Required, attrprefix.PrefixCacheMatchInfoDataKey)
 }
 
 // TestProduce_CancelledContextDoesNotPublish verifies that when the

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -182,7 +182,7 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	return sticky
 }
 
-func (p *Plugin) Consumes() fwkplugin.ConsumesResult {
+func (p *Plugin) Consumes() fwkplugin.DataDependencies {
 	required := map[fwkplugin.DataKey]any{
 		p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{},
 	}
@@ -192,7 +192,7 @@ func (p *Plugin) Consumes() fwkplugin.ConsumesResult {
 	if p.config.MaxTokensInFlightPenalty > 0 {
 		required[p.inFlightLoadDataKey] = attrconcurrency.InFlightLoad{}
 	}
-	return fwkplugin.ConsumesResult{Required: required}
+	return fwkplugin.DataDependencies{Required: required}
 }
 
 func (p *Plugin) prefixCacheScore(ep fwksched.Endpoint) float64 {

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -182,17 +182,17 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	return sticky
 }
 
-func (p *Plugin) Consumes() map[fwkplugin.DataKey]any {
-	res := map[fwkplugin.DataKey]any{
+func (p *Plugin) Consumes() fwkplugin.ConsumesResult {
+	required := map[fwkplugin.DataKey]any{
 		p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{},
 	}
 	if p.config.MaxTTFTPenaltyMs > 0 {
-		res[p.latencyPredictionInfoDataKey] = attrlatency.LatencyPredictionInfo{}
+		required[p.latencyPredictionInfoDataKey] = attrlatency.LatencyPredictionInfo{}
 	}
 	if p.config.MaxTokensInFlightPenalty > 0 {
-		res[p.inFlightLoadDataKey] = attrconcurrency.InFlightLoad{}
+		required[p.inFlightLoadDataKey] = attrconcurrency.InFlightLoad{}
 	}
-	return res
+	return fwkplugin.ConsumesResult{Required: required}
 }
 
 func (p *Plugin) prefixCacheScore(ep fwksched.Endpoint) float64 {

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -155,33 +155,33 @@ func TestConsumes_ConditionalAttributes(t *testing.T) {
 	// Everything disabled
 	p := newTestPlugin(Config{MaxTTFTPenaltyMs: 0, MaxTokensInFlightPenalty: 0})
 	consumed := p.Consumes()
-	_, ok := consumed[p.inFlightLoadDataKey]
+	_, ok := consumed.Required[p.inFlightLoadDataKey]
 	assert.False(t, ok, "InFlightLoadDataKey should not be consumed when penalty is 0")
-	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
 	assert.False(t, ok, "LatencyPredictionInfoDataKey should not be consumed when penalty is 0")
 
 	// Only TTFT enabled
 	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, MaxTokensInFlightPenalty: 0})
 	consumed = p.Consumes()
-	_, ok = consumed[p.inFlightLoadDataKey]
+	_, ok = consumed.Required[p.inFlightLoadDataKey]
 	assert.False(t, ok)
-	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
 	assert.True(t, ok)
 
 	// Only In-flight enabled
 	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 0, MaxTokensInFlightPenalty: 100})
 	consumed = p.Consumes()
-	_, ok = consumed[p.inFlightLoadDataKey]
+	_, ok = consumed.Required[p.inFlightLoadDataKey]
 	assert.True(t, ok)
-	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
 	assert.False(t, ok)
 
 	// Both enabled
 	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, MaxTokensInFlightPenalty: 100})
 	consumed = p.Consumes()
-	_, ok = consumed[p.inFlightLoadDataKey]
+	_, ok = consumed.Required[p.inFlightLoadDataKey]
 	assert.True(t, ok)
-	_, ok = consumed[p.latencyPredictionInfoDataKey]
+	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
 	assert.True(t, ok)
 }
 

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -141,8 +141,8 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	}
 }
 
-func (p *Plugin) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{
+func (p *Plugin) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{p.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -141,8 +141,8 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	}
 }
 
-func (p *Plugin) Consumes() map[fwkplugin.DataKey]any {
-	return map[fwkplugin.DataKey]any{
-		p.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{},
+func (p *Plugin) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{
+		Required: map[fwkplugin.DataKey]any{p.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -232,8 +232,10 @@ func (h *Handler) WithName(name string) *Handler {
 }
 
 // Consumes defines data types consumed by this plugin (through the PD decider).
-func (*Handler) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{}}
+func (*Handler) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{}},
+	}
 }
 
 func newDisaggProfileHandler(handlerType, decodeProfile, prefillProfile, encodeProfile string, pdDecider, encodeDecider deciderPlugin) *Handler {

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -232,8 +232,8 @@ func (h *Handler) WithName(name string) *Handler {
 }
 
 // Consumes defines data types consumed by this plugin (through the PD decider).
-func (*Handler) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (*Handler) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -127,8 +127,10 @@ type PdProfileHandler struct {
 }
 
 // Consumes defines data types consumed by this plugin (through the PD decider).
-func (h *PdProfileHandler) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{h.dk: attrprefix.PrefixCacheMatchInfo{}}
+func (h *PdProfileHandler) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{h.dk: attrprefix.PrefixCacheMatchInfo{}},
+	}
 }
 
 // TypedName returns the typed name of the plugin.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -127,8 +127,8 @@ type PdProfileHandler struct {
 }
 
 // Consumes defines data types consumed by this plugin (through the PD decider).
-func (h *PdProfileHandler) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (h *PdProfileHandler) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{h.dk: attrprefix.PrefixCacheMatchInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -380,7 +380,7 @@ func TestConsumes(t *testing.T) {
 	require.NoError(t, err)
 
 	consumed := handler.Consumes()
-	assert.Contains(t, consumed, attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test"))
+	assert.Contains(t, consumed.Required, attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test"))
 }
 
 func TestWithName(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -149,6 +149,9 @@ func (s *ActiveRequest) Consumes() map[plugin.DataKey]any {
 	}
 }
 
+// OptionalConsumes returns nil as this plugin has no optional data dependencies.
+func (s *ActiveRequest) OptionalConsumes() map[plugin.DataKey]any { return nil }
+
 // Score scores the given endpoints based on the number of active requests
 // being served by each endpoint. The score is normalized to a range of 0-1.
 func (s *ActiveRequest) Score(ctx context.Context, _ *scheduling.InferenceRequest,

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -143,8 +143,8 @@ func (s *ActiveRequest) Category() scheduling.ScorerCategory {
 }
 
 // Consumes returns the in-flight load attribute required for scoring.
-func (s *ActiveRequest) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (s *ActiveRequest) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -143,14 +143,11 @@ func (s *ActiveRequest) Category() scheduling.ScorerCategory {
 }
 
 // Consumes returns the in-flight load attribute required for scoring.
-func (s *ActiveRequest) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{
-		s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{},
+func (s *ActiveRequest) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{}},
 	}
 }
-
-// OptionalConsumes returns nil as this plugin has no optional data dependencies.
-func (s *ActiveRequest) OptionalConsumes() map[plugin.DataKey]any { return nil }
 
 // Score scores the given endpoints based on the number of active requests
 // being served by each endpoint. The score is normalized to a range of 0-1.

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -149,8 +149,8 @@ func TestActiveRequestScorer_Consumes(t *testing.T) {
 	scorer := NewActiveRequest(ctx, nil)
 	consumes := scorer.Consumes()
 
-	require.Len(t, consumes, 1)
-	assert.Equal(t, attrconcurrency.InFlightLoad{}, consumes[attrconcurrency.InFlightLoadDataKey])
+	require.Len(t, consumes.Required, 1)
+	assert.Equal(t, attrconcurrency.InFlightLoad{}, consumes.Required[attrconcurrency.InFlightLoadDataKey])
 }
 
 func TestActiveRequestScorer_TypedName(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -375,8 +375,8 @@ func (s *Plugin) compositeScores(ctx context.Context, endpoints []fwksched.Endpo
 	return scores
 }
 
-func (s *Plugin) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{
+func (s *Plugin) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
 			s.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{},
 			s.prefixMatchDataKey:           attrprefix.PrefixCacheMatchInfo{},

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -375,10 +375,12 @@ func (s *Plugin) compositeScores(ctx context.Context, endpoints []fwksched.Endpo
 	return scores
 }
 
-func (s *Plugin) Consumes() map[fwkplugin.DataKey]any {
-	return map[fwkplugin.DataKey]any{
-		s.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{},
-		s.prefixMatchDataKey:           attrprefix.PrefixCacheMatchInfo{},
+func (s *Plugin) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{
+		Required: map[fwkplugin.DataKey]any{
+			s.latencyPredictionInfoDataKey: attrlatency.LatencyPredictionInfo{},
+			s.prefixMatchDataKey:           attrprefix.PrefixCacheMatchInfo{},
+		},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
@@ -85,8 +85,8 @@ func (s *Scorer) Category() scheduling.ScorerCategory {
 }
 
 // Consumes returns the endpoint data consumed by this scorer.
-func (s *Scorer) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (s *Scorer) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{s.mmMatchDataKey: attrmm.EncoderCacheMatchInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
@@ -89,6 +89,9 @@ func (s *Scorer) Consumes() map[plugin.DataKey]any {
 	return map[plugin.DataKey]any{s.mmMatchDataKey: attrmm.EncoderCacheMatchInfo{}}
 }
 
+// OptionalConsumes returns nil as this plugin has no optional data dependencies.
+func (s *Scorer) OptionalConsumes() map[plugin.DataKey]any { return nil }
+
 // Score scores endpoints by matched multimodal encoder-cache item size divided
 // by total multimodal request item size.
 func (s *Scorer) Score(ctx context.Context, req *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
@@ -85,12 +85,11 @@ func (s *Scorer) Category() scheduling.ScorerCategory {
 }
 
 // Consumes returns the endpoint data consumed by this scorer.
-func (s *Scorer) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{s.mmMatchDataKey: attrmm.EncoderCacheMatchInfo{}}
+func (s *Scorer) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{s.mmMatchDataKey: attrmm.EncoderCacheMatchInfo{}},
+	}
 }
-
-// OptionalConsumes returns nil as this plugin has no optional data dependencies.
-func (s *Scorer) OptionalConsumes() map[plugin.DataKey]any { return nil }
 
 // Score scores endpoints by matched multimodal encoder-cache item size divided
 // by total multimodal request item size.

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer_test.go
@@ -42,7 +42,7 @@ func TestScorerConsumesMatchInfo(t *testing.T) {
 	scorer := New(testName, "")
 
 	consumes := scorer.Consumes()
-	assert.Contains(t, consumes, attrmm.EncoderCacheMatchInfoKey)
+	assert.Contains(t, consumes.Required, attrmm.EncoderCacheMatchInfoKey)
 	assert.Equal(t, scheduling.Affinity, scorer.Category())
 	assert.Equal(t, Type, scorer.TypedName().Type)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -128,6 +128,9 @@ func (s *NoHitLRU) Consumes() map[plugin.DataKey]any {
 	}
 }
 
+// OptionalConsumes returns nil as this plugin has no optional data dependencies.
+func (s *NoHitLRU) OptionalConsumes() map[plugin.DataKey]any { return nil }
+
 // isColdRequest determines if a request is cold by checking endpoint prefix-cache attributes.
 // Returns true when no endpoint reports any cache-hit blocks, or when no attribute is present.
 func (s *NoHitLRU) isColdRequest(ctx context.Context, endpoints []scheduling.Endpoint) bool {

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -122,14 +122,11 @@ func (s *NoHitLRU) Category() scheduling.ScorerCategory {
 	return scheduling.Distribution
 }
 
-func (s *NoHitLRU) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{
-		s.dk: attrprefix.PrefixCacheMatchInfo{},
+func (s *NoHitLRU) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{s.dk: attrprefix.PrefixCacheMatchInfo{}},
 	}
 }
-
-// OptionalConsumes returns nil as this plugin has no optional data dependencies.
-func (s *NoHitLRU) OptionalConsumes() map[plugin.DataKey]any { return nil }
 
 // isColdRequest determines if a request is cold by checking endpoint prefix-cache attributes.
 // Returns true when no endpoint reports any cache-hit blocks, or when no attribute is present.

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -122,8 +122,8 @@ func (s *NoHitLRU) Category() scheduling.ScorerCategory {
 	return scheduling.Distribution
 }
 
-func (s *NoHitLRU) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (s *NoHitLRU) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{s.dk: attrprefix.PrefixCacheMatchInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -94,8 +94,8 @@ func (p *Plugin) Produces() map[plugin.DataKey]any {
 }
 
 // Consumes returns the data consumed by the plugin.
-func (p *Plugin) Consumes() plugin.ConsumesResult {
-	return plugin.ConsumesResult{
+func (p *Plugin) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{}},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -94,8 +94,10 @@ func (p *Plugin) Produces() map[plugin.DataKey]any {
 }
 
 // Consumes returns the data consumed by the plugin.
-func (p *Plugin) Consumes() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{}}
+func (p *Plugin) Consumes() plugin.ConsumesResult {
+	return plugin.ConsumesResult{
+		Required: map[plugin.DataKey]any{p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{}},
+	}
 }
 
 // Score returns the scoring result for the given list of pods based on prefix cache match info.

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -78,9 +78,9 @@ func (s *TokenLoadScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-func (s *TokenLoadScorer) Consumes() map[fwkplugin.DataKey]any {
-	return map[fwkplugin.DataKey]any{
-		s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{},
+func (s *TokenLoadScorer) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{
+		Required: map[fwkplugin.DataKey]any{s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{}},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -78,8 +78,8 @@ func (s *TokenLoadScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-func (s *TokenLoadScorer) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{
+func (s *TokenLoadScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{}},
 	}
 }

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -124,8 +124,8 @@ func (m *mockDataProducerPlugin) Produces() map[fwkplugin.DataKey]any {
 	return m.produces
 }
 
-func (m *mockDataProducerPlugin) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{Required: m.consumes}
+func (m *mockDataProducerPlugin) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{Required: m.consumes}
 }
 
 func (m *mockDataProducerPlugin) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -124,8 +124,8 @@ func (m *mockDataProducerPlugin) Produces() map[fwkplugin.DataKey]any {
 	return m.produces
 }
 
-func (m *mockDataProducerPlugin) Consumes() map[fwkplugin.DataKey]any {
-	return m.consumes
+func (m *mockDataProducerPlugin) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{Required: m.consumes}
 }
 
 func (m *mockDataProducerPlugin) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -234,8 +234,8 @@ func (p *dagTestPlugin) Produces() map[fwkplugin.DataKey]any {
 	return p.produces
 }
 
-func (p *dagTestPlugin) Consumes() fwkplugin.ConsumesResult {
-	return fwkplugin.ConsumesResult{Required: p.consumes}
+func (p *dagTestPlugin) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{Required: p.consumes}
 }
 
 func TestExecutePluginsAsDAG(t *testing.T) {

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -234,8 +234,8 @@ func (p *dagTestPlugin) Produces() map[fwkplugin.DataKey]any {
 	return p.produces
 }
 
-func (p *dagTestPlugin) Consumes() map[fwkplugin.DataKey]any {
-	return p.consumes
+func (p *dagTestPlugin) Consumes() fwkplugin.ConsumesResult {
+	return fwkplugin.ConsumesResult{Required: p.consumes}
 }
 
 func TestExecutePluginsAsDAG(t *testing.T) {


### PR DESCRIPTION
Closes #1224

## What problem does this solve?

Right now, if a plugin wants to use a data key only when it's available
(like using tokenized input if present, otherwise falling back), there's
no clean way to express that. The only option is `Consumes()`, which
errors out if no producer exists — even if the plugin could work fine
without it.

## What this PR does

Adds a new `MayConsumePlugin` interface with a `MayConsume()` method.
If a plugin declares a key here and no producer exists, the framework
logs a warning at startup instead of failing. The plugin handles the
missing data case itself at runtime.

## Files changed

- `plugins.go` — new `MayConsumePlugin` interface
- `data_graph.go` — warn instead of error for unproduced optional keys
- `data_graph_test.go` — 3 test cases for the new behavior