### PR TITLE
Bump vllm render image to v0.21.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -505,7 +505,7 @@ components:
 Then deploy with:
 
 ```bash
-VLLM_IMAGE=vllm/vllm-openai:v0.16.0 \
+VLLM_IMAGE=vllm/vllm-openai:v0.21.0 \
   kubectl kustomize deploy/environments/prod/p-d \
   | envsubst | kubectl apply -f -
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,7 +83,7 @@ Creates a new `kind` cluster (or reuses an existing one) in the `default` namesp
 > You can pre-pull external images to avoid slow downloads:
 > ```
 > docker pull ghcr.io/llm-d/llm-d-inference-sim:v0.9.0
-> docker pull vllm/vllm-openai-cpu:v0.19.1
+> docker pull vllm/vllm-openai-cpu:v0.21.0
 > ```
 
 ### Accessing the Gateway
@@ -621,7 +621,7 @@ kubectl --context kind-e2e-tests get pods
 | `VLLM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.9.0` | vLLM container image to deploy. Can be a simulator or a real vLLM image (e.g., `vllm/vllm-openai:v0.16.0`) |
 | `VLLM_SIM_MODE` | `echo` | Simulator response mode. Supported values: `echo` (returns the input prompt as the response), `random` (returns a random sentence from a pre-defined bank) |
 | `SIDECAR_IMAGE` | `ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev` | Routing sidecar image loaded into the Kind cluster |
-| `VLLM_RENDER_IMAGE` | `vllm/vllm-openai-cpu:v0.19.1` | vLLM renderer image loaded into the Kind cluster |
+| `VLLM_RENDER_IMAGE` | `vllm/vllm-openai-cpu:v0.21.0` | vLLM renderer image loaded into the Kind cluster |
 
 ### Coverage
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ export VLLM_IMAGE ?= $(VLLM_SIMULATOR_TAG_BASE):$(VLLM_SIMULATOR_TAG)
 
 # CPU-only vLLM image that exposes `vllm launch render` for the token-producer
 # plugin's HTTP backend.
-export VLLM_RENDER_IMAGE ?= vllm/vllm-openai-cpu:v0.19.1
+export VLLM_RENDER_IMAGE ?= vllm/vllm-openai-cpu:v0.21.0
 
 BUILDER_TAG ?= dev
 BUILDER_TAG_BASE ?= $(IMAGE_REGISTRY)/$(BUILDER_IMAGE_NAME)

--- a/config/manifests/vllm/cpu-deployment.yaml
+++ b/config/manifests/vllm/cpu-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: "vllm/vllm-openai-cpu:latest" # formal images can be found in https://hub.docker.com/r/vllm/vllm-openai-cpu/tags
+          image: "vllm/vllm-openai-cpu:v0.21.0" # formal images can be found in https://hub.docker.com/r/vllm/vllm-openai-cpu/tags
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/deploy/components/overlays/simulator/kustomization.yaml
+++ b/deploy/components/overlays/simulator/kustomization.yaml
@@ -55,18 +55,28 @@ patches:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          failureThreshold: 600
+          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: /health
             port: 8082
-          initialDelaySeconds: 10
           periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 1
         readinessProbe:
           httpGet:
             path: /health
             port: 8082
-          initialDelaySeconds: 5
           periodSeconds: 5
+          failureThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - name: model-cache
           mountPath: /root/.cache/huggingface
@@ -96,18 +106,28 @@ patches:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          failureThreshold: 600
+          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: /health
             port: 8082
-          initialDelaySeconds: 10
           periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 1
         readinessProbe:
           httpGet:
             path: /health
             port: 8082
-          initialDelaySeconds: 5
           periodSeconds: 5
+          failureThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - name: model-cache
           mountPath: /root/.cache/huggingface

--- a/deploy/environments/dev/README.md
+++ b/deploy/environments/dev/README.md
@@ -69,7 +69,7 @@ Variables substituted at deploy time via `envsubst` or Go test `substituteMany`:
 | `VLLM_SIM_MODE` | Simulator response mode: `echo` (returns input) or `random` (random sentences) | `echo` |
 | `VLLM_IMAGE` | vLLM container image (simulator or real) | `ghcr.io/llm-d/llm-d-inference-sim:v0.9.0` |
 | `SIDECAR_IMAGE` | Routing sidecar image | `ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev` |
-| `VLLM_RENDER_IMAGE` | vLLM render sidecar image | `vllm/vllm-openai-cpu:v0.19.1` |
+| `VLLM_RENDER_IMAGE` | vLLM render sidecar image | `vllm/vllm-openai-cpu:v0.21.0` |
 | `MODEL_NAME` | Model name passed to vLLM. Can be a real HuggingFace model (e.g. `TinyLlama/TinyLlama-1.1B-Chat-v1.0`, `Qwen/Qwen3-VL-2B-Instruct`) or an arbitrary name when using the simulator (e.g. `food-review`) | `food-review` |
 | `POOL_NAME` | InferencePool name | `food-review-inference-pool` |
 | `VLLM_REPLICA_COUNT_E` | Encode deployment replicas | `1` |

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -64,7 +64,7 @@ export SIDECAR_IMAGE
 
 # Set a default VLLM_RENDER_IMAGE if not provided (CPU-only vLLM image that
 # runs `vllm launch render` for the token-producer plugin's HTTP backend).
-export VLLM_RENDER_IMAGE="${VLLM_RENDER_IMAGE:-vllm/vllm-openai-cpu:v0.19.1}"
+export VLLM_RENDER_IMAGE="${VLLM_RENDER_IMAGE:-vllm/vllm-openai-cpu:v0.21.0}"
 
 # Set the inference pool name for the deployment
 export POOL_NAME="${POOL_NAME:-${MODEL_NAME_SAFE}-inference-pool}"

--- a/scripts/pull_images.sh
+++ b/scripts/pull_images.sh
@@ -14,7 +14,7 @@ SIDECAR_TAG="${SIDECAR_TAG:-dev}"
 export EPP_IMAGE="${EPP_IMAGE:-ghcr.io/llm-d/llm-d-router-endpoint-picker:${EPP_TAG}}"
 export VLLM_IMAGE="${VLLM_IMAGE:-ghcr.io/llm-d/llm-d-inference-sim:${VLLM_SIMULATOR_TAG}}"
 export SIDECAR_IMAGE="${SIDECAR_IMAGE:-ghcr.io/llm-d/llm-d-router-disagg-sidecar:${SIDECAR_TAG}}"
-export VLLM_RENDER_IMAGE="${VLLM_RENDER_IMAGE:-vllm/vllm-openai-cpu:v0.19.1}"
+export VLLM_RENDER_IMAGE="${VLLM_RENDER_IMAGE:-vllm/vllm-openai-cpu:v0.21.0}"
 
 TARGETOS="${TARGETOS:-linux}"
 TARGETARCH="${TARGETARCH:-$(go env GOARCH)}"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -66,7 +66,7 @@ var (
 	eppImage         = env.GetEnvString("EPP_IMAGE", "ghcr.io/llm-d/llm-d-router-endpoint-picker:dev", ginkgo.GinkgoLogr)
 	vllmSimImage     = env.GetEnvString("VLLM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.9.0", ginkgo.GinkgoLogr)
 	sideCarImage     = env.GetEnvString("SIDECAR_IMAGE", "ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev", ginkgo.GinkgoLogr)
-	vllmRenderImage  = env.GetEnvString("VLLM_RENDER_IMAGE", "vllm/vllm-openai-cpu:v0.19.1", ginkgo.GinkgoLogr)
+	vllmRenderImage  = env.GetEnvString("VLLM_RENDER_IMAGE", "vllm/vllm-openai-cpu:v0.21.0", ginkgo.GinkgoLogr)
 	// nsName is the namespace in which the K8S objects will be created
 	nsName = env.GetEnvString("NAMESPACE", "default", ginkgo.GinkgoLogr)
 

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -23,18 +23,28 @@ spec:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          failureThreshold: 600
+          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: /health
             port: 8082
-          initialDelaySeconds: 10
           periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 1
         readinessProbe:
           httpGet:
             path: /health
             port: 8082
-          initialDelaySeconds: 5
           periodSeconds: 5
+          failureThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - name: model-cache
           mountPath: /root/.cache/huggingface

--- a/test/testdata/sim-deployment.yaml
+++ b/test/testdata/sim-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: vllm-render
-        image: vllm/vllm-openai-cpu:v0.19.1
+        image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
The current vllm version (v0.19.1) uses "Phase 1" of the disaggregated serving protocol, where the Render Server omits processed tensor data (mm_kwargs) from its response. This forces the downstream /generate service to redundantly re-process and re-encode multimodal inputs (images/video) from scratch.

Upgrading to v0.21.0 resolves this by bringing in the "Phase 2" implementation (PR #38405), allowing the Render Server to serialize and pass tensors directly over the wire.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1376

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Bump default vLLM render image from v0.19.1 to v0.21.0
```
