### PR TITLE
ci: drop pull_request_target from PR checks workflow

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -8,10 +8,6 @@ on:
   pull_request:
     branches:
       - main
-  pull_request_target:
-    branches:
-      - main
-    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: read
@@ -23,12 +19,6 @@ concurrency:
 
 jobs:
   check-changes:
-    # pull_request_target fires even when GITHUB_TOKEN creates the PR (e.g. the
-    # release-notes bot). pull_request does not. We register pull_request_target
-    # so bot-created PRs get a "skipped" conclusion that satisfies branch
-    # protection, but we skip all real work: pull_request already covers human
-    # PRs, and running twice would cause the concurrency group to cancel one run.
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The PR-checks workflow registers both `pull_request` and `pull_request_target` and skips the latter via an `if:` guard, which leaves a duplicate SKIPPED check row on every PR. The dual-event registration was a workaround for bot PRs created with `GITHUB_TOKEN` (which does not fire `pull_request`); both PR-creating workflows in this repo now use App-installation tokens, which do fire `pull_request`, so `pull_request_target` is redundant.

**Which issue(s) this PR fixes**:
NA

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
