### PR TITLE
[Helm] inferenceObjective available for both modes and graduate the httproute option

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -206,30 +206,37 @@ router:
 
 ---
 
-### 3. InferencePool Configuration
+### 3. InferencePool & InferenceObjectives Configuration
 
-Settings for managing the `InferencePool` Kubernetes resource which logically groups the backend model servers.
+Settings for managing the `InferencePool` Kubernetes resource and optional `InferenceObjective` priority routing rules.
 
-#### InferencePool Parameters
+> [!IMPORTANT]
+> `inferenceObjectives` can only be configured when `inferencePool.create` is `true`. Creating `InferenceObjectives` without creating an `InferencePool` is not supported and will trigger a chart validation error.
+
+#### InferencePool & InferenceObjectives Parameters
 
 | **Parameter Name** | **Description** | **Default** |
 | :--- | :--- | :--- |
 | `router.inferencePool.create` | Whether to create the `InferencePool` resource. Set to `false` in standalone mode for Service-backed routing. | `true` |
-| `router.inferencePool.apiVersion` | The API version of the `InferencePool` resource. | `inference.networking.k8s.io/v1` |
-| `router.inferencePool.group` | The API group of the `InferencePool` resource. | `inference.networking.k8s.io` |
 | `router.inferencePool.failureMode` | EPP failure mode when external processing fails (configured on the pool). Options: `[FailOpen, FailClosed]`. | `FailOpen` |
+| `router.inferenceObjectives` | List of names and priorities to create optional `InferenceObjective` resources. | `[]` |
 
-#### Complete InferencePool Example
+#### Complete InferencePool & InferenceObjectives Example
 
 ```yaml
 router:
   inferencePool:
     # Enable or disable InferencePool resource creation (false in standalone service-backed mode)
     create: true
-    apiVersion: inference.networking.k8s.io/v1
-    group: inference.networking.k8s.io
     # If EPP fails to process the request, route anyway (FailOpen) or fail the request (FailClosed)
     failureMode: FailClosed
+  
+  # Optional: Define InferenceObjective(s) for this InferencePool
+  inferenceObjectives:
+    - name: high-priority
+      priority: 100
+    - name: background-batch
+      priority: 10
 ```
 
 ---
@@ -273,101 +280,7 @@ router:
 
 ---
 
