### PR TITLE
refactor(unifiedInferenceReqeustBody)[1/n]: unify request body prompt and token representations

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -66,10 +66,14 @@ func (RawPayload) IsParsed() bool    { return false }
 // InferenceRequestBody contains the request-body fields that we parse out as user input,
 // to be used in forming scheduling decisions.
 type InferenceRequestBody struct {
-	// Prompt is the unified representation of the user input.
-	Prompt *UnifiedPrompt
-	// Tokens is the pre-tokenized input provided by the client.
-	Tokens *TokenizedInput
+	// Prompts contains the unified representation of the user inputs.
+	// Supports batching (multiple prompts). For a single-prompt request,
+	// the input is located at index 0 (Prompts[0]).
+	Prompts []UnifiedPrompt
+	// TokenInputs is the pre-tokenized input provided by the client.
+	// Supports batching (multiple token streams). For a single-prompt request,
+	// the input is located at index 0 (TokenInputs[0]).
+	TokenInputs []TokenizedInput
 	// ExtractedCacheSalt is an optional request parameter to isolate prefix caches for security reasons.
 	ExtractedCacheSalt string
 
@@ -87,6 +91,7 @@ type InferenceRequestBody struct {
 	Embeddings *EmbeddingsRequest `json:"embeddings,omitempty"`
 	// GenerateRequest is the representation of the vLLM /inference/v1/generate request body.
 	Generate *GenerateRequest `json:"generate,omitempty"`
+
 	// Payload contains the unmarshaled request payload or raw bytes.
 	// If the payload is unmarshaled, we can perform advanced processing (like prefix cache aware routing).
 	// If it remains as raw bytes, such processing may not be supported.
@@ -103,28 +108,23 @@ type InferenceRequestBody struct {
 // TokenizedInput represents pre-tokenized input provided by the client,
 // including multimodal features if present.
 type TokenizedInput struct {
-	// TokenIDs are the pre-tokenized input token IDs. It supports an array of token
-	// arrays to accommodate batched prompts (e.g., from /completions).
-	TokenIDs [][]uint32
+	// TokenIDs are the pre-tokenized input token IDs for a single prompt.
+	TokenIDs []uint32
 	// MultiModalFeatures holds one entry per multimodal item in prompt order.
 	MultiModalFeatures []MultiModalFeature
 }
 
-// UnifiedPrompt is a unified representation of the user input (prompt) for all request types.
+// UnifiedPrompt is a unified representation of the user input (prompt) for a single request item.
 type UnifiedPrompt struct {
-	// Items represents structured chat history or conversation items.
-	Items []PromptItem
-	// Tools field for function calling capabilities.
-	Tools []any
-	// Documents field for HuggingFace RAG documents.
-	Documents []any
+	// Messages represents the structured chat history or conversation turns.
+	Messages []PromptMessage
 }
 
-// PromptItem represents a single turn or message in a conversation.
-type PromptItem struct {
+// PromptMessage represents a single turn or message in a conversation.
+type PromptMessage struct {
 	// Role specifies the role (e.g., 'user', 'assistant', 'system').
 	Role string
-	// Blocks contains the content blocks for this item.
+	// Blocks contains the content blocks for this message.
 	Blocks []PromptBlock
 }
 
@@ -136,19 +136,23 @@ const (
 	BlockTypeImage BlockType = "image"
 	BlockTypeAudio BlockType = "audio"
 	BlockTypeVideo BlockType = "video"
+	BlockTypeTool  BlockType = "tool"
+	BlockTypeDoc   BlockType = "document"
 )
 
-// PromptBlock represents a content block (text or asset) within a prompt item.
+// PromptBlock represents a content block (text, asset, tool, or document) within a prompt item.
 type PromptBlock struct {
-	// Type specifies the block type (e.g., 'text', 'image').
+	// Type specifies the block type (e.g., 'text', 'image', 'tool', 'document').
 	Type BlockType
-	// Text contains raw text content.
+	// Text contains raw text content (e.g. text block, document content, tool description).
 	Text string
 	// AssetURI refers to a multimodal asset (e.g., image URL, audio data hash).
 	AssetURI string
+	// Data holds structured data for complex blocks (like Tool or Document).
+	Data any
 }
 
-// TokenizedPrompt contains the result of tokenizing the request prompt.
+// TokenizedPrompt contains the result of tokenizing a single request prompt.
 // It is consumed by scheduling and request-control plugins that benefit from
 // actual token data such as prefix-cache awareness.
 type TokenizedPrompt struct {
@@ -173,26 +177,15 @@ type MultiModalFeature struct {
 	Length int
 }
 
-// PromptText returns a plain-text representation of the prompt.
+// PromptText returns a plain-text representation of the prompt, aggregating all batched prompts.
 func (r *InferenceRequestBody) PromptText() string {
-	if r.Prompt != nil {
+	if len(r.Prompts) > 0 {
 		var sb strings.Builder
-		for _, item := range r.Prompt.Items {
-			for _, block := range item.Blocks {
-				if block.Type == BlockTypeText && block.Text != "" {
-					sb.WriteString(block.Text)
-					sb.WriteString(" ")
-				}
-			}
-		}
-		if len(r.Prompt.Documents) > 0 {
-			for _, doc := range r.Prompt.Documents {
-				if str, ok := doc.(string); ok {
-					sb.WriteString(str)
-					sb.WriteString(" ")
-				} else {
-					if bytes, err := json.Marshal(doc); err == nil {
-						sb.Write(bytes)
+		for _, prompt := range r.Prompts {
+			for _, msg := range prompt.Messages {
+				for _, block := range msg.Blocks {
+					if (block.Type == BlockTypeText || block.Type == BlockTypeDoc) && block.Text != "" {
+						sb.WriteString(block.Text)
 						sb.WriteString(" ")
 					}
 				}
@@ -250,17 +243,14 @@ func (r *InferenceRequestBody) PromptText() string {
 
 // InputTokenCountHint returns a best-effort input token count when the
 // caller knows it exactly (token-ID inputs), or -1 when the count has
-// to be estimated from text.
+// to be estimated from text. It aggregates counts from all batched tokens.
 func (r *InferenceRequestBody) InputTokenCountHint() int {
-	if r.Prompt != nil || r.Tokens != nil {
-		if r.Tokens != nil && len(r.Tokens.TokenIDs) > 0 {
-			total := 0
-			for _, ids := range r.Tokens.TokenIDs {
-				total += len(ids)
-			}
-			return total
+	if len(r.TokenInputs) > 0 {
+		total := 0
+		for _, t := range r.TokenInputs {
+			total += len(t.TokenIDs)
 		}
-		return -1
+		return total
 	}
 
 	// Fallback to old fields
@@ -827,4 +817,37 @@ type AnthropicImageSource struct {
 	MediaType string `json:"media_type,omitempty"`
 	Data      string `json:"data,omitempty"`
 	URL       string `json:"url,omitempty"`
+}
+
+// ConvertMMFeaturesToUpstream flattens the kv-cache map-shaped multimodal
+// metadata into the upstream flat list, sorted by placeholder offset.
+func ConvertMMFeaturesToUpstream(src *tokenization.MultiModalFeatures) []MultiModalFeature {
+	if src == nil || len(src.MMHashes) == 0 {
+		return nil
+	}
+
+	var items []MultiModalFeature
+	for modality, hashes := range src.MMHashes {
+		ranges, ok := src.MMPlaceholders[modality]
+		if !ok {
+			continue
+		}
+		n := len(hashes)
+		if len(ranges) < n {
+			n = len(ranges)
+		}
+		for i := 0; i < n; i++ {
+			items = append(items, MultiModalFeature{
+				Modality: Modality(modality),
+				Hash:     hashes[i],
+				Offset:   ranges[i].Offset,
+				Length:   ranges[i].Length,
+			})
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Offset < items[j].Offset })
+	return items
 }

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -132,12 +132,12 @@ type PromptMessage struct {
 type BlockType string
 
 const (
-	BlockTypeText  BlockType = "text"
-	BlockTypeImage BlockType = "image"
-	BlockTypeAudio BlockType = "audio"
-	BlockTypeVideo BlockType = "video"
-	BlockTypeTool  BlockType = "tool"
-	BlockTypeDoc   BlockType = "document"
+	BlockTypeText     BlockType = "text"
+	BlockTypeImage    BlockType = "image"
+	BlockTypeAudio    BlockType = "audio"
+	BlockTypeVideo    BlockType = "video"
+	BlockTypeTool     BlockType = "tool"
+	BlockTypeDocument BlockType = "document"
 )
 
 // PromptBlock represents a content block (text, asset, tool, or document) within a prompt item.
@@ -184,7 +184,7 @@ func (r *InferenceRequestBody) PromptText() string {
 		for _, prompt := range r.Prompts {
 			for _, msg := range prompt.Messages {
 				for _, block := range msg.Blocks {
-					if (block.Type == BlockTypeText || block.Type == BlockTypeDoc) && block.Text != "" {
+					if (block.Type == BlockTypeText || block.Type == BlockTypeDocument) && block.Text != "" {
 						sb.WriteString(block.Text)
 						sb.WriteString(" ")
 					}
@@ -817,37 +817,4 @@ type AnthropicImageSource struct {
 	MediaType string `json:"media_type,omitempty"`
 	Data      string `json:"data,omitempty"`
 	URL       string `json:"url,omitempty"`
-}
-
-// ConvertMMFeaturesToUpstream flattens the kv-cache map-shaped multimodal
-// metadata into the upstream flat list, sorted by placeholder offset.
-func ConvertMMFeaturesToUpstream(src *tokenization.MultiModalFeatures) []MultiModalFeature {
-	if src == nil || len(src.MMHashes) == 0 {
-		return nil
-	}
-
-	var items []MultiModalFeature
-	for modality, hashes := range src.MMHashes {
-		ranges, ok := src.MMPlaceholders[modality]
-		if !ok {
-			continue
-		}
-		n := len(hashes)
-		if len(ranges) < n {
-			n = len(ranges)
-		}
-		for i := 0; i < n; i++ {
-			items = append(items, MultiModalFeature{
-				Modality: Modality(modality),
-				Hash:     hashes[i],
-				Offset:   ranges[i].Offset,
-				Length:   ranges[i].Length,
-			})
-		}
-	}
-	if len(items) == 0 {
-		return nil
-	}
-	sort.Slice(items, func(i, j int) bool { return items[i].Offset < items[j].Offset })
-	return items
 }

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -65,8 +65,14 @@ func (RawPayload) IsParsed() bool    { return false }
 
 // InferenceRequestBody contains the request-body fields that we parse out as user input,
 // to be used in forming scheduling decisions.
-// An InferenceRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, ConversationsRequest, EmbeddingsRequest, GenerateRequest, or MessagesRequest.
 type InferenceRequestBody struct {
+	// Prompt is the unified representation of the user input.
+	Prompt *UnifiedPrompt
+	// Tokens is the pre-tokenized input provided by the client.
+	Tokens *TokenizedInput
+	// ExtractedCacheSalt is an optional request parameter to isolate prefix caches for security reasons.
+	ExtractedCacheSalt string
+
 	// CompletionsRequest is the representation of the OpenAI /v1/completions request body.
 	Completions *CompletionsRequest `json:"completions,omitempty"`
 	// ChatCompletionsRequest is the representation of the OpenAI /v1/chat/completions request body.
@@ -94,6 +100,53 @@ type InferenceRequestBody struct {
 	Stream bool `json:"-"`
 }
 
+// TokenizedInput represents pre-tokenized input provided by the client,
+// including multimodal features if present.
+type TokenizedInput struct {
+	// TokenIDs are the pre-tokenized input token IDs.
+	TokenIDs []uint32
+	// MultiModalFeatures holds one entry per multimodal item in prompt order.
+	MultiModalFeatures []MultiModalFeature
+}
+
+// UnifiedPrompt is a unified representation of the user input (prompt) for all request types.
+type UnifiedPrompt struct {
+	// Items represents structured chat history or conversation items.
+	Items []PromptItem
+	// Tools field for function calling capabilities.
+	Tools []any
+	// Documents field for HuggingFace RAG documents.
+	Documents []any
+}
+
+// PromptItem represents a single turn or message in a conversation.
+type PromptItem struct {
+	// Role specifies the role (e.g., 'user', 'assistant', 'system').
+	Role string
+	// Blocks contains the content blocks for this item.
+	Blocks []PromptBlock
+}
+
+// BlockType identifies the type of content block in a prompt.
+type BlockType string
+
+const (
+	BlockTypeText  BlockType = "text"
+	BlockTypeImage BlockType = "image"
+	BlockTypeAudio BlockType = "audio"
+	BlockTypeVideo BlockType = "video"
+)
+
+// PromptBlock represents a content block (text or asset) within a prompt item.
+type PromptBlock struct {
+	// Type specifies the block type (e.g., 'text', 'image').
+	Type BlockType
+	// Text contains raw text content.
+	Text string
+	// AssetURI refers to a multimodal asset (e.g., image URL, audio data hash).
+	AssetURI string
+}
+
 // TokenizedPrompt contains the result of tokenizing the request prompt.
 // It is consumed by scheduling and request-control plugins that benefit from
 // actual token data such as prefix-cache awareness.
@@ -119,9 +172,35 @@ type MultiModalFeature struct {
 	Length int
 }
 
-// PromptText returns a plain-text representation of the prompt from whichever
-// API type is populated, analogous to CacheSalt().
+// PromptText returns a plain-text representation of the prompt.
 func (r *InferenceRequestBody) PromptText() string {
+	if r.Prompt != nil {
+		var sb strings.Builder
+		for _, item := range r.Prompt.Items {
+			for _, block := range item.Blocks {
+				if block.Type == BlockTypeText && block.Text != "" {
+					sb.WriteString(block.Text)
+					sb.WriteString(" ")
+				}
+			}
+		}
+		if len(r.Prompt.Documents) > 0 {
+			for _, doc := range r.Prompt.Documents {
+				if str, ok := doc.(string); ok {
+					sb.WriteString(str)
+					sb.WriteString(" ")
+				} else {
+					if bytes, err := json.Marshal(doc); err == nil {
+						sb.Write(bytes)
+						sb.WriteString(" ")
+					}
+				}
+			}
+		}
+		return strings.TrimSpace(sb.String())
+	}
+
+	// Fallback to old fields
 	switch {
 	case r.Completions != nil:
 		return r.Completions.Prompt.PlainText()
@@ -172,6 +251,14 @@ func (r *InferenceRequestBody) PromptText() string {
 // caller knows it exactly (token-ID inputs), or -1 when the count has
 // to be estimated from text.
 func (r *InferenceRequestBody) InputTokenCountHint() int {
+	if r.Prompt != nil || r.Tokens != nil {
+		if r.Tokens != nil && len(r.Tokens.TokenIDs) > 0 {
+			return len(r.Tokens.TokenIDs)
+		}
+		return -1
+	}
+
+	// Fallback to old fields
 	if r.Completions != nil {
 		return r.Completions.Prompt.TokenCountHint()
 	}
@@ -184,7 +271,13 @@ func (r *InferenceRequestBody) InputTokenCountHint() int {
 	return -1
 }
 
+// CacheSalt returns the cache salt if populated.
 func (r *InferenceRequestBody) CacheSalt() string {
+	if r.ExtractedCacheSalt != "" {
+		return r.ExtractedCacheSalt
+	}
+
+	// Fallback to old fields
 	if r.Conversations != nil {
 		return r.Conversations.CacheSalt
 	}

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -103,8 +103,9 @@ type InferenceRequestBody struct {
 // TokenizedInput represents pre-tokenized input provided by the client,
 // including multimodal features if present.
 type TokenizedInput struct {
-	// TokenIDs are the pre-tokenized input token IDs.
-	TokenIDs []uint32
+	// TokenIDs are the pre-tokenized input token IDs. It supports an array of token
+	// arrays to accommodate batched prompts (e.g., from /completions).
+	TokenIDs [][]uint32
 	// MultiModalFeatures holds one entry per multimodal item in prompt order.
 	MultiModalFeatures []MultiModalFeature
 }
@@ -253,7 +254,11 @@ func (r *InferenceRequestBody) PromptText() string {
 func (r *InferenceRequestBody) InputTokenCountHint() int {
 	if r.Prompt != nil || r.Tokens != nil {
 		if r.Tokens != nil && len(r.Tokens.TokenIDs) > 0 {
-			return len(r.Tokens.TokenIDs)
+			total := 0
+			for _, ids := range r.Tokens.TokenIDs {
+				total += len(ids)
+			}
+			return total
 		}
 		return -1
 	}

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -150,6 +150,84 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 			},
 			expected: "hello world",
 		},
+		{
+			name: "unified prompt with single text block",
+			body: &InferenceRequestBody{
+				Prompt: &UnifiedPrompt{
+					Items: []PromptItem{
+						{
+							Role: "user",
+							Blocks: []PromptBlock{
+								{Type: BlockTypeText, Text: "hello"},
+							},
+						},
+					},
+				},
+			},
+			expected: "hello",
+		},
+		{
+			name: "unified prompt with multiple text blocks and empty role",
+			body: &InferenceRequestBody{
+				Prompt: &UnifiedPrompt{
+					Items: []PromptItem{
+						{
+							Role: "system",
+							Blocks: []PromptBlock{
+								{Type: BlockTypeText, Text: "instructions"},
+							},
+						},
+						{
+							Role: "",
+							Blocks: []PromptBlock{
+								{Type: BlockTypeText, Text: "user input"},
+								{Type: BlockTypeImage, AssetURI: "http://image"}, // ignored in text
+							},
+						},
+					},
+				},
+			},
+			expected: "instructions user input",
+		},
+		{
+			name: "unified prompt with documents",
+			body: &InferenceRequestBody{
+				Prompt: &UnifiedPrompt{
+					Items: []PromptItem{
+						{
+							Role: "user",
+							Blocks: []PromptBlock{
+								{Type: BlockTypeText, Text: "query"},
+							},
+						},
+					},
+					Documents: []any{
+						"doc1 text",
+						map[string]any{"content": "doc2 text"},
+					},
+				},
+			},
+			expected: `query doc1 text {"content":"doc2 text"}`,
+		},
+		{
+			name: "unified prompt prioritized over legacy completions",
+			body: &InferenceRequestBody{
+				Prompt: &UnifiedPrompt{
+					Items: []PromptItem{
+						{
+							Role: "user",
+							Blocks: []PromptBlock{
+								{Type: BlockTypeText, Text: "unified"},
+							},
+						},
+					},
+				},
+				Completions: &CompletionsRequest{
+					Prompt: Prompt{Raw: "legacy"},
+				},
+			},
+			expected: "unified",
+		},
 	}
 
 	for _, tt := range tests {
@@ -327,6 +405,38 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 			body:     &InferenceRequestBody{},
 			wantHint: -1,
 		},
+		{
+			name: "unified tokens returns count",
+			body: &InferenceRequestBody{
+				Tokens: &TokenizedInput{
+					TokenIDs: []uint32{10, 20, 30},
+				},
+			},
+			wantHint: 3,
+		},
+		{
+			name: "unified prompt with nil tokens returns -1",
+			body: &InferenceRequestBody{
+				Prompt: &UnifiedPrompt{
+					Items: []PromptItem{
+						{Blocks: []PromptBlock{{Type: BlockTypeText, Text: "hello"}}},
+					},
+				},
+			},
+			wantHint: -1,
+		},
+		{
+			name: "unified tokens prioritized over legacy completions",
+			body: &InferenceRequestBody{
+				Tokens: &TokenizedInput{
+					TokenIDs: []uint32{10, 20, 30},
+				},
+				Completions: &CompletionsRequest{
+					Prompt: Prompt{TokenIDs: []uint32{1, 2}},
+				},
+			},
+			wantHint: 3,
+		},
 	}
 
 	for _, tt := range tests {
@@ -436,6 +546,88 @@ func TestGenerateRequest_UnmarshalJSON(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, g.TokenIDs)
+		})
+	}
+}
+
+func TestInferenceRequestBody_CacheSalt(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     *InferenceRequestBody
+		expected string
+	}{
+		{
+			name: "extracted cache salt returned directly",
+			body: &InferenceRequestBody{
+				ExtractedCacheSalt: "salt-123",
+			},
+			expected: "salt-123",
+		},
+		{
+			name: "fallback to conversations cache salt",
+			body: &InferenceRequestBody{
+				Conversations: &ConversationsRequest{
+					CacheSalt: "conv-salt",
+				},
+			},
+			expected: "conv-salt",
+		},
+		{
+			name: "fallback to responses cache salt",
+			body: &InferenceRequestBody{
+				Responses: &ResponsesRequest{
+					CacheSalt: "resp-salt",
+				},
+			},
+			expected: "resp-salt",
+		},
+		{
+			name: "fallback to chat completions cache salt",
+			body: &InferenceRequestBody{
+				ChatCompletions: &ChatCompletionsRequest{
+					CacheSalt: "chat-salt",
+				},
+			},
+			expected: "chat-salt",
+		},
+		{
+			name: "prioritizes extracted cache salt over legacy",
+			body: &InferenceRequestBody{
+				ExtractedCacheSalt: "extracted",
+				Conversations: &ConversationsRequest{
+					CacheSalt: "conv",
+				},
+				Responses: &ResponsesRequest{
+					CacheSalt: "resp",
+				},
+				ChatCompletions: &ChatCompletionsRequest{
+					CacheSalt: "chat",
+				},
+			},
+			expected: "extracted",
+		},
+		{
+			name: "prioritizes conversations over responses in fallback",
+			body: &InferenceRequestBody{
+				Conversations: &ConversationsRequest{
+					CacheSalt: "conv",
+				},
+				Responses: &ResponsesRequest{
+					CacheSalt: "resp",
+				},
+			},
+			expected: "conv",
+		},
+		{
+			name:     "empty body returns empty string",
+			body:     &InferenceRequestBody{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.body.CacheSalt())
 		})
 	}
 }

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -409,7 +409,7 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 			name: "unified tokens returns count",
 			body: &InferenceRequestBody{
 				Tokens: &TokenizedInput{
-					TokenIDs: []uint32{10, 20, 30},
+					TokenIDs: [][]uint32{{10, 20, 30}},
 				},
 			},
 			wantHint: 3,
@@ -429,7 +429,7 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 			name: "unified tokens prioritized over legacy completions",
 			body: &InferenceRequestBody{
 				Tokens: &TokenizedInput{
-					TokenIDs: []uint32{10, 20, 30},
+					TokenIDs: [][]uint32{{10, 20, 30}},
 				},
 				Completions: &CompletionsRequest{
 					Prompt: Prompt{TokenIDs: []uint32{1, 2}},

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -153,12 +153,14 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		{
 			name: "unified prompt with single text block",
 			body: &InferenceRequestBody{
-				Prompt: &UnifiedPrompt{
-					Items: []PromptItem{
-						{
-							Role: "user",
-							Blocks: []PromptBlock{
-								{Type: BlockTypeText, Text: "hello"},
+				Prompts: []UnifiedPrompt{
+					{
+						Messages: []PromptMessage{
+							{
+								Role: "user",
+								Blocks: []PromptBlock{
+									{Type: BlockTypeText, Text: "hello"},
+								},
 							},
 						},
 					},
@@ -169,19 +171,21 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		{
 			name: "unified prompt with multiple text blocks and empty role",
 			body: &InferenceRequestBody{
-				Prompt: &UnifiedPrompt{
-					Items: []PromptItem{
-						{
-							Role: "system",
-							Blocks: []PromptBlock{
-								{Type: BlockTypeText, Text: "instructions"},
+				Prompts: []UnifiedPrompt{
+					{
+						Messages: []PromptMessage{
+							{
+								Role: "system",
+								Blocks: []PromptBlock{
+									{Type: BlockTypeText, Text: "instructions"},
+								},
 							},
-						},
-						{
-							Role: "",
-							Blocks: []PromptBlock{
-								{Type: BlockTypeText, Text: "user input"},
-								{Type: BlockTypeImage, AssetURI: "http://image"}, // ignored in text
+							{
+								Role: "",
+								Blocks: []PromptBlock{
+									{Type: BlockTypeText, Text: "user input"},
+									{Type: BlockTypeImage, AssetURI: "http://image"}, // ignored in text
+								},
 							},
 						},
 					},
@@ -192,18 +196,18 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		{
 			name: "unified prompt with documents",
 			body: &InferenceRequestBody{
-				Prompt: &UnifiedPrompt{
-					Items: []PromptItem{
-						{
-							Role: "user",
-							Blocks: []PromptBlock{
-								{Type: BlockTypeText, Text: "query"},
+				Prompts: []UnifiedPrompt{
+					{
+						Messages: []PromptMessage{
+							{
+								Role: "user",
+								Blocks: []PromptBlock{
+									{Type: BlockTypeText, Text: "query"},
+									{Type: BlockTypeDoc, Text: "doc1 text"},
+									{Type: BlockTypeDoc, Text: `{"content":"doc2 text"}`},
+								},
 							},
 						},
-					},
-					Documents: []any{
-						"doc1 text",
-						map[string]any{"content": "doc2 text"},
 					},
 				},
 			},
@@ -212,12 +216,14 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		{
 			name: "unified prompt prioritized over legacy completions",
 			body: &InferenceRequestBody{
-				Prompt: &UnifiedPrompt{
-					Items: []PromptItem{
-						{
-							Role: "user",
-							Blocks: []PromptBlock{
-								{Type: BlockTypeText, Text: "unified"},
+				Prompts: []UnifiedPrompt{
+					{
+						Messages: []PromptMessage{
+							{
+								Role: "user",
+								Blocks: []PromptBlock{
+									{Type: BlockTypeText, Text: "unified"},
+								},
 							},
 						},
 					},
@@ -408,8 +414,10 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 		{
 			name: "unified tokens returns count",
 			body: &InferenceRequestBody{
-				Tokens: &TokenizedInput{
-					TokenIDs: [][]uint32{{10, 20, 30}},
+				TokenInputs: []TokenizedInput{
+					{
+						TokenIDs: []uint32{10, 20, 30},
+					},
 				},
 			},
 			wantHint: 3,
@@ -417,9 +425,11 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 		{
 			name: "unified prompt with nil tokens returns -1",
 			body: &InferenceRequestBody{
-				Prompt: &UnifiedPrompt{
-					Items: []PromptItem{
-						{Blocks: []PromptBlock{{Type: BlockTypeText, Text: "hello"}}},
+				Prompts: []UnifiedPrompt{
+					{
+						Messages: []PromptMessage{
+							{Blocks: []PromptBlock{{Type: BlockTypeText, Text: "hello"}}},
+						},
 					},
 				},
 			},
@@ -428,8 +438,10 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 		{
 			name: "unified tokens prioritized over legacy completions",
 			body: &InferenceRequestBody{
-				Tokens: &TokenizedInput{
-					TokenIDs: [][]uint32{{10, 20, 30}},
+				TokenInputs: []TokenizedInput{
+					{
+						TokenIDs: []uint32{10, 20, 30},
+					},
 				},
 				Completions: &CompletionsRequest{
 					Prompt: Prompt{TokenIDs: []uint32{1, 2}},

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -203,8 +203,8 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 								Role: "user",
 								Blocks: []PromptBlock{
 									{Type: BlockTypeText, Text: "query"},
-									{Type: BlockTypeDoc, Text: "doc1 text"},
-									{Type: BlockTypeDoc, Text: `{"content":"doc2 text"}`},
+									{Type: BlockTypeDocument, Text: "doc1 text"},
+									{Type: BlockTypeDocument, Text: `{"content":"doc2 text"}`},
 								},
 							},
 						},


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/cleanup

**What this PR does / why we need it**:



This PR refactors the HTTP request parsers (OpenAI, vLLM HTTP, and Anthropic Messages) to use the newly introduced unified, batch-friendly slice-of-struct fields (`Prompts []UnifiedPrompt` and `TokenInputs []TokenizedInput`) in `InferenceRequestBody`.


### Proposed Go Structures

```go
type InferenceRequestBody struct {
	// Prompts contains the unified representation of the user inputs.
	// Supports batching (multiple prompts). For a single-prompt request,
	// the input is located at index 0 (Prompts[0]).
	Prompts []UnifiedPrompt

	// TokenInputs is the pre-tokenized input provided by the client.
	// Supports batching (multiple token streams). For a single-prompt request,
	// the input is located at index 0 (TokenInputs[0]).
	TokenInputs []TokenizedInput
    
	// ... other compatibility fields
}

// UnifiedPrompt is a unified representation of the user input (prompt) for a single request item.
type UnifiedPrompt struct {
	// Messages represents the structured chat history or conversation turns.
	Messages []PromptMessage
}

// PromptMessage represents a single turn or message in a conversation.
type PromptMessage struct {
	// Role specifies the role (e.g., 'user', 'assistant', 'system').
	Role string
	// Blocks contains the content blocks for this message.
	Blocks []PromptBlock
}

// PromptBlock identifies the type and carries the raw content for a media chunk (text, image, tool, doc).
type PromptBlock struct {
	Type     BlockType
	Text     string
	AssetURI string
	Data     any
}
```

---

### Detailed Mapping Guide for All 7 Request Types

Here is the side-by-side JSON comparison showing exactly how each incoming endpoint request is parsed and converted into EPP's unified request body fields (**`prompts`** and **`token_inputs`**).

#### 1a. OpenAI Chat Completions (`/v1/chat/completions`) - Text Turn with Tools
* **Flow**: Maps incoming messages turns to `messages` turns, and swallows global `tools` into the `system` turn's blocks at index 0.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "model": "test",
  "messages": [
    {"role": "user", "content": "hello"}
  ],
  "tools": [
    {"type": "function", "function": {"name": "get_weather"}}
  ]
}
```

</td>
<td>

```json
{
  "prompts": [
    {
      "messages": [
        {
          "role": "system",
          "blocks": [
            {
              "type": "tool",
              "data": {"type": "function", "function": {"name": "get_weather"}}
            }
          ]
        },
        {
          "role": "user",
          "blocks": [
            {
              "type": "text",
              "text": "hello"
            }
          ]
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>


---

#### 1b. OpenAI Chat Completions (`/v1/chat/completions`) - Multimodal Turn
* **Flow**: Maps rich-media content block arrays directly into separate unified **`PromptBlock`** elements (e.g., a text block and an image block) within the same message turn blocks.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "model": "test-vision",
  "messages": [
    {
      "role": "user",
      "content": [
        {"type": "text", "text": "What is in this image?"},
        {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
      ]
    }
  ]
}
```

</td>
<td>

```json
{
  "prompts": [
    {
      "messages": [
        {
          "role": "user",
          "blocks": [
            {
              "type": "text",
              "text": "What is in this image?"
            },
            {
              "type": "image",
              "asset_uri": "https://example.com/image.png"
            }
          ]
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>

---

#### 2. Claude Messages (`/v1/messages`)
* **Flow**: Maps top-level system prompt and global `tools` into the `system` message turn at `messages[0]`, and maps conversational turns to subsequent turns. Converts structured image base64 sources into EPP's unified image blocks.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "model": "claude-3",
  "system": "You are a helpful assistant.",
  "messages": [
    {"role": "user", "content": "Hello"}
  ],
  "tools": [
    {"name": "get_weather", "description": "Get weather"}
  ]
}
```

</td>
<td>

```json
{
  "prompts": [
    {
      "messages": [
        {
          "role": "system",
          "blocks": [
            {
              "type": "text",
              "text": "You are a helpful assistant."
            },
            {
              "type": "tool",
              "data": {"name": "get_weather", "description": "Get weather"}
            }
          ]
        },
        {
          "role": "user",
          "blocks": [
            {
              "type": "text",
              "text": "Hello"
            }
          ]
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>

---

#### 3. OpenAI Completions (`/v1/completions`) - Text Batching
* **Flow**: Maps each prompt string in the batch `prompt` array into a completely separate independent `UnifiedPrompt` structure in the `prompts` slice.
* **Note**: If the `prompt` is a batched array of multiple strings, EPP maps each string to its own separate `UnifiedPrompt` structure inside the `prompts` slice. This is structurally represented as an array of prompts, ensuring that batch items are kept independent.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "model": "gpt-3.5-turbo-instruct",
  "prompt": ["prompt 1", "prompt 2"]
}
```

</td>
<td>

```json
{
  "prompts": [
    { // First UnifiedPrompt
      "messages": [
        {
          "role": "",
          "blocks": [{"type": "text", "text": "prompt 1"}]
        }
      ]
    },
    { // Second UnifiedPrompt
      "messages": [
        {
          "role": "",
          "blocks": [{"type": "text", "text": "prompt 2"}]
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>

---

#### 4. OpenAI Embeddings (`/v1/embeddings`) - Text Batching
* **Flow**: Maps batched prompt strings into separate `UnifiedPrompt` structures in the `prompts` slice.
* **Note**: If the `input` is a batched array of multiple strings, EPP maps each string to its own separate `UnifiedPrompt` structure inside the `prompts` slice. This is structurally represented as an array of prompts, ensuring that batch items are kept independent.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "model": "text-embedding-3-small",
  "input": ["embedding 1", "embedding 2"]
}
```

</td>
<td>

```json
{
  "prompts": [
    { // First UnifiedPrompt
      "messages": [
        {
          "role": "",
          "blocks": [{"type": "text", "text": "embedding 1"}]
        }
      ]
    },
    { // Second UnifiedPrompt
      "messages": [
        {
          "role": "",
          "blocks": [{"type": "text", "text": "embedding 2"}]
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>

---

#### 5. OpenAI Responses (`/v1/responses`)
* **Flow**: Maps top-level `instructions` and global `tools` into the system message turn at `messages[0]`, and maps `input` into a user turn block.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "model": "gpt-4o",
  "input": "How do I check Python instance?",
  "instructions": "Talk like a pirate.",
  "tools": [{"type": "function", "function": {"name": "get_weather"}}]
}
```

</td>
<td>

```json
{
  "prompts": [
    {
      "messages": [
        {
          "role": "system",
          "blocks": [
            {"type": "text", "text": "Talk like a pirate."},
            {
              "type": "tool",
              "data": {"type": "function", "function": {"name": "get_weather"}}
            }
          ]
        },
        {
          "role": "",
          "blocks": [{"type": "text", "text": "How do I check Python instance?"}]
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>

---

#### 6. OpenAI Conversations (`/v1/conversations`)
* **Flow**: Loops through history items and maps roles and contents directly into conversation turns.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "model": "gpt-4o",
  "items": [
    {"role": "user", "content": "hello"},
    {"role": "assistant", "content": "hi"}
  ]
}
```

</td>
<td>

```json
{
  "prompts": [
    {
      "messages": [
        {
          "role": "user",
          "blocks": [{"type": "text", "text": "hello"}]
        },
        {
          "role": "assistant",
          "blocks": [{"type": "text", "text": "hi"}]
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>

---

#### 7. vLLM HTTP Generate (`/inference/v1/generate`)
* **Flow**: Maps raw pre-tokenized `token_ids` directly to EPP's `token_inputs` batch slice. Flattens map-shaped multimodal placeholder ranges and hashes into a flat unified list.

<table>
<tr>
<td><b>Incoming Request JSON</b></td>
<td><b>EPP Unified JSON</b></td>
</tr>
<tr>
<td>

```json
{
  "token_ids": [151644, 872, 198, 3838, 151645],
  "features": {
    "mm_hashes": {"image": ["abc123hash"]},
    "mm_placeholders": {"image": [{"offset": 1, "length": 3}]}
  }
}
```

</td>
<td>

```json
{
  "token_inputs": [
    {
      "token_ids": [151644, 872, 198, 3838, 151645],
      "multimodal_features": [
        {
          "modality": "image",
          "hash": "abc123hash",
          "offset": 1,
          "length": 3
        }
      ]
    }
  ]
}
```

</td>
</tr>
</table>


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of # https://github.com/llm-d/llm-d-router/issues/1364#issuecomment-4560679710

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
