### PR TITLE
Fix:  config drift of vllmConfig.URL after field rename 

### DIFF
--- a/deploy/config/epp-mm-embeddings-cache-config.yaml
+++ b/deploy/config/epp-mm-embeddings-cache-config.yaml
@@ -6,7 +6,7 @@ plugins:
     parameters:
       modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
       vllm:
-        http: http://localhost:8000
+        url: http://localhost:8000
   - type: endpoint-notification-source
   - type: metrics-data-source
   - type: core-metrics-extractor

--- a/deploy/config/epp-precise-prefix-cache-split-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-split-config.yaml
@@ -7,7 +7,7 @@ plugins:
     parameters:
       modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
       vllm:
-        http: http://localhost:8000
+        url: http://localhost:8000
   - type: endpoint-notification-source
   - type: metrics-data-source
   - type: core-metrics-extractor


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

PR #1079 renamed vllmConfig.HTTP → vllmConfig.URL with JSON tag http → url. The code change was made, but two config  files in deploy/config/ were missed during the rename update.

EPP fails to start with configuration loading error due to unknown field http in vllm block 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
