### PR TITLE
proxy: document and test /v1/rerank passthrough to decoder

### DIFF
--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -44,6 +44,11 @@ var (
 
 	// ResponsesPath is the OpenAI Responses API path
 	ResponsesPath = "/v1/responses"
+
+	// RerankPath is the OpenAI-compatible rerank path used by vLLM and compatible servers.
+	// Rerank requests do not require KV-cache-aware scheduling and are proxied directly
+	// to the decoder without modification.
+	RerankPath = "/v1/rerank"
 )
 
 func openAIAPIAttr(apiType APIType) attribute.KeyValue {

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -394,6 +394,8 @@ func (s *Server) createRoutes() *http.ServeMux {
 
 	s.decoderProxy = s.createDecoderProxyHandler(s.config.DecoderURL, s.config.InsecureSkipVerifyForDecoder)
 
+	// All other paths (e.g. /v1/rerank, /v1/embeddings) are proxied directly to the
+	// decoder without KV-cache-aware scheduling, as they do not produce generated tokens.
 	mux.Handle("/", s.decoderProxy)
 
 	return mux

--- a/pkg/sidecar/proxy/proxy_test.go
+++ b/pkg/sidecar/proxy/proxy_test.go
@@ -118,12 +118,14 @@ var _ = Describe("Reverse Proxy", func() {
 			Entry("when the path is /v1/chat/completions and secure proxy is false", "/v1/chat/completions", false),
 			Entry("when the path is /v1/completions and secure proxy is false", "/v1/completions", false),
 			Entry("when the path is /v1/embeddings and secure proxy is false", "/v1/embeddings", false),
+			Entry("when the path is /v1/rerank and secure proxy is false", "/v1/rerank", false),
 			Entry("when the path is /score and secure proxy is false", "/score", false),
 			Entry("when the path is /healthz and secure proxy is false", "/healthz", false),
 
 			Entry("when the path is /v1/chat/completions and secure proxy is true", "/v1/chat/completions", true),
 			Entry("when the path is /v1/completions and secure proxy is true", "/v1/completions", true),
 			Entry("when the path is /v1/embeddings and secure proxy is true", "/v1/embeddings", true),
+			Entry("when the path is /v1/rerank and secure proxy is true", "/v1/rerank", true),
 			Entry("when the path is /score and secure proxy is true", "/score", true),
 			Entry("when the path is /healthz and secure proxy is true", "/healthz", true),
 		)


### PR DESCRIPTION
## Summary

This PR adds explicit documentation, a named constant, and regression tests for the `/v1/rerank` passthrough behaviour in the PD-sidecar.

### Background

When deploying a reranker model (e.g. `Qwen3-Reranker-0.6B`) behind an llm-d `InferencePool`, rerank requests sent to the sidecar at `/v1/rerank` received a `400 BadRequest` error with the message:

```
inference error: BadRequest - invalid completions request: must have prompt field
```

This was observed with the older `llm-d-routing-sidecar:v0.8.0` image which validated **all** incoming request bodies as completions requests requiring a `prompt` field. The current `llm-d-router` code already handles this correctly — `/v1/rerank` falls through to the `decoderProxy` catch-all in `createRoutes()`. However this behaviour was implicit and untested.

Tracked in: #1340

### Changes

- **`pkg/sidecar/proxy/chat_completions.go`**: Add `RerankPath = "/v1/rerank"` constant alongside `ChatCompletionsPath`, `CompletionsPath`, and `ResponsesPath`, making it clear that this path is a known, explicitly supported non-generation endpoint.

- **`pkg/sidecar/proxy/proxy.go`**: Add a comment in `createRoutes()` documenting that the catch-all `mux.Handle("/", s.decoderProxy)` intentionally handles non-generation paths (rerank, embeddings, etc.) as direct decoder pass-throughs without KV-cache scheduling.

- **`pkg/sidecar/proxy/proxy_test.go`**: Add two new `Entry` cases to the existing `"should forward requests to decode server"` table test, covering `POST /v1/rerank` with both plain HTTP and TLS proxy modes.

### Why this is the right fix

KV-cache-aware scheduling (disaggregated prefill) is only meaningful for generation endpoints that produce tokens. Rerankers and embedding models produce scores/vectors, not tokens, and must not be routed through the prefill/decode disaggregation path. The catch-all passthrough is correct; this PR makes the intent explicit and tested.
