### PR TITLE
fix: make PR kind label workflow work with pull_request_target

### DIFF
--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -1,7 +1,7 @@
 name: Apply kind labels from PR body
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened]
     branches:
       - main


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:

/kind bug
-->

**What this PR does / why we need it**:
Fixes `pr-kind-label.yaml` workflow to label PR by kind

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1167

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
