### PR TITLE
refactor(unifiedInferenceReqeustBody)[3/n]: migrate vLLM gRPC parser to populate unified request body

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -561,7 +561,6 @@ func TestGenerateRequest_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
-
 func TestInferenceRequestBody_CacheSalt(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -203,14 +203,18 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 	case conversationsAPI:
 		var conversations fwkrh.ConversationsRequest
 		if err := json.Unmarshal(rawBody, &conversations); err == nil && len(conversations.Items) > 0 {
-			return &fwkrh.InferenceRequestBody{Conversations: &conversations}, nil
+			body := convertConversations(&conversations)
+			body.Conversations = &conversations
+			return body, nil
 		}
 		return nil, errors.New("invalid conversations request: must have items field")
 
 	case responsesAPI:
 		var responses fwkrh.ResponsesRequest
 		if err := json.Unmarshal(rawBody, &responses); err == nil && responses.Input != nil {
-			return &fwkrh.InferenceRequestBody{Responses: &responses}, nil
+			body := convertResponses(&responses)
+			body.Responses = &responses
+			return body, nil
 		}
 		return nil, errors.New("invalid responses request: must have input field")
 
@@ -218,7 +222,9 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 		var chatCompletions fwkrh.ChatCompletionsRequest
 		if err := json.Unmarshal(rawBody, &chatCompletions); err == nil {
 			if err = validateChatCompletionsMessages(chatCompletions.Messages); err == nil {
-				return &fwkrh.InferenceRequestBody{ChatCompletions: &chatCompletions}, nil
+				body := convertChatCompletions(&chatCompletions)
+				body.ChatCompletions = &chatCompletions
+				return body, nil
 			}
 		}
 		return nil, errors.New("invalid chat completions request: must have valid messages field")
@@ -226,14 +232,18 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 	case completionsAPI:
 		var completions fwkrh.CompletionsRequest
 		if err := json.Unmarshal(rawBody, &completions); err == nil && !completions.Prompt.IsEmpty() {
-			return &fwkrh.InferenceRequestBody{Completions: &completions}, nil
+			body := convertCompletions(&completions)
+			body.Completions = &completions
+			return body, nil
 		}
 		return nil, errors.New("invalid completions request: must have prompt field")
 
 	case embeddingsAPI:
 		var embeddings fwkrh.EmbeddingsRequest
 		if err := json.Unmarshal(rawBody, &embeddings); err == nil && !embeddings.Input.IsEmpty() {
-			return &fwkrh.InferenceRequestBody{Embeddings: &embeddings}, nil
+			body := convertEmbeddings(&embeddings)
+			body.Embeddings = &embeddings
+			return body, nil
 		}
 		return nil, errors.New("invalid embeddings request: must have input field")
 	default:
@@ -375,5 +385,347 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 			}
 		}
 	}
