### PR TITLE
fix(openai): parse prompt tokens details usage

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -516,7 +516,7 @@ type Usage struct {
 	PromptTokens       int                 `json:"prompt_tokens"`
 	CompletionTokens   int                 `json:"completion_tokens"`
 	TotalTokens        int                 `json:"total_tokens"`
-	PromptTokenDetails *PromptTokenDetails `json:"prompt_token_details,omitempty"`
+	PromptTokenDetails *PromptTokenDetails `json:"prompt_tokens_details,omitempty"`
 }
 
 type PromptTokenDetails struct {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -264,7 +264,46 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 	if responseErr != nil {
 		return nil, responseErr
 	}
+usg, ok := responseBody["usage"].(map[string]any)
+if !ok {
+  return nil, nil
+}
 
+usage := fwkrh.Usage{}
+
+// Chat/Completions APIs use prompt_tokens. Responses/Conversations APIs use input_tokens.
+for _, it := range []string{"prompt_tokens", "input_tokens"} {
+  if v, ok := usg[it]; ok && v != nil {
+    usage.PromptTokens = toInt(v)
+    break
+  } 
+}
+
+// Chat/Completions APIs use completion_tokens. Responses/Conversations APIs use output_tokens.
+for _, ot := range []string{"completion_tokens", "output_tokens"} {
+  if v, ok := usg[ot]; ok && v != nil {
+    usage.CompletionTokens = toInt(v)
+    break
+  } 
+}
+
+// Chat/Completions APIs use prompt_tokens_details. Responses/Conversations APIs use input_tokens_details.
+for _, details := range []string{"prompt_tokens_details", "input_tokens_details"} {
+  if detailsMap, ok := usg[details].(map[string]any); ok {
+    if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
+      usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
+        CachedTokens: toInt(cachedTokens),
+      }
+    }
+  }
+}
+
+// total_tokens field name is consistent across all API types
+if v, ok := usg["total_tokens"]; ok && v != nil {
+  usage.TotalTokens = toInt(v)
+}
+
+return &usage, nil
 	if responseBody["usage"] != nil {
 		usg, ok := responseBody["usage"].(map[string]any)
 		if !ok {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -47,6 +47,16 @@ const (
 	// The base media type for Server-Sent Events. We check for this substring
 	// to account for optional parameters like "; charset=utf-8" often appended by proxies.
 	eventStreamType = "text/event-stream"
+
+	usageField               = "usage"
+	promptTokensField        = "prompt_tokens"
+	inputTokensField         = "input_tokens"
+	completionTokensField    = "completion_tokens"
+	outputTokensField        = "output_tokens"
+	promptTokensDetailsField = "prompt_tokens_details"
+	inputTokensDetailsField  = "input_tokens_details"
+	cachedTokensField        = "cached_tokens"
+	totalTokensField         = "total_tokens"
 )
 
 // compile-time type validation
@@ -264,91 +274,46 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 	if responseErr != nil {
 		return nil, responseErr
 	}
-usg, ok := responseBody["usage"].(map[string]any)
-if !ok {
-  return nil, nil
-}
+	usg, ok := responseBody[usageField].(map[string]any)
+	if !ok {
+		return nil, nil //nolint:nilnil
+	}
 
-usage := fwkrh.Usage{}
+	usage := fwkrh.Usage{}
 
-// Chat/Completions APIs use prompt_tokens. Responses/Conversations APIs use input_tokens.
-for _, it := range []string{"prompt_tokens", "input_tokens"} {
-  if v, ok := usg[it]; ok && v != nil {
-    usage.PromptTokens = toInt(v)
-    break
-  } 
-}
-
-// Chat/Completions APIs use completion_tokens. Responses/Conversations APIs use output_tokens.
-for _, ot := range []string{"completion_tokens", "output_tokens"} {
-  if v, ok := usg[ot]; ok && v != nil {
-    usage.CompletionTokens = toInt(v)
-    break
-  } 
-}
-
-// Chat/Completions APIs use prompt_tokens_details. Responses/Conversations APIs use input_tokens_details.
-for _, details := range []string{"prompt_tokens_details", "input_tokens_details"} {
-  if detailsMap, ok := usg[details].(map[string]any); ok {
-    if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
-      usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
-        CachedTokens: toInt(cachedTokens),
-      }
-    }
-  }
-}
-
-// total_tokens field name is consistent across all API types
-if v, ok := usg["total_tokens"]; ok && v != nil {
-  usage.TotalTokens = toInt(v)
-}
-
-return &usage, nil
-	if responseBody["usage"] != nil {
-		usg, ok := responseBody["usage"].(map[string]any)
-		if !ok {
-			// Malformed upstream response: "usage" present but not a JSON object.
-			return nil, nil //nolint:nilnil
+	// Chat/Completions APIs use prompt_tokens. Responses/Conversations APIs use input_tokens.
+	for _, inputTokens := range []string{promptTokensField, inputTokensField} {
+		if v, ok := usg[inputTokens]; ok && v != nil {
+			usage.PromptTokens = toInt(v)
+			break
 		}
+	}
 
-		usage := fwkrh.Usage{}
-
-		// Chat/Completions APIs use prompt_tokens. Responses/Conversations APIs use input_tokens.
-		for _, inputTokens := range []string{"prompt_tokens", "input_tokens"} {
-			if v, ok := usg[inputTokens]; ok && v != nil {
-				usage.PromptTokens = toInt(v)
-				break
-			}
+	// Chat/Completions APIs use completion_tokens. Responses/Conversations APIs use output_tokens.
+	for _, outputTokens := range []string{completionTokensField, outputTokensField} {
+		if v, ok := usg[outputTokens]; ok && v != nil {
+			usage.CompletionTokens = toInt(v)
+			break
 		}
+	}
 
-		// Chat/Completions APIs use completion_tokens. Responses/Conversations APIs use output_tokens.
-		for _, outputTokens := range []string{"completion_tokens", "output_tokens"} {
-			if v, ok := usg[outputTokens]; ok && v != nil {
-				usage.CompletionTokens = toInt(v)
-				break
-			}
-		}
-
-		// Chat/Completions APIs use prompt_tokens_details. Responses/Conversations APIs use input_tokens_details.
-		for _, details := range []string{"prompt_tokens_details", "input_tokens_details"} {
-			if detailsMap, ok := usg[details].(map[string]any); ok {
-				if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
-					usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
-						CachedTokens: toInt(cachedTokens),
-					}
+	// Chat/Completions APIs use prompt_tokens_details. Responses/Conversations APIs use input_tokens_details.
+	for _, details := range []string{promptTokensDetailsField, inputTokensDetailsField} {
+		if detailsMap, ok := usg[details].(map[string]any); ok {
+			if cachedTokens, ok := detailsMap[cachedTokensField]; ok {
+				usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
+					CachedTokens: toInt(cachedTokens),
 				}
 			}
 		}
-
-		// total_tokens field name is consistent across all API types.
-		if v, ok := usg["total_tokens"]; ok && v != nil {
-			usage.TotalTokens = toInt(v)
-		}
-
-		return &usage, nil
 	}
-	// No usage data
-	return nil, nil //nolint:nilnil
+
+	// total_tokens field name is consistent across all API types.
+	if v, ok := usg[totalTokensField]; ok && v != nil {
+		usage.TotalTokens = toInt(v)
+	}
+
+	return &usage, nil
 }
 
 // Example message if "stream_options": {"include_usage": "true"} is included in the request:

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -43,13 +43,6 @@ const (
 	streamingRespPrefix = "data: "
 	streamingEndMsg     = "data: [DONE]"
 
-	// OpenAI API object types
-	objectTypeResponse            = "response"
-	objectTypeConversation        = "conversation"
-	objectTypeChatCompletion      = "chat.completion"
-	objectTypeChatCompletionChunk = "chat.completion.chunk"
-	objectTypeTextCompletion      = "text_completion"
-
 	contentType = "content-type"
 	// The base media type for Server-Sent Events. We check for this substring
 	// to account for optional parameters like "; charset=utf-8" often appended by proxies.
@@ -278,10 +271,28 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 			// Malformed upstream response: "usage" present but not a JSON object.
 			return nil, nil //nolint:nilnil
 		}
-		objectType, _ := responseBody["object"].(string)
-		usage := extractUsageByAPIType(usg, objectType)
-		if usg["prompt_token_details"] != nil {
-			if detailsMap, ok := usg["prompt_token_details"].(map[string]any); ok {
+
+		usage := fwkrh.Usage{}
+
+		// Chat/Completions APIs use prompt_tokens. Responses/Conversations APIs use input_tokens.
+		for _, inputTokens := range []string{"prompt_tokens", "input_tokens"} {
+			if v, ok := usg[inputTokens]; ok && v != nil {
+				usage.PromptTokens = toInt(v)
+				break
+			}
+		}
+
+		// Chat/Completions APIs use completion_tokens. Responses/Conversations APIs use output_tokens.
+		for _, outputTokens := range []string{"completion_tokens", "output_tokens"} {
+			if v, ok := usg[outputTokens]; ok && v != nil {
+				usage.CompletionTokens = toInt(v)
+				break
+			}
+		}
+
+		// Chat/Completions APIs use prompt_tokens_details. Responses/Conversations APIs use input_tokens_details.
+		for _, details := range []string{"prompt_tokens_details", "input_tokens_details"} {
+			if detailsMap, ok := usg[details].(map[string]any); ok {
 				if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
 					usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
 						CachedTokens: toInt(cachedTokens),
@@ -289,55 +300,16 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 				}
 			}
 		}
+
+		// total_tokens field name is consistent across all API types.
+		if v, ok := usg["total_tokens"]; ok && v != nil {
+			usage.TotalTokens = toInt(v)
+		}
+
 		return &usage, nil
 	}
 	// No usage data
 	return nil, nil //nolint:nilnil
-}
-
-// extractUsageByAPIType extracts usage statistics using the appropriate field names
-// based on the OpenAI API type identified by the "object" field.
-func extractUsageByAPIType(usg map[string]any, objectType string) fwkrh.Usage {
-	usage := fwkrh.Usage{}
-
-	switch {
-	case strings.HasPrefix(objectType, objectTypeResponse) || strings.HasPrefix(objectType, objectTypeConversation):
-		// Responses/Conversations APIs use input_tokens/output_tokens
-		if v, ok := usg["input_tokens"]; ok && v != nil {
-			usage.PromptTokens = toInt(v)
-		}
-		if v, ok := usg["output_tokens"]; ok && v != nil {
-			usage.CompletionTokens = toInt(v)
-		}
-	case objectType == objectTypeChatCompletion || objectType == objectTypeChatCompletionChunk || objectType == objectTypeTextCompletion:
-		// Traditional APIs use prompt_tokens/completion_tokens
-		if v, ok := usg["prompt_tokens"]; ok && v != nil {
-			usage.PromptTokens = toInt(v)
-		}
-		if v, ok := usg["completion_tokens"]; ok && v != nil {
-			usage.CompletionTokens = toInt(v)
-		}
-	default:
-		// Fallback: try both field naming conventions
-		if v, ok := usg["input_tokens"]; ok && v != nil {
-			usage.PromptTokens = toInt(v)
-		} else if v, ok := usg["prompt_tokens"]; ok && v != nil {
-			usage.PromptTokens = toInt(v)
-		}
-
-		if v, ok := usg["output_tokens"]; ok && v != nil {
-			usage.CompletionTokens = toInt(v)
-		} else if v, ok := usg["completion_tokens"]; ok && v != nil {
-			usage.CompletionTokens = toInt(v)
-		}
-	}
-
-	// total_tokens field name is consistent across all API types
-	if v, ok := usg["total_tokens"]; ok && v != nil {
-		usage.TotalTokens = toInt(v)
-	}
-
-	return usage
 }
 
 // Example message if "stream_options": {"include_usage": "true"} is included in the request:

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
@@ -28,8 +28,8 @@ func TestExtractUsage_MalformedFields_NoPanic(t *testing.T) {
 			body: `{"object":"chat.completion","usage":"oops"}`,
 		},
 		{
-			name: "prompt_token_details_is_number",
-			body: `{"object":"chat.completion","usage":{"prompt_token_details":0,"prompt_tokens":7}}`,
+			name: "prompt_tokens_details_is_number",
+			body: `{"object":"chat.completion","usage":{"prompt_tokens_details":0,"prompt_tokens":7}}`,
 		},
 		{
 			name: "prompt_tokens_is_string",

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -866,14 +866,38 @@ func TestOpenAIParser_ParseResponse(t *testing.T) {
 			},
 		},
 		{
-			name: "Full Usage with Cached Token details",
+			name: "Full usage with standard cached token details",
 			body: []byte(`{
-				"object": "chat.completion",
+					"object": "chat.completion",
+					"usage": {
+						"prompt_tokens": 100,
+						"completion_tokens": 50,
+						"total_tokens": 150,
+						"prompt_tokens_details": {
+							"cached_tokens": 40
+						}
+					}
+			}`),
+			want: &fwkrh.ParsedResponse{
+				Usage: &fwkrh.Usage{
+					PromptTokens:     100,
+					CompletionTokens: 50,
+					TotalTokens:      150,
+					PromptTokenDetails: &fwkrh.PromptTokenDetails{
+						CachedTokens: 40,
+					},
+				},
+			},
+		},
+		{
+			name: "Responses API with cached input token details",
+			body: []byte(`{
+				"object": "response",
 				"usage": {
-					"prompt_tokens": 100,
-					"completion_tokens": 50,
+					"input_tokens": 100,
+					"output_tokens": 50,
 					"total_tokens": 150,
-					"prompt_token_details": {
+					"input_tokens_details": {
 						"cached_tokens": 40
 					}
 				}
@@ -955,7 +979,7 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 		},
 		{
 			name:  "Usage and DONE in the same multi-line response",
-			chunk: []byte("data: {\"usage\":{\"prompt_tokens\":10,\"prompt_token_details\":{\"cached_tokens\":10}}}\ndata: [DONE]"),
+			chunk: []byte("data: {\"usage\":{\"prompt_tokens\":10,\"prompt_tokens_details\":{\"cached_tokens\":10}}}\ndata: [DONE]"),
 			want: &fwkrh.ParsedResponse{
 				Usage: &fwkrh.Usage{
 					PromptTokens: 10,
@@ -994,6 +1018,9 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 					PromptTokens:     31,
 					CompletionTokens: 3,
 					TotalTokens:      34,
+					PromptTokenDetails: &fwkrh.PromptTokenDetails{
+						CachedTokens: 16,
+					},
 				},
 			},
 		},

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -110,7 +110,7 @@ const (
 			"prompt_tokens": 11,
 			"total_tokens": 111,
 			"completion_tokens": 100,
-			"prompt_token_details": {
+			"prompt_tokens_details": {
 				"cached_tokens": 10
 			}
 		}
@@ -123,7 +123,7 @@ const (
 	streamingBodyWithUsage = `data: {"id":"cmpl-41764c93-f9d2-4f31-be08-3ba04fa25394","object":"text_completion","created":1740002445,"model":"food-review-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}
 data: [DONE]
 	`
-	streamingBodyWithUsageAndCachedTokens = `data: {"id":"cmpl-41764c93-f9d2-4f31-be08-3ba04fa25394","object":"text_completion","created":1740002445,"model":"food-review-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10,"prompt_token_details":{"cached_tokens":5}}}
+	streamingBodyWithUsageAndCachedTokens = `data: {"id":"cmpl-41764c93-f9d2-4f31-be08-3ba04fa25394","object":"text_completion","created":1740002445,"model":"food-review-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10,"prompt_tokens_details":{"cached_tokens":5}}}
 data: [DONE]
 	`
 )


### PR DESCRIPTION
## Summary

Fixes cached token usage extraction in the EPP OpenAI parser.
This caused EPP to silently drop cached token usage from normal responses, so prompt cached-token metrics were not recorded.

## Changes

- Parse `cached_tokens` from `usage.prompt_tokens_details`.
- Parse Responses API cached input tokens from `usage.input_tokens_details`.
- Update the internal `Usage` JSON tag to emit `prompt_tokens_details`.
- Update parser and handler tests to cover the standard plural field.

## Why

This is a usage/accounting correctness fix. Without it, cache-hit observability can be misleading because EPP records prompt/output tokens but misses cached prompt tokens.



Fixes #1273
