### PR TITLE
feat: update encoder cache structure and add encoder-cache query and hit metrics

### DIFF
--- a/deploy/config/epp-mm-embeddings-cache-config.yaml
+++ b/deploy/config/epp-mm-embeddings-cache-config.yaml
@@ -12,7 +12,7 @@ plugins:
   - type: core-metrics-extractor
   - type: mm-embeddings-cache-producer
     parameters:
-      cacheSize: 10000
+      cacheSizeInMB: 2048
   - type: mm-embeddings-cache-scorer
   - type: precise-prefix-cache-scorer
     parameters:

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/README.md
@@ -38,8 +38,8 @@ This plugin produces:
 
 The producer supports the following runtime parameters:
 
-- `cacheSize` (integer, default: `10000`): maximum number of multimodal hash entries
-  retained in the best-effort pod-affinity cache.
+- `cacheSizeInMB` (integer, default: `2048`, 2 GiB): per-endpoint memory budget in
+  mebibytes (MiB) for the best-effort pod-affinity LRU.
 
 **Configuration Examples:**
 
@@ -47,7 +47,7 @@ The producer supports the following runtime parameters:
 plugins:
   - type: mm-embeddings-cache-producer
     parameters:
-      cacheSize: 10000
+      cacheSizeInMB: 2048
   - type: mm-embeddings-cache-scorer
 schedulingProfiles:
   - name: encoder-cache-aware
@@ -69,7 +69,7 @@ plugins:
         http: http://localhost:8000
   - type: mm-embeddings-cache-producer
     parameters:
-      cacheSize: 10000
+      cacheSizeInMB: 2048
   - type: mm-embeddings-cache-scorer
 schedulingProfiles:
   - name: decode

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/README.md
@@ -38,7 +38,7 @@ This plugin produces:
 
 The producer supports the following runtime parameters:
 
-- `cacheSizeInMB` (integer, default: `2048`, 2 GiB): per-endpoint memory budget in
+- `cacheSizeInMBPerServer` (integer, default: `2048`, 2 GiB): per-endpoint memory budget in
   mebibytes (MiB) for the best-effort pod-affinity LRU.
 
 **Configuration Examples:**
@@ -47,7 +47,7 @@ The producer supports the following runtime parameters:
 plugins:
   - type: mm-embeddings-cache-producer
     parameters:
-      cacheSizeInMB: 2048
+      cacheSizeInMBPerServer: 2048
   - type: mm-embeddings-cache-scorer
 schedulingProfiles:
   - name: encoder-cache-aware
@@ -69,7 +69,7 @@ plugins:
         http: http://localhost:8000
   - type: mm-embeddings-cache-producer
     parameters:
