### PR TITLE
Feat/add currequest tokens

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
@@ -23,6 +23,7 @@ import (
 )
 
 var InFlightLoadDataKey = plugin.NewDataKey("InFlightLoadDataKey", inflightloadconstants.InFlightLoadProducerType)
+var CurrentRequestLoadDataKey = plugin.NewDataKey("CurrentRequestLoadDataKey", inflightloadconstants.InFlightLoadProducerType)
 
 // InFlightLoad captures the current real-time load of an endpoint as tracked by the EPP.
 type InFlightLoad struct {

--- a/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
@@ -23,7 +23,7 @@ import (
 )
 
 var InFlightLoadDataKey = plugin.NewDataKey("InFlightLoadDataKey", inflightloadconstants.InFlightLoadProducerType)
-var CurrentRequestLoadDataKey = plugin.NewDataKey("CurrentRequestLoadDataKey", inflightloadconstants.InFlightLoadProducerType)
+var CurrentRequestEndpointImpactDataKey = plugin.NewDataKey("CurrentRequestEndpointImpactDataKey", inflightloadconstants.InFlightLoadProducerType)
 
 // InFlightLoad captures the current real-time load of an endpoint as tracked by the EPP.
 type InFlightLoad struct {

--- a/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
@@ -23,6 +23,12 @@ import (
 )
 
 var InFlightLoadDataKey = plugin.NewDataKey("InFlightLoadDataKey", inflightloadconstants.InFlightLoadProducerType)
+
+// CurrentRequestEndpointImpactDataKey carries the estimated per-endpoint cost of the
+// request currently being scheduled. Set by InFlightLoadProducer.Produce
+// for each candidate endpoint based on that endpoint's prefix-cache match;
+// consumed by load-aware scorers to include the request's own impact when
+// scoring. Lifecycle: overwritten each scheduling cycle; never cleared.
 var CurrentRequestEndpointImpactDataKey = plugin.NewDataKey("CurrentRequestEndpointImpactDataKey", inflightloadconstants.InFlightLoadProducerType)
 
 // InFlightLoad captures the current real-time load of an endpoint as tracked by the EPP.

--- a/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
@@ -22,27 +22,55 @@ import (
 	inflightloadconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/constants"
 )
 
+// InFlightLoadDataKey carries the per-endpoint in-flight load snapshot used by
+// load-aware scorers. Populated by InFlightLoadProducer.Produce on each
+// candidate endpoint at the start of every scheduling cycle.
+//
+// The snapshot is per-cycle (stored on the per-cycle endpoint clone produced
+// by fwksched.NewEndpoint) and combines two semantically distinct sources:
+//   - Tokens / Requests: accumulated load from already in-flight requests,
+//     read from the producer's persistent trackers.
+//   - UncachedRequestTokens: the projected work this request would add to
+//     the endpoint if scheduled here, computed fresh from the request being
+//     scored and the endpoint's prefix-cache state. Not persisted.
 var InFlightLoadDataKey = plugin.NewDataKey("InFlightLoadDataKey", inflightloadconstants.InFlightLoadProducerType)
 
-// CurrentRequestEndpointImpactDataKey carries the estimated per-endpoint cost of the
-// request currently being scheduled. Set by InFlightLoadProducer.Produce
-// for each candidate endpoint based on that endpoint's prefix-cache match;
-// consumed by load-aware scorers to include the request's own impact when
-// scoring. Lifecycle: overwritten each scheduling cycle; never cleared.
-var CurrentRequestEndpointImpactDataKey = plugin.NewDataKey("CurrentRequestEndpointImpactDataKey", inflightloadconstants.InFlightLoadProducerType)
-
-// InFlightLoad captures the current real-time load of an endpoint as tracked by the EPP.
+// InFlightLoad captures the current real-time load of an endpoint as tracked
+// by the EPP, plus the projected impact of the request currently being scheduled.
 type InFlightLoad struct {
-	Tokens   int64
+	// Tokens is the in-flight token count this endpoint has committed to,
+	// accumulated from past scheduling decisions. Updated by PreRequest (when
+	// an endpoint is chosen) and OnEvicted (when its request stream ends);
+	// snapshotted into this struct each cycle by InFlightLoadProducer.Produce.
+	Tokens int64
+
+	// Requests is the in-flight request count this endpoint has committed to,
+	// maintained with the same lifecycle as Tokens.
 	Requests int64
+
+	// UncachedRequestTokens is a speculative projection: the work the request
+	// currently being scheduled would add to this endpoint if it landed here.
+	// Includes the uncached input portion (accounting for prefix-cache hits)
+	// plus the estimated output when the producer is configured with
+	// AddEstimatedOutputTokens=true. Computed fresh by Produce on every cycle
+	// from the request being scored and this endpoint's prefix-cache state;
+	// never committed to endpoint state and not decremented on stream end.
+	// Zero when no request is in scope (e.g., background snapshots).
+	//
+	// Could equivalently be computed inside any scorer that needs it, but
+	// it's produced here so every consumer reads the same value — single
+	// source of truth for the current request's per-endpoint impact.
+	UncachedRequestTokens int64
 }
 
+// Clone returns an independent copy of the InFlightLoad. The value-copy
+// idiom (cp := *l) covers every field automatically; new fields added to
+// InFlightLoad do not require updating Clone, as long as they remain value
+// types (no slices, maps, or pointers requiring deep copy).
 func (l *InFlightLoad) Clone() fwkdl.Cloneable {
 	if l == nil {
 		return nil
 	}
-	return &InFlightLoad{
-		Tokens:   l.Tokens,
-		Requests: l.Requests,
-	}
+	cp := *l
+	return &cp
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -195,7 +195,10 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 }
 
 func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
-	inputTokens := p.tokenEstimator.EstimateInput(request)
+	var inputTokens int64
+	if request != nil {
+		inputTokens = p.tokenEstimator.EstimateInput(request)
+	}
 
 	for _, e := range endpoints {
 		if e == nil || e.GetMetadata() == nil {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -71,14 +71,13 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 	}
 
 	return &InFlightLoadProducer{
-		typedName:                           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker:                      newConcurrencyTracker(),
-		tokenTracker:                        newConcurrencyTracker(),
-		tokenEstimator:                      NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens:            cfg.AddEstimatedOutputTokens,
-		dk:                                  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
-		currentRequestEndpointImpactDataKey: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(name),
-		PluginState:                         fwkplugin.NewPluginState(ctx),
+		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:           newConcurrencyTracker(),
+		tokenTracker:             newConcurrencyTracker(),
+		tokenEstimator:           NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
+		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		PluginState:              fwkplugin.NewPluginState(ctx),
 	}, nil
 }
 
@@ -91,14 +90,13 @@ var (
 )
 
 type InFlightLoadProducer struct {
-	typedName                           fwkplugin.TypedName
-	requestTracker                      *concurrencyTracker
-	tokenTracker                        *concurrencyTracker
-	tokenEstimator                      TokenEstimator
-	addEstimatedOutputTokens            bool
-	PluginState                         *fwkplugin.PluginState
-	dk                                  fwkplugin.DataKey
-	currentRequestEndpointImpactDataKey fwkplugin.DataKey
+	typedName                fwkplugin.TypedName
+	requestTracker           *concurrencyTracker
+	tokenTracker             *concurrencyTracker
+	tokenEstimator           TokenEstimator
+	addEstimatedOutputTokens bool
+	PluginState              *fwkplugin.PluginState
+	dk                       fwkplugin.DataKey
 }
 
 // addedTokensEntry tracks a request's contribution to the global token and
@@ -204,19 +202,19 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.Infe
 			continue
 		}
 		endpointID := e.GetMetadata().NamespacedName.String()
-		e.Put(p.dk.String(), &attrconcurrency.InFlightLoad{
+
+		load := &attrconcurrency.InFlightLoad{
 			Tokens:   p.tokenTracker.get(endpointID),
 			Requests: p.requestTracker.get(endpointID),
-		})
-
-		if request != nil {
-			// Estimate the load this request would add if scheduled to this endpoint.
-			tokens := p.estimateRequestTokens(e, inputTokens)
-			e.Put(p.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{
-				Tokens:   tokens,
-				Requests: 1,
-			})
 		}
+		if request != nil {
+			// Project this request's additional work onto the endpoint: uncached
+			// input tokens (per its prefix-cache state) plus estimated output
+			// when the producer is configured to include it. Per-cycle, not
+			// persisted in the tracker — that happens only on PreRequest.
+			load.UncachedRequestTokens = p.estimateRequestTokens(e, inputTokens)
+		}
+		e.Put(p.dk.String(), load)
 	}
 	return nil
 }
