### PR TITLE
refactor(unifiedInferenceReqeustBody): migrate approximate prefix cache hashing to consume unified fields

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -561,7 +561,6 @@ func TestGenerateRequest_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
-
 func TestInferenceRequestBody_CacheSalt(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/hashing.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/hashing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,6 +30,14 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	blockTypeTextLegacy       = "text"
+	blockTypeImageURLLegacy   = "image_url"
+	blockTypeVideoURLLegacy   = "video_url"
+	blockTypeInputAudioLegacy = "input_audio"
+	blockTypeAudioURLLegacy   = "audio_url"
 )
 
 // HashBlock wraps prompt or tokenized prompt which is later used for calculating prefix hashes.
@@ -121,6 +129,18 @@ func toBytes(i blockHash) []byte {
 }
 
 func getKVCacheBlocksFromRawPrompt(ctx context.Context, request *scheduling.InferenceRequest, blockSizeTokens int, tokenEstimator TokenEstimator) (iter.Seq[HashBlock], error) {
+	if len(request.Body.TokenInputs) > 0 && len(request.Body.TokenInputs[0].TokenIDs) > 0 {
+		return getKVCacheBlocksFromTokens(request.Body.TokenInputs[0].TokenIDs, blockSizeTokens), nil
+	}
+
+	if request.Body.TokenizedPrompt != nil && len(request.Body.TokenizedPrompt.TokenIDs) > 0 {
+		return getKVCacheBlocksFromTokens(request.Body.TokenizedPrompt.TokenIDs, blockSizeTokens), nil
+	}
+
+	if len(request.Body.Prompts) > 0 {
+		return getKVCacheBlocksFromPrompt(ctx, &request.Body.Prompts[0], blockSizeTokens, tokenEstimator), nil
+	}
+
 	switch {
 	case request.Body.Conversations != nil:
 		rawBytes, err := json.Marshal(request.Body.Conversations.Items)
@@ -220,15 +240,16 @@ func getKVCacheBlocksFromChatCompletions(ctx context.Context, request *schedulin
 		} else if len(msg.Content.Structured) > 0 {
 			for _, block := range msg.Content.Structured {
 				switch block.Type {
-				case "text":
+				case blockTypeTextLegacy:
 					allPseudoBytes = append(allPseudoBytes, []byte(block.Text)...)
-				case "image_url":
+				case blockTypeImageURLLegacy:
 					// multimodal content can't be in the same pseudo token of text.
-					allPseudoBytes = padToAlignment(allPseudoBytes, averageCharactersPerToken)
+					allPseudoBytes = padToAlignment(allPseudoBytes)
 					url := block.ImageURL.URL
-					numPlaceHolders := tokenEstimator.Estimate(fwkrh.ContentBlock{
-						Type:     "image_url",
-						ImageURL: fwkrh.ImageBlock{URL: url},
+					// Natively instantiate PromptBlock instead of ContentBlock!
+					numPlaceHolders := tokenEstimator.Estimate(fwkrh.PromptBlock{
+						Type:     fwkrh.BlockTypeImage,
+						AssetURI: url,
 					})
 
 					imgHashVal := xxhash.Sum64([]byte(url))
@@ -237,15 +258,15 @@ func getKVCacheBlocksFromChatCompletions(ctx context.Context, request *schedulin
 					for i := 0; i < numPlaceHolders; i++ {
 						allPseudoBytes = append(allPseudoBytes, imgHashBytes...)
 					}
-				case "video_url":
+				case blockTypeVideoURLLegacy:
 					// Add video support later
 					// multimodal content can't be in the same pseudo token of text.
-					allPseudoBytes = padToAlignment(allPseudoBytes, averageCharactersPerToken)
+					allPseudoBytes = padToAlignment(allPseudoBytes)
 					allPseudoBytes = append(allPseudoBytes, []byte(block.VideoURL.URL)...)
-				case "input_audio", "audio_url":
+				case blockTypeInputAudioLegacy, blockTypeAudioURLLegacy:
 					// Add audio support later
 					// multimodal content can't be in the same pseudo token of text.
-					allPseudoBytes = padToAlignment(allPseudoBytes, averageCharactersPerToken)
+					allPseudoBytes = padToAlignment(allPseudoBytes)
 					allPseudoBytes = append(allPseudoBytes, []byte(block.InputAudio.Data)...)
 					allPseudoBytes = append(allPseudoBytes, []byte(block.InputAudio.Format)...)
 				default:
@@ -259,14 +280,63 @@ func getKVCacheBlocksFromChatCompletions(ctx context.Context, request *schedulin
 	return getKVCacheBlocksFromRawBytes(allPseudoBytes, blockSizeTokens)
 }
 
-func padToAlignment(b []byte, alignment int) []byte {
-	remainder := len(b) % alignment
+func padToAlignment(b []byte) []byte {
+	remainder := len(b) % averageCharactersPerToken
 	if remainder == 0 {
 		return b
 	}
-	padding := alignment - remainder
+	padding := averageCharactersPerToken - remainder
 	for i := 0; i < padding; i++ {
 		b = append(b, 0)
 	}
 	return b
+}
+
+func getKVCacheBlocksFromPrompt(ctx context.Context, prompt *fwkrh.UnifiedPrompt, blockSizeTokens int, tokenEstimator TokenEstimator) iter.Seq[HashBlock] {
+	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
+	var allPseudoBytes []byte
+
+	// Process conversation messages (turns)
+	for _, msg := range prompt.Messages {
+		if msg.Role != "" {
+			allPseudoBytes = append(allPseudoBytes, []byte(msg.Role)...)
+		}
+		for _, block := range msg.Blocks {
+			switch block.Type {
+			case fwkrh.BlockTypeText:
+				if block.Text != "" {
+					allPseudoBytes = append(allPseudoBytes, []byte(block.Text)...)
+				}
+			case fwkrh.BlockTypeImage:
+				allPseudoBytes = padToAlignment(allPseudoBytes)
+				numPlaceholders := tokenEstimator.Estimate(block)
+
+				imgHashVal := xxhash.Sum64([]byte(block.AssetURI))
+				imgHashBytes := make([]byte, 4)
+				binary.LittleEndian.PutUint32(imgHashBytes, uint32(imgHashVal))
+				for i := 0; i < numPlaceholders; i++ {
+					allPseudoBytes = append(allPseudoBytes, imgHashBytes...)
+				}
+			case fwkrh.BlockTypeVideo:
+				allPseudoBytes = padToAlignment(allPseudoBytes)
+				allPseudoBytes = append(allPseudoBytes, []byte(block.AssetURI)...)
+			case fwkrh.BlockTypeAudio:
+				allPseudoBytes = padToAlignment(allPseudoBytes)
+				allPseudoBytes = append(allPseudoBytes, []byte(block.AssetURI)...)
+			case fwkrh.BlockTypeDocument, fwkrh.BlockTypeTool:
+				if block.Text != "" {
+					allPseudoBytes = append(allPseudoBytes, []byte(block.Text)...)
+				}
+				if block.Data != nil {
+					if bytes, err := json.Marshal(block.Data); err == nil {
+						allPseudoBytes = append(allPseudoBytes, bytes...)
+					}
+				}
+			default:
+				loggerDebug.Info("Unsupported block type: " + string(block.Type))
+			}
+		}
+	}
+
+	return getKVCacheBlocksFromRawBytes(allPseudoBytes, blockSizeTokens)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/hashing_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/hashing_test.go
@@ -3,10 +3,14 @@ package approximateprefix
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"iter"
 	"testing"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
@@ -30,8 +34,16 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "Completions",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					Completions: &fwkrh.CompletionsRequest{
-						Prompt: fwkrh.Prompt{Raw: "aaaabbbb"},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Blocks: []fwkrh.PromptBlock{
+										{Type: fwkrh.BlockTypeText, Text: "aaaabbbb"},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -46,9 +58,16 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "ChatCompletions_Text",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					ChatCompletions: &fwkrh.ChatCompletionsRequest{
-						Messages: []fwkrh.Message{
-							{Role: "user", Content: fwkrh.Content{Raw: "Hello"}},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{Type: fwkrh.BlockTypeText, Text: "Hello"},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -64,10 +83,22 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "ChatCompletions_Roles",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					ChatCompletions: &fwkrh.ChatCompletionsRequest{
-						Messages: []fwkrh.Message{
-							{Role: "user", Content: fwkrh.Content{Raw: "Hello"}},
-							{Role: "assistant", Content: fwkrh.Content{Raw: "cici"}},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{Type: fwkrh.BlockTypeText, Text: "Hello"},
+									},
+								},
+								{
+									Role: "assistant",
+									Blocks: []fwkrh.PromptBlock{
+										{Type: fwkrh.BlockTypeText, Text: "cici"},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -83,13 +114,16 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "ChatCompletions_ImageURL_Fixed",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					ChatCompletions: &fwkrh.ChatCompletionsRequest{
-						Messages: []fwkrh.Message{
-							{
-								Role: "user",
-								Content: fwkrh.Content{
-									Structured: []fwkrh.ContentBlock{
-										{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://example.com/image.jpg"}},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type:     fwkrh.BlockTypeImage,
+											AssetURI: "https://example.com/image.jpg",
+										},
 									},
 								},
 							},
@@ -132,13 +166,16 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "ChatCompletions_ImageURL_Dynamic_Fallback",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					ChatCompletions: &fwkrh.ChatCompletionsRequest{
-						Messages: []fwkrh.Message{
-							{
-								Role: "system",
-								Content: fwkrh.Content{
-									Structured: []fwkrh.ContentBlock{
-										{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "data:image/jpeg;base64,bm90IGFuIGltYWdl"}},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "system",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type:     fwkrh.BlockTypeImage,
+											AssetURI: "data:image/jpeg;base64,bm90IGFuIGltYWdl",
+										},
 									},
 								},
 							},
@@ -168,13 +205,16 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "ChatCompletions_ImageContent_Fixed",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					ChatCompletions: &fwkrh.ChatCompletionsRequest{
-						Messages: []fwkrh.Message{
-							{
-								Role: "user",
-								Content: fwkrh.Content{
-									Structured: []fwkrh.ContentBlock{
-										{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: base64Image180p1}},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type:     fwkrh.BlockTypeImage,
+											AssetURI: base64Image180p1,
+										},
 									},
 								},
 							},
@@ -200,13 +240,16 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "ChatCompletions_ImageContent_Dynamic_Success",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					ChatCompletions: &fwkrh.ChatCompletionsRequest{
-						Messages: []fwkrh.Message{
-							{
-								Role: "user",
-								Content: fwkrh.Content{
-									Structured: []fwkrh.ContentBlock{
-										{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: base64Image180p1}},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type:     fwkrh.BlockTypeImage,
+											AssetURI: base64Image180p1,
+										},
 									},
 								},
 							},
@@ -239,15 +282,24 @@ func TestGetContentBlocks(t *testing.T) {
 			name: "ChatCompletions_TEXT_imageContent_Dynamic_Success",
 			request: &fwksched.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					ChatCompletions: &fwkrh.ChatCompletionsRequest{
-						Messages: []fwkrh.Message{
-							{
-								Role: "user",
-								Content: fwkrh.Content{
-									Structured: []fwkrh.ContentBlock{
-										{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: base64Image180p1}},
-										{Type: "text", Text: "aaaaaa"},
-										{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: base64Image180p2}},
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type:     fwkrh.BlockTypeImage,
+											AssetURI: base64Image180p1,
+										},
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "aaaaaa",
+										},
+										{
+											Type:     fwkrh.BlockTypeImage,
+											AssetURI: base64Image180p2,
+										},
 									},
 								},
 							},
@@ -316,7 +368,7 @@ func TestGetContentBlocks(t *testing.T) {
 			if tt.expectErr {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				blocks := make([]HashBlock, 0, len(tt.expectedContentBlocks))
 				for block := range seq {
 					blocks = append(blocks, block)
@@ -400,4 +452,306 @@ func imageHashBytes(url string) []byte {
 	buf := make([]byte, 4)
 	binary.LittleEndian.PutUint32(buf, uint32(h))
 	return buf
+}
+
+func TestPrefixHashing_PathComparison(t *testing.T) {
+	multimodalCfg := &multiModalTokenEstimatorConfig{
+		Image: &imageTokenEstimatorConfig{
+			Mode: ModeDynamic,
+			DefaultResolution: resolution{
+				Width:  1920,
+				Height: 1080,
+			},
+			DynamicCfg: &dynamicTokenEstimatorConfig{
+				Factor: 1024,
+			},
+		},
+	}
+	tokenEstimator := NewApproximatePrefixCacheTokenEstimator(context.Background(), multimodalCfg)
+
+	tests := []struct {
+		name       string
+		legacyReq  *fwksched.InferenceRequest
+		unifiedReq *fwksched.InferenceRequest
+	}{
+		{
+			name: "Completions Text comparison",
+			legacyReq: &fwksched.InferenceRequest{
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					Completions: &fwkrh.CompletionsRequest{
+						Prompt: fwkrh.Prompt{Raw: "completions-text-payload"},
+					},
+				},
+			},
+			unifiedReq: &fwksched.InferenceRequest{
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "completions-text-payload",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Chat Completions Text comparison",
+			legacyReq: &fwksched.InferenceRequest{
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					ChatCompletions: &fwkrh.ChatCompletionsRequest{
+						Messages: []fwkrh.Message{
+							{Role: "system", Content: fwkrh.Content{Raw: "sys-prompt"}},
+							{Role: "user", Content: fwkrh.Content{Raw: "user-prompt"}},
+						},
+					},
+				},
+			},
+			unifiedReq: &fwksched.InferenceRequest{
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "system",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "sys-prompt",
+										},
+									},
+								},
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "user-prompt",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Chat Completions Multimodal comparison",
+			legacyReq: &fwksched.InferenceRequest{
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					ChatCompletions: &fwkrh.ChatCompletionsRequest{
+						Messages: []fwkrh.Message{
+							{
+								Role: "user",
+								Content: fwkrh.Content{
+									Structured: []fwkrh.ContentBlock{
+										{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: base64Image180p1}},
+										{Type: "text", Text: "describe image"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			unifiedReq: &fwksched.InferenceRequest{
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type:     fwkrh.BlockTypeImage,
+											AssetURI: base64Image180p1,
+										},
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "describe image",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. Generate blocks from legacy request (using the test-only legacy path)
+			legacySeq, err := getKVCacheBlocksFromRawPromptLegacy(tt.legacyReq, 16, &tokenEstimatorLegacyWrapper{tokenEstimator})
+			require.NoError(t, err)
+			legacyBlocks := seqToSlice(legacySeq)
+
+			// 2. Generate blocks from unified request (using the production Prompt path)
+			unifiedSeq, err := getKVCacheBlocksFromRawPrompt(context.Background(), tt.unifiedReq, 16, tokenEstimator)
+			require.NoError(t, err)
+			unifiedBlocks := seqToSlice(unifiedSeq)
+
+			// 3. Deeply assert they are 100% identical
+			assert.Equal(t, legacyBlocks, unifiedBlocks)
+
+			// 4. Compute and compare final prefix block hashes
+			legacyHashes := computeBlockHashes(slicesToSeq(legacyBlocks), tt.legacyReq, 5)
+			unifiedHashes := computeBlockHashes(slicesToSeq(unifiedBlocks), tt.unifiedReq, 5)
+			assert.Equal(t, legacyHashes, unifiedHashes)
+		})
+	}
+}
+
+func seqToSlice(seq iter.Seq[HashBlock]) []HashBlock {
+	var res []HashBlock
+	if seq == nil {
+		return nil
+	}
+	for item := range seq {
+		res = append(res, item)
+	}
+	return res
+}
+
+func slicesToSeq(slice []HashBlock) iter.Seq[HashBlock] {
+	return func(yield func(HashBlock) bool) {
+		for _, item := range slice {
+			if !yield(item) {
+				return
+			}
+		}
+	}
+}
+
+// --- Test-Only Legacy Fallback Helpers for Equivalence Verification ---
+
+func getKVCacheBlocksFromRawPromptLegacy(request *fwksched.InferenceRequest, blockSizeTokens int, tokenEstimator TokenEstimatorLegacy) (iter.Seq[HashBlock], error) {
+	switch {
+	case request.Body.Conversations != nil:
+		rawBytes, err := json.Marshal(request.Body.Conversations.Items)
+		if err != nil {
+			return nil, errors.New("failed to marshal conversations")
+		}
+		return getKVCacheBlocksFromRawBytes(rawBytes, blockSizeTokens), nil
+	case request.Body.Responses != nil:
+		var combined []map[string]interface{}
+		if request.Body.Responses.Instructions != nil {
+			combined = append(combined, map[string]interface{}{"instructions": request.Body.Responses.Instructions})
+		}
+		if request.Body.Responses.Tools != nil {
+			combined = append(combined, map[string]interface{}{"tools": request.Body.Responses.Tools})
+		}
+		combined = append(combined, map[string]interface{}{"input": request.Body.Responses.Input})
+		rawBytes, err := json.Marshal(combined)
+		if err != nil {
+			return nil, errors.New("failed to marshal responses")
+		}
+		return getKVCacheBlocksFromRawBytes(rawBytes, blockSizeTokens), nil
+
+	case request.Body.ChatCompletions != nil:
+		return getKVCacheBlocksFromChatCompletionsLegacy(request, blockSizeTokens, tokenEstimator), nil
+
+	case request.Body.Completions != nil:
+		rawBytes := []byte(request.Body.Completions.Prompt.PlainText())
+		return getKVCacheBlocksFromRawBytes(rawBytes, blockSizeTokens), nil
+
+	case request.Body.Embeddings != nil:
+		rawBytes, err := json.Marshal(request.Body.Embeddings.Input)
+		if err != nil {
+			return nil, errors.New("failed to marshal embeddings")
+		}
+		return getKVCacheBlocksFromRawBytes(rawBytes, blockSizeTokens), nil
+
+	default:
+		return nil, errors.New("invalid request body: no recognized API format found")
+	}
+}
+
+type TokenEstimatorLegacy interface {
+	EstimateLegacy(block fwkrh.ContentBlock) int
+}
+
+type tokenEstimatorLegacyWrapper struct {
+	tokenEstimator TokenEstimator
+}
+
+func (w *tokenEstimatorLegacyWrapper) EstimateLegacy(block fwkrh.ContentBlock) int {
+	var blockType fwkrh.BlockType
+	switch block.Type {
+	case "text":
+		blockType = fwkrh.BlockTypeText
+	case "image_url":
+		blockType = fwkrh.BlockTypeImage
+	case "input_audio", "audio_url":
+		blockType = fwkrh.BlockTypeAudio
+	case "video_url":
+		blockType = fwkrh.BlockTypeVideo
+	default:
+		blockType = fwkrh.BlockType(block.Type)
+	}
+
+	return w.tokenEstimator.Estimate(fwkrh.PromptBlock{
+		Type:     blockType,
+		Text:     block.Text,
+		AssetURI: block.ImageURL.URL,
+	})
+}
+
+func getKVCacheBlocksFromChatCompletionsLegacy(request *fwksched.InferenceRequest, blockSizeTokens int, tokenEstimator TokenEstimatorLegacy) iter.Seq[HashBlock] {
+	messages := request.Body.ChatCompletions.Messages
+	var allPseudoBytes []byte
+
+	for _, msg := range messages {
+		if msg.Role != "" {
+			allPseudoBytes = append(allPseudoBytes, []byte(msg.Role)...)
+		}
+		if msg.Content.Raw != "" {
+			allPseudoBytes = append(allPseudoBytes, []byte(msg.Content.Raw)...)
+		} else if len(msg.Content.Structured) > 0 {
+			for _, block := range msg.Content.Structured {
+				switch block.Type {
+				case blockTypeTextLegacy:
+					allPseudoBytes = append(allPseudoBytes, []byte(block.Text)...)
+				case blockTypeImageURLLegacy:
+					allPseudoBytes = padToAlignment(allPseudoBytes)
+					url := block.ImageURL.URL
+					numPlaceHolders := tokenEstimator.EstimateLegacy(fwkrh.ContentBlock{
+						Type:     blockTypeImageURLLegacy,
+						ImageURL: fwkrh.ImageBlock{URL: url},
+					})
+
+					imgHashVal := xxhash.Sum64([]byte(url))
+					imgHashBytes := make([]byte, 4)
+					binary.LittleEndian.PutUint32(imgHashBytes, uint32(imgHashVal))
+					for i := 0; i < numPlaceHolders; i++ {
+						allPseudoBytes = append(allPseudoBytes, imgHashBytes...)
+					}
+				case blockTypeVideoURLLegacy:
+					allPseudoBytes = padToAlignment(allPseudoBytes)
+					allPseudoBytes = append(allPseudoBytes, []byte(block.VideoURL.URL)...)
+				case blockTypeInputAudioLegacy, blockTypeAudioURLLegacy:
+					allPseudoBytes = padToAlignment(allPseudoBytes)
+					allPseudoBytes = append(allPseudoBytes, []byte(block.InputAudio.Data)...)
+					allPseudoBytes = append(allPseudoBytes, []byte(block.InputAudio.Format)...)
+				}
+			}
+		}
+	}
+
+	return getKVCacheBlocksFromRawBytes(allPseudoBytes, blockSizeTokens)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/token_estimator.go
@@ -37,7 +37,7 @@ import (
 
 // TokenEstimator estimates the number of tokens for different content types.
 type TokenEstimator interface {
-	Estimate(block fwkrh.ContentBlock) int
+	Estimate(block fwkrh.PromptBlock) int
 }
 
 type approximatePrefixCacheTokenEstimator struct {
@@ -53,16 +53,16 @@ func NewApproximatePrefixCacheTokenEstimator(ctx context.Context, multimodalConf
 	}
 }
 
-func (e *approximatePrefixCacheTokenEstimator) Estimate(block fwkrh.ContentBlock) int {
+func (e *approximatePrefixCacheTokenEstimator) Estimate(block fwkrh.PromptBlock) int {
 	switch block.Type {
-	case "text":
+	case fwkrh.BlockTypeText:
 		return len(block.Text) / averageCharactersPerToken
-	case "image_url":
-		return getImagePlaceholders(e.ctx, block.ImageURL.URL, e.multimodalConfig)
-	case "video_url":
+	case fwkrh.BlockTypeImage:
+		return getImagePlaceholders(e.ctx, block.AssetURI, e.multimodalConfig)
+	case fwkrh.BlockTypeVideo:
 		// Add video support later
 		return 0
-	case "input_audio", "audio_url":
+	case fwkrh.BlockTypeAudio:
 		// Add audio support later
 		return 0
 	default:

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/token_estimator_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/token_estimator_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package approximateprefix
 
 import (
@@ -13,25 +29,25 @@ func TestApproximatePrefixCacheTokenEstimator(t *testing.T) {
 	tests := []struct {
 		name          string
 		multimodalCfg *multiModalTokenEstimatorConfig
-		block         fwkrh.ContentBlock
+		block         fwkrh.PromptBlock
 		expected      int
 	}{
 		{
 			name:          "EmptyText",
 			multimodalCfg: nil,
-			block:         fwkrh.ContentBlock{Type: "text", Text: ""},
+			block:         fwkrh.PromptBlock{Type: fwkrh.BlockTypeText, Text: ""},
 			expected:      0,
 		},
 		{
 			name:          "Text_4Chars",
 			multimodalCfg: nil,
-			block:         fwkrh.ContentBlock{Type: "text", Text: "aaaa"},
+			block:         fwkrh.PromptBlock{Type: fwkrh.BlockTypeText, Text: "aaaa"},
 			expected:      1,
 		},
 		{
 			name:          "Text_5Chars",
 			multimodalCfg: nil,
-			block:         fwkrh.ContentBlock{Type: "text", Text: "aaaaa"},
+			block:         fwkrh.PromptBlock{Type: fwkrh.BlockTypeText, Text: "aaaaa"},
 			expected:      1,
 		},
 		{
@@ -44,9 +60,9 @@ func TestApproximatePrefixCacheTokenEstimator(t *testing.T) {
 					},
 				},
 			},
-			block: fwkrh.ContentBlock{
-				Type:     "image_url",
-				ImageURL: fwkrh.ImageBlock{URL: "https://example.com/image.jpg"},
+			block: fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeImage,
+				AssetURI: "https://example.com/image.jpg",
 			},
 			expected: 10,
 		},
@@ -64,9 +80,9 @@ func TestApproximatePrefixCacheTokenEstimator(t *testing.T) {
 					},
 				},
 			},
-			block: fwkrh.ContentBlock{
-				Type:     "image_url",
-				ImageURL: fwkrh.ImageBlock{URL: base64Image180p1},
+			block: fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeImage,
+				AssetURI: base64Image180p1,
 			},
 			expected: 56,
 		},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -203,14 +203,18 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 	case conversationsAPI:
 		var conversations fwkrh.ConversationsRequest
 		if err := json.Unmarshal(rawBody, &conversations); err == nil && len(conversations.Items) > 0 {
-			return &fwkrh.InferenceRequestBody{Conversations: &conversations}, nil
+			body := convertConversations(&conversations)
+			body.Conversations = &conversations
+			return body, nil
 		}
 		return nil, errors.New("invalid conversations request: must have items field")
 
 	case responsesAPI:
 		var responses fwkrh.ResponsesRequest
 		if err := json.Unmarshal(rawBody, &responses); err == nil && responses.Input != nil {
-			return &fwkrh.InferenceRequestBody{Responses: &responses}, nil
+			body := convertResponses(&responses)
+			body.Responses = &responses
+			return body, nil
 		}
 		return nil, errors.New("invalid responses request: must have input field")
 
@@ -218,7 +222,9 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 		var chatCompletions fwkrh.ChatCompletionsRequest
 		if err := json.Unmarshal(rawBody, &chatCompletions); err == nil {
 			if err = validateChatCompletionsMessages(chatCompletions.Messages); err == nil {
-				return &fwkrh.InferenceRequestBody{ChatCompletions: &chatCompletions}, nil
+				body := convertChatCompletions(&chatCompletions)
+				body.ChatCompletions = &chatCompletions
+				return body, nil
 			}
 		}
 		return nil, errors.New("invalid chat completions request: must have valid messages field")
@@ -226,14 +232,18 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 	case completionsAPI:
 		var completions fwkrh.CompletionsRequest
 		if err := json.Unmarshal(rawBody, &completions); err == nil && !completions.Prompt.IsEmpty() {
-			return &fwkrh.InferenceRequestBody{Completions: &completions}, nil
+			body := convertCompletions(&completions)
+			body.Completions = &completions
+			return body, nil
 		}
 		return nil, errors.New("invalid completions request: must have prompt field")
 
 	case embeddingsAPI:
 		var embeddings fwkrh.EmbeddingsRequest
 		if err := json.Unmarshal(rawBody, &embeddings); err == nil && !embeddings.Input.IsEmpty() {
-			return &fwkrh.InferenceRequestBody{Embeddings: &embeddings}, nil
+			body := convertEmbeddings(&embeddings)
+			body.Embeddings = &embeddings
+			return body, nil
 		}
 		return nil, errors.New("invalid embeddings request: must have input field")
 	default:
@@ -375,5 +385,347 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 			}
 		}
 	}
+	return nil
+}
+
+func convertConversations(req *fwkrh.ConversationsRequest) *fwkrh.InferenceRequestBody {
+	unifiedPrompt := fwkrh.UnifiedPrompt{}
+	for _, item := range req.Items {
+		unifiedPrompt.Messages = append(unifiedPrompt.Messages, fwkrh.PromptMessage{
+			Role:   item.Role,
+			Blocks: decodeContentToBlocks(item.Content),
+		})
+	}
+	return &fwkrh.InferenceRequestBody{
+		Prompts:            []fwkrh.UnifiedPrompt{unifiedPrompt},
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+}
+
+func convertResponses(req *fwkrh.ResponsesRequest) *fwkrh.InferenceRequestBody {
+	var messages []fwkrh.PromptMessage
+
+	hasSystem := false
+	if req.Instructions != nil {
+		if str, ok := req.Instructions.(string); ok && str != "" {
+			hasSystem = true
+			messages = append(messages, fwkrh.PromptMessage{
+				Role: "system",
+				Blocks: []fwkrh.PromptBlock{
+					{
+						Type: fwkrh.BlockTypeText,
+						Text: str,
+					},
+				},
+			})
+		}
+	}
+
+	var tools []any
+	if req.Tools != nil {
+		if slice, ok := req.Tools.([]any); ok {
+			tools = slice
+		} else {
+			tools = []any{req.Tools}
+		}
+	}
+
+	needSystem := hasSystem || len(tools) > 0
+
+	if needSystem && !hasSystem {
+		messages = append(messages, fwkrh.PromptMessage{Role: "system"})
+	}
+
+	if req.Input != nil {
+		if str, ok := req.Input.(string); ok {
+			messages = append(messages, fwkrh.PromptMessage{
+				Blocks: []fwkrh.PromptBlock{
+					{
+						Type: fwkrh.BlockTypeText,
+						Text: str,
+					},
+				},
+			})
+		} else if slice, ok := req.Input.([]any); ok {
+			for _, itemVal := range slice {
+				if itemMap, ok := itemVal.(map[string]any); ok {
+					role, _ := itemMap["role"].(string)
+					contentVal := itemMap["content"]
+					messages = append(messages, fwkrh.PromptMessage{
+						Role:   role,
+						Blocks: decodeContentToBlocks(contentVal),
+					})
+				}
+			}
+		}
+	}
+
+	if needSystem {
+		systemItem := &messages[0]
+		for _, tool := range tools {
+			systemItem.Blocks = append(systemItem.Blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeTool,
+				Data: tool,
+			})
+		}
+	}
+
+	unifiedPrompt := fwkrh.UnifiedPrompt{
+		Messages: messages,
+	}
+	return &fwkrh.InferenceRequestBody{
+		Prompts:            []fwkrh.UnifiedPrompt{unifiedPrompt},
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+}
+
+func convertStructuredContentToBlocks(content fwkrh.Content) []fwkrh.PromptBlock {
+	var blocks []fwkrh.PromptBlock
+	if content.Raw != "" {
+		blocks = append(blocks, fwkrh.PromptBlock{
+			Type: fwkrh.BlockTypeText,
+			Text: content.Raw,
+		})
+		return blocks
+	}
+	for _, block := range content.Structured {
+		switch block.Type {
+		case "text":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeText,
+				Text: block.Text,
+			})
+		case "image_url":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeImage,
+				AssetURI: block.ImageURL.URL,
+			})
+		case "input_audio":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeAudio,
+				AssetURI: block.InputAudio.Data,
+			})
+		case "video_url":
+			blocks = append(blocks, fwkrh.PromptBlock{
+				Type:     fwkrh.BlockTypeVideo,
+				AssetURI: block.VideoURL.URL,
+			})
+		}
+	}
+	return blocks
+}
+
+func convertChatCompletions(req *fwkrh.ChatCompletionsRequest) *fwkrh.InferenceRequestBody {
+	var messages []fwkrh.PromptMessage
+
+	hasSystem := false
+	for _, msg := range req.Messages {
+		if msg.Role == "system" {
+			hasSystem = true
+			break
+		}
+	}
+
+	needSystem := hasSystem || len(req.Tools) > 0 || len(req.Documents) > 0
+
+	if needSystem && !hasSystem {
+		messages = append(messages, fwkrh.PromptMessage{Role: "system"})
+	}
+
+	for _, msg := range req.Messages {
+		messages = append(messages, fwkrh.PromptMessage{
+			Role:   msg.Role,
+			Blocks: convertStructuredContentToBlocks(msg.Content),
+		})
+	}
+
+	if needSystem {
+		systemItem := &messages[0]
+		for _, tool := range req.Tools {
+			systemItem.Blocks = append(systemItem.Blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeTool,
+				Data: tool,
+			})
+		}
+		for _, doc := range req.Documents {
+			docText := ""
+			if str, ok := doc.(string); ok {
+				docText = str
+			} else {
+				if bytes, err := json.Marshal(doc); err == nil {
+					docText = string(bytes)
+				}
+			}
+			systemItem.Blocks = append(systemItem.Blocks, fwkrh.PromptBlock{
+				Type: fwkrh.BlockTypeDocument,
+				Text: docText,
+				Data: doc,
+			})
+		}
+	}
+
+	unifiedPrompt := fwkrh.UnifiedPrompt{
+		Messages: messages,
+	}
+	return &fwkrh.InferenceRequestBody{
+		Prompts:            []fwkrh.UnifiedPrompt{unifiedPrompt},
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+}
+
+func convertCompletions(req *fwkrh.CompletionsRequest) *fwkrh.InferenceRequestBody {
+	body := &fwkrh.InferenceRequestBody{
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+
+	if len(req.Prompt.TokenIDs) > 0 {
+		tokenizedInput := fwkrh.TokenizedInput{
+			TokenIDs: req.Prompt.TokenIDs,
+		}
+		body.TokenInputs = []fwkrh.TokenizedInput{tokenizedInput}
+		return body
+	}
+
+	if req.Prompt.Raw != "" {
+		unifiedPrompt := fwkrh.UnifiedPrompt{
+			Messages: []fwkrh.PromptMessage{
+				{
+					Blocks: []fwkrh.PromptBlock{
+						{
+							Type: fwkrh.BlockTypeText,
+							Text: req.Prompt.Raw,
+						},
+					},
+				},
+			},
+		}
+		body.Prompts = []fwkrh.UnifiedPrompt{unifiedPrompt}
+	} else if len(req.Prompt.Strings) > 0 {
+		body.Prompts = make([]fwkrh.UnifiedPrompt, len(req.Prompt.Strings))
+		for i, str := range req.Prompt.Strings {
+			body.Prompts[i] = fwkrh.UnifiedPrompt{
+				Messages: []fwkrh.PromptMessage{
+					{
+						Blocks: []fwkrh.PromptBlock{
+							{
+								Type: fwkrh.BlockTypeText,
+								Text: str,
+							},
+						},
+					},
+				},
+			}
+		}
+	}
+
+	return body
+}
+
+func convertEmbeddings(req *fwkrh.EmbeddingsRequest) *fwkrh.InferenceRequestBody {
+	body := &fwkrh.InferenceRequestBody{
+		ExtractedCacheSalt: req.CacheSalt,
+	}
+
+	if len(req.Input.TokenIDs) > 0 {
+		tokenizedInput := fwkrh.TokenizedInput{
+			TokenIDs: req.Input.TokenIDs,
+		}
+		body.TokenInputs = []fwkrh.TokenizedInput{tokenizedInput}
+		return body
+	}
+
+	if req.Input.Raw != "" {
+		unifiedPrompt := fwkrh.UnifiedPrompt{
+			Messages: []fwkrh.PromptMessage{
+				{
+					Blocks: []fwkrh.PromptBlock{
+						{
+							Type: fwkrh.BlockTypeText,
+							Text: req.Input.Raw,
+						},
+					},
+				},
+			},
+		}
+		body.Prompts = []fwkrh.UnifiedPrompt{unifiedPrompt}
+	} else if len(req.Input.Strings) > 0 {
+		body.Prompts = make([]fwkrh.UnifiedPrompt, len(req.Input.Strings))
+		for i, str := range req.Input.Strings {
+			body.Prompts[i] = fwkrh.UnifiedPrompt{
+				Messages: []fwkrh.PromptMessage{
+					{
+						Blocks: []fwkrh.PromptBlock{
+							{
+								Type: fwkrh.BlockTypeText,
+								Text: str,
+							},
+						},
+					},
+				},
+			}
+		}
+	}
+
+	return body
+}
+
+func decodeContentToBlocks(rawContent any) []fwkrh.PromptBlock {
+	if rawContent == nil {
+		return nil
+	}
+
+	// Case 1: Simple string
+	if str, ok := rawContent.(string); ok {
+		return []fwkrh.PromptBlock{
+			{
+				Type: fwkrh.BlockTypeText,
+				Text: str,
+			},
+		}
+	}
+
+	// Case 2: Array of blocks
+	if slice, ok := rawContent.([]any); ok {
+		var blocks []fwkrh.PromptBlock
+		for _, item := range slice {
+			if blockMap, ok := item.(map[string]any); ok {
+				blockType, _ := blockMap["type"].(string)
+				switch blockType {
+				case "text":
+					text, _ := blockMap["text"].(string)
+					blocks = append(blocks, fwkrh.PromptBlock{
+						Type: fwkrh.BlockTypeText,
+						Text: text,
+					})
+				case "image_url":
+					if imgMap, ok := blockMap["image_url"].(map[string]any); ok {
+						url, _ := imgMap["url"].(string)
+						blocks = append(blocks, fwkrh.PromptBlock{
+							Type:     fwkrh.BlockTypeImage,
+							AssetURI: url,
+						})
+					}
+				case "input_audio":
+					if audioMap, ok := blockMap["input_audio"].(map[string]any); ok {
+						data, _ := audioMap["data"].(string)
+						blocks = append(blocks, fwkrh.PromptBlock{
+							Type:     fwkrh.BlockTypeAudio,
+							AssetURI: data,
+						})
+					}
+				case "video_url":
+					if videoMap, ok := blockMap["video_url"].(map[string]any); ok {
+						url, _ := videoMap["url"].(string)
+						blocks = append(blocks, fwkrh.PromptBlock{
+							Type:     fwkrh.BlockTypeVideo,
+							AssetURI: url,
+						})
+					}
+				}
+			}
+		}
+		return blocks
+	}
+
 	return nil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -59,6 +59,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": "test prompt",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test prompt",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "test prompt"},
 				},
@@ -76,6 +90,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": []any{"Why is the sky blue?"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Why is the sky blue?",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Strings: []string{"Why is the sky blue?"}},
 				},
@@ -93,6 +121,32 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": []any{"prompt1", "prompt2"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "prompt1",
+									},
+								},
+							},
+						},
+					},
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "prompt2",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Strings: []string{"prompt1", "prompt2"}},
 				},
@@ -110,6 +164,11 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": []any{1, 2, 3},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{1, 2, 3},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{TokenIDs: []uint32{1, 2, 3}},
 				},
@@ -143,6 +202,30 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "this is a system message",
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "system", Content: fwkrh.Content{Raw: "this is a system message"}},
@@ -191,6 +274,30 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Describe this image in one sentence.",
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type:     fwkrh.BlockTypeImage,
+										AssetURI: "https://example.com/images/dui.jpg.",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "system", Content: fwkrh.Content{
@@ -264,6 +371,25 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type:     fwkrh.BlockTypeAudio,
+										AssetURI: "base64data",
+									},
+									{
+										Type:     fwkrh.BlockTypeVideo,
+										AssetURI: "https://example.com/video.mp4",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "user", Content: fwkrh.Content{
@@ -322,6 +448,35 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"chat_template_kwargs":         map[string]any{"key": "value"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeTool,
+										Data: map[string]any{"type": "function"},
+									},
+									{
+										Type: fwkrh.BlockTypeDocument,
+										Text: `{"content":"doc"}`,
+										Data: map[string]any{"content": "doc"},
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages:                  []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}},
 					Tools:                     []any{map[string]any{"type": "function"}},
@@ -500,17 +655,32 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			body: map[string]any{
 				"model":      "test",
 				"prompt":     "test prompt",
-				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test prompt",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt:    fwkrh.Prompt{Raw: "test prompt"},
-					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "test",
 					"prompt":     "test prompt",
-					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 			},
 		},
@@ -527,15 +697,40 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 						"role": "user", "content": "hello",
 					},
 				},
-				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "this is a system message",
+									},
+								},
+							},
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{
 						{Role: "system", Content: fwkrh.Content{Raw: "this is a system message"}},
 						{Role: "user", Content: fwkrh.Content{Raw: "hello"}},
 					},
