### PR TITLE
Drop top-level 'tokens' field from body before forwarding request to vLLM

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -48,6 +48,7 @@ const (
 	// to account for optional parameters like "; charset=utf-8" often appended by proxies.
 	eventStreamType = "text/event-stream"
 
+	tokensField              = "tokens"
 	usageField               = "usage"
 	promptTokensField        = "prompt_tokens"
 	inputTokensField         = "input_tokens"
@@ -106,7 +107,7 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if err != nil {
 		return nil, err
 	}
-	delete(bodyMap, "tokens")
+	delete(bodyMap, tokensField)
 	extractedBody.Payload = fwkrh.PayloadMap(bodyMap)
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		extractedBody.Stream = true

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -106,6 +106,7 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if err != nil {
 		return nil, err
 	}
+	delete(bodyMap, "tokens")
 	extractedBody.Payload = fwkrh.PayloadMap(bodyMap)
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		extractedBody.Stream = true

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -173,7 +173,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"tokens": map[string]any{
 					"token_ids": []any{1, 2, 3},
 					"features": map[string]any{
-						"mm_hashes":        map[string]any{"image": []any{"abc"}},
+						"mm_hashes":       map[string]any{"image": []any{"abc"}},
 						"mm_placeholders": map[string]any{"image": []any{map[string]any{"offset": 1, "length": 3}}},
 					},
 				},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -163,6 +163,54 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
+			name:    "chat completions request body strips top-level tokens field",
+			headers: map[string]string{":path": "/v1/chat/completions"},
+			body: map[string]any{
+				"model": "test",
+				"messages": []any{
+					map[string]any{"role": "user", "content": "hello"},
+				},
+				"tokens": map[string]any{
+					"token_ids": []any{1, 2, 3},
+					"features": map[string]any{
+						"mm_hashes":        map[string]any{"image": []any{"abc"}},
+						"mm_placeholders": map[string]any{"image": []any{map[string]any{"offset": 1, "length": 3}}},
+					},
+				},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				ChatCompletions: &fwkrh.ChatCompletionsRequest{
+					Messages: []fwkrh.Message{
+						{Role: "user", Content: fwkrh.Content{Raw: "hello"}},
+					},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model": "test",
+					"messages": []any{
+						map[string]any{"role": "user", "content": "hello"},
+					},
+				},
+			},
+		},
+		{
+			name:    "completions request body strips top-level tokens field",
+			headers: map[string]string{":path": "/v1/completions"},
+			body: map[string]any{
+				"model":  "test",
+				"prompt": "hello",
+				"tokens": map[string]any{"token_ids": []any{1, 2, 3}},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Completions: &fwkrh.CompletionsRequest{
+					Prompt: fwkrh.Prompt{Raw: "hello"},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model":  "test",
+					"prompt": "hello",
+				},
+			},
+		},
+		{
 			name:    "chat completions request body with multi-modal content",
 			headers: map[string]string{":path": "/v1/chat/completions"},
 			body: map[string]any{

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -193,24 +193,6 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
-			name:    "completions request body strips top-level tokens field",
-			headers: map[string]string{":path": "/v1/completions"},
-			body: map[string]any{
-				"model":  "test",
-				"prompt": "hello",
-				"tokens": map[string]any{"token_ids": []any{1, 2, 3}},
-			},
-			want: &fwkrh.InferenceRequestBody{
-				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{Raw: "hello"},
-				},
-				Payload: fwkrh.PayloadMap{
-					"model":  "test",
-					"prompt": "hello",
-				},
-			},
-		},
-		{
 			name:    "chat completions request body with multi-modal content",
 			headers: map[string]string{":path": "/v1/chat/completions"},
 			body: map[string]any{


### PR DESCRIPTION
## Summary:

A top-level `tokens` block on `/v1/chat/completions` requests (`token_ids` / `mm_hashes` / `mm_placeholders`) is not part of the OpenAI API. When it presents, vLLM wars about this and proceeds. 

`tokens` key is dropped from the `PayloadMap` in the parser (after it's stored for routing purposes), so the field is gone by
the time `repackage` re-marshals the body for forwarding.

### Which issue(s) this PR fixes:
Fixes [#1367](https://github.com/llm-d/llm-d-router/issues/1367)