@@ -441,8 +439,7 @@ func nonNeg(v int64) int64 {
 
 func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
-		p.dk:                                  attrconcurrency.InFlightLoad{},
-		p.currentRequestEndpointImpactDataKey: attrconcurrency.InFlightLoad{},
+		p.dk: attrconcurrency.InFlightLoad{},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -210,11 +210,7 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.Infe
 		})
 
 		// Estimate the load this request would add if scheduled to this endpoint.
-		adjustedInput := uncachedInputTokens(e, inputTokens)
-		tokens := adjustedInput
-		if p.addEstimatedOutputTokens {
-			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
-		}
+		tokens := p.estimateRequestTokens(e, inputTokens)
 		e.Put(p.currentRequestEndpointImpactDK.String(), &attrconcurrency.InFlightLoad{
 			Tokens:   tokens,
 			Requests: 1,
@@ -261,12 +257,7 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 		// Prefer the prefix producer's view (real tokens) when available so the
 		// match-length and the input length are in the same units; fall back to
 		// the (estimated) input tokens otherwise.
-		adjustedInput := uncachedInputTokens(endpoint, inputTokens)
-		tokens := adjustedInput
-		if p.addEstimatedOutputTokens {
-			// Output tokens are based on the full input, not the cached portion.
-			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
-		}
+		tokens := p.estimateRequestTokens(endpoint, inputTokens)
 
 		p.tokenTracker.add(eid, tokens)
 
@@ -283,6 +274,16 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 			entry,
 		)
 	}
+}
+
+func (p *InFlightLoadProducer) estimateRequestTokens(endpoint fwksched.Endpoint, inputTokens int64) int64 {
+	adjustedInput := uncachedInputTokens(endpoint, inputTokens)
+	tokens := adjustedInput
+	if p.addEstimatedOutputTokens {
+		// Output tokens are based on the full input, not the cached portion.
+		tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+	}
+	return tokens
 }
 
 func (p *InFlightLoadProducer) ResponseBody(

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -77,6 +77,7 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 		tokenEstimator:           NewSimpleTokenEstimator(),
 		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
 		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		currentRequestLoadDK:     attrconcurrency.CurrentRequestLoadDataKey.WithNonEmptyProducerName(name),
 		PluginState:              fwkplugin.NewPluginState(ctx),
 	}, nil
 }
@@ -97,6 +98,7 @@ type InFlightLoadProducer struct {
 	addEstimatedOutputTokens bool
 	PluginState              *fwkplugin.PluginState
 	dk                       fwkplugin.DataKey
+	currentRequestLoadDK     fwkplugin.DataKey
 }
 
 // addedTokensEntry tracks a request's contribution to the global token and
