### PR TITLE
docs: backfill release-note fragments for PRs #1030, #1218, #1276

### DIFF
--- a/release-notes.d/unreleased/1030.md
+++ b/release-notes.d/unreleased/1030.md
@@ -1,0 +1,7 @@
+---
+pr: 1030
+url: https://github.com/llm-d/llm-d-router/pull/1030
+author: kaushikmitr
+date: 2026-05-25
+---
+InFlightLoadProducer now reliably tracks global token and request counts in the presence of timeouts, disconnects, and long-lived streams.

--- a/release-notes.d/unreleased/1218.md
+++ b/release-notes.d/unreleased/1218.md
@@ -1,0 +1,7 @@
+---
+pr: 1218
+url: https://github.com/llm-d/llm-d-router/pull/1218
+author: ezrasilvera
+date: 2026-05-25
+---
+EPP can now run without a Kubernetes cluster. When `dataLayer.discovery.pluginRef` is set, the runner skips controller-manager setup and drives endpoint discovery through the file-discovery plugin ("file-discovery"). See pkg/epp/framework/plugins/datalayer/discovery/file/README.md for more details.

--- a/release-notes.d/unreleased/1218.md
+++ b/release-notes.d/unreleased/1218.md
@@ -4,4 +4,4 @@ url: https://github.com/llm-d/llm-d-router/pull/1218
 author: ezrasilvera
 date: 2026-05-25
 ---
-EPP can now run without a Kubernetes cluster. When `dataLayer.discovery.pluginRef` is set, the runner skips controller-manager setup and drives endpoint discovery through the file-discovery plugin ("file-discovery"). See pkg/epp/framework/plugins/datalayer/discovery/file/README.md for more details.
+EPP can now run without a Kubernetes cluster. When `dataLayer.discovery.pluginRef` is set, the runner skips controller-manager setup and drives endpoint discovery through the file-discovery plugin ("file-discovery"). See docs/discovery.md and pkg/epp/framework/plugins/datalayer/discovery/file/README.md for more details.

--- a/release-notes.d/unreleased/1276.md
+++ b/release-notes.d/unreleased/1276.md
@@ -1,0 +1,7 @@
+---
+pr: 1276
+url: https://github.com/llm-d/llm-d-router/pull/1276
+author: zhouyou9505
+date: 2026-05-25
+---
+Fix cached prompt-token usage extraction in the EPP OpenAI parser. `cached_tokens` is now read from `usage.prompt_tokens_details` (and from `usage.input_tokens_details` for the Responses API), so prompt cache-hit metrics are recorded instead of being silently dropped.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
Adds release-note fragments for three PRs that did not include a `release-note` block in their description, but may have user facing implications.

The wording is a best-guess summary derived from each PR's description. Original authors are encouraged to review and suggest amendments to this branch if the phrasing should change before assembly.

cc @kaushikmitr (#1030), @ezrasilvera (#1218), @zhouyou9505 (#1276)

**Which issue(s) this PR fixes**:
NA

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
