### PR TITLE
fix(epp/flowcontrol/registry): guard propagateStatsDelta against concurrent band deletion

### DIFF
--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -481,7 +481,13 @@ func (fr *FlowRegistry) buildFlowComponents(key flowcontrol.FlowKey) (*flowCompo
 
 // propagateStatsDelta is the top-level, lock-free aggregator for all statistics.
 func (fr *FlowRegistry) propagateStatsDelta(priority int, lenDelta, byteSizeDelta int64) {
-	val, _ := fr.perPriorityBandStats.Load(priority)
+	val, ok := fr.perPriorityBandStats.Load(priority)
+	if !ok {
+		// The band was concurrently removed by the GC path holding fr.mu.Lock(). The
+		// stats delta is lost, which is acceptable for an eventually-consistent counter
+		// of a band that no longer exists.
+		return
+	}
 	stats := val.(*bandStats)
 	stats.len.Add(lenDelta)
 	stats.byteSize.Add(byteSizeDelta)

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -255,6 +255,27 @@ func TestFlowRegistry_Stats(t *testing.T) {
 	assert.Equal(t, globalStats.TotalByteSize, totalShardBytes, "The shard byte size must equal global byte size")
 }
 
+// TestFlowRegistry_PropagateStatsDelta_UnknownPriority_NoPanic is a
+// regression test for #980. The top-level propagateStatsDelta aggregator
+// is documented as lock-free; the GC's removePriorityBand holds the
+// registry's write lock and can Delete the perPriorityBandStats entry
+// between the lock-free Load and the type assertion. Before the fix, the
+// unchecked val.(*bandStats) panics with "interface conversion:
+// interface {} is nil, not *registry.bandStats" when val is nil. Same
+// reasoning as the shard-level test: drive nil through the type
+// assertion directly via an unknown priority rather than orchestrating
+// the race.
+func TestFlowRegistry_PropagateStatsDelta_UnknownPriority_NoPanic(t *testing.T) {
+	t.Parallel()
+	h := newRegistryTestHarness(t, harnessOptions{})
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("propagateStatsDelta panicked on unknown priority: %v", r)
+		}
+	}()
+	h.fr.propagateStatsDelta(nonExistentPriority, 1, 100)
+}
+
 // --- Garbage Collection Tests ---
 
 func TestFlowRegistry_GarbageCollection(t *testing.T) {

--- a/pkg/epp/flowcontrol/registry/shard.go
+++ b/pkg/epp/flowcontrol/registry/shard.go
@@ -372,7 +372,13 @@ func (s *registryShard) updateConfig(newConfig *ShardConfig) {
 // It atomically updates the relevant band's stats, the shard's total stats, and propagates the delta to the parent
 // registry.
 func (s *registryShard) propagateStatsDelta(priority int, lenDelta, byteSizeDelta int64) {
-	val, _ := s.priorityBands.Load(priority)
+	val, ok := s.priorityBands.Load(priority)
+	if !ok {
+		// The band was concurrently removed by the GC path holding s.mu.Lock(). The
+		// stats delta is lost, which is acceptable for an eventually-consistent counter
+		// of a queue that no longer exists.
+		return
+	}
 	band := val.(*priorityBand)
 	band.len.Add(lenDelta)
 	band.byteSize.Add(byteSizeDelta)

--- a/pkg/epp/flowcontrol/registry/shard_test.go
+++ b/pkg/epp/flowcontrol/registry/shard_test.go
@@ -153,6 +153,27 @@ func TestShard_Stats(t *testing.T) {
 		"Priority band byte size must reflect the items queued at that level")
 }
 
+// TestShard_PropagateStatsDelta_UnknownPriority_NoPanic is a regression
+// test for #980. propagateStatsDelta is invoked lock-free on the stats hot
+// path; the GC's deletePriorityBand holds s.mu.Lock() and can delete a
+// band's sync.Map entry between the lock-free Load and the type assertion.
+// Before the fix, the unchecked val.(*priorityBand) panics with
+// "interface conversion: interface {} is nil, not *registry.priorityBand"
+// when val is nil. The shape of the bug is the same whether nil comes
+// from a never-populated priority or from a concurrent Delete, so this
+// test exercises the never-populated case directly without needing to
+// orchestrate the race.
+func TestShard_PropagateStatsDelta_UnknownPriority_NoPanic(t *testing.T) {
+	t.Parallel()
+	h := newShardTestHarness(t)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("propagateStatsDelta panicked on unknown priority: %v", r)
+		}
+	}()
+	h.shard.propagateStatsDelta(nonExistentPriority, 1, 100)
+}
+
 func TestShard_Accessors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #980. Both `propagateStatsDelta` callsites in the flow-control registry pulled a priority-band entry out of a `sync.Map` lock-free and immediately type-asserted without checking the `ok` return:

- `pkg/epp/flowcontrol/registry/shard.go:375` — `val, _ := s.priorityBands.Load(priority); band := val.(*priorityBand)`
- `pkg/epp/flowcontrol/registry/registry.go:484` — `val, _ := fr.perPriorityBandStats.Load(priority); stats := val.(*bandStats)`

The GC path that removes bands holds the shard/registry write lock, so a concurrent `Delete()` can land between the lock-free `Load` and the type assertion, leaving `val == nil` and panicking the EPP goroutine processing the stats delta. Source comments at both callsites make the lock-free design explicit, so the right fix is to make the consumer tolerate the missing entry, not to add locking.

Switched both `Load` calls to comma-ok form with an early return when the band has already been collected. Dropping a single stats delta against a band that no longer exists is acceptable for an eventually-consistent aggregator; panicking the EPP goroutine is not.

## Verified locally

Both vectors panic on current `main` with exactly the messages from the issue:

```
TestShard_PropagateStatsDelta_UnknownPriority_NoPanic
  panic: interface conversion: interface {} is nil, not *registry.priorityBand
TestFlowRegistry_PropagateStatsDelta_UnknownPriority_NoPanic
  panic: interface conversion: interface {} is nil, not *registry.bandStats
```

After the fix:
- both new regression tests pass
- `go test -race ./pkg/epp/flowcontrol/registry/...` passes (including existing concurrency tests `TestShard_Concurrency_MixedWorkload` and `TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety`)
- `make test-unit-epp` and `make presubmit` are green

## Test plan
- [x] `go test ./pkg/epp/flowcontrol/registry/...`
- [x] `go test -race ./pkg/epp/flowcontrol/registry/...`
- [x] `make test-unit-epp`
- [x] `make presubmit` (DCO, signed commits, go-mod-check, format, lint, govulncheck)
- [ ] Reviewer to confirm "drop the delta on a deleted band" is the desired semantics (alternative: log at V(4) or higher)