@@ -194,7 +196,9 @@ func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datala
 	return nil
 }
 
-func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+	inputTokens := p.tokenEstimator.EstimateInput(request)
+
 	for _, e := range endpoints {
 		if e == nil || e.GetMetadata() == nil {
 			continue
@@ -203,6 +207,17 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceR
 		e.Put(p.dk.String(), &attrconcurrency.InFlightLoad{
 			Tokens:   p.tokenTracker.get(endpointID),
 			Requests: p.requestTracker.get(endpointID),
+		})
+
+		// Estimate the load this request would add if scheduled to this endpoint.
+		adjustedInput := uncachedInputTokens(e, inputTokens)
+		tokens := adjustedInput
+		if p.addEstimatedOutputTokens {
+			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
+		}
+		e.Put(p.currentRequestLoadDK.String(), &attrconcurrency.InFlightLoad{
+			Tokens:   tokens,
+			Requests: 1,
 		})
 	}
 	return nil
@@ -423,7 +438,8 @@ func nonNeg(v int64) int64 {
 
 func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
-		p.dk: attrconcurrency.InFlightLoad{},
+		p.dk:                 attrconcurrency.InFlightLoad{},
+		p.currentRequestLoadDK: attrconcurrency.InFlightLoad{},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -77,7 +77,7 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 		tokenEstimator:           NewSimpleTokenEstimator(),
 		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
 		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
-		currentRequestLoadDK:     attrconcurrency.CurrentRequestLoadDataKey.WithNonEmptyProducerName(name),
+		currentRequestEndpointImpactDK: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(name),
 		PluginState:              fwkplugin.NewPluginState(ctx),
 	}, nil
 }
@@ -98,7 +98,7 @@ type InFlightLoadProducer struct {
 	addEstimatedOutputTokens bool
 	PluginState              *fwkplugin.PluginState
 	dk                       fwkplugin.DataKey
-	currentRequestLoadDK     fwkplugin.DataKey
+	currentRequestEndpointImpactDK fwkplugin.DataKey
 }
 
 // addedTokensEntry tracks a request's contribution to the global token and
@@ -215,7 +215,7 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.Infe
 		if p.addEstimatedOutputTokens {
 			tokens += p.tokenEstimator.EstimateOutput(inputTokens)
 		}
-		e.Put(p.currentRequestLoadDK.String(), &attrconcurrency.InFlightLoad{
+		e.Put(p.currentRequestEndpointImpactDK.String(), &attrconcurrency.InFlightLoad{
 			Tokens:   tokens,
 			Requests: 1,
 		})
@@ -439,7 +439,7 @@ func nonNeg(v int64) int64 {
 func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
 		p.dk:                 attrconcurrency.InFlightLoad{},
-		p.currentRequestLoadDK: attrconcurrency.InFlightLoad{},
+		p.currentRequestEndpointImpactDK: attrconcurrency.InFlightLoad{},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -71,14 +71,14 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 	}
 
 	return &InFlightLoadProducer{
-		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
-		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
-		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
-		currentRequestEndpointImpactDK: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(name),
-		PluginState:              fwkplugin.NewPluginState(ctx),
+		typedName:                           fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:                      newConcurrencyTracker(),
+		tokenTracker:                        newConcurrencyTracker(),
+		tokenEstimator:                      NewSimpleTokenEstimator(),
+		addEstimatedOutputTokens:            cfg.AddEstimatedOutputTokens,
+		dk:                                  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		currentRequestEndpointImpactDataKey: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(name),
+		PluginState:                         fwkplugin.NewPluginState(ctx),
 	}, nil
 }
 
@@ -91,14 +91,14 @@ var (
 )
 
 type InFlightLoadProducer struct {
-	typedName                fwkplugin.TypedName
-	requestTracker           *concurrencyTracker
-	tokenTracker             *concurrencyTracker
-	tokenEstimator           TokenEstimator
-	addEstimatedOutputTokens bool
-	PluginState              *fwkplugin.PluginState
-	dk                       fwkplugin.DataKey
-	currentRequestEndpointImpactDK fwkplugin.DataKey
+	typedName                           fwkplugin.TypedName
+	requestTracker                      *concurrencyTracker
+	tokenTracker                        *concurrencyTracker
+	tokenEstimator                      TokenEstimator
+	addEstimatedOutputTokens            bool
+	PluginState                         *fwkplugin.PluginState
+	dk                                  fwkplugin.DataKey
+	currentRequestEndpointImpactDataKey fwkplugin.DataKey
 }
 
 // addedTokensEntry tracks a request's contribution to the global token and
@@ -209,12 +209,14 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.Infe
 			Requests: p.requestTracker.get(endpointID),
 		})
 
-		// Estimate the load this request would add if scheduled to this endpoint.
-		tokens := p.estimateRequestTokens(e, inputTokens)
-		e.Put(p.currentRequestEndpointImpactDK.String(), &attrconcurrency.InFlightLoad{
-			Tokens:   tokens,
-			Requests: 1,
-		})
+		if request != nil {
+			// Estimate the load this request would add if scheduled to this endpoint.
+			tokens := p.estimateRequestTokens(e, inputTokens)
+			e.Put(p.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{
+				Tokens:   tokens,
+				Requests: 1,
+			})
+		}
 	}
 	return nil
 }