+	return nil
+}
+
+func convertConversations(req *fwkrh.ConversationsRequest) *fwkrh.InferenceRequestBody {
+	unifiedPrompt := fwkrh.UnifiedPrompt{}
+	for _, item := range req.Items {
+		unifiedPrompt.Messages = append(unifiedPrompt.Messages, fwkrh.PromptMessage{
+			Role:   item.Role,
+			Blocks: decodeContentToBlocks(item.Content),
+		})
+	}
+	return &fwkrh.InferenceRequestBody{
+		Prompts:            []fwkrh.UnifiedPrompt{unifiedPrompt},
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+}
+
+func convertResponses(req *fwkrh.ResponsesRequest) *fwkrh.InferenceRequestBody {
+	var messages []fwkrh.PromptMessage
+
+	hasSystem := false
+	if req.Instructions != nil {
+		if str, ok := req.Instructions.(string); ok && str != "" {
+			hasSystem = true
+			messages = append(messages, fwkrh.PromptMessage{
+				Role: "system",
+				Blocks: []fwkrh.PromptBlock{
+					{
+						Type: fwkrh.BlockTypeText,
+						Text: str,
+					},
+				},
+			})
+		}
+	}
+
+	var tools []any
+	if req.Tools != nil {
+		if slice, ok := req.Tools.([]any); ok {
+			tools = slice
+		} else {
+			tools = []any{req.Tools}
+		}
+	}
+
+	needSystem := hasSystem || len(tools) > 0
+
+	if needSystem && !hasSystem {
+		messages = append(messages, fwkrh.PromptMessage{Role: "system"})
+	}
+
+	if req.Input != nil {
+		if str, ok := req.Input.(string); ok {
+			messages = append(messages, fwkrh.PromptMessage{
+				Blocks: []fwkrh.PromptBlock{
+					{
+						Type: fwkrh.BlockTypeText,
+						Text: str,
+					},
+				},
+			})
+		} else if slice, ok := req.Input.([]any); ok {
+			for _, itemVal := range slice {
+				if itemMap, ok := itemVal.(map[string]any); ok {
+					role, _ := itemMap["role"].(string)
+					contentVal := itemMap["content"]
+					messages = append(messages, fwkrh.PromptMessage{
+						Role:   role,
+						Blocks: decodeContentToBlocks(contentVal),
+					})
+				}
+			}
+		}
+	}
+
+	if needSystem {
+		systemItem := &messages[0]
+		for _, tool := range tools {
+			systemItem.Blocks = append(systemItem.Blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeTool,
+				Data: tool,
+			})
+		}
+	}
+
+	unifiedPrompt := fwkrh.UnifiedPrompt{
+		Messages: messages,
+	}
+	return &fwkrh.InferenceRequestBody{
+		Prompts:            []fwkrh.UnifiedPrompt{unifiedPrompt},
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+}
+
+func convertStructuredContentToBlocks(content fwkrh.Content) []fwkrh.PromptBlock {
+	var blocks []fwkrh.PromptBlock
+	if content.Raw != "" {
+		blocks = append(blocks, fwkrh.PromptBlock{
+			Type: fwkrh.BlockTypeText,
+			Text: content.Raw,
+		})
+		return blocks
+	}
+	for _, block := range content.Structured {
+		switch block.Type {
+		case "text":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeText,
+				Text: block.Text,
+			})
+		case "image_url":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeImage,
+				AssetURI: block.ImageURL.URL,
+			})
+		case "input_audio":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeAudio,
+				AssetURI: block.InputAudio.Data,
+			})
+		case "video_url":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeVideo,
+				AssetURI: block.VideoURL.URL,
+			})
+		}
+	}
+	return blocks
+}
+
+func convertChatCompletions(req *fwkrh.ChatCompletionsRequest) *fwkrh.InferenceRequestBody {
+	var messages []fwkrh.PromptMessage
+
+	hasSystem := false
+	for _, msg := range req.Messages {
+		if msg.Role == "system" {
+			hasSystem = true
+			break
+		}
+	}
+
+	needSystem := hasSystem || len(req.Tools) > 0 || len(req.Documents) > 0
+
+	if needSystem && !hasSystem {
+		messages = append(messages, fwkrh.PromptMessage{Role: "system"})
+	}
+
+	for _, msg := range req.Messages {
+		messages = append(messages, fwkrh.PromptMessage{
+			Role:   msg.Role,
+			Blocks: convertStructuredContentToBlocks(msg.Content),
+		})
+	}
+
+	if needSystem {
+		systemItem := &messages[0]
+		for _, tool := range req.Tools {
+			systemItem.Blocks = append(systemItem.Blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeTool,
+				Data: tool,
+			})
+		}
+		for _, doc := range req.Documents {
+			docText := ""
+			if str, ok := doc.(string); ok {
+				docText = str
+			} else {
+				if bytes, err := json.Marshal(doc); err == nil {
+					docText = string(bytes)
+				}
+			}
+			systemItem.Blocks = append(systemItem.Blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeDocument,
+				Text: docText,
+				Data: doc,
+			})
+		}
+	}
+
+	unifiedPrompt := fwkrh.UnifiedPrompt{
+		Messages: messages,
+	}
+	return &fwkrh.InferenceRequestBody{
+		Prompts:            []fwkrh.UnifiedPrompt{unifiedPrompt},
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+}
+
+func convertCompletions(req *fwkrh.CompletionsRequest) *fwkrh.InferenceRequestBody {
+	body := &fwkrh.InferenceRequestBody{
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+
+	if len(req.Prompt.TokenIDs) > 0 {
+		tokenizedInput := fwkrh.TokenizedInput{
+			TokenIDs: req.Prompt.TokenIDs,
+		}
+		body.TokenInputs = []fwkrh.TokenizedInput{tokenizedInput}
+		return body
+	}
+
+	if req.Prompt.Raw != "" {
+		unifiedPrompt := fwkrh.UnifiedPrompt{
+			Messages: []fwkrh.PromptMessage{
+				{
+					Blocks: []fwkrh.PromptBlock{
+						{
+							Type: fwkrh.BlockTypeText,
+							Text: req.Prompt.Raw,
+						},
+					},
+				},
+			},
+		}
+		body.Prompts = []fwkrh.UnifiedPrompt{unifiedPrompt}
+	} else if len(req.Prompt.Strings) > 0 {
+		body.Prompts = make([]fwkrh.UnifiedPrompt, len(req.Prompt.Strings))
+		for i, str := range req.Prompt.Strings {
+			body.Prompts[i] = fwkrh.UnifiedPrompt{
+				Messages: []fwkrh.PromptMessage{
+					{
+						Blocks: []fwkrh.PromptBlock{
+							{
+								Type: fwkrh.BlockTypeText,
+								Text: str,
+							},
+						},
+					},
+				},
+			}
+		}
+	}
+
+	return body
+}
+
+func convertEmbeddings(req *fwkrh.EmbeddingsRequest) *fwkrh.InferenceRequestBody {
+	body := &fwkrh.InferenceRequestBody{
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+
+	if len(req.Input.TokenIDs) > 0 {
+		tokenizedInput := fwkrh.TokenizedInput{
+			TokenIDs: req.Input.TokenIDs,
+		}
+		body.TokenInputs = []fwkrh.TokenizedInput{tokenizedInput}
+		return body
+	}
+
+	if req.Input.Raw != "" {
+		unifiedPrompt := fwkrh.UnifiedPrompt{
+			Messages: []fwkrh.PromptMessage{
+				{
+					Blocks: []fwkrh.PromptBlock{
+						{
+							Type: fwkrh.BlockTypeText,
+							Text: req.Input.Raw,
+						},
+					},
+				},
+			},
+		}
+		body.Prompts = []fwkrh.UnifiedPrompt{unifiedPrompt}
+	} else if len(req.Input.Strings) > 0 {
+		body.Prompts = make([]fwkrh.UnifiedPrompt, len(req.Input.Strings))
+		for i, str := range req.Input.Strings {
+			body.Prompts[i] = fwkrh.UnifiedPrompt{
+				Messages: []fwkrh.PromptMessage{
+					{
+						Blocks: []fwkrh.PromptBlock{
+							{
+								Type: fwkrh.BlockTypeText,
+								Text: str,
+							},
+						},
+					},
+				},
+			}
+		}
+	}
+
+	return body
+}
+
+func decodeContentToBlocks(rawContent any) []fwkrh.PromptBlock {
+	if rawContent == nil {
+		return nil
+	}
+
+	// Case 1: Simple string
+	if str, ok := rawContent.(string); ok {
+		return []fwkrh.PromptBlock{
+			{
+				Type: fwkrh.BlockTypeText,
+				Text: str,
+			},
+		}
+	}
+
+	// Case 2: Array of blocks
+	if slice, ok := rawContent.([]any); ok {
+		var blocks []fwkrh.PromptBlock
+		for _, item := range slice {
+			if blockMap, ok := item.(map[string]any); ok {
+				blockType, _ := blockMap["type"].(string)
+				switch blockType {
+				case "text":
+					text, _ := blockMap["text"].(string)
+					blocks = append(blocks, fwkrh.PromptBlock{
+						Type: fwkrh.BlockTypeText,
+						Text: text,
+					})
+				case "image_url":
+					if imgMap, ok := blockMap["image_url"].(map[string]any); ok {
+						url, _ := imgMap["url"].(string)
+						blocks = append(blocks, fwkrh.PromptBlock{
+							Type:     fwkrh.BlockTypeImage,
+							AssetURI: url,
+						})
+					}
+				case "input_audio":
+					if audioMap, ok := blockMap["input_audio"].(map[string]any); ok {
+						data, _ := audioMap["data"].(string)
+						blocks = append(blocks, fwkrh.PromptBlock{
+							Type:     fwkrh.BlockTypeAudio,
+							AssetURI: data,
+						})
+					}
+				case "video_url":
+					if videoMap, ok := blockMap["video_url"].(map[string]any); ok {
+						url, _ := videoMap["url"].(string)
+						blocks = append(blocks, fwkrh.PromptBlock{
+							Type:     fwkrh.BlockTypeVideo,
+							AssetURI: url,
+						})
+					}
+				}
+			}
+		}
+		return blocks
+	}
+
 	return nil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -59,6 +59,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": "test prompt",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test prompt",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "test prompt"},
 				},
@@ -76,6 +90,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": []any{"Why is the sky blue?"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Why is the sky blue?",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Strings: []string{"Why is the sky blue?"}},
 				},
