### PR TITLE
feat: add support in Helm chart for new tokenizer render

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -303,51 +303,118 @@ router:
 
 ### 5. Sidecar Tokenizer Configuration (`router.tokenizer.*`)
 
-Runs a tokenizer sidecar container to expose a Unix Domain Socket (UDS) to EPP, allowing EPP to tokenize incoming requests and enable precise, token-count-aware routing policies (e.g., precise prefix-cache matching).
+Runs a tokenizer sidecar that EPP queries to tokenize incoming requests, enabling precise, token-count-aware routing policies (e.g., precise prefix-cache matching).
 
-#### Tokenizer Sidecar Parameters
+Two mutually exclusive backends are supported:
+
+* **`render`** — calls vLLM's `/v1/completions/render` and `/v1/chat/completions/render` over loopback HTTP. The sidecar runs `vllm launch render <modelName> --port=<port>`. Wire EPP to it via `router.epp.pluginsCustomConfig` with `type: token-producer` and `vllm:`. This is the recommended backend.
+* **`uds`** — *deprecated*. Runs the `llm-d-uds-tokenizer` image and exposes a gRPC-over-Unix-Domain-Socket to EPP at `/tmp/tokenizer/tokenizer-uds.socket`. Wire EPP to it via `router.epp.pluginsCustomConfig` with `type: tokenizer` and `udsTokenizerConfig:`. Kept for migration only and will be removed in a future release.
+
+Enabling both backends at install time is rejected by chart validation.
+
+#### Tokenizer Common Parameters
 
 | **Parameter Name** | **Description** | **Default** |
 | :--- | :--- | :--- |
-| `router.tokenizer.enabled` | Enable a tokenizer UDS sidecar container in the EPP deployment. | `false` |
-| `router.tokenizer.image.registry` | Tokenizer container image registry. | `ghcr.io/llm-d` |
-| `router.tokenizer.image.repository` | Tokenizer container image repository. | `llm-d-uds-tokenizer` |
-| `router.tokenizer.image.tag` | Tokenizer container image tag. | `vllm-v0.19.1` |
-| `router.tokenizer.image.pullPolicy` | Tokenizer container image pull policy. | `IfNotPresent` |
-| `router.tokenizer.env` | Extra environment variables for the tokenizer container (e.g., HuggingFace token). `TOKENIZERS_DIR` and `HF_HOME` are templated automatically. | `[HF_TOKEN]` |
-| `router.tokenizer.resources` | Tokenizer container resource requests and limits. | `requests.cpu: "8"`, `requests.memory: 8Gi` |
-| `router.tokenizer.volumeMounts` | Extra volume mounts for the tokenizer container (e.g., for model files). | `[]` |
+| `router.tokenizer.modelName` | **REQUIRED** when `render` is enabled. Model name passed as the first positional arg to the render sidecar's `vllm launch render` command. | `""` |
 