-      cacheSizeInMB: 2048
+      cacheSizeInMBPerServer: 2048
   - type: mm-embeddings-cache-scorer
 schedulingProfiles:
   - name: decode

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/export_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/export_test.go
@@ -17,18 +17,20 @@ limitations under the License.
 package multimodal
 
 import (
-	"maps"
-
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
+// cacheSnapshot returns a hash→pod-set view of the per-endpoint caches for assertions.
 func (p *Producer) cacheSnapshot() map[string]map[string]struct{} {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
-	snapshot := make(map[string]map[string]struct{}, p.cache.Len())
-	for _, hash := range p.cache.Keys() {
-		if pods, ok := p.cache.Get(hash); ok {
-			snapshot[hash] = maps.Clone(pods)
+	snapshot := map[string]map[string]struct{}{}
+	for pod, podCache := range p.caches {
+		for _, hash := range podCache.Keys() {
+			if snapshot[hash] == nil {
+				snapshot[hash] = map[string]struct{}{}
+			}
+			snapshot[hash][pod] = struct{}{}
 		}
 	}
 	return snapshot
@@ -37,12 +39,7 @@ func (p *Producer) cacheSnapshot() map[string]map[string]struct{} {
 func (p *Producer) putCacheEntry(hash string, pods ...k8stypes.NamespacedName) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	podSet := map[string]struct{}{}
-	if existing, ok := p.cache.Get(hash); ok {
-		podSet = maps.Clone(existing)
-	}
 	for _, pod := range pods {
-		podSet[pod.String()] = struct{}{}
+		p.getOrCreatePodCache(pod.String()).Add(hash, struct{}{})
 	}
-	p.cache.Add(hash, podSet)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multimodal
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	compbasemetrics "k8s.io/component-base/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
+)
+
+const llmdSubsystem = "llm_d_router_epp"
+
+var (
+	// encoderCacheQueriesTotal counts every multimodal item hash lookup against the LRU.
+	encoderCacheQueriesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: llmdSubsystem,
+			Name:      "encoder_cache_queries_total",
+			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups made against the encoder-cache affinity LRU.", compbasemetrics.ALPHA),
+		},
+	)
+
+	// encoderCacheHitsTotal counts the subset of encoder_cache_queries_total where
+	// the item hash was already present in the LRU. Divide by queries_total for hit rate.
+	encoderCacheHitsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: llmdSubsystem,
+			Name:      "encoder_cache_hits_total",
+			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups that found a match in the encoder-cache affinity LRU.", compbasemetrics.ALPHA),
+		},
+	)
+
+	registerOnce sync.Once
+)
+
+func registerEncoderCacheMetrics() {
+	registerOnce.Do(func() {
+		metrics.Registry.MustRegister(encoderCacheQueriesTotal)
+		metrics.Registry.MustRegister(encoderCacheHitsTotal)
+	})
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
@@ -39,13 +39,15 @@ var (
 	)
 
 	// encoderCacheHitsTotal counts the subset of encoder_cache_queries_total where
-	// the item hash was already present in the LRU. Divide by queries_total for hit rate.
-	encoderCacheHitsTotal = prometheus.NewCounter(
+	// the item hash was already present in the endpoint's LRU, labelled by pod.
+	// Divide by queries_total for hit rate.
+	encoderCacheHitsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: llmdSubsystem,
 			Name:      "encoder_cache_hits_total",
-			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups that found a match in the encoder-cache affinity LRU.", compbasemetrics.ALPHA),
+			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups that found a match in the encoder-cache affinity LRU, by endpoint.", compbasemetrics.ALPHA),
 		},
+		[]string{"pod"},
 	)
 
 	registerOnce sync.Once

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
@@ -30,12 +30,13 @@ const llmdSubsystem = "llm_d_router_epp"
 
 var (
 	// encoderCacheQueriesTotal counts every multimodal item hash lookup against the LRU.
-	encoderCacheQueriesTotal = prometheus.NewCounter(
+	encoderCacheQueriesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: llmdSubsystem,
 			Name:      "encoder_cache_queries_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups made against the encoder-cache affinity LRU.", compbasemetrics.ALPHA),
 		},
+		[]string{"plugin_type", "plugin_name"},
 	)
 
 	// encoderCacheHitsTotal counts the subset of encoder_cache_queries_total where
@@ -47,7 +48,7 @@ var (
 			Name:      "encoder_cache_hits_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups that found a match in the encoder-cache affinity LRU, by endpoint.", compbasemetrics.ALPHA),
 		},