@@ -439,8 +441,8 @@ func nonNeg(v int64) int64 {
 
 func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
-		p.dk:                 attrconcurrency.InFlightLoad{},
-		p.currentRequestEndpointImpactDK: attrconcurrency.InFlightLoad{},
+		p.dk:                                  attrconcurrency.InFlightLoad{},
+		p.currentRequestEndpointImpactDataKey: attrconcurrency.InFlightLoad{},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -45,10 +45,10 @@ type Config struct {
 var _ fwksched.Scorer = &TokenLoadScorer{}
 
 type TokenLoadScorer struct {
-	typedName            fwkplugin.TypedName
-	queueThresholdTokens float64
-	inFlightLoadDataKey  fwkplugin.DataKey
-	currentRequestEndpointImpactDK fwkplugin.DataKey
+	typedName                           fwkplugin.TypedName
+	queueThresholdTokens                float64
+	inFlightLoadDataKey                 fwkplugin.DataKey
+	currentRequestEndpointImpactDataKey fwkplugin.DataKey
 }
 
 func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -65,10 +65,10 @@ func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handl
 	}
 
 	return &TokenLoadScorer{
-		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: name},
-		queueThresholdTokens: float64(cfg.QueueThresholdTokens),
-		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
-		currentRequestEndpointImpactDK: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
+		typedName:                           fwkplugin.TypedName{Type: TokenLoadScorerType, Name: name},
+		queueThresholdTokens:                float64(cfg.QueueThresholdTokens),
+		inFlightLoadDataKey:                 attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
+		currentRequestEndpointImpactDataKey: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
 	}, nil
 }
 
@@ -82,8 +82,8 @@ func (s *TokenLoadScorer) Category() fwksched.ScorerCategory {
 
 func (s *TokenLoadScorer) Consumes() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
-		s.inFlightLoadDataKey:  attrconcurrency.InFlightLoad{},
-		s.currentRequestEndpointImpactDK: attrconcurrency.InFlightLoad{},
+		s.inFlightLoadDataKey:                 attrconcurrency.InFlightLoad{},
+		s.currentRequestEndpointImpactDataKey: attrconcurrency.InFlightLoad{},
 	}
 }
 
@@ -96,13 +96,13 @@ func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.InferenceReques
 		tokenLoad := 0.0
 
 		if val, ok := endpoint.Get(s.inFlightLoadDataKey.String()); ok {
-			if load, ok := val.(*attrconcurrency.InFlightLoad); ok {
+			if load, ok := val.(*attrconcurrency.InFlightLoad); ok && load != nil {
 				tokenLoad = float64(load.Tokens)
 			}
 		}
 
-		if val, ok := endpoint.Get(s.currentRequestEndpointImpactDK.String()); ok {
-			if load, ok := val.(*attrconcurrency.InFlightLoad); ok {
+		if val, ok := endpoint.Get(s.currentRequestEndpointImpactDataKey.String()); ok {
+			if load, ok := val.(*attrconcurrency.InFlightLoad); ok && load != nil {
 				tokenLoad += float64(load.Tokens)
 			}
 		}

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -45,10 +45,9 @@ type Config struct {
 var _ fwksched.Scorer = &TokenLoadScorer{}
 
 type TokenLoadScorer struct {
-	typedName                           fwkplugin.TypedName
-	queueThresholdTokens                float64
-	inFlightLoadDataKey                 fwkplugin.DataKey
-	currentRequestEndpointImpactDataKey fwkplugin.DataKey
+	typedName            fwkplugin.TypedName
+	queueThresholdTokens float64
+	inFlightLoadDataKey  fwkplugin.DataKey
 }
 
 func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -65,10 +64,9 @@ func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handl
 	}
 
 	return &TokenLoadScorer{
-		typedName:                           fwkplugin.TypedName{Type: TokenLoadScorerType, Name: name},
-		queueThresholdTokens:                float64(cfg.QueueThresholdTokens),
-		inFlightLoadDataKey:                 attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
-		currentRequestEndpointImpactDataKey: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
+		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: name},
+		queueThresholdTokens: float64(cfg.QueueThresholdTokens),
+		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
 	}, nil
 }
 
@@ -82,8 +80,7 @@ func (s *TokenLoadScorer) Category() fwksched.ScorerCategory {
 
 func (s *TokenLoadScorer) Consumes() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
-		s.inFlightLoadDataKey:                 attrconcurrency.InFlightLoad{},
-		s.currentRequestEndpointImpactDataKey: attrconcurrency.InFlightLoad{},
+		s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{},
 	}
 }
 
@@ -95,15 +92,12 @@ func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.InferenceReques
 		endpointID := endpoint.GetMetadata().NamespacedName.String()
 		tokenLoad := 0.0
 
+		// Single read: accumulated in-flight load plus the projected impact
+		// of the request being scored, both carried on the same InFlightLoad
+		// struct populated by InFlightLoadProducer.Produce.
 		if val, ok := endpoint.Get(s.inFlightLoadDataKey.String()); ok {
 			if load, ok := val.(*attrconcurrency.InFlightLoad); ok && load != nil {
-				tokenLoad = float64(load.Tokens)
-			}
-		}
-
-		if val, ok := endpoint.Get(s.currentRequestEndpointImpactDataKey.String()); ok {
-			if load, ok := val.(*attrconcurrency.InFlightLoad); ok && load != nil {
-				tokenLoad += float64(load.Tokens)
+				tokenLoad = float64(load.Tokens + load.UncachedRequestTokens)
 			}
 		}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -48,7 +48,7 @@ type TokenLoadScorer struct {
 	typedName            fwkplugin.TypedName
 	queueThresholdTokens float64
 	inFlightLoadDataKey  fwkplugin.DataKey
-	currentRequestLoadDK fwkplugin.DataKey
+	currentRequestEndpointImpactDK fwkplugin.DataKey
 }
 
 func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -68,7 +68,7 @@ func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handl
 		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: name},
 		queueThresholdTokens: float64(cfg.QueueThresholdTokens),
 		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
-		currentRequestLoadDK: attrconcurrency.CurrentRequestLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
+		currentRequestEndpointImpactDK: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
 	}, nil
 }
 
