### PR TITLE
Helm deprecation checks

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -63,6 +63,27 @@ helm install vllm-qwen3-32b ./config/charts/llm-d-router-gateway \
 ```
 ---
 
+## Migrating from gateway-api-inference-extension
+
+If you previously used the `gateway-api-inference-extension` Helm charts (either `inferencepool` or `standalone`), please note that the `llm-d-router` charts have been restructured.
+
+To prevent accidental misconfiguration, the new charts include strict validation checks that will **fail the installation** if they detect legacy top-level keys in your values file or command-line flags.
+
+You must migrate your values according to the following mapping:
+
+### Value Mapping Guide
+
+| Legacy Key (Top-level) | New Key (Nested/Renamed) | Description |
+| :--- | :--- | :--- |
+| `inferenceExtension.*` | `router.epp.*` <br> `router.monitoring.*` <br> `router.tracing.*` <br> `router.latencyPredictor.*` | EPP configuration has been restructured and nested under the `router` block. |
+| `inferencePool.*` | `router.modelServers.*` <br> `router.inferencePool.*` | Model server configuration and pool control flags have moved under `router`. |
+| `inferenceObjectives` | `router.inferenceObjectives` | Objectives list has moved under `router`. |
+| `experimentalHttpRoute` | `httpRoute` | Gateway HTTPRoute configuration has been renamed (Gateway chart only). |
+
+For a detailed list of all new configuration options, refer to the [Configuration & Customization](#configuration--customization) section below.
+
+---
+
 ## Configuration & Customization
 
 Since both charts use `routerlib` under the hood, all configurations and customizations are shared under the `router` values block. EPP and the llm-d Router can be customized by grouping configuration blocks in your `values.yaml` file. Below is the complete documentation and reference for each component.

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -330,6 +330,7 @@ EPP resource validations
 EPP generic validations
 */}}
 {{- define "llm-d-router.validations.epp" -}}
+{{- include "llm-d-router.validations.deprecations" . }}
 {{- include "llm-d-router.validations.epp.resources" . }}
 {{- include "llm-d-router.validations.epp.inferenceObjectives" . }}
 {{- end -}}
@@ -340,5 +341,27 @@ EPP inferenceObjectives validations
 {{- define "llm-d-router.validations.epp.inferenceObjectives" -}}
 {{- if and (eq .Values.router.inferencePool.create false) .Values.router.inferenceObjectives }}
 {{- fail ".Values.router.inferenceObjectives can only be configured when .Values.router.inferencePool.create is true." }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Deprecation validations
+*/}}
+{{- define "llm-d-router.validations.deprecations" -}}
+{{- if .Values.inferenceExtension }}
+{{- fail "Top-level 'inferenceExtension' is deprecated. Please migrate your values to 'router.epp' and other 'router.*' fields." }}
+{{- end }}
+{{- if .Values.inferencePool }}
+{{- fail "Top-level 'inferencePool' is deprecated. Please migrate your values to 'router.modelServers' and 'router.inferencePool'." }}
+{{- end }}
+{{- if .Values.experimentalHttpRoute }}
+  {{- if eq .Chart.Name "llm-d-router-gateway" }}
+    {{- fail "Top-level 'experimentalHttpRoute' is deprecated. Please migrate your values to 'httpRoute'." }}
+  {{- else }}
+    {{- fail "Top-level 'experimentalHttpRoute' is deprecated and not supported in this chart." }}
+  {{- end }}
+{{- end }}
+{{- if .Values.inferenceObjectives }}
+{{- fail "Top-level 'inferenceObjectives' is deprecated. Please migrate your values to 'router.inferenceObjectives'." }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:

Adds deprecation checks to the changes that was made to the helm charts.

**Which issue(s) this PR fixes**:
Part of https://github.com/llm-d/llm-d-router/issues/1285
Part of https://github.com/llm-d/llm-d-router/issues/1284
Part of https://github.com/llm-d/llm-d-router/issues/1165

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The helm charts are now released as part of the llm-d router project, they went through several structural changes and validation safeguards for users migrating from  gateway-api-inference-extension ; see the "Migrating from gateway-api-inference-extension" section in https://github.com/llm-d/llm-d-router/blob/main/config/charts/README.md for the migration guide.
```
