### PR TITLE
fix(openai): parse prompt_tokens_details cached usage

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -516,7 +516,7 @@ type Usage struct {
 	PromptTokens       int                 `json:"prompt_tokens"`
 	CompletionTokens   int                 `json:"completion_tokens"`
 	TotalTokens        int                 `json:"total_tokens"`
-	PromptTokenDetails *PromptTokenDetails `json:"prompt_token_details,omitempty"`
+	PromptTokenDetails *PromptTokenDetails `json:"prompt_tokens_details,omitempty"`
 }
 
 type PromptTokenDetails struct {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -54,6 +54,10 @@ const (
 	// The base media type for Server-Sent Events. We check for this substring
 	// to account for optional parameters like "; charset=utf-8" often appended by proxies.
 	eventStreamType = "text/event-stream"
+
+	promptTokensDetailsField = "prompt_tokens_details"
+	inputTokensDetailsField  = "input_tokens_details"
+	cachedTokensField        = "cached_tokens"
 )
 
 // compile-time type validation
@@ -280,14 +284,8 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 		}
 		objectType, _ := responseBody["object"].(string)
 		usage := extractUsageByAPIType(usg, objectType)
-		if usg["prompt_token_details"] != nil {
-			if detailsMap, ok := usg["prompt_token_details"].(map[string]any); ok {
-				if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
-					usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
-						CachedTokens: toInt(cachedTokens),
-					}
-				}
-			}
+		if details := extractPromptTokenDetails(usg); details != nil {
+			usage.PromptTokenDetails = details
 		}
 		return &usage, nil
 	}
@@ -340,6 +338,21 @@ func extractUsageByAPIType(usg map[string]any, objectType string) fwkrh.Usage {
 	return usage
 }
 
+func extractPromptTokenDetails(usg map[string]any) *fwkrh.PromptTokenDetails {
+	for _, field := range []string{promptTokensDetailsField, inputTokensDetailsField} {
+		detailsMap, ok := usg[field].(map[string]any)
+		if !ok {
+			continue
+		}
+		if cachedTokens, ok := detailsMap[cachedTokensField]; ok {
+			return &fwkrh.PromptTokenDetails{
+				CachedTokens: toInt(cachedTokens),
+			}
+		}
+	}
+	return nil
+}
+
 // Example message if "stream_options": {"include_usage": "true"} is included in the request:
 // data: {"id":"...","object":"text_completion","created":1739400043,"model":"small-segment-lora-0","choices":[],
 // "usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}
