### PR TITLE
add per-request attribute store to InferenceRequest

### DIFF
--- a/pkg/epp/framework/interface/plugin/plugin_state.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state.go
@@ -43,10 +43,15 @@ func NewPluginState(ctx context.Context) *PluginState {
 	return pluginState
 }
 
-// PluginState provides a mechanism for plugins to store and retrieve arbitrary data by multiple extension points.
-// Data stored by the plugin in one extension point can be written, read or altered by another extension point.
-// The data stored in PluginState is always stored in the context of a given request.
-// If the data hasn't been accessed during "stalenessThreshold", it is cleaned by a cleanup internal mechanism.
+// PluginState is per-plugin scratch storage scoped to a single request. A plugin's
+// extension points (e.g. PreRequest, ResponseBody) can write, read, and alter entries
+// here to coordinate within that plugin. Entries are keyed by RequestID and reaped
+// after "stalenessThreshold" of inactivity.
+//
+// PluginState is not a cross-plugin handoff channel. Data shared between plugins must
+// flow through the Producer/Consumer DAG: write to Endpoint AttributeMap for
+// per-endpoint data, or to the InferenceRequest attribute store for per-request data.
+// The DAG validates type compatibility and execution ordering; PluginState does not.
 //
 // Note: PluginState uses a sync.Map to back the storage, because it is thread safe.
 // It's aimed to optimize for the "write once and read many times" scenarios.

--- a/pkg/epp/framework/interface/scheduling/attributes.go
+++ b/pkg/epp/framework/interface/scheduling/attributes.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import "sync"
+
+// PutAttribute stores value at key in the request's attribute store.
+// The backing store is lazily allocated on first write.
+// Callers must not write concurrently to the same request from multiple goroutines.
+func (r *InferenceRequest) PutAttribute(key string, value any) {
+	if r.attributes == nil {
+		r.attributes = &sync.Map{}
+	}
+	r.attributes.Store(key, value)
+}
+
+// GetAttribute returns the value stored at key, or nil and false if absent.
+// Prefer ReadRequestAttribute for type-safe access.
+func (r *InferenceRequest) GetAttribute(key string) (any, bool) {
+	if r.attributes == nil {
+		return nil, false
+	}
+	return r.attributes.Load(key)
+}
+
+// AttributeKeys returns the keys currently present in the request's attribute store.
+// The order is unspecified.
+func (r *InferenceRequest) AttributeKeys() []string {
+	keys := make([]string, 0)
+	if r.attributes == nil {
+		return keys
+	}
+	r.attributes.Range(func(k, _ any) bool {
+		if s, ok := k.(string); ok {
+			keys = append(keys, s)
+		}
+		return true
+	})
+	return keys
+}
+
+// ReadRequestAttribute returns the value stored at key, type-asserted to T.
+// It returns the zero value of T and false if the key is missing or the value
+// is not of type T.
+func ReadRequestAttribute[T any](r *InferenceRequest, key string) (T, bool) {
+	var zero T
+	v, ok := r.GetAttribute(key)
+	if !ok {
+		return zero, false
+	}
+	t, ok := v.(T)
+	if !ok {
+		return zero, false
+	}
+	return t, true
+}

--- a/pkg/epp/framework/interface/scheduling/attributes_test.go
+++ b/pkg/epp/framework/interface/scheduling/attributes_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestAttributes_PutThenGet(t *testing.T) {
+	r := &InferenceRequest{}
+
+	r.PutAttribute("session", "abc")
+	v, ok := r.GetAttribute("session")
+	assert.True(t, ok)
+	assert.Equal(t, "abc", v)
+
+	_, ok = r.GetAttribute("missing")
+	assert.False(t, ok)
+}
+
+func TestRequestAttributes_KeysAfterPuts(t *testing.T) {
+	r := &InferenceRequest{}
+
+	r.PutAttribute("a", 1)
+	r.PutAttribute("b", "two")
+	r.PutAttribute("a", 11) // overwrite
+
+	assert.ElementsMatch(t, []string{"a", "b"}, r.AttributeKeys())
+}
+
+func TestReadRequestAttribute(t *testing.T) {
+	r := &InferenceRequest{}
+	r.PutAttribute("count", 42)
+	r.PutAttribute("name", "alpha")
+
+	count, ok := ReadRequestAttribute[int](r, "count")
+	assert.True(t, ok)
+	assert.Equal(t, 42, count)
+
+	name, ok := ReadRequestAttribute[string](r, "name")
+	assert.True(t, ok)
+	assert.Equal(t, "alpha", name)
+
+	missing, ok := ReadRequestAttribute[int](r, "absent")
+	assert.False(t, ok)
+	assert.Equal(t, 0, missing)
+
+	mismatch, ok := ReadRequestAttribute[string](r, "count")
+	assert.False(t, ok)
+	assert.Equal(t, "", mismatch)
+}
+
+func TestRequestAttributes_ZeroValueRequestIsUsable(t *testing.T) {
+	var r InferenceRequest
+
+	r.PutAttribute("k", "v")
+	v, ok := r.GetAttribute("k")
+	assert.True(t, ok)
+	assert.Equal(t, "v", v)
+}
+
+func TestRequestAttributes_ConcurrentAfterInit(t *testing.T) {
+	r := &InferenceRequest{}
+	r.PutAttribute("seed", 0) // ensure the store is allocated before concurrent writers start
+
+	const writers = 8
+	const writes = 200
+	var wg sync.WaitGroup
+
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < writes; i++ {
+				key := strconv.Itoa(id) + ":" + strconv.Itoa(i)
+				r.PutAttribute(key, i)
+				if v, ok := ReadRequestAttribute[int](r, key); !ok || v != i {
+					t.Errorf("round-trip failed for %s: ok=%v v=%v", key, ok, v)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	assert.Len(t, r.AttributeKeys(), writers*writes+1)
+}

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
@@ -57,6 +58,11 @@ type InferenceRequest struct {
 	RequestSizeBytes int
 	// SchedulingResult captures the scheduling decisions made during the cycle.
 	SchedulingResult *SchedulingResult
+
+	// attributes holds per-request data produced and consumed across plugins.
+	// Access via PutAttribute, GetAttribute, AttributeKeys, and ReadRequestAttribute.
+	// A nil pointer is valid; the store is lazily allocated on first write.
+	attributes *sync.Map
 }
 
 func (r *InferenceRequest) String() string {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a request-scoped attribute map on `InferenceRequest` so producers and consumers can flow per-request data through the existing Producer/Consumer DAG, alongside the per-endpoint `AttributeMap`. Today there is no natural home for request-only attributes (session id, agent id, parsed token bag): producers have to duplicate the value across every endpoint or abuse `PluginState` as a cross-plugin handoff channel. The DAG keys off `DataKey` types regardless of where the producer stores the data, so storage location is a producer-side choice and intentionally not validated.

The store uses `any` rather than `Cloneable`. `Endpoint.AttributeMap` requires `Cloneable` because endpoints are snapshotted; `InferenceRequest` is not cloned, so the constraint would be a tax with no benefit. Type-safe access is via the generic `ReadRequestAttribute[T]` helper. Sequential per-request access is the documented contract, matching how data producers actually run.

Also tightens the `PluginState` doc comment to say it is per-plugin scratch keyed by request id and not a mechanism for sharing data across plugins; cross-plugin data flow should go through the DAG.

**Which issue(s) this PR fixes**:

Fixes #1336

**Release note**:

```release-note
NONE
```