@@ -83,7 +83,7 @@ func (s *TokenLoadScorer) Category() fwksched.ScorerCategory {
 func (s *TokenLoadScorer) Consumes() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
 		s.inFlightLoadDataKey:  attrconcurrency.InFlightLoad{},
-		s.currentRequestLoadDK: attrconcurrency.InFlightLoad{},
+		s.currentRequestEndpointImpactDK: attrconcurrency.InFlightLoad{},
 	}
 }
 
@@ -101,7 +101,7 @@ func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.InferenceReques
 			}
 		}
 
-		if val, ok := endpoint.Get(s.currentRequestLoadDK.String()); ok {
+		if val, ok := endpoint.Get(s.currentRequestEndpointImpactDK.String()); ok {
 			if load, ok := val.(*attrconcurrency.InFlightLoad); ok {
 				tokenLoad += float64(load.Tokens)
 			}

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -48,6 +48,7 @@ type TokenLoadScorer struct {
 	typedName            fwkplugin.TypedName
 	queueThresholdTokens float64
 	inFlightLoadDataKey  fwkplugin.DataKey
+	currentRequestLoadDK fwkplugin.DataKey
 }
 
 func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -67,6 +68,7 @@ func TokenLoadScorerFactory(name string, params *json.Decoder, _ fwkplugin.Handl
 		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: name},
 		queueThresholdTokens: float64(cfg.QueueThresholdTokens),
 		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
+		currentRequestLoadDK: attrconcurrency.CurrentRequestLoadDataKey.WithNonEmptyProducerName(cfg.InFlightLoadProducerName),
 	}, nil
 }
 
@@ -80,7 +82,8 @@ func (s *TokenLoadScorer) Category() fwksched.ScorerCategory {
 
 func (s *TokenLoadScorer) Consumes() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{
-		s.inFlightLoadDataKey: attrconcurrency.InFlightLoad{},
+		s.inFlightLoadDataKey:  attrconcurrency.InFlightLoad{},
+		s.currentRequestLoadDK: attrconcurrency.InFlightLoad{},
 	}
 }
 
@@ -95,6 +98,12 @@ func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.InferenceReques
 		if val, ok := endpoint.Get(s.inFlightLoadDataKey.String()); ok {
 			if load, ok := val.(*attrconcurrency.InFlightLoad); ok {
 				tokenLoad = float64(load.Tokens)
+			}
+		}
+
+		if val, ok := endpoint.Get(s.currentRequestLoadDK.String()); ok {
+			if load, ok := val.(*attrconcurrency.InFlightLoad); ok {
+				tokenLoad += float64(load.Tokens)
 			}
 		}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -36,7 +36,7 @@ func TestTokenLoadScorer(t *testing.T) {
 		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
 		queueThresholdTokens: threshold,
 		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
-		currentRequestLoadDK: attrconcurrency.CurrentRequestLoadDataKey.WithNonEmptyProducerName(""),
+		currentRequestEndpointImpactDK: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(""),
 	}
 
 	pod1NN := types.NamespacedName{Namespace: "default", Name: "pod1"}
@@ -50,13 +50,13 @@ func TestTokenLoadScorer(t *testing.T) {
 	}
 
 	// pod1: 0 in-flight + 250 current = 250. Score = 1 - 250/1000 = 0.75
-	endpoints[0].Put(attrconcurrency.CurrentRequestLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+	endpoints[0].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 	// pod2: 250 in-flight + 250 current = 500. Score = 1 - 500/1000 = 0.5
 	endpoints[1].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
-	endpoints[1].Put(attrconcurrency.CurrentRequestLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+	endpoints[1].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 	// pod3: 750 in-flight + 250 current = 1000. Score = 1 - 1000/1000 = 0.0
 	endpoints[2].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 750})
-	endpoints[2].Put(attrconcurrency.CurrentRequestLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+	endpoints[2].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 
 	scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -33,34 +33,47 @@ func TestTokenLoadScorer(t *testing.T) {
 	threshold := 1000.0
 
 	scorer := &TokenLoadScorer{
-		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
-		queueThresholdTokens: threshold,
-		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
+		typedName:                      fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
+		queueThresholdTokens:           threshold,
+		inFlightLoadDataKey:            attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
 		currentRequestEndpointImpactDK: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(""),
 	}
 
-	pod1NN := types.NamespacedName{Namespace: "default", Name: "pod1"}
-	pod2NN := types.NamespacedName{Namespace: "default", Name: "pod2"}
-	pod3NN := types.NamespacedName{Namespace: "default", Name: "pod3"}
+	t.Run("basic scoring with request impact", func(t *testing.T) {
+		pod1NN := types.NamespacedName{Namespace: "default", Name: "pod1"}
+		pod2NN := types.NamespacedName{Namespace: "default", Name: "pod2"}
+		pod3NN := types.NamespacedName{Namespace: "default", Name: "pod3"}
 
-	endpoints := []fwksched.Endpoint{
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod1NN}, &fwkdl.Metrics{}, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod2NN}, &fwkdl.Metrics{}, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod3NN}, &fwkdl.Metrics{}, nil),
-	}
+		endpoints := []fwksched.Endpoint{
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod1NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod2NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod3NN}, &fwkdl.Metrics{}, nil),
+		}
 
