### PR TITLE
ci: add standalone lint workflow

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -1,0 +1,105 @@
+name: CI - Lint
+
+on:
+  push:
+    branches:
+      - main
+      - 'release-*'
+  pull_request:
+    branches:
+      - main
+  pull_request_target:
+    branches:
+      - main
+    types: [ opened, synchronize, reopened ]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-changes:
+    # pull_request_target fires even when GITHUB_TOKEN creates the PR (e.g. the
+    # release-notes bot). pull_request does not. We register pull_request_target
+    # so bot-created PRs get a "skipped" conclusion that satisfies branch
+    # protection, but we skip all real work: pull_request already covers human
+    # PRs, and running twice would cause the concurrency group to cancel one run.
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            src:
+              - '**/*.go'
+              - Dockerfile.*
+              - Makefile*
+              - go.mod
+              - go.sum
+              - .golangci.yml
+              - .typos.toml
+              - scripts/**
+              - hack/**
+              - test/**
+              - .github/workflows/ci-lint.yaml
+
+  lint:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.src == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify go.mod and go.sum are tidy
+        run: go mod tidy -diff
+
+      - name: Create Go cache dirs
+        id: go-cache
+        run: |
+          mkdir -p "$HOME/.cache/llm-d-gomodcache" "$HOME/.cache/llm-d-gobuildcache"
+          echo "mod=$HOME/.cache/llm-d-gomodcache" >> "$GITHUB_OUTPUT"
+          echo "build=$HOME/.cache/llm-d-gobuildcache" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ steps.go-cache.outputs.mod }}
+            ${{ steps.go-cache.outputs.build }}
+          key: go-cache-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-cache-${{ runner.os }}-
+
+      - name: Run make build
+        env:
+          GO_MOD_CACHE_VOL: ${{ steps.go-cache.outputs.mod }}
+          GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
+        run: make build
+
+      - name: Run make lint
+        env:
+          GO_MOD_CACHE_VOL: ${{ steps.go-cache.outputs.mod }}
+          GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
+        run: make lint
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+          govulncheck ./...

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -123,14 +123,6 @@ jobs:
           restore-keys: |
             go-cache-
 
-      - name: Run make lint
-        run: make lint
-
-      - name: Run govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-          govulncheck ./...
-
       - name: Run make build
         shell: bash
         run: make build

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -96,15 +96,6 @@ jobs:
       - name: Sanity check repo contents
         run: ls -la
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Verify go.mod and go.sum are tidy
-        run: go mod tidy -diff
-
       - name: Create and resolve Go cache volumes
         id: go-cache
         run: |
@@ -122,10 +113,6 @@ jobs:
           key: go-cache-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-cache-
-
-      - name: Run make build
-        shell: bash
-        run: make build
 
       # Restore the baseline saved from the last main push so the compare step
       # can diff against it. Missing cache (first PR ever) is not an error;

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -96,6 +96,12 @@ jobs:
       - name: Sanity check repo contents
         run: ls -la
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false # only needed for `go list` in Makefile; module cache managed by the explicit cache step below
+
       - name: Create and resolve Go cache volumes
         id: go-cache
         run: |


### PR DESCRIPTION
**Context:**
Lint runs as the first steps of `lint-and-test`, but the result surfaces under that generic job name — there is no separate lint signal in the PR status panel and lint cannot be required independently.

**Before:**
Lint and test failures look identical in the checks UI.

**After:**
`ci-lint.yaml` adds a named `lint` check; `ci-pr-checks.yaml` drops `setup-go`, `go mod tidy`, `make build`, `make lint`, and `govulncheck` — all now owned by the lint workflow. Add `lint` to required status checks after this merges.