### PR TITLE
fix: resolve gRPC size parameter omission in runWithFileDiscovery runner initialization

### DIFF
--- a/cmd/epp/runner/run_with_file_discovery_test.go
+++ b/cmd/epp/runner/run_with_file_discovery_test.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -26,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -94,6 +96,8 @@ dataLayer:
 	opts.PoolName = "test-pool"
 	opts.PoolNamespace = "test-ns"
 	opts.ConfigText = configText
+	opts.GRPCMaxRecvMsgSize = 6 * 1024 * 1024
+	opts.GRPCMaxSendMsgSize = 6 * 1024 * 1024
 
 	r := NewRunner()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -132,6 +136,45 @@ dataLayer:
 	extProcConn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", grpcPort), time.Second)
 	require.NoError(t, err, "ext_proc port should accept TCP connections")
 	_ = extProcConn.Close()
+
+	// Verify that the gRPC maximum message size limit is correctly set to 6MB.
+	// We send a request body of 4.5MB which exceeds the default 4MB limit but is within 6MB.
+	cc, err := grpc.NewClient(fmt.Sprintf("127.0.0.1:%d", grpcPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer cc.Close()
+
+	client := pb.NewExternalProcessorClient(cc)
+	process, err := client.Process(ctx)
+	require.NoError(t, err)
+
+	largeBodySize := 4500000 // 4.5MB
+	largeBodyBytes := make([]byte, largeBodySize)
+	for i := range largeBodyBytes {
+		largeBodyBytes[i] = 'a'
+	}
+	largeBodyJSON, err := json.Marshal(map[string]any{
+		"model":  "stub",
+		"prompt": string(largeBodyBytes),
+	})
+	require.NoError(t, err)
+
+	request := &pb.ProcessingRequest{
+		Request: &pb.ProcessingRequest_RequestBody{
+			RequestBody: &pb.HttpBody{
+				Body:        largeBodyJSON,
+				EndOfStream: true,
+			},
+		},
+	}
+
+	err = process.Send(request)
+	if err == nil {
+		_, err = process.Recv()
+	}
+	if err != nil {
+		assert.NotContains(t, err.Error(), "ResourceExhausted")
+		assert.NotContains(t, err.Error(), "message larger than max")
+	}
 
 	// Confirm the resolved discovery plugin matches the one the loader registered.
 	disc, err := r.resolveDiscovery(rawConfig)

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -950,6 +950,8 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 		Parser:                           r.parser,
 		SaturationDetector:               eppConfig.SaturationDetector,
 		UseExperimentalDatalayerV2:       useNewMetrics,
+		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
+		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
 	}
 
 	r.customCollectors = append(r.customCollectors, collectors.NewInferencePoolMetricsCollector(ds))


### PR DESCRIPTION
 
/kind bug
 
**What this PR does / why we need it**:

 Issue: 
EPP running in FileDiscovery mode (non-Kubernetes environment) with custom gRPC size limits set via  --grpc-max-recv-msg-size  or  --grpc-max-send-msg-size . Inference payloads exceed default 4MiB limit.  Request fails. gRPC stream terminates with  ResourceExhausted  error ("received message larger than max").

gRPC server should processe messages up to configured size limit.
  
Root Cause:  
runWithFileDiscovery  initializes  ExtProcServerRunner  without forwarding  opts.GRPCMaxRecvMsgSize  and  opts.GRPCMaxSendMsgSize values. Size parameters default to 0, falling back to default 4MiB.


 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