-	// pod1: 0 in-flight + 250 current = 250. Score = 1 - 250/1000 = 0.75
-	endpoints[0].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
-	// pod2: 250 in-flight + 250 current = 500. Score = 1 - 500/1000 = 0.5
-	endpoints[1].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
-	endpoints[1].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
-	// pod3: 750 in-flight + 250 current = 1000. Score = 1 - 1000/1000 = 0.0
-	endpoints[2].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 750})
-	endpoints[2].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		// pod1: 0 in-flight + 250 current = 250. Score = 1 - 250/1000 = 0.75
+		endpoints[0].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		// pod2: 250 in-flight + 250 current = 500. Score = 1 - 500/1000 = 0.5
+		endpoints[1].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[1].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		// pod3: 750 in-flight + 250 current = 1000. Score = 1 - 1000/1000 = 0.0
+		endpoints[2].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 750})
+		endpoints[2].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 
-	scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
-	assert.InDelta(t, 0.75, scores[endpoints[0]], 0.0001, "Pod1 (0 + 250 tokens) should have score 0.75")
-	assert.InDelta(t, 0.5, scores[endpoints[1]], 0.0001, "Pod2 (250 + 250 tokens) should have score 0.5")
-	assert.InDelta(t, 0.0, scores[endpoints[2]], 0.0001, "Pod3 (750 + 250 tokens) should have score 0.0")
+		assert.InDelta(t, 0.75, scores[endpoints[0]], 0.0001, "Pod1 (0 + 250 tokens) should have score 0.75")
+		assert.InDelta(t, 0.5, scores[endpoints[1]], 0.0001, "Pod2 (250 + 250 tokens) should have score 0.5")
+		assert.InDelta(t, 0.0, scores[endpoints[2]], 0.0001, "Pod3 (750 + 250 tokens) should have score 0.0")
+	})
+
+	t.Run("missing data keys degrades gracefully", func(t *testing.T) {
+		podNN := types.NamespacedName{Namespace: "default", Name: "pod-no-data"}
+		endpoints := []fwksched.Endpoint{
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podNN}, &fwkdl.Metrics{}, nil),
+		}
+
+		// No keys set; should score as if 0 token load
+		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with missing keys should have score 1.0 (0 load)")
+	})
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -33,13 +33,37 @@ func TestTokenLoadScorer(t *testing.T) {
 	threshold := 1000.0
 
 	scorer := &TokenLoadScorer{
-		typedName:                      fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
-		queueThresholdTokens:           threshold,
-		inFlightLoadDataKey:            attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
-		currentRequestEndpointImpactDK: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(""),
+		typedName:                           fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
+		queueThresholdTokens:                threshold,
+		inFlightLoadDataKey:                 attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
+		currentRequestEndpointImpactDataKey: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(""),
 	}
 
-	t.Run("basic scoring with request impact", func(t *testing.T) {
+	t.Run("in-flight load only", func(t *testing.T) {
+		pod1NN := types.NamespacedName{Namespace: "default", Name: "pod1"}
+		pod2NN := types.NamespacedName{Namespace: "default", Name: "pod2"}
+		pod3NN := types.NamespacedName{Namespace: "default", Name: "pod3"}
+
+		endpoints := []fwksched.Endpoint{
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod1NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod2NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod3NN}, &fwkdl.Metrics{}, nil),
+		}
+
+		// pod1: 0 in-flight. Score = 1 - 0/1000 = 1.0
+		// pod2: 500 in-flight. Score = 1 - 500/1000 = 0.5
+		endpoints[1].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 500})
+		// pod3: 1000 in-flight. Score = 1 - 1000/1000 = 0.0
+		endpoints[2].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 1000})
+
+		scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, endpoints)
+
+		assert.InDelta(t, 1.0, scores[endpoints[0]], 0.0001, "Pod1 (0 tokens) should have score 1.0")
+		assert.InDelta(t, 0.5, scores[endpoints[1]], 0.0001, "Pod2 (500 tokens) should have score 0.5")
+		assert.InDelta(t, 0.0, scores[endpoints[2]], 0.0001, "Pod3 (1000 tokens) should have score 0.0")
+	})
+
+	t.Run("in-flight load plus current request impact", func(t *testing.T) {
 		pod1NN := types.NamespacedName{Namespace: "default", Name: "pod1"}
 		pod2NN := types.NamespacedName{Namespace: "default", Name: "pod2"}
 		pod3NN := types.NamespacedName{Namespace: "default", Name: "pod3"}
@@ -51,13 +75,13 @@ func TestTokenLoadScorer(t *testing.T) {
 		}
 
 		// pod1: 0 in-flight + 250 current = 250. Score = 1 - 250/1000 = 0.75
-		endpoints[0].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[0].Put(scorer.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 		// pod2: 250 in-flight + 250 current = 500. Score = 1 - 500/1000 = 0.5
-		endpoints[1].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
-		endpoints[1].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[1].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[1].Put(scorer.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 		// pod3: 750 in-flight + 250 current = 1000. Score = 1 - 1000/1000 = 0.0
-		endpoints[2].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 750})
-		endpoints[2].Put(attrconcurrency.CurrentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[2].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 750})
+		endpoints[2].Put(scorer.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 
 		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
@@ -75,5 +99,20 @@ func TestTokenLoadScorer(t *testing.T) {
 		// No keys set; should score as if 0 token load
 		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with missing keys should have score 1.0 (0 load)")
+	})
+
+	t.Run("typed nil attributes handle gracefully", func(t *testing.T) {
+		podNN := types.NamespacedName{Namespace: "default", Name: "pod-typed-nil"}
+		endpoints := []fwksched.Endpoint{
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podNN}, &fwkdl.Metrics{}, nil),
+		}
+
+		var nilLoad *attrconcurrency.InFlightLoad
+		endpoints[0].Put(scorer.inFlightLoadDataKey.String(), nilLoad)
+		endpoints[0].Put(scorer.currentRequestEndpointImpactDataKey.String(), nilLoad)
+
+		// Typed nils; should score as if 0 token load (no panic)
+		scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, endpoints)
+		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with typed nil attributes should have score 1.0 (0 load)")
 	})
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -33,10 +33,9 @@ func TestTokenLoadScorer(t *testing.T) {
 	threshold := 1000.0
 
 	scorer := &TokenLoadScorer{
-		typedName:                           fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
-		queueThresholdTokens:                threshold,
-		inFlightLoadDataKey:                 attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
-		currentRequestEndpointImpactDataKey: attrconcurrency.CurrentRequestEndpointImpactDataKey.WithNonEmptyProducerName(""),
+		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
+		queueThresholdTokens: threshold,
+		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
 	}
 
 	t.Run("in-flight load only", func(t *testing.T) {
@@ -50,13 +49,13 @@ func TestTokenLoadScorer(t *testing.T) {
 			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod3NN}, &fwkdl.Metrics{}, nil),
 		}
 
-		// pod1: 0 in-flight. Score = 1 - 0/1000 = 1.0
-		// pod2: 500 in-flight. Score = 1 - 500/1000 = 0.5
+		// pod1: 0 in-flight, no current-request impact. Score = 1 - 0/1000 = 1.0
+		// pod2: 500 in-flight, no current-request impact. Score = 1 - 500/1000 = 0.5
 		endpoints[1].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 500})