-### 5. Gateway-Specific Configuration (`llm-d-router-gateway` only)
-
-Configures routing policies and optional Gateway API integration features exclusive to the Gateway implementation chart.
-
-#### Gateway-Specific Parameters
-
-| **Parameter Name** | **Description** | **Default** |
-| :--- | :--- | :--- |
-| `inferenceObjectives` | List of names and priorities to create optional `InferenceObjective` resources. | `[]` |
-| `provider.name` | Name of Gateway implementation. Options: `[none, gke, istio]`. | `none` |
-| `provider.istio.destinationRule.host` | Custom host value for Istio DestinationRule. | `""` |
-| `provider.istio.destinationRule.trafficPolicy.connectionPool` | Connection pool settings for Istio DestinationRule. | `{}` |
-| `experimentalHttpRoute.enabled` | Deploy an `HTTPRoute` resource as part of the gateway chart. | `false` |
-| `experimentalHttpRoute.inferenceGatewayName` | Target Gateway name for the `HTTPRoute`. | `inference-gateway` |
-| `experimentalHttpRoute.inferenceGatewayNamespace` | Target Gateway namespace for the `HTTPRoute`. | `""` |
-| `experimentalHttpRoute.requestTimeout` | Request timeout for the `HTTPRoute` (Istio/non-GKE only). | `300s` |
-
-#### Complete Gateway Example
-
-```yaml
-inferenceObjectives:
-  - name: high-priority
-    priority: 100
-  - name: background-batch
-    priority: 10
-
-provider:
-  name: gke # Use GKE gateway implementation
-  
-experimentalHttpRoute:
-  enabled: true
-  inferenceGatewayName: "my-company-gateway"
-  inferenceGatewayNamespace: "gateway-infra"
-  requestTimeout: "120s"
-```
-
----
-
-### 6. Sidecar Proxy Configuration (`router.proxy.*`)
-
-Used primarily in **Standalone Mode** to spin up a proxy container (Envoy sidecar or Agentgateway sidecar) alongside EPP to intercept and route incoming traffic.
-
-#### Proxy Sidecar Parameters
-
-| **Parameter Name** | **Description** | **Default** |
-| :--- | :--- | :--- |
-| `router.proxy.enabled` | Enable a sidecar proxy container in the EPP deployment. | `false` |
-| `router.proxy.proxyType` | **Standalone only**. Type of sidecar proxy. Options: `[envoy, agentgateway]`. | `envoy` |
-| `router.proxy.name` | Name of the sidecar container. | `""` |
-| `router.proxy.image` | Sidecar container image. | `""` |
-| `router.proxy.imagePullPolicy` | Sidecar container image pull policy. | `IfNotPresent` |
-| `router.proxy.command` | Sidecar container command. | `""` |
-| `router.proxy.args` | Sidecar container arguments. | `[]` |
-| `router.proxy.env` | Sidecar container environment variables. | `[]` |
-| `router.proxy.ports` | Sidecar container ports. | `[]` |
-| `router.proxy.livenessProbe` | Sidecar container liveness probe. | `{}` |
-| `router.proxy.readinessProbe` | Sidecar container readiness probe. | `{}` |
-| `router.proxy.resources` | Sidecar container resource requests and limits. | `{}` |
-| `router.proxy.volumeMounts` | Sidecar container volume mounts. | `[]` |
-| `router.proxy.volumes` | Sidecar container volumes. | `[]` |
-| `router.proxy.configMapData` | Key-value pairs to include in a ConfigMap created for the sidecar. | `{}` |
-| `router.proxy.agentgateway.service.create` | **Agentgateway only**. Create a dedicated model Service for the Agentgateway proxy. | `true` |
-| `router.proxy.agentgateway.service.name` | **Agentgateway only**. Name of the model Service to route to. | `""` |
-| `router.proxy.agentgateway.service.namespace` | **Agentgateway only**. Namespace of the model Service. Defaults to release namespace. | `""` |
-| `router.proxy.agentgateway.service.ports` | **Agentgateway only**. Port list for the model Service (must match `modelServers.targetPorts`). | `[]` |
-
-#### Complete Proxy Sidecar Example (Agentgateway Service-Backed)
-
-To deploy EPP in standalone mode with an Agentgateway sidecar routing traffic directly to an existing model Service `my-model-service` (bypassing `InferencePool` creation):
-
-```yaml
-router:
-  inferencePool:
-    create: false # Disable InferencePool creation
-
-  proxy:
-    enabled: true
-    proxyType: agentgateway
-    resources:
-      requests:
-        cpu: "2"
-        memory: 4Gi
-      limits:
-        memory: 8Gi
-    agentgateway:
-      service:
-        create: true # Create a Service to route client traffic to EPP
-        name: "my-model-service"
-        ports:
-          - 8000 # Intercept traffic on port 8000
-```
-
----
-
-### 7. Sidecar Tokenizer Configuration (`router.tokenizer.*`)
+### 5. Sidecar Tokenizer Configuration (`router.tokenizer.*`)
 
 Runs a tokenizer sidecar container to expose a Unix Domain Socket (UDS) to EPP, allowing EPP to tokenize incoming requests and enable precise, token-count-aware routing policies (e.g., precise prefix-cache matching).
 
@@ -418,7 +331,7 @@ router:
 
 ---
 
-### 8. Sidecar Latency Predictor Configuration (`router.latencyPredictor.*`)
+### 6. Sidecar Latency Predictor Configuration (`router.latencyPredictor.*`)
 
 Enables latency predictor containers inside the EPP deployment to feed metrics to a latency scorer plugin, allowing EPP to route traffic based on real-time predicted latencies.
 
@@ -451,4 +364,97 @@ router:
       LATENCY_MAX_SAMPLE_SIZE: "20000"
       LATENCY_MAX_CONCURRENT_DISPATCHES: "48"
       LATENCY_COALESCE_WINDOW_MS: "2"
