### PR TITLE
flowcontrol: move priority band provisioning off request hot path

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -379,7 +379,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 	endpointCandidates := contracts.EndpointCandidates(requestcontrol.NewDatastoreEndpointCandidates(ds,
 		requestcontrol.WithDisableEndpointSubsetFilter(opts.DisableEndpointSubsetFilter)))
-	endpointCandidates, admissionController := r.initAdmissionControl(ctx, opts, eppConfig, endpointCandidates)
+	endpointCandidates, admissionController, priorityBandControlPlane := r.initAdmissionControl(ctx, opts, eppConfig, endpointCandidates)
 
 	director := requestcontrol.NewDirectorWithConfig(ds, scheduler, admissionController, endpointCandidates, r.requestControlConfig)
 
@@ -397,6 +397,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		Director:                         director,
 		ParserRegistry:                   r.parserRegistry,
 		SaturationDetector:               eppConfig.SaturationDetector,
+		PriorityBandControlPlane:         priorityBandControlPlane,
 		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
 		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
 	}
@@ -822,11 +823,12 @@ func (r *Runner) initAdmissionControl(
 	opts *runserver.Options,
 	eppConfig *config.Config,
 	endpointCandidates contracts.EndpointCandidates,
-) (contracts.EndpointCandidates, requestcontrol.AdmissionController) {
+) (contracts.EndpointCandidates, requestcontrol.AdmissionController, contracts.PriorityBandControlPlane) {
 	if !r.featureGates[flowcontrol.FeatureGate] {
 		setupLog.Info("Experimental Flow Control layer is disabled, using legacy admission control")
 		return endpointCandidates,
-			requestcontrol.NewLegacyAdmissionController(eppConfig.SaturationDetector, endpointCandidates)
+			requestcontrol.NewLegacyAdmissionController(eppConfig.SaturationDetector, endpointCandidates),
+			nil
 	}
 	endpointCandidates = requestcontrol.NewCachedEndpointCandidates(ctx, endpointCandidates, 50*time.Millisecond)
 	setupLog.Info("Initializing experimental Flow Control layer")
@@ -843,7 +845,7 @@ func (r *Runner) initAdmissionControl(
 		},
 	)
 	go registry.Run(ctx)
-	return endpointCandidates, requestcontrol.NewFlowControlAdmissionController(fc, opts.PoolName)
+	return endpointCandidates, requestcontrol.NewFlowControlAdmissionController(fc, opts.PoolName), registry
 }
 
 // runWithFileDiscovery handles the execution path when a discovery plugin is configured.
@@ -918,7 +920,9 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	// EndpointPickerConfig.flowControl still apply.
 	endpointCandidates := contracts.EndpointCandidates(requestcontrol.NewDatastoreEndpointCandidates(ds,
 		requestcontrol.WithDisableEndpointSubsetFilter(opts.DisableEndpointSubsetFilter)))
-	endpointCandidates, admissionController := r.initAdmissionControl(ctx, opts, eppConfig, endpointCandidates)
+	// File-discovery mode has no InferenceObjective reconciler to drive the
+	// control plane; static bands from config apply at registry construction.
+	endpointCandidates, admissionController, _ := r.initAdmissionControl(ctx, opts, eppConfig, endpointCandidates)
 	director := requestcontrol.NewDirectorWithConfig(ds, scheduler, admissionController, endpointCandidates, r.requestControlConfig)
 
 	gknn := common.GKNN{

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -844,7 +844,6 @@ func (r *Runner) initAdmissionControl(
 			UsageLimitPolicy:   eppConfig.FlowControlConfig.UsageLimitPolicy,
 		},
 	)
-	go registry.Run(ctx)
 	return endpointCandidates, requestcontrol.NewFlowControlAdmissionController(fc, opts.PoolName), registry
 }
 