-#### Complete Tokenizer Sidecar Example
+#### Tokenizer Render (vLLM `/render`) Parameters
+
+| **Parameter Name** | **Description** | **Default** |
+| :--- | :--- | :--- |
+| `router.tokenizer.render.enabled` | Enable the vLLM `/render` sidecar in the EPP deployment. | `false` |
+| `router.tokenizer.render.image.registry` | Render container image registry. | `docker.io` |
+| `router.tokenizer.render.image.repository` | Render container image repository. | `vllm/vllm-openai-cpu` |
+| `router.tokenizer.render.image.tag` | Render container image tag. | `v0.19.1` |
+| `router.tokenizer.render.image.pullPolicy` | Render container image pull policy. | `IfNotPresent` |
+| `router.tokenizer.render.port` | Container port the sidecar listens on. | `8000` |
+| `router.tokenizer.render.command` | Override container command. Empty renders `["vllm", "launch", "render"]`. | `[]` |
+| `router.tokenizer.render.args` | Override container args. Empty renders `["<modelName>", "--port=<port>"]`. | `[]` |
+| `router.tokenizer.render.env` | Extra environment variables (e.g., HuggingFace token). | `[HF_TOKEN]` |
+| `router.tokenizer.render.resources` | Render container resource requests and limits. | `requests.cpu: "4"`, `requests.memory: 8Gi` |
+| `router.tokenizer.render.volumeMounts` | Extra volume mounts for the render container. | `[]` |
+| `router.tokenizer.render.readinessProbe` | Readiness probe spec. | `httpGet /health on the render-http named port`, `periodSeconds: 5` |
+
+#### Tokenizer UDS Parameters (deprecated)
+
+| **Parameter Name** | **Description** | **Default** |
+| :--- | :--- | :--- |
+| `router.tokenizer.uds.enabled` | Enable the deprecated UDS tokenizer sidecar. | `false` |
+| `router.tokenizer.uds.image.registry` | UDS tokenizer container image registry. | `ghcr.io/llm-d` |
+| `router.tokenizer.uds.image.repository` | UDS tokenizer container image repository. | `llm-d-uds-tokenizer` |
+| `router.tokenizer.uds.image.tag` | UDS tokenizer container image tag. | `vllm-v0.19.1` |
+| `router.tokenizer.uds.image.pullPolicy` | UDS tokenizer container image pull policy. | `IfNotPresent` |
+| `router.tokenizer.uds.env` | Extra environment variables. `TOKENIZERS_DIR` and `HF_HOME` are templated automatically. | `[HF_TOKEN]` |
+| `router.tokenizer.uds.resources` | UDS tokenizer container resource requests and limits. | `requests.cpu: "8"`, `requests.memory: 8Gi` |
+| `router.tokenizer.uds.volumeMounts` | Extra volume mounts for the UDS tokenizer container. | `[]` |
+
+#### Tokenizer Render Example (recommended)
 
 ```yaml
 router:
+  epp:
+    volumes:
+      - name: model-cache-volume
+        persistentVolumeClaim:
+          claimName: pvc-model-cache
   tokenizer:
-    enabled: true
-    image:
-      registry: ghcr.io/llm-d
-      repository: llm-d-uds-tokenizer
-      tag: vllm-v0.19.1
-    env:
-      - name: HF_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: my-hf-token-secret
-            key: token
-    resources:
-      requests:
-        cpu: "8"
-        memory: 8Gi
-      limits:
-        memory: 16Gi
-    volumeMounts:
-      # If pre-loading models from an external volume:
-      - mountPath: /models
-        name: model-cache-volume
-  volumes:
-    - name: model-cache-volume
-      persistentVolumeClaim:
-        claimName: pvc-model-cache
+    modelName: "Qwen/Qwen3-32B"
+    render:
+      enabled: true
+      image:
+        registry: docker.io
+        repository: vllm/vllm-openai-cpu
+        tag: v0.19.1
+      env:
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: my-hf-token-secret
+              key: token
+      resources:
+        requests:
+          cpu: "4"
+          memory: 8Gi
+        limits:
+          memory: 16Gi
+      volumeMounts:
+        # If pre-loading models from an external volume:
+        - mountPath: /models
+          name: model-cache-volume
+```
+
+#### Tokenizer UDS Example (deprecated)
+
+```yaml
+router:
+  epp:
+    volumes:
+      - name: model-cache-volume
+        persistentVolumeClaim:
+          claimName: pvc-model-cache
+  tokenizer:
+    uds:
+      enabled: true
+      image:
+        registry: ghcr.io/llm-d
+        repository: llm-d-uds-tokenizer
+        tag: vllm-v0.19.1
+      env:
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: my-hf-token-secret
+              key: token
+      resources:
+        requests:
+          cpu: "8"
+          memory: 8Gi
+        limits:
+          memory: 16Gi
+      volumeMounts:
+        # If pre-loading models from an external volume:
+        - mountPath: /models
+          name: model-cache-volume
 ```
 
 ---

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -258,33 +258,76 @@ spec:
         {{- if .Values.router.epp.volumeMounts }}
         {{- toYaml .Values.router.epp.volumeMounts | nindent 12 }}
         {{- end }}
-        {{- if .Values.router.tokenizer.enabled }}
+        {{- if .Values.router.tokenizer.uds.enabled }}
             - name: tokenizer-uds
               mountPath: /tmp/tokenizer
         {{- end }}
-        {{- if .Values.router.tokenizer.enabled }}
+        {{- if .Values.router.tokenizer.uds.enabled }}
         - name: tokenizer-uds
