### PR TITLE
docs: update release template image links to new image names

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -98,7 +98,7 @@ This document defines the process for releasing llm-d-router.
     git push ${REMOTE} v${MAJOR}.${MINOR}.${PATCH}
     ```
 
-1. Pushing the tag triggers CI action to build and publish the container image to the [ghcr registry].
+1. Pushing the tag triggers CI action to build and publish the [EPP image] and [sidecar image] to the [ghcr registry].
 1. Test the steps in the tagged quickstart guide after the PR merges. TODO add e2e tests! <!-- link to an e2e tests once we have such one -->
 
 ### Create the release!
@@ -126,6 +126,8 @@ Use the following steps to announce the release.
 1. Close this issue.
 
 [repo]: https://github.com/llm-d/llm-d-router
-[ghcr registry]: https://github.com/llm-d/llm-d-router/pkgs/container/llm-d-inference-scheduler # TODO: we need udpate this once image are pushed with new name
+[ghcr registry]: https://github.com/orgs/llm-d/packages?repo_name=llm-d-router
+[EPP image]: https://github.com/llm-d/llm-d-router/pkgs/container/llm-d-router-endpoint-picker
+[sidecar image]: https://github.com/llm-d/llm-d-router/pkgs/container/llm-d-router-disagg-sidecar
 [new release]: https://github.com/llm-d/llm-d-router/releases/new
 [issue]: https://github.com/llm-d/llm-d-router/issues/new/choose


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind cleanup

**What this PR does / why we need it**:

The repository rename produced two published container images (`llm-d-router-endpoint-picker` and `llm-d-router-disagg-sidecar`) under the new repo name. The release template still pointed `[ghcr registry]` at the old `llm-d-inference-scheduler` package path with a TODO.

**Which issue(s) this PR fixes**:
Refs #1103

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```