### PR TITLE
Standardize real model usage across all E2E tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.5
 	k8s.io/apiextensions-apiserver v0.35.5
 	k8s.io/apimachinery v0.35.5
@@ -141,6 +140,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.35.5 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.5
 	k8s.io/apiextensions-apiserver v0.35.5
 	k8s.io/apimachinery v0.35.5
@@ -140,7 +141,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.35.5 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -37,14 +37,7 @@ EPP_IMAGE="${EPP_IMAGE:-${IMAGE_REGISTRY}/llm-d-router-endpoint-picker:${EPP_TAG
 export EPP_IMAGE
 
 # Set the model name to deploy.
-# When Encode disaggregation is enabled (multimodal pipeline), default to a
-# multimodal model. Otherwise use the standard text-only model.
-# Note: DISAGG_E/DISAGG_P are set later in this script, so read the raw env vars here.
-if [ "${DISAGG_E:-false}" == "true" ] || [ "${EPD_ENABLED:-false}" == "true" ] || [ "${EPD_ENABLED:-false}" == "\"true\"" ]; then
-  export MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-VL-2B-Instruct}"
-else
-  export MODEL_NAME="${MODEL_NAME:-TinyLlama/TinyLlama-1.1B-Chat-v1.0}"
-fi
+export MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-VL-2B-Instruct}"
 # Extract model family (e.g., "meta-llama" from "meta-llama/Llama-3.1-8B-Instruct")
 export MODEL_FAMILY="${MODEL_NAME%%/*}"
 # Extract model ID (e.g., "Llama-3.1-8B-Instruct")

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -1,5 +1,9 @@
 package e2e
 
+import (
+	"github.com/llm-d/llm-d-router/test/utils"
+)
+
 // Simple EPP configuration for running without P/D
 const simpleConfig = `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
@@ -185,7 +189,7 @@ kind: EndpointPickerConfig
 plugins:
 - type: token-producer
   parameters:
-    modelName: Qwen/Qwen2.5-1.5B-Instruct
+    modelName: ` + utils.ModelName + `
     vllm:
       url: http://localhost:8000
 - type: precise-prefix-cache-scorer
@@ -217,7 +221,7 @@ kind: EndpointPickerConfig
 plugins:
 - type: token-producer
   parameters:
-    modelName: Qwen/Qwen2.5-1.5B-Instruct
+    modelName: ` + utils.ModelName + `
     vllm:
       url: http://localhost:8000
 - type: precise-prefix-cache-scorer

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			gomega.Expect(decodePods).Should(gomega.HaveLen(2))
 
 			ginkgo.By("Verifying requests route successfully before disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			targetPod := decodePods[0]
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying new requests eventually route to a pod other than the killed one")
 			gomega.Eventually(func() error {
-				nsHdr, podHdr, _, err := tryCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdr, _, err := tryCompletion(simplePrompt)
 				if err != nil {
 					return err
 				}
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying requests succeed after recovery")
 			for range 3 {
-				nsHdr, _, _ = runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, _, _ = runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			}
 		})
@@ -185,7 +185,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying requests succeed after recovery")
 			for range 3 {
-				nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, _, _ := runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			}
 		})
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
 			ginkgo.By("Verifying requests succeed before disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			ginkgo.By("Scaling deployment to zero")
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying requests succeed after recovery")
 			gomega.Eventually(func() string {
-				nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, _, _ := runCompletion(simplePrompt)
 				return nsHdr
 			}, eppRecoveryTimeout, 2*time.Second).Should(gomega.Equal(nsName))
 		})
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
 
 			ginkgo.By("Verifying requests succeed before EPP disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			ginkgo.By("Finding EPP pod")
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
 
 			ginkgo.By("Verifying requests succeed before disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			ginkgo.By("Starting background traffic")

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -33,7 +33,7 @@ var disruptionClient = &http.Client{Timeout: 10 * time.Second}
 
 // sendRawCompletion sends a completion request and returns the HTTP status code.
 func sendRawCompletion() (int, error) {
-	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":10}`, simModelName, simplePrompt)
+	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":10}`, testutils.ModelName, simplePrompt)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/completions", port), strings.NewReader(body))
 	if err != nil {
 		return 0, err
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			gomega.Expect(decodePods).Should(gomega.HaveLen(2))
 
 			ginkgo.By("Verifying requests route successfully before disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			targetPod := decodePods[0]
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying new requests eventually route to a pod other than the killed one")
 			gomega.Eventually(func() error {
-				nsHdr, podHdr, _, err := tryCompletion(simplePrompt, simModelName)
+				nsHdr, podHdr, _, err := tryCompletion(simplePrompt, testutils.ModelName)
 				if err != nil {
 					return err
 				}
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying requests succeed after recovery")
 			for range 3 {
-				nsHdr, _, _ = runCompletion(simplePrompt, simModelName)
+				nsHdr, _, _ = runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			}
 		})
@@ -185,7 +185,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying requests succeed after recovery")
 			for range 3 {
-				nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+				nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			}
 		})
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
 			ginkgo.By("Verifying requests succeed before disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			ginkgo.By("Scaling deployment to zero")
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 			ginkgo.By("Verifying requests succeed after recovery")
 			gomega.Eventually(func() string {
-				nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+				nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
 				return nsHdr
 			}, eppRecoveryTimeout, 2*time.Second).Should(gomega.Equal(nsName))
 		})
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
 
 			ginkgo.By("Verifying requests succeed before EPP disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			ginkgo.By("Finding EPP pod")
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
 
 			ginkgo.By("Verifying requests succeed before disruption")
-			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, _, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			ginkgo.By("Starting background traffic")
@@ -341,7 +341,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label("Disrup
 
 func sendStreamingCompletion(connected chan<- string) error {
 	longPrompt := strings.Repeat("This is a longer prompt to keep the stream open. ", 20)
-	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":100,"stream":true}`, simModelName, longPrompt)
+	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":100,"stream":true}`, testutils.ModelName, longPrompt)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/completions", port), strings.NewReader(body))
 	if err != nil {
 		connected <- ""

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -36,10 +36,6 @@ const (
 	crdKustomizePath = "../../config/crd"
 	// inferExtManifest is the manifest for the inference extension test resources.
 	inferExtManifest = "../../deploy/components/inference-gateway/inference-pools.yaml"
-	// simModelName is the test model name.
-	simModelName = "food-review"
-	// kvModelName is the model name used in KV tests.
-	kvModelName = "Qwen/Qwen2.5-1.5B-Instruct"
 	// envoyManifest is the manifest for the envoy proxy test resources.
 	envoyManifest = "../../deploy/environments/dev/e2e-infra/envoy.yaml"
 	// eppManifest is the manifest for the deployment of the EPP
@@ -303,7 +299,7 @@ func createEnvoy() {
 }
 
 func createInferencePool(numTargetPorts int, toDelete bool) []string {
-	poolName := simModelName + "-inference-pool"
+	poolName := testutils.ModelServerName + "-inference-pool"
 
 	if toDelete {
 		objName := []string{"inferencepool/" + poolName}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	poolName              = simModelName + "-inference-pool"
+	poolName              = testutils.ModelServerName + "-inference-pool"
 	podSelector           = map[string]string{"app": poolName}
 	prefillSelector       = map[string]string{"llm-d.ai/role": "prefill"}
 	decodeSelector        = map[string]string{"llm-d.ai/role": "decode"}
@@ -64,11 +64,11 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
@@ -98,42 +98,42 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
 			gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
-			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrCompletion).Should(gomega.BeElementOf(decodePods))
 
-			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrChat).Should(gomega.BeElementOf(decodePods))
 
 			// Do an extra completion call with a different prompt
-			nsHdr, podHdr, _ := runCompletion(extraPrompt, simModelName)
+			nsHdr, podHdr, _ := runCompletion(extraPrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run completion with the original prompt
-			nsHdr, podHdr, _ = runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrCompletion))
 
 			// Do an extra chat completion call with a different prompt
-			nsHdr, podHdr, _ = runChatCompletion(extraPrompt, simModelName)
+			nsHdr, podHdr, _ = runChatCompletion(extraPrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run chat completion with the original prompt
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrChat))
 
 			// Metrics Validation
-			labelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, simModelName)
+			labelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, testutils.ModelName)
 			prefillDecodeCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_pd_decision_total", labelFilter)
 			prefillDecodeCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_pd_decision_total", labelFilter)
 