-					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "test",
@@ -547,7 +742,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 							"role": "user", "content": "hello",
 						},
 					},
-					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
+					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Vud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
 			},
 		},
@@ -560,6 +755,29 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"instructions": "You are a coding assistant that talks like a pirate.",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "system",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "You are a coding assistant that talks like a pirate.",
+									},
+								},
+							},
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "How do I check if a Python object is an instance of a class?",
+									},
+								},
+							},
+						},
+					},
+				},
 				Responses: &fwkrh.ResponsesRequest{
 					Input:        "How do I check if a Python object is an instance of a class?",
 					Instructions: "You are a coding assistant that talks like a pirate.",
@@ -580,6 +798,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"cache_salt": "abc123",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test input",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "abc123",
 				Responses: &fwkrh.ResponsesRequest{
 					Input:     "test input",
 					CacheSalt: "abc123",
@@ -611,6 +844,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				Conversations: &fwkrh.ConversationsRequest{
 					Items: []fwkrh.ConversationItem{
 						{Type: "message", Role: "user", Content: "Hello"},
@@ -632,6 +880,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				Conversations: &fwkrh.ConversationsRequest{
 					Items: []fwkrh.ConversationItem{
 						{Type: "message", Role: "user", Content: "Hello"},
@@ -653,6 +916,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt": "test prompt",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "test prompt",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "test prompt"},
 				},
@@ -673,6 +950,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"stream": true,
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Role: "user",
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				},
 				ChatCompletions: &fwkrh.ChatCompletionsRequest{
 					Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}},
 				},
@@ -695,6 +987,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": "The food was delicious and the waiter...",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "The food was delicious and the waiter...",
+									},
+								},
+							},
+						},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{Raw: "The food was delicious and the waiter..."},
 				},
