### PR TITLE
fix: allow unstale workflow to remove labels from PRs

### DIFF
--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -1,20 +1,32 @@
-name: 'Unstale Issue'
+name: 'Unstale Issue or PR'
 
 on:
   issues:
     types: [ reopened ]
   issue_comment:
     types: [ created ]
+  pull_request:
+    types: [ reopened ]
 
 jobs:
   remove-stale:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     if: >-
-      github.event.issue.state == 'open' &&
-      (contains(github.event.issue.labels.*.name, 'lifecycle/stale') || 
-       contains(github.event.issue.labels.*.name, 'lifecycle/rotten'))
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.state == 'open' &&
+        (contains(github.event.pull_request.labels.*.name, 'lifecycle/stale') ||
+         contains(github.event.pull_request.labels.*.name, 'lifecycle/rotten'))
+      ) ||
+      (
+        github.event_name != 'pull_request' &&
+        github.event.issue.state == 'open' &&
+        (contains(github.event.issue.labels.*.name, 'lifecycle/stale') ||
+         contains(github.event.issue.labels.*.name, 'lifecycle/rotten'))
+      )
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v6
@@ -22,6 +34,8 @@ jobs:
       - name: 'Remove stale labels'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
-          echo "Removing 'stale' label from issue #${{ github.event.issue.number }}"
-          gh issue edit ${{ github.event.issue.number }} --remove-label "lifecycle/stale,lifecycle/rotten"
+          echo "Removing stale labels from item #$TARGET_NUMBER"
+          gh issue edit "$TARGET_NUMBER" --remove-label "lifecycle/stale" || true
+          gh issue edit "$TARGET_NUMBER" --remove-label "lifecycle/rotten" || true


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
-->

**What this PR does / why we need it**:
Updates the unstale workflow - [unstale.yaml](https://github.com/llm-d/llm-d-router/blob/main/.github/workflows/unstale.yaml) so it can remove stale labels from PRs and handles `lifecycle/stale` and `lifecycle/rotten` more safely by removing them individually.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #676 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