-			labelFilter2 := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, simModelName)
+			labelFilter2 := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, testutils.ModelName)
 			decodeOnlyCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_pd_decision_total", labelFilter2)
 			decodeOnlyCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_pd_decision_total", labelFilter2)
 
@@ -170,22 +170,22 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
 				// Test regular completion request
-				nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, simModelName)
+				nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdrCompletion).Should(gomega.BeElementOf(decodePods))
 
 				// Test regular chat completion request
-				nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, simModelName)
+				nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdrChat).Should(gomega.BeElementOf(decodePods))
 
 				// Run completion with a different prompt
-				nsHdr, podHdr, _ := runCompletion(extraPrompt, simModelName)
+				nsHdr, podHdr, _ := runCompletion(extraPrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 				// Run completion with original prompt (should go to same pod due to prefix cache)
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, simModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 				gomega.Expect(podHdr).Should(gomega.Equal(podHdrCompletion))
@@ -208,7 +208,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
 				// Test streaming completion request
-				nsHdr, podHdr := runStreamingCompletion(simplePrompt, simModelName)
+				nsHdr, podHdr := runStreamingCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
@@ -218,7 +218,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 				// Run streaming completion with a different prompt
-				nsHdr, podHdr = runStreamingCompletion(extraPrompt, simModelName)
+				nsHdr, podHdr = runStreamingCompletion(extraPrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
@@ -347,42 +347,42 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
 			gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
-			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrCompletion).Should(gomega.BeElementOf(decodePods))
 
-			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrChat).Should(gomega.BeElementOf(decodePods))
 
 			// Do an extra completion call with a different prompt
-			nsHdr, podHdr, _ := runCompletion(extraPrompt, simModelName)
+			nsHdr, podHdr, _ := runCompletion(extraPrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run completion with the original prompt
-			nsHdr, podHdr, _ = runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrCompletion))
 
 			// Do an extra chat completion call with a different prompt
-			nsHdr, podHdr, _ = runChatCompletion(extraPrompt, simModelName)
+			nsHdr, podHdr, _ = runChatCompletion(extraPrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run chat completion with the original prompt
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrChat))
 
 			// Metrics Validation
-			labelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, simModelName)
+			labelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, testutils.ModelName)
 			prefillDecodeCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", labelFilter)
 			prefillDecodeCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_disagg_decision_total", labelFilter)
 
-			labelFilter2 := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, simModelName)
+			labelFilter2 := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, testutils.ModelName)
 			decodeOnlyCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", labelFilter2)
 			decodeOnlyCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_disagg_decision_total", labelFilter2)
 
@@ -408,11 +408,11 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
@@ -442,7 +442,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillDecodePods).Should(gomega.HaveLen(decodeReplicas))
 
 			// Text request: encode stage skipped, routed directly to a prefill-decode pod
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(prefillDecodePods))
 
@@ -476,14 +476,14 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(prefillDecodePods))
 
 			// Metrics: text + image_embeds requests recorded as decode-only (encode skipped)
-			decodeOnlyFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, simModelName)
+			decodeOnlyFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, testutils.ModelName)
 			decodeOnlyCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", decodeOnlyFilter)
 			decodeOnlyCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_disagg_decision_total", decodeOnlyFilter)
 			gomega.Expect(decodeOnlyCount).Should(gomega.Equal(2))
 			gomega.Expect(decodeOnlyCountllmDRouterEpp).Should(gomega.Equal(2))
 
 			// Metrics: encode-decode decisions recorded (2 single-image + 1 multi-image + 1 video + 1 audio)
-			labelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeEncodeDecode, simModelName)
+			labelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeEncodeDecode, testutils.ModelName)
 			encodeDecodeCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", labelFilter)
 			encodeDecodeCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_disagg_decision_total", labelFilter)
 			gomega.Expect(encodeDecodeCount).Should(gomega.Equal(5))
@@ -518,7 +518,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
 			// Text request: encode stage skipped, prefill triggered by prefix-based-pd-decider
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
@@ -548,8 +548,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Metrics: text + image_embeds requests recorded as decode-only or prefill-decode (encode skipped)
-			pdLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, simModelName)
-			doLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, simModelName)
+			pdLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, testutils.ModelName)
+			doLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, testutils.ModelName)
 			pdCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", pdLabelFilter)
 			pdCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_disagg_decision_total", pdLabelFilter)
 			doCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", doLabelFilter)
@@ -561,8 +561,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			// Metrics: 4 multimodal requests each produce either encode-prefill-decode or encode-decode
 			// (encode-decode occurs if the prefix cache hits on the second same-image request).
 			// The 3 requests with unique content (1st image, multi-image, video) always produce encode-prefill-decode.
-			// epdLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeEncodePrefillDecode, simModelName)
-			// edLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeEncodeDecode, simModelName)
+			// epdLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeEncodePrefillDecode, testutils.ModelName)
+			// edLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeEncodeDecode, testutils.ModelName)
 			// epdCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", epdLabelFilter)
 			// epdCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_disagg_decision_total", epdLabelFilter)
 			// edCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", edLabelFilter)
@@ -599,18 +599,18 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(epdPods).Should(gomega.HaveLen(replicas))
 
 			// Text completion: encode skipped, routes to decode profile -> single deployment
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(epdPods[0]))
 
 			// Text chat completion: same routing as above
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(epdPods[0]))
 
 			// Metrics: text requests recorded as decode-only or prefill-decode (encode skipped)
-			pdLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, simModelName)
-			doLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, simModelName)
+			pdLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypePrefillDecode, testutils.ModelName)
+			doLabelFilter := fmt.Sprintf(`decision_type=%q,model_name="%s"`, metrics.DecisionTypeDecodeOnly, testutils.ModelName)
 			pdCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", pdLabelFilter)
 			pdCountllmDRouterEpp := getCounterMetric(metricsURL, "llm_d_router_epp_disagg_decision_total", pdLabelFilter)
 			doCount := getCounterMetric(metricsURL, "llm_d_inference_scheduler_disagg_decision_total", doLabelFilter)
