### PR TITLE
ci: stage release notes as per-PR fragments

### DIFF
--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -6,9 +6,13 @@ on:
 jobs:
   check-signed-commits:
     name: Check signed commits in PR
+    # Skip signed-commits enforcement for bot-authored release-notes branches
+    # (per-PR fragments under release-notes/pr-*, assembly under release-notes/assemble-*).
+    # The release-notes App can't sign commits; fragment content is sourced from
+    # already-reviewed PR bodies and assembly is a deterministic transform.
     if: |
-      !startsWith(github.head_ref, 'release-notes/pr-') ||
-      github.event.pull_request.user.login != 'github-actions[bot]'
+      !startsWith(github.head_ref, 'release-notes/') ||
+      !endsWith(github.event.pull_request.user.login, '[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -6,13 +6,18 @@ on:
 jobs:
   check-signed-commits:
     name: Check signed commits in PR
-    # Skip signed-commits enforcement for bot-authored release-notes branches
-    # (per-PR fragments under release-notes/pr-*, assembly under release-notes/assemble-*).
-    # The release-notes App can't sign commits; fragment content is sourced from
-    # already-reviewed PR bodies and assembly is a deterministic transform.
+    # Skip signed-commits enforcement for bot-authored release-notes branches:
+    # per-PR fragments under release-notes/pr-*, assembly under
+    # release-notes/assemble-*. The release-notes App can't sign commits;
+    # fragment content is sourced from already-reviewed PR bodies and
+    # assembly is a deterministic transform. Pin to the two specific prefixes
+    # so an unrelated bot pushing to release-notes/<other> doesn't bypass.
     if: |
-      !startsWith(github.head_ref, 'release-notes/') ||
-      !endsWith(github.event.pull_request.user.login, '[bot]')
+      !(
+        (startsWith(github.head_ref, 'release-notes/pr-') ||
+         startsWith(github.head_ref, 'release-notes/assemble-')) &&
+        endsWith(github.event.pull_request.user.login, '[bot]')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -35,5 +35,7 @@ jobs:
       - name: Run lychee link checker
         uses: lycheeverse/lychee-action@v2.8.0
         with:
-          args: '--config .lychee.toml --verbose --no-progress **/*.md'
+          # Exclude release-notes.d/ — fragments are sourced verbatim from
+          # PR bodies; let the original PR's link check be authoritative.
+          args: '--config .lychee.toml --verbose --no-progress --exclude-path release-notes.d **/*.md'
           fail: true

--- a/.github/workflows/release-notes-assemble.yaml
+++ b/.github/workflows/release-notes-assemble.yaml
@@ -27,10 +27,13 @@ jobs:
         run: |
           echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout main
+      - name: Checkout tagged commit
+        # Check out the tagged commit (not main HEAD) so a fragment merged
+        # into main between the tag push and this workflow's run is not
+        # accidentally rolled into the wrong release.
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.sha }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Assemble fragments and open PR
@@ -56,7 +59,11 @@ jobs:
             pr=$(sed -n 's/^pr: *//p' "$f" | head -1)
             url=$(sed -n 's/^url: *//p' "$f" | head -1)
             date=$(sed -n 's/^date: *//p' "$f" | head -1)
-            note=$(awk '/^---$/{c++; next} c==2' "$f" | sed '/^[[:space:]]*$/d' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+            # Print everything after the second `---` line verbatim — once
+            # we're past the closing frontmatter marker, a body line that
+            # happens to be `---` (Markdown horizontal rule) must be kept,
+            # not counted as a third delimiter.
+            note=$(awk 'p {print; next} /^---$/ {if (++c == 2) p = 1}' "$f" | sed '/^[[:space:]]*$/d' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
             if [[ -z "$pr" || -z "$url" || -z "$date" || -z "$note" ]]; then
               echo "Malformed fragment: $f" >&2
               exit 1
@@ -86,10 +93,16 @@ jobs:
           git checkout -b "$BRANCH"
           git add RELEASE-NOTES.md
           git commit -s -m "docs: assemble release notes for ${TAG}"
-          git push origin "$BRANCH"
+          # Force-push so a re-run (re-tag, manual workflow re-run) overwrites
+          # the prior branch rather than failing non-fast-forward.
+          git push -f origin "$BRANCH"
 
-          gh pr create \
-            --title "docs: assemble release notes for ${TAG}" \
-            --body "Assembles staged release-note fragments into RELEASE-NOTES.md for ${TAG} and removes the fragments." \
-            --base main \
-            --head "$BRANCH"
+          if gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "Assembly PR already open for $BRANCH; pushed update."
+          else
+            gh pr create \
+              --title "docs: assemble release notes for ${TAG}" \
+              --body "Assembles staged release-note fragments into RELEASE-NOTES.md for ${TAG} and removes the fragments." \
+              --base main \
+              --head "$BRANCH"
+          fi

--- a/.github/workflows/release-notes-assemble.yaml
+++ b/.github/workflows/release-notes-assemble.yaml
@@ -1,0 +1,95 @@
+name: Assemble Release Notes on Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  assemble:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_NOTES_APP_ID }}
+          private-key: ${{ secrets.RELEASE_NOTES_APP_PRIVATE_KEY }}
+
+      - name: Get App user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Assemble fragments and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          fragments=( release-notes.d/unreleased/*.md )
+          if [[ ${#fragments[@]} -eq 0 ]]; then
+            echo "No fragments to assemble for ${TAG}; exiting."
+            exit 0
+          fi
+
+          tmp=$(mktemp)
+          for f in "${fragments[@]}"; do
+            # Extract frontmatter values: strip "key: " prefix, take first match.
+            # Plain field-split breaks on URLs because they contain colons.
+            pr=$(sed -n 's/^pr: *//p' "$f" | head -1)
+            url=$(sed -n 's/^url: *//p' "$f" | head -1)
+            date=$(sed -n 's/^date: *//p' "$f" | head -1)
+            note=$(awk '/^---$/{c++; next} c==2' "$f" | sed '/^[[:space:]]*$/d' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+            if [[ -z "$pr" || -z "$url" || -z "$date" || -z "$note" ]]; then
+              echo "Malformed fragment: $f" >&2
+              exit 1
+            fi
+            printf '%s\t%s\t%s\t%s\n' "$date" "$pr" "$url" "$note" >> "$tmp"
+          done
+
+          sort -k1,1 -k2,2n "$tmp" -o "$tmp"
+
+          today=$(date -u +%Y-%m-%d)
+          new_section=$(mktemp)
+          printf 'RELEASE %s %s\n' "$TAG" "$today" > "$new_section"
+          while IFS=$'\t' read -r date pr url note; do
+            printf '%s %s %s\n' "$date" "$url" "$note" >> "$new_section"
+          done < "$tmp"
+          printf '\n' >> "$new_section"
+
+          touch RELEASE-NOTES.md
+          cat "$new_section" RELEASE-NOTES.md > RELEASE-NOTES.md.new
+          mv RELEASE-NOTES.md.new RELEASE-NOTES.md
+
+          git rm -- release-notes.d/unreleased/*.md
+
+          BRANCH="release-notes/assemble-${TAG}"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add RELEASE-NOTES.md
+          git commit -s -m "docs: assemble release notes for ${TAG}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "docs: assemble release notes for ${TAG}" \
+            --body "Assembles staged release-note fragments into RELEASE-NOTES.md for ${TAG} and removes the fragments." \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/release-notes-update.yaml
+++ b/.github/workflows/release-notes-update.yaml
@@ -11,22 +11,43 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_NOTES_APP_ID }}
+          private-key: ${{ secrets.RELEASE_NOTES_APP_PRIVATE_KEY }}
+
+      - name: Get App user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
 
-      - name: Update RELEASE-NOTES.md and open PR
+      - name: Stage release-note fragment and open PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          set -euo pipefail
+
           NOTE=$(printf '%s' "$PR_BODY" | tr -d '\r' | \
             sed -n '/^```release-note/,/^```/p' | sed '1d;$d' | xargs)
 
@@ -35,19 +56,28 @@ jobs:
             exit 0
           fi
 
-          touch RELEASE-NOTES.md
-          printf '%s\n%s\n' "${PR_MERGED_AT:0:10} $PR_URL $NOTE" "$(cat RELEASE-NOTES.md)" > RELEASE-NOTES.md
+          mkdir -p release-notes.d/unreleased
+          FRAGMENT="release-notes.d/unreleased/${PR_NUMBER}.md"
+          {
+            echo "---"
+            echo "pr: ${PR_NUMBER}"
+            echo "url: ${PR_URL}"
+            echo "author: ${PR_AUTHOR}"
+            echo "date: ${PR_MERGED_AT:0:10}"
+            echo "---"
+            echo "${NOTE}"
+          } > "$FRAGMENT"
 
           BRANCH="release-notes/pr-${PR_NUMBER}"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add RELEASE-NOTES.md
-          git commit -s -m "docs: update release notes for PR #${PR_NUMBER}"
+          git add "$FRAGMENT"
+          git commit -s -m "docs: add release-note fragment for PR #${PR_NUMBER}"
           git push origin "$BRANCH"
 
           gh pr create \
-            --title "update release notes for PR #${PR_NUMBER}" \
-            --body "Updates RELEASE-NOTES.md with the release note from ${PR_URL}." \
+            --title "docs: add release-note fragment for PR #${PR_NUMBER}" \
+            --body "Stages release-note fragment for ${PR_URL}. Will be assembled into RELEASE-NOTES.md at the next release tag." \
             --base main \
             --head "$BRANCH"

--- a/.github/workflows/release-notes-update.yaml
+++ b/.github/workflows/release-notes-update.yaml
@@ -48,8 +48,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Extract the release-note block, collapse to a single line.
+          # Avoid `xargs` here: with no command it runs `echo` which interprets
+          # quotes, so notes containing apostrophes (e.g. "Don't ...") would
+          # error and the fragment would be silently dropped.
           NOTE=$(printf '%s' "$PR_BODY" | tr -d '\r' | \
-            sed -n '/^```release-note/,/^```/p' | sed '1d;$d' | xargs)
+            sed -n '/^```release-note/,/^```/p' | sed '1d;$d' | \
+            tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')
 
           if [[ -z "$NOTE" || "${NOTE,,}" == "none" ]]; then
             echo "No valid release note found. Exiting."
@@ -74,10 +79,17 @@ jobs:
           git checkout -b "$BRANCH"
           git add "$FRAGMENT"
           git commit -s -m "docs: add release-note fragment for PR #${PR_NUMBER}"
-          git push origin "$BRANCH"
+          # Force-push so re-runs on the same PR (e.g. after a transient
+          # token failure) overwrite the existing branch instead of failing
+          # non-fast-forward.
+          git push -f origin "$BRANCH"
 
-          gh pr create \
-            --title "docs: add release-note fragment for PR #${PR_NUMBER}" \
-            --body "Stages release-note fragment for ${PR_URL}. Will be assembled into RELEASE-NOTES.md at the next release tag." \
-            --base main \
-            --head "$BRANCH"
+          if gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "PR already open for $BRANCH; pushed update."
+          else
+            gh pr create \
+              --title "docs: add release-note fragment for PR #${PR_NUMBER}" \
+              --body "Stages release-note fragment for ${PR_URL}. Will be assembled into RELEASE-NOTES.md at the next release tag." \
+              --base main \
+              --head "$BRANCH"
+          fi

--- a/.typos.toml
+++ b/.typos.toml
@@ -19,9 +19,11 @@ extend-exclude = [
     "testdata/",
     # Generated protobuf files
     "pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen/",
-    # Release-note fragments are sourced verbatim from PR bodies; let the
-    # original PR's typo check be authoritative.
-    "release-notes.d/",
-    "RELEASE-NOTES.md"
+    # Fragment files are sourced verbatim from human PR bodies; the bot
+    # can't fix typos itself, so don't fail fragment PRs on them. Typos in
+    # the assembled RELEASE-NOTES.md (also a bot PR, but reviewed by a
+    # maintainer before merge) are still checked so they get caught before
+    # landing on main.
+    "release-notes.d/"
 ]
 

--- a/.typos.toml
+++ b/.typos.toml
@@ -18,6 +18,10 @@ extend-exclude = [
     "build/",
     "testdata/",
     # Generated protobuf files
-    "pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen/"
+    "pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen/",
+    # Release-note fragments are sourced verbatim from PR bodies; let the
+    # original PR's typo check be authoritative.
+    "release-notes.d/",
+    "RELEASE-NOTES.md"
 ]
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,4 @@
+RELEASE pre-fragments 2026-05-24
 2026-05-21 https://github.com/llm-d/llm-d-router/pull/1155 Add CLI flags --grpc-max-recv-msg-size, --grpc-max-send-msg-size, and --grpc-enable-compression to EPP to support large multi-modal payloads and over-the-wire compression.
 2026-05-18 https://github.com/llm-d/llm-d-router/pull/1171 EPP scheduler hot path now allocates ~90% less per request on large fleets (100+ endpoints) and runs ~50% faster. Behavior is unchanged; the optimization eliminates per-endpoint allocations that occurred even when DEBUG logging was disabled.
 2026-05-14 https://github.com/llm-d/llm-d-router/pull/683 Add sidecar configuration specified via either `--configuration-file <path>` or `--configuration <text>`. Both YAML and JSON formats are allowed. Configuration field names are the same as the CLI flags. CLI has priority over the configuration file or text.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Replaces the single-file release-notes flow with a fragment-based staging approach to fix three structural issues with the current setup. See #1212.


**Which issue(s) this PR fixes**:

Fixes #1212

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