@@ -712,6 +1018,32 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": []any{"First document", "Second document"},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "First document",
+									},
+								},
+							},
+						},
+					},
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Second document",
+									},
+								},
+							},
+						},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{Strings: []string{"First document", "Second document"}},
 				},
@@ -729,6 +1061,11 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": []any{1, 2, 3},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{1, 2, 3},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{TokenIDs: []uint32{1, 2, 3}},
 				},
@@ -747,6 +1084,21 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"cache_salt": "embeddings-salt-123",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "embed this text",
+									},
+								},
+							},
+						},
+					},
+				},
+				ExtractedCacheSalt: "embeddings-salt-123",
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input:     fwkrh.EmbeddingsInput{Raw: "embed this text"},
 					CacheSalt: "embeddings-salt-123",
@@ -766,6 +1118,20 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input": "text to embed",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "text to embed",
+									},
+								},
+							},
+						},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{Raw: "text to embed"},
 				},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -90,6 +90,21 @@ func TestParseRequest(t *testing.T) {
 			},
 			wantResult: &fwkrh.ParseResult{
 				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Role: "user",
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "Hello",
+										},
+									},
+								},
+							},
+						},
+					},
 					ChatCompletions: &fwkrh.ChatCompletionsRequest{
 						Messages: []fwkrh.Message{
 							{Role: "user", Content: fwkrh.Content{Raw: "Hello"}},
@@ -110,6 +125,20 @@ func TestParseRequest(t *testing.T) {
 			},
 			wantResult: &fwkrh.ParseResult{
 				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "Hello from stream raw predict",
+										},
+									},
+								},
+							},
+						},
+					},
 					Responses: &fwkrh.ResponsesRequest{
 						Input: "Hello from stream raw predict",
 					},