-          image: {{ .Values.router.tokenizer.image.registry }}/{{ .Values.router.tokenizer.image.repository }}:{{ .Values.router.tokenizer.image.tag }}
-          imagePullPolicy: {{ .Values.router.tokenizer.image.pullPolicy | default "IfNotPresent" }}
+          image: {{ .Values.router.tokenizer.uds.image.registry }}/{{ .Values.router.tokenizer.uds.image.repository }}:{{ .Values.router.tokenizer.uds.image.tag }}
+          imagePullPolicy: {{ .Values.router.tokenizer.uds.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: TOKENIZERS_DIR
               value: /tokenizers
             - name: HF_HOME
               value: /tokenizers
-            {{- if .Values.router.tokenizer.env }}
-            {{- toYaml .Values.router.tokenizer.env | nindent 12 }}
+            {{- if .Values.router.tokenizer.uds.env }}
+            {{- toYaml .Values.router.tokenizer.uds.env | nindent 12 }}
             {{- end }}
-          {{- if .Values.router.tokenizer.resources }}
+          {{- if .Values.router.tokenizer.uds.resources }}
           resources:
-            {{- toYaml .Values.router.tokenizer.resources | nindent 12 }}
+            {{- toYaml .Values.router.tokenizer.uds.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /tokenizers
               name: tokenizers
             - mountPath: /tmp/tokenizer
               name: tokenizer-uds
-            {{- if .Values.router.tokenizer.volumeMounts }}
-            {{- toYaml .Values.router.tokenizer.volumeMounts | nindent 12 }}
+            {{- if .Values.router.tokenizer.uds.volumeMounts }}
+            {{- toYaml .Values.router.tokenizer.uds.volumeMounts | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- if .Values.router.tokenizer.render.enabled }}
+        {{- $render := .Values.router.tokenizer.render }}
+        {{- $renderPort := $render.port | default 8000 | int }}
+        - name: vllm-render
+          image: {{ $render.image.registry }}/{{ $render.image.repository }}:{{ $render.image.tag }}
+          imagePullPolicy: {{ $render.image.pullPolicy | default "IfNotPresent" }}
+          command:
+          {{- if $render.command }}
+          {{- toYaml $render.command | nindent 12 }}
+          {{- else }}
+            - vllm
+            - launch
+            - render
+          {{- end }}
+          args:
+          {{- if $render.args }}
+          {{- toYaml $render.args | nindent 12 }}
+          {{- else }}
+            - {{ .Values.router.tokenizer.modelName | quote }}
+            - {{ printf "--port=%d" $renderPort | quote }}
+          {{- end }}
+          ports:
+            - name: render-http
+              containerPort: {{ $renderPort }}
+          {{- with $render.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $render.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $render.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /root/.cache/huggingface
+              name: model-cache
+            {{- with $render.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- end }}
       {{- include "llm-d-router.latencyPredictor.containers" . | nindent 8 }}
@@ -292,10 +335,14 @@ spec:
       {{- if .Values.router.epp.volumes }}
       {{- toYaml .Values.router.epp.volumes | nindent 8 }}
       {{- end }}
-      {{- if .Values.router.tokenizer.enabled }}
+      {{- if .Values.router.tokenizer.uds.enabled }}
         - name: tokenizers
           emptyDir: {}
         - name: tokenizer-uds
+          emptyDir: {}
+      {{- end }}
+      {{- if .Values.router.tokenizer.render.enabled }}
+        - name: model-cache
           emptyDir: {}
       {{- end }}
       {{- if and $proxy.enabled (eq $proxyType "agentgateway") $proxyConfigMapName }}

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -333,6 +333,23 @@ EPP generic validations
 {{- include "llm-d-router.validations.deprecations" . }}
 {{- include "llm-d-router.validations.epp.resources" . }}
 {{- include "llm-d-router.validations.epp.inferenceObjectives" . }}
+{{- include "llm-d-router.validations.epp.tokenizer" . }}
+{{- end -}}
+
+{{/*
+Tokenizer validations: enforce mutual exclusion of uds/render sidecars and
+require modelName for the render sidecar's command args.
+*/}}
+{{- define "llm-d-router.validations.epp.tokenizer" -}}
+{{- $tokenizer := .Values.router.tokenizer | default dict }}
+{{- $udsEnabled := dig "uds" "enabled" false $tokenizer }}
+{{- $renderEnabled := dig "render" "enabled" false $tokenizer }}
+{{- if and $udsEnabled $renderEnabled }}
+{{- fail ".Values.router.tokenizer.uds.enabled and .Values.router.tokenizer.render.enabled are mutually exclusive; enable at most one." }}
+{{- end }}
+{{- if and $renderEnabled (not (dig "modelName" "" $tokenizer)) }}
+{{- fail ".Values.router.tokenizer.modelName is required when render is enabled." }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -66,25 +66,63 @@ epp:
 proxy:
   enabled: false    
 
-# Tokenizer sidecar configuration
+# Tokenizer sidecar. uds and render are mutually exclusive (chart fails if
+# both enabled). modelName is passed to the render sidecar's command args
+# (required when render.enabled). EPP is wired to the sidecar via
+# `router.epp.pluginsCustomConfig`.
 tokenizer:
-  enabled: false
-  image:
-    registry: ghcr.io/llm-d
-    repository: llm-d-uds-tokenizer
-    tag: vllm-v0.19.1
-    pullPolicy: IfNotPresent
-  env:
-    - name: HF_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: llm-d-hf-token
-          key: HF_TOKEN
-  resources:
-    requests:
-      cpu: "8"
-      memory: 8Gi
-    
+  modelName: ""
+
+  # Deprecated. Use render instead.
+  uds:
+    enabled: false
+    image:
+      registry: ghcr.io/llm-d
+      repository: llm-d-uds-tokenizer
+      tag: vllm-v0.19.1
+      pullPolicy: IfNotPresent
+    env:
+      - name: HF_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: llm-d-hf-token
+            key: HF_TOKEN
+    resources:
+      requests:
+        cpu: "8"
+        memory: 8Gi
+    volumeMounts: []
+
+  render:
+    enabled: false
+    image:
+      registry: docker.io
+      repository: vllm/vllm-openai-cpu
+      tag: v0.19.1
+      pullPolicy: IfNotPresent
+    port: 8000
+    command: []
+    args: []
+    env:
+      - name: HF_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: llm-d-hf-token
+            key: HF_TOKEN
+    resources:
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    volumeMounts: []
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: render-http
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 60
+
 # Monitoring configuration for EPP
 monitoring:
   interval: "10s"


### PR DESCRIPTION


**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

- add new schema router.tokenizer.render | router.tokenzier.uds
- the current route.tokenizer can only enable of disable for UDS the main issue is it hardcoded mount
- also introduce `router.tokenizer.modelName` which need to be used for render backend

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