@@ -657,7 +657,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
 			for range 5 {
-				nsHdr, podHdr, _ := runCompletion(simplePrompt, kvModelName)
+				nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
@@ -681,18 +681,18 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
 			// Test completions
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, kvModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
 			// Test chat completions
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, kvModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
 			// Repeat to verify prefix cache affinity with pre-tokenized prompts
 			for range 3 {
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, kvModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
@@ -716,7 +716,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			var nsHdr, podHdr string
 			for range 5 {
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, simModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
@@ -730,7 +730,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			var scaledNsHdr, scaledPodHdr string
 			// Run inference multiple times until one is scheduled on the new pod
 			for range 30 {
-				scaledNsHdr, scaledPodHdr, _ = runCompletion(extraPrompt, simModelName)
+				scaledNsHdr, scaledPodHdr, _ = runCompletion(extraPrompt, testutils.ModelName)
 				gomega.Expect(scaledNsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(scaledPodHdr).Should(gomega.BeElementOf(scaledUpDecodePods))
 				if scaledPodHdr != podHdr {
@@ -748,7 +748,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			// Run multiple times and insure that they are scheduled on the remaining pod
 			for range 5 {
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, simModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(scaledDownDecodePods[0]))
 			}
@@ -770,7 +770,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
-			nsHdr, podHdr, portHdr := runCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, portHdr := runCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
@@ -778,7 +778,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			// Run inference multiple times until one is scheduled on the other port
 			for range 30 {
-				parallelNsHdr, parallelPodHdr, parallelPortHdr = runCompletion(extraPrompt, simModelName)
+				parallelNsHdr, parallelPodHdr, parallelPortHdr = runCompletion(extraPrompt, testutils.ModelName)
 				gomega.Expect(parallelNsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(parallelPodHdr).Should(gomega.Equal(decodePods[0]))
 				if parallelPortHdr != portHdr {
@@ -787,13 +787,13 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			}
 			gomega.Expect(parallelPortHdr).ShouldNot(gomega.Equal(portHdr))
 
-			nsHdr, podHdr, portHdr = runChatCompletion(simplePrompt, simModelName)
+			nsHdr, podHdr, portHdr = runChatCompletion(simplePrompt, testutils.ModelName)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
 			// Run inference multiple times until one is scheduled on the other port
 			for range 30 {
-				parallelNsHdr, parallelPodHdr, parallelPortHdr = runChatCompletion(extraPrompt, simModelName)
+				parallelNsHdr, parallelPodHdr, parallelPortHdr = runChatCompletion(extraPrompt, testutils.ModelName)
 				gomega.Expect(parallelNsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(parallelPodHdr).Should(gomega.Equal(decodePods[0]))
 				if parallelPortHdr != portHdr {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -64,11 +64,11 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
@@ -98,32 +98,32 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
 			gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
-			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrCompletion).Should(gomega.BeElementOf(decodePods))
 
-			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrChat).Should(gomega.BeElementOf(decodePods))
 
 			// Do an extra completion call with a different prompt
-			nsHdr, podHdr, _ := runCompletion(extraPrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(extraPrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run completion with the original prompt
-			nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrCompletion))
 
 			// Do an extra chat completion call with a different prompt
-			nsHdr, podHdr, _ = runChatCompletion(extraPrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(extraPrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run chat completion with the original prompt
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrChat))
@@ -170,22 +170,22 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
 				// Test regular completion request
-				nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdrCompletion).Should(gomega.BeElementOf(decodePods))
 
 				// Test regular chat completion request
-				nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdrChat).Should(gomega.BeElementOf(decodePods))
 
 				// Run completion with a different prompt
-				nsHdr, podHdr, _ := runCompletion(extraPrompt, testutils.ModelName)
+				nsHdr, podHdr, _ := runCompletion(extraPrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 				// Run completion with original prompt (should go to same pod due to prefix cache)
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 				gomega.Expect(podHdr).Should(gomega.Equal(podHdrCompletion))
@@ -347,32 +347,32 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
 			gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
-			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdrCompletion, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrCompletion).Should(gomega.BeElementOf(decodePods))
 
-			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdrChat, _ := runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdrChat).Should(gomega.BeElementOf(decodePods))
 
 			// Do an extra completion call with a different prompt
-			nsHdr, podHdr, _ := runCompletion(extraPrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(extraPrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run completion with the original prompt
-			nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrCompletion))
 
 			// Do an extra chat completion call with a different prompt
-			nsHdr, podHdr, _ = runChatCompletion(extraPrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(extraPrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
 			// Run chat completion with the original prompt
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 			gomega.Expect(podHdr).Should(gomega.Equal(podHdrChat))
@@ -408,11 +408,11 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
@@ -442,7 +442,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillDecodePods).Should(gomega.HaveLen(decodeReplicas))
 
 			// Text request: encode stage skipped, routed directly to a prefill-decode pod
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(prefillDecodePods))
 
@@ -518,7 +518,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
 			// Text request: encode stage skipped, prefill triggered by prefix-based-pd-decider
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
@@ -599,12 +599,12 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(epdPods).Should(gomega.HaveLen(replicas))
 
 			// Text completion: encode skipped, routes to decode profile -> single deployment
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(epdPods[0]))
 
 			// Text chat completion: same routing as above
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(epdPods[0]))
 
@@ -657,7 +657,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
 			for range 5 {
-				nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdr, _ := runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
@@ -681,18 +681,18 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
 			// Test completions
-			nsHdr, podHdr, _ := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
 			// Test chat completions
-			nsHdr, podHdr, _ = runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, _ = runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
 			// Repeat to verify prefix cache affinity with pre-tokenized prompts
 			for range 3 {
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
@@ -716,7 +716,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			var nsHdr, podHdr string
 			for range 5 {
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
@@ -730,7 +730,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			var scaledNsHdr, scaledPodHdr string
 			// Run inference multiple times until one is scheduled on the new pod
 			for range 30 {
-				scaledNsHdr, scaledPodHdr, _ = runCompletion(extraPrompt, testutils.ModelName)
+				scaledNsHdr, scaledPodHdr, _ = runCompletion(extraPrompt)
 				gomega.Expect(scaledNsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(scaledPodHdr).Should(gomega.BeElementOf(scaledUpDecodePods))
 				if scaledPodHdr != podHdr {
@@ -748,7 +748,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			// Run multiple times and insure that they are scheduled on the remaining pod
 			for range 5 {
-				nsHdr, podHdr, _ = runCompletion(simplePrompt, testutils.ModelName)
+				nsHdr, podHdr, _ = runCompletion(simplePrompt)
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.Equal(scaledDownDecodePods[0]))
 			}
@@ -770,7 +770,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
-			nsHdr, podHdr, portHdr := runCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, portHdr := runCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
@@ -778,7 +778,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			// Run inference multiple times until one is scheduled on the other port
 			for range 30 {
-				parallelNsHdr, parallelPodHdr, parallelPortHdr = runCompletion(extraPrompt, testutils.ModelName)
+				parallelNsHdr, parallelPodHdr, parallelPortHdr = runCompletion(extraPrompt)
 				gomega.Expect(parallelNsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(parallelPodHdr).Should(gomega.Equal(decodePods[0]))
 				if parallelPortHdr != portHdr {
@@ -787,13 +787,13 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			}
 			gomega.Expect(parallelPortHdr).ShouldNot(gomega.Equal(portHdr))
 
-			nsHdr, podHdr, portHdr = runChatCompletion(simplePrompt, testutils.ModelName)
+			nsHdr, podHdr, portHdr = runChatCompletion(simplePrompt)
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
 			// Run inference multiple times until one is scheduled on the other port
 			for range 30 {
-				parallelNsHdr, parallelPodHdr, parallelPortHdr = runChatCompletion(extraPrompt, testutils.ModelName)
+				parallelNsHdr, parallelPodHdr, parallelPortHdr = runChatCompletion(extraPrompt)
 				gomega.Expect(parallelNsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(parallelPodHdr).Should(gomega.Equal(decodePods[0]))
 				if parallelPortHdr != portHdr {

--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -11,7 +11,7 @@ The end-to-end tests are designed to validate end-to-end Gateway API Inference E
 - [Go](https://golang.org/doc/install) installed on your machine.
 - [Make](https://www.gnu.org/software/make/manual/make.html) installed to run the end-to-end test target.
 - (Optional) When using the GPU-based vLLM deployment, a Hugging Face Hub token with access to the
-  [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) model is required.
+  [Qwen/Qwen3-VL-2B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct) model is required.
   After obtaining the token and being granted access to the model, set the `HF_TOKEN` environment variable:
 
    ```sh
@@ -64,5 +64,5 @@ Follow these steps to run the end-to-end tests:
    make test-e2e-gaie
    ```
 
-   The test suite prints details for each step. Note that the `vllm-qwen3-32b` model server deployment
+   The test suite prints details for each step. Note that the `vllm-qwen3-2b-instruct` model server deployment
    may take several minutes to report an `Available=True` status due to the time required for bootstrapping.

--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
 	"github.com/llm-d/llm-d-router/pkg/epp/util/env"
 	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
+
+	"github.com/llm-d/llm-d-router/test/utils"
 )
 
 const (
@@ -46,18 +48,14 @@ const (
 	defaultCurlInterval = time.Second * 5
 	// defaultNsName is the default name of the Namespace used for tests. Can override using the E2E_NS environment variable.
 	defaultNsName = "inf-ext-e2e"
-	// modelServerName is the name of the model server test resources.
-	modelServerName = "vllm-qwen3-32b"
-	// modelName is the test model name.
-	modelName = "food-review"
 	// targetModelName is the target model name of the test model server.
-	targetModelName = modelName + "-1"
+	targetModelName = utils.ModelName + "-1"
 	// envoyName is the name of the envoy proxy test resources.
 	envoyName = "envoy"
 	// envoyPort is the listener port number of the test envoy proxy.
 	envoyPort = "8081"
 	// inferExtName is the name of the inference extension test resources.
-	inferExtName = "vllm-qwen3-32b-epp"
+	inferExtName = utils.ModelServerName + "-epp"
 	// metricsReaderSecretName is the name of the metrics reader secret which stores sa token to read epp metrics.
 	metricsReaderSecretName = "inference-gateway-sa-metrics-reader-secret"
 	// clientManifest is the manifest for the client test resources.

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -32,6 +32,7 @@ import (
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
+	testutils "github.com/llm-d/llm-d-router/test/utils"
 	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
 )
 
@@ -48,7 +49,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 
 		ginkgo.By("Modifying deployment using local image for testing (temporary).")
 		deploy := &appsv1.Deployment{}
-		key := types.NamespacedName{Name: modelServerName, Namespace: testConfig.NsName}
+		key := types.NamespacedName{Name: testutils.ModelServerName, Namespace: testConfig.NsName}
 
 		gomega.Eventually(func() error {
 			err := testConfig.K8sClient.Get(testConfig.Context, key, deploy)
@@ -132,7 +133,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 		}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("Restoring vLLM Deployment and InferencePool.")
-		key := types.NamespacedName{Name: modelServerName, Namespace: testConfig.NsName}
+		key := types.NamespacedName{Name: testutils.ModelServerName, Namespace: testConfig.NsName}
 
 		// Restore InferencePool
 		pool := &v1.InferencePool{}

--- a/test/e2e/epp/utils_test.go
+++ b/test/e2e/epp/utils_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
+
+	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
 const (
@@ -67,7 +69,7 @@ const (
 func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
 	return igwtestutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
 		SetPriority(2).
-		SetPoolRef(modelServerName).
+		SetPoolRef(testutils.ModelServerName).
 		Obj()
 }
 
@@ -115,7 +117,7 @@ func verifyTrafficRouting() {
 
 		// Skip embeddings API if server returns 404 (not all models support embeddings).
 		if t.api == apiEmbeddings {
-			probeCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, t.api, t.promptOrMessages, false)
+			probeCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, testutils.ModelName, curlTimeout, t.api, t.promptOrMessages, false)
 			probeResp, probeErr := igwtestutils.ExecCommandInPod(testConfig, curlPodName, curlPodName, probeCmd)
 			if probeErr == nil && strings.Contains(probeResp, statusNotFound) {
 				ginkgo.Skip("Skipping " + apiEmbeddings + ": server returned 404 (embeddings may not be supported by this model)")
@@ -124,7 +126,7 @@ func verifyTrafficRouting() {
 
 		// Expected ports and client-facing model name (response model is rewritten back to the incoming name)
 		expectedPort := generateSequence(firstPort, numPorts)
-		expectedModel := []string{modelName}
+		expectedModel := []string{testutils.ModelName}
 
 		// Observed ports and InferenceObjective target models
 		actualModel := make(map[string]int)
@@ -157,7 +159,7 @@ func verifyTrafficRouting() {
 				currentPromptOrMessages = t.promptOrMessages
 			}
 
-			curlCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, t.api, currentPromptOrMessages, false)
+			curlCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, testutils.ModelName, curlTimeout, t.api, currentPromptOrMessages, false)
 
 			var resp string
 			var err error
@@ -211,7 +213,7 @@ func verifyMetrics() {
 
 	// Generate traffic by sending requests through the inference extension.
 	ginkgo.By("Generating traffic through the inference extension")
-	curlCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, modelName, curlTimeout, apiCompletions, testPrompt, true)
+	curlCmd := getCurlCommand(envoyName, testConfig.NsName, envoyPort, testutils.ModelName, curlTimeout, apiCompletions, testPrompt, true)
 
 	// Run the curl command multiple times to generate some metrics data.
 
@@ -249,7 +251,7 @@ func verifyMetrics() {
 	// Construct the metric scraping curl command using Pod IP.
 	metricScrapeCmd := getMetricsScrapeCommand(podIP, token)
 
-	modelServerPods, err := getPodsByLabel(testConfig.Context, testConfig.K8sClient, testConfig.NsName, "app", modelServerName)
+	modelServerPods, err := getPodsByLabel(testConfig.Context, testConfig.K8sClient, testConfig.NsName, "app", testutils.ModelServerName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected to find model server pods")
 
 	// Define the metrics we expect to see
@@ -294,7 +296,7 @@ func verifyMetrics() {
 				"inference_pool_per_pod_queue_size{model_server_pod=\"%s-rank-%d\",name=\"%s\"}",
 				modelServerPod.Name,
 				rank,
-				modelServerName,
+				testutils.ModelServerName,
 			)
 			expectedMetrics = append(expectedMetrics, metricQueueSize)
 
@@ -302,7 +304,7 @@ func verifyMetrics() {
 				"llm_d_router_epp_per_endpoint_queue_size{model_server_endpoint=\"%s-rank-%d\",name=\"%s\"}",
 				modelServerPod.Name,
 				rank,
-				modelServerName,
+				testutils.ModelServerName,
 			)
 			expectedMetrics = append(expectedMetrics, metricQueueSizeNew)
 		}

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -48,14 +48,14 @@ func doPost(path, body string, extraHeaders map[string]string) (string, string, 
 	return resp.Header.Get("x-inference-namespace"), resp.Header.Get("x-inference-pod"), respBody
 }
 
-func runCompletion(prompt string, theModel openai.CompletionNewParamsModel) (string, string, string) {
+func runCompletion(prompt string) (string, string, string) {
 	var httpResp *http.Response
 
 	completionParams := openai.CompletionNewParams{
 		Prompt: openai.CompletionNewParamsPromptUnion{
 			OfString: openai.String(prompt),
 		},
-		Model: theModel,
+		Model: testutils.ModelName,
 	}
 
 	ginkgo.By(fmt.Sprintf("Sending Completion Request: (port %s) %#v", port, completionParams))
@@ -74,11 +74,11 @@ func runCompletion(prompt string, theModel openai.CompletionNewParamsModel) (str
 
 // tryCompletion is like runCompletion but returns an error instead of asserting,
 // intended for use inside Eventually blocks where transient failures are acceptable.
-func tryCompletion(prompt string, theModel openai.CompletionNewParamsModel) (string, string, string, error) {
+func tryCompletion(prompt string) (string, string, string, error) {
 	var httpResp *http.Response
 	completionParams := openai.CompletionNewParams{
 		Prompt: openai.CompletionNewParamsPromptUnion{OfString: openai.String(prompt)},
-		Model:  theModel,
+		Model:  testutils.ModelName,
 	}
 	resp, err := newOpenAIClient().Completions.New(
 		testConfig.Context,
@@ -99,14 +99,14 @@ func tryCompletion(prompt string, theModel openai.CompletionNewParamsModel) (str
 	return ns, pod, p, nil
 }
 
-func runChatCompletion(prompt, modelName string) (string, string, string) {
+func runChatCompletion(prompt string) (string, string, string) {
 	var httpResp *http.Response
 
 	params := openai.ChatCompletionNewParams{
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage(prompt),
 		},
-		Model: modelName,
+		Model: testutils.ModelName,
 	}
 	resp, err := newOpenAIClient().Chat.Completions.New(testConfig.Context, params, option.WithResponseInto(&httpResp))
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+
+	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
 func newOpenAIClient() *openai.Client {
@@ -136,7 +138,7 @@ func runChatCompletionWithImages(imageURLs ...string) (string, string) {
 		sb.WriteString(fmt.Sprintf(`{"type":"image_url","image_url":{"url":%q},"uuid":"image-%d"},`, url, i))
 	}
 	body := fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":[%s{"type":"text","text":"Describe what you see."}]}],"max_tokens":150}`,
-		simModelName, sb.String())
+		testutils.ModelName, sb.String())
 	return runRawChatCompletion(body)
 }
 
@@ -145,7 +147,7 @@ func runChatCompletionWithImages(imageURLs ...string) (string, string) {
 func runChatCompletionWithVideo() (string, string) {
 	ginkgo.By("Sending Multimodal Chat Completion Request with video: " + testVideoURL)
 	body := fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":[{"type":"text","text":"What is happening in this video?"},{"type":"video_url","video_url":{"url":%q}}]}]}`,
-		simModelName, testVideoURL)
+		testutils.ModelName, testVideoURL)
 	return runRawChatCompletion(body)
 }
 
@@ -156,7 +158,7 @@ func runChatCompletionWithVideo() (string, string) {
 func runChatCompletionWithImageEmbeds() (string, string) {
 	ginkgo.By("Sending Chat Completion Request with image_embeds")
 	body := fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":[{"type":"text","text":"Describe this embedded image:"},{"type":"image_embeds","image_embeds":%q,"uuid":"embedded-image-1"}]}]}`,
-		simModelName, testImageEmbeds)
+		testutils.ModelName, testImageEmbeds)
 	return runRawChatCompletion(body)
 }
 
@@ -166,7 +168,7 @@ func runChatCompletionWithImageEmbeds() (string, string) {
 func runChatCompletionWithAudio() (string, string) {
 	ginkgo.By("Sending Chat Completion Request with input_audio")
 	body := fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":[{"type":"text","text":"What is being said in this audio clip?"},{"type":"input_audio","input_audio":{"data":%q,"format":"wav"}}]}],"max_tokens":100}`,
-		simModelName, testAudioData)
+		testutils.ModelName, testAudioData)
 	return runRawChatCompletion(body)
 }
 
@@ -180,7 +182,7 @@ func runStreamingCompletion(prompt string, theModel openai.CompletionNewParamsMo
 
 func runStreamingChatCompletion(prompt string) (string, string) {
 	ginkgo.By(fmt.Sprintf("Sending Streaming Chat Completion Request: (port %s)", port))
-	body := fmt.Sprintf(`{"model":"%s","messages":[{"role":"user","content":"%s"}],"stream":true}`, simModelName, prompt)
+	body := fmt.Sprintf(`{"model":"%s","messages":[{"role":"user","content":"%s"}],"stream":true}`, testutils.ModelName, prompt)
 	ns, pod, respBody := doPost("/v1/chat/completions", body, nil)
 	ginkgo.By(fmt.Sprintf("Streaming Chat Completion received response length: %d bytes", len(respBody)))
 	return ns, pod
@@ -191,7 +193,7 @@ func runStreamingChatCompletion(prompt string) (string, string) {
 // Returns namespace header, pod header, and the finish reason from the response.
 func runCompletionWithCacheThreshold(prompt string, cacheHitThreshold float64, forceCacheThresholdFinishReason bool) (string, string, string) {
 	ginkgo.By(fmt.Sprintf("Sending Completion Request with cache_hit_threshold=%v, forceCacheThreshold=%v", cacheHitThreshold, forceCacheThresholdFinishReason))
-	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":10,"cache_hit_threshold":%v}`, simModelName, prompt, cacheHitThreshold)
+	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":10,"cache_hit_threshold":%v}`, testutils.ModelName, prompt, cacheHitThreshold)
 	extraHeaders := cacheThresholdHeaders(forceCacheThresholdFinishReason)
 	ns, pod, respBody := doPost("/v1/completions", body, extraHeaders)
 	finishReason := extractFinishReason(string(respBody))
@@ -202,7 +204,7 @@ func runCompletionWithCacheThreshold(prompt string, cacheHitThreshold float64, f
 // runStreamingCompletionWithCacheThreshold sends a streaming completion request with cache_hit_threshold.
 func runStreamingCompletionWithCacheThreshold(prompt string, cacheHitThreshold float64, forceCacheThresholdFinishReason bool) (string, string, string) {
 	ginkgo.By(fmt.Sprintf("Sending Streaming Completion Request with cache_hit_threshold=%v, forceCacheThreshold=%v", cacheHitThreshold, forceCacheThresholdFinishReason))
-	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":10,"stream":true,"cache_hit_threshold":%v}`, simModelName, prompt, cacheHitThreshold)
+	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":10,"stream":true,"cache_hit_threshold":%v}`, testutils.ModelName, prompt, cacheHitThreshold)
 	extraHeaders := cacheThresholdHeaders(forceCacheThresholdFinishReason)
 	ns, pod, respBody := doPost("/v1/completions", body, extraHeaders)
 	finishReason := extractFinishReasonFromStreaming(string(respBody))

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -18,7 +18,7 @@ import (
 
 func createModelServersFromKustomize(kustomizeDir string, extra map[string]string) []string {
 	subs := map[string]string{
-		"${MODEL_NAME}":              simModelName,
+		"${MODEL_NAME}":              testutils.ModelName,
 		"${POOL_NAME}":               poolName,
 		"${VLLM_IMAGE}":              vllmSimImage,
 		"${VLLM_RENDER_IMAGE}":       vllmRenderImage,
@@ -61,7 +61,7 @@ func createModelServersDecode(replicas int) []string {
 
 func createModelServersDecodeKV(replicas int) []string {
 	return createModelServersFromKustomize(epdDeploymentDir, map[string]string{
-		"${MODEL_NAME}":           kvModelName,
+		"${MODEL_NAME}":           testutils.ModelName,
 		"${KV_CACHE_ENABLED}":     "true",
 		"${VLLM_REPLICA_COUNT_D}": strconv.Itoa(replicas),
 	})
@@ -147,9 +147,9 @@ func createEndPointPicker(eppConfig string) []string {
 			"${VLLM_RENDER_IMAGE}": vllmRenderImage,
 			// The render sidecar needs a real, fetchable model. Sim tests
 			// don't query it; the cost is paying weights-load on every EPP.
-			"${MODEL_NAME}":            kvModelName,
+			"${MODEL_NAME}":            testutils.ModelName,
 			"${NAMESPACE}":             nsName,
-			"${POOL_NAME}":             simModelName + "-inference-pool",
+			"${POOL_NAME}":             testutils.ModelServerName + "-inference-pool",
 			"${METRICS_ENDPOINT_AUTH}": "false",
 		})
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -145,8 +145,7 @@ func runKustomize(kustomizeDir string) []string {
 	session, err := gexec.Start(command, nil, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
-	res := strings.Split(string(session.Out.Contents()), "\n---")
-	return res
+	return strings.Split(string(session.Out.Contents()), "\n---")
 }
 
 // removeEmptyArgs strips YAML list items that are empty strings after variable

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -211,7 +209,6 @@ func isModelReal(modelName string) bool {
 // initContainer and the model-cache volume stripped from any Deployment.
 func removeRenderSidecar(inputs []string) []string {
 	outputs := make([]string, len(inputs))
-
 	for idx, input := range inputs {
 		docs := strings.Split(input, "\n---")
 		rendered := make([]string, 0, len(docs))
@@ -223,7 +220,6 @@ func removeRenderSidecar(inputs []string) []string {
 		}
 		outputs[idx] = strings.Join(rendered, "\n---\n")
 	}
-
 	return outputs
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -145,7 +145,8 @@ func runKustomize(kustomizeDir string) []string {
 	session, err := gexec.Start(command, nil, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
-	return strings.Split(string(session.Out.Contents()), "\n---")
+	res := strings.Split(string(session.Out.Contents()), "\n---")
+	return res
 }
 
 // removeEmptyArgs strips YAML list items that are empty strings after variable

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -209,6 +211,7 @@ func isModelReal(modelName string) bool {
 // initContainer and the model-cache volume stripped from any Deployment.
 func removeRenderSidecar(inputs []string) []string {
 	outputs := make([]string, len(inputs))
+
 	for idx, input := range inputs {
 		docs := strings.Split(input, "\n---")
 		rendered := make([]string, 0, len(docs))
@@ -220,6 +223,7 @@ func removeRenderSidecar(inputs []string) []string {
 		}
 		outputs[idx] = strings.Join(rendered, "\n---\n")
 	}
+
 	return outputs
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	testutils "github.com/llm-d/llm-d-router/test/utils"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -363,11 +365,11 @@ func getPodRequestCount(podName string) int {
 
 // parseRequestCountFromMetrics extracts the request count from Prometheus metrics output.
 func parseRequestCountFromMetrics(metricsOutput string) int {
-	// Look for vllm:e2e_request_latency_seconds_count{model_name="food-review"} <count>
+	// Look for vllm:e2e_request_latency_seconds_count{model_name="<model name>"} <count>
 	lines := strings.Split(metricsOutput, "\n")
 	for _, line := range lines {
 		if strings.Contains(line, "vllm:e2e_request_latency_seconds_count") &&
-			strings.Contains(line, "food-review") {
+			strings.Contains(line, testutils.ModelName) {
 			// Extract the count value after the last space
 			parts := strings.Fields(line)
 			if len(parts) >= 2 {

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -57,6 +57,7 @@ import (
 	eppServer "github.com/llm-d/llm-d-router/pkg/epp/server"
 	testutil "github.com/llm-d/llm-d-router/pkg/epp/util/testing"
 	integration "github.com/llm-d/llm-d-router/test/integration"
+	"github.com/llm-d/llm-d-router/test/utils"
 )
 
 // Global State (Initialized in TestMain)
@@ -69,7 +70,7 @@ var (
 )
 
 const (
-	testPoolName = "vllm-qwen3-32b-pool"
+	testPoolName = utils.ModelServerName + "-pool"
 
 	// mockDataSourceType is the plugin type name used for the mock data source in integration tests.
 	mockDataSourceType = "mock-metrics-source"

--- a/test/integration/epp_test.go
+++ b/test/integration/epp_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	testutil "github.com/llm-d/llm-d-router/pkg/epp/util/testing"
 )
 
 type inferenceResponse struct {
@@ -26,7 +28,7 @@ type inferenceChoice struct {
 
 func TestEndpointPickerBasics(t *testing.T) {
 	inferenceURL := fmt.Sprintf("%s/v1/completions", gatewayURL)
-	jsonData := []byte(`{"model":"food-review","prompt":"hi","max_tokens":10,"temperature":0}`)
+	jsonData := []byte(`{"model":"` + utils.ModelName + `","prompt":"hi","max_tokens":10,"temperature":0}`)
 
 	t.Logf("sending POST to %s: %s", inferenceURL, jsonData)
 	resp, err := http.Post(inferenceURL, "application/json", bytes.NewBuffer(jsonData))
@@ -45,7 +47,7 @@ func TestEndpointPickerBasics(t *testing.T) {
 	t.Logf("checking HTTP response body: %s", respBytes)
 	infResp := inferenceResponse{}
 	require.NoError(t, json.Unmarshal(respBytes, &infResp))
-	assert.Equal(t, "food-review", infResp.Model)
+	assert.Equal(t, testutil.ModelName, infResp.Model)
 	require.True(t, len(infResp.Choices) > 0)
 	assert.NotEmpty(t, infResp.Choices[0].Text)
 }

--- a/test/sidecar/README.md
+++ b/test/sidecar/README.md
@@ -27,7 +27,7 @@ Send a request:
 $ curl http://localhost:8000/v1/completions \
       -H "Content-Type: application/json" \
       -H "x-prefiller-url: http://qwen-prefiller:8000" \
-      -d '{"model": "Qwen/Qwen2-0.5B", "prompt": "Question: Greta worked 40 hours and was paid $12 per hour. Her friend Lisa earned $15 per hour at her job. How many hours would Lisa have to work to equal Gretas earnings for 40 hours?", "max_tokens": 200 }'
+      -d '{"model": "Qwen/Qwen3-VL-2B-Instruct", "prompt": "Question: Greta worked 40 hours and was paid $12 per hour. Her friend Lisa earned $15 per hour at her job. How many hours would Lisa have to work to equal Gretas earnings for 40 hours?", "max_tokens": 200 }'
 ```
 
 Observe the decoder logs:

--- a/test/sidecar/config/base/pod-qwen.yaml
+++ b/test/sidecar/config/base/pod-qwen.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: qwen2-0--5b
+  name: vllm-qwen3-2b-instruct 
 spec:
   initContainers:
     - name: routing-proxy
@@ -27,11 +27,11 @@ spec:
       image: vllm/vllm-openai:v0.8.2
       args:
         - "--port=8001"
-        - "--model=Qwen/Qwen2-0.5B"
+        - "--model=Qwen/Qwen3-2B-Instruct"
       # TODO: patch
       #args:
       #  - serve
-      #  - Qwen/Qwen2-0.5B
+      #  - Qwen/Qwen3-2B-Instruct
       # env:
       #   - name: NVIDIA_VISIBLE_DEVICES
       #     value: "0" # Limit PyTorch to GPU 0

--- a/test/sidecar/config/gateway/llmroute.yaml
+++ b/test/sidecar/config/gateway/llmroute.yaml
@@ -11,7 +11,7 @@ spec:
     - backendRefs:
         - group: inference.networking.x-k8s.io
           kind: InferencePool
-          name: qwen2-0-5b
+          name: vllm-qwen3-2b-instruct
           port: 8000
           weight: 1
       matches:

--- a/test/sidecar/config/nixl/inferencepool.yaml
+++ b/test/sidecar/config/nixl/inferencepool.yaml
@@ -1,14 +1,14 @@
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
-  name: qwen2-0-5b
+  name: vllm-qwen3-2b-instruct
 spec:
   selector:
     matchLabels:
       llm-d.ai/inference-serving: "true"
-      llm-d.ai/model: qwen2-0-5b
+      llm-d.ai/model: qwen3-2b-instruct
   endpointPickerRef:
-    name: qwen2-0-5b-epp
+    name: vllm-qwen3-2b-instruct-epp
     kind: Service
     port:
       number: 9002

--- a/test/sidecar/config/nixl/qwen-decoder-pod.yaml
+++ b/test/sidecar/config/nixl/qwen-decoder-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: qwen-decoder
     llm-d.ai/inference-serving: "true"
-    llm-d.ai/model: "qwen2-0-5b"
+    llm-d.ai/model: "vllm-qwen3-2b-instruct"
     llm-d.ai/role: "decode"
 spec:
   affinity:
@@ -40,7 +40,7 @@ spec:
         allowPrivilegeEscalation: false
       args:
         - "--model"
-        - "Qwen/Qwen2-0.5B"
+        - "Qwen/Qwen3-VL-2B-Instruct"
         - "--port"
         - "8200"
         - "--enforce-eager"

--- a/test/sidecar/config/nixl/qwen-epp-svc.yaml
+++ b/test/sidecar/config/nixl/qwen-epp-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: qwen2-0-5b-epp
+  name: vllm-qwen3-2b-instruct-epp
 spec:
   ports:
     - protocol: TCP
@@ -10,4 +10,4 @@ spec:
       appProtocol: http2
   type: ClusterIP
   selector:
-    app: qwen2-0-5b-epp
+    app: vllm-qwen3-2b-instruct-epp

--- a/test/sidecar/config/nixl/qwen-epp.yaml
+++ b/test/sidecar/config/nixl/qwen-epp.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: qwen2-0-5b-epp
+  name: vllm-qwen3-2b-instruct-epp
   labels:
-    app: qwen2-0-5b-epp
+    app: vllm-qwen3-2b-instruct-epp
 spec:
   selector:
     matchLabels:
-      app: qwen2-0-5b-epp
+      app: vllm-qwen3-2b-instruct-epp
   template:
     metadata:
       labels:
-        app: qwen2-0-5b-epp
+        app: vllm-qwen3-2b-instruct-epp
     spec:
       containers:
         - args:
             - --poolName
-            - qwen2-0-5b
+            - qwen3-2b-instruct
             - --poolNamespace
             - serverless-workstream
             - -v

--- a/test/sidecar/config/nixl/qwen-prefiller-pod.yaml
+++ b/test/sidecar/config/nixl/qwen-prefiller-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: qwen-prefiller
     llm-d.ai/inference-serving: "true"
-    llm-d.ai/model: "qwen2-0-5b"
+    llm-d.ai/model: "vllm-qwen3-2b-instruct"
     llm-d.ai/role: "prefill"
 spec:
   affinity:
@@ -24,7 +24,7 @@ spec:
         allowPrivilegeEscalation: false
       args:
         - "--model"
-        - "Qwen/Qwen2-0.5B"
+        - "Qwen/Qwen3-VL-2B-Instruct"
         - "--port"
         - "8000"
         - "--enforce-eager"

--- a/test/sidecar/e2e/e2e_test.go
+++ b/test/sidecar/e2e/e2e_test.go
@@ -25,11 +25,12 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive
 
 	"github.com/llm-d/llm-d-router/test/sidecar/utils"
+	tutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
 const (
 	namespace   = "hc4ai-operator"
-	qwenPodName = "qwen2-0--5b"
+	qwenPodName = tutils.ModelName
 )
 
 var _ = Describe("Sidecar", Ordered, func() {

--- a/test/sidecar/req-book.txt
+++ b/test/sidecar/req-book.txt
@@ -1,14 +1,14 @@
  curl  http://localhost:8000/v1/completions \
       -H "Content-Type: application/json" \
        -d '{
-        "model": "Qwen/Qwen2-0.5B",
+        "model": "Qwen/Qwen3-VL-2B-Instruct",
         "prompt": "Author-contribution statements and acknowledgements in research papers should state clearly and specifically whether, and to what extent, the authors used AI technologies such as ChatGPT in the preparation of their manuscript and analysis. They should also indicate which LLMs were used. This will alert editors and reviewers to scrutinize manuscripts more carefully for potential biases, inaccuracies and improper source crediting. Likewise, scientific journals should be transparent about their use of LLMs, for example when selecting submitted manuscripts. Mention the large language model based product mentioned in the paragraph above:"
       }'
 
  curl  http://localhost:8000/v1/chat/completions \
       -H "Content-Type: application/json" \
       -d '{
-        "model": "Qwen/Qwen2-0.5B",
+        "model": "Qwen/Qwen3-VL-2B-Instruct",
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content":"Author-contribution statements and acknowledgements in research papers should state clearly and specifically whether, and to what extent, the authors used AI technologies such as ChatGPT in the preparation of their manuscript and analysis. They should also indicate which LLMs were used. This will alert editors and reviewers to scrutinize manuscripts more carefully for potential biases, inaccuracies and improper source crediting. Likewise, scientific journals should be transparent about their use of LLMs, for example when selecting submitted manuscripts. Mention the large language model based product mentioned in the paragraph above:"}
@@ -36,7 +36,7 @@ curl http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -H "x-prefiller-url: http://localhost:8002" \
   -d '{
-    "model": "Qwen/Qwen2-0.5B",
+    "model": "Qwen/Qwen3-VL-2B-Instruct",
     "prompt": "I am working on learning to run benchmarks in my openshift cluster. I was wondering if you could provide me a list of best practices when collecting metrics on the k8s platform, and furthermore, any OCP specific optimizations that are applicable here. Finally please help me construct a plan to support testing metrics collection for testing and dev environments such as minikube or kind.",
     "max_tokens": 200,
     "temperature": 0
@@ -45,7 +45,7 @@ curl http://localhost:8000/v1/completions \
 curl http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
-        "model":"Qwen/Qwen2-0.5B",
+        "model":"Qwen/Qwen3-VL-2B-Instruct",
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "I am working on learning to run benchmarks in my openshift cluster. I was wondering if you could provide me a list of best practices when collecting metrics on the k8s platform, and furthermore, any OCP specific optimizations that are applicable here. Finally please help me construct a plan to support testing metrics collection for testing and dev environments such as minikube or kind."}
@@ -54,4 +54,4 @@ curl http://localhost:8000/v1/chat/completions \
     }'
 
 
-lm_eval --model local-completions --tasks gsm8k --model_args model="Qwen/Qwen2-0.5B",base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=5,max_retries=3,tokenized_requests=False
+lm_eval --model local-completions --tasks gsm8k --model_args model="Qwen/Qwen3-VL-2B-Instruct",base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=5,max_retries=3,tokenized_requests=False

--- a/test/testdata/envoy.yaml
+++ b/test/testdata/envoy.yaml
@@ -100,7 +100,7 @@ data:
                           grpc_service:
                             envoy_grpc:
                               cluster_name: ext_proc
-                              authority: vllm-qwen3-32b-epp.$E2E_NS:9002
+                              authority: vllm-qwen3-2b-instruct-epp.$E2E_NS:9002
                             timeout: 10s
                           processing_mode:
                             request_header_mode: SEND
@@ -205,7 +205,7 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: vllm-qwen3-32b-epp.$E2E_NS
+                          address: vllm-qwen3-2b-instruct-epp.$E2E_NS
                           port_value: 9002
                     load_balancing_weight: 1
 ---

--- a/test/testdata/inferencepool-e2e.yaml
+++ b/test/testdata/inferencepool-e2e.yaml
@@ -2,15 +2,15 @@ apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
   labels:
-  name: vllm-qwen3-32b
+  name: vllm-qwen3-2b-instruct
 spec:
   targetPorts:
     - number: 8000
   selector:
     matchLabels:
-      app: vllm-qwen3-32b
+      app: vllm-qwen3-2b-instruct
   endpointPickerRef:
-    name: vllm-qwen3-32b-epp
+    name: vllm-qwen3-2b-instruct-epp
     namespace: $E2E_NS
     kind: Service
     port:
@@ -19,11 +19,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 spec:
   selector:
-    app: vllm-qwen3-32b-epp
+    app: vllm-qwen3-2b-instruct-epp
   ports:
     - protocol: TCP
       port: 9002
@@ -34,7 +34,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 ---
 kind: Role
@@ -63,7 +63,7 @@ metadata:
   namespace: $E2E_NS
 subjects:
 - kind: ServiceAccount
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -94,7 +94,7 @@ metadata:
   name: auth-reviewer-binding
 subjects:
 - kind: ServiceAccount
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -124,21 +124,21 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
   labels:
-    app: vllm-qwen3-32b-epp
+    app: vllm-qwen3-2b-instruct-epp
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vllm-qwen3-32b-epp
+      app: vllm-qwen3-2b-instruct-epp
   template:
     metadata:
       labels:
-        app: vllm-qwen3-32b-epp
+        app: vllm-qwen3-2b-instruct-epp
     spec:
-      serviceAccountName: vllm-qwen3-32b-epp
+      serviceAccountName: vllm-qwen3-2b-instruct-epp
       # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
       terminationGracePeriodSeconds: 130
       containers:
@@ -147,7 +147,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name
-        - "vllm-qwen3-32b"
+        - "vllm-qwen3-2b-instruct"
         - --pool-namespace
         - "$E2E_NS"
         - --v

--- a/test/testdata/inferencepool-leader-election-e2e.yaml
+++ b/test/testdata/inferencepool-leader-election-e2e.yaml
@@ -2,14 +2,14 @@ apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
   labels:
-  name: vllm-qwen3-32b
+  name: vllm-qwen3-2b-instruct
 spec:
   targetPorts:
    - number: 8000
   selector:
-    app: vllm-qwen3-32b
+    app: vllm-qwen3-2b-instruct
   endpointPickerRef:
-    name: vllm-qwen3-32b-epp
+    name: vllm-qwen3-2b-instruct-epp
     namespace: $E2E_NS
     kind: Service
     port:
@@ -18,11 +18,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 spec:
   selector:
-    app: vllm-qwen3-32b-epp
+    app: vllm-qwen3-2b-instruct-epp
   ports:
     - protocol: TCP
       port: 9002
@@ -33,7 +33,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 ---
 kind: Role
@@ -75,7 +75,7 @@ metadata:
   namespace: $E2E_NS
 subjects:
 - kind: ServiceAccount
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -89,7 +89,7 @@ metadata:
   namespace: $E2E_NS
 subjects:
 - kind: ServiceAccount
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -120,7 +120,7 @@ metadata:
   name: auth-reviewer-binding
 subjects:
 - kind: ServiceAccount
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -150,21 +150,21 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-qwen3-32b-epp
+  name: vllm-qwen3-2b-instruct-epp
   namespace: $E2E_NS
   labels:
-    app: vllm-qwen3-32b-epp
+    app: vllm-qwen3-2b-instruct-epp
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vllm-qwen3-32b-epp
+      app: vllm-qwen3-2b-instruct-epp
   template:
     metadata:
       labels:
-        app: vllm-qwen3-32b-epp
+        app: vllm-qwen3-2b-instruct-epp
     spec:
-      serviceAccountName: vllm-qwen3-32b-epp
+      serviceAccountName: vllm-qwen3-2b-instruct-epp
       # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
       terminationGracePeriodSeconds: 130
       containers:
@@ -173,7 +173,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name
-        - "vllm-qwen3-32b"
+        - "vllm-qwen3-2b-instruct"
         - --pool-namespace
         - "$E2E_NS"
         - --v

--- a/test/testdata/inferencepool-with-model-hermetic.yaml
+++ b/test/testdata/inferencepool-with-model-hermetic.yaml
@@ -1,14 +1,14 @@
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
-  name: vllm-qwen3-32b-pool
+  name: vllm-qwen3-2b-instruct-pool
   namespace: default
 spec:
   targetPorts:
     - number: 8000
   selector:
     matchLabels:
-      app: vllm-qwen3-32b-pool
+      app: vllm-qwen3-2b-instruct-pool
   endpointPickerRef:
     name: epp
     kind: Service
@@ -23,7 +23,7 @@ metadata:
 spec:
   priority: 2
   poolRef:
-    name: vllm-qwen3-32b-pool
+    name: vllm-qwen3-2b-instruct-pool
   targetModels:
   - name: sql-lora-1fdg2
     weight: 100
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   poolRef:
-    name: vllm-qwen3-32b-pool
+    name: vllm-qwen3-2b-instruct-pool
   targetModels:
   - name: sql-lora-1fdg3
     weight: 100
@@ -47,7 +47,7 @@ metadata:
   namespace: default
 spec:
   poolRef:
-    name: vllm-qwen3-32b-pool
+    name: vllm-qwen3-2b-instruct-pool
   targetModels:
   - name: sql-lora-1fdg3
     weight: 100
@@ -60,7 +60,7 @@ metadata:
 spec:
   priority: 2
   poolRef:
-    name: vllm-qwen3-32b-pool
+    name: vllm-qwen3-2b-instruct-pool
   targetModels:
   - name: my-model-12345
     weight: 100
@@ -73,7 +73,7 @@ metadata:
 spec:
   priority: 2
   poolRef:
-    name: vllm-qwen3-32b-pool   
+    name: vllm-qwen3-2b-instruct-pool   
 ---
 apiVersion: llm-d.ai/v1alpha2
 kind: InferenceObjective
@@ -83,7 +83,7 @@ metadata:
 spec:
   priority: 4
   poolRef:
-    name: vllm-qwen3-32b-pool
+    name: vllm-qwen3-2b-instruct-pool
 ---
 apiVersion: llm-d.ai/v1alpha2
 kind: InferenceModelRewrite
@@ -92,7 +92,7 @@ metadata:
   namespace: default
 spec:
   poolRef:
-    name: vllm-qwen3-32b-pool
+    name: vllm-qwen3-2b-instruct-pool
   rules:
   - matches:
     - model:

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-qwen3-06b
+  name: vllm-qwen3-32b
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vllm-qwen3-06b
+      app: vllm-qwen3-32b
   template:
     metadata:
       labels:
-        app: vllm-qwen3-06b
+        app: vllm-qwen3-32b
         inference.networking.k8s.io/engine-type: vllm
     spec:
       initContainers:
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]
-        args: ["launch", "render", "Qwen/Qwen3-0.6B", "--port=8082"]
+        args: ["launch", "render", "Qwen/Qwen3-32B", "--port=8082"]
         ports:
         - name: http
           containerPort: 8082
@@ -57,7 +57,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --model
-        - Qwen/Qwen3-0.6B
+        - Qwen/Qwen3-32B
         - --port
         - "8000"
         - --max-loras

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-qwen3-32b
+  name: vllm-qwen3-06b
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vllm-qwen3-32b
+      app: vllm-qwen3-06b
   template:
     metadata:
       labels:
-        app: vllm-qwen3-32b
+        app: vllm-qwen3-06b
         inference.networking.k8s.io/engine-type: vllm
     spec:
       initContainers:
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]
-        args: ["launch", "render", "Qwen/Qwen3-32B", "--port=8082"]
+        args: ["launch", "render", "Qwen/Qwen3-0.6B", "--port=8082"]
         ports:
         - name: http
           containerPort: 8082
@@ -57,7 +57,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --model
-        - Qwen/Qwen3-32B
+        - Qwen/Qwen3-0.6B
         - --port
         - "8000"
         - --max-loras

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-qwen3-32b
+  name: vllm-qwen3-2b-instruct
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: vllm-qwen3-32b
+      app: vllm-qwen3-2b-instruct
   template:
     metadata:
       labels:
-        app: vllm-qwen3-32b
+        app: vllm-qwen3-2b-instruct
         inference.networking.k8s.io/engine-type: vllm
     spec:
       initContainers:
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]
-        args: ["launch", "render", "Qwen/Qwen3-32B", "--port=8082"]
+        args: ["launch", "render", "Qwen/Qwen3-VL-2B-Instruct", "--port=8082"]
         ports:
         - name: http
           containerPort: 8082
@@ -57,13 +57,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --model
-        - Qwen/Qwen3-32B
+        - Qwen/Qwen3-VL-2B-Instruct
         - --port
         - "8000"
         - --max-loras
         - "2"
         - --lora-modules
-        - '{"name": "food-review-1"}'
+        - '{"name": "Qwen/Qwen3-VL-2B-Instruct-1"}'
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/utils/common.go
+++ b/test/utils/common.go
@@ -1,0 +1,10 @@
+package utils
+
+// the model name used in tests. Should be a real model that can be pulled for rendering
+const ModelName = "Qwen/Qwen3-VL-2B-Instruct"
+
+// server pod name based onthe model name, used for pool and epp pod names
+const ModelServerName = "vllm-qwen3-2b-instruct"
+
+// "HuggingFaceTB/SmolVLM-500M-Instruct"
+// "Qwen/Qwen2-0.5B"

--- a/test/utils/common.go
+++ b/test/utils/common.go
@@ -5,6 +5,3 @@ const ModelName = "Qwen/Qwen3-VL-2B-Instruct"
 
 // server pod name based onthe model name, used for pool and epp pod names
 const ModelServerName = "vllm-qwen3-2b-instruct"
-
-// "HuggingFaceTB/SmolVLM-500M-Instruct"
-// "Qwen/Qwen2-0.5B"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, different parts of the E2E tests use different models. Some use real HuggingFace models, e.g. `Qwen/Qwen2-0.5B` or`Qwen/Qwen3-32B`, and some places use `model="food-review"`.

The E2E test uses a simulator as the backend, and its latest version (v0.9.0) utilizes a vLLM render that expects real model names. 

Since the specific model used doesn't impact the test logic, standardizing on a single model across all tests will make it much easier to manage the render sidecar.

This PR updates all tests to use `Qwen/Qwen2.5-1.5B-Instruct`, which was chosen because it supports both simple text requests and multi-modal messages.

Fixes #1374 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