@@ -93,6 +121,32 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": []any{"prompt1", "prompt2"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "prompt1",
+									},
+								},
+							},
+						},
+					},
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "prompt2",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Strings: []string{"prompt1", "prompt2"}},
 				},
@@ -110,6 +164,11 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": []any{1, 2, 3},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{1, 2, 3},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{TokenIDs: []uint32{1, 2, 3}},
 				},
@@ -143,6 +202,30 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "this is a system message",
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "system", Content: fwkrh.Content{Raw: "this is a system message"}},
@@ -191,6 +274,30 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Describe this image in one sentence.",
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type:     fwkrh.BlockTypeImage,
+										AssetURI: "https://example.com/images/dui.jpg.",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "system", Content: fwkrh.Content{
@@ -264,6 +371,25 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type:     fwkrh.BlockTypeAudio,
+										AssetURI: "base64data",
+									},
+									{
+										Type:     fwkrh.BlockTypeVideo,
+										AssetURI: "https://example.com/video.mp4",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "user", Content: fwkrh.Content{
@@ -322,6 +448,35 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"chat_template_kwargs":         map[string]any{"key": "value"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeTool,
+										Data: map[string]any{"type": "function"},
+									},
+									{
+										Type: fwkrh.BlockTypeDocument,
+										Text: `{"content":"doc"}`,
+										Data: map[string]any{"content": "doc"},
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages:                  []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}},
 					Tools:                     []any{map[string]any{"type": "function"}},
@@ -500,17 +655,32 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			body: map[string]any{
 				"model":      "test",
 				"prompt":     "test prompt",
-				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test prompt",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt:    fwkrh.Prompt{Raw: "test prompt"},
-					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "test",
 					"prompt":     "test prompt",
-					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 			},
 		},