+```
+
+---
+
+## Deployment Mode Specific Configurations
+
+Depending on your target deployment architecture (Gateway Mode vs Standalone Mode), utilize the following specific configurations.
+
+---
+
+### Gateway Mode Configuration
+
+Configures routing policies, target Gateway interfaces, and priority objectives exclusive to the Gateway implementation chart (`llm-d-router-gateway`).
+
+#### Gateway-Specific Parameters
+
+| **Parameter Name** | **Description** | **Default** |
+| :--- | :--- | :--- |
+| `provider.name` | Name of Gateway implementation. Options: `[none, gke, istio]`. | `none` |
+| `provider.istio.destinationRule.host` | Custom host value for Istio DestinationRule. | `""` |
+| `provider.istio.destinationRule.trafficPolicy.connectionPool` | Connection pool settings for Istio DestinationRule. | `{}` |
+| `httpRoute.create` | Deploy an `HTTPRoute` resource as part of the gateway chart. | `false` |
+| `httpRoute.inferenceGatewayName` | Target Gateway name for the `HTTPRoute`. | `inference-gateway` |
+| `httpRoute.inferenceGatewayNamespace` | Target Gateway namespace for the `HTTPRoute`. | `""` |
+| `httpRoute.requestTimeout` | Request timeout for the `HTTPRoute` (Istio/non-GKE only). | `300s` |
+
+#### Complete Gateway Example
+
+```yaml
+provider:
+  name: gke # Use GKE gateway implementation
+  
+httpRoute:
+  create: true
+  inferenceGatewayName: "my-company-gateway"
+  inferenceGatewayNamespace: "gateway-infra"
+  requestTimeout: "120s"
+```
+
+---
+
+### Standalone Mode Configuration
+
+Configures EPP to run with a sidecar proxy container (Envoy proxy or Agentgateway proxy) to intercept and route client traffic directly to model servers (exclusive to `llm-d-router-standalone`).
+
+#### Proxy Sidecar Parameters
+
+| **Parameter Name** | **Description** | **Default** |
+| :--- | :--- | :--- |
+| `router.proxy.enabled` | Enable a sidecar proxy container in the EPP deployment. | `false` |
+| `router.proxy.proxyType` | **Standalone only**. Type of sidecar proxy. Options: `[envoy, agentgateway]`. | `envoy` |
+| `router.proxy.name` | Name of the sidecar container. | `""` |
+| `router.proxy.image` | Sidecar container image. | `""` |
+| `router.proxy.imagePullPolicy` | Sidecar container image pull policy. | `IfNotPresent` |
+| `router.proxy.command` | Sidecar container command. | `""` |
+| `router.proxy.args` | Sidecar container arguments. | `[]` |
+| `router.proxy.env` | Sidecar container environment variables. | `[]` |
+| `router.proxy.ports` | Sidecar container ports. | `[]` |
+| `router.proxy.livenessProbe` | Sidecar container liveness probe. | `{}` |
+| `router.proxy.readinessProbe` | Sidecar container readiness probe. | `{}` |
+| `router.proxy.resources` | Sidecar container resource requests and limits. | `{}` |
+| `router.proxy.volumeMounts` | Sidecar container volume mounts. | `[]` |
+| `router.proxy.volumes` | Sidecar container volumes. | `[]` |
+| `router.proxy.configMapData` | Key-value pairs to include in a ConfigMap created for the sidecar. | `{}` |
+| `router.proxy.agentgateway.service.create` | **Agentgateway only**. Create a dedicated model Service for the Agentgateway proxy. | `true` |
+| `router.proxy.agentgateway.service.name` | **Agentgateway only**. Name of the model Service to route to. | `""` |
+| `router.proxy.agentgateway.service.namespace` | **Agentgateway only**. Namespace of the model Service. Defaults to release namespace. | `""` |
+| `router.proxy.agentgateway.service.ports` | **Agentgateway only**. Port list for the model Service (must match `modelServers.targetPorts`). | `[]` |
+
+#### Complete Proxy Sidecar Example (Agentgateway Service-Backed)
+
+To deploy EPP in standalone mode with an Agentgateway sidecar routing traffic directly to an existing model Service `my-model-service` (bypassing `InferencePool` creation):
+
+```yaml
+router:
+  inferencePool:
+    create: false # Disable InferencePool creation
+
+  proxy:
+    enabled: true
+    proxyType: agentgateway
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+      limits:
+        memory: 8Gi
+    agentgateway:
+      service:
+        create: true # Create a Service to route client traffic to EPP
+        name: "my-model-service"
+        ports:
+          - 8000 # Intercept traffic on port 8000
 ```

--- a/config/charts/llm-d-router-gateway/templates/_helpers.tpl
+++ b/config/charts/llm-d-router-gateway/templates/_helpers.tpl
@@ -2,8 +2,8 @@
 Create a default fully qualified app name for inferenceGateway.
 */}}
 {{- define "llm-d-router-gateway.fullname" -}}
-  {{- if .Values.experimentalHttpRoute.inferenceGatewayName -}}
-    {{- .Values.experimentalHttpRoute.inferenceGatewayName | trunc 63 | trimSuffix "-" -}}
+  {{- if .Values.httpRoute.inferenceGatewayName -}}
+    {{- .Values.httpRoute.inferenceGatewayName | trunc 63 | trimSuffix "-" -}}
   {{- else -}}
     {{- printf "%s-inference-gateway" .Release.Name| trunc 63 | trimSuffix "-" -}}
   {{- end -}}

--- a/config/charts/llm-d-router-gateway/templates/httproute.yaml
+++ b/config/charts/llm-d-router-gateway/templates/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.experimentalHttpRoute.enabled }}
+{{- if .Values.httpRoute.create }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -9,8 +9,8 @@ spec:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: {{ include "llm-d-router-gateway.fullname" . }}
-    {{- if .Values.experimentalHttpRoute.inferenceGatewayNamespace }}
-    namespace: {{ .Values.experimentalHttpRoute.inferenceGatewayNamespace }}
+    {{- if .Values.httpRoute.inferenceGatewayNamespace }}
+    namespace: {{ .Values.httpRoute.inferenceGatewayNamespace }}
     {{- end }}
   rules:
   - backendRefs:
@@ -21,13 +21,13 @@ spec:
     - path:
         type: PathPrefix
         value: /
-      {{- if or .Values.experimentalHttpRoute.baseModel .Values.experimentalHttpRoute.headerMatches }}
+      {{- if or .Values.httpRoute.baseModel .Values.httpRoute.headerMatches }}
       headers:
-      {{- $headerMatches := deepCopy (.Values.experimentalHttpRoute.headerMatches | default dict) }}
-      {{- if .Values.experimentalHttpRoute.baseModel }}
+      {{- $headerMatches := deepCopy (.Values.httpRoute.headerMatches | default dict) }}
+      {{- if .Values.httpRoute.baseModel }}
         - type: Exact
           name: X-Gateway-Base-Model-Name
-          value: {{ .Values.experimentalHttpRoute.baseModel }}
+          value: {{ .Values.httpRoute.baseModel }}
       {{- end }}
       {{- range $key, $value := $headerMatches }}
         - type: Exact
@@ -37,6 +37,6 @@ spec:
       {{- end }}
     {{- if ne (lower .Values.provider.name) "gke" }}
     timeouts:
-      request: {{ .Values.experimentalHttpRoute.requestTimeout }}
+      request: {{ .Values.httpRoute.requestTimeout }}
     {{- end }}
 {{- end }}

--- a/config/charts/llm-d-router-gateway/templates/inferenceextension.yaml
+++ b/config/charts/llm-d-router-gateway/templates/inferenceextension.yaml
@@ -1,4 +1,4 @@
-{{ include "llm-d-router.validations.epp.resources" $ }}
+{{ include "llm-d-router.validations.epp" $ }}
 {{ include "inference-extension.config" . }}
 {{ include "inference-extension.deployment" . }}
 {{ include "inference-extension.lead-election-rbac" . }}

--- a/config/charts/llm-d-router-gateway/values.yaml
+++ b/config/charts/llm-d-router-gateway/values.yaml
@@ -21,10 +21,9 @@ provider:
         #   http:
         #     maxRequestsPerConnection: 256000
 
-# experimentalHttpRoute section is used to deploy httproute as part of the epp helm chart.
-# this section is temporary and should be extracted to a separate chart.
-experimentalHttpRoute:
-  enabled: false # a flag to indicate whether to create the httproute as part of the chart or not.
+# httpRoute section is used to deploy an HTTPRoute resource as part of the gateway chart.
+httpRoute:
+  create: false # a flag to indicate whether to create the httproute as part of the chart or not.
   inferenceGatewayName: inference-gateway
   inferenceGatewayNamespace: ""
   # HTTPRoute request timeout. Defaults to "300s". Unused when provider.name is gke.
@@ -34,14 +33,4 @@ experimentalHttpRoute:
   #  x-my-custom-route-header: route-name
 
 
-# Optional: Define InferenceObjective(s) for this InferencePool.
-# Each InferenceObjective associates a name and priority with the InferencePool
-# created in the chart release.
-# Users reference these objectives by name in their request headers.
-# This is only used for when InferenceObjectives are known ahead of time,
-# they can still be created out of band of the chart release as needed.
-inferenceObjectives: []
-#   - name: high-priority
-#     priority: 5
-#   - name: low-priority
-#     priority: 1
+

--- a/config/charts/llm-d-router-gateway/values.yaml
+++ b/config/charts/llm-d-router-gateway/values.yaml
@@ -31,6 +31,3 @@ httpRoute:
   # Example header matches:
   # headerMatches:
   #  x-my-custom-route-header: route-name
-
-
-

--- a/config/charts/llm-d-router-standalone/templates/inferenceextension.yaml
+++ b/config/charts/llm-d-router-standalone/templates/inferenceextension.yaml
@@ -1,4 +1,4 @@
-{{ include "llm-d-router.validations.epp.resources" $ }}
+{{ include "llm-d-router.validations.epp" $ }}
 {{ include "llm-d-router.validations.standalone" . }}
 {{ include "inference-extension.config" . }}
 {{ include "inference-extension.deployment" . }}

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -121,7 +121,7 @@ spec:
               - --pool-namespace
               - {{ .Release.Namespace }}
               - --pool-group
-              - {{ .Values.router.inferencePool.group | default "inference.networking.k8s.io" | quote }}
+              - "inference.networking.k8s.io"
           {{- end }}
           {{- if not .Values.router.latencyPredictor.enabled }}
           # Legacy metric CLI flags (skipped when dataLayer is enabled via latency predictor).

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -325,3 +325,20 @@ EPP resource validations
 {{- $_ := required ".Values.router.epp.resources.requests.cpu is required. EPP is a critical component that must have CPU requests set." .Values.router.epp.resources.requests.cpu }}
 {{- $_ := required ".Values.router.epp.resources.requests.memory is required. EPP is a critical component that must have memory requests set." .Values.router.epp.resources.requests.memory }}
 {{- end -}}
+
+{{/*
+EPP generic validations
+*/}}
+{{- define "llm-d-router.validations.epp" -}}
+{{- include "llm-d-router.validations.epp.resources" . }}
+{{- include "llm-d-router.validations.epp.inferenceObjectives" . }}
+{{- end -}}
+
+{{/*
+EPP inferenceObjectives validations
+*/}}
+{{- define "llm-d-router.validations.epp.inferenceObjectives" -}}
+{{- if and (eq .Values.router.inferencePool.create false) .Values.router.inferenceObjectives }}
+{{- fail ".Values.router.inferenceObjectives can only be configured when .Values.router.inferencePool.create is true." }}
+{{- end }}
+{{- end -}}

--- a/config/charts/routerlib/templates/_inferenceobjective.yaml
+++ b/config/charts/routerlib/templates/_inferenceobjective.yaml
@@ -1,4 +1,5 @@
-{{- range .Values.inferenceObjectives }}
+{{- define "inference-extension.inferenceobjective-resource" -}}
+{{- range .Values.router.inferenceObjectives }}
 ---
 apiVersion: llm-d.ai/v1alpha2
 kind: InferenceObjective
@@ -10,6 +11,7 @@ metadata:
 spec:
   priority: {{ .priority }}
   poolRef:
-    group: {{ index (splitList "/" $.Values.router.inferencePool.apiVersion) 0 }}
+    group: "inference.networking.k8s.io"
     name: {{ $.Release.Name }}
+{{- end }}
 {{- end }}

--- a/config/charts/routerlib/templates/_inferencepool.yaml
+++ b/config/charts/routerlib/templates/_inferencepool.yaml
@@ -36,5 +36,6 @@ spec:
 {{- if ne .Values.router.inferencePool.create false }}
 {{- include "llm-d-router.validations.gateway.common" . }}
 {{- include "inference-extension.inferencepool" . }}
+{{- include "inference-extension.inferenceobjective-resource" . }}
 {{- end }}
 {{- end }}

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -118,8 +118,13 @@ tracing:
 
 inferencePool:
   create: true
-  apiVersion: inference.networking.k8s.io/v1
   failureMode: "FailOpen"
+
+inferenceObjectives: []
+# - name: high-priority
+#   priority: 5
+# - name: low-priority
+#   priority: 1
 
 modelServers:
   type: vllm # vllm, sglang, triton-tensorrt-llm, trtllm-serve, triton


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

- Creating InferenceObjectives is now available for both gateway and standalone mode when creating inferencePool is enabled.
- Graduated HTTPRoute option from experimental

**Which issue(s) this PR fixes**:
Fixes https://github.com/llm-d/llm-d-router/issues/1285
Fixes https://github.com/llm-d/llm-d-router/issues/1284

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
