### PR TITLE
refactor: flow control, move plugin resolution into the config loader

### DIFF
--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -174,7 +174,7 @@ func InstantiateAndConfigure(
 	var flowControlConfig *flowcontrol.Config
 	if featureGates[flowcontrol.FeatureGate] {
 		var err error
-		flowControlConfig, err = flowcontrol.NewConfigFromAPI(rawConfig.FlowControl, handle)
+		flowControlConfig, err = buildFlowControlConfig(rawConfig.FlowControl, handle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load flow control config: %w", err)
 		}

--- a/pkg/epp/config/loader/flowcontrol.go
+++ b/pkg/epp/config/loader/flowcontrol.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/flowcontrol.go
+++ b/pkg/epp/config/loader/flowcontrol.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/controller"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
+	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// buildFlowControlConfig resolves all flow-control policy plugins
+// and returns the Config.
+func buildFlowControlConfig(
+	apiConfig *configapi.FlowControlConfig,
+	handle fwkplugin.Handle,
+) (*flowcontrol.Config, error) {
+	defaults, err := buildPriorityBandPolicyDefaults(handle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve default flow-control policies: %w", err)
+	}
+
+	registryConfig, err := buildRegistryConfig(apiConfig, defaults, handle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create registry config: %w", err)
+	}
+
+	ctrlCfg, err := controller.NewConfigFromAPI(apiConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create controller config: %w", err)
+	}
+
+	usageLimitRef := registry.DefaultUsageLimitPolicyRef
+	if apiConfig != nil && apiConfig.UsageLimitPolicyPluginRef != "" {
+		usageLimitRef = apiConfig.UsageLimitPolicyPluginRef
+	}
+	usageLimitPolicy, err := resolvePlugin[fwkfc.UsageLimitPolicy](handle, usageLimitRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve usage limit policy: %w", err)
+	}
+
+	return flowcontrol.NewConfig(ctrlCfg, registryConfig, usageLimitPolicy), nil
+}
+
+func buildPriorityBandPolicyDefaults(handle fwkplugin.Handle) (registry.PriorityBandPolicyDefaults, error) {
+	orderingPolicy, err := resolvePlugin[fwkfc.OrderingPolicy](handle, registry.DefaultOrderingPolicyRef)
+	if err != nil {
+		return registry.PriorityBandPolicyDefaults{}, err
+	}
+	fairnessPolicy, err := resolvePlugin[fwkfc.FairnessPolicy](handle, registry.DefaultFairnessPolicyRef)
+	if err != nil {
+		return registry.PriorityBandPolicyDefaults{}, err
+	}
+
+	return registry.PriorityBandPolicyDefaults{
+		OrderingPolicy: orderingPolicy,
+		FairnessPolicy: fairnessPolicy,
+	}, nil
+}
+
+// buildRegistryConfig translates the API flow-control configuration into a
+// registry.Config, resolving per-band policy overrides via the handle.
+func buildRegistryConfig(
+	apiConfig *configapi.FlowControlConfig,
+	defaults registry.PriorityBandPolicyDefaults,
+	handle fwkplugin.Handle,
+) (*registry.Config, error) {
+	if apiConfig == nil {
+		return registry.NewConfig(defaults)
+	}
+
+	opts := make([]registry.ConfigOption, 0, len(apiConfig.PriorityBands)+3)
+
+	maxBytes, err := resolveQuantity(apiConfig.MaxBytes, "global MaxBytes")
+	if err != nil {
+		return nil, err
+	}
+	if maxBytes > 0 {
+		opts = append(opts, registry.WithMaxBytes(maxBytes))
+	}
+
+	maxRequests, err := resolveQuantity(apiConfig.MaxRequests, "global MaxRequests")
+	if err != nil {
+		return nil, err
+	}
+	if maxRequests > 0 {
+		opts = append(opts, registry.WithMaxRequests(maxRequests))
+	}
+
+	if apiConfig.DefaultPriorityBand != nil {
+		pb, err := buildPriorityBand(defaults, handle, apiConfig.DefaultPriorityBand)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, registry.WithDefaultPriorityBand(pb))
+	}
+
+	if apiConfig.DefaultNegativePriorityBand != nil {
+		pb, err := buildPriorityBand(defaults, handle, apiConfig.DefaultNegativePriorityBand)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, registry.WithDefaultNegativePriorityBand(pb))
+	}
+
+	for _, band := range apiConfig.PriorityBands {
+		pb, err := buildPriorityBand(defaults, handle, &band)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, registry.WithPriorityBand(pb))
+	}
+
+	return registry.NewConfig(defaults, opts...)
+}
+
+// buildPriorityBand translates a single API PriorityBandConfig into a registry.PriorityBandConfig,
+// resolving any per-band policy overrides via the handle.
+func buildPriorityBand(
+	defaults registry.PriorityBandPolicyDefaults,
+	handle fwkplugin.Handle,
+	band *configapi.PriorityBandConfig,
+) (*registry.PriorityBandConfig, error) {
+	bandOpts := make([]registry.PriorityBandConfigOption, 0, 4)
+
+	maxBytes, err := resolveQuantity(band.MaxBytes, fmt.Sprintf("priority band %d MaxBytes", band.Priority))
+	if err != nil {
+		return nil, err
+	}
+	if maxBytes > 0 {
+		bandOpts = append(bandOpts, registry.WithBandMaxBytes(maxBytes))
+	}
+
+	maxRequests, err := resolveQuantity(band.MaxRequests, fmt.Sprintf("priority band %d MaxRequests", band.Priority))
+	if err != nil {
+		return nil, err
+	}
+	if maxRequests > 0 {
+		bandOpts = append(bandOpts, registry.WithBandMaxRequests(maxRequests))
+	}
+
+	if band.OrderingPolicyRef != "" {
+		policy, err := resolvePlugin[fwkfc.OrderingPolicy](handle, band.OrderingPolicyRef)
+		if err != nil {
+			return nil, err
+		}
+		bandOpts = append(bandOpts, registry.WithOrderingPolicy(policy))
+	}
+	if band.FairnessPolicyRef != "" {
+		policy, err := resolvePlugin[fwkfc.FairnessPolicy](handle, band.FairnessPolicyRef)
+		if err != nil {
+			return nil, err
+		}
+		bandOpts = append(bandOpts, registry.WithFairnessPolicy(policy))
+	}
+
+	pb, err := registry.NewPriorityBandConfig(band.Priority, defaults, bandOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create priority band config for priority %d: %w", band.Priority, err)
+	}
+	return pb, nil
+}
+
+func resolveQuantity(q *resource.Quantity, fieldName string) (uint64, error) {
+	if q == nil {
+		return 0, nil
+	}
+	v := q.Value()
+	if v < 0 {
+		return 0, fmt.Errorf("%s must be non-negative, got %d", fieldName, v)
+	}
+	return uint64(v), nil
+}
+
+// resolvePlugin looks up a plugin by name in the handle and asserts its type.
+func resolvePlugin[T fwkplugin.Plugin](handle fwkplugin.Handle, ref string) (T, error) {
+	var zero T
+	v := handle.Plugin(ref)
+	if v == nil {
+		return zero, fmt.Errorf("plugin %q not found", ref)
+	}
+	typed, ok := v.(T)
+	if !ok {
+		return zero, fmt.Errorf("plugin %q does not implement %T (actual type: %T)", ref, zero, v)
+	}
+	return typed, nil
+}

--- a/pkg/epp/config/loader/flowcontrol.go
+++ b/pkg/epp/config/loader/flowcontrol.go
@@ -108,7 +108,7 @@ func buildRegistryConfig(
 	}
 
 	if apiConfig.DefaultPriorityBand != nil {
-		pb, err := buildPriorityBand(defaults, handle, apiConfig.DefaultPriorityBand)
+		pb, err := buildPriorityBand(defaults, handle, apiConfig.DefaultPriorityBand, "default priority band")
 		if err != nil {
 			return nil, err
 		}
@@ -116,15 +116,17 @@ func buildRegistryConfig(
 	}
 
 	if apiConfig.DefaultNegativePriorityBand != nil {
-		pb, err := buildPriorityBand(defaults, handle, apiConfig.DefaultNegativePriorityBand)
+		pb, err := buildPriorityBand(defaults, handle, apiConfig.DefaultNegativePriorityBand, "default negative priority band")
 		if err != nil {
 			return nil, err
 		}
 		opts = append(opts, registry.WithDefaultNegativePriorityBand(pb))
 	}
 
-	for _, band := range apiConfig.PriorityBands {
-		pb, err := buildPriorityBand(defaults, handle, &band)
+	for i := range apiConfig.PriorityBands {
+		band := &apiConfig.PriorityBands[i]
+		label := fmt.Sprintf("priority band %d", band.Priority)
+		pb, err := buildPriorityBand(defaults, handle, band, label)
 		if err != nil {
 			return nil, err
 		}
@@ -135,15 +137,17 @@ func buildRegistryConfig(
 }
 
 // buildPriorityBand translates a single API PriorityBandConfig into a registry.PriorityBandConfig,
-// resolving any per-band policy overrides via the handle.
+// resolving any per-band policy overrides via the handle. The label is used in error messages
+// (e.g., "default priority band", "priority band 5").
 func buildPriorityBand(
 	defaults registry.PriorityBandPolicyDefaults,
 	handle fwkplugin.Handle,
 	band *configapi.PriorityBandConfig,
+	label string,
 ) (*registry.PriorityBandConfig, error) {
 	bandOpts := make([]registry.PriorityBandConfigOption, 0, 4)
 
-	maxBytes, err := resolveQuantity(band.MaxBytes, fmt.Sprintf("priority band %d MaxBytes", band.Priority))
+	maxBytes, err := resolveQuantity(band.MaxBytes, label+" MaxBytes")
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +155,7 @@ func buildPriorityBand(
 		bandOpts = append(bandOpts, registry.WithBandMaxBytes(maxBytes))
 	}
 
-	maxRequests, err := resolveQuantity(band.MaxRequests, fmt.Sprintf("priority band %d MaxRequests", band.Priority))
+	maxRequests, err := resolveQuantity(band.MaxRequests, label+" MaxRequests")
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +180,7 @@ func buildPriorityBand(
 
 	pb, err := registry.NewPriorityBandConfig(band.Priority, defaults, bandOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create priority band config for priority %d: %w", band.Priority, err)
+		return nil, fmt.Errorf("failed to create %s config: %w", label, err)
 	}
 	return pb, nil
 }

--- a/pkg/epp/config/loader/flowcontrol_test.go
+++ b/pkg/epp/config/loader/flowcontrol_test.go
@@ -236,7 +236,7 @@ func TestBuildRegistryConfig(t *testing.T) {
 					MaxBytes: ptr.To(resource.MustParse("-5")),
 				},
 			},
-			expectedErr: "MaxBytes must be non-negative",
+			expectedErr: "default priority band MaxBytes must be non-negative",
 		},
 
 		// --- MaxRequests: Happy Paths ---
@@ -359,7 +359,7 @@ func TestBuildRegistryConfig(t *testing.T) {
 					MaxRequests: ptr.To(resource.MustParse("-5")),
 				},
 			},
-			expectedErr: "MaxRequests must be non-negative",
+			expectedErr: "default priority band MaxRequests must be non-negative",
 		},
 
 		// --- DefaultNegativePriorityBand ---
@@ -399,7 +399,7 @@ func TestBuildRegistryConfig(t *testing.T) {
 					MaxBytes: ptr.To(resource.MustParse("-1")),
 				},
 			},
-			expectedErr: "MaxBytes must be non-negative",
+			expectedErr: "default negative priority band MaxBytes must be non-negative",
 		},
 	}
 