@@ -359,16 +372,6 @@ func extractUsageByAPIType(usg map[string]any, objectType string) fwkrh.Usage {
 //
 // It extracts usage from events with type="response.completed".
 func extractUsageStreaming(responseText string) *fwkrh.Usage {
-
-	var streamResponse struct {
-		Usage    *fwkrh.Usage `json:"usage"`
-		Response struct {
-			Usage  map[string]any `json:"usage"`
-			Object string         `json:"object"`
-		} `json:"response"`
-		Type string `json:"type"`
-	}
-
 	lines := strings.SplitSeq(responseText, "\n")
 	for line := range lines {
 		if !strings.HasPrefix(line, streamingRespPrefix) {
@@ -380,19 +383,27 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 		}
 
 		byteSlice := []byte(content)
+		var streamResponse map[string]any
 		if err := json.Unmarshal(byteSlice, &streamResponse); err != nil {
 			continue
 		}
+
 		// Standard ChatCompletion / vLLM usage format
-		if streamResponse.Usage != nil {
-			return streamResponse.Usage
+		if streamResponse["usage"] != nil {
+			if usage, err := extractUsage(byteSlice); err == nil && usage != nil {
+				return usage
+			}
 		}
+
 		// Responses API streaming format
-		if streamResponse.Response.Usage != nil && streamResponse.Type == "response.completed" {
+		response, _ := streamResponse["response"].(map[string]any)
+		usageMap, _ := response["usage"].(map[string]any)
+		if usageMap != nil && streamResponse["type"] == "response.completed" {
+			objectType, _ := response["object"].(string)
 			// Convert map[string]any to JSON and parse
 			jsonBytes, _ := json.Marshal(map[string]any{
-				"usage":  streamResponse.Response.Usage,
-				"object": streamResponse.Response.Object,
+				"usage":  usageMap,
+				"object": objectType,
 			})
 			if usage, err := extractUsage(jsonBytes); err == nil && usage != nil {
 				return usage

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
@@ -28,8 +28,8 @@ func TestExtractUsage_MalformedFields_NoPanic(t *testing.T) {
 			body: `{"object":"chat.completion","usage":"oops"}`,
 		},
 		{
-			name: "prompt_token_details_is_number",
-			body: `{"object":"chat.completion","usage":{"prompt_token_details":0,"prompt_tokens":7}}`,
+			name: "prompt_tokens_details_is_number",
+			body: `{"object":"chat.completion","usage":{"prompt_tokens_details":0,"prompt_tokens":7}}`,
 		},
 		{
 			name: "prompt_tokens_is_string",

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -866,17 +866,17 @@ func TestOpenAIParser_ParseResponse(t *testing.T) {
 			},
 		},
 		{
-			name: "Full Usage with Cached Token details",
+			name: "Full usage with standard cached token details",
 			body: []byte(`{
-				"object": "chat.completion",
-				"usage": {
-					"prompt_tokens": 100,
-					"completion_tokens": 50,
-					"total_tokens": 150,
-					"prompt_token_details": {
-						"cached_tokens": 40
+					"object": "chat.completion",
+					"usage": {
+						"prompt_tokens": 100,
+						"completion_tokens": 50,
+						"total_tokens": 150,
+						"prompt_tokens_details": {
+							"cached_tokens": 40
+						}
 					}
-				}
 			}`),
 			want: &fwkrh.ParsedResponse{
 				Usage: &fwkrh.Usage{
@@ -955,7 +955,7 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 		},
 		{
 			name:  "Usage and DONE in the same multi-line response",
-			chunk: []byte("data: {\"usage\":{\"prompt_tokens\":10,\"prompt_token_details\":{\"cached_tokens\":10}}}\ndata: [DONE]"),
+			chunk: []byte("data: {\"usage\":{\"prompt_tokens\":10,\"prompt_tokens_details\":{\"cached_tokens\":10}}}\ndata: [DONE]"),
 			want: &fwkrh.ParsedResponse{
 				Usage: &fwkrh.Usage{
 					PromptTokens: 10,
@@ -994,6 +994,9 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 					PromptTokens:     31,
 					CompletionTokens: 3,
 					TotalTokens:      34,
+					PromptTokenDetails: &fwkrh.PromptTokenDetails{
+						CachedTokens: 16,
+					},
 				},
 			},
 		},

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -110,7 +110,7 @@ const (
 			"prompt_tokens": 11,
 			"total_tokens": 111,
 			"completion_tokens": 100,
-			"prompt_token_details": {
+			"prompt_tokens_details": {
 				"cached_tokens": 10
 			}
 		}
@@ -123,7 +123,7 @@ const (
 	streamingBodyWithUsage = `data: {"id":"cmpl-41764c93-f9d2-4f31-be08-3ba04fa25394","object":"text_completion","created":1740002445,"model":"food-review-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}
 data: [DONE]
 	`
-	streamingBodyWithUsageAndCachedTokens = `data: {"id":"cmpl-41764c93-f9d2-4f31-be08-3ba04fa25394","object":"text_completion","created":1740002445,"model":"food-review-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10,"prompt_token_details":{"cached_tokens":5}}}
+	streamingBodyWithUsageAndCachedTokens = `data: {"id":"cmpl-41764c93-f9d2-4f31-be08-3ba04fa25394","object":"text_completion","created":1740002445,"model":"food-review-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10,"prompt_tokens_details":{"cached_tokens":5}}}
 data: [DONE]
 	`
 )


### PR DESCRIPTION
## Summary

Fixes cached token usage extraction in the EPP OpenAI parser.

The parser was reading cached token usage from the non-standard field:

```json
usage.prompt_token_details.cached_tokens
```

but OpenAI-compatible responses, vLLM, and the router sidecar cached-token rewriter use:

```json
usage.prompt_tokens_details.cached_tokens
```

This caused EPP to silently drop cached token usage from normal responses, so prompt cached-token metrics were not recorded.

## Changes

- Parse `cached_tokens` from `usage.prompt_tokens_details`.
- Parse Responses API cached input tokens from `usage.input_tokens_details`.
- Update the internal `Usage` JSON tag to emit `prompt_tokens_details`.
- Update parser and handler tests to cover the standard plural field.

## Why

This is a usage/accounting correctness fix. Without it, cache-hit observability can be misleading because EPP records prompt/output tokens but misses cached prompt tokens.

## Testing

```bash
go mod tidy
go test ./pkg/epp/framework/plugins/requesthandling/parsers/openai ./pkg/epp/handlers ./pkg/epp/framework/plugins/requestcontrol/requestattributereporter
go test ./pkg/epp/...
```

Fixes #1273
