### PR TITLE
Fourth step in refactoring of the Flow Control layer

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -386,7 +386,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		endpointCandidates = requestcontrol.NewCachedEndpointCandidates(ctx, endpointCandidates, time.Millisecond*50)
 		setupLog.Info("Initializing experimental Flow Control layer")
 		registry := fcregistry.NewFlowRegistry(eppConfig.FlowControlConfig.Registry, setupLog)
-		fc, err := fccontroller.NewFlowController(
+		fc := fccontroller.NewFlowController(
 			ctx,
 			opts.PoolName,
 			eppConfig.FlowControlConfig.Controller,
@@ -397,9 +397,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 				UsageLimitPolicy:   eppConfig.FlowControlConfig.UsageLimitPolicy,
 			},
 		)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to initialize Flow Controller: %w", err)
-		}
+		fc.Start()
 		go registry.Run(ctx)
 		admissionController = requestcontrol.NewFlowControlAdmissionController(fc, opts.PoolName)
 	} else {

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -397,7 +397,6 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 				UsageLimitPolicy:   eppConfig.FlowControlConfig.UsageLimitPolicy,
 			},
 		)
-		fc.Start()
 		go registry.Run(ctx)
 		admissionController = requestcontrol.NewFlowControlAdmissionController(fc, opts.PoolName)
 	} else {

--- a/pkg/epp/flowcontrol/README.md
+++ b/pkg/epp/flowcontrol/README.md
@@ -95,8 +95,8 @@ The Flow Controller framework is built on several key components that work in co
 be highly modular and scalable, with clear separation of concerns. For a deep dive into the specific design choices and
 their justifications, please refer to the detailed documentation within the relevant sub-packages.
 
-1.  **The `FlowController` Engine (`./controller`)**: The central, sharded orchestrator responsible for the main request
-    processing loop. It manages a pool of workers that distribute incoming requests, apply policies, and dispatch
+1.  **The `FlowController` Engine (`./controller`)**: The central, orchestrator responsible for the main request
+    processing loop. It manages a worker that distributes incoming requests, apply policies, and dispatch
     requests to the backends. Its design focuses on high throughput and backpressure.
 
 2.  **Pluggable `Policy` Framework (`./framework`)**: This defines the core interfaces for all pluggable logic. It
@@ -108,8 +108,8 @@ their justifications, please refer to the detailed documentation within the rele
     implementations (e.g., FIFO, Priority Heap) while maintaining a stable interface.
 
 4.  **The `FlowRegistry` (`./registry`, `./contracts`)**: This is the stateful control plane of the system. It manages
-    the configuration and lifecycle of all flows, policies, and queues. It presents a sharded view of its state to the
-    `FlowController` workers to enable parallel operation with minimal lock contention.
+    the configuration and lifecycle of all flows, policies, and queues. It presents a view of its state to the
+    `FlowController` worker.
 
 5.  **Core Types and Service Contracts (`./types`, `./contracts`)**: These packages define the foundational data
     structures (e.g., `FlowControlRequest`), errors, and service interfaces that decouple the engine from its

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -257,10 +257,9 @@ func setupBenchmarkHarness(
 	cfg := customCfg
 	if cfg == nil {
 		cfg = &controller.Config{
-			DefaultRequestTTL:               5 * time.Minute,
-			ProcessorReconciliationInterval: 1 * time.Hour, // Effectively disabled
-			ExpiryCleanupInterval:           1 * time.Hour, // Effectively disabled
-			EnqueueChannelBufferSize:        2000,
+			DefaultRequestTTL:        5 * time.Minute,
+			ExpiryCleanupInterval:    1 * time.Hour, // Effectively disabled
+			EnqueueChannelBufferSize: 2000,
 		}
 	}
 

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -264,15 +264,13 @@ func setupBenchmarkHarness(
 		}
 	}
 
-	fc, err := controller.NewFlowController(ctx, "benchmark", cfg, controller.Deps{
+	fc := controller.NewFlowController(ctx, "benchmark", cfg, controller.Deps{
 		Registry:           reg,
 		SaturationDetector: detector,
 		EndpointCandidates: &mocks.MockEndpointCandidates{},
 		UsageLimitPolicy:   usagelimits.DefaultPolicy()},
 	)
-	if err != nil {
-		b.Fatalf("Failed to init FlowController: %v", err)
-	}
+	fc.Start()
 
 	return fc, detector
 }

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -269,7 +269,6 @@ func setupBenchmarkHarness(
 		EndpointCandidates: &mocks.MockEndpointCandidates{},
 		UsageLimitPolicy:   usagelimits.DefaultPolicy()},
 	)
-	fc.Start()
 
 	return fc, detector
 }

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -169,10 +169,9 @@ func BenchmarkFlowController_TopologyChurn(b *testing.B) {
 	ctx := b.Context()
 
 	cfg := &controller.Config{
-		DefaultRequestTTL:               5 * time.Minute,
-		ProcessorReconciliationInterval: 1 * time.Hour, // Effectively disabled
-		ExpiryCleanupInterval:           1 * time.Hour, // Effectively disabled
-		EnqueueChannelBufferSize:        100,
+		DefaultRequestTTL:        5 * time.Minute,
+		ExpiryCleanupInterval:    1 * time.Hour, // Effectively disabled
+		EnqueueChannelBufferSize: 100,
 	}
 
 	fc, detector := setupBenchmarkHarness(ctx, b, 1, 100, nil, cfg)
@@ -226,10 +225,9 @@ func BenchmarkFlowController_MassCancellation(b *testing.B) {
 	ctx := b.Context()
 
 	cfg := &controller.Config{
-		DefaultRequestTTL:               5 * time.Minute,
-		ProcessorReconciliationInterval: 1 * time.Hour,         // Effectively disabled
-		ExpiryCleanupInterval:           10 * time.Millisecond, // Hyper-aggressive sweep for benchmark
-		EnqueueChannelBufferSize:        100,
+		DefaultRequestTTL:        5 * time.Minute,
+		ExpiryCleanupInterval:    10 * time.Millisecond, // Hyper-aggressive sweep for benchmark
+		EnqueueChannelBufferSize: 100,
 	}
 
 	// Use the permanently saturated detector to guarantee all requests queue and definitively rot.

--- a/pkg/epp/flowcontrol/contracts/errors.go
+++ b/pkg/epp/flowcontrol/contracts/errors.go
@@ -31,13 +31,6 @@ var (
 	// ErrPolicyQueueIncompatible indicates that a selected policy is not compatible with the capabilities of the queue.
 	ErrPolicyQueueIncompatible = errors.New("policy is not compatible with queue capabilities")
 
-	// ErrInvalidShardCount indicates that an invalid shard count was provided (e.g., zero or negative).
-	ErrInvalidShardCount = errors.New("invalid shard count")
-
-	// ErrShardDraining indicates that an operation could not be completed because the target shard is in the process of
-	// being gracefully drained. The caller should retry the operation on a different, Active shard.
-	ErrShardDraining = errors.New("shard is draining")
-
 	// ErrInvalidQueueItemHandle indicates that a QueueItemHandle provided to a SafeQueue operation (e.g.,
 	// SafeQueue.Remove()) is not valid for that queue, has been invalidated, or does not correspond to an actual item in
 	// the queue.

--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -18,7 +18,7 @@ limitations under the License.
 //
 // # Testing Philosophy: High-Fidelity Mocks
 //
-// The components that consume these contracts, particularly the `controller.ShardProcessor`, are complex, concurrent
+// The components that consume these contracts, particularly the `controller.Processor`, are complex, concurrent
 // orchestrators. Testing them reliably requires more than simple stubs. It requires high-fidelity mocks that allow for
 // the deterministic simulation of race conditions and specific failure modes.
 //
@@ -66,14 +66,14 @@ func (m *MockRegistryDataPlane) FairnessPolicy(priority int) (flowcontrol.Fairne
 	if m.FairnessPolicyFunc != nil {
 		return m.FairnessPolicyFunc(priority)
 	}
-	return nil, errors.New("sentinel error for mock shard")
+	return nil, errors.New("sentinel error for mock data plane")
 }
 
 func (m *MockRegistryDataPlane) PriorityBandAccessor(priority int) (flowcontrol.PriorityBandAccessor, error) {
 	if m.PriorityBandAccessorFunc != nil {
 		return m.PriorityBandAccessorFunc(priority)
 	}
-	return nil, errors.New("sentinel error for mock shard")
+	return nil, errors.New("sentinel error for mock data plane")
 }
 
 func (m *MockRegistryDataPlane) AllOrderedPriorityLevels() []int {
@@ -199,7 +199,7 @@ var _ contracts.SafeQueue = &MockSafeQueue{}
 // --- ManagedQueue Mock ---
 
 // MockManagedQueue is a high-fidelity, thread-safe mock of the `contracts.ManagedQueue` interface, designed
-// specifically for testing the concurrent `controller/internal.ShardProcessor`.
+// specifically for testing the concurrent `controller/internal.Processor`.
 //
 // This mock is essential for creating deterministic and focused unit tests. It allows for precise control over queue
 // behavior and enables the testing of critical edge cases (e.g., empty queues, dispatch failures) in complete

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -121,8 +121,7 @@ type ActiveFlowConnection interface {
 //
 // Conformance: Implementations MUST be goroutine-safe.
 type ManagedQueue interface {
-	// Add attempts to enqueue an item, performing an atomic check on the parent shard's lifecycle state before adding
-	// the item to the underlying queue.
+	// Add attempts to enqueue an item.
 	Add(item flowcontrol.QueueItemAccessor) error
 
 	// Remove atomically finds and removes an item from the underlying queue using its handle.

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -38,14 +38,6 @@ import (
 //     When the lease count drops to zero, the flow becomes "Idle".
 //  4. Garbage Collection: The implementation MUST automatically garbage collect a flow after it has remained
 //     continuously Idle for a configurable duration.
-//
-// # System Invariants
-//
-// Concrete implementations MUST uphold the following invariants:
-//
-//  1. Shard Consistency: All configured priority bands and registered flow instances must exist on every Active shard.
-//  2. Capacity Partitioning: Global and per-band capacity limits must be uniformly partitioned across all Active
-//     shards.
 type FlowRegistry interface {
 	FlowRegistryObserver
 	FlowRegistryDataPlane
@@ -83,23 +75,23 @@ type FlowRegistryDataPlane interface {
 	// ErrFlowInstanceNotFound if no instance exists for the given key.
 	ManagedQueue(key flowcontrol.FlowKey) (ManagedQueue, error)
 
-	// FairnessPolicy retrieves the FairnessPolicy singleton configured for the specified priority band on this shard.
+	// FairnessPolicy retrieves the FairnessPolicy singleton configured for the specified priority band.
 	// This method provides access to the immutable logic component that governs inter-flow contention.
 	// The registry guarantees that a non-nil policy is returned for any active priority band.
 	//
 	// Returns:
 	//   - FairnessPolicy: The active policy instance.
-	//   - error: A wrapped ErrPriorityBandNotFound if the priority level is not configured on this shard.
+	//   - error: A wrapped ErrPriorityBandNotFound if the priority level is not configured.
 	FairnessPolicy(priority int) (flowcontrol.FairnessPolicy, error)
 
 	// PriorityBandAccessor retrieves the read-only view of the "Flow Group" for a specific priority level.
-	// This accessor provides the state of all contending flows within the band (as seen by this shard) and serves as the
+	// This accessor provides the state of all contending flows within the band and serves as the
 	// primary input for FairnessPolicy execution.
 	//
 	// Returns an error wrapping ErrPriorityBandNotFound if the priority level is not configured.
 	PriorityBandAccessor(priority int) (flowcontrol.PriorityBandAccessor, error)
 
-	// AllOrderedPriorityLevels returns all configured priority levels that this shard is aware of, sorted in descending
+	// AllOrderedPriorityLevels returns all configured priority levels, sorted in descending
 	// numerical order. This order corresponds to highest priority (highest numeric value) to lowest priority (lowest
 	// numeric value).
 	// The returned slice provides a definitive, ordered list of priority levels for iteration, for example, by a
@@ -123,15 +115,14 @@ type ActiveFlowConnection interface {
 	FlowKey() flowcontrol.FlowKey
 }
 
-// ManagedQueue defines the interface for a flow's queue on a specific shard.
+// ManagedQueue defines the interface for a flow's queue.
 // It acts as a stateful decorator that *use an underlying SafeQueue, augmenting it with statistics tracking, and
-// lifecycle awareness (e.g., rejecting adds when a shard is draining).
+// lifecycle awareness.
 //
 // Conformance: Implementations MUST be goroutine-safe.
 type ManagedQueue interface {
 	// Add attempts to enqueue an item, performing an atomic check on the parent shard's lifecycle state before adding
 	// the item to the underlying queue.
-	// Returns ErrShardDraining if the parent shard is no longer Active.
 	Add(item flowcontrol.QueueItemAccessor) error
 
 	// Remove atomically finds and removes an item from the underlying queue using its handle.
@@ -151,9 +142,9 @@ type ManagedQueue interface {
 // AggregateStats holds globally aggregated statistics for the entire `FlowRegistry`.
 // It is a read-only data object representing a near-consistent snapshot of the registry's state.
 type AggregateStats struct {
-	// TotalCapacityBytes is the globally configured maximum total byte size limit across all priority bands and shards.
+	// TotalCapacityBytes is the globally configured maximum total byte size limit across all priority bands.
 	TotalCapacityBytes uint64
-	// TotalCapacityRequests is the globally configured maximum total request count limit across all priority bands and shards.
+	// TotalCapacityRequests is the globally configured maximum total request count limit across all priority bands.
 	TotalCapacityRequests uint64
 	// TotalByteSize is the total byte size of all items currently queued across the entire system.
 	TotalByteSize uint64
@@ -169,8 +160,7 @@ type PriorityBandStats struct {
 	// Priority is the numerical priority level this struct describes.
 	Priority int
 	// CapacityBytes is the configured maximum total byte size for this priority band.
-	// When viewed via `AggregateStats`, this is the global limit. When viewed via `ShardStats`, this is the partitioned
-	// value for that specific shard.
+	// When viewed via `AggregateStats`, this is the global limit.
 	// The `controller.FlowController` enforces this limit.
 	// A default non-zero value is guaranteed if not configured.
 	CapacityBytes uint64

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -26,8 +26,6 @@ import (
 const (
 	// defaultExpiryCleanupInterval is the default frequency for scanning for expired items.
 	defaultExpiryCleanupInterval = 1 * time.Second
-	// defaultProcessorReconciliationInterval is the default frequency for the supervisor loop.
-	defaultProcessorReconciliationInterval = 5 * time.Second
 	// defaultEnqueueChannelBufferSize is the default size of a worker's incoming request buffer.
 	defaultEnqueueChannelBufferSize = 100
 )
@@ -42,11 +40,6 @@ type Config struct {
 	// ExpiryCleanupInterval is the interval at which each processor scans its queues for expired items.
 	// Optional: Defaults to `defaultExpiryCleanupInterval` (1 second).
 	ExpiryCleanupInterval time.Duration
-
-	// ProcessorReconciliationInterval is the frequency at which the `FlowController`'s supervisor loop garbage collects
-	// stale workers.
-	// Optional: Defaults to `defaultProcessorReconciliationInterval` (5 seconds).
-	ProcessorReconciliationInterval time.Duration
 
 	// EnqueueChannelBufferSize is the size of the buffered channel that accepts incoming requests for each
 	// processor. This buffer acts as a shock absorber, decoupling the high-frequency distributor from the processor's
@@ -72,9 +65,8 @@ func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig) (*Config, error) {
 // NewConfig creates a new Config with the given options, applying defaults and validation.
 func NewConfig(opts ...ConfigOption) (*Config, error) {
 	c := &Config{
-		ExpiryCleanupInterval:           defaultExpiryCleanupInterval,
-		ProcessorReconciliationInterval: defaultProcessorReconciliationInterval,
-		EnqueueChannelBufferSize:        defaultEnqueueChannelBufferSize,
+		ExpiryCleanupInterval:    defaultExpiryCleanupInterval,
+		EnqueueChannelBufferSize: defaultEnqueueChannelBufferSize,
 	}
 
 	for _, opt := range opts {
@@ -101,13 +93,6 @@ func WithExpiryCleanupInterval(d time.Duration) ConfigOption {
 	}
 }
 
-// WithProcessorReconciliationInterval sets the processor reconciliation interval.
-func WithProcessorReconciliationInterval(d time.Duration) ConfigOption {
-	return func(c *Config) {
-		c.ProcessorReconciliationInterval = d
-	}
-}
-
 // WithEnqueueChannelBufferSize sets the size of the enqueue channel buffer.
 func WithEnqueueChannelBufferSize(size int) ConfigOption {
 	return func(c *Config) {
@@ -122,9 +107,6 @@ func (c *Config) validate() error {
 	}
 	if c.ExpiryCleanupInterval <= 0 {
 		return fmt.Errorf("ExpiryCleanupInterval must be positive, but got %v", c.ExpiryCleanupInterval)
-	}
-	if c.ProcessorReconciliationInterval <= 0 {
-		return fmt.Errorf("ProcessorReconciliationInterval must be positive, but got %v", c.ProcessorReconciliationInterval)
 	}
 	if c.EnqueueChannelBufferSize < 0 {
 		return fmt.Errorf("EnqueueChannelBufferSize cannot be negative, but got %d", c.EnqueueChannelBufferSize)

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	// Optional: If zero, no TTL is applied by default and we rely solely on request context cancellation.
 	DefaultRequestTTL time.Duration
 
-	// ExpiryCleanupInterval is the interval at which each shard processor scans its queues for expired items.
+	// ExpiryCleanupInterval is the interval at which each processor scans its queues for expired items.
 	// Optional: Defaults to `defaultExpiryCleanupInterval` (1 second).
 	ExpiryCleanupInterval time.Duration
 
@@ -48,7 +48,7 @@ type Config struct {
 	// Optional: Defaults to `defaultProcessorReconciliationInterval` (5 seconds).
 	ProcessorReconciliationInterval time.Duration
 
-	// EnqueueChannelBufferSize is the size of the buffered channel that accepts incoming requests for each shard
+	// EnqueueChannelBufferSize is the size of the buffered channel that accepts incoming requests for each
 	// processor. This buffer acts as a shock absorber, decoupling the high-frequency distributor from the processor's
 	// serial execution loop and allowing the system to handle short bursts of traffic without blocking.
 	// Optional: Defaults to `defaultEnqueueChannelBufferSize` (100).

--- a/pkg/epp/flowcontrol/controller/config_test.go
+++ b/pkg/epp/flowcontrol/controller/config_test.go
@@ -41,10 +41,9 @@ func TestNewConfig(t *testing.T) {
 			opts:      nil,
 			expectErr: false,
 			expectedCfg: Config{
-				DefaultRequestTTL:               0,
-				ExpiryCleanupInterval:           defaultExpiryCleanupInterval,
-				ProcessorReconciliationInterval: defaultProcessorReconciliationInterval,
-				EnqueueChannelBufferSize:        defaultEnqueueChannelBufferSize,
+				DefaultRequestTTL:        0,
+				ExpiryCleanupInterval:    defaultExpiryCleanupInterval,
+				EnqueueChannelBufferSize: defaultEnqueueChannelBufferSize,
 			},
 		},
 		{
@@ -54,10 +53,9 @@ func TestNewConfig(t *testing.T) {
 			},
 			expectErr: false,
 			expectedCfg: Config{
-				DefaultRequestTTL:               10 * time.Second,
-				ExpiryCleanupInterval:           defaultExpiryCleanupInterval,
-				ProcessorReconciliationInterval: defaultProcessorReconciliationInterval,
-				EnqueueChannelBufferSize:        defaultEnqueueChannelBufferSize,
+				DefaultRequestTTL:        10 * time.Second,
+				ExpiryCleanupInterval:    defaultExpiryCleanupInterval,
+				EnqueueChannelBufferSize: defaultEnqueueChannelBufferSize,
 			},
 		},
 		{
@@ -65,15 +63,13 @@ func TestNewConfig(t *testing.T) {
 			opts: []ConfigOption{
 				WithDefaultRequestTTL(10 * time.Second),
 				WithExpiryCleanupInterval(2 * time.Second),
-				WithProcessorReconciliationInterval(10 * time.Second),
 				WithEnqueueChannelBufferSize(50),
 			},
 			expectErr: false,
 			expectedCfg: Config{
-				DefaultRequestTTL:               10 * time.Second,
-				ExpiryCleanupInterval:           2 * time.Second,
-				ProcessorReconciliationInterval: 10 * time.Second,
-				EnqueueChannelBufferSize:        50,
+				DefaultRequestTTL:        10 * time.Second,
+				ExpiryCleanupInterval:    2 * time.Second,
+				EnqueueChannelBufferSize: 50,
 			},
 		},
 		{
@@ -94,13 +90,6 @@ func TestNewConfig(t *testing.T) {
 			name: "ZeroExpiryCleanupInterval_ShouldError",
 			opts: []ConfigOption{
 				WithExpiryCleanupInterval(0),
-			},
-			expectErr: true,
-		},
-		{
-			name: "InvalidProcessorReconciliationInterval_ShouldError",
-			opts: []ConfigOption{
-				WithProcessorReconciliationInterval(-1 * time.Second),
 			},
 			expectErr: true,
 		},
@@ -145,8 +134,6 @@ func TestNewConfigFromAPI(t *testing.T) {
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, defaultExpiryCleanupInterval, cfg.ExpiryCleanupInterval,
 					"ExpiryCleanupInterval should be defaulted")
-				assert.Equal(t, defaultProcessorReconciliationInterval, cfg.ProcessorReconciliationInterval,
-					"ProcessorReconciliationInterval should be defaulted")
 				assert.Equal(t, defaultEnqueueChannelBufferSize, cfg.EnqueueChannelBufferSize,
 					"EnqueueChannelBufferSize should be defaulted")
 				assert.Equal(t, time.Duration(0), cfg.DefaultRequestTTL, "DefaultRequestTTL should default to 0 (disabled)")
@@ -170,8 +157,6 @@ func TestNewConfigFromAPI(t *testing.T) {
 			},
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, 1*time.Minute, cfg.DefaultRequestTTL)
-				// ProcessorReconciliationInterval is not exposed, so it should stay default.
-				assert.Equal(t, defaultProcessorReconciliationInterval, cfg.ProcessorReconciliationInterval)
 			},
 		},
 		{

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -18,7 +18,7 @@ limitations under the License.
 //
 // The FlowController is the central processing engine of the Flow Control layer. It is a high-throughput
 // component responsible for managing the lifecycle of all incoming requests. It achieves this by acting as a stateless
-// supervisor that orchestrates a  stateful worker (SProcessor).
+// supervisor that orchestrates a stateful worker (Processor).
 package controller
 
 import (

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Package controller contains the implementation of the FlowController engine.
 //
-// The FlowController is the central processing engine of the Flow Control layer. It is a sharded, high-throughput
+// The FlowController is the central processing engine of the Flow Control layer. It is a high-throughput
 // component responsible for managing the lifecycle of all incoming requests. It achieves this by acting as a stateless
-// supervisor that orchestrates a pool of stateful workers (ShardProcessors), distributing incoming requests among them.
+// supervisor that orchestrates a  stateful worker (SProcessor).
 package controller
 
 import (
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -55,8 +54,8 @@ type processor interface {
 	SubmitOrBlock(ctx context.Context, item *internal.FlowItem) error
 }
 
-// shardProcessorFactory defines the signature for creating a shardProcessor.
-type shardProcessorFactory func(
+// processorFactory defines the signature for creating a Processor.
+type processorFactory func(
 	ctx context.Context,
 	registry contracts.FlowRegistry,
 	saturationDetector flowcontrol.SaturationDetector,
@@ -68,19 +67,11 @@ type shardProcessorFactory func(
 	logger logr.Logger,
 ) processor
 
-var _ processor = &internal.ShardProcessor{}
-
-// managedWorker holds the state for a single supervised worker.
-type managedWorker struct {
-	processor processor
-}
+var _ processor = &internal.Processor{}
 
 // FlowController is the central, high-throughput engine of the Flow Control layer.
-// It is designed as a stateless distributor that orchestrates a pool of stateful workers (ShardProcessor), following a
+// It is designed as a stateless distributor that orchestrates a stateful worker (Processor), following a
 // supervisor-worker pattern.
-//
-// The controller's run loop executes periodically, acting as a garbage collector that keeps the pool of running
-// workers synchronized with the dynamic shard topology of the FlowRegistry.
 //
 // Request Lifecycle Management:
 //
@@ -92,14 +83,15 @@ type managedWorker struct {
 type FlowController struct {
 	// --- Immutable dependencies (set at construction) ---
 
-	config                *Config
-	registry              registryClient
-	saturationDetector    flowcontrol.SaturationDetector
-	endpointCandidates    contracts.EndpointCandidates
-	usageLimitPolicy      flowcontrol.UsageLimitPolicy
-	clock                 clock.WithTicker
-	logger                logr.Logger
-	shardProcessorFactory shardProcessorFactory
+	config             *Config
+	registry           registryClient
+	saturationDetector flowcontrol.SaturationDetector
+	endpointCandidates contracts.EndpointCandidates
+	usageLimitPolicy   flowcontrol.UsageLimitPolicy
+	clock              clock.WithTicker
+	logger             logr.Logger
+	processorFactory   processorFactory
+	processor          processor
 
 	// --- Lifecycle state ---
 
@@ -108,9 +100,6 @@ type FlowController struct {
 	parentCtx context.Context
 
 	// --- Concurrent state ---
-
-	// worker is a highly concurrent pointer storing the managedWorker.
-	worker atomic.Pointer[managedWorker]
 
 	// wg waits for all worker goroutines to terminate during shutdown.
 	wg sync.WaitGroup
@@ -132,7 +121,7 @@ func NewFlowController(
 	poolName string,
 	config *Config,
 	deps Deps,
-) (*FlowController, error) {
+) *FlowController {
 	if deps.Clock == nil {
 		deps.Clock = clock.RealClock{}
 	}
@@ -147,7 +136,7 @@ func NewFlowController(
 		parentCtx:          ctx,
 	}
 
-	fc.shardProcessorFactory = func(
+	fc.processorFactory = func(
 		ctx context.Context,
 		registry contracts.FlowRegistry,
 		saturationDetector flowcontrol.SaturationDetector,
@@ -158,7 +147,7 @@ func NewFlowController(
 		enqueueChannelBufferSize int,
 		logger logr.Logger,
 	) processor {
-		return internal.NewShardProcessor(
+		return internal.NewProcessor(
 			ctx,
 			poolName,
 			registry,
@@ -172,7 +161,28 @@ func NewFlowController(
 		)
 	}
 
-	return fc, nil
+	return fc
+}
+
+func (fc *FlowController) Start() {
+	// Construct a new worker, but do not start its goroutine yet.
+	fc.processor = fc.processorFactory(
+		fc.parentCtx,
+		fc.registry,
+		fc.saturationDetector,
+		fc.endpointCandidates,
+		fc.usageLimitPolicy,
+		fc.clock,
+		fc.config.ExpiryCleanupInterval,
+		fc.config.EnqueueChannelBufferSize,
+		fc.logger,
+	)
+
+	fc.logger.V(logutil.DEFAULT).Info("Starting the Processor.")
+	fc.wg.Go(func() {
+		fc.processor.Run(fc.parentCtx)
+	})
+
 }
 
 // EnqueueAndWait is the primary, synchronous entry point to the Flow Control system. It submits a request and blocks
@@ -262,7 +272,7 @@ func (fc *FlowController) EnqueueAndWait(
 }
 
 // tryDistribution handles a single attempt to select a shard and submit a request.
-// It uses the provided `conn` to identify candidate shards.
+// It uses the provided `conn` to access the registry data plane.
 // If this function returns an error, it guarantees that the provided `item` has been finalized.
 func (fc *FlowController) tryDistribution(
 	reqCtx context.Context,
@@ -281,7 +291,6 @@ func (fc *FlowController) tryDistribution(
 	// We must create a fresh FlowItem on each attempt as finalization is per-lifecycle.
 	item := internal.NewItem(req, effectiveTTL, enqueueTime)
 
-	worker := fc.getOrStartWorker()
 	dp := conn.GetDataPlane()
 	_, err := dp.ManagedQueue(conn.FlowKey())
 	if err != nil {
@@ -292,7 +301,7 @@ func (fc *FlowController) tryDistribution(
 		return item, err
 	}
 
-	outcome, err := fc.distributeRequest(reqCtx, item, worker)
+	outcome, err := fc.distributeRequest(reqCtx, item)
 	if err == nil {
 		// Success: Ownership of the item has been transferred to the processor.
 		return item, nil
@@ -372,59 +381,17 @@ func (fc *FlowController) createRequestContext(
 func (fc *FlowController) distributeRequest(
 	ctx context.Context,
 	item *internal.FlowItem,
-	worker *managedWorker,
 ) (types.QueueOutcome, error) {
 	reqID := item.OriginalRequest().ID()
-	if err := worker.processor.Submit(item); err == nil {
+	if err := fc.processor.Submit(item); err == nil {
 		return types.QueueOutcomeNotYetFinalized, nil
 	}
 
 	// processor is busy. Attempt a single blocking submission to the candidate.
 	fc.logger.V(logutil.TRACE).Info("Processor is busy, attempting blocking submit", "requestID", reqID)
-	err := worker.processor.SubmitOrBlock(ctx, item)
+	err := fc.processor.SubmitOrBlock(ctx, item)
 	if err != nil {
 		return types.QueueOutcomeRejectedOther, fmt.Errorf("%w: request not accepted: %w", types.ErrRejected, err)
 	}
 	return types.QueueOutcomeNotYetFinalized, nil // Success, ownership transferred.
-}
-
-// getOrStartWorker implements the lazy-loading and startup of shard processors.
-// It ensures that exactly one worker goroutine is started for each shard, using atomic operations
-// (sync.Map.LoadOrStore). The worker's processor goroutine is only started after it has successfully been registered,
-// preventing race conditions where multiple goroutines create and start the same worker.
-func (fc *FlowController) getOrStartWorker() *managedWorker {
-	if w := fc.worker.Load(); w != nil {
-		return w
-	}
-
-	// Construct a new worker, but do not start its goroutine yet.
-	processor := fc.shardProcessorFactory(
-		fc.parentCtx,
-		fc.registry,
-		fc.saturationDetector,
-		fc.endpointCandidates,
-		fc.usageLimitPolicy,
-		fc.clock,
-		fc.config.ExpiryCleanupInterval,
-		fc.config.EnqueueChannelBufferSize,
-		fc.logger,
-	)
-	newWorker := &managedWorker{
-		processor: processor,
-	}
-
-	// Atomically load or store. This is the critical synchronization step.
-	swapped := fc.worker.CompareAndSwap(nil, newWorker)
-	if !swapped {
-		// Another goroutine beat us to it. The `newWorker` we created was not stored.
-		return fc.worker.Load()
-	}
-
-	// We won the race. The newWorker was stored. Now, start the processor's long-running goroutine.
-	fc.logger.V(logutil.DEFAULT).Info("Starting the Processor worker.")
-	fc.wg.Go(func() {
-		processor.Run(fc.parentCtx)
-	})
-
-	return newWorker
 }

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -98,11 +97,6 @@ type FlowController struct {
 	// parentCtx is the root context for the controller's lifecycle, established when NewFlowController is called.
 	// It is the parent for all long-lived worker goroutines.
 	parentCtx context.Context
-
-	// --- Concurrent state ---
-
-	// wg waits for all worker goroutines to terminate during shutdown.
-	wg sync.WaitGroup
 }
 
 // Deps groups the external FlowController build dependencies to construct a FlowController.

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -106,6 +106,7 @@ type Deps struct {
 	EndpointCandidates contracts.EndpointCandidates
 	UsageLimitPolicy   flowcontrol.UsageLimitPolicy
 	Clock              clock.WithTicker
+	ProcessorFactory   processorFactory
 }
 
 // NewFlowController creates and starts a new FlowController instance.
@@ -130,35 +131,35 @@ func NewFlowController(
 		parentCtx:          ctx,
 	}
 
-	fc.processorFactory = func(
-		ctx context.Context,
-		registry contracts.FlowRegistry,
-		saturationDetector flowcontrol.SaturationDetector,
-		endpointCandidates contracts.EndpointCandidates,
-		usageLimitPolicy flowcontrol.UsageLimitPolicy,
-		clock clock.WithTicker,
-		cleanupSweepInterval time.Duration,
-		enqueueChannelBufferSize int,
-		logger logr.Logger,
-	) processor {
-		return internal.NewProcessor(
-			ctx,
-			poolName,
-			registry,
-			saturationDetector,
-			endpointCandidates,
-			usageLimitPolicy,
-			clock,
-			cleanupSweepInterval,
-			enqueueChannelBufferSize,
-			logger,
-		)
+	if deps.ProcessorFactory == nil {
+		fc.processorFactory = func(
+			ctx context.Context,
+			registry contracts.FlowRegistry,
+			saturationDetector flowcontrol.SaturationDetector,
+			endpointCandidates contracts.EndpointCandidates,
+			usageLimitPolicy flowcontrol.UsageLimitPolicy,
+			clock clock.WithTicker,
+			cleanupSweepInterval time.Duration,
+			enqueueChannelBufferSize int,
+			logger logr.Logger,
+		) processor {
+			return internal.NewProcessor(
+				ctx,
+				poolName,
+				registry,
+				saturationDetector,
+				endpointCandidates,
+				usageLimitPolicy,
+				clock,
+				cleanupSweepInterval,
+				enqueueChannelBufferSize,
+				logger,
+			)
+		}
+	} else {
+		fc.processorFactory = deps.ProcessorFactory
 	}
 
-	return fc
-}
-
-func (fc *FlowController) Start() {
 	// Construct a new worker, but do not start its goroutine yet.
 	fc.processor = fc.processorFactory(
 		fc.parentCtx,
@@ -172,10 +173,13 @@ func (fc *FlowController) Start() {
 		fc.logger,
 	)
 
+	return fc
+}
+
+func (fc *FlowController) Start() {
 	fc.logger.V(logutil.DEFAULT).Info("Starting the Processor.")
-	fc.wg.Go(func() {
-		fc.processor.Run(fc.parentCtx)
-	})
+
+	go fc.processor.Run(fc.parentCtx)
 
 }
 

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -173,14 +173,11 @@ func NewFlowController(
 		fc.logger,
 	)
 
-	return fc
-}
-
-func (fc *FlowController) Start() {
 	fc.logger.V(logutil.DEFAULT).Info("Starting the Processor.")
 
 	go fc.processor.Run(fc.parentCtx)
 
+	return fc
 }
 
 // EnqueueAndWait is the primary, synchronous entry point to the Flow Control system. It submits a request and blocks

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Note on Time-Based Lifecycle Tests:
 // Tests validating the controller's handling of request TTLs (e.g., OnReqCtxTimeout*) rely on real-time timers
-// (context.WithDeadline). The injected testclock.FakeClock is used to control the timing of internal loops (like
-// reconciliation), but it cannot manipulate the timers used by the standard context package. Therefore, these specific
+// (context.WithDeadline). The injected testclock.FakeClock is used to control the timing of internal loops,
+// but it cannot manipulate the timers used by the standard context package. Therefore, these specific
 // tests use time.Sleep or assertions on real-time durations.
 
 package controller
@@ -89,6 +89,7 @@ func newUnitHarness(
 	t *testing.T,
 	cfg *Config,
 	registry *mockRegistryClient,
+	processor *mockProcessor,
 	opts ...unitHarnessOption,
 ) *testHarness {
 	t.Helper()
@@ -103,7 +104,7 @@ func newUnitHarness(
 	mockDetector := &mockSaturationDetector{}
 	mockEndpointCandidates := &mocks.MockEndpointCandidates{}
 
-	mockProcessorFactory := &mockProcessorFactory{}
+	mockProcessorFactory := &mockProcessorFactory{processor: processor}
 
 	usageLimitPolicy := usagelimits.DefaultPolicy()
 
@@ -118,9 +119,8 @@ func newUnitHarness(
 		EndpointCandidates: mockEndpointCandidates,
 		UsageLimitPolicy:   usageLimitPolicy,
 		Clock:              harnessOpts.clock,
+		ProcessorFactory:   mockProcessorFactory.new,
 	})
-	fc.processorFactory = mockProcessorFactory.new
-
 	h := &testHarness{
 		fc:                   fc,
 		cfg:                  cfg,
@@ -304,7 +304,16 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnReqCtxExpiredBeforeDistribution", func(t *testing.T) {
 			t.Parallel()
 			// Test that if the request context provided to EnqueueAndWait is already expired, it returns immediately.
-			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 1 * time.Minute}, nil)
+
+			// Configure processor to block until context expiry.
+			processor := &mockProcessor{
+				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
+				SubmitOrBlockFunc: func(ctx context.Context, _ *internal.FlowItem) error {
+					<-ctx.Done()              // Wait for the context to be done.
+					return context.Cause(ctx) // Return the cause.
+				},
+			}
+			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 1 * time.Minute}, nil, processor)
 
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {
 				return fn(&mockActiveFlowConnection{
@@ -313,14 +322,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				})
 			}
 			h.mockRegistry.FlowRegistryDataPlane = &mocks.MockRegistryDataPlane{}
-			// Configure processor to block until context expiry.
-			h.mockProcessorFactory.processor = &mockProcessor{
-				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
-				SubmitOrBlockFunc: func(ctx context.Context, _ *internal.FlowItem) error {
-					<-ctx.Done()              // Wait for the context to be done.
-					return context.Cause(ctx) // Return the cause.
-				},
-			}
 			h.fc.Start()
 
 			req := newTestRequest(defaultFlowKey)
@@ -341,12 +342,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			t.Parallel()
 			// Create a context specifically for the controller's lifecycle.
 			ctx, cancel := context.WithCancel(t.Context())
-			h := newUnitHarness(ctx, t, &Config{}, nil)
+			h := newUnitHarness(ctx, t, &Config{}, nil, nil)
 			cancel() // Immediately stop the controller.
-
-			// Wait for the controller's run loop and all workers (none in this case) to exit.
-			// We need to wait because the shutdown process is asynchronous.
-			h.fc.wg.Wait()
 
 			req := newTestRequest(defaultFlowKey)
 			// The request context is valid, but the controller itself is stopped.
@@ -361,7 +358,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnRegistryConnectionError", func(t *testing.T) {
 			t.Parallel()
 			mockRegistry := &mockRegistryClient{FlowRegistryDataPlane: &mocks.MockRegistryDataPlane{}}
-			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
+			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry, nil)
 
 			expectedErr := errors.New("simulated connection failure")
 			// Configure the registry to fail when attempting to retrieve ActiveFlowConnection.
@@ -384,7 +381,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnManagedQueueError", func(t *testing.T) {
 			t.Parallel()
 			mockRegistry := &mockRegistryClient{FlowRegistryDataPlane: &mocks.MockRegistryDataPlane{}}
-			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
+			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry, nil)
 
 			// Create a faulty setup that successfully leases the flow but fails to return the
 			// ManagedQueue. This setup should be considered as unavailable.
@@ -422,7 +419,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 
 		testCases := []struct {
 			name           string
-			setupProcessor func(t *testing.T, h *testHarness)
+			setupProcessor func(t *testing.T) *mockProcessor
 			// requestTTL overrides the default TTL for time-sensitive tests.
 			requestTTL      time.Duration
 			expectedOutcome types.QueueOutcome
@@ -431,8 +428,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		}{
 			{
 				name: "SubmitSucceeds_NonBlocking",
-				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor = &mockProcessor{
+				setupProcessor: func(t *testing.T) *mockProcessor {
+					return &mockProcessor{
 						SubmitFunc: func(item *internal.FlowItem) error {
 							// Simulate asynchronous processing and successful dispatch.
 							go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
@@ -447,8 +444,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				// NOTE: This relies on real time passing, as context.WithDeadline timers cannot be controlled by FakeClock.
 				name:       "Rejects_AfterBlocking_WhenTTL_Expires",
 				requestTTL: 50 * time.Millisecond, // Short TTL to keep the test fast.
-				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor = &mockProcessor{
+				setupProcessor: func(t *testing.T) *mockProcessor {
+					return &mockProcessor{
 						// Reject the non-blocking attempt.
 						SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 						// Block the fallback attempt until the context (carrying the TTL deadline) expires.
@@ -467,8 +464,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			},
 			{
 				name: "Rejects_OnProcessorShutdownDuringSubmit",
-				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor = &mockProcessor{
+				setupProcessor: func(t *testing.T) *mockProcessor {
+					return &mockProcessor{
 						// Simulate the processor shutting down during the non-blocking handoff.
 						SubmitFunc: func(_ *internal.FlowItem) error { return types.ErrFlowControllerNotRunning },
 						SubmitOrBlockFunc: func(_ context.Context, _ *internal.FlowItem) error {
@@ -482,8 +479,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			},
 			{
 				name: "Rejects_OnProcessorShutdownDuringSubmitOrBlock",
-				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor = &mockProcessor{
+				setupProcessor: func(t *testing.T) *mockProcessor {
+					return &mockProcessor{
 						SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 						// Simulate the processor shutting down during the blocking handoff.
 						SubmitOrBlockFunc: func(_ context.Context, _ *internal.FlowItem) error {
@@ -509,7 +506,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				if tc.requestTTL > 0 {
 					harnessConfig.DefaultRequestTTL = tc.requestTTL
 				}
-				h := newUnitHarness(t.Context(), t, harnessConfig, mockRegistry)
+				h := newUnitHarness(t.Context(), t, harnessConfig, mockRegistry, tc.setupProcessor(t))
 
 				// Configure the registry to return the specified setup.
 				mockRegistry.WithConnectionFunc = func(
@@ -521,7 +518,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 						FlowKeyV:  key,
 					})
 				}
-				tc.setupProcessor(t, h)
 				h.fc.Start()
 
 				// Act
@@ -574,8 +570,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				})
 			}
 			// Use a long TTL to ensure the failure is due to cancellation, not timeout.
-			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry)
-			h.mockProcessorFactory.processor = &mockProcessor{
+			processor := &mockProcessor{
 				// Reject non-blocking attempt.
 				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 				// Block the fallback attempt until the context is cancelled.
@@ -584,6 +579,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					return ctx.Err()
 				},
 			}
+			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry, processor)
 			h.fc.Start()
 
 			// Create a cancellable context for the request.
@@ -612,7 +608,19 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnReqCtxCancelledAfterDistribution", func(t *testing.T) {
 			t.Parallel()
 			// Use a long TTL to ensure the failure is due to cancellation.
-			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, nil)
+
+			// Channel for synchronization.
+			itemSubmitted := make(chan *internal.FlowItem, 1)
+
+			// Configure the processor to accept the item but never finalize it, simulating a queued request.
+			processor := &mockProcessor{
+				SubmitFunc: func(item *internal.FlowItem) error {
+					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
+					itemSubmitted <- item
+					return nil
+				},
+			}
+			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, nil, processor)
 
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {
 				return fn(&mockActiveFlowConnection{
@@ -622,17 +630,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			}
 			h.mockRegistry.FlowRegistryDataPlane = &mocks.MockRegistryDataPlane{}
 
-			// Channel for synchronization.
-			itemSubmitted := make(chan *internal.FlowItem, 1)
-
-			// Configure the processor to accept the item but never finalize it, simulating a queued request.
-			h.mockProcessorFactory.processor = &mockProcessor{
-				SubmitFunc: func(item *internal.FlowItem) error {
-					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
-					itemSubmitted <- item
-					return nil
-				},
-			}
 			h.fc.Start()
 
 			reqCtx, cancelReq := context.WithCancel(context.Background())
@@ -686,29 +683,29 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 		t.Run("OnReqCtxTimeoutAfterDistribution", func(t *testing.T) {
 			t.Parallel()
 			// Configure a short TTL to keep the test reasonably fast.
+
+			itemSubmitted := make(chan *internal.FlowItem, 1)
+
+			// Configure the processor to accept the item but never finalize it.
+			processor := &mockProcessor{
+				SubmitFunc: func(item *internal.FlowItem) error {
+					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
+					itemSubmitted <- item
+					return nil
+				},
+			}
+
 			const requestTTL = 50 * time.Millisecond
 			h := newUnitHarness(t.Context(), t, &Config{
-				DefaultRequestTTL:               requestTTL,
-				ProcessorReconciliationInterval: time.Minute,
-				ExpiryCleanupInterval:           time.Minute,
-			}, nil, withHarnessClock(clock.RealClock{}))
+				DefaultRequestTTL:     requestTTL,
+				ExpiryCleanupInterval: time.Minute,
+			}, nil, processor, withHarnessClock(clock.RealClock{}))
 
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {
 				return fn(&mockActiveFlowConnection{
 					RegistryV: h.mockRegistry,
 					FlowKeyV:  key,
 				})
-			}
-
-			itemSubmitted := make(chan *internal.FlowItem, 1)
-
-			// Configure the processor to accept the item but never finalize it.
-			h.mockProcessorFactory.processor = &mockProcessor{
-				SubmitFunc: func(item *internal.FlowItem) error {
-					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
-					itemSubmitted <- item
-					return nil
-				},
 			}
 			h.fc.Start()
 
@@ -787,10 +784,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				return err
 			}
 
-			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
-
 			// 2. Setup Processor: Simulate a long wait in the queue.
-			h.mockProcessorFactory.processor = &mockProcessor{
+			processor := &mockProcessor{
 				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 				SubmitOrBlockFunc: func(ctx context.Context, item *internal.FlowItem) error {
 					close(processorEntered) // Signal that we are now "queued"
@@ -805,6 +800,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					}
 				},
 			}
+
+			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry, processor)
 			h.fc.Start()
 
 			// 3. Run EnqueueAndWait in the background.
@@ -845,13 +842,12 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 }
 
 // TestFlowController_WorkerManagement covers the lifecycle of the processor (worker), including startup
-// and shutdown.
 func TestFlowController_WorkerManagement(t *testing.T) {
 	t.Parallel()
 
-	// Reconciliation validates that the controller correctly identifies and shuts down workers whose shards no longer
+	// Startup validates that the controller correctly identifies and shuts down workers whose shards no longer
 	// exist in the registry.
-	t.Run("Reconciliation", func(t *testing.T) {
+	t.Run("Startup", func(t *testing.T) {
 		t.Parallel()
 
 		mockRegistry := &mockRegistryClient{
@@ -860,12 +856,14 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 				// The current state of the world according to the registry.
 				return contracts.AggregateStats{}
 			}}
-		h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
+
+		// Initialize the processor mock with the channel needed to synchronize startup.
+		processor := &mockProcessor{runStarted: make(chan struct{})}
+
+		h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry, processor)
 
 		// Pre-populate the controller with initial worker, simulating a previous state.
 
-		// Initialize the processor mock with the channel needed to synchronize startup.
-		h.mockProcessorFactory.processor = &mockProcessor{runStarted: make(chan struct{})}
 		// Start the worker using the internal mechanism.
 		h.fc.Start()
 

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -837,8 +837,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 func TestFlowController_WorkerManagement(t *testing.T) {
 	t.Parallel()
 
-	// Startup validates that the controller correctly identifies and shuts down workers whose shards no longer
-	// exist in the registry.
+	// Startup validates that the worker starts
 	t.Run("Startup", func(t *testing.T) {
 		t.Parallel()
 
@@ -853,10 +852,6 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 		processor := &mockProcessor{runStarted: make(chan struct{})}
 
 		h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry, processor)
-
-		// Pre-populate the controller with initial worker, simulating a previous state.
-
-		// Start the worker using the internal mechanism.
 
 		// Wait for the worker goroutine to have started and captured its context.
 		select {

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -159,7 +159,6 @@ func newIntegrationHarness(ctx context.Context, t *testing.T, cfg *Config, regis
 		UsageLimitPolicy:   usageLimitPolicy,
 		Clock:              mockClock,
 	})
-	fc.Start()
 
 	h := &testHarness{
 		fc:           fc,
@@ -322,7 +321,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				})
 			}
 			h.mockRegistry.FlowRegistryDataPlane = &mocks.MockRegistryDataPlane{}
-			h.fc.Start()
 
 			req := newTestRequest(defaultFlowKey)
 			// Use a context with a deadline in the past.
@@ -518,7 +516,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 						FlowKeyV:  key,
 					})
 				}
-				h.fc.Start()
 
 				// Act
 				var outcome types.QueueOutcome
@@ -580,7 +577,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				},
 			}
 			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry, processor)
-			h.fc.Start()
 
 			// Create a cancellable context for the request.
 			reqCtx, cancelReq := context.WithCancel(context.Background())
@@ -629,8 +625,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				})
 			}
 			h.mockRegistry.FlowRegistryDataPlane = &mocks.MockRegistryDataPlane{}
-
-			h.fc.Start()
 
 			reqCtx, cancelReq := context.WithCancel(context.Background())
 			req := newTestRequest(defaultFlowKey)
@@ -707,7 +701,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					FlowKeyV:  key,
 				})
 			}
-			h.fc.Start()
 
 			req := newTestRequest(defaultFlowKey)
 			// Use a context for the call itself that won't time out independently.
@@ -802,7 +795,6 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			}
 
 			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry, processor)
-			h.fc.Start()
 
 			// 3. Run EnqueueAndWait in the background.
 			go func() {
@@ -865,7 +857,6 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 		// Pre-populate the controller with initial worker, simulating a previous state.
 
 		// Start the worker using the internal mechanism.
-		h.fc.Start()
 
 		// Wait for the worker goroutine to have started and captured its context.
 		select {

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -67,7 +66,7 @@ type testHarness struct {
 	// mockClock provides access to FakeClock methods (Step, HasWaiters) if and only if the underlying clock is a
 	// FakeClock.
 	mockClock            *testclock.FakeClock
-	mockProcessorFactory *mockShardProcessorFactory
+	mockProcessorFactory *mockProcessorFactory
 }
 
 // unitHarnessOption allows configuring the test harness.
@@ -104,7 +103,7 @@ func newUnitHarness(
 	mockDetector := &mockSaturationDetector{}
 	mockEndpointCandidates := &mocks.MockEndpointCandidates{}
 
-	mockProcessorFactory := &mockShardProcessorFactory{}
+	mockProcessorFactory := &mockProcessorFactory{}
 
 	usageLimitPolicy := usagelimits.DefaultPolicy()
 
@@ -113,15 +112,14 @@ func newUnitHarness(
 		registry = &mockRegistryClient{FlowRegistryDataPlane: &mocks.MockRegistryDataPlane{}}
 	}
 
-	fc, err := NewFlowController(ctx, "test-pool", cfg, Deps{
+	fc := NewFlowController(ctx, "test-pool", cfg, Deps{
 		Registry:           registry,
 		SaturationDetector: mockDetector,
 		EndpointCandidates: mockEndpointCandidates,
 		UsageLimitPolicy:   usageLimitPolicy,
 		Clock:              harnessOpts.clock,
 	})
-	require.NoError(t, err, "failed to create FlowController for unit test harness")
-	fc.shardProcessorFactory = mockProcessorFactory.new
+	fc.processorFactory = mockProcessorFactory.new
 
 	h := &testHarness{
 		fc:                   fc,
@@ -138,7 +136,7 @@ func newUnitHarness(
 	return h
 }
 
-// newIntegrationHarness creates a test environment that uses real `ShardProcessor`s, suitable for integration tests
+// newIntegrationHarness creates a test environment that uses real `Processor`s, suitable for integration tests
 // validating the controller-processor interaction.
 func newIntegrationHarness(ctx context.Context, t *testing.T, cfg *Config, registry *mockRegistryClient) *testHarness {
 	t.Helper()
@@ -154,14 +152,14 @@ func newIntegrationHarness(ctx context.Context, t *testing.T, cfg *Config, regis
 		}
 	}
 
-	fc, err := NewFlowController(ctx, "test-pool", cfg, Deps{
+	fc := NewFlowController(ctx, "test-pool", cfg, Deps{
 		Registry:           registry,
 		SaturationDetector: mockDetector,
 		EndpointCandidates: mockEndpointCandidates,
 		UsageLimitPolicy:   usageLimitPolicy,
 		Clock:              mockClock,
 	})
-	require.NoError(t, err, "failed to create FlowController for integration test harness")
+	fc.Start()
 
 	h := &testHarness{
 		fc:           fc,
@@ -216,8 +214,8 @@ func (m *mockRegistryClient) Stats() contracts.AggregateStats {
 	return contracts.AggregateStats{}
 }
 
-// mockShardProcessor is a mock for the internal `shardProcessor` interface.
-type mockShardProcessor struct {
+// mockProcessor is a mock for the internal `Processor` interface.
+type mockProcessor struct {
 	SubmitFunc        func(item *internal.FlowItem) error
 	SubmitOrBlockFunc func(ctx context.Context, item *internal.FlowItem) error
 	// runCtx captures the context provided to the Run method for lifecycle assertions.
@@ -227,21 +225,21 @@ type mockShardProcessor struct {
 	runStarted chan struct{}
 }
 
-func (m *mockShardProcessor) Submit(item *internal.FlowItem) error {
+func (m *mockProcessor) Submit(item *internal.FlowItem) error {
 	if m.SubmitFunc != nil {
 		return m.SubmitFunc(item)
 	}
 	return nil
 }
 
-func (m *mockShardProcessor) SubmitOrBlock(ctx context.Context, item *internal.FlowItem) error {
+func (m *mockProcessor) SubmitOrBlock(ctx context.Context, item *internal.FlowItem) error {
 	if m.SubmitOrBlockFunc != nil {
 		return m.SubmitOrBlockFunc(ctx, item)
 	}
 	return nil
 }
 
-func (m *mockShardProcessor) Run(ctx context.Context) {
+func (m *mockProcessor) Run(ctx context.Context) {
 	m.runCtxMu.Lock()
 	m.runCtx = ctx
 	m.runCtxMu.Unlock()
@@ -253,19 +251,19 @@ func (m *mockShardProcessor) Run(ctx context.Context) {
 }
 
 // Context returns the context captured during the Run method call.
-func (m *mockShardProcessor) Context() context.Context {
+func (m *mockProcessor) Context() context.Context {
 	m.runCtxMu.RLock()
 	defer m.runCtxMu.RUnlock()
 	return m.runCtx
 }
 
-// mockShardProcessorFactory allows tests to inject specific `mockShardProcessor` instances.
-type mockShardProcessorFactory struct {
-	processor atomic.Pointer[mockShardProcessor]
+// mockProcessorFactory allows tests to inject specific `mockProcessor` instances.
+type mockProcessorFactory struct {
+	processor *mockProcessor
 }
 
-// new is the factory function conforming to the `shardProcessorFactory` signature.
-func (f *mockShardProcessorFactory) new(
+// new is the factory function conforming to the `ProcessorFactory` signature.
+func (f *mockProcessorFactory) new(
 	_ context.Context, // The factory does not use the lifecycle context; it's passed to the processor's Run method later.
 	_ contracts.FlowRegistry,
 	_ flowcontrol.SaturationDetector,
@@ -276,11 +274,11 @@ func (f *mockShardProcessorFactory) new(
 	_ int,
 	_ logr.Logger,
 ) processor {
-	if proc := f.processor.Load(); proc != nil {
-		return proc
+	if f.processor != nil {
+		return f.processor
 	}
 	// Return a default mock processor if one is not explicitly registered by the test.
-	return &mockShardProcessor{}
+	return &mockProcessor{}
 }
 
 var defaultFlowKey = flowcontrol.FlowKey{ID: "test-flow", Priority: 100}
@@ -316,13 +314,14 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			}
 			h.mockRegistry.FlowRegistryDataPlane = &mocks.MockRegistryDataPlane{}
 			// Configure processor to block until context expiry.
-			h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+			h.mockProcessorFactory.processor = &mockProcessor{
 				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 				SubmitOrBlockFunc: func(ctx context.Context, _ *internal.FlowItem) error {
 					<-ctx.Done()              // Wait for the context to be done.
 					return context.Cause(ctx) // Return the cause.
 				},
-			})
+			}
+			h.fc.Start()
 
 			req := newTestRequest(defaultFlowKey)
 			// Use a context with a deadline in the past.
@@ -387,8 +386,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			mockRegistry := &mockRegistryClient{FlowRegistryDataPlane: &mocks.MockRegistryDataPlane{}}
 			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
 
-			// Create a faulty shard that successfully leases the flow but fails to return the
-			// ManagedQueue. This shard should be considered as unavailable.
+			// Create a faulty setup that successfully leases the flow but fails to return the
+			// ManagedQueue. This setup should be considered as unavailable.
 			faultyRegistry := &mocks.MockRegistryDataPlane{
 				ManagedQueueFunc: func(_ flowcontrol.FlowKey) (contracts.ManagedQueue, error) {
 					return nil, errors.New("invariant violation: queue retrieval failed")
@@ -433,13 +432,13 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			{
 				name: "SubmitSucceeds_NonBlocking",
 				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+					h.mockProcessorFactory.processor = &mockProcessor{
 						SubmitFunc: func(item *internal.FlowItem) error {
 							// Simulate asynchronous processing and successful dispatch.
 							go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
 							return nil
 						},
-					})
+					}
 				},
 				expectedOutcome: types.QueueOutcomeDispatched,
 			},
@@ -449,7 +448,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				name:       "Rejects_AfterBlocking_WhenTTL_Expires",
 				requestTTL: 50 * time.Millisecond, // Short TTL to keep the test fast.
 				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+					h.mockProcessorFactory.processor = &mockProcessor{
 						// Reject the non-blocking attempt.
 						SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 						// Block the fallback attempt until the context (carrying the TTL deadline) expires.
@@ -457,7 +456,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 							<-ctx.Done()
 							return ctx.Err()
 						},
-					})
+					}
 				},
 				// No runActions needed; we rely on the real-time timer to expire.
 				// When the blocking call fails due to context expiry, the outcome is RejectedOther.
@@ -469,13 +468,13 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			{
 				name: "Rejects_OnProcessorShutdownDuringSubmit",
 				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+					h.mockProcessorFactory.processor = &mockProcessor{
 						// Simulate the processor shutting down during the non-blocking handoff.
 						SubmitFunc: func(_ *internal.FlowItem) error { return types.ErrFlowControllerNotRunning },
 						SubmitOrBlockFunc: func(_ context.Context, _ *internal.FlowItem) error {
 							return types.ErrFlowControllerNotRunning
 						},
-					})
+					}
 				},
 				expectedOutcome: types.QueueOutcomeRejectedOther,
 				expectErr:       true,
@@ -484,13 +483,13 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			{
 				name: "Rejects_OnProcessorShutdownDuringSubmitOrBlock",
 				setupProcessor: func(t *testing.T, h *testHarness) {
-					h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+					h.mockProcessorFactory.processor = &mockProcessor{
 						SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 						// Simulate the processor shutting down during the blocking handoff.
 						SubmitOrBlockFunc: func(_ context.Context, _ *internal.FlowItem) error {
 							return types.ErrFlowControllerNotRunning
 						},
-					})
+					}
 				},
 				expectedOutcome: types.QueueOutcomeRejectedOther,
 				expectErr:       true,
@@ -512,7 +511,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 				}
 				h := newUnitHarness(t.Context(), t, harnessConfig, mockRegistry)
 
-				// Configure the registry to return the specified shards.
+				// Configure the registry to return the specified setup.
 				mockRegistry.WithConnectionFunc = func(
 					key flowcontrol.FlowKey,
 					fn func(conn contracts.ActiveFlowConnection) error,
@@ -523,6 +522,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					})
 				}
 				tc.setupProcessor(t, h)
+				h.fc.Start()
 
 				// Act
 				var outcome types.QueueOutcome
@@ -575,7 +575,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			}
 			// Use a long TTL to ensure the failure is due to cancellation, not timeout.
 			h := newUnitHarness(t.Context(), t, &Config{DefaultRequestTTL: 10 * time.Second}, mockRegistry)
-			h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+			h.mockProcessorFactory.processor = &mockProcessor{
 				// Reject non-blocking attempt.
 				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 				// Block the fallback attempt until the context is cancelled.
@@ -583,7 +583,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					<-ctx.Done()
 					return ctx.Err()
 				},
-			})
+			}
+			h.fc.Start()
 
 			// Create a cancellable context for the request.
 			reqCtx, cancelReq := context.WithCancel(context.Background())
@@ -625,13 +626,14 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			itemSubmitted := make(chan *internal.FlowItem, 1)
 
 			// Configure the processor to accept the item but never finalize it, simulating a queued request.
-			h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+			h.mockProcessorFactory.processor = &mockProcessor{
 				SubmitFunc: func(item *internal.FlowItem) error {
 					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
 					itemSubmitted <- item
 					return nil
 				},
-			})
+			}
+			h.fc.Start()
 
 			reqCtx, cancelReq := context.WithCancel(context.Background())
 			req := newTestRequest(defaultFlowKey)
@@ -701,13 +703,14 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			itemSubmitted := make(chan *internal.FlowItem, 1)
 
 			// Configure the processor to accept the item but never finalize it.
-			h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+			h.mockProcessorFactory.processor = &mockProcessor{
 				SubmitFunc: func(item *internal.FlowItem) error {
 					item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
 					itemSubmitted <- item
 					return nil
 				},
-			})
+			}
+			h.fc.Start()
 
 			req := newTestRequest(defaultFlowKey)
 			// Use a context for the call itself that won't time out independently.
@@ -787,7 +790,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			h := newUnitHarness(t.Context(), t, &Config{}, mockRegistry)
 
 			// 2. Setup Processor: Simulate a long wait in the queue.
-			h.mockProcessorFactory.processor.Store(&mockShardProcessor{
+			h.mockProcessorFactory.processor = &mockProcessor{
 				SubmitFunc: func(_ *internal.FlowItem) error { return internal.ErrProcessorBusy },
 				SubmitOrBlockFunc: func(ctx context.Context, item *internal.FlowItem) error {
 					close(processorEntered) // Signal that we are now "queued"
@@ -801,7 +804,8 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 						return ctx.Err()
 					}
 				},
-			})
+			}
+			h.fc.Start()
 
 			// 3. Run EnqueueAndWait in the background.
 			go func() {
@@ -861,115 +865,16 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 		// Pre-populate the controller with initial worker, simulating a previous state.
 
 		// Initialize the processor mock with the channel needed to synchronize startup.
-		h.mockProcessorFactory.processor.Store(&mockShardProcessor{runStarted: make(chan struct{})})
+		h.mockProcessorFactory.processor = &mockProcessor{runStarted: make(chan struct{})}
 		// Start the worker using the internal mechanism.
-		h.fc.getOrStartWorker()
-
-		require.NotNil(t, h.mockProcessorFactory.processor.Load(), "pre-condition: initial worker not set up correctly")
+		h.fc.Start()
 
 		// Wait for the worker goroutine to have started and captured its context.
-		proc := h.mockProcessorFactory.processor.Load()
 		select {
-		case <-proc.runStarted:
+		case <-h.mockProcessorFactory.processor.runStarted:
 			// Worker is running.
 		case <-time.After(2 * time.Second):
 			t.Fatalf("timed out waiting for worker to start")
-		}
-	})
-
-	// Validates the atomicity of worker creation and ensures resource cleanup for the loser of the race.
-	t.Run("WorkerCreationRace", func(t *testing.T) {
-		t.Parallel()
-
-		// This test orchestrates a deterministic race condition.
-		factoryEntered := make(chan *mockShardProcessor, 2)
-		continueFactory := make(chan struct{})
-		// Map to store the construction context for each processor instance, allowing us to verify cleanup.
-		constructionContexts := sync.Map{}
-
-		h := newUnitHarness(t.Context(), t, &Config{}, nil)
-
-		// Inject a custom factory to control the timing of worker creation.
-		h.fc.shardProcessorFactory = func(
-			ctx context.Context, // The context created by getOrStartWorker for the potential new processor.
-			registry contracts.FlowRegistry,
-			_ flowcontrol.SaturationDetector,
-			_ contracts.EndpointCandidates,
-			_ flowcontrol.UsageLimitPolicy,
-			_ clock.WithTicker,
-			_ time.Duration,
-			_ int,
-			_ logr.Logger,
-		) processor {
-			// This function is called by getOrStartWorker before the LoadOrStore check.
-			proc := &mockShardProcessor{runStarted: make(chan struct{})}
-			constructionContexts.Store(proc, ctx) // Capture the construction context.
-
-			// Signal entry and then block, allowing another goroutine to enter.
-			factoryEntered <- proc
-			<-continueFactory
-			return proc
-		}
-
-		var wg sync.WaitGroup
-		wg.Add(2)
-
-		// Start two goroutines that will race to create the same worker.
-		go func() {
-			defer wg.Done()
-			h.fc.getOrStartWorker()
-		}()
-		go func() {
-			defer wg.Done()
-			h.fc.getOrStartWorker()
-		}()
-
-		// 1. Wait for both goroutines to enter the factory and create their respective processor instances.
-		proc1 := <-factoryEntered
-		proc2 := <-factoryEntered
-
-		// 2. Unblock both goroutines, allowing them to race to workers.LoadOrStore.
-		close(continueFactory)
-		wg.Wait()
-
-		// 3. Identify the winner and the loser.
-		storedWorker := h.fc.worker.Load()
-		require.NotNil(t, storedWorker, "a worker must have been successfully stored in the map")
-
-		winnerProc := storedWorker.processor.(*mockShardProcessor)
-
-		var loserProc *mockShardProcessor
-		if winnerProc == proc1 {
-			loserProc = proc2
-		} else {
-			loserProc = proc1
-		}
-
-		// 4. Validate the state of the winning processor.
-		// Wait for the Run method to be called on the winner (only the winner should start).
-		select {
-		case <-winnerProc.runStarted:
-			// Success.
-		case <-time.After(1 * time.Second):
-			t.Fatal("timed out waiting for the winning worker's Run method to be called")
-		}
-
-		// The winning processor's context must remain active.
-		require.NotNil(t, winnerProc.Context(), "winner's context should not be nil (Run was called)")
-		select {
-		case <-winnerProc.Context().Done():
-			t.Error("context of the winning worker should not be cancelled")
-		default:
-			// Success
-		}
-
-		// 5. Validate the state of the losing processor and resource cleanup.
-		// The losing processor's Run method must NOT be called.
-		select {
-		case <-loserProc.runStarted:
-			t.Error("Run was incorrectly called on the losing worker")
-		default:
-			// Success
 		}
 	})
 }
@@ -979,7 +884,7 @@ func setupRegistryForConcurrency(t *testing.T, flowKey flowcontrol.FlowKey) *moc
 	t.Helper()
 	mockRegistry := &mockRegistryClient{}
 
-	// Configure the shard and its dependencies required by the real ShardProcessor implementation.
+	// Configure the registry and its dependencies required by the real Processor implementation.
 
 	// Use high-fidelity mock queues (MockManagedQueue) that implement the necessary interfaces and synchronization.
 	currentQueue := &mocks.MockManagedQueue{FlowKeyV: flowKey}
@@ -988,7 +893,7 @@ func setupRegistryForConcurrency(t *testing.T, flowKey flowcontrol.FlowKey) *moc
 		ManagedQueueFunc: func(_ flowcontrol.FlowKey) (contracts.ManagedQueue, error) {
 			return currentQueue, nil
 		},
-		// Configuration required for ShardProcessor initialization and dispatch logic.
+		// Configuration required for Processor initialization and dispatch logic.
 		AllOrderedPriorityLevelsFunc: func() []int { return []int{flowKey.Priority} },
 		PriorityBandAccessorFunc: func(priority int) (flowcontrol.PriorityBandAccessor, error) {
 			if priority == flowKey.Priority {
@@ -1038,8 +943,8 @@ func setupRegistryForConcurrency(t *testing.T, flowKey flowcontrol.FlowKey) *moc
 	return mockRegistry
 }
 
-// TestFlowController_Concurrency_Distribution performs an integration test under high contention, using real
-// ShardProcessors.
+// TestFlowController_Concurrency_Distribution performs an integration test under high contention, using a real
+// Processor.
 // It validates the thread-safety of the distribution logic and the overall system throughput.
 func TestFlowController_Concurrency_Distribution(t *testing.T) {
 	const (
@@ -1050,7 +955,7 @@ func TestFlowController_Concurrency_Distribution(t *testing.T) {
 	// Arrange
 	mockRegistry := setupRegistryForConcurrency(t, defaultFlowKey)
 
-	// Initialize the integration harness with real ShardProcessors.
+	// Initialize the integration harness with a real Processor.
 	h := newIntegrationHarness(t.Context(), t, &Config{
 		// Use a generous buffer to focus the test on distribution logic rather than backpressure.
 		EnqueueChannelBufferSize: numRequests,

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -43,14 +43,14 @@ const maxCleanupWorkers = 4
 // internal buffer is momentarily full and cannot accept new work.
 var ErrProcessorBusy = errors.New("shard processor is busy")
 
-// ShardProcessor is the core worker of the FlowController.
+// Processor is the core worker of the FlowController.
 //
 // It is paired one-to-one with a RegistryShard instance and is responsible for all request lifecycle operations on that
 // shard, from the point an item is successfully submitted to it.
 //
 // # Request Lifecycle Management & Ownership
 //
-// The ShardProcessor takes ownership of a FlowItem only after it has been successfully sent to its internal enqueueChan
+// The Processor takes ownership of a FlowItem only after it has been successfully sent to its internal enqueueChan
 // via Submit or SubmitOrBlock (i.e., when these methods return nil).
 // Once the Processor takes ownership, it is solely responsible for ensuring that item.Finalize() or
 // item.FinalizeWithOutcome() is called exactly once for that item, under all circumstances (dispatch, rejection, sweep,
@@ -64,7 +64,7 @@ var ErrProcessorBusy = errors.New("shard processor is busy")
 // To ensure correctness and high performance, the processor uses a single-goroutine, actor-based model. The main run
 // loop is the sole writer for all state-mutating operations. This makes complex transactions (like capacity checks)
 // inherently atomic without coarse-grained locks.
-type ShardProcessor struct {
+type Processor struct {
 	poolName             string
 	registry             contracts.FlowRegistry
 	saturationDetector   flowcontrol.SaturationDetector
@@ -86,8 +86,8 @@ type ShardProcessor struct {
 	shutdownOnce   sync.Once
 }
 
-// NewShardProcessor creates a new ShardProcessor instance.
-func NewShardProcessor(
+// NewProcessor creates a new Processor instance.
+func NewProcessor(
 	ctx context.Context,
 	poolName string,
 	registry contracts.FlowRegistry,
@@ -98,8 +98,8 @@ func NewShardProcessor(
 	cleanupSweepInterval time.Duration,
 	enqueueChannelBufferSize int,
 	logger logr.Logger,
-) *ShardProcessor {
-	return &ShardProcessor{
+) *Processor {
+	return &Processor{
 		registry:             registry,
 		poolName:             poolName,
 		saturationDetector:   saturationDetector,
@@ -124,7 +124,7 @@ func NewShardProcessor(
 // Possible errors:
 //   - ErrProcessorBusy: The processor's input channel is full.
 //   - types.ErrFlowControllerNotRunning: The processor is shutting down.
-func (sp *ShardProcessor) Submit(item *FlowItem) error {
+func (sp *Processor) Submit(item *FlowItem) error {
 	if sp.isShuttingDown.Load() {
 		return types.ErrFlowControllerNotRunning
 	}
@@ -150,7 +150,7 @@ func (sp *ShardProcessor) Submit(item *FlowItem) error {
 // Possible errors:
 //   - ctx.Err(): The provided context was cancelled or its deadline exceeded.
 //   - types.ErrFlowControllerNotRunning: The processor is shutting down.
-func (sp *ShardProcessor) SubmitOrBlock(ctx context.Context, item *FlowItem) error {
+func (sp *Processor) SubmitOrBlock(ctx context.Context, item *FlowItem) error {
 	if sp.isShuttingDown.Load() {
 		return types.ErrFlowControllerNotRunning
 	}
@@ -168,7 +168,7 @@ func (sp *ShardProcessor) SubmitOrBlock(ctx context.Context, item *FlowItem) err
 // Run is the main operational loop for the shard processor. It must be run as a goroutine.
 // It uses a `select` statement to interleave accepting new requests with dispatching existing ones, balancing
 // responsiveness with throughput.
-func (sp *ShardProcessor) Run(ctx context.Context) {
+func (sp *Processor) Run(ctx context.Context) {
 	sp.logger.V(logutil.DEFAULT).Info("Shard processor run loop starting.")
 	defer sp.logger.V(logutil.DEFAULT).Info("Shard processor run loop stopped.")
 
@@ -215,7 +215,7 @@ func (sp *ShardProcessor) Run(ctx context.Context) {
 
 // enqueue processes an item received from the enqueueChan.
 // It handles capacity checks, checks for external finalization, and either admits the item to a queue or rejects it.
-func (sp *ShardProcessor) enqueue(item *FlowItem) {
+func (sp *Processor) enqueue(item *FlowItem) {
 
 	req := item.OriginalRequest()
 	key := req.FlowKey()
@@ -285,7 +285,7 @@ func (sp *ShardProcessor) enqueue(item *FlowItem) {
 // hasCapacity checks if the shard and the specific priority band have enough capacity.
 // This check reflects actual resource utilization, including "zombie" items (finalized but unswept), to prevent
 // physical resource overcommitment.
-func (sp *ShardProcessor) hasCapacity(priority int, itemByteSize uint64) bool {
+func (sp *Processor) hasCapacity(priority int, itemByteSize uint64) bool {
 	stats := sp.registry.Stats()
 	if stats.TotalCapacityBytes > 0 && stats.TotalByteSize+itemByteSize > stats.TotalCapacityBytes {
 		return false
@@ -319,7 +319,7 @@ func (sp *ShardProcessor) hasCapacity(priority int, itemByteSize uint64) bool {
 // However, if a selected item is saturated (cannot be scheduled), the cycle stops immediately. This enforces HoL
 // blocking to respect the policy's decision and prevent priority inversion, where dispatching lower-priority work might
 // exacerbate the saturation affecting the high-priority item.
-func (sp *ShardProcessor) dispatchCycle(ctx context.Context) bool {
+func (sp *Processor) dispatchCycle(ctx context.Context) bool {
 	dispatchCycleStart := time.Now()
 	defer func() {
 		metrics.RecordFlowControlDispatchCycleDuration(time.Since(dispatchCycleStart))
@@ -375,7 +375,7 @@ func (sp *ShardProcessor) dispatchCycle(ctx context.Context) bool {
 }
 
 // selectItem applies the configured fairness and ordering policies to select a single item.
-func (sp *ShardProcessor) selectItem(
+func (sp *Processor) selectItem(
 	ctx context.Context,
 	flowGroup flowcontrol.PriorityBandAccessor,
 ) (flowcontrol.QueueItemAccessor, error) {
@@ -397,7 +397,7 @@ func (sp *ShardProcessor) selectItem(
 }
 
 // dispatchItem handles the final steps of dispatching an item: removing it from the queue and finalizing its outcome.
-func (sp *ShardProcessor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
+func (sp *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
 	req := itemAcc.OriginalRequest()
 	key := req.FlowKey()
 	managedQ, err := sp.registry.ManagedQueue(key)
@@ -422,7 +422,7 @@ func (sp *ShardProcessor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) er
 
 // runCleanupSweep starts a background goroutine that periodically scans all queues for externally finalized items
 // ("zombie" items) and removes them in batches.
-func (sp *ShardProcessor) runCleanupSweep(ctx context.Context) {
+func (sp *Processor) runCleanupSweep(ctx context.Context) {
 	defer sp.wg.Done()
 	logger := sp.logger.WithName("runCleanupSweep")
 	logger.V(logutil.DEFAULT).Info("Shard cleanup sweep goroutine starting.")
@@ -443,7 +443,7 @@ func (sp *ShardProcessor) runCleanupSweep(ctx context.Context) {
 
 // sweepFinalizedItems performs a single scan of all queues, removing finalized items in batch and releasing their
 // memory.
-func (sp *ShardProcessor) sweepFinalizedItems() {
+func (sp *Processor) sweepFinalizedItems() {
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		predicate := func(itemAcc flowcontrol.QueueItemAccessor) bool {
 			return itemAcc.(*FlowItem).FinalState() != nil
@@ -457,7 +457,7 @@ func (sp *ShardProcessor) sweepFinalizedItems() {
 
 // shutdown handles the graceful termination of the processor, ensuring all pending items (in channel and queues) are
 // Finalized.
-func (sp *ShardProcessor) shutdown() {
+func (sp *Processor) shutdown() {
 	sp.shutdownOnce.Do(func() {
 		sp.isShuttingDown.Store(true)
 		sp.logger.V(logutil.DEFAULT).Info("Shard processor shutting down.")
@@ -483,7 +483,7 @@ func (sp *ShardProcessor) shutdown() {
 }
 
 // evictAll drains all queues on the shard, finalizes every item, and releases their memory.
-func (sp *ShardProcessor) evictAll() {
+func (sp *Processor) evictAll() {
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		key := managedQ.FlowQueueAccessor().FlowKey()
 		removedItems := managedQ.Drain()
@@ -509,7 +509,7 @@ func (sp *ShardProcessor) evictAll() {
 
 // processAllQueuesConcurrently iterates over all queues in all priority bands on the shard and executes the given
 // `processFn` for each queue using a dynamically sized worker pool.
-func (sp *ShardProcessor) processAllQueuesConcurrently(
+func (sp *Processor) processAllQueuesConcurrently(
 	ctxName string,
 	processFn func(mq contracts.ManagedQueue, logger logr.Logger),
 ) {

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -84,7 +84,7 @@ type testHarness struct {
 	startSignal chan struct{}
 
 	// Core components under test
-	processor          *ShardProcessor
+	processor          *Processor
 	clock              *testclock.FakeClock
 	logger             logr.Logger
 	saturationDetector *mockSaturationDetector
@@ -132,7 +132,7 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 		}
 	}
 
-	h.processor = NewShardProcessor(
+	h.processor = NewProcessor(
 		h.ctx,
 		"test-pool",
 		h,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR is the forth step in a process of simplifying the Flow Control component's code base.

In particular this PR:
1. The FlowController's processor is now started via a dedicated Start() function, usually called right after creating the FlowController. Various tests are noted exceptions to this rule.
2. The FlowController's processor is now referenced via a simple field in the FlowController.
3. The word shard has been removed in many places, in types names (ShardProcessor -> Processor), in comments, and in documentation.

**Notes** to the reviewers:
1. The removal of of the word shard in the code base is an on going effort. It will be completed in future PRs
2. Nits from previous PRs will be handled in a future PR.

**Which issue(s) this PR fixes**:
Refs: #889

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