--- a/pkg/epp/config/loader/flowcontrol_test.go
+++ b/pkg/epp/config/loader/flowcontrol_test.go
@@ -1,0 +1,603 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
+	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	fwkfcmocks "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/edf"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
+	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
+)
+
+func newFlowControlTestHandle(t *testing.T) fwkplugin.Handle {
+	t.Helper()
+	handle := igwtestutils.NewTestHandle(t.Context())
+	handle.AddPlugin(globalstrict.GlobalStrictFairnessPolicyType, &fwkfcmocks.MockFairnessPolicy{
+		TypedNameV: fwkplugin.TypedName{
+			Type: globalstrict.GlobalStrictFairnessPolicyType,
+			Name: globalstrict.GlobalStrictFairnessPolicyType,
+		},
+	})
+	handle.AddPlugin(roundrobin.RoundRobinFairnessPolicyType, &fwkfcmocks.MockFairnessPolicy{
+		TypedNameV: fwkplugin.TypedName{
+			Type: roundrobin.RoundRobinFairnessPolicyType,
+			Name: roundrobin.RoundRobinFairnessPolicyType,
+		},
+	})
+	handle.AddPlugin(fcfs.FCFSOrderingPolicyType, &fwkfcmocks.MockOrderingPolicy{
+		TypedNameV: fwkplugin.TypedName{
+			Type: fcfs.FCFSOrderingPolicyType,
+			Name: fcfs.FCFSOrderingPolicyType,
+		},
+	})
+	handle.AddPlugin(edf.EDFOrderingPolicyType, &fwkfcmocks.MockOrderingPolicy{
+		TypedNameV: fwkplugin.TypedName{
+			Type: edf.EDFOrderingPolicyType,
+			Name: edf.EDFOrderingPolicyType,
+		},
+		RequiredQueueCapabilitiesV: []fwkfc.QueueCapability{fwkfc.CapabilityPriorityConfigurable},
+	})
+	handle.AddPlugin(usagelimits.StaticUsageLimitPolicyType, usagelimits.DefaultPolicy())
+	return handle
+}
+
+func TestBuildRegistryConfig(t *testing.T) {
+	t.Parallel()
+	handle := newFlowControlTestHandle(t)
+	defaults, err := buildPriorityBandPolicyDefaults(handle)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name        string
+		apiConfig   *configapi.FlowControlConfig
+		assertion   func(*testing.T, *registry.Config)
+		expectedErr string
+	}{
+		// --- Happy Paths ---
+		{
+			name: "ShouldSucceed_WithFullConfiguration",
+			apiConfig: &configapi.FlowControlConfig{
+				MaxBytes: ptr.To(resource.MustParse("100")),
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority: 1,
+						MaxBytes: ptr.To(resource.MustParse("50")),
+					},
+				},
+				DefaultPriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("10")),
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				assert.Equal(t, uint64(100), cfg.MaxBytes, "Global MaxBytes should be correctly translated")
+
+				// Verify Explicit Band
+				require.Contains(t, cfg.PriorityBands, 1, "Configured priority band should be present")
+				assert.Equal(t, uint64(50), cfg.PriorityBands[1].MaxBytes, "Band MaxBytes should be correctly translated")
+
+				// Verify Default Template
+				require.NotNil(t, cfg.DefaultPriorityBand, "DefaultPriorityBand should be configured")
+				assert.Equal(t, uint64(10), cfg.DefaultPriorityBand.MaxBytes,
+					"DefaultPriorityBand template MaxBytes should be translated")
+			},
+		},
+		{
+			name: "ShouldSucceed_WithKubernetesQuantityFormat",
+			apiConfig: &configapi.FlowControlConfig{
+				MaxBytes: ptr.To(resource.MustParse("1Gi")),
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority: 1,
+						MaxBytes: ptr.To(resource.MustParse("500Mi")),
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				assert.Equal(t, uint64(1073741824), cfg.MaxBytes,
+					"1Gi should be correctly parsed as 1073741824 bytes")
+				require.Contains(t, cfg.PriorityBands, 1)
+				assert.Equal(t, uint64(524288000), cfg.PriorityBands[1].MaxBytes,
+					"500Mi should be correctly parsed as 524288000 bytes")
+			},
+		},
+		{
+			name: "ShouldSucceed_WithPolicyReferences",
+			apiConfig: &configapi.FlowControlConfig{
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority:          1,
+						OrderingPolicyRef: edf.EDFOrderingPolicyType,
+						FairnessPolicyRef: roundrobin.RoundRobinFairnessPolicyType,
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.Contains(t, cfg.PriorityBands, 1, "Configured priority band should be present")
+				band := cfg.PriorityBands[1]
+				assert.Equal(t, edf.EDFOrderingPolicyType, band.OrderingPolicy.TypedName().Name,
+					"OrderingPolicy should be correctly translated")
+				assert.Equal(t, roundrobin.RoundRobinFairnessPolicyType, band.FairnessPolicy.TypedName().Name,
+					"FairnessPolicy should be correctly translated")
+			},
+		},
+		{
+			name:      "ShouldSucceed_WithNilConfig_AndApplySystemDefaults",
+			apiConfig: nil,
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				assert.Equal(t, uint64(0), cfg.MaxBytes, "Default global limit should be 0 (unlimited)")
+				require.NotNil(t, cfg.DefaultPriorityBand,
+					"Default priority band template should be initialized automatically")
+				assert.Equal(t, uint64(1_000_000_000) /* registry default: 1 GB */, cfg.DefaultPriorityBand.MaxBytes,
+					"Default template should use system default capacity")
+			},
+		},
+
+		// --- Defaulting Logic (Nil vs Zero) ---
+		{
+			name: "ShouldApplyDefault_WhenBandMaxBytesIsNil",
+			apiConfig: &configapi.FlowControlConfig{
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority: 1,
+						// MaxBytes and MaxRequests omitted
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.Contains(t, cfg.PriorityBands, 1)
+				assert.Equal(t, uint64(1_000_000_000) /* registry default: 1 GB */, cfg.PriorityBands[1].MaxBytes,
+					"Omitted MaxBytes (nil) should result in system default capacity (1GB)")
+			},
+		},
+		{
+			name: "ShouldApplyDefault_WhenBandMaxBytesIsZero",
+			apiConfig: &configapi.FlowControlConfig{
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority: 1,
+						MaxBytes: ptr.To(resource.MustParse("0")), // Explicitly zero,
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.Contains(t, cfg.PriorityBands, 1)
+				assert.Equal(t, uint64(1_000_000_000) /* registry default: 1 GB */, cfg.PriorityBands[1].MaxBytes,
+					"Explicit MaxBytes (0) should be treated as 'Use Default' (1GB)")
+			},
+		},
+		{
+			name: "ShouldApplyDefault_WhenDefaultPriorityBandMaxBytesIsZero",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultPriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("0")), // Explicitly zero,
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.NotNil(t, cfg.DefaultPriorityBand)
+				assert.Equal(t, uint64(1_000_000_000) /* registry default: 1 GB */, cfg.DefaultPriorityBand.MaxBytes,
+					"Explicit 0 in DefaultPriorityBand template should be treated as 'Use Default'")
+			},
+		},
+
+		// --- Validation Errors ---
+		{
+			name: "ShouldError_WithNegativeGlobalMaxBytes",
+			apiConfig: &configapi.FlowControlConfig{
+				MaxBytes: ptr.To(resource.MustParse("-1")),
+			},
+			expectedErr: "global MaxBytes must be non-negative",
+		},
+		{
+			name: "ShouldError_WithNegativePriorityBandMaxBytes",
+			apiConfig: &configapi.FlowControlConfig{
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority: 1,
+						MaxBytes: ptr.To(resource.MustParse("-100")),
+					},
+				},
+			},
+			expectedErr: "priority band 1 MaxBytes must be non-negative",
+		},
+		{
+			name: "ShouldError_WithNegativeDefaultPriorityBandMaxBytes",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultPriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("-5")),
+				},
+			},
+			expectedErr: "MaxBytes must be non-negative",
+		},
+
+		// --- MaxRequests: Happy Paths ---
+		{
+			name: "ShouldSucceed_WithMaxBytesAndMaxRequests",
+			apiConfig: &configapi.FlowControlConfig{
+				MaxBytes:    ptr.To(resource.MustParse("1Gi")),
+				MaxRequests: ptr.To(resource.MustParse("5000")),
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority:    100,
+						MaxBytes:    ptr.To(resource.MustParse("1Gi")),
+						MaxRequests: ptr.To(resource.MustParse("5000")),
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				assert.Equal(t, uint64(1073741824), cfg.MaxBytes, "Global MaxBytes should be 1Gi")
+				assert.Equal(t, uint64(5000), cfg.MaxRequests, "Global MaxRequests should be 5000")
+
+				require.Contains(t, cfg.PriorityBands, 100, "Priority band 100 should be present")
+				band := cfg.PriorityBands[100]
+				assert.Equal(t, uint64(1073741824), band.MaxBytes, "Band MaxBytes should be 1Gi")
+				assert.Equal(t, uint64(5000), band.MaxRequests, "Band MaxRequests should be 5000")
+			},
+		},
+		{
+			name: "ShouldSucceed_WithOnlyMaxRequests_NoMaxBytes",
+			apiConfig: &configapi.FlowControlConfig{
+				MaxRequests: ptr.To(resource.MustParse("1000")),
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority:    1,
+						MaxRequests: ptr.To(resource.MustParse("500")),
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				assert.Equal(t, uint64(0), cfg.MaxBytes, "Global MaxBytes should be 0 (no global byte limit)")
+				assert.Equal(t, uint64(1000), cfg.MaxRequests, "Global MaxRequests should be 1000")
+
+				require.Contains(t, cfg.PriorityBands, 1)
+				band := cfg.PriorityBands[1]
+				assert.Equal(t, uint64(1_000_000_000) /* registry default: 1 GB */, band.MaxBytes,
+					"Band MaxBytes should fall back to system default when not configured")
+				assert.Equal(t, uint64(500), band.MaxRequests, "Band MaxRequests should be 500")
+			},
+		},
+		{
+			name: "ShouldSucceed_WithDefaultPriorityBandMaxRequests",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultPriorityBand: &configapi.PriorityBandConfig{
+					MaxRequests: ptr.To(resource.MustParse("200")),
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.NotNil(t, cfg.DefaultPriorityBand)
+				assert.Equal(t, uint64(200), cfg.DefaultPriorityBand.MaxRequests,
+					"DefaultPriorityBand MaxRequests should be translated")
+			},
+		},
+
+		// --- MaxRequests: Defaulting Logic ---
+		{
+			name: "ShouldDefaultToZero_WhenMaxRequestsIsNil",
+			apiConfig: &configapi.FlowControlConfig{
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority: 1,
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.Contains(t, cfg.PriorityBands, 1)
+				assert.Equal(t, uint64(0), cfg.PriorityBands[1].MaxRequests,
+					"Omitted MaxRequests should default to 0 (no request limit)")
+			},
+		},
+		{
+			name: "ShouldDefaultToZero_WhenMaxRequestsIsZero",
+			apiConfig: &configapi.FlowControlConfig{
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority:    1,
+						MaxRequests: ptr.To(resource.MustParse("0")),
+					},
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.Contains(t, cfg.PriorityBands, 1)
+				assert.Equal(t, uint64(0), cfg.PriorityBands[1].MaxRequests,
+					"Explicit MaxRequests=0 should remain 0 (no request limit)")
+			},
+		},
+
+		// --- MaxRequests: Validation Errors ---
+		{
+			name: "ShouldError_WithNegativeGlobalMaxRequests",
+			apiConfig: &configapi.FlowControlConfig{
+				MaxRequests: ptr.To(resource.MustParse("-1")),
+			},
+			expectedErr: "global MaxRequests must be non-negative",
+		},
+		{
+			name: "ShouldError_WithNegativePriorityBandMaxRequests",
+			apiConfig: &configapi.FlowControlConfig{
+				PriorityBands: []configapi.PriorityBandConfig{
+					{
+						Priority:    1,
+						MaxRequests: ptr.To(resource.MustParse("-100")),
+					},
+				},
+			},
+			expectedErr: "priority band 1 MaxRequests must be non-negative",
+		},
+		{
+			name: "ShouldError_WithNegativeDefaultPriorityBandMaxRequests",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultPriorityBand: &configapi.PriorityBandConfig{
+					MaxRequests: ptr.To(resource.MustParse("-5")),
+				},
+			},
+			expectedErr: "MaxRequests must be non-negative",
+		},
+
+		// --- DefaultNegativePriorityBand ---
+		{
+			name: "ShouldSucceed_WithDefaultNegativePriorityBand",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultNegativePriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("100")),
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				require.NotNil(t, cfg.DefaultNegativePriorityBand)
+				assert.Equal(t, uint64(100), cfg.DefaultNegativePriorityBand.MaxBytes,
+					"DefaultNegativePriorityBand MaxBytes should be translated")
+				assert.NotNil(t, cfg.DefaultNegativePriorityBand.OrderingPolicy,
+					"DefaultNegativePriorityBand should have defaults applied")
+			},
+		},
+		{
+			name: "ShouldFallBackToDefaultBand_WhenNegativeBandIsNil",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultPriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("500")),
+				},
+			},
+			assertion: func(t *testing.T, cfg *registry.Config) {
+				assert.Nil(t, cfg.DefaultNegativePriorityBand,
+					"DefaultNegativePriorityBand should remain nil when not configured")
+				require.NotNil(t, cfg.DefaultPriorityBand)
+				assert.Equal(t, uint64(500), cfg.DefaultPriorityBand.MaxBytes)
+			},
+		},
+		{
+			name: "ShouldError_WithNegativeDefaultNegativePriorityBandMaxBytes",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultNegativePriorityBand: &configapi.PriorityBandConfig{
+					MaxBytes: ptr.To(resource.MustParse("-1")),
+				},
+			},
+			expectedErr: "MaxBytes must be non-negative",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, err := buildRegistryConfig(tc.apiConfig, defaults, handle)
+
+			if tc.expectedErr != "" {
+				require.Error(t, err, "buildRegistryConfig should return an error")
+				assert.Contains(t, err.Error(), tc.expectedErr, "Error message should contain expected text")
+				assert.Nil(t, cfg, "Config should be nil when error occurs")
+			} else {
+				require.NoError(t, err, "buildRegistryConfig should not return an error for valid input")
+				require.NotNil(t, cfg, "Config should not be nil on success")
+				if tc.assertion != nil {
+					tc.assertion(t, cfg)
+				}
+			}
+		})
+	}
+}
+
+// --- Tests for buildFlowControlConfig ---
+// Moved from flowcontrol/config_test.go TestNewConfigFromAPI.
+// Table-driven to match the original style.
+
+func TestBuildFlowControlConfig(t *testing.T) {
+	t.Parallel()
+	handle := newFlowControlTestHandle(t)
+
+	const funcPolicyName = "func-policy"
+	handle.AddPlugin(funcPolicyName, usagelimits.NewPolicyFunc(funcPolicyName, func(_ context.Context, _ float64, priorities []int) []float64 {
+		result := make([]float64, len(priorities))
+		for i := range result {
+			result[i] = 0.8
+		}
+		return result
+	}))
+
+	const structPolicyName = "struct-policy"
+	handle.AddPlugin(structPolicyName, &constantPointEightPolicy{})
+
+	testCases := []struct {
+		name      string
+		apiConfig *configapi.FlowControlConfig
+		assertion func(*testing.T, *flowcontrol.Config)
+	}{
+		{
+			name:      "Success - Nil Config defaults",
+			apiConfig: nil,
+			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
+				assert.NotNil(t, cfg.Registry, "Registry config sub-struct should be initialized even when API config is nil")
+				assert.NotNil(t, cfg.Controller,
+					"Controller config sub-struct should be initialized even when API config is nil")
+				assert.NotZero(t, cfg.Controller.EnqueueChannelBufferSize,
+					"Controller should contain default values (EnqueueChannelBufferSize) when API config is nil")
+			},
+		},
+		{
+			name: "Success - Explicit Values",
+			apiConfig: &configapi.FlowControlConfig{
+				MaxBytes: ptr.To(resource.MustParse("2048")),
+			},
+			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
+				assert.Equal(t, uint64(2048), cfg.Registry.MaxBytes,
+					"MaxBytes should be correctly translated from resource.Quantity in API to uint64 in internal config")
+			},
+		},
+		{
+			name:      "Success - Default UsageLimitPolicy when UsageLimit is nil",
+			apiConfig: nil,
+			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
+				require.NotNil(t, cfg.UsageLimitPolicy, "UsageLimitPolicy should be resolved even when not explicitly configured")
+				ceilings := cfg.UsageLimitPolicy.ComputeLimit(context.Background(), 0.5, []int{0})
+				assert.Equal(t, []float64{1.0}, ceilings, "Default noop policy should return 1.0 (no gating)")
+			},
+		},
+		{
+			name: "Success - UsageLimitPolicyPluginRef is resolved",
+			apiConfig: &configapi.FlowControlConfig{
+				UsageLimitPolicyPluginRef: usagelimits.StaticUsageLimitPolicyType,
+			},
+			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
+				require.NotNil(t, cfg.UsageLimitPolicy, "UsageLimitPolicy should be resolved from the handle")
+				ceilings := cfg.UsageLimitPolicy.ComputeLimit(context.Background(), 0.5, []int{0})
+				assert.Equal(t, []float64{1.0}, ceilings, "Noop policy should return 1.0 (no gating)")
+			},
+		},
+		{
+			name: "Success - Func-based UsageLimitPolicy resolved via PluginRef",
+			apiConfig: &configapi.FlowControlConfig{
+				UsageLimitPolicyPluginRef: funcPolicyName,
+			},
+			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
+				require.NotNil(t, cfg.UsageLimitPolicy)
+				ctx := context.Background()
+				for _, tc := range []struct {
+					name       string
+					priority   int
+					saturation float64
+				}{
+					{"zero saturation", 0, 0.0},
+					{"half saturation", 1, 0.5},
+					{"full saturation", 5, 1.0},
+				} {
+					assert.Equal(t, []float64{0.8}, cfg.UsageLimitPolicy.ComputeLimit(ctx, tc.saturation, []int{tc.priority}),
+						"func-based policy should return 0.8 at %s", tc.name)
+				}
+			},
+		},
+		{
+			name: "Success - Struct-based UsageLimitPolicy resolved via PluginRef",
+			apiConfig: &configapi.FlowControlConfig{
+				UsageLimitPolicyPluginRef: structPolicyName,
+			},
+			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
+				require.NotNil(t, cfg.UsageLimitPolicy)
+				ctx := context.Background()
+				for _, tc := range []struct {
+					name       string
+					priority   int
+					saturation float64
+				}{
+					{"zero saturation", 0, 0.0},
+					{"half saturation", 1, 0.5},
+					{"full saturation", 5, 1.0},
+				} {
+					assert.Equal(t, []float64{0.8}, cfg.UsageLimitPolicy.ComputeLimit(ctx, tc.saturation, []int{tc.priority}),
+						"struct-based policy should return 0.8 at %s", tc.name)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := buildFlowControlConfig(tc.apiConfig, handle)
+
+			require.NoError(t, err, "buildFlowControlConfig should not return an error for valid configuration")
+			require.NotNil(t, cfg, "buildFlowControlConfig should return a non-nil Config object on success")
+
+			if tc.assertion != nil {
+				tc.assertion(t, cfg)
+			}
+		})
+	}
+}
+
+func TestBuildFlowControlConfig_Errors(t *testing.T) {
+	t.Parallel()
+	handle := newFlowControlTestHandle(t)
+
+	t.Run("Error - UsageLimitPolicy plugin not found", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildFlowControlConfig(&configapi.FlowControlConfig{
+			UsageLimitPolicyPluginRef: "non-existent-policy",
+		}, handle)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-existent-policy")
+	})
+}
+
+func TestBuildPriorityBandPolicyDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ShouldResolveDefaultOrderingAndFairnessPolicies", func(t *testing.T) {
+		t.Parallel()
+		handle := newFlowControlTestHandle(t)
+		defaults, err := buildPriorityBandPolicyDefaults(handle)
+		require.NoError(t, err)
+		require.NotNil(t, defaults.OrderingPolicy)
+		assert.Equal(t, fcfs.FCFSOrderingPolicyType, defaults.OrderingPolicy.TypedName().Name)
+		require.NotNil(t, defaults.FairnessPolicy)
+		assert.Equal(t, globalstrict.GlobalStrictFairnessPolicyType, defaults.FairnessPolicy.TypedName().Name)
+	})
+}
+
+// constantPointEightPolicy is a hand-rolled UsageLimitPolicy implementation that always returns 0.8.
+// It exists to show that any struct satisfying the interface can be registered and resolved,
+// without relying on the usagelimits.NewPolicyFunc helper.
+type constantPointEightPolicy struct{}
+
+func (p *constantPointEightPolicy) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{
+		Type: "constant-point-eight-policy-type",
+		Name: "constant-point-eight-policy",
+	}
+}
+
+func (p *constantPointEightPolicy) ComputeLimit(_ context.Context, _ float64, priorities []int) []float64 {
+	result := make([]float64, len(priorities))
+	for i := range result {
+		result[i] = 0.8
+	}
+	return result
+}
+
+var _ fwkfc.UsageLimitPolicy = (*constantPointEightPolicy)(nil)

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -74,7 +74,6 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
@@ -190,7 +189,7 @@ func (r *benchRequest) ReceivedTimestamp() time.Time                   { return 
 func setupRegistry(
 	ctx context.Context,
 	b *testing.B,
-	handle plugin.Handle,
+	defaults registry.PriorityBandPolicyDefaults,
 	p priorityLevels,
 ) contracts.FlowRegistry {
 	b.Helper()
@@ -201,7 +200,7 @@ func setupRegistry(
 
 	for i := 0; i < int(p); i++ {
 		band, err := registry.NewPriorityBandConfig(
-			handle, i,
+			i, defaults,
 			registry.WithBandMaxBytes(10_000_000_000), // Prevent capacity-based rejections.
 		)
 		if err != nil {
@@ -210,7 +209,7 @@ func setupRegistry(
 		cfgOpts = append(cfgOpts, registry.WithPriorityBand(band))
 	}
 
-	regCfg, err := registry.NewConfig(handle, cfgOpts...)
+	regCfg, err := registry.NewConfig(defaults, cfgOpts...)
 	if err != nil {
 		b.Fatalf("Failed to create registry config: %v", err)
 	}
@@ -245,7 +244,12 @@ func setupBenchmarkHarness(
 	}
 	handle.AddPlugin(registry.DefaultOrderingPolicyRef, oPolicy)
 
-	reg := setupRegistry(ctx, b, handle, p)
+	defaults := registry.PriorityBandPolicyDefaults{
+		OrderingPolicy: oPolicy.(flowcontrol.OrderingPolicy),
+		FairnessPolicy: fPolicy.(flowcontrol.FairnessPolicy),
+	}
+
+	reg := setupRegistry(ctx, b, defaults, p)
 
 	detector := customDetector
 	if detector == nil {

--- a/pkg/epp/flowcontrol/config.go
+++ b/pkg/epp/flowcontrol/config.go
@@ -19,11 +19,9 @@ package flowcontrol
 import (
 	"fmt"
 
-	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/controller"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
 const FeatureGate = "flowControl"
@@ -48,40 +46,12 @@ func (c *Config) String() string {
 	return fmt.Sprintf("%+v", temp(*c))
 }
 
-// NewConfigFromAPI creates a new Config by translating the top-level API configuration.
-func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig, handle plugin.Handle) (*Config, error) {
-	registryConfig, err := registry.NewConfigFromAPI(apiConfig, handle)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create registry config: %w", err)
+// NewConfig constructs a Config from pre-resolved components.
+// All plugin resolution is performed by the config loader before calling this constructor.
+func NewConfig(ctrl *controller.Config, reg *registry.Config, ulp flowcontrol.UsageLimitPolicy) *Config {
+	return &Config{
+		Controller:       ctrl,
+		Registry:         reg,
+		UsageLimitPolicy: ulp,
 	}
-	ctrlCfg, err := controller.NewConfigFromAPI(apiConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create controller config: %w", err)
-	}
-	usageLimitPolicy, err := ensureUsageLimitPolicy(apiConfig, handle)
-	if err != nil {
-		return nil, err
-	}
-	cfg := &Config{
-		Controller:       ctrlCfg,
-		Registry:         registryConfig,
-		UsageLimitPolicy: usageLimitPolicy,
-	}
-	return cfg, nil
-}
-
-func ensureUsageLimitPolicy(apiConfig *configapi.FlowControlConfig, handle plugin.Handle) (flowcontrol.UsageLimitPolicy, error) {
-	ref := registry.DefaultUsageLimitPolicyRef
-	if apiConfig != nil && apiConfig.UsageLimitPolicyPluginRef != "" {
-		ref = apiConfig.UsageLimitPolicyPluginRef
-	}
-	p := handle.Plugin(ref)
-	if p == nil {
-		return nil, fmt.Errorf("usage limit policy plugin '%s' not found", ref)
-	}
-	usageLimitPolicy, ok := p.(flowcontrol.UsageLimitPolicy)
-	if !ok {
-		return nil, fmt.Errorf("plugin '%s' does not implement UsageLimitPolicy", ref)
-	}
-	return usageLimitPolicy, nil
 }

--- a/pkg/epp/flowcontrol/config_test.go
+++ b/pkg/epp/flowcontrol/config_test.go
@@ -17,186 +17,41 @@ limitations under the License.
 package flowcontrol
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/ptr"
 
-	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
-	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol/mocks"
-	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/controller"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
-	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
 )
 
-func TestNewConfigFromAPI(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	t.Parallel()
 
-	handle := igwtestutils.NewTestHandle(context.Background())
-	handle.AddPlugin(globalstrict.GlobalStrictFairnessPolicyType, &mocks.MockFairnessPolicy{
-		TypedNameV: fwkplugin.TypedName{
-			Name: globalstrict.GlobalStrictFairnessPolicyType,
-			Type: globalstrict.GlobalStrictFairnessPolicyType,
-		},
+	t.Run("all fields are correctly assigned", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := &controller.Config{EnqueueChannelBufferSize: 42}
+		reg := &registry.Config{MaxBytes: 1024}
+		ulp := usagelimits.DefaultPolicy()
+
+		cfg := NewConfig(ctrl, reg, ulp)
+
+		assert.NotNil(t, cfg, "NewConfig should return a non-nil Config")
+		assert.Same(t, ctrl, cfg.Controller, "Controller should be the same pointer passed in")
+		assert.Same(t, reg, cfg.Registry, "Registry should be the same pointer passed in")
+		assert.Same(t, ulp, cfg.UsageLimitPolicy, "UsageLimitPolicy should be the same pointer passed in")
 	})
-	handle.AddPlugin(fcfs.FCFSOrderingPolicyType, &mocks.MockOrderingPolicy{
-		TypedNameV: fwkplugin.TypedName{
-			Name: fcfs.FCFSOrderingPolicyType,
-			Type: fcfs.FCFSOrderingPolicyType,
-		},
+
+	t.Run("nil values are handled gracefully", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := NewConfig(nil, nil, nil)
+
+		assert.NotNil(t, cfg, "NewConfig should return a non-nil Config even when all arguments are nil")
+		assert.Nil(t, cfg.Controller, "Controller should be nil when nil was passed")
+		assert.Nil(t, cfg.Registry, "Registry should be nil when nil was passed")
+		assert.Nil(t, cfg.UsageLimitPolicy, "UsageLimitPolicy should be nil when nil was passed")
 	})
-	handle.AddPlugin(usagelimits.StaticUsageLimitPolicyType, usagelimits.DefaultPolicy())
-
-	// A func-based custom policy that always returns 0.8 — demonstrates that users can define
-	// their policy in the standard plugins section and reference it via UsageLimit.PluginRef.
-	const funcPolicyName = "func-policy"
-	handle.AddPlugin(funcPolicyName, usagelimits.NewPolicyFunc(funcPolicyName, func(_ context.Context, _ float64, priorities []int) []float64 {
-		result := make([]float64, len(priorities))
-		for i := range result {
-			result[i] = 0.8
-		}
-		return result
-	}))
-
-	// A hand-rolled struct implementing UsageLimitPolicy — demonstrates that any struct
-	// satisfying the interface can be registered and resolved, without relying on usagelimits helpers.
-	const structPolicyName = "struct-policy"
-	handle.AddPlugin(structPolicyName, &constantPointEightPolicy{})
-
-	testCases := []struct {
-		name        string
-		apiConfig   *configapi.FlowControlConfig
-		assertion   func(*testing.T, *Config)
-		expectedErr string
-	}{
-		{
-			name:      "Success - Nil Config defaults",
-			apiConfig: nil,
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.NotNil(t, cfg.Registry, "Registry config sub-struct should be initialized even when API config is nil")
-				assert.NotNil(t, cfg.Controller,
-					"Controller config sub-struct should be initialized even when API config is nil")
-				assert.NotZero(t, cfg.Controller.EnqueueChannelBufferSize,
-					"Controller should contain default values (EnqueueChannelBufferSize) when API config is nil")
-			},
-		},
-		{
-			name: "Success - Explicit Values",
-			apiConfig: &configapi.FlowControlConfig{
-				MaxBytes: ptr.To(resource.MustParse("2048")),
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, uint64(2048), cfg.Registry.MaxBytes,
-					"MaxBytes should be correctly translated from resource.Quantity in API to uint64 in internal config")
-			},
-		},
-		{
-			name:      "Success - Default UsageLimitPolicy when UsageLimit is nil",
-			apiConfig: nil,
-			assertion: func(t *testing.T, cfg *Config) {
-				require.NotNil(t, cfg.UsageLimitPolicy, "UsageLimitPolicy should be resolved even when not explicitly configured")
-				ceilings := cfg.UsageLimitPolicy.ComputeLimit(context.Background(), 0.5, []int{0})
-				assert.Equal(t, []float64{1.0}, ceilings, "Default noop policy should return 1.0 (no gating)")
-			},
-		},
-		{
-			name: "Success - UsageLimitPolicyPluginRef is resolved",
-			apiConfig: &configapi.FlowControlConfig{
-				UsageLimitPolicyPluginRef: usagelimits.StaticUsageLimitPolicyType,
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.NotNil(t, cfg.UsageLimitPolicy, "UsageLimitPolicy should be resolved from the handle")
-				ceilings := cfg.UsageLimitPolicy.ComputeLimit(context.Background(), 0.5, []int{0})
-				assert.Equal(t, []float64{1.0}, ceilings, "Noop policy should return 1.0 (no gating)")
-			},
-		},
-		{
-			name: "Success - Func-based UsageLimitPolicy resolved via PluginRef",
-			apiConfig: &configapi.FlowControlConfig{
-				UsageLimitPolicyPluginRef: funcPolicyName,
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.NotNil(t, cfg.UsageLimitPolicy)
-				ctx := context.Background()
-				for _, tc := range []struct {
-					name       string
-					priority   int
-					saturation float64
-				}{
-					{"zero saturation", 0, 0.0},
-					{"half saturation", 1, 0.5},
-					{"full saturation", 5, 1.0},
-				} {
-					assert.Equal(t, []float64{0.8}, cfg.UsageLimitPolicy.ComputeLimit(ctx, tc.saturation, []int{tc.priority}),
-						"func-based policy should return 0.8 at %s", tc.name)
-				}
-			},
-		},
-		{
-			name: "Success - Struct-based UsageLimitPolicy resolved via PluginRef",
-			apiConfig: &configapi.FlowControlConfig{
-				UsageLimitPolicyPluginRef: structPolicyName,
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.NotNil(t, cfg.UsageLimitPolicy)
-				ctx := context.Background()
-				for _, tc := range []struct {
-					name       string
-					priority   int
-					saturation float64
-				}{
-					{"zero saturation", 0, 0.0},
-					{"half saturation", 1, 0.5},
-					{"full saturation", 5, 1.0},
-				} {
-					assert.Equal(t, []float64{0.8}, cfg.UsageLimitPolicy.ComputeLimit(ctx, tc.saturation, []int{tc.priority}),
-						"struct-based policy should return 0.8 at %s", tc.name)
-				}
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			cfg, err := NewConfigFromAPI(tc.apiConfig, handle)
-
-			require.NoError(t, err, "NewConfigFromAPI should not return an error for valid configuration")
-			require.NotNil(t, cfg, "NewConfigFromAPI should return a non-nil Config object on success")
-
-			if tc.assertion != nil {
-				tc.assertion(t, cfg)
-			}
-		})
-	}
 }
-
-// constantPointEightPolicy is a hand-rolled UsageLimitPolicy implementation that always returns 0.8.
-// It exists to show that any struct satisfying the interface can be registered and resolved,
-// without relying on the usagelimits.NewPolicyFunc helper.
-type constantPointEightPolicy struct{}
-
-func (p *constantPointEightPolicy) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{
-		Type: "constant-point-eight-policy-type",
-		Name: "constant-point-eight-policy",
-	}
-}
-
-func (p *constantPointEightPolicy) ComputeLimit(_ context.Context, _ float64, priorities []int) []float64 {
-	result := make([]float64, len(priorities))
-	for i := range result {
-		result[i] = 0.8
-	}
-	return result
-}
-
-// compile-time check that constantPointEightPolicy satisfies the interface.
-var _ fwkfc.UsageLimitPolicy = (*constantPointEightPolicy)(nil)

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -316,7 +316,7 @@ type PriorityBandConfigOption func(*PriorityBandConfig) error
 func WithOrderingPolicy(policy flowcontrol.OrderingPolicy) PriorityBandConfigOption {
 	return func(p *PriorityBandConfig) error {
 		if policy == nil {
-			return errors.New("OrderingPolicy cannot be nil")
+			return errors.New("ordering policy cannot be nil")
 		}
 		p.OrderingPolicy = policy
 		return nil
@@ -327,7 +327,7 @@ func WithOrderingPolicy(policy flowcontrol.OrderingPolicy) PriorityBandConfigOpt
 func WithFairnessPolicy(policy flowcontrol.FairnessPolicy) PriorityBandConfigOption {
 	return func(p *PriorityBandConfig) error {
 		if policy == nil {
-			return errors.New("FairnessPolicy cannot be nil")
+			return errors.New("fairness policy cannot be nil")
 		}
 		p.FairnessPolicy = policy
 		return nil
@@ -365,7 +365,7 @@ func WithBandMaxRequests(maxRequests uint64) PriorityBandConfigOption {
 // validation.
 //
 // Arguments:
-//   - defaults: D`efault policy instances, provided by the config loader.
+//   - defaults: Default policy instances, provided by the config loader.
 //   - opts: Optional configuration overrides.
 func NewConfig(defaults PriorityBandPolicyDefaults, opts ...ConfigOption) (*Config, error) {
 	builder := &configBuilder{

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -22,13 +22,9 @@ import (
 	"slices"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
-	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/framework/plugins/queue"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
@@ -104,6 +100,14 @@ func (r *runtimeCapabilityChecker) CheckCompatibility(p flowcontrol.OrderingPoli
 }
 
 // --- Configuration ---
+
+// PriorityBandPolicyDefaults carries pre-resolved default policy instances.
+// It is populated by the config loader (the single boundary for plugin resolution)
+// and passed into registry constructors so they never need to access the plugin Handle.
+type PriorityBandPolicyDefaults struct {
+	OrderingPolicy flowcontrol.OrderingPolicy
+	FairnessPolicy flowcontrol.FairnessPolicy
+}
 
 // Config holds the master configuration for the entire FlowRegistry.
 // It serves as the top-level blueprint, defining global settings and the templates for its priority bands.
@@ -308,56 +312,26 @@ func withCapabilityChecker(checker capabilityChecker) ConfigOption {
 // PriorityBandConfigOption defines a functional option for configuring a single PriorityBandConfig.
 type PriorityBandConfigOption func(*PriorityBandConfig) error
 
-// WithOrderingPolicy sets the name/reference of the inter-flow fairness policy (e.g., "fcfs-ordering-policy").
-// TODO(kubernetes-sigs/gateway-api-inference-extension#1794): This option is primarily used by the configuration
-// loader to wire up policies instantiated from the plugin registry.
-func WithOrderingPolicy(ref string, handle plugin.Handle) PriorityBandConfigOption {
+// WithOrderingPolicy sets the ordering policy instance for this priority band.
+func WithOrderingPolicy(policy flowcontrol.OrderingPolicy) PriorityBandConfigOption {
 	return func(p *PriorityBandConfig) error {
-		policy, err := orderingPolicy(ref, handle)
-		if err != nil {
-			return err
+		if policy == nil {
+			return errors.New("OrderingPolicy cannot be nil")
 		}
 		p.OrderingPolicy = policy
 		return nil
 	}
 }
 
-func orderingPolicy(ref string, handle plugin.Handle) (flowcontrol.OrderingPolicy, error) {
-	v := handle.Plugin(ref)
-	if v == nil {
-		return nil, fmt.Errorf("no ordering policy registered for name %q", ref)
-	}
-	policy, ok := v.(flowcontrol.OrderingPolicy)
-	if !ok {
-		return nil, fmt.Errorf("plugin %q is not a flowcontrol.OrderingPolicy (type: %T)", ref, v)
-	}
-	return policy, nil
-}
-
-// WithFairnessPolicy sets the name/reference of the inter-flow fairness policy (e.g., "round-robin-fairness-policy").
-// TODO(kubernetes-sigs/gateway-api-inference-extension#1794): This option is primarily used by the configuration
-// loader to wire up policies instantiated from the plugin registry.
-func WithFairnessPolicy(ref string, handle plugin.Handle) PriorityBandConfigOption {
+// WithFairnessPolicy sets the fairness policy instance for this priority band.
+func WithFairnessPolicy(policy flowcontrol.FairnessPolicy) PriorityBandConfigOption {
 	return func(p *PriorityBandConfig) error {
-		policy, err := fairnessPolicy(ref, handle)
-		if err != nil {
-			return err
+		if policy == nil {
+			return errors.New("FairnessPolicy cannot be nil")
 		}
 		p.FairnessPolicy = policy
 		return nil
 	}
-}
-
-func fairnessPolicy(ref string, handle plugin.Handle) (flowcontrol.FairnessPolicy, error) {
-	v := handle.Plugin(ref)
-	if v == nil {
-		return nil, fmt.Errorf("no fairness policy registered for name %q", ref)
-	}
-	policy, ok := v.(flowcontrol.FairnessPolicy)
-	if !ok {
-		return nil, fmt.Errorf("plugin %q is not a flowcontrol.FairnessPolicy (type: %T)", ref, v)
-	}
-	return policy, nil
 }
 
 // WithQueue sets the queue implementation (e.g., "ListQueue") for flows in this band.
@@ -387,143 +361,13 @@ func WithBandMaxRequests(maxRequests uint64) PriorityBandConfigOption {
 	}
 }
 
-// --- Constructors ---
-
-// resolveQuantity extracts and validates a resource.Quantity value.
-// Returns 0 if q is nil.
-func resolveQuantity(q *resource.Quantity, fieldName string) (uint64, error) {
-	if q == nil {
-		return 0, nil
-	}
-	v := q.Value()
-	if v < 0 {
-		return 0, fmt.Errorf("%s must be non-negative, got %d", fieldName, v)
-	}
-	return uint64(v), nil
-}
-
-// NewConfigFromAPI creates a new Config by translating the API configuration.
-func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig, handle plugin.Handle) (*Config, error) {
-	if apiConfig == nil {
-		return NewConfig(handle)
-	}
-
-	opts := make([]ConfigOption, 0, len(apiConfig.PriorityBands)+3)
-
-	maxBytes, err := resolveQuantity(apiConfig.MaxBytes, "global MaxBytes")
-	if err != nil {
-		return nil, err
-	}
-	if maxBytes > 0 {
-		opts = append(opts, WithMaxBytes(maxBytes))
-	}
-
-	maxRequests, err := resolveQuantity(apiConfig.MaxRequests, "global MaxRequests")
-	if err != nil {
-		return nil, err
-	}
-	if maxRequests > 0 {
-		opts = append(opts, WithMaxRequests(maxRequests))
-	}
-
-	if apiConfig.DefaultPriorityBand != nil {
-		templateBand, err := buildDefaultPriorityBandTemplate(handle, apiConfig.DefaultPriorityBand)
-		if err != nil {
-			return nil, err
-		}
-		opts = append(opts, WithDefaultPriorityBand(templateBand))
-	}
-
-	if apiConfig.DefaultNegativePriorityBand != nil {
-		templateBand, err := buildDefaultPriorityBandTemplate(handle, apiConfig.DefaultNegativePriorityBand)
-		if err != nil {
-			return nil, err
-		}
-		opts = append(opts, WithDefaultNegativePriorityBand(templateBand))
-	}
-
-	for _, band := range apiConfig.PriorityBands {
-		pb, err := buildPriorityBand(handle, band)
-		if err != nil {
-			return nil, err
-		}
-		opts = append(opts, WithPriorityBand(pb))
-	}
-
-	return NewConfig(handle, opts...)
-}
-
-func buildDefaultPriorityBandTemplate(
-	handle plugin.Handle,
-	apiBand *configapi.PriorityBandConfig,
-) (*PriorityBandConfig, error) {
-	bandOpts := make([]PriorityBandConfigOption, 0, 3)
-	maxBytes, err := resolveQuantity(apiBand.MaxBytes, "DefaultPriorityBand MaxBytes")
-	if err != nil {
-		return nil, err
-	}
-	if maxBytes > 0 {
-		bandOpts = append(bandOpts, WithBandMaxBytes(maxBytes))
-	}
-	maxRequests, err := resolveQuantity(apiBand.MaxRequests, "DefaultPriorityBand MaxRequests")
-	if err != nil {
-		return nil, err
-	}
-	if maxRequests > 0 {
-		bandOpts = append(bandOpts, WithBandMaxRequests(maxRequests))
-	}
-	if apiBand.OrderingPolicyRef != "" {
-		bandOpts = append(bandOpts, WithOrderingPolicy(apiBand.OrderingPolicyRef, handle))
-	}
-	if apiBand.FairnessPolicyRef != "" {
-		bandOpts = append(bandOpts, WithFairnessPolicy(apiBand.FairnessPolicyRef, handle))
-	}
-
-	// We pass priority 0 as placeholder since it's a template.
-	templateBand, err := NewPriorityBandConfig(handle, 0, bandOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create default priority band template: %w", err)
-	}
-	return templateBand, nil
-}
-
-func buildPriorityBand(handle plugin.Handle, band configapi.PriorityBandConfig) (*PriorityBandConfig, error) {
-	bandOpts := make([]PriorityBandConfigOption, 0, 3)
-	maxBytes, err := resolveQuantity(band.MaxBytes, fmt.Sprintf("priority band %d MaxBytes", band.Priority))
-	if err != nil {
-		return nil, err
-	}
-	if maxBytes > 0 {
-		bandOpts = append(bandOpts, WithBandMaxBytes(maxBytes))
-	}
-	maxRequests, err := resolveQuantity(band.MaxRequests, fmt.Sprintf("priority band %d MaxRequests", band.Priority))
-	if err != nil {
-		return nil, err
-	}
-	if maxRequests > 0 {
-		bandOpts = append(bandOpts, WithBandMaxRequests(maxRequests))
-	}
-	if band.OrderingPolicyRef != "" {
-		bandOpts = append(bandOpts, WithOrderingPolicy(band.OrderingPolicyRef, handle))
-	}
-	if band.FairnessPolicyRef != "" {
-		bandOpts = append(bandOpts, WithFairnessPolicy(band.FairnessPolicyRef, handle))
-	}
-
-	pb, err := NewPriorityBandConfig(handle, band.Priority, bandOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create priority band config for priority %d: %w", band.Priority, err)
-	}
-	return pb, nil
-}
-
 // NewConfig creates a new Config populated with system defaults, applies the provided options, and enforces strict
 // validation.
 //
 // Arguments:
-//   - handle: A plugin.Handle required to resolve the default policies.
+//   - defaults: D`efault policy instances, provided by the config loader.
 //   - opts: Optional configuration overrides.
-func NewConfig(handle plugin.Handle, opts ...ConfigOption) (*Config, error) {
+func NewConfig(defaults PriorityBandPolicyDefaults, opts ...ConfigOption) (*Config, error) {
 	builder := &configBuilder{
 		config: &Config{
 			MaxBytes:              0, // no limit enforced
@@ -544,27 +388,27 @@ func NewConfig(handle plugin.Handle, opts ...ConfigOption) (*Config, error) {
 	// Initialize DefaultPriorityBand if missing.
 	// This ensures we always have a template for dynamic provisioning.
 	if builder.config.DefaultPriorityBand == nil {
-		template, err := NewPriorityBandConfig(handle, 0)
+		template, err := NewPriorityBandConfig(0, defaults)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create default priority band: %w", err)
 		}
 		builder.config.DefaultPriorityBand = template
 	} else {
-		if err := builder.config.DefaultPriorityBand.applyDefaults(handle); err != nil {
+		if err := builder.config.DefaultPriorityBand.applyDefaults(defaults); err != nil {
 			return nil, fmt.Errorf("failed to apply defaults to DefaultPriorityBand: %w", err)
 		}
 	}
 
 	// Apply defaults to DefaultNegativePriorityBand if set.
 	if builder.config.DefaultNegativePriorityBand != nil {
-		if err := builder.config.DefaultNegativePriorityBand.applyDefaults(handle); err != nil {
+		if err := builder.config.DefaultNegativePriorityBand.applyDefaults(defaults); err != nil {
 			return nil, fmt.Errorf("failed to apply defaults to DefaultNegativePriorityBand: %w", err)
 		}
 	}
 
 	// Apply defaults to all explicitly configured bands.
 	for _, band := range builder.config.PriorityBands {
-		if err := band.applyDefaults(handle); err != nil {
+		if err := band.applyDefaults(defaults); err != nil {
 			return nil, fmt.Errorf("failed to apply defaults to priority band %d: %w", band.Priority, err)
 		}
 	}
@@ -578,8 +422,8 @@ func NewConfig(handle plugin.Handle, opts ...ConfigOption) (*Config, error) {
 // NewPriorityBandConfig creates a new band configuration with the required fields.
 // It applies system defaults first, then applies any provided options to override those defaults.
 func NewPriorityBandConfig(
-	handle plugin.Handle,
 	priority int,
+	defaults PriorityBandPolicyDefaults,
 	opts ...PriorityBandConfigOption,
 ) (*PriorityBandConfig, error) {
 	pb := &PriorityBandConfig{
@@ -592,7 +436,7 @@ func NewPriorityBandConfig(
 		}
 	}
 
-	if err := pb.applyDefaults(handle); err != nil {
+	if err := pb.applyDefaults(defaults); err != nil {
 		return nil, err
 	}
 
@@ -601,13 +445,12 @@ func NewPriorityBandConfig(
 
 // --- Validation, Defaults & Hydration ---
 
-func (p *PriorityBandConfig) applyDefaults(handle plugin.Handle) error {
+func (p *PriorityBandConfig) applyDefaults(defaults PriorityBandPolicyDefaults) error {
 	if p.OrderingPolicy == nil {
-		policy, err := orderingPolicy(DefaultOrderingPolicyRef, handle)
-		if err != nil {
-			return err
+		if defaults.OrderingPolicy == nil {
+			return fmt.Errorf("no default ordering policy provided and none set on band %d", p.Priority)
 		}
-		p.OrderingPolicy = policy
+		p.OrderingPolicy = defaults.OrderingPolicy
 	}
 	if p.Queue == "" {
 		p.Queue = defaultQueue
@@ -621,11 +464,10 @@ func (p *PriorityBandConfig) applyDefaults(handle plugin.Handle) error {
 		p.MaxBytes = defaultPriorityBandMaxBytes
 	}
 	if p.FairnessPolicy == nil {
-		policy, err := fairnessPolicy(DefaultFairnessPolicyRef, handle)
-		if err != nil {
-			return err
+		if defaults.FairnessPolicy == nil {
+			return fmt.Errorf("no default fairness policy provided and none set on band %d", p.Priority)
 		}
-		p.FairnessPolicy = policy
+		p.FairnessPolicy = defaults.FairnessPolicy
 	}
 	return nil
 }

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -342,7 +342,7 @@ func TestNewPriorityBandConfig(t *testing.T) {
 		t.Parallel()
 		pb, err := NewPriorityBandConfig(1, defaults, WithFairnessPolicy(nil))
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "FairnessPolicy cannot be nil")
+		assert.Contains(t, err.Error(), "fairness policy cannot be nil")
 		assert.Nil(t, pb)
 	})
 

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -22,10 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/ptr"
 
-	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/framework/plugins/queue"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
@@ -35,38 +32,25 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/edf"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
-	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
 )
 
-func newTestPluginsHandle(t *testing.T) plugin.Handle {
-	t.Helper()
-	handle := igwtestutils.NewTestHandle(t.Context())
-	handle.AddPlugin(globalstrict.GlobalStrictFairnessPolicyType, &fwkfcmocks.MockFairnessPolicy{
-		TypedNameV: plugin.TypedName{
-			Type: globalstrict.GlobalStrictFairnessPolicyType,
-			Name: globalstrict.GlobalStrictFairnessPolicyType,
+// newTestPriorityBandPolicyDefaults returns a PriorityBandPolicyDefaults populated with mock policies
+// using the default policy refs (FCFS ordering, GlobalStrict fairness).
+func newTestPriorityBandPolicyDefaults() PriorityBandPolicyDefaults {
+	return PriorityBandPolicyDefaults{
+		OrderingPolicy: &fwkfcmocks.MockOrderingPolicy{
+			TypedNameV: plugin.TypedName{
+				Type: fcfs.FCFSOrderingPolicyType,
+				Name: fcfs.FCFSOrderingPolicyType,
+			},
 		},
-	})
-	handle.AddPlugin(roundrobin.RoundRobinFairnessPolicyType, &fwkfcmocks.MockFairnessPolicy{
-		TypedNameV: plugin.TypedName{
-			Type: roundrobin.RoundRobinFairnessPolicyType,
-			Name: roundrobin.RoundRobinFairnessPolicyType,
+		FairnessPolicy: &fwkfcmocks.MockFairnessPolicy{
+			TypedNameV: plugin.TypedName{
+				Type: globalstrict.GlobalStrictFairnessPolicyType,
+				Name: globalstrict.GlobalStrictFairnessPolicyType,
+			},
 		},
-	})
-	handle.AddPlugin(fcfs.FCFSOrderingPolicyType, &fwkfcmocks.MockOrderingPolicy{
-		TypedNameV: plugin.TypedName{
-			Type: fcfs.FCFSOrderingPolicyType,
-			Name: fcfs.FCFSOrderingPolicyType,
-		},
-	})
-	handle.AddPlugin(edf.EDFOrderingPolicyType, &fwkfcmocks.MockOrderingPolicy{
-		TypedNameV: plugin.TypedName{
-			Type: edf.EDFOrderingPolicyType,
-			Name: edf.EDFOrderingPolicyType,
-		},
-		RequiredQueueCapabilitiesV: []flowcontrol.QueueCapability{flowcontrol.CapabilityPriorityConfigurable},
-	})
-	return handle
+	}
 }
 
 // mockCapabilityChecker is a test double for verifying that NewConfig correctly delegates compatibility checks.
@@ -84,8 +68,8 @@ func (m *mockCapabilityChecker) CheckCompatibility(p flowcontrol.OrderingPolicy,
 // mustBand is a helper to simplify test table setup.
 // It panics if the band config creation fails, which should not happen with valid static inputs.
 func mustBand(t *testing.T, priority int, opts ...PriorityBandConfigOption) *PriorityBandConfig {
-	handle := newTestPluginsHandle(t)
-	pb, err := NewPriorityBandConfig(handle, priority, opts...)
+	defaults := newTestPriorityBandPolicyDefaults()
+	pb, err := NewPriorityBandConfig(priority, defaults, opts...)
 	require.NoError(t, err, "failed to create test band")
 	return pb
 }
@@ -96,7 +80,7 @@ func TestNewConfig(t *testing.T) {
 	testCases := []struct {
 		name          string
 		opts          []ConfigOption
-		handle        plugin.Handle
+		defaults      PriorityBandPolicyDefaults
 		expectErr     bool
 		expectedErrIs error // Optional: check for specific wrapped error
 		assertion     func(*testing.T, *Config)
@@ -107,7 +91,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []ConfigOption{
 				WithPriorityBand(mustBand(t, 1)),
 			},
-			handle: newTestPluginsHandle(t),
+			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, defaultFlowGCTimeout, cfg.FlowGCTimeout, "FlowGCTimeout should be defaulted")
 				assert.Equal(t, defaultPriorityBandGCTimeout, cfg.PriorityBandGCTimeout, "PriorityBandGCTimeout should be defaulted")
@@ -130,7 +114,7 @@ func TestNewConfig(t *testing.T) {
 				WithPriorityBandGCTimeout(2 * time.Hour),
 				WithPriorityBand(mustBand(t, 1)),
 			},
-			handle: newTestPluginsHandle(t),
+			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, uint64(5000), cfg.MaxBytes)
 				assert.Equal(t, 1*time.Hour, cfg.FlowGCTimeout)
@@ -142,7 +126,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []ConfigOption{
 				WithPriorityBand(&PriorityBandConfig{Priority: 1}),
 			},
-			handle: newTestPluginsHandle(t),
+			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
 				require.Contains(t, cfg.PriorityBands, 1)
 				band := cfg.PriorityBands[1]
@@ -158,7 +142,7 @@ func TestNewConfig(t *testing.T) {
 				// No WithPriorityBand options provided.
 				// This relies entirely on dynamic provisioning.
 			},
-			handle: newTestPluginsHandle(t),
+			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Empty(t, cfg.PriorityBands, "PriorityBands map should be empty")
 				require.NotNil(t, cfg.DefaultPriorityBand, "DefaultPriorityBand template must be initialized")
@@ -177,7 +161,7 @@ func TestNewConfig(t *testing.T) {
 					checkCompatibilityFunc: func(flowcontrol.OrderingPolicy, queue.RegisteredQueueName) error { return nil },
 				}),
 			},
-			handle: newTestPluginsHandle(t),
+			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
 				require.NotNil(t, cfg.DefaultPriorityBand)
 				assert.Equal(t, queue.RegisteredQueueName("CustomQueue"), cfg.DefaultPriorityBand.Queue)
@@ -191,13 +175,13 @@ func TestNewConfig(t *testing.T) {
 		{
 			name:      "ShouldError_WhenFlowGCTimeoutIsInvalid",
 			opts:      []ConfigOption{WithFlowGCTimeout(-1 * time.Second)},
-			handle:    newTestPluginsHandle(t),
+			defaults:  newTestPriorityBandPolicyDefaults(),
 			expectErr: true,
 		},
 		{
 			name:      "ShouldError_WhenPriorityBandGCTimeoutIsNegative",
 			opts:      []ConfigOption{WithPriorityBandGCTimeout(-1 * time.Second)},
-			handle:    newTestPluginsHandle(t),
+			defaults:  newTestPriorityBandPolicyDefaults(),
 			expectErr: true,
 		},
 		{
@@ -206,7 +190,7 @@ func TestNewConfig(t *testing.T) {
 				WithFlowGCTimeout(10 * time.Minute),
 				WithPriorityBandGCTimeout(5 * time.Minute), // Less than flow timeout
 			},
-			handle:    newTestPluginsHandle(t),
+			defaults:  newTestPriorityBandPolicyDefaults(),
 			expectErr: true,
 		},
 		{
@@ -215,7 +199,7 @@ func TestNewConfig(t *testing.T) {
 				WithFlowGCTimeout(10 * time.Minute),
 				WithPriorityBandGCTimeout(10 * time.Minute), // Equal is OK
 			},
-			handle: newTestPluginsHandle(t),
+			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, 10*time.Minute, cfg.PriorityBandGCTimeout)
 			},
@@ -226,7 +210,7 @@ func TestNewConfig(t *testing.T) {
 				WithFlowGCTimeout(5 * time.Minute),
 				WithPriorityBandGCTimeout(15 * time.Minute),
 			},
-			handle: newTestPluginsHandle(t),
+			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, 15*time.Minute, cfg.PriorityBandGCTimeout)
 			},
@@ -239,21 +223,21 @@ func TestNewConfig(t *testing.T) {
 				WithPriorityBand(mustBand(t, 1)),
 				WithPriorityBand(mustBand(t, 1)), // Same priority level
 			},
-			handle:    newTestPluginsHandle(t),
+			defaults:  newTestPriorityBandPolicyDefaults(),
 			expectErr: true,
 		},
 		{
 			name:      "ShouldError_WhenBandIsNil",
 			opts:      []ConfigOption{WithPriorityBand(nil)},
-			handle:    newTestPluginsHandle(t),
+			defaults:  newTestPriorityBandPolicyDefaults(),
 			expectErr: true,
 		},
 
 		// --- Hydration Failures ---
 		{
-			name:      "ShouldError_WhenDefaultPolicyMissingFromHandle",
+			name:      "ShouldError_WhenDefaultPolicyMissingFromDefaults",
 			opts:      []ConfigOption{WithPriorityBand(&PriorityBandConfig{Priority: 1})},
-			handle:    igwtestutils.NewTestHandle(t.Context()), // Handle has no plugin.
+			defaults:  PriorityBandPolicyDefaults{}, // Zero value: nil policies trigger the error path.
 			expectErr: true,
 		},
 
@@ -268,7 +252,7 @@ func TestNewConfig(t *testing.T) {
 					},
 				}),
 			},
-			handle:        newTestPluginsHandle(t),
+			defaults:      newTestPriorityBandPolicyDefaults(),
 			expectErr:     true,
 			expectedErrIs: contracts.ErrPolicyQueueIncompatible,
 		},
@@ -277,7 +261,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []ConfigOption{
 				WithPriorityBand(mustBand(t, 1, WithQueue("non-existent-queue"))),
 			},
-			handle:    newTestPluginsHandle(t),
+			defaults:  newTestPriorityBandPolicyDefaults(),
 			expectErr: true,
 		},
 	}
@@ -286,7 +270,7 @@ func TestNewConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg, err := NewConfig(tc.handle, tc.opts...)
+			cfg, err := NewConfig(tc.defaults, tc.opts...)
 
 			if tc.expectErr {
 				require.Error(t, err, "expected validation error")
@@ -307,16 +291,37 @@ func TestNewConfig(t *testing.T) {
 
 func TestNewPriorityBandConfig(t *testing.T) {
 	t.Parallel()
-	handle := newTestPluginsHandle(t)
+	defaults := newTestPriorityBandPolicyDefaults()
+
+	mockEDFOrdering := &fwkfcmocks.MockOrderingPolicy{
+		TypedNameV: plugin.TypedName{
+			Type: edf.EDFOrderingPolicyType,
+			Name: edf.EDFOrderingPolicyType,
+		},
+		RequiredQueueCapabilitiesV: []flowcontrol.QueueCapability{flowcontrol.CapabilityPriorityConfigurable},
+	}
+	mockRRFairness := &fwkfcmocks.MockFairnessPolicy{
+		TypedNameV: plugin.TypedName{
+			Type: roundrobin.RoundRobinFairnessPolicyType,
+			Name: roundrobin.RoundRobinFairnessPolicyType,
+		},
+	}
+	mockFCFSOrdering := &fwkfcmocks.MockOrderingPolicy{
+		TypedNameV: plugin.TypedName{
+			Type: fcfs.FCFSOrderingPolicyType,
+			Name: fcfs.FCFSOrderingPolicyType,
+		},
+	}
+	mockGSFairness := &fwkfcmocks.MockFairnessPolicy{
+		TypedNameV: plugin.TypedName{
+			Type: globalstrict.GlobalStrictFairnessPolicyType,
+			Name: globalstrict.GlobalStrictFairnessPolicyType,
+		},
+	}
 
 	t.Run("ShouldApplyUserOverrides", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 1,
-			WithQueue(queue.RegisteredQueueName("CustomQueue")),
-			WithBandMaxBytes(999),
-			WithOrderingPolicy(edf.EDFOrderingPolicyType, handle),
-			WithFairnessPolicy(roundrobin.RoundRobinFairnessPolicyType, handle),
-		)
+		pb, err := NewPriorityBandConfig(1, defaults, WithQueue(queue.RegisteredQueueName("CustomQueue")), WithBandMaxBytes(999), WithOrderingPolicy(mockEDFOrdering), WithFairnessPolicy(mockRRFairness))
 		require.NoError(t, err)
 		assert.Equal(t, queue.RegisteredQueueName("CustomQueue"), pb.Queue)
 		assert.Equal(t, uint64(999), pb.MaxBytes)
@@ -328,27 +333,22 @@ func TestNewPriorityBandConfig(t *testing.T) {
 
 	t.Run("ShouldError_OnInvalidOptions", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 1, WithQueue(""))
+		pb, err := NewPriorityBandConfig(1, defaults, WithQueue(""))
 		assert.Error(t, err, "Should error when setting empty queue")
 		assert.Nil(t, pb)
 	})
 
-	t.Run("ShouldError_WhenPolicyRefUnknown", func(t *testing.T) {
+	t.Run("ShouldError_WhenNilPolicyProvided", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 1,
-			WithFairnessPolicy("UnknownPolicy", handle),
-		)
+		pb, err := NewPriorityBandConfig(1, defaults, WithFairnessPolicy(nil))
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no fairness policy registered for name")
+		assert.Contains(t, err.Error(), "FairnessPolicy cannot be nil")
 		assert.Nil(t, pb)
 	})
 
 	t.Run("ShouldDefaultToHeap_WhenPolicyRequiresIt", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 10,
-			WithOrderingPolicy(edf.EDFOrderingPolicyType, handle),
-			WithFairnessPolicy(globalstrict.GlobalStrictFairnessPolicyType, handle),
-		)
+		pb, err := NewPriorityBandConfig(10, defaults, WithOrderingPolicy(mockEDFOrdering), WithFairnessPolicy(mockGSFairness))
 		require.NoError(t, err)
 		assert.Equal(t, queue.RegisteredQueueName(queue.MaxMinHeapName), pb.Queue,
 			"EDF requires PriorityConfigurable, so should default to MaxMinHeap")
@@ -356,10 +356,7 @@ func TestNewPriorityBandConfig(t *testing.T) {
 
 	t.Run("ShouldDefaultToList_WhenPolicyDoesNotRequirePriority", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 20,
-			WithOrderingPolicy(fcfs.FCFSOrderingPolicyType, handle),
-			WithFairnessPolicy(globalstrict.GlobalStrictFairnessPolicyType, handle),
-		)
+		pb, err := NewPriorityBandConfig(20, defaults, WithOrderingPolicy(mockFCFSOrdering), WithFairnessPolicy(mockGSFairness))
 		require.NoError(t, err)
 		assert.Equal(t, queue.RegisteredQueueName(queue.ListQueueName), pb.Queue,
 			"FCFS does not require PriorityConfigurable, so should default to ListQueue")
@@ -368,7 +365,7 @@ func TestNewPriorityBandConfig(t *testing.T) {
 
 func TestConfig_Partition(t *testing.T) {
 	t.Parallel()
-	handle := newTestPluginsHandle(t)
+	defaults := newTestPriorityBandPolicyDefaults()
 
 	// Setup:
 	// Global: 103 MaxBytes.
@@ -376,7 +373,7 @@ func TestConfig_Partition(t *testing.T) {
 	// Band 2: 0 MaxBytes (will default to 1GB).
 	// Band 3: 20 MaxBytes.
 	cfg, err := NewConfig(
-		handle,
+		defaults,
 		WithMaxBytes(103),
 		WithPriorityBand(mustBand(t, 1, WithBandMaxBytes(55))),
 		WithPriorityBand(mustBand(t, 2, WithBandMaxBytes(0))), // Explicit 0 implies default behavior via logic.
@@ -392,10 +389,10 @@ func TestConfig_Partition(t *testing.T) {
 
 func TestConfig_Clone(t *testing.T) {
 	t.Parallel()
-	handle := newTestPluginsHandle(t)
+	defaults := newTestPriorityBandPolicyDefaults()
 
 	original, err := NewConfig(
-		handle,
+		defaults,
 		WithMaxBytes(1000),
 		WithPriorityBand(mustBand(t, 1)),
 		WithPriorityBand(mustBand(t, 2)),
@@ -428,7 +425,7 @@ func TestConfig_Clone(t *testing.T) {
 
 	t.Run("ShouldDeepCopyDefaultPriorityBand", func(t *testing.T) {
 		t.Parallel()
-		original, err := NewConfig(newTestPluginsHandle(t))
+		original, err := NewConfig(newTestPriorityBandPolicyDefaults())
 		require.NoError(t, err)
 
 		clone := original.Clone()
@@ -438,364 +435,13 @@ func TestConfig_Clone(t *testing.T) {
 	})
 }
 
-func TestNewConfigFromAPI(t *testing.T) {
-	t.Parallel()
-	handle := newTestPluginsHandle(t)
-
-	testCases := []struct {
-		name        string
-		apiConfig   *configapi.FlowControlConfig
-		assertion   func(*testing.T, *Config)
-		expectedErr string
-	}{
-		// --- Happy Paths ---
-		{
-			name: "ShouldSucceed_WithFullConfiguration",
-			apiConfig: &configapi.FlowControlConfig{
-				MaxBytes: ptr.To(resource.MustParse("100")),
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority: 1,
-						MaxBytes: ptr.To(resource.MustParse("50")),
-					},
-				},
-				DefaultPriorityBand: &configapi.PriorityBandConfig{
-					MaxBytes: ptr.To(resource.MustParse("10")),
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, uint64(100), cfg.MaxBytes, "Global MaxBytes should be correctly translated")
-
-				// Verify Explicit Band
-				require.Contains(t, cfg.PriorityBands, 1, "Configured priority band should be present")
-				assert.Equal(t, uint64(50), cfg.PriorityBands[1].MaxBytes, "Band MaxBytes should be correctly translated")
-				assert.Equal(t, uint64(50), cfg.PriorityBands[1].MaxBytes, "Band MaxBytes should be correctly translated")
-
-				// Verify Default Template
-				require.NotNil(t, cfg.DefaultPriorityBand, "DefaultPriorityBand should be configured")
-				assert.Equal(t, uint64(10), cfg.DefaultPriorityBand.MaxBytes,
-					"DefaultPriorityBand template MaxBytes should be translated")
-			},
-		},
-		{
-			name: "ShouldSucceed_WithKubernetesQuantityFormat",
-			apiConfig: &configapi.FlowControlConfig{
-				MaxBytes: ptr.To(resource.MustParse("1Gi")),
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority: 1,
-						MaxBytes: ptr.To(resource.MustParse("500Mi")),
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, uint64(1073741824), cfg.MaxBytes,
-					"1Gi should be correctly parsed as 1073741824 bytes")
-				require.Contains(t, cfg.PriorityBands, 1)
-				assert.Equal(t, uint64(524288000), cfg.PriorityBands[1].MaxBytes,
-					"500Mi should be correctly parsed as 524288000 bytes")
-			},
-		},
-		{
-			name: "ShouldSucceed_WithPolicyReferences",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority:          1,
-						OrderingPolicyRef: edf.EDFOrderingPolicyType,
-						FairnessPolicyRef: roundrobin.RoundRobinFairnessPolicyType,
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.Contains(t, cfg.PriorityBands, 1, "Configured priority band should be present")
-				band := cfg.PriorityBands[1]
-				assert.Equal(t, edf.EDFOrderingPolicyType, band.OrderingPolicy.TypedName().Name,
-					"OrderingPolicy should be correctly translated")
-				assert.Equal(t, roundrobin.RoundRobinFairnessPolicyType, band.FairnessPolicy.TypedName().Name,
-					"FairnessPolicy should be correctly translated")
-			},
-		},
-		{
-			name:      "ShouldSucceed_WithNilConfig_AndApplySystemDefaults",
-			apiConfig: nil,
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, uint64(0), cfg.MaxBytes, "Default global limit should be 0 (unlimited)")
-				require.NotNil(t, cfg.DefaultPriorityBand,
-					"Default priority band template should be initialized automatically")
-				assert.Equal(t, defaultPriorityBandMaxBytes, cfg.DefaultPriorityBand.MaxBytes,
-					"Default template should use system default capacity")
-			},
-		},
-
-		// --- Defaulting Logic (Nil vs Zero) ---
-		{
-			name: "ShouldApplyDefault_WhenBandMaxBytesIsNil",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority: 1,
-						// MaxBytes and MaxRequests omitted
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.Contains(t, cfg.PriorityBands, 1)
-				assert.Equal(t, defaultPriorityBandMaxBytes, cfg.PriorityBands[1].MaxBytes,
-					"Omitted MaxBytes (nil) should result in system default capacity (1GB)")
-			},
-		},
-		{
-			name: "ShouldApplyDefault_WhenBandMaxBytesIsZero",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority: 1,
-						MaxBytes: ptr.To(resource.MustParse("0")), // Explicitly zero,
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.Contains(t, cfg.PriorityBands, 1)
-				assert.Equal(t, defaultPriorityBandMaxBytes, cfg.PriorityBands[1].MaxBytes,
-					"Explicit MaxBytes (0) should be treated as 'Use Default' (1GB)")
-			},
-		},
-		{
-			name: "ShouldApplyDefault_WhenDefaultPriorityBandMaxBytesIsZero",
-			apiConfig: &configapi.FlowControlConfig{
-				DefaultPriorityBand: &configapi.PriorityBandConfig{
-					MaxBytes: ptr.To(resource.MustParse("0")), // Explicitly zero,
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.NotNil(t, cfg.DefaultPriorityBand)
-				assert.Equal(t, defaultPriorityBandMaxBytes, cfg.DefaultPriorityBand.MaxBytes,
-					"Explicit 0 in DefaultPriorityBand template should be treated as 'Use Default'")
-			},
-		},
-
-		// --- Validation Errors ---
-		{
-			name: "ShouldError_WithNegativeGlobalMaxBytes",
-			apiConfig: &configapi.FlowControlConfig{
-				MaxBytes: ptr.To(resource.MustParse("-1")),
-			},
-			expectedErr: "global MaxBytes must be non-negative",
-		},
-		{
-			name: "ShouldError_WithNegativePriorityBandMaxBytes",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority: 1,
-						MaxBytes: ptr.To(resource.MustParse("-100")),
-					},
-				},
-			},
-			expectedErr: "priority band 1 MaxBytes must be non-negative",
-		},
-		{
-			name: "ShouldError_WithNegativeDefaultPriorityBandMaxBytes",
-			apiConfig: &configapi.FlowControlConfig{
-				DefaultPriorityBand: &configapi.PriorityBandConfig{
-					MaxBytes: ptr.To(resource.MustParse("-5")),
-				},
-			},
-			expectedErr: "DefaultPriorityBand MaxBytes must be non-negative",
-		},
-
-		// --- MaxRequests: Happy Paths ---
-		{
-			name: "ShouldSucceed_WithMaxBytesAndMaxRequests",
-			apiConfig: &configapi.FlowControlConfig{
-				MaxBytes:    ptr.To(resource.MustParse("1Gi")),
-				MaxRequests: ptr.To(resource.MustParse("5000")),
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority:    100,
-						MaxBytes:    ptr.To(resource.MustParse("1Gi")),
-						MaxRequests: ptr.To(resource.MustParse("5000")),
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, uint64(1073741824), cfg.MaxBytes, "Global MaxBytes should be 1Gi")
-				assert.Equal(t, uint64(5000), cfg.MaxRequests, "Global MaxRequests should be 5000")
-
-				require.Contains(t, cfg.PriorityBands, 100, "Priority band 100 should be present")
-				band := cfg.PriorityBands[100]
-				assert.Equal(t, uint64(1073741824), band.MaxBytes, "Band MaxBytes should be 1Gi")
-				assert.Equal(t, uint64(5000), band.MaxRequests, "Band MaxRequests should be 5000")
-			},
-		},
-		{
-			name: "ShouldSucceed_WithOnlyMaxRequests_NoMaxBytes",
-			apiConfig: &configapi.FlowControlConfig{
-				MaxRequests: ptr.To(resource.MustParse("1000")),
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority:    1,
-						MaxRequests: ptr.To(resource.MustParse("500")),
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, uint64(0), cfg.MaxBytes, "Global MaxBytes should be 0 (no global byte limit)")
-				assert.Equal(t, uint64(1000), cfg.MaxRequests, "Global MaxRequests should be 1000")
-
-				require.Contains(t, cfg.PriorityBands, 1)
-				band := cfg.PriorityBands[1]
-				assert.Equal(t, defaultPriorityBandMaxBytes, band.MaxBytes,
-					"Band MaxBytes should fall back to system default when not configured")
-				assert.Equal(t, uint64(500), band.MaxRequests, "Band MaxRequests should be 500")
-			},
-		},
-		{
-			name: "ShouldSucceed_WithDefaultPriorityBandMaxRequests",
-			apiConfig: &configapi.FlowControlConfig{
-				DefaultPriorityBand: &configapi.PriorityBandConfig{
-					MaxRequests: ptr.To(resource.MustParse("200")),
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.NotNil(t, cfg.DefaultPriorityBand)
-				assert.Equal(t, uint64(200), cfg.DefaultPriorityBand.MaxRequests,
-					"DefaultPriorityBand MaxRequests should be translated")
-			},
-		},
-
-		// --- MaxRequests: Defaulting Logic ---
-		{
-			name: "ShouldDefaultToZero_WhenMaxRequestsIsNil",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority: 1,
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.Contains(t, cfg.PriorityBands, 1)
-				assert.Equal(t, uint64(0), cfg.PriorityBands[1].MaxRequests,
-					"Omitted MaxRequests should default to 0 (no request limit)")
-			},
-		},
-		{
-			name: "ShouldDefaultToZero_WhenMaxRequestsIsZero",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority:    1,
-						MaxRequests: ptr.To(resource.MustParse("0")),
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.Contains(t, cfg.PriorityBands, 1)
-				assert.Equal(t, uint64(0), cfg.PriorityBands[1].MaxRequests,
-					"Explicit MaxRequests=0 should remain 0 (no request limit)")
-			},
-		},
-
-		// --- MaxRequests: Validation Errors ---
-		{
-			name: "ShouldError_WithNegativeGlobalMaxRequests",
-			apiConfig: &configapi.FlowControlConfig{
-				MaxRequests: ptr.To(resource.MustParse("-1")),
-			},
-			expectedErr: "global MaxRequests must be non-negative",
-		},
-		{
-			name: "ShouldError_WithNegativePriorityBandMaxRequests",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority:    1,
-						MaxRequests: ptr.To(resource.MustParse("-100")),
-					},
-				},
-			},
-			expectedErr: "priority band 1 MaxRequests must be non-negative",
-		},
-		{
-			name: "ShouldError_WithNegativeDefaultPriorityBandMaxRequests",
-			apiConfig: &configapi.FlowControlConfig{
-				DefaultPriorityBand: &configapi.PriorityBandConfig{
-					MaxRequests: ptr.To(resource.MustParse("-5")),
-				},
-			},
-			expectedErr: "DefaultPriorityBand MaxRequests must be non-negative",
-		},
-
-		// --- DefaultNegativePriorityBand ---
-		{
-			name: "ShouldSucceed_WithDefaultNegativePriorityBand",
-			apiConfig: &configapi.FlowControlConfig{
-				DefaultNegativePriorityBand: &configapi.PriorityBandConfig{
-					MaxBytes: ptr.To(resource.MustParse("100")),
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.NotNil(t, cfg.DefaultNegativePriorityBand)
-				assert.Equal(t, uint64(100), cfg.DefaultNegativePriorityBand.MaxBytes,
-					"DefaultNegativePriorityBand MaxBytes should be translated")
-				assert.NotNil(t, cfg.DefaultNegativePriorityBand.OrderingPolicy,
-					"DefaultNegativePriorityBand should have defaults applied")
-			},
-		},
-		{
-			name: "ShouldFallBackToDefaultBand_WhenNegativeBandIsNil",
-			apiConfig: &configapi.FlowControlConfig{
-				DefaultPriorityBand: &configapi.PriorityBandConfig{
-					MaxBytes: ptr.To(resource.MustParse("500")),
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				assert.Nil(t, cfg.DefaultNegativePriorityBand,
-					"DefaultNegativePriorityBand should remain nil when not configured")
-				require.NotNil(t, cfg.DefaultPriorityBand)
-				assert.Equal(t, uint64(500), cfg.DefaultPriorityBand.MaxBytes)
-			},
-		},
-		{
-			name: "ShouldError_WithNegativeDefaultNegativePriorityBandMaxBytes",
-			apiConfig: &configapi.FlowControlConfig{
-				DefaultNegativePriorityBand: &configapi.PriorityBandConfig{
-					MaxBytes: ptr.To(resource.MustParse("-1")),
-				},
-			},
-			expectedErr: "DefaultPriorityBand MaxBytes must be non-negative",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			cfg, err := NewConfigFromAPI(tc.apiConfig, handle)
-
-			if tc.expectedErr != "" {
-				require.Error(t, err, "NewConfigFromAPI should return an error")
-				assert.Contains(t, err.Error(), tc.expectedErr, "Error message should contain expected text")
-				assert.Nil(t, cfg, "Config should be nil when error occurs")
-			} else {
-				require.NoError(t, err, "NewConfigFromAPI should not return an error for valid input")
-				require.NotNil(t, cfg, "Config should not be nil on success")
-				if tc.assertion != nil {
-					tc.assertion(t, cfg)
-				}
-			}
-		})
-	}
-}
-
 func TestNewConfig_DefaultNegativePriorityBand(t *testing.T) {
 	t.Parallel()
-	handle := newTestPluginsHandle(t)
+	defaults := newTestPriorityBandPolicyDefaults()
 
 	t.Run("ShouldAcceptNegativeBandTemplate", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := NewConfig(handle,
+		cfg, err := NewConfig(defaults,
 			WithDefaultNegativePriorityBand(&PriorityBandConfig{
 				MaxBytes: 500,
 			}),
@@ -809,7 +455,7 @@ func TestNewConfig_DefaultNegativePriorityBand(t *testing.T) {
 
 	t.Run("ShouldAllowZeroMaxBytes_ForSheddableTraffic", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := NewConfig(handle,
+		cfg, err := NewConfig(defaults,
 			WithDefaultNegativePriorityBand(&PriorityBandConfig{}),
 		)
 		require.NoError(t, err)
@@ -820,7 +466,7 @@ func TestNewConfig_DefaultNegativePriorityBand(t *testing.T) {
 
 	t.Run("ShouldValidateNegativeBandTemplate", func(t *testing.T) {
 		t.Parallel()
-		_, err := NewConfig(handle,
+		_, err := NewConfig(defaults,
 			WithDefaultNegativePriorityBand(&PriorityBandConfig{
 				Queue: "non-existent-queue",
 			}),
@@ -830,7 +476,7 @@ func TestNewConfig_DefaultNegativePriorityBand(t *testing.T) {
 
 	t.Run("ShouldCloneNegativeBandTemplate", func(t *testing.T) {
 		t.Parallel()
-		original, err := NewConfig(handle,
+		original, err := NewConfig(defaults,
 			WithDefaultNegativePriorityBand(&PriorityBandConfig{
 				MaxBytes: 200,
 			}),

--- a/pkg/epp/flowcontrol/registry/registry_helpers_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_helpers_test.go
@@ -59,7 +59,7 @@ func newTestHarness(t *testing.T) *testHarness {
 	t.Helper()
 
 	globalConfig, err := NewConfig(
-		newTestPluginsHandle(t),
+		newTestPriorityBandPolicyDefaults(),
 		WithPriorityBand(&PriorityBandConfig{Priority: highPriority}),
 		WithPriorityBand(&PriorityBandConfig{Priority: lowPriority}),
 	)
@@ -392,7 +392,7 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 
 		// Update the config definition first (simulating the Registry's job).
 		dynamicPrio := 15
-		newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio)
+		newBandCfg, err := NewPriorityBandConfig(dynamicPrio, newTestPriorityBandPolicyDefaults())
 		require.NoError(t, err)
 		h.registry.config.PriorityBands[dynamicPrio] = newBandCfg
 
@@ -414,7 +414,7 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 
 		// Prepare config.
 		dynamicPrio := 15
-		newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio)
+		newBandCfg, err := NewPriorityBandConfig(dynamicPrio, newTestPriorityBandPolicyDefaults())
 		require.NoError(t, err)
 		h.registry.config.PriorityBands[dynamicPrio] = newBandCfg
 
@@ -525,7 +525,7 @@ func TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety(t *testing.T) {
 	h := newTestHarness(t)
 
 	dynamicPrio := 15
-	newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio)
+	newBandCfg, err := NewPriorityBandConfig(dynamicPrio, newTestPriorityBandPolicyDefaults())
 	require.NoError(t, err)
 	h.registry.config.PriorityBands[dynamicPrio] = newBandCfg
 

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -62,7 +62,7 @@ func newRegistryTestHarness(t *testing.T, opts harnessOptions) *registryTestHarn
 		cfg = opts.config.Clone()
 	} else {
 		cfg, err = NewConfig(
-			newTestPluginsHandle(t),
+			newTestPriorityBandPolicyDefaults(),
 			WithFlowGCTimeout(5*time.Minute),
 			WithPriorityBand(&PriorityBandConfig{Priority: highPriority}),
 			WithPriorityBand(&PriorityBandConfig{Priority: lowPriority}),
@@ -157,16 +157,16 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 	t.Run("ShouldFail_WhenJITFails", func(t *testing.T) {
 		t.Parallel()
 
-		handle := newTestPluginsHandle(t)
+		defaults := newTestPriorityBandPolicyDefaults()
 		badQueueName := queue.RegisteredQueueName("non-existent-queue")
-		badBand, err := NewPriorityBandConfig(handle, highPriority, WithQueue(badQueueName))
+		badBand, err := NewPriorityBandConfig(highPriority, defaults, WithQueue(badQueueName))
 		require.NoError(t, err)
 
 		// Create a Config that uses a mock checker to bypass the strict validation.
 		// The default checker would reject "non-existent-policy", but our mock says it's fine.
 		// This allows us to instantiate the Registry with a latent configuration bomb.
 		cfg, err := NewConfig(
-			handle,
+			defaults,
 			WithPriorityBand(badBand),
 			withCapabilityChecker(&mockCapabilityChecker{
 				checkCompatibilityFunc: func(flowcontrol.OrderingPolicy, queue.RegisteredQueueName) error {
@@ -396,10 +396,10 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 
 	t.Run("ShouldUseNegativeBandTemplate_WhenPriorityBelowZero", func(t *testing.T) {
 		t.Parallel()
-		handle := newTestPluginsHandle(t)
+		defaults := newTestPriorityBandPolicyDefaults()
 
 		negativeMaxBytes := uint64(256)
-		cfg, err := NewConfig(handle,
+		cfg, err := NewConfig(defaults,
 			WithDefaultNegativePriorityBand(&PriorityBandConfig{
 				MaxBytes: negativeMaxBytes,
 			}),
@@ -426,9 +426,9 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 
 	t.Run("ShouldFallBackToDefaultBand_WhenNegativeTemplateIsNil", func(t *testing.T) {
 		t.Parallel()
-		handle := newTestPluginsHandle(t)
+		defaults := newTestPriorityBandPolicyDefaults()
 
-		cfg, err := NewConfig(handle)
+		cfg, err := NewConfig(defaults)
 		require.NoError(t, err)
 
 		h := newRegistryTestHarness(t, harnessOptions{config: cfg})
@@ -451,10 +451,10 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 
 	t.Run("ShouldUseDefaultBand_WhenPositivePriorityWithNegativeTemplate", func(t *testing.T) {
 		t.Parallel()
-		handle := newTestPluginsHandle(t)
+		defaults := newTestPriorityBandPolicyDefaults()
 
 		negativeMaxBytes := uint64(100)
-		cfg, err := NewConfig(handle,
+		cfg, err := NewConfig(defaults,
 			WithDefaultNegativePriorityBand(&PriorityBandConfig{
 				MaxBytes: negativeMaxBytes,
 			}),
@@ -1196,7 +1196,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 // requests waiting on the same flow initialization.
 func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	t.Parallel()
-	handle := newTestPluginsHandle(t)
+	defaults := newTestPriorityBandPolicyDefaults()
 
 	// Create a registry with a capability checker that passes validation but using a queue name that doesn't exist.
 	// This ensures NewConfig succeeds, but JIT (ensureFlowInfrastructure) fails when trying to instantiate the queue.
@@ -1209,10 +1209,10 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 
 	// We create a custom band config that uses this failing queue.
 	// We set it as the default band so that dynamic provisioning is used.
-	failingBand, err := NewPriorityBandConfig(handle, 0, WithQueue(failQueueName))
+	failingBand, err := NewPriorityBandConfig(0, defaults, WithQueue(failQueueName))
 	require.NoError(t, err)
 
-	cfg, err := NewConfig(handle, withCapabilityChecker(mockChecker), WithDefaultPriorityBand(failingBand))
+	cfg, err := NewConfig(defaults, withCapabilityChecker(mockChecker), WithDefaultPriorityBand(failingBand))
 	require.NoError(t, err)
 
 	registry := NewFlowRegistry(cfg, logr.Discard())


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind cleanup

**What this PR does / why we need it**:

Moves all flow-control plugin resolution (ordering, fairness, and usage-limit policies) from `pkg/epp/flowcontrol/` into `pkg/epp/config/loader/`, making the config loader the single boundary for plugin resolution. After this change, `plugin.Handle` is strictly isolated to the loader package and flow-control internals only receive fully hydrated policy instances.

Key changes:

  - `registry/config.go`: removed `plugin.Handle` from all signatures; `WithOrderingPolicy/WithFairnessPolicy` accept instances directly; introduced `PriorityBandPolicyDefaults` to carry pre-resolved defaults
  - flowcontrol/config.go: replaced `NewConfigFromAPI(apiConfig, handle)` with constructor `NewConfig(ctrl, reg, ulp)` 
  - `loader/flowcontrol.go`: new file, `buildFlowControlConfig()` resolves all policies via the `Handle`, translates API config, and passes resolved instances to registry constructors
  - Collapsed `buildDefaultPriorityBandTemplate()` into `buildPriorityBand()` (identical logic)
  - Introduced a generic `resolvePlugin[T]()` helper for type-safe plugin resolution
  - All deleted tests should have carried over to `loader/flowcontrol_test.go`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1077

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