@@ -527,15 +697,40 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 						"role": "user", "content": "hello",
 					},
 				},
-				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "this is a system message",
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "system", Content: fwkrh.Content{Raw: "this is a system message"}},
 						{Role: "user", Content: fwkrh.Content{Raw: "hello"}},
 					},
-					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "test",
@@ -547,7 +742,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 							"role": "user", "content": "hello",
 						},
 					},
-					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 			},
 		},
@@ -560,6 +755,29 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"instructions": "You are a coding assistant that talks like a pirate.",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "You are a coding assistant that talks like a pirate.",
+									},
+								},
+							},
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "How do I check if a Python object is an instance of a class?",
+									},
+								},
+							},
+						},
+					},
+				},
 				Responses: &fwkrh.ResponsesRequest{
 					Input:        "How do I check if a Python object is an instance of a class?",
 					Instructions: "You are a coding assistant that talks like a pirate.",
@@ -580,6 +798,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"cache_salt": "abc123",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test input",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "abc123",
 				Responses: &fwkrh.ResponsesRequest{
 					Input:     "test input",
 					CacheSalt: "abc123",
@@ -611,6 +844,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				Conversations: &fwkrh.ConversationsRequest{
 					Items: []fwkrh.ConversationItem{
 						{Type: "message", Role: "user", Content: "Hello"},
@@ -632,6 +880,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				Conversations: &fwkrh.ConversationsRequest{
 					Items: []fwkrh.ConversationItem{
 						{Type: "message", Role: "user", Content: "Hello"},
@@ -653,6 +916,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": "test prompt",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test prompt",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "test prompt"},
 				},
@@ -673,6 +950,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"stream": true,
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}},
 				},
@@ -695,6 +987,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": "The food was delicious and the waiter...",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "The food was delicious and the waiter...",
+									},
+								},
+							},
+						},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{Raw: "The food was delicious and the waiter..."},
 				},
