### PR TITLE
Stabilize EPP integration tests and improve sync diagnostics

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
@@ -77,7 +77,10 @@ func (m *NotificationExtractor) ExtractNotification(_ context.Context, event fwk
 	return m.extractErr
 }
 
-// GetEvents returns a copy of all recorded events.
+// GetEvents returns an immutable snapshot of all recorded events.
+// It is safe to call concurrently: the snapshot is copied under the internal
+// lock, so callers can iterate the returned slice without holding any lock and
+// without racing against concurrent ExtractNotification calls.
 func (m *NotificationExtractor) GetEvents() []fwkdl.NotificationEvent {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -444,24 +444,29 @@ func (h *TestHarness) WaitForReadyPodsMetric(expectedCount int) {
 // WaitForSync blocks until the EPP Datastore has synced the expected number of pods.
 func (h *TestHarness) WaitForSync(expectedPods int, checkModelObjective string) *TestHarness {
 	h.t.Helper()
-	require.Eventually(h.t, func() bool {
-		if h.hasCRDs() && !h.Datastore.PoolHasSynced() {
-			return false
-		}
 
-		if len(h.Datastore.PodList(datastore.AllPodsPredicate)) != expectedPods {
+	var lastPoolSynced bool
+	var lastPodsFound int
+	require.Eventually(h.t, func() bool {
+		hasCRDs := h.hasCRDs()
+		lastPoolSynced = h.Datastore.PoolHasSynced()
+		lastPodsFound = len(h.Datastore.PodList(datastore.AllPodsPredicate))
+		if hasCRDs && !lastPoolSynced {
 			return false
 		}
-		if h.hasCRDs() && checkModelObjective != "" && h.Datastore.ObjectiveGet(checkModelObjective) == nil {
+		if lastPodsFound != expectedPods {
+			return false
+		}
+		if hasCRDs && checkModelObjective != "" && h.Datastore.ObjectiveGet(checkModelObjective) == nil {
 			return false
 		}
 		return true
 	}, 10*time.Second, 50*time.Millisecond,
-		"Datastore sync timed out.\n- runMode: standaloneStrategy=%v\n- PoolSynced: %v\n- Pods Found: %d (Expected: %d)",
+		"Datastore sync timed out (runMode=%v standaloneStrategy=%v poolSynced=%v podsFound=%d expected=%d)",
 		h.runMode,
 		h.standaloneStrategy,
-		h.Datastore.PoolHasSynced(),
-		len(h.Datastore.PodList(datastore.AllPodsPredicate)),
+		lastPoolSynced,
+		lastPodsFound,
 		expectedPods,
 	)
 	return h

--- a/test/integration/epp/runtime_notification_test.go
+++ b/test/integration/epp/runtime_notification_test.go
@@ -55,7 +55,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 	tests := []struct {
 		name    string
 		setup   func(*datalayer.Runtime) (*mocks.NotificationExtractor, error)
-		trigger func(*testSetup) error
+		trigger func(*testing.T, *testSetup, *mocks.NotificationExtractor) error
 		verify  func(*mocks.NotificationExtractor, int) bool
 	}{
 		{
@@ -63,7 +63,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 			setup: func(r *datalayer.Runtime) (*mocks.NotificationExtractor, error) {
 				return setupRuntimeWithExtractor(r, "test-extractor-add")
 			},
-			trigger: func(s *testSetup) error {
+			trigger: func(_ *testing.T, s *testSetup, _ *mocks.NotificationExtractor) error {
 				pod := newTestPod("test-pod", s.namespace)
 				return s.mgrClient.Create(s.ctx, pod)
 			},
@@ -85,7 +85,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 			setup: func(r *datalayer.Runtime) (*mocks.NotificationExtractor, error) {
 				return setupRuntimeWithExtractor(r, "test-extractor-update")
 			},
-			trigger: func(s *testSetup) error {
+			trigger: func(_ *testing.T, s *testSetup, _ *mocks.NotificationExtractor) error {
 				pod := newTestPod("test-pod-update", s.namespace)
 				if err := s.mgrClient.Create(s.ctx, pod); err != nil {
 					return err
@@ -110,13 +110,25 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 			setup: func(r *datalayer.Runtime) (*mocks.NotificationExtractor, error) {
 				return setupRuntimeWithExtractor(r, "test-extractor-delete")
 			},
-			trigger: func(s *testSetup) error {
+			trigger: func(t *testing.T, s *testSetup, ext *mocks.NotificationExtractor) error {
 				pod := newTestPod("test-pod-delete", s.namespace)
 				if err := s.mgrClient.Create(s.ctx, pod); err != nil {
 					return err
 				}
-				// Wait a bit to ensure the pod is synced before deletion
-				time.Sleep(100 * time.Millisecond)
+				// Wait for the informer to deliver the add event before deleting.
+				// GetEvents() returns a locked, immutable snapshot so iterating the
+				// local variable below is free of data races with concurrent
+				// ExtractNotification calls from the informer goroutine.
+				require.Eventually(t, func() bool {
+					snapshot := ext.GetEvents()
+					for _, e := range snapshot {
+						if e.Type == fwkdl.EventAddOrUpdate && e.Object.GetName() == pod.Name {
+							return true
+						}
+					}
+					return false
+				}, eventWaitTimeout, eventPollInterval,
+					"add event for pod %q not received before delete", pod.Name)
 				return s.mgrClient.Delete(s.ctx, pod)
 			},
 			verify: func(ext *mocks.NotificationExtractor, initialCount int) bool {
@@ -146,7 +158,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 				}
 				return ext1, r.Configure(cfg, false, "", logger)
 			},
-			trigger: func(s *testSetup) error {
+			trigger: func(_ *testing.T, s *testSetup, _ *mocks.NotificationExtractor) error {
 				pod := newTestPod("test-pod-multi", s.namespace)
 				return s.mgrClient.Create(s.ctx, pod)
 			},
@@ -169,7 +181,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 				}
 				return workingExtractor, r.Configure(cfg, false, "", logger)
 			},
-			trigger: func(s *testSetup) error {
+			trigger: func(_ *testing.T, s *testSetup, _ *mocks.NotificationExtractor) error {
 				pod := newTestPod("test-pod-error", s.namespace)
 				return s.mgrClient.Create(s.ctx, pod)
 			},
@@ -193,7 +205,7 @@ func TestRuntimeNotificationDispatch(t *testing.T) {
 
 			initialCount := len(extractor.GetEvents())
 
-			err = tc.trigger(setup)
+			err = tc.trigger(t, setup, extractor)
 			require.NoError(t, err)
 
 			require.Eventually(t, func() bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR improves the EPP integration test harness by fixing the datastore sync timeout message and making notification tests deterministic.  
It replaces a flaky sleep-based delete flow with an event-based wait, which reduces CI flakiness and makes failures easier to diagnose.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