--- a/pkg/epp/controller/inferenceobjective_reconciler.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler.go
@@ -32,12 +32,14 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 )
 
 type InferenceObjectiveReconciler struct {
 	client.Reader
-	Datastore datastore.Datastore
-	PoolGKNN  common.GKNN
+	Datastore                datastore.Datastore
+	PoolGKNN                 common.GKNN
+	PriorityBandControlPlane contracts.PriorityBandControlPlane
 }
 
 func (c *InferenceObjectiveReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -64,15 +66,30 @@ func (c *InferenceObjectiveReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if notFound || !infObjective.DeletionTimestamp.IsZero() || infObjective.Spec.PoolRef.Name != v1alpha2.ObjectName(c.PoolGKNN.Name) || infObjective.Spec.PoolRef.Group != v1alpha2.Group(c.PoolGKNN.Group) {
 		// InferenceObjective object got deleted or changed the referenced inferencePool.
 		c.Datastore.ObjectiveDelete(req.NamespacedName)
+		c.syncPriorityBands()
 		return ctrl.Result{}, nil
 	}
 
 	// Add or update if the InferenceObjective instance has a creation timestamp older than the existing entry of the model.
 	logger = logger.WithValues("poolRef", infObjective.Spec.PoolRef)
 	c.Datastore.ObjectiveSet(infObjective)
+	c.syncPriorityBands()
 	logger.Info("Added/Updated InferenceObjective")
 
 	return ctrl.Result{}, nil
+}
+
+func (c *InferenceObjectiveReconciler) syncPriorityBands() {
+	if c.PriorityBandControlPlane == nil {
+		return
+	}
+	desired := make(map[int]struct{})
+	for _, objective := range c.Datastore.ObjectiveGetAll() {
+		if objective.Spec.Priority != nil {
+			desired[int(*objective.Spec.Priority)] = struct{}{}
+		}
+	}
+	c.PriorityBandControlPlane.SubmitDesiredPriorities(desired)
 }
 
 func (c *InferenceObjectiveReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -214,7 +214,7 @@ func setupRegistry(
 	}
 
 	reg := registry.NewFlowRegistry(regCfg, logr.Discard())
-	// Registry maintenance (GC, priority band sync) runs in the ShardProcessor loop started by FlowController.
+	// Registry maintenance (GC, priority band sync) runs in the Processor loop started by FlowController.
 	return reg
 }
 

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -187,7 +187,6 @@ func (r *benchRequest) ReceivedTimestamp() time.Time                   { return 
 
 // setupRegistry provisions the concrete FlowRegistry.
 func setupRegistry(
-	ctx context.Context,
 	b *testing.B,
 	defaults registry.PriorityBandPolicyDefaults,
 	p priorityLevels,
@@ -215,8 +214,7 @@ func setupRegistry(
 	}
 
 	reg := registry.NewFlowRegistry(regCfg, logr.Discard())
-
-	go reg.Run(ctx)
+	// Registry maintenance (GC, priority band sync) runs in the ShardProcessor loop started by FlowController.
 	return reg
 }
 
@@ -249,7 +247,7 @@ func setupBenchmarkHarness(
 		FairnessPolicy: fPolicy.(flowcontrol.FairnessPolicy),
 	}
 
-	reg := setupRegistry(ctx, b, defaults, p)
+	reg := setupRegistry(b, defaults, p)
 
 	detector := customDetector
 	if detector == nil {

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -348,7 +348,7 @@ func setupFullPathBenchmark(ctx context.Context, b *testing.B, name string, numP
 		OrderingPolicy: oPolicy.(flowcontrol.OrderingPolicy),
 		FairnessPolicy: fPolicy.(flowcontrol.FairnessPolicy),
 	}
-	reg := setupRegistry(ctx, b, defaults, priorityLevels(numPriorities))
+	reg := setupRegistry(b, defaults, priorityLevels(numPriorities))
 
 	fc := controller.NewFlowController(ctx, name+"-bench", &controller.Config{
 		DefaultRequestTTL:        5 * time.Minute,

--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
@@ -96,6 +97,22 @@ func (m *MockRegistryDataPlane) WithConnection(key flowcontrol.FlowKey, fn func(
 	}
 	return nil
 }
+
+func (m *MockRegistryDataPlane) SubmitDesiredPriorities(_ map[int]struct{}) {}
+
+func (m *MockRegistryDataPlane) PriorityBandUpdateChannel() <-chan map[int]struct{} {
+	return nil
+}
+
+func (m *MockRegistryDataPlane) FlowGCTimeout() time.Duration {
+	return time.Minute
+}
+
+func (m *MockRegistryDataPlane) ApplyDesiredPriorities(_ map[int]struct{}) {}
+
+func (m *MockRegistryDataPlane) ExecuteGCCycle() {}
+
+var _ contracts.FlowRegistry = &MockRegistryDataPlane{}
 
 var _ contracts.FlowRegistryDataPlane = &MockRegistryDataPlane{}
 

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -55,7 +55,7 @@ type PriorityBandControlPlane interface {
 	SubmitDesiredPriorities(desired map[int]struct{})
 }
 
-// FlowRegistryBackground exposes hooks consumed by the ShardProcessor maintenance loop.
+// FlowRegistryBackground exposes hooks consumed by the Processor maintenance loop.
 type FlowRegistryBackground interface {
 	PriorityBandUpdateChannel() <-chan map[int]struct{}
 	FlowGCTimeout() time.Duration

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -17,6 +17,8 @@ limitations under the License.
 package contracts
 
 import (
+	"time"
+
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 )
 
@@ -31,16 +33,34 @@ import (
 // A flow instance, identified by its immutable FlowKey, has a lease-based lifecycle managed by this interface.
 // Any implementation MUST adhere to this lifecycle:
 //
-//  1. Lease Acquisition: A client calls Connect to acquire a lease. This signals that the flow is in use and protects
-//     it from garbage collection. If the flow does not exist, it is created Just-In-Time (JIT).
+//  1. Lease Acquisition: A client calls WithConnection to acquire a lease. This signals that the flow is in use and
+//     protects it from garbage collection. If the flow instance does not exist, it is created on first use.
+//     Priority bands must be provisioned by the control plane before use; they are not created on the request path.
 //  2. Active State: A flow is "Active" as long as its lease count is greater than zero.
-//  3. Lease Release: The client MUST call `Close()` on the returned `FlowConnection` to release the lease.
+//  3. Lease Release: When the WithConnection callback returns, the lease is released.
 //     When the lease count drops to zero, the flow becomes "Idle".
 //  4. Garbage Collection: The implementation MUST automatically garbage collect a flow after it has remained
 //     continuously Idle for a configurable duration.
 type FlowRegistry interface {
 	FlowRegistryObserver
 	FlowRegistryDataPlane
+	PriorityBandControlPlane
+	FlowRegistryBackground
+}
+
+// PriorityBandControlPlane submits priority band topology updates from the control plane.
+type PriorityBandControlPlane interface {
+	// SubmitDesiredPriorities queues the set of priority levels that should remain provisioned.
+	// Dynamic bands not in this set become eligible for removal once idle.
+	SubmitDesiredPriorities(desired map[int]struct{})
+}
+
+// FlowRegistryBackground exposes hooks consumed by the ShardProcessor maintenance loop.
+type FlowRegistryBackground interface {
+	PriorityBandUpdateChannel() <-chan map[int]struct{}
+	FlowGCTimeout() time.Duration
+	ApplyDesiredPriorities(desired map[int]struct{})
+	ExecuteGCCycle()
 }
 
 // FlowRegistryObserver defines the read-only, observation interface for the registry.
@@ -55,8 +75,8 @@ type FlowRegistryDataPlane interface {
 	// It is the primary and sole entry point for interacting with the data path.
 	//
 	// This method handles the entire lifecycle of a flow connection:
-	// 1. Just-In-Time (JIT) Registration: If the flow for the given FlowKey does not exist, it is created and registered
-	//    automatically.
+	// 1. Flow Registration: If the flow for the given FlowKey does not exist, it is created and registered
+	//    automatically. Priority bands must be provisioned by the control plane before use.
 	// 2. Lease Acquisition: It acquires a lifecycle lease, protecting the flow from garbage collection.
 	// 3. Callback Execution: It invokes the provided function `fn`, passing in a temporary `ActiveFlowConnection` handle.
 	// 4. Guaranteed Lease Release: It ensures the lease is safely released when the callback function returns.

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -83,17 +83,17 @@ var _ processor = &internal.Processor{}
 type FlowController struct {
 	// --- Immutable dependencies (set at construction) ---
 
-	config                *Config
-	registry              registryClient
-	flowRegistry          contracts.FlowRegistry
-	registryBackground    contracts.FlowRegistryBackground
-	saturationDetector    flowcontrol.SaturationDetector
-	endpointCandidates    contracts.EndpointCandidates
-	usageLimitPolicy      flowcontrol.UsageLimitPolicy
-	clock                 clock.WithTicker
-	logger                logr.Logger
-	processorFactory      processorFactory
-	processor             processor
+	config             *Config
+	registry           registryClient
+	flowRegistry       contracts.FlowRegistry
+	registryBackground contracts.FlowRegistryBackground
+	saturationDetector flowcontrol.SaturationDetector
+	endpointCandidates contracts.EndpointCandidates
+	usageLimitPolicy   flowcontrol.UsageLimitPolicy
+	clock              clock.WithTicker
+	logger             logr.Logger
+	processorFactory   processorFactory
+	processor          processor
 
 	// --- Lifecycle state ---
 

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -57,6 +57,7 @@ type processor interface {
 type processorFactory func(
 	ctx context.Context,
 	registry contracts.FlowRegistry,
+	registryBackground contracts.FlowRegistryBackground,
 	saturationDetector flowcontrol.SaturationDetector,
 	endpointCandidates contracts.EndpointCandidates,
 	usageLimitPolicy flowcontrol.UsageLimitPolicy,
@@ -82,15 +83,17 @@ var _ processor = &internal.Processor{}
 type FlowController struct {
 	// --- Immutable dependencies (set at construction) ---
 
-	config             *Config
-	registry           registryClient
-	saturationDetector flowcontrol.SaturationDetector
-	endpointCandidates contracts.EndpointCandidates
-	usageLimitPolicy   flowcontrol.UsageLimitPolicy
-	clock              clock.WithTicker
-	logger             logr.Logger
-	processorFactory   processorFactory
-	processor          processor
+	config                *Config
+	registry              registryClient
+	flowRegistry          contracts.FlowRegistry
+	registryBackground    contracts.FlowRegistryBackground
+	saturationDetector    flowcontrol.SaturationDetector
+	endpointCandidates    contracts.EndpointCandidates
+	usageLimitPolicy      flowcontrol.UsageLimitPolicy
+	clock                 clock.WithTicker
+	logger                logr.Logger
+	processorFactory      processorFactory
+	processor             processor
 
 	// --- Lifecycle state ---
 
@@ -120,9 +123,15 @@ func NewFlowController(
 	if deps.Clock == nil {
 		deps.Clock = clock.RealClock{}
 	}
+	var registryBackground contracts.FlowRegistryBackground
+	if bg, ok := deps.Registry.(contracts.FlowRegistryBackground); ok {
+		registryBackground = bg
+	}
 	fc := &FlowController{
 		config:             config,
 		registry:           deps.Registry,
+		flowRegistry:       deps.Registry,
+		registryBackground: registryBackground,
 		saturationDetector: deps.SaturationDetector,
 		endpointCandidates: deps.EndpointCandidates,
 		usageLimitPolicy:   deps.UsageLimitPolicy,
@@ -135,6 +144,7 @@ func NewFlowController(
 		fc.processorFactory = func(
 			ctx context.Context,
 			registry contracts.FlowRegistry,
+			registryBackground contracts.FlowRegistryBackground,
 			saturationDetector flowcontrol.SaturationDetector,
 			endpointCandidates contracts.EndpointCandidates,
 			usageLimitPolicy flowcontrol.UsageLimitPolicy,
@@ -147,6 +157,7 @@ func NewFlowController(
 				ctx,
 				poolName,
 				registry,
+				registryBackground,
 				saturationDetector,
 				endpointCandidates,
 				usageLimitPolicy,
@@ -163,7 +174,8 @@ func NewFlowController(
 	// Construct a new worker, but do not start its goroutine yet.
 	fc.processor = fc.processorFactory(
 		fc.parentCtx,
-		fc.registry,
+		fc.flowRegistry,
+		fc.registryBackground,
 		fc.saturationDetector,
 		fc.endpointCandidates,
 		fc.usageLimitPolicy,
@@ -227,7 +239,7 @@ func (fc *FlowController) EnqueueAndWait(
 
 	// 2. Acquire a lease for the Flow.
 	// We hold this lease for the entire duration of the request (Distribution + Queueing).
-	err := fc.registry.WithConnection(flowKey, func(conn contracts.ActiveFlowConnection) error {
+	err := fc.withConnectionWithDemotion(flowKey, func(conn contracts.ActiveFlowConnection) error {
 
 		select { // Non-blocking check on controller lifecycle.
 		case <-fc.parentCtx.Done():
@@ -264,6 +276,26 @@ func (fc *FlowController) EnqueueAndWait(
 	}
 
 	return finalOutcome, err
+}
+
+// withConnectionWithDemotion acquires a flow connection, demoting to priority 0 when the requested band is not yet provisioned.
+func (fc *FlowController) withConnectionWithDemotion(
+	key flowcontrol.FlowKey,
+	fn func(conn contracts.ActiveFlowConnection) error,
+) error {
+	err := fc.registry.WithConnection(key, fn)
+	if err == nil || !errors.Is(err, contracts.ErrPriorityBandNotFound) || key.Priority == 0 {
+		return err
+	}
+
+	fc.logger.V(logutil.DEFAULT).Info(
+		"Priority band not provisioned, demoting request to priority 0",
+		"originalPriority", key.Priority,
+		"flowID", key.ID,
+	)
+	demotedKey := key
+	demotedKey.Priority = 0
+	return fc.registry.WithConnection(demotedKey, fn)
 }
 
 // tryDistribution handles a single attempt to select a shard and submit a request.

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -213,6 +213,20 @@ func (m *mockRegistryClient) Stats() contracts.AggregateStats {
 	return contracts.AggregateStats{}
 }
 
+func (m *mockRegistryClient) SubmitDesiredPriorities(_ map[int]struct{}) {}
+
+func (m *mockRegistryClient) PriorityBandUpdateChannel() <-chan map[int]struct{} {
+	return nil
+}
+
+func (m *mockRegistryClient) FlowGCTimeout() time.Duration {
+	return time.Minute
+}
+
+func (m *mockRegistryClient) ApplyDesiredPriorities(_ map[int]struct{}) {}
+
+func (m *mockRegistryClient) ExecuteGCCycle() {}
+
 // mockProcessor is a mock for the internal `Processor` interface.
 type mockProcessor struct {
 	SubmitFunc        func(item *internal.FlowItem) error
@@ -265,6 +279,7 @@ type mockProcessorFactory struct {
 func (f *mockProcessorFactory) new(
 	_ context.Context, // The factory does not use the lifecycle context; it's passed to the processor's Run method later.
 	_ contracts.FlowRegistry,
+	_ contracts.FlowRegistryBackground,
 	_ flowcontrol.SaturationDetector,
 	_ contracts.EndpointCandidates,
 	_ flowcontrol.UsageLimitPolicy,

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -67,6 +67,7 @@ var ErrProcessorBusy = errors.New("shard processor is busy")
 type Processor struct {
 	poolName             string
 	registry             contracts.FlowRegistry
+	registryBackground   contracts.FlowRegistryBackground
 	saturationDetector   flowcontrol.SaturationDetector
 	endpointCandidates   contracts.EndpointCandidates
 	usageLimitPolicy     flowcontrol.UsageLimitPolicy
@@ -91,6 +92,7 @@ func NewProcessor(
 	ctx context.Context,
 	poolName string,
 	registry contracts.FlowRegistry,
+	registryBackground contracts.FlowRegistryBackground,
 	saturationDetector flowcontrol.SaturationDetector,
 	endpointCandidates contracts.EndpointCandidates,
 	usageLimitPolicy flowcontrol.UsageLimitPolicy,
@@ -101,6 +103,7 @@ func NewProcessor(
 ) *Processor {
 	return &Processor{
 		registry:             registry,
+		registryBackground:   registryBackground,
 		poolName:             poolName,
 		saturationDetector:   saturationDetector,
 		endpointCandidates:   endpointCandidates,
@@ -179,8 +182,17 @@ func (sp *Processor) Run(ctx context.Context) {
 	dispatchTicker := sp.clock.NewTicker(time.Millisecond)
 	defer dispatchTicker.Stop()
 
+	var gcCh <-chan time.Time
+	var priorityBandUpdateCh <-chan map[int]struct{}
+	if sp.registryBackground != nil {
+		gcTicker := sp.clock.NewTicker(sp.registryBackground.FlowGCTimeout())
+		defer gcTicker.Stop()
+		gcCh = gcTicker.C()
+		priorityBandUpdateCh = sp.registryBackground.PriorityBandUpdateChannel()
+	}
+
 	// This is the main worker loop. It continuously processes incoming requests and dispatches queued requests until the
-	// context is cancelled. The `select` statement has three cases:
+	// context is cancelled. The `select` statement has these cases:
 	//
 	//  1. Context Cancellation: The highest priority is shutting down. If the context's `Done` channel is closed, the
 	//     loop will drain all queues and exit. This is the primary exit condition.
@@ -188,6 +200,8 @@ func (sp *Processor) Run(ctx context.Context) {
 	//     processor is responsive to new work.
 	//  3. Dispatch Ticker: Periodically triggers a dispatch cycle to attempt to dispatch items from existing queues,
 	//     ensuring that queued work is processed even when no new items arrive.
+	//  4. Priority Band Updates: Applies control-plane priority band topology changes.
+	//  5. Registry GC: Periodically garbage-collects idle flows and priority bands.
 	for {
 		select {
 		case <-ctx.Done():
@@ -209,6 +223,10 @@ func (sp *Processor) Run(ctx context.Context) {
 			sp.dispatchCycle(ctx) // Process immediately when an item arrives
 		case <-dispatchTicker.C():
 			sp.dispatchCycle(ctx) // Periodically attempt to dispatch from queues
+		case desired := <-priorityBandUpdateCh:
+			sp.registryBackground.ApplyDesiredPriorities(desired)
+		case <-gcCh:
+			sp.registryBackground.ExecuteGCCycle()
 		}
 	}
 }

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -135,6 +135,7 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 		h.ctx,
 		"test-pool",
 		h,
+		nil,
 		h.saturationDetector,
 		h.endpointCandidates,
 		usagelimits.DefaultPolicy(),

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -413,6 +413,17 @@ func NewConfig(defaults PriorityBandPolicyDefaults, opts ...ConfigOption) (*Conf
 		}
 	}
 
+	// Ensure priority 0 is always provisioned. It is the fallback band for unmatched requests
+	// and the demotion target in withConnectionWithDemotion.
+	if _, exists := builder.config.PriorityBands[0]; !exists {
+		zero := *builder.config.DefaultPriorityBand
+		zero.Priority = 0
+		if err := zero.applyDefaults(defaults); err != nil {
+			return nil, fmt.Errorf("failed to apply defaults to priority band 0: %w", err)
+		}
+		builder.config.PriorityBands[0] = &zero
+	}
+
 	if err := builder.config.validate(builder.checker); err != nil {
 		return nil, fmt.Errorf("invalid registry config: %w", err)
 	}

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -144,7 +144,8 @@ func TestNewConfig(t *testing.T) {
 			},
 			defaults: newTestPriorityBandPolicyDefaults(),
 			assertion: func(t *testing.T, cfg *Config) {
-				assert.Empty(t, cfg.PriorityBands, "PriorityBands map should be empty")
+				assert.Len(t, cfg.PriorityBands, 1, "PriorityBands should contain only the always-injected priority 0")
+				assert.Contains(t, cfg.PriorityBands, 0, "PriorityBands should contain priority 0")
 				require.NotNil(t, cfg.DefaultPriorityBand, "DefaultPriorityBand template must be initialized")
 				assert.Equal(t, defaultQueue, cfg.DefaultPriorityBand.Queue)
 				assert.NotNil(t, cfg.DefaultPriorityBand.FairnessPolicy)

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -117,7 +117,8 @@ type FlowRegistry struct {
 	// It is updated dynamically when new bands are provisioned.
 	orderedPriorityLevels []int
 
-	// initialPriorities tracks priority bands provisioned at startup. These are never removed by control-plane sync.
+	// initialPriorities tracks priority bands provisioned at startup.
+	// These are never removed by control-plane sync or garbage collection.
 	initialPriorities map[int]struct{}
 
 	// priorityBandUpdateCh carries desired priority topology updates from the control plane to the processor loop.
@@ -504,6 +505,12 @@ func (fr *FlowRegistry) cleanupPriorityBandResources(priorities []int) {
 func (fr *FlowRegistry) cleanupPriorityBandResourcesLocked(priority int) {
 	// Zombie protection: verify band was actually deleted from the state map.
 	if _, exists := fr.priorityBandStates.Load(priority); exists {
+		return
+	}
+
+	// Bands provisioned at startup are never collected. The transient band state is already gone,
+	// leaving the band in its startup state.
+	if _, static := fr.initialPriorities[priority]; static {
 		return
 	}
 

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -19,6 +19,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -170,14 +171,8 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 	return fr
 }
 
-// Run blocks until the provided context is cancelled.
-// Registry maintenance (priority band sync and GC) runs in the ShardProcessor loop.
-func (fr *FlowRegistry) Run(ctx context.Context) {
-	<-ctx.Done()
-}
-
 // RunMaintenanceLoop applies priority band updates and runs registry GC until ctx is cancelled.
-// Production uses the ShardProcessor loop; this helper supports tests that run without a FlowController.
+// Production uses the Processor loop; this helper supports tests that run without a FlowController.
 func (fr *FlowRegistry) RunMaintenanceLoop(ctx context.Context) {
 	gcTicker := fr.clock.NewTicker(fr.config.FlowGCTimeout)
 	defer gcTicker.Stop()
@@ -195,7 +190,7 @@ func (fr *FlowRegistry) RunMaintenanceLoop(ctx context.Context) {
 }
 
 // SubmitDesiredPriorities queues a priority band topology update for the processor loop.
-// The call never blocks: stale pending updates are dropped and the latest desired state is retained.
+// Stale pending updates are dropped so only the latest desired state is retained.
 func (fr *FlowRegistry) SubmitDesiredPriorities(desired map[int]struct{}) {
 	if desired == nil {
 		desired = map[int]struct{}{}
@@ -205,16 +200,14 @@ func (fr *FlowRegistry) SubmitDesiredPriorities(desired map[int]struct{}) {
 		copy[priority] = struct{}{}
 	}
 
+	// Drain any stale pending update so only the latest state is queued.
 	select {
 	case <-fr.priorityBandUpdateCh:
 	default:
 	}
 
-	select {
-	case fr.priorityBandUpdateCh <- copy:
-	default:
-		fr.ApplyDesiredPriorities(copy)
-	}
+	// After draining, the channel always has capacity; this send never blocks.
+	fr.priorityBandUpdateCh <- copy
 }
 
 // PriorityBandUpdateChannel returns the channel carrying desired priority topology updates.
@@ -228,20 +221,21 @@ func (fr *FlowRegistry) FlowGCTimeout() time.Duration {
 }
 
 // ApplyDesiredPriorities provisions missing priority bands and removes idle bands no longer desired.
-// It is invoked by the ShardProcessor maintenance loop.
+// It is invoked by the Processor maintenance loop.
 func (fr *FlowRegistry) ApplyDesiredPriorities(desired map[int]struct{}) {
 	if desired == nil {
 		desired = map[int]struct{}{}
 	}
 
 	fr.mu.Lock()
+	defer fr.mu.Unlock()
+
 	for priority := range desired {
 		if _, ok := fr.config.PriorityBands[priority]; !ok {
 			fr.provisionPriorityBandLocked(priority)
 		}
 	}
 
-	var toRemove []int
 	for priority := range fr.config.PriorityBands {
 		if _, static := fr.initialPriorities[priority]; static {
 			continue
@@ -249,20 +243,26 @@ func (fr *FlowRegistry) ApplyDesiredPriorities(desired map[int]struct{}) {
 		if _, wanted := desired[priority]; wanted {
 			continue
 		}
-		if fr.isPriorityBandIdle(priority) {
-			toRemove = append(toRemove, priority)
+		if !fr.isPriorityBandIdle(priority) {
+			continue
 		}
-	}
-	fr.mu.Unlock()
-
-	for _, priority := range toRemove {
-		fr.deletePriorityBand(priority)
+		// Re-verify under the lock: a concurrent request may have pinned the band
+		// in the window between isPriorityBandIdle and this check.
+		if val, ok := fr.priorityBandStates.Load(priority); ok {
+			if val.(*priorityBandState).isActive() {
+				continue
+			}
+		}
+		fr.priorityBandStates.Delete(priority)
+		fr.cleanupPriorityBandResourcesLocked(priority)
 	}
 }
 
 // ExecuteGCCycle runs a single registry garbage collection cycle.
 func (fr *FlowRegistry) ExecuteGCCycle() {
-	fr.executeGCCycle()
+	fr.logger.V(logging.DEBUG).Info("Starting periodic GC scan")
+	fr.gcFlows()
+	fr.gcPriorityBands()
 }
 
 // --- `contracts.FlowRegistryDataPlane` Implementation ---
@@ -396,12 +396,6 @@ func (fr *FlowRegistry) isPriorityBandIdle(priority int) bool {
 	return !val.(*priorityBandState).isActive()
 }
 
-// deletePriorityBand removes a priority band from the registry and all shards.
-func (fr *FlowRegistry) deletePriorityBand(priority int) {
-	fr.priorityBandStates.Delete(priority)           // Logical delete
-	fr.cleanupPriorityBandResources([]int{priority}) // Physical cleanup
-}
-
 // --- `contracts.FlowRegistryObserver` Implementation ---
 
 // Stats returns globally aggregated statistics for the entire `FlowRegistry`.
@@ -439,13 +433,6 @@ func (fr *FlowRegistry) Stats() contracts.AggregateStats {
 }
 
 // --- Garbage Collection ---
-
-// executeGCCycle orchestrates the periodic GC of Idle flows, idle priority bands, and Drained shards.
-func (fr *FlowRegistry) executeGCCycle() {
-	fr.logger.V(logging.DEBUG).Info("Starting periodic GC scan")
-	fr.gcFlows()
-	fr.gcPriorityBands()
-}
 
 // gcFlows removes idle flows.
 func (fr *FlowRegistry) gcFlows() {
@@ -507,35 +494,26 @@ func (fr *FlowRegistry) gcPriorityBands() {
 func (fr *FlowRegistry) cleanupPriorityBandResources(priorities []int) {
 	fr.mu.Lock()
 	defer fr.mu.Unlock()
-
 	for _, priority := range priorities {
-		// Zombie protection: verify band was actually deleted from map
-		if _, exists := fr.priorityBandStates.Load(priority); exists {
-			continue
-		}
-
-		// Delete from registry config
-		delete(fr.config.PriorityBands, priority)
-
-		// Delete from stats tracking
-		fr.perPriorityBandStats.Delete(priority)
-
-		// Remove from sync.Map
-		fr.priorityBands.Delete(priority)
-
-		// Remove from ordered list
-		for i, p := range fr.orderedPriorityLevels {
-			if p == priority {
-				fr.orderedPriorityLevels = append(
-					fr.orderedPriorityLevels[:i],
-					fr.orderedPriorityLevels[i+1:]...,
-				)
-				break
-			}
-		}
-
-		fr.logger.V(logging.DEFAULT).Info("Successfully deleted priority band", "priority", priority)
+		fr.cleanupPriorityBandResourcesLocked(priority)
 	}
+}
+
+// cleanupPriorityBandResourcesLocked performs the physical cleanup of a priority band.
+// The caller must hold fr.mu exclusively.
+func (fr *FlowRegistry) cleanupPriorityBandResourcesLocked(priority int) {
+	// Zombie protection: verify band was actually deleted from the state map.
+	if _, exists := fr.priorityBandStates.Load(priority); exists {
+		return
+	}
+
+	delete(fr.config.PriorityBands, priority)
+	fr.perPriorityBandStats.Delete(priority)
+	fr.priorityBands.Delete(priority)
+
+	fr.orderedPriorityLevels = slices.DeleteFunc(fr.orderedPriorityLevels, func(p int) bool { return p == priority })
+
+	fr.logger.V(logging.DEFAULT).Info("Successfully deleted priority band", "priority", priority)
 }
 
 // --- Internal Helpers ---

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/utils/clock"
@@ -114,9 +115,19 @@ type FlowRegistry struct {
 	// orderedPriorityLevels is a sorted list of active priority levels.
 	// It is updated dynamically when new bands are provisioned.
 	orderedPriorityLevels []int
+
+	// initialPriorities tracks priority bands provisioned at startup. These are never removed by control-plane sync.
+	initialPriorities map[int]struct{}
+
+	// priorityBandUpdateCh carries desired priority topology updates from the control plane to the processor loop.
+	priorityBandUpdateCh chan map[int]struct{}
 }
 
-var _ contracts.FlowRegistry = &FlowRegistry{}
+var (
+	_ contracts.FlowRegistry             = &FlowRegistry{}
+	_ contracts.PriorityBandControlPlane = &FlowRegistry{}
+	_ contracts.FlowRegistryBackground   = &FlowRegistry{}
+)
 
 // RegistryOption allows configuring the `FlowRegistry` during initialization.
 type RegistryOption func(*FlowRegistry)
@@ -135,8 +146,10 @@ func withClock(clk clock.WithTickerAndDelayedExecution) RegistryOption {
 func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption) *FlowRegistry {
 	cfg := config.Clone()
 	fr := &FlowRegistry{
-		config: cfg,
-		logger: logger.WithName("flow-registry"),
+		config:               cfg,
+		logger:               logger.WithName("flow-registry"),
+		initialPriorities:    make(map[int]struct{}),
+		priorityBandUpdateCh: make(chan map[int]struct{}, 1),
 	}
 
 	for _, opt := range opts {
@@ -147,6 +160,7 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 	}
 
 	for prio, bandConfig := range cfg.PriorityBands {
+		fr.initialPriorities[prio] = struct{}{}
 		fr.perPriorityBandStats.LoadOrStore(prio, &bandStats{})
 		fr.initPriorityBand(bandConfig)
 	}
@@ -156,22 +170,99 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 	return fr
 }
 
-// Run starts the registry's background garbage collection loop.
-// It blocks until the provided context is cancelled.
+// Run blocks until the provided context is cancelled.
+// Registry maintenance (priority band sync and GC) runs in the ShardProcessor loop.
 func (fr *FlowRegistry) Run(ctx context.Context) {
-	fr.logger.Info("Starting FlowRegistry background garbage collection loop")
-	defer fr.logger.Info("FlowRegistry background garbage collection loop stopped")
+	<-ctx.Done()
+}
+
+// RunMaintenanceLoop applies priority band updates and runs registry GC until ctx is cancelled.
+// Production uses the ShardProcessor loop; this helper supports tests that run without a FlowController.
+func (fr *FlowRegistry) RunMaintenanceLoop(ctx context.Context) {
 	gcTicker := fr.clock.NewTicker(fr.config.FlowGCTimeout)
 	defer gcTicker.Stop()
-
+	updateCh := fr.PriorityBandUpdateChannel()
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case desired := <-updateCh:
+			fr.ApplyDesiredPriorities(desired)
 		case <-gcTicker.C():
-			fr.executeGCCycle()
+			fr.ExecuteGCCycle()
 		}
 	}
+}
+
+// SubmitDesiredPriorities queues a priority band topology update for the processor loop.
+// The call never blocks: stale pending updates are dropped and the latest desired state is retained.
+func (fr *FlowRegistry) SubmitDesiredPriorities(desired map[int]struct{}) {
+	if desired == nil {
+		desired = map[int]struct{}{}
+	}
+	copy := make(map[int]struct{}, len(desired))
+	for priority := range desired {
+		copy[priority] = struct{}{}
+	}
+
+	select {
+	case <-fr.priorityBandUpdateCh:
+	default:
+	}
+
+	select {
+	case fr.priorityBandUpdateCh <- copy:
+	default:
+		fr.ApplyDesiredPriorities(copy)
+	}
+}
+
+// PriorityBandUpdateChannel returns the channel carrying desired priority topology updates.
+func (fr *FlowRegistry) PriorityBandUpdateChannel() <-chan map[int]struct{} {
+	return fr.priorityBandUpdateCh
+}
+
+// FlowGCTimeout returns the interval between registry garbage collection cycles.
+func (fr *FlowRegistry) FlowGCTimeout() time.Duration {
+	return fr.config.FlowGCTimeout
+}
+
+// ApplyDesiredPriorities provisions missing priority bands and removes idle bands no longer desired.
+// It is invoked by the ShardProcessor maintenance loop.
+func (fr *FlowRegistry) ApplyDesiredPriorities(desired map[int]struct{}) {
+	if desired == nil {
+		desired = map[int]struct{}{}
+	}
+
+	fr.mu.Lock()
+	for priority := range desired {
+		if _, ok := fr.config.PriorityBands[priority]; !ok {
+			fr.provisionPriorityBandLocked(priority)
+		}
+	}
+
+	var toRemove []int
+	for priority := range fr.config.PriorityBands {
+		if _, static := fr.initialPriorities[priority]; static {
+			continue
+		}
+		if _, wanted := desired[priority]; wanted {
+			continue
+		}
+		if fr.isPriorityBandIdle(priority) {
+			toRemove = append(toRemove, priority)
+		}
+	}
+	fr.mu.Unlock()
+
+	for _, priority := range toRemove {
+		fr.deletePriorityBand(priority)
+	}
+}
+
+// ExecuteGCCycle runs a single registry garbage collection cycle.
+func (fr *FlowRegistry) ExecuteGCCycle() {
+	fr.executeGCCycle()
 }
 
 // --- `contracts.FlowRegistryDataPlane` Implementation ---
@@ -182,7 +273,7 @@ func (fr *FlowRegistry) Run(ctx context.Context) {
 // This method relies on an atomic leasing mechanism, ensuring that active flows are never garbage collected while
 // requests are in flight.
 //
-// If the flow does not exist, it is provisioned Just-In-Time (JIT).
+// If the flow does not exist, it is provisioned on first use. The priority band must already exist.
 //
 // When a NEW flow is created, this method also increments the corresponding priority band's lease count,
 // establishing the invariant: bandState.leaseCount = number of active flows at this priority.
@@ -210,9 +301,8 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 	}
 	defer state.unpin(fr.clock.Now())
 
-	// 2. JIT provisioning: Ensure physical resources exist on shards.
-	// We use sync.Once to ensure we only pay the initialization cost (building components, locking shards) exactly once
-	// per flowState object.
+	// 2. Flow provisioning: Ensure physical resources exist.
+	// We use sync.Once to ensure we only pay the initialization cost exactly once per flowState object.
 	state.initialized.Do(func() {
 		state.initErr = fr.ensureFlowInfrastructure(key)
 	})
@@ -223,14 +313,13 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 		fr.flowStates.Delete(key)
 
 		// Release the band lease if we created the flow.
-		// If JIT provisioning fails for a new flow, we must release that lease to prevent leaking band leases.
 		if isNewFlow {
 			if bandVal, ok := fr.priorityBandStates.Load(key.Priority); ok {
 				bandVal.(*priorityBandState).unpin(fr.clock.Now())
 			}
 		}
 
-		return fmt.Errorf("failed to provision JIT flow resources: %w", state.initErr)
+		return state.initErr
 	}
 
 	// 3. Execute callback.
@@ -243,26 +332,16 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 //
 // NOTE: The caller (WithConnection) must already hold a lease on the priority band to prevent GC during this operation.
 func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error {
-	// 1. Ensure Priority Band exists.
 	fr.mu.RLock()
 	_, exists := fr.config.PriorityBands[key.Priority]
 	fr.mu.RUnlock()
 
 	if !exists {
-		if err := fr.ensurePriorityBand(key.Priority); err != nil {
-			return err
-		}
+		return fmt.Errorf("priority band %d not found: %w", key.Priority, contracts.ErrPriorityBandNotFound)
 	}
 
-	// Now we know the band exists (or we errored). Re-acquire Read Lock to safely read the topology and build components.
-
-	// 2. Synchronize shards.
-	// Acquire Read Lock to iterate the shard topology safely.
 	fr.mu.RLock()
-
 	components, err := fr.buildFlowComponents(key)
-
-	// Free the lock here as synchronizeFlow acquires the mutex for writes
 	fr.mu.RUnlock()
 
 	if err != nil {
@@ -271,21 +350,17 @@ func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error 
 
 	fr.synchronizeFlow(key, components.policy, components.queue)
 
-	fr.logger.V(logging.DEBUG).Info("JIT provisioned flow infrastructure", "flowKey", key)
+	fr.logger.V(logging.DEBUG).Info("Provisioned flow infrastructure", "flowKey", key)
 	return nil
 }
 
-// ensurePriorityBand safely provisions a new priority band.
-func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
-	fr.mu.Lock()
-	defer fr.mu.Unlock()
-
-	// Double-Check: Someone might have created it while we swapped locks in prepareNewFlow.
+// provisionPriorityBandLocked provisions a new priority band. The caller must hold fr.mu.
+func (fr *FlowRegistry) provisionPriorityBandLocked(priority int) {
 	if _, ok := fr.config.PriorityBands[priority]; ok {
-		return nil
+		return
 	}
 
-	fr.logger.V(logging.DEFAULT).Info("Dynamically provisioning new priority band", "priority", priority)
+	fr.logger.V(logging.DEFAULT).Info("Provisioning priority band from control plane", "priority", priority)
 
 	template := fr.config.DefaultPriorityBand
 	if priority < 0 && fr.config.DefaultNegativePriorityBand != nil {
@@ -302,8 +377,23 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 	})
 
 	fr.addPriorityBand(priority)
+}
 
+// ensurePriorityBand provisions a new priority band for tests and legacy callers.
+func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
+	fr.mu.Lock()
+	defer fr.mu.Unlock()
+
+	fr.provisionPriorityBandLocked(priority)
 	return nil
+}
+
+func (fr *FlowRegistry) isPriorityBandIdle(priority int) bool {
+	val, ok := fr.priorityBandStates.Load(priority)
+	if !ok {
+		return true
+	}
+	return !val.(*priorityBandState).isActive()
 }
 
 // deletePriorityBand removes a priority band from the registry and all shards.

--- a/pkg/epp/flowcontrol/registry/registry_helpers_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_helpers_test.go
@@ -122,7 +122,7 @@ func TestShard_New(t *testing.T) {
 		t.Parallel()
 		h := newTestHarness(t)
 
-		assert.Equal(t, []int{highPriority, lowPriority}, h.registry.AllOrderedPriorityLevels(),
+		assert.Equal(t, []int{highPriority, lowPriority, 0}, h.registry.AllOrderedPriorityLevels(),
 			"Registry must report configured priority levels sorted numerically (highest priority first)")
 
 		val, ok := h.registry.priorityBands.Load(highPriority)
@@ -400,7 +400,7 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 		h.registry.addPriorityBand(dynamicPrio)
 		h.registry.mu.Unlock()
 
-		expectedLevels := []int{highPriority, dynamicPrio, lowPriority} // 20, 15, 10
+		expectedLevels := []int{highPriority, dynamicPrio, lowPriority, 0} // 20, 15, 10, 0
 		assert.Equal(t, expectedLevels, h.registry.AllOrderedPriorityLevels(),
 			"New priority must be inserted into the sorted order correctly")
 
@@ -563,7 +563,8 @@ func TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety(t *testing.T) {
 			h.registry.addPriorityBand(dynamicPrio)
 			h.registry.mu.Unlock()
 
-			h.registry.deletePriorityBand(dynamicPrio)
+			h.registry.priorityBandStates.Delete(dynamicPrio)
+			h.registry.cleanupPriorityBandResources([]int{dynamicPrio})
 
 			h.registry.mu.Lock()
 			h.registry.config.PriorityBands[dynamicPrio] = newBandCfg
@@ -576,7 +577,7 @@ func TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety(t *testing.T) {
 	readersWg.Wait()
 
 	// If we reach here without the race detector firing, the implementation is safe.
-	// Final sanity: dynamic band should be removed, only the original two remain.
-	assert.Equal(t, []int{highPriority, lowPriority}, h.registry.AllOrderedPriorityLevels(),
+	// Final sanity: dynamic band should be removed. Priority 0 is always injected as a static band.
+	assert.Equal(t, []int{highPriority, lowPriority, 0}, h.registry.AllOrderedPriorityLevels(),
 		"After all add/delete cycles, only original priority levels should remain")
 }

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -262,7 +262,7 @@ func TestFlowRegistry_GarbageCollection(t *testing.T) {
 
 		h.openConnectionOnFlow(key)                            // Create a flow, which is born Idle.
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second) // Advance the clock just past the GC timeout.
-		h.fr.executeGCCycle()                                  // Manually and deterministically trigger a GC cycle.
+		h.fr.ExecuteGCCycle()                                  // Manually and deterministically trigger a GC cycle.
 
 		h.assertFlowDoesNotExist(key, "Idle flow should be collected by the GC")
 	})
@@ -293,7 +293,7 @@ func TestFlowRegistry_GarbageCollection(t *testing.T) {
 
 		<-leaseAcquired                              // Wait until the goroutine confirms that it has acquired the lease.
 		h.fakeClock.Step(h.config.FlowGCTimeout * 2) // Advance the clock well past the GC timeout.
-		h.fr.executeGCCycle()                        // Manually and deterministically trigger a GC cycle.
+		h.fr.ExecuteGCCycle()                        // Manually and deterministically trigger a GC cycle.
 
 		h.assertFlowExists(key, "An active flow must not be garbage collected, even after a forced GC cycle")
 	})
@@ -306,7 +306,7 @@ func TestFlowRegistry_GarbageCollection(t *testing.T) {
 		h.fakeClock.Step(h.config.FlowGCTimeout - time.Second) // Advance the clock to just before the GC timeout.
 		h.openConnectionOnFlow(key)                            // Open a new connection, resetting its idleness timer.
 		h.fakeClock.Step(2 * time.Second)                      // Advance the clock again.
-		h.fr.executeGCCycle()                                  // Manually and deterministically trigger a GC cycle.
+		h.fr.ExecuteGCCycle()                                  // Manually and deterministically trigger a GC cycle.
 
 		h.assertFlowExists(key, "Flow should survive GC because its idleness timer was reset")
 	})
@@ -336,7 +336,7 @@ func TestFlowRegistry_GarbageCollection(t *testing.T) {
 		state.mu.Unlock()
 
 		// Trigger GC.
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// The GC should have seen the leaseCount > 0 and skipped the deletion, despite the expired timestamp.
 		h.assertFlowExists(key, "Flow must not be collected if lease > 0, even if idle timer is expired")
@@ -718,7 +718,7 @@ func TestFlowRegistry_Concurrency(t *testing.T) {
 			defer wg.Done()
 			for range 10 {
 				h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-				h.fr.executeGCCycle()
+				h.fr.ExecuteGCCycle()
 				time.Sleep(5 * time.Millisecond)
 			}
 		}()
@@ -762,7 +762,8 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 		require.True(t, ok, "Band should exist in config")
 
 		// Delete the band
-		h.fr.deletePriorityBand(dynamicPrio)
+		h.fr.priorityBandStates.Delete(dynamicPrio)
+		h.fr.cleanupPriorityBandResources([]int{dynamicPrio})
 
 		// Verify band removed from registry config
 		h.fr.mu.RLock()
@@ -810,7 +811,8 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 		require.True(t, highExists && lowExists && dynamicExists, "All bands should exist")
 
 		// Delete the dynamic band
-		h.fr.deletePriorityBand(dynamicPrio)
+		h.fr.priorityBandStates.Delete(dynamicPrio)
+		h.fr.cleanupPriorityBandResources([]int{dynamicPrio})
 
 		// Verify static bands still exist
 		h.fr.mu.RLock()
@@ -830,7 +832,8 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 
 		// Try to delete a band that doesn't exist - should not panic
 		require.NotPanics(t, func() {
-			h.fr.deletePriorityBand(999)
+			h.fr.priorityBandStates.Delete(999)
+			h.fr.cleanupPriorityBandResources([]int{999})
 		})
 	})
 }
@@ -856,7 +859,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Step 1: Collect the flow (makes band empty)
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 		h.assertFlowDoesNotExist(key, "Flow should be collected")
 
 		// Band should still exist (in grace period)
@@ -867,7 +870,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Step 2: Wait for band GC timeout
 		h.fakeClock.Step(h.config.PriorityBandGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Band should be collected
 		h.fr.mu.RLock()
@@ -882,7 +885,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Advance time well past any GC timeout
 		h.fakeClock.Step(h.config.FlowGCTimeout + h.config.PriorityBandGCTimeout + time.Hour)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Static bands should still exist
 		h.fr.mu.RLock()
@@ -914,11 +917,11 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Collect all flows (all bands become empty)
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Wait for band GC timeout
 		h.fakeClock.Step(h.config.PriorityBandGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// All bands should be collected in a single GC cycle
 		h.fr.mu.RLock()
@@ -945,11 +948,11 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Collect the flow
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Collect the band
 		h.fakeClock.Step(h.config.PriorityBandGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Verify band is removed from registry config
 		h.fr.mu.RLock()
@@ -976,7 +979,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		// Create and collect flow (band becomes empty)
 		h.openConnectionOnFlow(key)
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Advance past band timeout to make it a GC candidate
 		h.fakeClock.Step(h.config.PriorityBandGCTimeout + time.Second)
@@ -1000,7 +1003,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		// Run GC - it should NOT collect the band because:
 		// 1. The band now has an active flow (not empty)
 		// 2. updateIdleBands will reset becameIdleAt because the band is no longer empty
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Band should NOT be collected (new flow exists)
 		h.fr.mu.RLock()
@@ -1091,7 +1094,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		flow1.mu.Unlock()
 
 		// Collect only flow-1 (the old one)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Verify band leaseCount is now 2
 		state.mu.Lock()
@@ -1102,7 +1105,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Now age the remaining flows and collect them
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Verify band leaseCount is now 0
 		state.mu.Lock()
@@ -1141,7 +1144,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		flow2.mu.Unlock()
 
 		// Collect flow-1 and flow-2, leaving flow-3 active
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Verify flow-3 still exists
 		h.assertFlowExists(key3, "Flow-3 should still exist")
@@ -1155,7 +1158,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		// Advance time, but NOT enough to make flow-3 eligible for GC
 		// (We need to avoid advancing past FlowGCTimeout from flow-3's creation time)
 		h.fakeClock.Step(time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Band should still NOT be collected (still has flow-3)
 		h.fr.mu.RLock()
@@ -1176,7 +1179,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Collect the last flow
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Verify band leaseCount is now 0
 		state.mu.Lock()
@@ -1187,7 +1190,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Now advance past band timeout and collect
 		h.fakeClock.Step(h.config.PriorityBandGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Band should be collected now
 		h.fr.mu.RLock()
@@ -1215,7 +1218,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 		// Collect the flow so the band becomes empty
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// Verify band leaseCount is now 0 and band is idle
 		state.mu.Lock()
@@ -1238,7 +1241,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		state.mu.Unlock()
 
 		// Trigger GC
-		h.fr.executeGCCycle()
+		h.fr.ExecuteGCCycle()
 
 		// The GC should have seen leaseCount > 0 and skipped deletion, despite
 		// the band being empty and the idle timer being expired.

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -897,6 +897,35 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		assert.True(t, lowExists, "Static low priority band should never be collected")
 	})
 
+	t.Run("ShouldNotCollectStaticBands_AfterFlowActivity", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
+		staticPriorities := []int{highPriority, 0}
+
+		// Opening a flow at a static priority creates a transient priorityBandState whose lease
+		// drops to zero once the flow idles, making the band a GC candidate.
+		for _, priority := range staticPriorities {
+			h.openConnectionOnFlow(flowcontrol.FlowKey{ID: "static-band-flow", Priority: priority})
+		}
+
+		// Collect the flows, then age the now-idle band states past the band GC timeout.
+		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
+		h.fr.ExecuteGCCycle()
+		h.fakeClock.Step(h.config.PriorityBandGCTimeout + time.Second)
+		h.fr.ExecuteGCCycle()
+
+		for _, priority := range staticPriorities {
+			h.fr.mu.RLock()
+			_, exists := h.fr.config.PriorityBands[priority]
+			h.fr.mu.RUnlock()
+			assert.True(t, exists, "Static band %d should survive GC after its flows are collected", priority)
+
+			key := flowcontrol.FlowKey{ID: "follow-up-flow", Priority: priority}
+			err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
+			assert.NoError(t, err, "Request at static priority %d should succeed after GC", priority)
+		}
+	})
+
 	t.Run("ShouldCollectMultipleBands_InOneCycle", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -75,11 +75,10 @@ func newRegistryTestHarness(t *testing.T, opts harnessOptions) *registryTestHarn
 	fr := NewFlowRegistry(cfg, logr.Discard(), registryOpts...)
 
 	if !opts.manualGC {
-		// Start the GC loop in the background.
 		ctx, cancel := context.WithCancel(context.Background())
 		var wg sync.WaitGroup
 		wg.Go(func() {
-			fr.Run(ctx)
+			fr.RunMaintenanceLoop(ctx)
 		})
 		t.Cleanup(func() {
 			cancel()
@@ -113,6 +112,12 @@ func (h *registryTestHarness) assertFlowDoesNotExist(key flowcontrol.FlowKey, ms
 // openConnectionOnFlow ensures a flow is registered for the provided `key`.
 func (h *registryTestHarness) openConnectionOnFlow(key flowcontrol.FlowKey) {
 	h.t.Helper()
+	h.fr.mu.RLock()
+	_, exists := h.fr.config.PriorityBands[key.Priority]
+	h.fr.mu.RUnlock()
+	if !exists {
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{key.Priority: {}})
+	}
 	err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
 	require.NoError(h.t, err, "Registering flow %s should not fail", key)
 	h.assertFlowExists(key, "Flow %s should exist after registration", key)
@@ -343,17 +348,49 @@ func TestFlowRegistry_GarbageCollection(t *testing.T) {
 func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 	t.Parallel()
 
+	t.Run("SubmitDesiredPriorities_DoesNotBlockWithoutProcessor", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for i := range 100 {
+				h.fr.SubmitDesiredPriorities(map[int]struct{}{i: {}})
+			}
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("SubmitDesiredPriorities blocked without a processor consumer")
+		}
+	})
+
+	t.Run("ShouldRejectUnknownPriority_WhenBandNotProvisioned", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+		key := flowcontrol.FlowKey{ID: "unprovisioned-flow", Priority: 55}
+
+		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
+			return nil
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, contracts.ErrPriorityBandNotFound)
+	})
+
 	t.Run("ShouldCreateBand_WhenPriorityIsUnknown", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{})
 		dynamicPrio := 55
 		key := flowcontrol.FlowKey{ID: "dynamic-flow", Priority: dynamicPrio}
 
-		// Connect with a new priority.
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{dynamicPrio: {}})
+
 		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
 			return nil
 		})
-		require.NoError(t, err, "WithConnection should succeed for dynamic priority")
+		require.NoError(t, err, "WithConnection should succeed after control-plane provisioning")
 
 		h.fr.mu.RLock()
 		_, existsInConfig := h.fr.config.PriorityBands[dynamicPrio]
@@ -374,6 +411,8 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		dynamicPrio := 77
 		key := flowcontrol.FlowKey{ID: "race-flow", Priority: dynamicPrio}
 
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{dynamicPrio: {}})
+
 		var wg sync.WaitGroup
 		concurrency := 10
 		wg.Add(concurrency)
@@ -381,7 +420,6 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		for range concurrency {
 			go func() {
 				defer wg.Done()
-				// Everyone tries to trigger provisioning simultaneously.
 				_ = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
 			}()
 		}
@@ -399,7 +437,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		dynamicPrio := 88
 		key := flowcontrol.FlowKey{ID: "scaling-flow", Priority: dynamicPrio}
 
-		// Create dynamic band
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{dynamicPrio: {}})
 		h.openConnectionOnFlow(key)
 
 		_, policyErr := h.fr.FairnessPolicy(dynamicPrio)
@@ -427,6 +465,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		negativePrio := -5
 		key := flowcontrol.FlowKey{ID: "negative-flow", Priority: negativePrio}
 
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{negativePrio: {}})
 		err = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
 			return nil
 		})
@@ -452,6 +491,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		negativePrio := -3
 		key := flowcontrol.FlowKey{ID: "fallback-flow", Priority: negativePrio}
 
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{negativePrio: {}})
 		err = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
 			return nil
 		})
@@ -482,6 +522,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		positivePrio := 42
 		key := flowcontrol.FlowKey{ID: "positive-flow", Priority: positivePrio}
 
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{positivePrio: {}})
 		err = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
 			return nil
 		})
@@ -1208,14 +1249,13 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 	})
 }
 
-// TestFlowRegistry_JITErrorScoping ensures that JIT provisioning errors are correctly propagated to all concurrent
+// TestFlowRegistry_FlowErrorScoping ensures that flow provisioning errors are correctly propagated to all concurrent
 // requests waiting on the same flow initialization.
-func TestFlowRegistry_JITErrorScoping(t *testing.T) {
+func TestFlowRegistry_FlowErrorScoping(t *testing.T) {
 	t.Parallel()
 	defaults := newTestPriorityBandPolicyDefaults()
 
 	// Create a registry with a capability checker that passes validation but using a queue name that doesn't exist.
-	// This ensures NewConfig succeeds, but JIT (ensureFlowInfrastructure) fails when trying to instantiate the queue.
 	failQueueName := queue.RegisteredQueueName("NonExistentQueue")
 	mockChecker := &mockCapabilityChecker{
 		checkCompatibilityFunc: func(p flowcontrol.OrderingPolicy, q queue.RegisteredQueueName) error {
@@ -1223,8 +1263,8 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 		},
 	}
 
-	// We create a custom band config that uses this failing queue.
-	// We set it as the default band so that dynamic provisioning is used.
+	// Set the failing queue as the default band so the priority provisioned
+	// below inherits it and flow initialization fails.
 	failingBand, err := NewPriorityBandConfig(0, defaults, WithQueue(failQueueName))
 	require.NoError(t, err)
 
@@ -1234,15 +1274,13 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	registry := NewFlowRegistry(cfg, logr.Discard())
 
 	key := flowcontrol.FlowKey{
-		Priority: 100, // Dynamic, will trigger ensurePriorityBand
+		Priority: 100,
 		ID:       "flow-should-fail",
 	}
+	registry.ApplyDesiredPriorities(map[int]struct{}{100: {}})
 
 	// Simulate contention:
-	// We acquire the registry RLock.
-	// JIT provisioning (dynamic band) requires registry Lock (Write Lock).
-	// So the first thread to reach ensurePriorityBand will block until we release this lock.
-	// All other threads will pile up behind it on sync.Once.
+	// We acquire the registry RLock while flow infrastructure is provisioned.
 	registry.mu.RLock()
 
 	const concurrency = 10
@@ -1279,6 +1317,6 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	wg.Wait()
 
 	// Assertion: all requests should fail.
-	assert.Equal(t, int32(concurrency), errorCount.Load(), "All requests should fail JIT provisioning")
-	assert.Equal(t, int32(0), successCount.Load(), "No request should succeed if JIT failed")
+	assert.Equal(t, int32(concurrency), errorCount.Load(), "All requests should fail flow provisioning")
+	assert.Equal(t, int32(0), successCount.Load(), "No request should succeed if flow provisioning failed")
 }

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -40,6 +40,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/controller"
 	datalayerlogger "github.com/llm-d/llm-d-router/pkg/epp/datalayer/logger"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-router/pkg/epp/requestcontrol"
@@ -60,6 +61,7 @@ type ExtProcServerRunner struct {
 	Director                         *requestcontrol.Director
 	ParserRegistry                   *handlers.ParserRegistry
 	SaturationDetector               fwkfc.SaturationDetector
+	PriorityBandControlPlane         contracts.PriorityBandControlPlane
 	GRPCMaxRecvMsgSize               int
 	GRPCMaxSendMsgSize               int
 }
@@ -112,9 +114,10 @@ func (r *ExtProcServerRunner) SetupWithManager(mgr ctrl.Manager) error {
 
 		if r.ControllerCfg.hasInferenceObjective {
 			if err := (&controller.InferenceObjectiveReconciler{
-				Datastore: r.Datastore,
-				Reader:    mgr.GetClient(),
-				PoolGKNN:  r.GKNN,
+				Datastore:                r.Datastore,
+				Reader:                   mgr.GetClient(),
+				PoolGKNN:                 r.GKNN,
+				PriorityBandControlPlane: r.PriorityBandControlPlane,
 			}).SetupWithManager(mgr); err != nil {
 				return fmt.Errorf("failed setting up InferenceObjectiveReconciler - %w", err)
 			}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind bug

**What this PR does / why we need it**:

Fixed issue #1184 using the channel-based design agreed in the issue discussion @shmuelk @LukeAVanDrie

- **Control plane**: `InferenceObjectiveReconciler` collects desired priority levels from the datastore on each reconcile and submits them via non-blocking `SubmitDesiredPriorities` (sync fallback when the processor is not yet consuming).
- **Processor loop**: `ShardProcessor` applies topology updates and runs registry GC from its main `select`; the standalone `FlowRegistry.Run` GC goroutine is no longer started.
- **Data plane**: `ensureFlowInfrastructure` no longer JIT-provisions priority bands on the request path; missing bands return `ErrPriorityBandNotFound` (flow queues are still created on first use).
- **Fallback**: `FlowController` demotes requests to priority 0 when the requested band is not yet provisioned (availability-first).


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1184 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