@@ -712,6 +1018,32 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": []any{"First document", "Second document"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "First document",
+									},
+								},
+							},
+						},
+					},
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Second document",
+									},
+								},
+							},
+						},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{Strings: []string{"First document", "Second document"}},
 				},
@@ -729,6 +1061,11 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": []any{1, 2, 3},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{1, 2, 3},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{TokenIDs: []uint32{1, 2, 3}},
 				},
@@ -747,6 +1084,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"cache_salt": "embeddings-salt-123",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "embed this text",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "embeddings-salt-123",
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input:     fwkrh.EmbeddingsInput{Raw: "embed this text"},
 					CacheSalt: "embeddings-salt-123",
@@ -766,6 +1118,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": "text to embed",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "text to embed",
+									},
+								},
+							},
+						},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{Raw: "text to embed"},
 				},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -90,6 +90,21 @@ func TestParseRequest(t *testing.T) {
 			},
 			wantResult: &fwkrh.ParseResult{
 				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "Hello",
+										},
+									},
+								},
+							},
+						},
+					},
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
 						Messages: []fwkrh.Message{
 							{Role: "user", Content: fwkrh.Content{Raw: "Hello"}},
@@ -110,6 +125,20 @@ func TestParseRequest(t *testing.T) {
 			},
 			wantResult: &fwkrh.ParseResult{
 				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "Hello from stream raw predict",
+										},
+									},
+								},
+							},
+						},
+					},
 					Responses: &fwkrh.ResponsesRequest{
 						Input: "Hello from stream raw predict",
 					},