-		[]string{"pod"},
+		[]string{"plugin_type", "plugin_name", "pod"},
 	)
 
 	registerOnce sync.Once

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multimodal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	attrmm "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/multimodal"
+)
+
+func TestRecordItemLookupsMetrics(t *testing.T) {
+	producer := newTestProducer(t, nil, nil)
+
+	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal)
+	initialHits := testutil.ToFloat64(encoderCacheHitsTotal)
+
+	// Case 1: Cache Misses
+	items := []attrmm.MatchItem{
+		{Hash: "hash-1", Size: 1},
+		{Hash: "hash-2", Size: 1},
+	}
+	producer.recordItemLookups(items)
+
+	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal))
+	assert.Equal(t, initialHits, testutil.ToFloat64(encoderCacheHitsTotal))
+
+	// Case 2: Cache Hits (add one to cache first)
+	producer.cache.Add("hash-1", map[string]struct{}{"pod-a": {}})
+	
+	items = []attrmm.MatchItem{
+		{Hash: "hash-1", Size: 1}, // Hit
+		{Hash: "hash-3", Size: 1}, // Miss
+	}
+	producer.recordItemLookups(items)
+
+	assert.Equal(t, initialQueries+4, testutil.ToFloat64(encoderCacheQueriesTotal))
+	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal))
+}
+
+func TestRegisterEncoderCacheMetrics(t *testing.T) {
+	// registerEncoderCacheMetrics uses sync.Once, so multiple calls are safe.
+	// We can't easily verify registration against a mock registry because it uses the global metrics.Registry.
+	// But we can verify it doesn't panic.
+	assert.NotPanics(t, func() {
+		registerEncoderCacheMetrics()
+		registerEncoderCacheMetrics()
+	})
+}
+
+func TestProduceRecordsMetrics(t *testing.T) {
+	producer := newTestProducer(t, nil, nil)
+	request := requestWithHashes("req-1", map[string]int{"hash-1": 1, "hash-2": 1})
+
+	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal)
+	
+	// Produce should call recordItemLookups
+	require.NoError(t, producer.Produce(context.Background(), request, nil))
+
+	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal))
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
@@ -34,8 +34,8 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 	pod := k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"}
 	podKey := pod.String()
 
-	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal)
-	initialHits := testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(podKey))
+	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName))
+	initialHits := testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey))
 
 	// Case 1: Cache Misses
 	items := []attrmm.MatchItem{
@@ -44,8 +44,8 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 	}
 	producer.recordItemLookups(items)
 
-	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal))
-	assert.Equal(t, initialHits, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(podKey)))
+	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName)))
+	assert.Equal(t, initialHits, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey)))
 
 	// Case 2: Cache Hits (add one to cache first)
 	producer.putCacheEntry("hash-1", pod)
@@ -56,8 +56,8 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 	}
 	producer.recordItemLookups(items)
 
-	assert.Equal(t, initialQueries+4, testutil.ToFloat64(encoderCacheQueriesTotal))
-	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(podKey)))
+	assert.Equal(t, initialQueries+4, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName)))
+	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey)))
 }
 
 func TestRegisterEncoderCacheMetrics(t *testing.T) {
@@ -74,10 +74,10 @@ func TestProduceRecordsMetrics(t *testing.T) {
 	producer := newTestProducer(t, nil, nil)
 	request := requestWithHashes("req-1", map[string]int{"hash-1": 1, "hash-2": 1})
 
-	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal)
+	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName))
 
 	// Produce should call recordItemLookups
 	require.NoError(t, producer.Produce(context.Background(), request, nil))
 
-	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal))
+	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName)))
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	attrmm "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/multimodal"
 )
@@ -30,8 +31,11 @@ import (
 func TestRecordItemLookupsMetrics(t *testing.T) {
 	producer := newTestProducer(t, nil, nil)
 
+	pod := k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"}
+	podKey := pod.String()
+
 	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal)
-	initialHits := testutil.ToFloat64(encoderCacheHitsTotal)
+	initialHits := testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(podKey))
 
 	// Case 1: Cache Misses
 	items := []attrmm.MatchItem{
@@ -41,10 +45,10 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 	producer.recordItemLookups(items)
 
 	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal))
-	assert.Equal(t, initialHits, testutil.ToFloat64(encoderCacheHitsTotal))
+	assert.Equal(t, initialHits, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(podKey)))
 
 	// Case 2: Cache Hits (add one to cache first)
