### PR TITLE
feat(sessionid): add session-id producer plugin

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -65,6 +65,7 @@ import (
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/models"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	attrsession "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/session"
 	discoveryfile "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/discovery/file"
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
@@ -86,6 +87,7 @@ import (
 	mmproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal"
 	preciseproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache"
 	latencyproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/preadmitter/agentidentity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
@@ -555,6 +557,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.RegisterAsDefaultProducer(latencyproducer.LatencyDataProviderPluginType, latencyproducer.PredictedLatencyFactory, attrlatency.LatencyPredictionInfoDataKey)
 	fwkplugin.Register(tokenizer.PluginType, tokenizer.PluginFactory)
 	fwkplugin.Register(tokenizer.LegacyPluginType, tokenizer.LegacyPluginFactory) //nolint:staticcheck // intentional: keep backward compatibility
+	fwkplugin.RegisterAsDefaultProducer(sessionid.SessionIDProducerType, sessionid.Factory, attrsession.SessionIDDataKey)
 
 	// Latency predictor plugins
 	fwkplugin.Register(latencyslo.LatencyAdmissionPluginType, latencyslo.LatencyAdmissionFactory)

--- a/pkg/epp/framework/plugins/datalayer/attribute/session/README.md
+++ b/pkg/epp/framework/plugins/datalayer/attribute/session/README.md
@@ -1,0 +1,19 @@
+# Session Attributes
+
+Per-request session identity used by affinity-aware scorers and filters.
+
+## `SessionID`
+
+Holds the session identifier extracted from a request. Stored on the
+`InferenceRequest` attribute store (one entry per request, not per endpoint).
+
+- **Key**: `SessionIDDataKey` (default producer: `session-id-producer`)
+- **Type**: `SessionID` (string alias)
+- **Reader helper**: `session.ReadSessionID(request)` returns the value and a
+  presence boolean. Consumers should prefer this over reading the attribute
+  directly so the storage choice stays encapsulated.
+
+## Producers
+
+- **`session-id-producer`** (Request Control): extracts the session
+  identifier from a configured request header or named cookie.

--- a/pkg/epp/framework/plugins/datalayer/attribute/session/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/session/data_types.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package session declares the SessionID attribute that carries per-request
+// session identity for affinity scoring and filtering. The value is published
+// once per request on the InferenceRequest attribute store.
+package session
+
+import (
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	sessionidconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/constants"
+)
+
+// SessionIDDataKey identifies the session identifier published on the request
+// attribute store. The default producer is the session-id-producer.
+var SessionIDDataKey = plugin.NewDataKey("SessionIDDataKey", sessionidconstants.SessionIDProducerType)
+
+// SessionID is the session identifier extracted from a request.
+type SessionID string
+
+// ReadSessionID returns the SessionID published by the default producer on the
+// request attribute store, or "" and false if absent.
+//
+// Consumers should use this helper rather than reading the attribute directly:
+// it encapsulates both the key construction and the type assertion, so a
+// future change of storage location or value type does not ripple through
+// every reader.
+func ReadSessionID(r *fwksched.InferenceRequest) (SessionID, bool) {
+	key := SessionIDDataKey.WithNonEmptyProducerName(sessionidconstants.SessionIDProducerType).String()
+	return fwksched.ReadRequestAttribute[SessionID](r, key)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/README.md
@@ -1,0 +1,34 @@
+# Session ID Producer Plugin
+
+**Type:** `session-id-producer`
+
+Extracts a session identifier from each inference request and publishes it as the `SessionID` attribute on the `InferenceRequest` attribute store. Affinity-aware scorers and filters consume this attribute via `session.ReadSessionID(request)` without needing to know whether the session was carried in a header or a cookie.
+
+The producer is a no-op when the configured source is absent or empty; consumers must treat the missing attribute as "no session preference".
+
+## Parameters
+
+Exactly one of the following must be set:
+
+- `headerName`: name of the request header whose value is the session identifier. Comparison is case-insensitive (header names in the request are lowercased).
+- `cookieName`: name of the cookie within the standard `Cookie` request header whose value is the session identifier.
+
+## Examples
+
+```yaml
+plugins:
+  - type: session-id-producer
+    parameters:
+      headerName: x-session-id
+```
+
+```yaml
+plugins:
+  - type: session-id-producer
+    parameters:
+      cookieName: llm-d-session
+```
+
+## Related Documentation
+
+- [Session Attributes](../../../datalayer/attribute/session/README.md)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/constants/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/constants/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sessionidconstants
+
+const (
+	// SessionIDProducerType is the default producer type for SessionIDDataKey.
+	SessionIDProducerType = "session-id-producer"
+)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sessionid provides a DataProducer that extracts a session
+// identifier from a configured request header or named cookie and publishes
+// it as a SessionID attribute on the InferenceRequest attribute store, so
+// that affinity-aware scorers and filters can read it without knowing how
+// the session was carried on the wire.
+package sessionid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrsession "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/session"
+	sessionidconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/constants"
+)
+
+// SessionIDProducerType is the plugin type registered with the framework.
+const SessionIDProducerType = sessionidconstants.SessionIDProducerType
+
+// cookieHeader is the standard HTTP request header carrying cookies.
+// Headers in InferenceRequest are normalized to lowercase.
+const cookieHeader = "cookie"
+
+// Parameters configures the session-id producer.
+//
+// Exactly one of HeaderName or CookieName must be set:
+//   - HeaderName: read the value of the named request header verbatim.
+//   - CookieName: parse the standard "cookie" request header and read the
+//     value of the named cookie.
+type Parameters struct {
+	HeaderName string `json:"headerName"`
+	CookieName string `json:"cookieName"`
+}
+
+var _ requestcontrol.DataProducer = &Producer{}
+
+// Producer extracts a session identifier from each incoming request and
+// publishes it as an endpoint attribute.
+type Producer struct {
+	typedName  fwkplugin.TypedName
+	dk         fwkplugin.DataKey
+	headerName string
+	cookieName string
+}
+
+// Factory builds a Producer from raw plugin parameters.
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	params := Parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' producer: %w", SessionIDProducerType, err)
+		}
+	}
+
+	header := strings.ToLower(strings.TrimSpace(params.HeaderName))
+	cookie := strings.TrimSpace(params.CookieName)
+
+	switch {
+	case header == "" && cookie == "":
+		return nil, fmt.Errorf("'%s' requires exactly one of headerName or cookieName to be set", SessionIDProducerType)
+	case header != "" && cookie != "":
+		return nil, fmt.Errorf("'%s' requires exactly one of headerName or cookieName to be set, not both", SessionIDProducerType)
+	}
+
+	return &Producer{
+		typedName:  fwkplugin.TypedName{Type: SessionIDProducerType, Name: name},
+		dk:         attrsession.SessionIDDataKey.WithNonEmptyProducerName(name),
+		headerName: header,
+		cookieName: cookie,
+	}, nil
+}
+
+// TypedName returns the type and name of the plugin.
+func (p *Producer) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// Produces declares the SessionID attribute key written by this producer.
+func (p *Producer) Produces() map[fwkplugin.DataKey]any {
+	return map[fwkplugin.DataKey]any{p.dk: attrsession.SessionID("")}
+}
+
+// Produce extracts the session identifier from the request and writes it to
+// the request's attribute store. When no identifier can be found the
+// producer is a no-op; consumers must handle absence as "no session
+// preference".
+func (p *Producer) Produce(_ context.Context, request *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
+	if request == nil {
+		return nil
+	}
+	id := p.extract(request)
+	if id == "" {
+		return nil
+	}
+	request.PutAttribute(p.dk.String(), attrsession.SessionID(id))
+	return nil
+}
+
+func (p *Producer) extract(request *fwksched.InferenceRequest) string {
+	if request == nil || request.Headers == nil {
+		return ""
+	}
+	if p.headerName != "" {
+		return strings.TrimSpace(request.Headers[p.headerName])
+	}
+	return strings.TrimSpace(cookieValue(request.Headers[cookieHeader], p.cookieName))
+}
+
+// cookieValue returns the value of the named cookie within an HTTP Cookie
+// header, or the empty string if the header is empty or the cookie is not
+// present. The header is parsed verbatim per RFC 6265 syntax: cookies are
+// separated by "; " and each pair is "name=value".
+func cookieValue(header, name string) string {
+	if header == "" || name == "" {
+		return ""
+	}
+	for pair := range strings.SplitSeq(header, ";") {
+		pair = strings.TrimSpace(pair)
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		if k == name {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sessionid_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrsession "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/session"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid"
+)
+
+func mustFactory(t *testing.T, params string) *sessionid.Producer {
+	t.Helper()
+	plg, err := sessionid.Factory("session-id-producer", fwkplugin.StrictDecoder(json.RawMessage(params)), nil)
+	require.NoError(t, err)
+	p, ok := plg.(*sessionid.Producer)
+	require.True(t, ok, "factory must return *Producer")
+	return p
+}
+
+func TestFactory_Validation(t *testing.T) {
+	t.Parallel()
+
+	const validationErr = "requires exactly one of headerName or cookieName"
+
+	tests := []struct {
+		name      string
+		params    json.RawMessage
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "header only", params: json.RawMessage(`{"headerName":"x-session-id"}`)},
+		{name: "cookie only", params: json.RawMessage(`{"cookieName":"llm-d-session"}`)},
+		{name: "header normalized", params: json.RawMessage(`{"headerName":" X-Session-ID "}`)},
+		{name: "empty object", params: json.RawMessage(`{}`), wantErr: true, errSubstr: validationErr},
+		{name: "both set", params: json.RawMessage(`{"headerName":"x","cookieName":"y"}`), wantErr: true, errSubstr: validationErr},
+		{name: "empty strings", params: json.RawMessage(`{"headerName":"","cookieName":""}`), wantErr: true, errSubstr: validationErr},
+		{name: "invalid json", params: json.RawMessage(`not-json`), wantErr: true, errSubstr: "failed to parse"},
+		{name: "unknown field", params: json.RawMessage(`{"headerName":"x","other":"y"}`), wantErr: true, errSubstr: "failed to parse"},
+		{name: "nil raw message", params: nil, wantErr: true, errSubstr: validationErr},
+		{name: "zero-length raw message", params: json.RawMessage{}, wantErr: true, errSubstr: validationErr},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := sessionid.Factory("p", fwkplugin.StrictDecoder(tc.params), nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSubstr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestProduce_HeaderMode(t *testing.T) {
+	t.Parallel()
+
+	producer := mustFactory(t, `{"headerName":"x-session-id"}`)
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name:    "value present",
+			headers: map[string]string{"x-session-id": "user-42"},
+			want:    "user-42",
+		},
+		{
+			name:    "value trimmed",
+			headers: map[string]string{"x-session-id": "  user-42  "},
+			want:    "user-42",
+		},
+		{
+			name:    "header absent",
+			headers: map[string]string{"other": "irrelevant"},
+		},
+		{
+			name:    "value empty",
+			headers: map[string]string{"x-session-id": ""},
+		},
+		{
+			name: "headers nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := &fwksched.InferenceRequest{Headers: tc.headers}
+
+			err := producer.Produce(context.Background(), req, nil)
+			require.NoError(t, err)
+
+			got, ok := attrsession.ReadSessionID(req)
+			if tc.want == "" {
+				assert.False(t, ok, "no session id should be published")
+				return
+			}
+			assert.True(t, ok)
+			assert.Equal(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestProduce_CookieMode(t *testing.T) {
+	t.Parallel()
+
+	producer := mustFactory(t, `{"cookieName":"llm-d-session"}`)
+
+	tests := []struct {
+		name   string
+		cookie string
+		want   string
+	}{
+		{
+			name:   "single cookie",
+			cookie: "llm-d-session=abc123",
+			want:   "abc123",
+		},
+		{
+			name:   "named cookie among others",
+			cookie: "csrf=xyz; llm-d-session=abc123; theme=dark",
+			want:   "abc123",
+		},
+		{
+			name:   "name not present",
+			cookie: "csrf=xyz; theme=dark",
+		},
+		{
+			name:   "header empty",
+			cookie: "",
+		},
+		{
+			name:   "malformed pair",
+			cookie: "no-equals; llm-d-session=abc",
+			want:   "abc",
+		},
+		{
+			name:   "value empty",
+			cookie: "llm-d-session=",
+		},
+		{
+			name:   "value trimmed",
+			cookie: "llm-d-session= abc123 ; other=v",
+			want:   "abc123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := &fwksched.InferenceRequest{
+				Headers: map[string]string{"cookie": tc.cookie},
+			}
+
+			err := producer.Produce(context.Background(), req, nil)
+			require.NoError(t, err)
+
+			got, ok := attrsession.ReadSessionID(req)
+			if tc.want == "" {
+				assert.False(t, ok)
+				return
+			}
+			assert.True(t, ok)
+			assert.Equal(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestProduce_NilRequest(t *testing.T) {
+	t.Parallel()
+
+	producer := mustFactory(t, `{"headerName":"x-session-id"}`)
+	err := producer.Produce(context.Background(), nil, nil)
+	require.NoError(t, err)
+}
+
+func TestProduce_NoSessionDoesNotAllocateStore(t *testing.T) {
+	t.Parallel()
+
+	producer := mustFactory(t, `{"headerName":"x-session-id"}`)
+	req := &fwksched.InferenceRequest{}
+
+	require.NoError(t, producer.Produce(context.Background(), req, nil))
+	assert.Empty(t, req.AttributeKeys(), "no extraction should leave the store unallocated")
+}
+
+func TestProduces_DeclaresKey(t *testing.T) {
+	t.Parallel()
+
+	producer := mustFactory(t, `{"headerName":"x"}`)
+	produces := producer.Produces()
+	expectedKey := attrsession.SessionIDDataKey.WithNonEmptyProducerName("session-id-producer")
+	_, ok := produces[expectedKey]
+	assert.True(t, ok, "Produces() must declare %v", expectedKey)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a `session-id-producer` DataProducer that extracts a session identifier from a configured request header or cookie and publishes it as the `SessionID` attribute on the `InferenceRequest` attribute store introduced in #1351. Future affinity-aware scorers and filters will consume the value through `session.ReadSessionID(request)`.

The plugin is configured with exactly one of `headerName` or `cookieName`. 
When the configured source is absent or empty the producer is a no-op, leaving the attribute unset so consumers can
treat absence as "no session preference".

This is the producer half of the session-affinity work tracked under #815. A follow-up PR will add the scorer/filter that consumes the attribute.

**Which issue(s) this PR fixes**:

Refs #815

**Release note**:
```release-note
Added a `session-id-producer` DataProducer plugin (type: `session-id-producer`), which extracts a session identifier from a
configured request header or cookie and publishes it as the `SessionID` attribute on the request attribute store for use by
future affinity-aware scorers and filters.
```