-		// pod3: 1000 in-flight. Score = 1 - 1000/1000 = 0.0
+		// pod3: 1000 in-flight, no current-request impact. Score = 1 - 1000/1000 = 0.0
 		endpoints[2].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 1000})
 
-		scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, endpoints)
+		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
 		assert.InDelta(t, 1.0, scores[endpoints[0]], 0.0001, "Pod1 (0 tokens) should have score 1.0")
 		assert.InDelta(t, 0.5, scores[endpoints[1]], 0.0001, "Pod2 (500 tokens) should have score 0.5")
@@ -75,13 +74,20 @@ func TestTokenLoadScorer(t *testing.T) {
 		}
 
 		// pod1: 0 in-flight + 250 current = 250. Score = 1 - 250/1000 = 0.75
-		endpoints[0].Put(scorer.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[0].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{
+			Tokens:                0,
+			UncachedRequestTokens: 250,
+		})
 		// pod2: 250 in-flight + 250 current = 500. Score = 1 - 500/1000 = 0.5
-		endpoints[1].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
-		endpoints[1].Put(scorer.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[1].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{
+			Tokens:                250,
+			UncachedRequestTokens: 250,
+		})
 		// pod3: 750 in-flight + 250 current = 1000. Score = 1 - 1000/1000 = 0.0
-		endpoints[2].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 750})
-		endpoints[2].Put(scorer.currentRequestEndpointImpactDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+		endpoints[2].Put(scorer.inFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{
+			Tokens:                750,
+			UncachedRequestTokens: 250,
+		})
 
 		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
@@ -90,18 +96,18 @@ func TestTokenLoadScorer(t *testing.T) {
 		assert.InDelta(t, 0.0, scores[endpoints[2]], 0.0001, "Pod3 (750 + 250 tokens) should have score 0.0")
 	})
 
-	t.Run("missing data keys degrades gracefully", func(t *testing.T) {
+	t.Run("missing data key degrades gracefully", func(t *testing.T) {
 		podNN := types.NamespacedName{Namespace: "default", Name: "pod-no-data"}
 		endpoints := []fwksched.Endpoint{
 			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podNN}, &fwkdl.Metrics{}, nil),
 		}
 
-		// No keys set; should score as if 0 token load
+		// No key set; should score as if 0 token load
 		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
-		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with missing keys should have score 1.0 (0 load)")
+		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with missing key should have score 1.0 (0 load)")
 	})
 
-	t.Run("typed nil attributes handle gracefully", func(t *testing.T) {
+	t.Run("typed nil attribute handles gracefully", func(t *testing.T) {
 		podNN := types.NamespacedName{Namespace: "default", Name: "pod-typed-nil"}
 		endpoints := []fwksched.Endpoint{
 			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podNN}, &fwkdl.Metrics{}, nil),
@@ -109,10 +115,9 @@ func TestTokenLoadScorer(t *testing.T) {
 
 		var nilLoad *attrconcurrency.InFlightLoad
 		endpoints[0].Put(scorer.inFlightLoadDataKey.String(), nilLoad)
-		endpoints[0].Put(scorer.currentRequestEndpointImpactDataKey.String(), nilLoad)
 
-		// Typed nils; should score as if 0 token load (no panic)
-		scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, endpoints)
-		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with typed nil attributes should have score 1.0 (0 load)")
+		// Typed nil; should score as if 0 token load (no panic)
+		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with typed nil attribute should have score 1.0 (0 load)")
 	})
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -36,6 +36,7 @@ func TestTokenLoadScorer(t *testing.T) {
 		typedName:            fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
 		queueThresholdTokens: threshold,
 		inFlightLoadDataKey:  attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
+		currentRequestLoadDK: attrconcurrency.CurrentRequestLoadDataKey.WithNonEmptyProducerName(""),
 	}
 
 	pod1NN := types.NamespacedName{Namespace: "default", Name: "pod1"}
@@ -48,15 +49,18 @@ func TestTokenLoadScorer(t *testing.T) {
 		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod3NN}, &fwkdl.Metrics{}, nil),
 	}
 
-	// pod1: 0 tokens (default)
-	// pod2: 500 tokens
-	endpoints[1].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 500})
-	// pod3: 1000 tokens
-	endpoints[2].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 1000})
+	// pod1: 0 in-flight + 250 current = 250. Score = 1 - 250/1000 = 0.75
+	endpoints[0].Put(attrconcurrency.CurrentRequestLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+	// pod2: 250 in-flight + 250 current = 500. Score = 1 - 500/1000 = 0.5
+	endpoints[1].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+	endpoints[1].Put(attrconcurrency.CurrentRequestLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
+	// pod3: 750 in-flight + 250 current = 1000. Score = 1 - 1000/1000 = 0.0
+	endpoints[2].Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 750})
+	endpoints[2].Put(attrconcurrency.CurrentRequestLoadDataKey.String(), &attrconcurrency.InFlightLoad{Tokens: 250})
 
 	scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
