### PR TITLE
fix(helm): Prevent silent proxy misconfigurations and traffic routing failures during upgrades

### DIFF
--- a/config/charts/llm-d-router-standalone/templates/_validations.tpl
+++ b/config/charts/llm-d-router-standalone/templates/_validations.tpl
@@ -13,6 +13,9 @@ common validations
 standalone validations
 */}}
 {{- define "llm-d-router.validations.standalone" -}}
+{{- if hasKey .Values.router "sidecar" -}}
+  {{- fail ".Values.router.sidecar has been refactored to .Values.router.proxy. Please update your values.yaml" -}}
+{{- end -}}
 {{- $proxy := .Values.router.proxy | default dict -}}
 {{- if $proxy.enabled -}}
   {{- $proxyType := default "envoy" ($proxy.proxyType | default "envoy") | lower -}}


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

 Issue Trigger Scenario: 
Users upgrade the Helm chart using a legacy values.yaml file (or helm upgrade --reuse-values) that still contains the deprecated router.sidecar.*  like router.sidecar.proxyType=agentgateway .
 The new deployment succeeds without any warnings, but the custom proxy settings are silently ignored. The  system falls back to default settings  router.proxy.proxyType=envoy , along with incorrect images and ports, leading to severe traffic routing disruptions.

 Expected Behavior: 
 The Helm upgrade  process should explicitly fail when detecting the deprecated configuration and alert the  user to migrate their settings to the new router.proxy.* namespace.
 
Root Cause: 
PR #1265  introduced a breaking change, it renamed the configuration from sidecar to proxy but completely removed the  template references to sidecar without adding a backward-compatibility validation check, causing Helm to silently bypass the  old keys.

Fix Method: 
Added a strict validation rule in config/charts/llm-d-router-standalone/templates/_validations.tpl. If the .Values.router.sidecar key is detected, the template immediately aborts via the fail function and prompts the user with the  correct configuration path.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
