### PR TITLE
feat(epp/preciseprefixcache): accept blockSizeTokens as top-level config alias

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -60,6 +60,16 @@ type kvCacheIndexer interface {
 // PluginConfig holds the configuration for the
 // Scorer plugin.
 type PluginConfig struct {
+	// BlockSizeTokens is the number of tokens per KV-block. When set, it
+	// overrides TokenProcessorConfig.BlockSize. The field is a top-level
+	// alias so operators can use a single field name across both the
+	// precise- and the approximate-prefix-cache plugins (the latter has
+	// always exposed blockSizeTokens directly). The legacy
+	// tokenProcessorConfig.blockSize remains accepted for backwards
+	// compatibility with configs that wrap the underlying kvblock
+	// config directly.
+	BlockSizeTokens int `json:"blockSizeTokens,omitempty"`
+
 	// TokenProcessorConfig holds the configuration for the `kvblock.TokenProcessor` which is
 	// used to process tokens into KV-block keys.
 	TokenProcessorConfig *kvblock.TokenProcessorConfig `json:"tokenProcessorConfig"`
@@ -81,6 +91,19 @@ type PluginConfig struct {
 	// If empty, defaultSpeculativeTTL is used. Only used when SpeculativeIndexing is true.
 	// Accepts Go duration strings (e.g. "2s", "500ms").
 	SpeculativeTTL string `json:"speculativeTTL"`
+}
+
+// applyAliases resolves top-level field aliases on the parsed config. The
+// top-level BlockSizeTokens, when set, overrides
+// TokenProcessorConfig.BlockSize so a single user-facing field name works
+// across both the precise- and the approximate-prefix-cache plugins.
+func (c *PluginConfig) applyAliases() {
+	if c.BlockSizeTokens > 0 {
+		if c.TokenProcessorConfig == nil {
+			c.TokenProcessorConfig = kvblock.DefaultTokenProcessorConfig()
+		}
+		c.TokenProcessorConfig.BlockSize = c.BlockSizeTokens
+	}
 }
 
 // compile-time type assertions
@@ -139,6 +162,7 @@ func PluginFactory(name string, rawParameters json.RawMessage,
 			return nil, fmt.Errorf("failed to parse %s plugin config: %w", PrecisePrefixCachePluginType, err)
 		}
 	}
+	parameters.applyAliases()
 
 	if parameters.IndexerConfig == nil {
 		return nil, errors.New("indexerConfig is required")

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_config_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_config_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package preciseprefixcache
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for #1157. The precise-prefix-cache plugin wraps the
+// external kvblock.TokenProcessorConfig whose block-size field is named
+// "blockSize". Users coming from the approximate-prefix-cache plugin (which
+// names the same concept "blockSizeTokens") would set blockSizeTokens at the
+// top level of this plugin's config and the value would be silently dropped,
+// leaving the scorer with the default 16-token block size.
+//
+// The fix is to accept blockSizeTokens as a top-level alias that overrides
+// TokenProcessorConfig.BlockSize when set, so a single config-field name
+// works across both prefix-cache plugins.
+func TestPluginConfig_BlockSizeTokensAlias(t *testing.T) {
+	cases := []struct {
+		name          string
+		raw           string
+		wantBlockSize int
+	}{
+		{
+			name:          "top-level blockSizeTokens sets BlockSize",
+			raw:           `{"blockSizeTokens":64}`,
+			wantBlockSize: 64,
+		},
+		{
+			name:          "legacy tokenProcessorConfig.blockSize still works",
+			raw:           `{"tokenProcessorConfig":{"blockSize":64}}`,
+			wantBlockSize: 64,
+		},
+		{
+			name:          "top-level blockSizeTokens wins over legacy",
+			raw:           `{"blockSizeTokens":128,"tokenProcessorConfig":{"blockSize":64}}`,
+			wantBlockSize: 128,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg PluginConfig
+			require.NoError(t, json.Unmarshal([]byte(tc.raw), &cfg))
+			cfg.applyAliases()
+			require.NotNil(t, cfg.TokenProcessorConfig)
+			require.Equal(t, tc.wantBlockSize, cfg.TokenProcessorConfig.BlockSize)
+		})
+	}
+}
+
+// Confirms that a default-constructed config (no TokenProcessorConfig, no
+// BlockSizeTokens) leaves resolution to New(), which falls back to
+// kvblock.DefaultTokenProcessorConfig().
+func TestPluginConfig_NoAliasesPreservesDefaults(t *testing.T) {
+	var cfg PluginConfig
+	cfg.applyAliases()
+	// No top-level BlockSizeTokens means we don't touch TokenProcessorConfig;
+	// New() handles the nil case by installing the kvblock default.
+	require.Nil(t, cfg.TokenProcessorConfig)
+	require.Equal(t, 16, kvblock.DefaultTokenProcessorConfig().BlockSize)
+}


### PR DESCRIPTION
## Summary

Fixes #1157. The precise-prefix-cache scorer wraps the external `kvblock.TokenProcessorConfig` whose block-size field is `blockSize`, while the sibling `approx-prefix-cache-producer` exposes the same concept as `blockSizeTokens`. Operators copying a working config from one plugin to the other (or following newer guides that document `blockSizeTokens`) would set `blockSizeTokens` at the top level of `precise-prefix-cache` and the value would be silently dropped — the scorer would fall through to the default 16-token block size.

This adds `BlockSizeTokens` as a top-level field on `PluginConfig`. When set, it overrides `TokenProcessorConfig.BlockSize`. The legacy `tokenProcessorConfig.blockSize` path remains accepted for backwards compatibility with configs that wrap the underlying `kvblock` config directly. Resolution happens in a new `PluginConfig.applyAliases` method invoked from `PluginFactory` right after `json.Unmarshal`.

This is also the right shape going forward once #1134 (strict plugin-config parsing) lands: today the orphan `blockSizeTokens` field is silently dropped; after #1134 it would be an outright error; after this PR it just works.

## Verified locally

Regression tests cover all four resolution cases:

- top-level `blockSizeTokens` sets `BlockSize`
- legacy `tokenProcessorConfig.blockSize` still works
- both set → top-level wins
- neither set → resolution untouched (handled by `New()`'s default)

`go test ./pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/...`, `make test-unit-epp`, `make test-integration-hermetic PATTERN='TestWellKnownConfigs'`, and `make presubmit` all green.

## Test plan
- [x] `go test ./pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/...`
- [x] `make test-unit-epp`
- [x] `make test-integration-hermetic PATTERN='TestWellKnownConfigs'`
- [x] `make presubmit` (DCO, signed commits, go-mod-check, format, lint, govulncheck)
- [ ] Reviewer to confirm "top-level wins over wrapped" precedence (alternative: log a warning when both are set)