-	producer.cache.Add("hash-1", map[string]struct{}{"pod-a": {}})
+	producer.putCacheEntry("hash-1", pod)
 
 	items = []attrmm.MatchItem{
 		{Hash: "hash-1", Size: 1}, // Hit
@@ -53,7 +57,7 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 	producer.recordItemLookups(items)
 
 	assert.Equal(t, initialQueries+4, testutil.ToFloat64(encoderCacheQueriesTotal))
-	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal))
+	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(podKey)))
 }
 
 func TestRegisterEncoderCacheMetrics(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
@@ -45,7 +45,7 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 
 	// Case 2: Cache Hits (add one to cache first)
 	producer.cache.Add("hash-1", map[string]struct{}{"pod-a": {}})
-	
+
 	items = []attrmm.MatchItem{
 		{Hash: "hash-1", Size: 1}, // Hit
 		{Hash: "hash-3", Size: 1}, // Miss
@@ -71,7 +71,7 @@ func TestProduceRecordsMetrics(t *testing.T) {
 	request := requestWithHashes("req-1", map[string]int{"hash-1": 1, "hash-2": 1})
 
 	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal)
-	
+
 	// Produce should call recordItemLookups
 	require.NoError(t, producer.Produce(context.Background(), request, nil))
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
@@ -18,7 +18,6 @@ package multimodal
 
 import (
 	"context"
-	"maps"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -52,18 +51,14 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 	p.wg.Go(func() {
 		p.mutex.Lock()
 		defer p.mutex.Unlock()
-		for _, item := range items {
-			pods := map[string]struct{}{}
-			if existing, ok := p.cache.Get(item.Hash); ok {
-				pods = maps.Clone(existing)
+		for _, endpoint := range targets {
+			metadata := endpoint.GetMetadata()
+			if metadata == nil {
+				continue
 			}
-			for _, endpoint := range targets {
-				if metadata := endpoint.GetMetadata(); metadata != nil {
-					pods[metadata.NamespacedName.String()] = struct{}{}
-				}
-			}
-			if len(pods) > 0 {
-				p.cache.Add(item.Hash, pods)
+			podCache := p.getOrCreatePodCache(metadata.NamespacedName.String())
+			for _, item := range items {
+				podCache.Add(item.Hash, struct{}{})
 			}
 		}
 	})

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -50,8 +50,8 @@ const (
 	// defaultCacheSizeInMB is 4 GiB (4096 MiB).
 	defaultCacheSizeInMB = 4096
 
-	// bytesPerLRUEntry is the assumed memory per tracked hash.
-	bytesPerLRUEntry = 2 * 1024 * 1024
+	// bytesPerImage is the assumed memory per tracked image.
+	bytesPerImage = 2 * 1024 * 1024
 )
 
 var (
@@ -65,8 +65,8 @@ var (
 
 // Parameters configures the multimodal encoder-cache data producer.
 type Parameters struct {
-	// CacheSizeInMB is the per-endpoint LRU memory budget in mebibytes (MiB).
-	CacheSizeInMB int `json:"cacheSizeInMB"`
+	// CacheSizeInMBPerServer is the per-endpoint LRU memory budget in mebibytes (MiB).
+	CacheSizeInMBPerServer int `json:"cacheSizeInMBPerServer"`
 }
 
 // lruCapacityFromCacheSizeMB converts a MiB budget to a maximum LRU entry count.
@@ -74,7 +74,7 @@ func lruCapacityFromCacheSizeMB(mb int) int {
 	if mb <= 0 {
 		mb = defaultCacheSizeInMB
 	}
-	n := (int64(mb) * 1024 * 1024) / bytesPerLRUEntry
+	n := (int64(mb) * 1024 * 1024) / bytesPerImage
 	if n < 1 {
 		return 1
 	}
@@ -125,7 +125,7 @@ func (s *requestState) Clone() plugin.StateData {
 func New(ctx context.Context, name string, params *Parameters, podList func() []k8stypes.NamespacedName) (*Producer, error) {
 	cacheSizeMB := 0
 	if params != nil {
-		cacheSizeMB = params.CacheSizeInMB
+		cacheSizeMB = params.CacheSizeInMBPerServer
 	}
 	cacheSize := lruCapacityFromCacheSizeMB(cacheSizeMB)
 
@@ -307,11 +307,12 @@ func itemSlice(itemsByHash map[string]attrmm.MatchItem) []attrmm.MatchItem {
 func (p *Producer) recordItemLookups(items []attrmm.MatchItem) {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
+	pluginType, pluginName := p.typedName.Type, p.typedName.Name
 	for _, item := range items {
-		encoderCacheQueriesTotal.Inc()
+		encoderCacheQueriesTotal.WithLabelValues(pluginType, pluginName).Inc()
 		for pod, podCache := range p.caches {
 			if podCache.Contains(item.Hash) {
-				encoderCacheHitsTotal.WithLabelValues(pod).Inc()
+				encoderCacheHitsTotal.WithLabelValues(pluginType, pluginName, pod).Inc()
 			}
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -47,8 +47,8 @@ const (
 
 	podCleanupInterval = 2 * time.Minute
 
-	// defaultCacheSizeInMB is 2 GiB (2048 MiB).
-	defaultCacheSizeInMB = 2048
+	// defaultCacheSizeInMB is 4 GiB (4096 MiB).
+	defaultCacheSizeInMB = 4096
 
 	// bytesPerLRUEntry is the assumed memory per tracked hash.
 	bytesPerLRUEntry = 2 * 1024 * 1024

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -111,6 +111,8 @@ func New(ctx context.Context, name string, params *Parameters, podList func() []
 		return nil, fmt.Errorf("failed to create multimodal encoder-cache LRU with size %d: %w", cacheSize, err)
 	}
 
+	registerEncoderCacheMetrics()
+
 	p := &Producer{
 		typedName:   plugin.TypedName{Type: ProducerType, Name: name},
 		dk:          attrmm.EncoderCacheMatchInfoKey.WithNonEmptyProducerName(name),
@@ -160,6 +162,8 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 		logger.Info("No multimodal content found, skipping encoder-cache match data")
 		return nil
 	}
+
+	p.recordItemLookups(requestItems)
 
 	if request != nil && request.RequestID != "" {
 		p.pluginState.Write(request.RequestID, plugin.StateKey(ProducerType), &requestState{items: requestItems})
@@ -265,6 +269,20 @@ func itemSlice(itemsByHash map[string]attrmm.MatchItem) []attrmm.MatchItem {
 		items = append(items, item)
 	}
 	return items
+}
+
+// recordItemLookups increments the queries counter for each item and the hits
+// counter for each item whose hash is already tracked in the LRU.
+// Contains is used instead of Get to avoid altering recency during a read-only path.
+func (p *Producer) recordItemLookups(items []attrmm.MatchItem) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	for _, item := range items {
+		encoderCacheQueriesTotal.Inc()
+		if p.cache.Contains(item.Hash) {
+			encoderCacheHitsTotal.Inc()
+		}
+	}
 }
 
 func (p *Producer) matchedItemsForPod(pod string, requestItems []attrmm.MatchItem) []attrmm.MatchItem {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -45,8 +45,13 @@ const (
 	// ProducerType is the type name used to register the multimodal data producer.
 	ProducerType = "mm-embeddings-cache-producer"
 
-	defaultCacheSize   = 10000
 	podCleanupInterval = 2 * time.Minute
+
+	// defaultCacheSizeInMB is 2 GiB (2048 MiB).
+	defaultCacheSizeInMB = 2048
+
+	// bytesPerLRUEntry is the assumed memory per tracked hash.
+	bytesPerLRUEntry = 2 * 1024 * 1024
 )
 
 var (
@@ -60,8 +65,23 @@ var (
 
 // Parameters configures the multimodal encoder-cache data producer.
 type Parameters struct {
-	// CacheSize defines the maximum number of mm_hash -> pod-set entries to track.
-	CacheSize int `json:"cacheSize"`
+	// CacheSizeInMB is the per-endpoint LRU memory budget in mebibytes (MiB).
+	CacheSizeInMB int `json:"cacheSizeInMB"`
+}
+
+// lruCapacityFromCacheSizeMB converts a MiB budget to a maximum LRU entry count.
+func lruCapacityFromCacheSizeMB(mb int) int {
+	if mb <= 0 {
+		mb = defaultCacheSizeInMB
+	}
+	n := (int64(mb) * 1024 * 1024) / bytesPerLRUEntry
+	if n < 1 {
+		return 1
+	}
+	if n > int64(^uint(0)>>1) {
+		return int(^uint(0) >> 1)
+	}
+	return int(n)
 }
 
 // Factory creates a multimodal encoder-cache data producer.
@@ -77,11 +97,13 @@ func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (pl
 }
 
 // Producer tracks multimodal content hashes and the pods that likely hold their
-// encoder-cache entries.
+// encoder-cache entries. Each pod has its own LRU cache of hashes, so eviction
+// is scoped per endpoint rather than global.
 type Producer struct {
 	typedName   plugin.TypedName
 	dk          plugin.DataKey
-	cache       *lru.Cache[string, map[string]struct{}]
+	caches      map[string]*lru.Cache[string, struct{}]
+	cacheSize   int
 	pluginState *plugin.PluginState
 	podList     func() []k8stypes.NamespacedName
 	mutex       sync.RWMutex
@@ -101,22 +123,19 @@ func (s *requestState) Clone() plugin.StateData {
 
 // New creates a Producer.
 func New(ctx context.Context, name string, params *Parameters, podList func() []k8stypes.NamespacedName) (*Producer, error) {
-	cacheSize := defaultCacheSize
-	if params != nil && params.CacheSize > 0 {
-		cacheSize = params.CacheSize
+	cacheSizeMB := 0
+	if params != nil {
+		cacheSizeMB = params.CacheSizeInMB
 	}
-
-	cache, err := lru.New[string, map[string]struct{}](cacheSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create multimodal encoder-cache LRU with size %d: %w", cacheSize, err)
-	}
+	cacheSize := lruCapacityFromCacheSizeMB(cacheSizeMB)
 
 	registerEncoderCacheMetrics()
 
 	p := &Producer{
 		typedName:   plugin.TypedName{Type: ProducerType, Name: name},
 		dk:          attrmm.EncoderCacheMatchInfoKey.WithNonEmptyProducerName(name),
-		cache:       cache,
+		caches:      make(map[string]*lru.Cache[string, struct{}]),
+		cacheSize:   cacheSize,
 		pluginState: plugin.NewPluginState(ctx),
 		podList:     podList,
 	}
@@ -124,6 +143,17 @@ func New(ctx context.Context, name string, params *Parameters, podList func() []
 		go p.cleanupLoop(ctx)
 	}
 	return p, nil
+}
+
+// getOrCreatePodCache returns the LRU cache for the given pod, creating one if absent.
+// Must be called with p.mutex held for write.
+func (p *Producer) getOrCreatePodCache(pod string) *lru.Cache[string, struct{}] {
+	if c, ok := p.caches[pod]; ok {
+		return c
+	}
+	c, _ := lru.New[string, struct{}](p.cacheSize)
+	p.caches[pod] = c
+	return c
 }
 
 func (p *Producer) cleanupLoop(ctx context.Context) {
@@ -271,30 +301,32 @@ func itemSlice(itemsByHash map[string]attrmm.MatchItem) []attrmm.MatchItem {
 	return items
 }
 
-// recordItemLookups increments the queries counter for each item and the hits
-// counter for each item whose hash is already tracked in the LRU.
+// recordItemLookups increments the queries counter for each item and, for every
+// endpoint whose LRU contains the hash, increments that endpoint's hits counter.
 // Contains is used instead of Get to avoid altering recency during a read-only path.
 func (p *Producer) recordItemLookups(items []attrmm.MatchItem) {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 	for _, item := range items {
 		encoderCacheQueriesTotal.Inc()
-		if p.cache.Contains(item.Hash) {
-			encoderCacheHitsTotal.Inc()
+		for pod, podCache := range p.caches {
+			if podCache.Contains(item.Hash) {
+				encoderCacheHitsTotal.WithLabelValues(pod).Inc()
+			}
 		}
 	}
 }
 
 func (p *Producer) matchedItemsForPod(pod string, requestItems []attrmm.MatchItem) []attrmm.MatchItem {
-	matchedItemsByHash := map[string]attrmm.MatchItem{}
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
+	podCache, ok := p.caches[pod]
+	if !ok {
+		return nil
+	}
+	matchedItemsByHash := map[string]attrmm.MatchItem{}
 	for _, item := range requestItems {
-		pods, ok := p.cache.Get(item.Hash)
-		if !ok {
-			continue
-		}
-		if _, ok := pods[pod]; ok {
+		if podCache.Contains(item.Hash) {
 			matchedItemsByHash[item.Hash] = item
 		}
 	}
@@ -316,21 +348,10 @@ func (p *Producer) removeStalePods() {
 
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	for _, hash := range p.cache.Keys() {
-		pods, ok := p.cache.Get(hash)
-		if !ok {
-			continue
+	for pod := range p.caches {
+		if _, ok := validPods[pod]; !ok {
+			delete(p.caches, pod)
 		}
-		for pod := range pods {
-			if _, ok := validPods[pod]; !ok {
-				delete(pods, pod)
-			}
-		}
-		if len(pods) == 0 {
-			p.cache.Remove(hash)
-			continue
-		}
-		p.cache.Add(hash, pods)
 	}
 }
 
@@ -353,16 +374,5 @@ func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error
 func (p *Producer) removePod(pod string) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	for _, hash := range p.cache.Keys() {
-		pods, ok := p.cache.Get(hash)
-		if !ok {
-			continue
-		}
-		delete(pods, pod)
-		if len(pods) == 0 {
-			p.cache.Remove(hash)
-			continue
-		}
-		p.cache.Add(hash, pods)
-	}
+	delete(p.caches, pod)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -38,11 +38,11 @@ import (
 func TestLRUCapacityFromCacheSizeMB(t *testing.T) {
 	assert.Equal(t, 2, lruCapacityFromCacheSizeMB(4))
 	assert.Equal(t, 1024, lruCapacityFromCacheSizeMB(2048))
-	assert.Equal(t, 1024, lruCapacityFromCacheSizeMB(0))
+	assert.Equal(t, 2048, lruCapacityFromCacheSizeMB(0))
 }
 
 func TestFactory(t *testing.T) {
-	raw, err := json.Marshal(map[string]any{"cacheSizeInMB": 4})
+	raw, err := json.Marshal(map[string]any{"cacheSizeInMBPerServer": 4})
 	require.NoError(t, err)
 
 	created, err := Factory("mm-producer", plugin.StrictDecoder(raw), &testHandle{ctx: context.Background()})
@@ -51,7 +51,7 @@ func TestFactory(t *testing.T) {
 	assert.Equal(t, "mm-producer", created.TypedName().Name)
 	assert.Equal(t, ProducerType, created.TypedName().Type)
 
-	_, err = Factory("bad", plugin.StrictDecoder(json.RawMessage(`{"cacheSizeInMB":"bad"}`)), &testHandle{ctx: context.Background()})
+	_, err = Factory("bad", plugin.StrictDecoder(json.RawMessage(`{"cacheSizeInMBPerServer":"bad"}`)), &testHandle{ctx: context.Background()})
 	require.Error(t, err)
 }
 
@@ -242,7 +242,7 @@ func TestProduceMatchesMultiplePodsAndPreRequestUpdatesPlacement(t *testing.T) {
 }
 
 func TestLRUEviction(t *testing.T) {
-	producer := newTestProducer(t, &Parameters{CacheSizeInMB: 4}, nil)
+	producer := newTestProducer(t, &Parameters{CacheSizeInMBPerServer: 4}, nil)
 	endpoint := newEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"})
 
 	for _, hash := range []string{"hash-1", "hash-2", "hash-3"} {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -35,8 +35,14 @@ import (
 	"github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
 )
 
+func TestLRUCapacityFromCacheSizeMB(t *testing.T) {
+	assert.Equal(t, 2, lruCapacityFromCacheSizeMB(4))
+	assert.Equal(t, 1024, lruCapacityFromCacheSizeMB(2048))
+	assert.Equal(t, 1024, lruCapacityFromCacheSizeMB(0))
+}
+
 func TestFactory(t *testing.T) {
-	raw, err := json.Marshal(map[string]any{"cacheSize": 4})
+	raw, err := json.Marshal(map[string]any{"cacheSizeInMB": 4})
 	require.NoError(t, err)
 
 	created, err := Factory("mm-producer", plugin.StrictDecoder(raw), &testHandle{ctx: context.Background()})
@@ -45,7 +51,7 @@ func TestFactory(t *testing.T) {
 	assert.Equal(t, "mm-producer", created.TypedName().Name)
 	assert.Equal(t, ProducerType, created.TypedName().Type)
 
-	_, err = Factory("bad", plugin.StrictDecoder(json.RawMessage(`{"cacheSize":"bad"}`)), &testHandle{ctx: context.Background()})
+	_, err = Factory("bad", plugin.StrictDecoder(json.RawMessage(`{"cacheSizeInMB":"bad"}`)), &testHandle{ctx: context.Background()})
 	require.Error(t, err)
 }
 
@@ -236,7 +242,7 @@ func TestProduceMatchesMultiplePodsAndPreRequestUpdatesPlacement(t *testing.T) {
 }
 
 func TestLRUEviction(t *testing.T) {
-	producer := newTestProducer(t, &Parameters{CacheSize: 2}, nil)
+	producer := newTestProducer(t, &Parameters{CacheSizeInMB: 4}, nil)
 	endpoint := newEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"})
 
 	for _, hash := range []string{"hash-1", "hash-2", "hash-3"} {

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/README.md
@@ -44,7 +44,7 @@ This plugin does not define any plugin-specific parameters.
 plugins:
   - type: mm-embeddings-cache-producer
     parameters:
-      cacheSize: 10000
+      cacheSizeInMB: 2048
   - type: mm-embeddings-cache-scorer
   - type: max-score-picker
 schedulingProfiles:

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/README.md
@@ -44,7 +44,7 @@ This plugin does not define any plugin-specific parameters.
 plugins:
   - type: mm-embeddings-cache-producer
     parameters:
-      cacheSizeInMB: 2048
+      cacheSizeInMBPerServer: 2048
   - type: mm-embeddings-cache-scorer
   - type: max-score-picker
 schedulingProfiles:


### PR DESCRIPTION


**What type of PR is this?**
/kind feature
/kind cleanup

**What this PR does / why we need it**:
This PR refactors the multimodal encoder-cache producer to use a per-endpoint cache structure and introduces metrics to track cache performance.

#### Key Changes:

1.  **Refactored Cache Architecture**: 
    - Shifted from a global `hash -> pod-set` map to individual LRU caches for each endpoint (`map[string]*lru.Cache`). 
    - This change ensures that eviction is scoped to each pod's specific affinity state, preventing a "noisy neighbor" effect where high churn on one endpoint could evict cache entries for others.

2.  **Memory-Aware Configuration**:
    - Replaced the `cacheSize` (entry count) parameter with `cacheSizeInMB`.
    - Added logic to calculate LRU capacity based on a mebibyte (MiB) budget (defaulting to 2048 MiB), assuming a fixed cost per tracked hash.

3.  **Performance Metrics**:
    - Introduced `llm_d_router_epp_encoder_cache_queries_total`: Tracks the total number of multimodal content lookups.
    - Introduced `llm_d_router_epp_encoder_cache_hits_total` (labeled by `pod`): Tracks successful matches in the LRU.
    - These metrics allow operators to calculate the item-level cache-warm rate for encoder-cache affinity routing.

4.  **Optimized Cleanup**:
    - Simplified the stale pod removal process. Instead of iterating through all hashes to prune pod sets, the producer now simply deletes the entire LRU instance for stale endpoints.


**Testing and validation**
Unit tests.
Metrics validation while running benchmarks:
<img width="1220" height="714" alt="image" src="https://github.com/user-attachments/assets/6ee34202-44aa-4c1c-997a-d0a1faacb51a" />
vLLM metrics aggregated across all pods for encoder cache

vs

<img width="1082" height="552" alt="image" src="https://github.com/user-attachments/assets/8df6c851-cb28-485d-9c72-0d21a3382b3b" />

newly added metrics in EPP

As we can see, the number align.

Benchmark numbers at 30 rps:
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-b56025cf-7fff-91b0-c998-330c9c8106b1"><div dir="ltr" style="margin-left:0pt;" align="left">
Metric | Without Encoder Cache | With Encoder Cache
-- | -- | --
p50 E2E (Median) | 0.176 s | 0.161 s
p90 E2E | 0.253 s | 0.223 s
p95 E2E | 0.285 s | 0.242 s
p99 E2E | 5.924 s | 0.286 s
Max E2E | 9.528 s | 0.398 s
Avg E2E | 0.344 s | 0.169 s

</div></b>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1384

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
updates the encoder cache size parameter name to cacheSizeInMB
```
