### PR TITLE
fix(ci): go module cache never saved due to permission error

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -105,13 +105,12 @@ jobs:
       - name: Verify go.mod and go.sum are tidy
         run: go mod tidy -diff
 
-      - name: Create and resolve Go cache volumes
+      - name: Create Go cache dirs
         id: go-cache
         run: |
-          docker volume create llm-d-gomodcache
-          docker volume create llm-d-gobuildcache
-          echo "mod=$(docker volume inspect llm-d-gomodcache -f '{{.Mountpoint}}')" >> $GITHUB_OUTPUT
-          echo "build=$(docker volume inspect llm-d-gobuildcache -f '{{.Mountpoint}}')" >> $GITHUB_OUTPUT
+          mkdir -p "$HOME/.cache/llm-d-gomodcache" "$HOME/.cache/llm-d-gobuildcache"
+          echo "mod=$HOME/.cache/llm-d-gomodcache" >> "$GITHUB_OUTPUT"
+          echo "build=$HOME/.cache/llm-d-gobuildcache" >> "$GITHUB_OUTPUT"
 
       - name: Cache Go modules and build cache
         uses: actions/cache@v5
@@ -119,9 +118,9 @@ jobs:
           path: |
             ${{ steps.go-cache.outputs.mod }}
             ${{ steps.go-cache.outputs.build }}
-          key: go-cache-${{ hashFiles('go.sum') }}
+          key: go-cache-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: |
-            go-cache-
+            go-cache-${{ runner.os }}-
 
       - name: Run make lint
         run: make lint
@@ -147,10 +146,16 @@ jobs:
 
       - name: Run unit tests
         shell: bash
+        env:
+          GO_MOD_CACHE_VOL: ${{ steps.go-cache.outputs.mod }}
+          GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
         run: make test-unit
 
       - name: Run hermetic integration tests
         shell: bash
+        env:
+          GO_MOD_CACHE_VOL: ${{ steps.go-cache.outputs.mod }}
+          GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
         run: make test-integration-hermetic
 
       - name: Compare coverage against main baseline

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -71,6 +71,9 @@ jobs:
     if: ${{ needs.check-changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      GO_MOD_CACHE_VOL: /home/runner/.cache/llm-d-gomodcache
+      GO_BUILD_CACHE_VOL: /home/runner/.cache/llm-d-gobuildcache
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -106,18 +109,14 @@ jobs:
         run: go mod tidy -diff
 
       - name: Create Go cache dirs
-        id: go-cache
-        run: |
-          mkdir -p "$HOME/.cache/llm-d-gomodcache" "$HOME/.cache/llm-d-gobuildcache"
-          echo "mod=$HOME/.cache/llm-d-gomodcache" >> "$GITHUB_OUTPUT"
-          echo "build=$HOME/.cache/llm-d-gobuildcache" >> "$GITHUB_OUTPUT"
+        run: mkdir -p "$GO_MOD_CACHE_VOL" "$GO_BUILD_CACHE_VOL"
 
       - name: Cache Go modules and build cache
         uses: actions/cache@v5
         with:
           path: |
-            ${{ steps.go-cache.outputs.mod }}
-            ${{ steps.go-cache.outputs.build }}
+            ${{ env.GO_MOD_CACHE_VOL }}
+            ${{ env.GO_BUILD_CACHE_VOL }}
           key: go-cache-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-cache-${{ runner.os }}-
@@ -146,16 +145,10 @@ jobs:
 
       - name: Run unit tests
         shell: bash
-        env:
-          GO_MOD_CACHE_VOL: ${{ steps.go-cache.outputs.mod }}
-          GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
         run: make test-unit
 
       - name: Run hermetic integration tests
         shell: bash
-        env:
-          GO_MOD_CACHE_VOL: ${{ steps.go-cache.outputs.mod }}
-          GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
         run: make test-integration-hermetic
 
       - name: Compare coverage against main baseline

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ GIT_COMMIT_SHA ?= $(shell git rev-parse HEAD 2>/dev/null)
 ROOT_RELEASE_TAG_MATCH ?= v[0-9]*
 BUILD_REF ?= $(shell git describe --tags --match '$(ROOT_RELEASE_TAG_MATCH)' --abbrev=0 2>/dev/null)
 
-# Named volumes for Go module and build caches, persisted across container runs and image rebuilds.
-GO_MOD_CACHE_VOL ?= llm-d-gomodcache
-GO_BUILD_CACHE_VOL ?= llm-d-gobuildcache
+# Host directories for Go module and build caches, bind-mounted into the builder container.
+GO_MOD_CACHE_VOL ?= $(HOME)/.cache/llm-d-gomodcache
+GO_BUILD_CACHE_VOL ?= $(HOME)/.cache/llm-d-gobuildcache
 
 # Common flags for running the builder container: mounts source, Go caches, and runs as current user.
 # Podman rootless requires --userns=keep-id to correctly map host UID; docker uses -u directly.
@@ -418,6 +418,7 @@ BUILDER_STAMP = build/.builder.stamp
 
 .PHONY: image-build-builder
 image-build-builder: check-container-tool ## Build builder image if missing locally, stamp missing, or Dockerfile.builder newer than stamp
+	@mkdir -p $(GO_MOD_CACHE_VOL) $(GO_BUILD_CACHE_VOL)
 	@if ! $(CONTAINER_RUNTIME) image inspect $(BUILDER_IMAGE) >/dev/null 2>&1 || \
 	    [ ! -f $(BUILDER_STAMP) ] || \
 	    [ Dockerfile.builder -nt $(BUILDER_STAMP) ]; then \


### PR DESCRIPTION
**Context:**
Docker named volumes are root-owned. The `actions/cache` post-step runs as the runner user, hits `EACCES` on the volume mountpoint, and silently gives up — the cache is never saved or restored.

```
Cache not found + EACCES: permission denied, lstat '/var/lib/docker/volumes/llm-d-gomodcache/_data'
```

**Before:**
Silent permission error in teardown; Go re-downloads all modules on every run.

**After:**
Cache saves on first run and restores on subsequent ones with the same `go.sum`.