-	assert.InDelta(t, 1.0, scores[endpoints[0]], 0.0001, "Pod1 (0 tokens) should have score 1.0")
-	assert.InDelta(t, 0.5, scores[endpoints[1]], 0.0001, "Pod2 (500 tokens) should have score 0.5")
-	assert.InDelta(t, 0.0, scores[endpoints[2]], 0.0001, "Pod3 (1000 tokens) should have score 0.0")
+	assert.InDelta(t, 0.75, scores[endpoints[0]], 0.0001, "Pod1 (0 + 250 tokens) should have score 0.75")
+	assert.InDelta(t, 0.5, scores[endpoints[1]], 0.0001, "Pod2 (250 + 250 tokens) should have score 0.5")
+	assert.InDelta(t, 0.0, scores[endpoints[2]], 0.0001, "Pod3 (750 + 250 tokens) should have score 0.0")
 }


### PR DESCRIPTION
## What does this PR do?

Extends the `InFlightLoadProducer` and `TokenLoadScorer` to factor the *currently scheduling request's* projected impact into endpoint load scoring, in addition to the existing in-flight load. Without this, load-aware scorers see only past commitments — a 50-token completion and a 5000-token long-context request look identical when scoring an endpoint, and big requests can pile onto already-saturated endpoints.

The projection is per-endpoint: each candidate gets a value that accounts for that endpoint's prefix-cache hit rate, so endpoints with better cache fit for this prompt naturally appear cheaper.

## Design

A new field `UncachedRequestTokens` is added to `attrconcurrency.InFlightLoad`:

```go
type InFlightLoad struct {
    Tokens                int64  // past commitments: accumulated across in-flight requests
    Requests              int64  // past commitments: accumulated across in-flight requests
    UncachedRequestTokens int64  // speculative: this request's projected impact on this endpoint
}
```

Two semantically distinct values share one struct, transported through one data key (`InFlightLoadDataKey`):

- **`Tokens` / `Requests`** — *past commitments.* Updated by `PreRequest` (when the scheduler picks an endpoint) and decremented by `OnEvicted` (when the request's stream ends). The exact contribution per request is remembered in PluginState so the decrement is a perfect undo.
- **`UncachedRequestTokens`** — *speculative projection.* Computed fresh by `InFlightLoadProducer.Produce` each scheduling cycle from the request being scored and the endpoint's prefix-cache state. Never committed to endpoint state, never decremented — once the cycle ends, the value is discarded.

`TokenLoadScorer.Score` sums them: `tokenLoad := load.Tokens + load.UncachedRequestTokens`. Endpoints with better prefix-cache fit get lower `UncachedRequestTokens` (less uncached work) and thus score higher.

### Why both values share one struct

`Tokens` is what the endpoint *has committed to*. `UncachedRequestTokens` is what the endpoint *would commit to* if the scheduler picks it. The field doc strings document the lifecycle distinction explicitly. Carrying both on the same struct means scorers see a complete per-endpoint load picture from a single data key without needing to assemble two values.

### Why a single source of truth for the projection

`UncachedRequestTokens` could equivalently be computed inside any scorer that needs it. It's produced once, in `InFlightLoadProducer.Produce`, so every consumer reads the same value — single source of truth for the current request's per-endpoint impact, consistent across scorers, with the estimation logic owned in one place. The producer also reuses the same helper (`estimateRequestTokens`) in `PreRequest` to compute the committed value, guaranteeing the projection and the eventual commitment use identical math.

## What changed

**`pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go`**
- Added `UncachedRequestTokens int64` field to `InFlightLoad`
- Switched `Clone` to the value-copy idiom (`cp := *l; return &cp`) so future field additions can't be silently dropped
- Per-field doc strings making the past-commitment vs. speculative-projection distinction explicit

**`pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go`**
- `Produce` populates all three fields in a single `Put` per endpoint; `UncachedRequestTokens` is set only when a request is in scope
- New `estimateRequestTokens` helper consolidates the per-endpoint impact calculation, used by both `Produce` and `PreRequest`

**`pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go`**
- `Score` reads the `InFlightLoad` attribute and sums `Tokens + UncachedRequestTokens`
- Typed-nil guard on the deserialized `*InFlightLoad` so a nil-stored attribute can't panic

**Tests**
- Split `TestTokenLoadScorer` into named subtests:
  - `in-flight load only` — committed in-flight load alone produces correct scores
  - `in-flight load plus current request impact` — both contributors add to the score
  - `missing data key degrades gracefully` — absent attribute scores as zero load (1.0)
  - `typed nil attribute handles gracefully` — typed-nil `*InFlightLoad` doesn't panic, scores as zero load

## Behavior

For deployments not running any load-aware scorer that reads `UncachedRequestTokens`, this is a no-op: the field is populated but unread. For deployments running `TokenLoadScorer`, scoring now reflects request-aware load, so large requests will naturally route away from already-busy endpoints and toward endpoints with favorable prefix-cache state.

## Testing

- `go test ./pkg/epp/framework/plugins/datalayer/attribute/concurrency/... -race`
- `go test ./pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/... -race`
- `go test ./pkg/epp/framework/plugins/scheduling/scorer/tokenload/... -race`

New `TestTokenLoadScorer` subtests cover the new contribution path, the missing-key case, and the typed-nil case.