@@ -127,6 +156,20 @@ func TestParseRequest(t *testing.T) {
 			},
 			wantResult: &fwkrh.ParseResult{
 				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "Hello from raw predict",
+										},
+									},
+								},
+							},
+						},
+					},
 					Responses: &fwkrh.ResponsesRequest{
 						Input: "Hello from raw predict",
 					},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -192,7 +192,20 @@ func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceR
 	var body *fwkrh.InferenceRequestBody
 	switch pbReq.Input.(type) {
 	case *pb.GenerateRequest_Text:
+		prompt := fwkrh.UnifiedPrompt{
+			Messages: []fwkrh.PromptMessage{
+				{
+					Blocks: []fwkrh.PromptBlock{
+						{
+							Type: fwkrh.BlockTypeText,
+							Text: pbReq.GetText(),
+						},
+					},
+				},
+			},
+		}
 		body = &fwkrh.InferenceRequestBody{
+			Prompts: []fwkrh.UnifiedPrompt{prompt},
 			Completions: &fwkrh.CompletionsRequest{
 				Prompt: fwkrh.Prompt{Raw: pbReq.GetText()},
 			},
@@ -206,14 +219,23 @@ func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceR
 		inputIDs := tokenized.GetInputIds()
 		copiedTokenIDsInt := make([]uint32, len(inputIDs))
 		copy(copiedTokenIDsInt, inputIDs)
+
+		mmFeatures := convertMultiModalFeatures(pbReq.GetMmInputs())
+
 		body = &fwkrh.InferenceRequestBody{
+			TokenInputs: []fwkrh.TokenizedInput{
+				{
+					TokenIDs:           copiedTokenIDsInt,
+					MultiModalFeatures: mmFeatures,
+				},
+			},
 			Completions: &fwkrh.CompletionsRequest{
 				Prompt: fwkrh.Prompt{TokenIDs: copiedTokenIDsInt},
 			},
 			Payload: fwkrh.PayloadProto{Message: pbReq},
 			TokenizedPrompt: &fwkrh.TokenizedPrompt{
 				TokenIDs:           copiedTokenIDsInt,
-				MultiModalFeatures: convertMultiModalFeatures(pbReq.GetMmInputs()),
+				MultiModalFeatures: mmFeatures,
 			},
 		}
 	default:
@@ -263,6 +285,11 @@ func convertEmbedToInferenceRequestBody(pbReq *pb.EmbedRequest) (*fwkrh.Inferenc
 		tokenIDs := make([]uint32, len(inputIDs))
 		copy(tokenIDs, inputIDs)
 		body = &fwkrh.InferenceRequestBody{
+			TokenInputs: []fwkrh.TokenizedInput{
+				{
+					TokenIDs: tokenIDs,
+				},
+			},
 			Embeddings: &fwkrh.EmbeddingsRequest{
 				Input: fwkrh.EmbeddingsInput{
 					TokenIDs: tokenIDs,

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -100,6 +100,20 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello world",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "Hello world"},
 				},
@@ -124,6 +138,11 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{11, 12, 13},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{
 						TokenIDs: []uint32{11, 12, 13},
@@ -162,6 +181,15 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{101, 102, 103, 104, 105},
+						MultiModalFeatures: []fwkrh.MultiModalFeature{
+							{Modality: fwkrh.ModalityImage, Hash: "hash-a", Offset: 1, Length: 2},
+							{Modality: fwkrh.ModalityImage, Hash: "hash-b", Offset: 4, Length: 1},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{TokenIDs: []uint32{101, 102, 103, 104, 105}},
 				},
@@ -210,6 +238,15 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{201, 202, 203, 204},
+						MultiModalFeatures: []fwkrh.MultiModalFeature{
+							{Modality: fwkrh.ModalityImage, Hash: "hash-only", Offset: 0, Length: 1},
+							{Modality: fwkrh.ModalityImage, Hash: "", Offset: 2, Length: 2},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{TokenIDs: []uint32{201, 202, 203, 204}},
 				},
@@ -267,6 +304,20 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello world",
+									},
+								},
+							},
+						},
+					},
+				},
 				Stream: true,
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "Hello world"},
@@ -290,6 +341,11 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Embed"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{4, 5, 6},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{
 						TokenIDs: []uint32{4, 5, 6},


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

This PR implements **Stage 3: vLLM gRPC Parser Migration** of the **InferenceRequestBody Standardization Plan** (see the [GitHub Issue Comment Plan](https://github.com/llm-d/llm-d-router/issues/1364#issuecomment-4560679710)).

The goal of this PR is to migrate EPP's vLLM native gRPC parser (`parsers/vllmgrpc`) to populate the new standardized, protocol-agnostic unified request-body fields (`Prompts` and `TokenInputs`) in `InferenceRequestBody`. This completes the parser-side migration for unified request body representations across EPP's OpenAI and vLLM gRPC parsers.

To align with the plural slice-of-structs representation merged in #1380 and #1381, this PR avoids the obsolete singular pointers (`Prompt`/`Tokens`) and directly targets the correct slice fields.

### Summary of Changes

1. **vLLM gRPC Request Parser (`vllmgrpc.go`)**:
    * Updated `convertToInferenceRequestBody` and `convertEmbedToInferenceRequestBody` to populate the standardized slice fields:
        * **GenerateRequest (Text)**: Maps native incoming text prompt into `Prompts` slice using the standard `UnifiedPrompt` with `Messages` containing `PromptMessage`.
        * **GenerateRequest (Tokenized)**: Maps raw client-provided input token IDs and parsed multimodal placeholders (`MmInputs`) directly into `TokenInputs` slice.
        * **EmbedRequest**: Maps raw client-provided input token IDs directly into `TokenInputs`.
2. **vLLM gRPC Parser Unit Tests (`vllmgrpc_test.go`)**:
    * Updated all existing test cases in `TestVllmGRPCParser_ParseRequest` to explicitly assert the expected populated `Prompts` and `TokenInputs` fields.
    * Removed any legacy singular pointer assertions, ensuring clean and robust coverage with zero test-helper ignore workarounds.

**Which issue(s) this PR fixes**:
Part of #1364

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
