### PR TITLE
fix(test): only reuse same kind cluster if kube current-context is set to it

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -23,7 +23,9 @@ SIM_IMAGE="${VLLM_IMAGE:-ghcr.io/llm-d/llm-d-inference-sim:v0.8.2}"
 MANIFEST_PATH="${MANIFEST_PATH:-${DIR}/../test/testdata/sim-deployment.yaml}"
 USE_KIND="${USE_KIND:-true}"
 
-# Tracks the name of a Kind cluster created by this script so cleanup knows
+KIND_CLUSTER_NAME="inference-e2e"
+
+# Tracks whether this script created the cluster so cleanup knows
 # whether to delete it (we never delete a cluster we didn't create ourselves).
 CREATED_CLUSTER=""
 
@@ -60,16 +62,18 @@ trap cleanup INT TERM
 
 if [ "${USE_KIND}" = "true" ]; then
   install_kind
-  if ! kubectl config current-context >/dev/null 2>&1; then
-    echo "No active kubecontext found. Creating a kind cluster for running the tests..."
-    kind create cluster --name inference-e2e
-    CREATED_CLUSTER=inference-e2e
-    load_images inference-e2e
+  current_context=$(kubectl config current-context 2>/dev/null || true)
+  if [ "${current_context}" = "kind-${KIND_CLUSTER_NAME}" ]; then
+    echo "Found an active kind cluster '${KIND_CLUSTER_NAME}' for running the tests..."
+    load_images "${KIND_CLUSTER_NAME}"
   else
-    current_context=$(kubectl config current-context)
-    current_kind_cluster="${current_context#kind-}"
-    echo "Found an active kind cluster '${current_kind_cluster}' for running the tests..."
-    load_images "${current_kind_cluster}"
+    if [ -n "${current_context}" ]; then
+      echo "WARNING: current kubecontext '${current_context}' is not kind-${KIND_CLUSTER_NAME}, ignoring it."
+    fi
+    echo "Creating kind cluster '${KIND_CLUSTER_NAME}' for running the tests..."
+    kind create cluster --name "${KIND_CLUSTER_NAME}"
+    CREATED_CLUSTER="${KIND_CLUSTER_NAME}"
+    load_images "${KIND_CLUSTER_NAME}"
   fi
 else
   # USE_KIND=false: caller is responsible for loading images into the cluster.

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -68,11 +68,17 @@ if [ "${USE_KIND}" = "true" ]; then
     load_images "${KIND_CLUSTER_NAME}"
   else
     if [ -n "${current_context}" ]; then
-      echo "WARNING: current kubecontext '${current_context}' is not kind-${KIND_CLUSTER_NAME}, ignoring it."
+      echo "WARNING: current kubecontext '${current_context}' is not kind-${KIND_CLUSTER_NAME}, wont use it." >&2
     fi
-    echo "Creating kind cluster '${KIND_CLUSTER_NAME}' for running the tests..."
-    kind create cluster --name "${KIND_CLUSTER_NAME}"
-    CREATED_CLUSTER="${KIND_CLUSTER_NAME}"
+    # if the cluster already exists but isn't the current context
+    if kind get clusters 2>/dev/null | grep -qx "${KIND_CLUSTER_NAME}"; then
+      echo "Found existing kind cluster '${KIND_CLUSTER_NAME}', switching context..."
+      kubectl config use-context "kind-${KIND_CLUSTER_NAME}"
+    else
+      echo "Creating new kind cluster '${KIND_CLUSTER_NAME}' for running the tests..."
+      kind create cluster --name "${KIND_CLUSTER_NAME}"
+      CREATED_CLUSTER="${KIND_CLUSTER_NAME}"
+    fi
     load_images "${KIND_CLUSTER_NAME}"
   fi
 else


### PR DESCRIPTION
- do not try to use other cluster for e2e test if current-context is set

**What type of PR is this?**
/kind bug



**What this PR does / why we need it**:
when i did "make test-e2e" for another PR, i had logined to an openshift cluster.
script detected that my context is set then it started use that one for e2e
the fix it explictliy to check if kind-inference-e2e exist and get set as current-context 
- yes: reuse this one
- other case: create one

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
