### PR TITLE
ci: cache vllm-openai-cpu image across e2e run

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -245,6 +245,45 @@ jobs:
         shell: bash
         run: docker system prune -af
 
+      # Cache the vllm rendering image across runs so e2e does not re-pull it
+      # from Docker Hub every time. Must run after `docker system prune -af`
+      # above, which would otherwise wipe the loaded image.
+      - name: Resolve VLLM_RENDER_IMAGE
+        id: vllm-image
+        shell: bash
+        run: |
+          set -euo pipefail
+          image=$(make -s env | awk -F= '/^VLLM_RENDER_IMAGE=/{print $2}')
+          [[ -n "$image" ]] || { echo "Could not resolve VLLM_RENDER_IMAGE from 'make env'"; exit 1; }
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      - name: Cache vllm rendering image
+        id: vllm-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/vllm-render-image.tar
+          key: docker-${{ steps.vllm-image.outputs.image }}
+
+      - name: Load or pull vllm rendering image
+        shell: bash
+        env:
+          VLLM_RENDER_IMAGE: ${{ steps.vllm-image.outputs.image }}
+          IMAGE_TAR: ${{ runner.temp }}/vllm-render-image.tar
+          CACHE_HIT: ${{ steps.vllm-cache.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [[ "$CACHE_HIT" == "true" ]]; then
+            docker load -i "$IMAGE_TAR"
+            # Cache is already populated; drop the tarball to free disk for kind.
+            rm -f "$IMAGE_TAR"
+          else
+            docker pull "$VLLM_RENDER_IMAGE"
+            # Stage to .tmp so an interrupted save cannot publish a partial tar
+            # that would poison the cache for subsequent runs.
+            docker save "$VLLM_RENDER_IMAGE" -o "$IMAGE_TAR.tmp"
+            mv "$IMAGE_TAR.tmp" "$IMAGE_TAR"
+          fi
+
       - name: Run make test-e2e
         shell: bash
         run: make test-e2e


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
## Summary

Cache the `vllm/vllm-openai-cpu` rendering image between e2e runs in the
`lint-and-test` job so PR CI does not re-pull a multi-hundred-MB image from
Docker Hub on every push.

The image is needed by `make test-e2e` via `make image-pull` →
`scripts/pull_images.sh`. Today every PR run downloads it fresh, then
`docker system prune -af` (added in #915 to free disk for kind) wipes any
copy the runner might have retained.



### Why we cache only `vllm-openai-cpu`

`make image-pull` also fetches `ghcr.io/llm-d/llm-d-inference-sim:v0.8.2`,
`ghcr.io/llm-d/llm-d-uds-tokenizer:dev`, and the EPP / sidecar images. Of
these, only `vllm-openai-cpu:v0.19.1` is worth caching:

- **`uds-tokenizer:dev` and the EPP / sidecar `dev` images** — `dev` is a
  moving tag. Caching by tag would serve stale bits; the EPP / sidecar are
  also rebuilt locally every run from the PR's source, so a cache could only
  ever be wrong.
- **`inference-sim:v0.8.2`** — pinned tag, so cacheable in principle, but
  pulled from GHCR (much higher rate limits than Docker Hub, faster from
  GitHub-hosted runners) and small (Go binary in a slim base). Wall-time
  savings would be seconds per run; not worth the extra workflow surface.
- **`vllm-openai-cpu:v0.19.1`** — pinned tag, pulled from Docker Hub
  (anonymous rate limits, slower mirror), and multi-hundred-MB. Highest
  payoff by a wide margin.

**Which issue(s) this PR fixes**:
Fixes #1328


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