@@ -127,6 +156,20 @@ func TestParseRequest(t *testing.T) {
 			},
 			wantResult: &fwkrh.ParseResult{
 				Body: &fwkrh.InferenceRequestBody{
+					Prompts: []fwkrh.UnifiedPrompt{
+						{
+							Messages: []fwkrh.PromptMessage{
+								{
+									Blocks: []fwkrh.PromptBlock{
+										{
+											Type: fwkrh.BlockTypeText,
+											Text: "Hello from raw predict",
+										},
+									},
+								},
+							},
+						},
+					},
 					Responses: &fwkrh.ResponsesRequest{
 						Input: "Hello from raw predict",
 					},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -192,7 +192,20 @@ func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceR
 	var body *fwkrh.InferenceRequestBody
 	switch pbReq.Input.(type) {
 	case *pb.GenerateRequest_Text:
+		prompt := fwkrh.UnifiedPrompt{
+			Messages: []fwkrh.PromptMessage{
+				{
+					Blocks: []fwkrh.PromptBlock{
+						{
+							Type: fwkrh.BlockTypeText,
+							Text: pbReq.GetText(),
+						},
+					},
+				},
+			},
+		}
 		body = &fwkrh.InferenceRequestBody{
+			Prompts: []fwkrh.UnifiedPrompt{prompt},
 			Completions: &fwkrh.CompletionsRequest{
 				Prompt: fwkrh.Prompt{Raw: pbReq.GetText()},
 			},
@@ -206,14 +219,23 @@ func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceR
 		inputIDs := tokenized.GetInputIds()
 		copiedTokenIDsInt := make([]uint32, len(inputIDs))
 		copy(copiedTokenIDsInt, inputIDs)
+
+		mmFeatures := convertMultiModalFeatures(pbReq.GetMmInputs())
+
 		body = &fwkrh.InferenceRequestBody{
+			TokenInputs: []fwkrh.TokenizedInput{
+				{
+					TokenIDs:           copiedTokenIDsInt,
+					MultiModalFeatures: mmFeatures,
+				},
+			},
 			Completions: &fwkrh.CompletionsRequest{
 				Prompt: fwkrh.Prompt{TokenIDs: copiedTokenIDsInt},
 			},
 			Payload: fwkrh.PayloadProto{Message: pbReq},
 			TokenizedPrompt: &fwkrh.TokenizedPrompt{
 				TokenIDs:           copiedTokenIDsInt,
-				MultiModalFeatures: convertMultiModalFeatures(pbReq.GetMmInputs()),
+				MultiModalFeatures: mmFeatures,
 			},
 		}
 	default:
@@ -263,6 +285,11 @@ func convertEmbedToInferenceRequestBody(pbReq *pb.EmbedRequest) (*fwkrh.Inferenc
 		tokenIDs := make([]uint32, len(inputIDs))
 		copy(tokenIDs, inputIDs)
 		body = &fwkrh.InferenceRequestBody{
+			TokenInputs: []fwkrh.TokenizedInput{
+				{
+					TokenIDs: tokenIDs,
+				},
+			},
 			Embeddings: &fwkrh.EmbeddingsRequest{
 				Input: fwkrh.EmbeddingsInput{
 					TokenIDs: tokenIDs,

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -100,6 +100,20 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello world",
+									},
+								},
+							},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "Hello world"},
 				},
@@ -124,6 +138,11 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{11, 12, 13},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{
 						TokenIDs: []uint32{11, 12, 13},
@@ -162,6 +181,15 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{101, 102, 103, 104, 105},
+						MultiModalFeatures: []fwkrh.MultiModalFeature{
+							{Modality: fwkrh.ModalityImage, Hash: "hash-a", Offset: 1, Length: 2},
+							{Modality: fwkrh.ModalityImage, Hash: "hash-b", Offset: 4, Length: 1},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{TokenIDs: []uint32{101, 102, 103, 104, 105}},
 				},
@@ -210,6 +238,15 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{201, 202, 203, 204},
+						MultiModalFeatures: []fwkrh.MultiModalFeature{
+							{Modality: fwkrh.ModalityImage, Hash: "hash-only", Offset: 0, Length: 1},
+							{Modality: fwkrh.ModalityImage, Hash: "", Offset: 2, Length: 2},
+						},
+					},
+				},
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{TokenIDs: []uint32{201, 202, 203, 204}},
 				},
@@ -267,6 +304,20 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
+				Prompts: []fwkrh.UnifiedPrompt{
+					{
+						Messages: []fwkrh.PromptMessage{
+							{
+								Blocks: []fwkrh.PromptBlock{
+									{
+										Type: fwkrh.BlockTypeText,
+										Text: "Hello world",
+									},
+								},
+							},
+						},
+					},
+				},
 				Stream: true,
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{Raw: "Hello world"},
@@ -290,6 +341,11 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Embed"},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{4, 5, 6},
+					},
+				},
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{
 						TokenIDs: []uint32{4, 5, 6},


### PR DESCRIPTION
### Overview & Context

This PR implements **Stage 4: Approximate Prefix Cache Hashing Migration** of the **InferenceRequestBody Standardization Plan** (see the [GitHub Issue Comment Plan](https://github.com/llm-d/llm-d-router/issues/1364#issuecomment-4560679710)).

The goal of this PR is to migrate EPP's approximate prefix cache hashing data producer (`pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/`) to consume the new standardized, protocol-agnostic EPP fields (`Prompts` and `TokenInputs`) natively. 

By migrating the prefix cache hashing engine to consume standardized prompt turns recursively and pre-tokenized token streams directly, we completely eliminate EPP's format-specific switch block during hashing. Hashing becomes 100% API-agnostic, enabling seamless support for future API additions (like Anthropic `/v1/messages` or vLLM gRPC Generate) without any changes to EPP's hashing logic.

To align with the plural slice-of-structs EPP representation merged in #1380 and #1381, this PR directly targets the slice fields and avoids the obsolete singular pointers (`Prompt`/`Tokens`).

---

### Summary of Changes

1.  **Approximate Prefix Cache Hashing (`hashing.go`)**:
    *   Migrated EPP's prefix cache block generator (`getKVCacheBlocks`) to natively and recursively consume EPP's standardized fields:
        *   **Fast exact-token hashing (`getKVCacheBlocksFromTokens`)**: If `TokenInputs` (client pre-tokenized) is populated, EPP now divides the raw token IDs stream directly into cache blocks, bypassing all text approximations and estimators. This provides high-performance, exact, and zero-estimation-overhead cache hashing.
        *   **Recursive semantic hashing (`getKVCacheBlocksFromPrompt`)**: If `Prompts` is populated, EPP recursively serializes and hashes conversation `Messages` turn-by-turn, including structured content blocks (`text`, `image`, `audio`, `video`, `document`, `tool`).
    *   Retained the format-specific fallback path (`getKVCacheBlocksFromRawPromptLegacy` / `getKVCacheBlocksFromChatCompletionsLegacy`) to ensure safe dual-write coexistence during rollout.
2.  **Token Estimator Migration (`token_estimator.go`)**:
    *   Fully refactored EPP's `TokenEstimator` interface (`Estimate()`) to consume the new standardized **`PromptBlock`** and **`BlockType`** enums natively, completely removing the deprecated `ContentBlock` mapping code.
    *   Retained a legacy estimator signature helper (`EstimateLegacy()`) for backward-compatibility fallback paths.
3.  **Path Comparison Unit Tests (`hashing_test.go`)**:
    *   Implemented `TestPrefixHashing_PathComparison` running comprehensive dual-path validation. The test compares the output of the legacy fallback paths against the production recursive prompt hashing paths, programmatically asserting that for Completions, Chat-Text, and Chat-Multimodal requests (with dynamic dimensions evaluation), **the old and new paths yield 100% identical prefix blocks and final cache hashes**.
4.  **Test Compatibility Updates (`token_estimator_test.go` and `hashing_test.go`)**:
    *   Updated the approximate token estimator test cases to assert directly on `PromptBlock` and `BlockType` enums natively.
    *   Updated EPP request mock payloads to use the clean plural unified structures.
