### PR TITLE
feat(parser): add /v1/rerank support to OpenAI request parser

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -61,7 +61,7 @@ func (RawPayload) IsParsed() bool    { return false }
 
 // InferenceRequestBody contains the request-body fields that we parse out as user input,
 // to be used in forming scheduling decisions.
-// An InferenceRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, ConversationsRequest, or EmbeddingsRequest.
+// An InferenceRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, ConversationsRequest, EmbeddingsRequest, or RerankRequest.
 type InferenceRequestBody struct {
 	// CompletionsRequest is the representation of the OpenAI /v1/completions request body.
 	Completions *CompletionsRequest `json:"completions,omitempty"`
@@ -73,6 +73,8 @@ type InferenceRequestBody struct {
 	Conversations *ConversationsRequest `json:"conversations,omitempty"`
 	// EmbeddingsRequest is the representation of the OpenAI /v1/embeddings request body.
 	Embeddings *EmbeddingsRequest `json:"embeddings,omitempty"`
+	// RerankRequest is the representation of the OpenAI-compatible /v1/rerank request body.
+	Rerank *RerankRequest `json:"rerank,omitempty"`
 	// Payload contains the unmarshaled request payload or raw bytes.
 	// If the payload is unmarshaled, we can perform advanced processing (like prefix cache aware routing).
 	// If it remains as raw bytes, such processing may not be supported.
@@ -138,6 +140,8 @@ func (r *InferenceRequestBody) PromptText() string {
 		return string(b)
 	case r.Embeddings != nil:
 		return r.Embeddings.Input.PlainText()
+	case r.Rerank != nil:
+		return r.Rerank.Query
 	default:
 		return ""
 	}
@@ -171,6 +175,9 @@ func (r *InferenceRequestBody) CacheSalt() string {
 	}
 	if r.Embeddings != nil {
 		return r.Embeddings.CacheSalt
+	}
+	if r.Rerank != nil {
+		return r.Rerank.CacheSalt
 	}
 	return ""
 }
@@ -422,6 +429,24 @@ func (e *EmbeddingsRequest) String() string {
 		return nilStr
 	}
 	return fmt.Sprintf("{InputType: %T}", e.Input)
+}
+
+// RerankRequest represents the OpenAI-compatible /v1/rerank request body structure.
+// See https://platform.openai.com/docs/api-reference/reranking/create.
+type RerankRequest struct {
+	// Query is the text query to compare documents against.
+	Query string `json:"query"`
+	// Documents is the list of documents to rerank.
+	Documents []string `json:"documents,omitempty"`
+	// CacheSalt is an optional request parameter to isolate prefix caches for security reasons.
+	CacheSalt string `json:"cache_salt,omitempty"`
+}
+
+func (r *RerankRequest) String() string {
+	if r == nil {
+		return nilStr
+	}
+	return fmt.Sprintf("{QueryLength: %d, DocumentCount: %d}", len(r.Query), len(r.Documents))
 }
 
 // ConversationItem represents a single item in a conversation

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -39,6 +39,7 @@ const (
 	chatCompletionsAPI = "chat/completions"
 	completionsAPI     = "completions"
 	embeddingsAPI      = "embeddings"
+	rerankAPI          = "rerank"
 
 	streamingRespPrefix = "data: "
 	streamingEndMsg     = "data: [DONE]"
@@ -188,6 +189,9 @@ func determineAPITypeFromPath(path string) string {
 	if strings.HasSuffix(path, "/embeddings") {
 		return embeddingsAPI
 	}
+	if strings.HasSuffix(path, "/rerank") {
+		return rerankAPI
+	}
 
 	// Default to completions API for backward compatibility with existing clients and integration tests
 	return completionsAPI
@@ -236,6 +240,14 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 			return &fwkrh.InferenceRequestBody{Embeddings: &embeddings}, nil
 		}
 		return nil, errors.New("invalid embeddings request: must have input field")
+
+	case rerankAPI:
+		var rerank fwkrh.RerankRequest
+		if err := json.Unmarshal(rawBody, &rerank); err == nil && rerank.Query != "" {
+			return &fwkrh.InferenceRequestBody{Rerank: &rerank}, nil
+		}
+		return nil, errors.New("invalid rerank request: must have query field")
+
 	default:
 		return nil, errors.New("unsupported API endpoint")
 	}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -792,6 +792,55 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:    "rerank request body",
+			headers: map[string]string{":path": "/v1/rerank"},
+			body: map[string]any{
+				"model":     "Qwen3-Reranker-0.6B",
+				"query":     "What is the capital of France?",
+				"documents": []any{"Paris is the capital.", "Berlin is a city."},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Rerank: &fwkrh.RerankRequest{
+					Query:     "What is the capital of France?",
+					Documents: []string{"Paris is the capital.", "Berlin is a city."},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model":     "Qwen3-Reranker-0.6B",
+					"query":     "What is the capital of France?",
+					"documents": []any{"Paris is the capital.", "Berlin is a city."},
+				},
+			},
+		},
+		{
+			name:    "rerank request with provider-specific path prefix",
+			headers: map[string]string{":path": "/v1/models/my-model/rerank"},
+			body: map[string]any{
+				"model":     "my-model",
+				"query":     "search query",
+				"documents": []any{"doc1", "doc2"},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Rerank: &fwkrh.RerankRequest{
+					Query:     "search query",
+					Documents: []string{"doc1", "doc2"},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model":     "my-model",
+					"query":     "search query",
+					"documents": []any{"doc1", "doc2"},
+				},
+			},
+		},
+		{
+			name:    "rerank request missing query rejected",
+			headers: map[string]string{":path": "/v1/rerank"},
+			body: map[string]any{
+				"model":     "Qwen3-Reranker-0.6B",
+				"documents": []any{"doc1"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

When using vLLM to serve a reranker model (e.g. `Qwen3-Reranker-0.6B`) behind an llm-d `InferencePool`, any request to `/v1/rerank` receives a 400 error:

```
invalid completions request: must have prompt field
```

## Root Cause

`determineAPITypeFromPath()` in `pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go` had no case for paths ending in `/rerank`. The function's default return value is `completionsAPI` (for backward compatibility), so rerank requests were incorrectly dispatched to the completions branch, which requires a `prompt` field that rerank requests don't have.

## Fix

- Add `rerankAPI = "rerank"` constant
- Add `strings.HasSuffix(path, "/rerank")` detection in `determineAPITypeFromPath()`
- Add `case rerankAPI:` in `extractRequestBody()` that validates the required `query` field
- Add `RerankRequest` struct (`query`, `documents`, `cache_salt`) to `types.go`
- Add `Rerank *RerankRequest` field to `InferenceRequestBody` with corresponding `PromptText()` and `CacheSalt()` method updates
- Add 3 test cases: valid rerank, provider-specific path prefix, missing-query rejection

Fixes #1340

## Testing

All existing tests continue to pass. Three new test cases added to `openai_test.go`.
