### PR TITLE
Allow skipped requests to go through scheduling profiles

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -30,10 +30,10 @@ type Parser interface {
 	// ParseRequest parses the request body and headers and returns the parsed result.
 	// There are three outcomes based on the return values:
 	// 1. err != nil: The request is invalid or cannot be parsed. The framework will fail the request early.
-	// 2. err == nil and result.Skip == true: The request is valid but EPP should stop intercepting the stream
+	// 2. err == nil and result.SkipResponseProcessing == true: The request is valid but EPP should stop intercepting the stream
 	//    after the request phase. The scheduling director will still route the request, but subsequent
 	//    response interception phases will be skipped.
-	// 3. err == nil and result.Skip == false: The request is valid and will be processed by the scheduling framework.
+	// 3. err == nil and result.SkipResponseProcessing == false: The request is valid and will be processed by the scheduling framework.
 	ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*ParseResult, error)
 
 	// ParseResponse parses the response payload.
@@ -52,7 +52,7 @@ type Parser interface {
 type ParseResult struct {
 	// Body contains the parsed inference request body.
 	Body *InferenceRequestBody
-	// Skip indicates whether to skip EPP stream interception for this request.
+	// SkipResponseProcessing indicates whether to skip EPP stream interception for this request.
 	// When set to true, the request will still go through the scheduling director
 	// (allowing routing decisions, profiles, and admission control to run),
 	// but the EPP will stop intercepting the stream after the request phase completes
@@ -60,7 +60,7 @@ type ParseResult struct {
 	//
 	// This allows fallback or non-standard requests to be routed using the configured
 	// policies without paying the overhead of response-phase interception.
-	Skip bool
+	SkipResponseProcessing bool
 }
 
 type ParsedResponse struct {

--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -30,9 +30,9 @@ type Parser interface {
 	// ParseRequest parses the request body and headers and returns the parsed result.
 	// There are three outcomes based on the return values:
 	// 1. err != nil: The request is invalid or cannot be parsed. The framework will fail the request early.
-	// 2. err == nil and result.Skip == true: The request is valid but should not be processed by the scheduling
-	//    framework (e.g., non-inference requests). The framework will fall back to routing the request to a random
-	//    endpoint and skip subsequent interception phases.
+	// 2. err == nil and result.Skip == true: The request is valid but EPP should stop intercepting the stream
+	//    after the request phase. The scheduling director will still route the request, but subsequent
+	//    response interception phases will be skipped.
 	// 3. err == nil and result.Skip == false: The request is valid and will be processed by the scheduling framework.
 	ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*ParseResult, error)
 
@@ -52,15 +52,14 @@ type Parser interface {
 type ParseResult struct {
 	// Body contains the parsed inference request body.
 	Body *InferenceRequestBody
-	// Skip indicates whether to skip the remaining processing phases in the EPP.
-	// This should only be used for non-inference related requests.
-	// When set to true, the request will bypass the scheduling director and will be
-	// routed to a random endpoint. The EPP will also stop intercepting the stream
-	// for this request (e.g., response headers and body will not be processed).
+	// Skip indicates whether to skip EPP stream interception for this request.
+	// When set to true, the request will still go through the scheduling director
+	// (allowing routing decisions, profiles, and admission control to run),
+	// but the EPP will stop intercepting the stream after the request phase completes
+	// (e.g., response headers and body will not be processed).
 	//
-	// Example: In a gRPC parser, if the request path does not match any known
-	// methods (e.g., neither Generate nor Embed for vLLM), setting Skip to true
-	// allows the request to proceed to a fallback endpoint without failing.
+	// This allows fallback or non-standard requests to be routed using the configured
+	// policies without paying the overhead of response-phase interception.
 	Skip bool
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -101,7 +101,7 @@ func (p *AnthropicParser) ParseRequest(_ context.Context, body []byte, headers m
 		result.Stream = true
 	}
 
-	return &fwkrh.ParseResult{Body: result, Skip: false}, nil
+	return &fwkrh.ParseResult{Body: result, SkipResponseProcessing: false}, nil
 }
 
 func (p *AnthropicParser) ParseResponse(_ context.Context, body []byte, headers map[string]string, _ bool) (*fwkrh.ParsedResponse, error) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -432,8 +432,8 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				return
 			}
 
-			if got.Skip != false {
-				t.Errorf("ParseRequest() got.Skip = %v, want false", got.Skip)
+			if got.SkipResponseProcessing != false {
+				t.Errorf("ParseRequest() got.SkipResponseProcessing = %v, want false", got.SkipResponseProcessing)
 			}
 
 			if diff := cmp.Diff(tt.want, got.Body); diff != "" {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -110,7 +110,7 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		extractedBody.Stream = true
 	}
-	return &fwkrh.ParseResult{Body: extractedBody, Skip: false}, nil
+	return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
 }
 
 // ParseResponse extracts usage metadata from the provider's response.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -809,8 +809,8 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				return
 			}
 
-			if got.Skip != false {
-				t.Errorf("ParseRequest() got.Skip = %v, want false", got.Skip)
+			if got.SkipResponseProcessing != false {
+				t.Errorf("ParseRequest() got.SkipResponseProcessing = %v, want false", got.SkipResponseProcessing)
 			}
 
 			if diff := cmp.Diff(tt.want, got.Body); diff != "" {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -72,7 +72,7 @@ func (p *PassthroughParser) ParseRequest(ctx context.Context, body []byte, heade
 		Body: &fwkrh.InferenceRequestBody{
 			Payload: fwkrh.RawPayload(body),
 		},
-		Skip: false,
+		SkipResponseProcessing: false,
 	}, nil
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
@@ -59,8 +59,8 @@ func TestPassthroughParser_ParseRequest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got.Skip != false {
-				t.Errorf("got.Skip = %v, want false", got.Skip)
+			if got.SkipResponseProcessing != false {
+				t.Errorf("got.SkipResponseProcessing = %v, want false", got.SkipResponseProcessing)
 			}
 			if diff := cmp.Diff(tt.wantBody, got.Body); diff != "" {
 				t.Errorf("Unexpected body (-want +got):\n%s", diff)

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -114,12 +114,7 @@ func (p *VertexAIParser) ParseRequest(ctx context.Context, body []byte, headers 
 		return p.parseVertexRequest(ctx, body, headers, &aiplatformpb.RawPredictRequest{}, "RawPredictRequest", openAIResponsesPath)
 
 	default:
-		return &fwkrh.ParseResult{
-			Body: &fwkrh.InferenceRequestBody{
-				Payload: fwkrh.RawPayload(body),
-			},
-			Skip: true,
-		}, nil
+		return &fwkrh.ParseResult{Skip: true}, nil
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -114,7 +114,12 @@ func (p *VertexAIParser) ParseRequest(ctx context.Context, body []byte, headers 
 		return p.parseVertexRequest(ctx, body, headers, &aiplatformpb.RawPredictRequest{}, "RawPredictRequest", openAIResponsesPath)
 
 	default:
-		return &fwkrh.ParseResult{Skip: true}, nil
+		return &fwkrh.ParseResult{
+			Body: &fwkrh.InferenceRequestBody{
+				Payload: fwkrh.RawPayload(body),
+			},
+			Skip: true,
+		}, nil
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -114,7 +114,7 @@ func (p *VertexAIParser) ParseRequest(ctx context.Context, body []byte, headers 
 		return p.parseVertexRequest(ctx, body, headers, &aiplatformpb.RawPredictRequest{}, "RawPredictRequest", openAIResponsesPath)
 
 	default:
-		return &fwkrh.ParseResult{Skip: true}, nil
+		return &fwkrh.ParseResult{SkipResponseProcessing: true}, nil
 	}
 }
 
@@ -172,5 +172,5 @@ func (p *VertexAIParser) parseVertexRequest(ctx context.Context, body []byte, he
 
 	inferenceRequestBody := parseResult.Body
 	inferenceRequestBody.Payload = fwkrh.PayloadProto{Message: req}
-	return &fwkrh.ParseResult{Body: inferenceRequestBody, Skip: parseResult.Skip}, nil
+	return &fwkrh.ParseResult{Body: inferenceRequestBody, SkipResponseProcessing: parseResult.SkipResponseProcessing}, nil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -114,7 +114,12 @@ func (p *VertexAIParser) ParseRequest(ctx context.Context, body []byte, headers 
 		return p.parseVertexRequest(ctx, body, headers, &aiplatformpb.RawPredictRequest{}, "RawPredictRequest", openAIResponsesPath)
 
 	default:
-		return &fwkrh.ParseResult{SkipResponseProcessing: true}, nil
+		return &fwkrh.ParseResult{
+			Body: &fwkrh.InferenceRequestBody{
+				Payload: fwkrh.RawPayload(body),
+			},
+			SkipResponseProcessing: true,
+		}, nil
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -140,6 +140,9 @@ func TestParseRequest(t *testing.T) {
 			body:    []byte{},
 			headers: map[string]string{":path": "/unsupported/path", "content-type": "application/grpc"},
 			wantResult: &fwkrh.ParseResult{
+				Body: &fwkrh.InferenceRequestBody{
+					Payload: fwkrh.RawPayload([]byte{}),
+				},
 				SkipResponseProcessing: true,
 			},
 		},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -140,9 +140,6 @@ func TestParseRequest(t *testing.T) {
 			body:    []byte{},
 			headers: map[string]string{":path": "/unsupported/path", "content-type": "application/grpc"},
 			wantResult: &fwkrh.ParseResult{
-				Body: &fwkrh.InferenceRequestBody{
-					Payload: fwkrh.RawPayload([]byte{}),
-				},
 				Skip: true,
 			},
 		},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -98,7 +98,7 @@ func TestParseRequest(t *testing.T) {
 					Stream:  true,
 					Payload: fwkrh.PayloadProto{Message: reqMsg},
 				},
-				Skip: false,
+				SkipResponseProcessing: false,
 			},
 		},
 		{
@@ -115,7 +115,7 @@ func TestParseRequest(t *testing.T) {
 					},
 					Payload: fwkrh.PayloadProto{Message: streamRawPredictReqMsg},
 				},
-				Skip: false,
+				SkipResponseProcessing: false,
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestParseRequest(t *testing.T) {
 					},
 					Payload: fwkrh.PayloadProto{Message: rawPredictReqMsg},
 				},
-				Skip: false,
+				SkipResponseProcessing: false,
 			},
 		},
 		{
@@ -140,7 +140,7 @@ func TestParseRequest(t *testing.T) {
 			body:    []byte{},
 			headers: map[string]string{":path": "/unsupported/path", "content-type": "application/grpc"},
 			wantResult: &fwkrh.ParseResult{
-				Skip: true,
+				SkipResponseProcessing: true,
 			},
 		},
 		{

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -140,6 +140,9 @@ func TestParseRequest(t *testing.T) {
 			body:    []byte{},
 			headers: map[string]string{":path": "/unsupported/path", "content-type": "application/grpc"},
 			wantResult: &fwkrh.ParseResult{
+				Body: &fwkrh.InferenceRequestBody{
+					Payload: fwkrh.RawPayload([]byte{}),
+				},
 				Skip: true,
 			},
 		},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -114,7 +114,12 @@ func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers 
 
 	default:
 		logger.V(logutil.TRACE).Info("unsupported gRPC path, skipping", "path", headers[parsers.MethodPathKey])
-		return &fwkrh.ParseResult{SkipResponseProcessing: true}, nil
+		return &fwkrh.ParseResult{
+			Body: &fwkrh.InferenceRequestBody{
+				Payload: fwkrh.RawPayload(body),
+			},
+			SkipResponseProcessing: true,
+		}, nil
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -98,7 +98,7 @@ func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers 
 			return nil, err
 		}
 		logger.V(logutil.TRACE).Info("parsed EmbedRequest")
-		return &fwkrh.ParseResult{Body: extractedBody, Skip: false}, nil
+		return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
 
 	case vllmGeneratePath:
 		var req pb.GenerateRequest
@@ -110,11 +110,11 @@ func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers 
 			return nil, err
 		}
 		logger.V(logutil.TRACE).Info("parsed GenerateRequest")
-		return &fwkrh.ParseResult{Body: extractedBody, Skip: false}, nil
+		return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
 
 	default:
 		logger.V(logutil.TRACE).Info("unsupported gRPC path, skipping", "path", headers[parsers.MethodPathKey])
-		return &fwkrh.ParseResult{Skip: true}, nil
+		return &fwkrh.ParseResult{SkipResponseProcessing: true}, nil
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -83,13 +83,13 @@ func TestVllmGRPCParser_PluginLifecycle(t *testing.T) {
 
 func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 	tests := []struct {
-		name          string
-		reqMsg        proto.Message
-		headers       map[string]string
-		malformedData []byte
-		wantErr       bool
-		wantSkip      bool
-		want          *fwkrh.InferenceRequestBody
+		name                       string
+		reqMsg                     proto.Message
+		headers                    map[string]string
+		malformedData              []byte
+		wantErr                    bool
+		wantSkipResponseProcessing bool
+		want                       *fwkrh.InferenceRequestBody
 	}{
 		{
 			name: "Valid Text Request",
@@ -306,10 +306,10 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
-			name:     "Unsupported Path skip",
-			reqMsg:   &pb.GenerateRequest{Input: &pb.GenerateRequest_Text{Text: "hello"}},
-			headers:  map[string]string{":path": "/unsupported/path"},
-			wantSkip: true,
+			name:                       "Unsupported Path skip",
+			reqMsg:                     &pb.GenerateRequest{Input: &pb.GenerateRequest_Text{Text: "hello"}},
+			headers:                    map[string]string{":path": "/unsupported/path"},
+			wantSkipResponseProcessing: true,
 		},
 		{
 			name:    "Embed Request missing tokenized input",
@@ -340,8 +340,8 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				return
 			}
 
-			if got.Skip != tt.wantSkip {
-				t.Errorf("got.Skip = %v, want %v", got.Skip, tt.wantSkip)
+			if got.SkipResponseProcessing != tt.wantSkipResponseProcessing {
+				t.Errorf("got.SkipResponseProcessing = %v, want %v", got.SkipResponseProcessing, tt.wantSkipResponseProcessing)
 			}
 
 			if diff := cmp.Diff(tt.want, got.Body, protocmp.Transform()); diff != "" {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -344,6 +344,12 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				t.Errorf("got.SkipResponseProcessing = %v, want %v", got.SkipResponseProcessing, tt.wantSkipResponseProcessing)
 			}
 
+			if tt.wantSkipResponseProcessing && tt.want == nil {
+				tt.want = &fwkrh.InferenceRequestBody{
+					Payload: fwkrh.RawPayload(payload),
+				}
+			}
+
 			if diff := cmp.Diff(tt.want, got.Body, protocmp.Transform()); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -125,5 +125,5 @@ func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResul
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		body.Stream = true
 	}
-	return &fwkrh.ParseResult{Body: body, Skip: false}, nil
+	return &fwkrh.ParseResult{Body: body, SkipResponseProcessing: false}, nil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -205,8 +205,8 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 			if tt.wantErr {
 				return
 			}
-			if got.Skip {
-				t.Errorf("ParseRequest() got.Skip = true, want false")
+			if got.SkipResponseProcessing {
+				t.Errorf("ParseRequest() got.SkipResponseProcessing = true, want false")
 			}
 			if diff := cmp.Diff(tt.want, got.Body); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -162,10 +162,10 @@ const (
 	// RequestEvicted indicates the request was evicted by flow control.
 	// The state machine sends an ImmediateResponse(429) to the proxy.
 	RequestEvicted StreamRequestState = 8
-	// RequestSkipped indicates the request parsing was skipped.
+	// RequestResponseProcessingSkipped indicates that EPP response-phase stream interception was skipped for this request.
 	// The state machine sends a RequestHeadersResponse and RequestBodyResponse with the routing decision
 	// from the scheduling director to the proxy, and then gracefully closes the stream to stop further external processing.
-	RequestSkipped StreamRequestState = 9
+	RequestResponseProcessingSkipped StreamRequestState = 9
 )
 
 // recvResult holds the result of a srv.Recv() call from the reader goroutine.
@@ -350,7 +350,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
-				if parseResult != nil && parseResult.Skip {
+				if parseResult != nil && parseResult.SkipResponseProcessing {
 					parseResult.Body = &fwkrh.InferenceRequestBody{
 						Payload: fwkrh.RawPayload(reqCtx.Request.RawBody),
 					}
@@ -379,8 +379,8 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				metrics.RecordRequestCounter(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Priority)
 				metrics.RecordRequestSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestSize)
 
-				if parseResult.Skip {
-					reqCtx.RequestState = RequestSkipped
+				if parseResult.SkipResponseProcessing {
+					reqCtx.RequestState = RequestResponseProcessingSkipped
 				}
 			}
 		case *extProcPb.ProcessingRequest_RequestTrailers:
@@ -453,7 +453,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		if err := reqCtx.updateStateAndSendIfNeeded(srv, logger); err != nil {
 			return err
 		}
-		if reqCtx.RequestState == RequestSkipped {
+		if reqCtx.RequestState == RequestResponseProcessingSkipped {
 			logger.V(logutil.DEFAULT).Info("EPP skipped response interception, routed request",
 				"targetEndpoint", reqCtx.TargetEndpoint,
 				"targetModel", reqCtx.TargetModelName)
@@ -539,7 +539,7 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 	}
 
 	// Handle skip — send response with the director's routing decision to the proxy.
-	if r.RequestState == RequestSkipped {
+	if r.RequestState == RequestResponseProcessingSkipped {
 		if r.reqHeaderResp != nil {
 			if err := srv.Send(r.reqHeaderResp); err != nil {
 				logger.Error(err, "error sending response")

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -350,12 +350,6 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
-				if parseResult != nil && parseResult.SkipResponseProcessing {
-					parseResult.Body = &fwkrh.InferenceRequestBody{
-						Payload: fwkrh.RawPayload(reqCtx.Request.RawBody),
-					}
-				}
-
 				reqCtx, err = s.director.HandleRequest(ctx, reqCtx, parseResult.Body)
 				if err != nil {
 					logger.Error(err, "Error handling request")

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -349,15 +349,6 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
-				if parseResult.Skip {
-					if err = s.fallbackToRandomEndpoint(ctx, reqCtx, reqCtx.RequestSize); err != nil {
-						logger.Error(err, "Error falling back to random endpoint")
-						break
-					}
-					reqCtx.RequestState = RequestSkipped
-					break
-				}
-
 				reqCtx, err = s.director.HandleRequest(ctx, reqCtx, parseResult.Body)
 				if err != nil {
 					logger.Error(err, "Error handling request")
@@ -380,6 +371,10 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				reqCtx.reqBodyResp = envoy.GenerateRequestBodyResponses(reqCtx.Request.RawBody)
 				metrics.RecordRequestCounter(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Priority)
 				metrics.RecordRequestSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestSize)
+
+				if parseResult.Skip {
+					reqCtx.RequestState = RequestSkipped
+				}
 			}
 		case *extProcPb.ProcessingRequest_RequestTrailers:
 			// This is currently unused.

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -160,10 +160,11 @@ const (
 	BodyResponseResponsesComplete    StreamRequestState = 6
 	TrailerResponseResponsesComplete StreamRequestState = 7
 	// RequestEvicted indicates the request was evicted by flow control.
-	// The state machine sends an ImmediateResponse(429) to Envoy.
+	// The state machine sends an ImmediateResponse(429) to the proxy.
 	RequestEvicted StreamRequestState = 8
 	// RequestSkipped indicates the request parsing was skipped.
-	// The state machine sends a RequestHeadersResponse and RequestBodyResponse with fallback routing(randomly pick an endpoint from inferencePool) to Envoy.
+	// The state machine sends a RequestHeadersResponse and RequestBodyResponse with the routing decision
+	// from the scheduling director to the proxy, and then gracefully closes the stream to stop further external processing.
 	RequestSkipped StreamRequestState = 9
 )
 
@@ -349,6 +350,12 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
+				if parseResult != nil && parseResult.Skip {
+					parseResult.Body = &fwkrh.InferenceRequestBody{
+						Payload: fwkrh.RawPayload(reqCtx.Request.RawBody),
+					}
+				}
+
 				reqCtx, err = s.director.HandleRequest(ctx, reqCtx, parseResult.Body)
 				if err != nil {
 					logger.Error(err, "Error handling request")
@@ -447,7 +454,9 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			return err
 		}
 		if reqCtx.RequestState == RequestSkipped {
-			logger.V(logutil.DEFAULT).Info("EPP skipped the request")
+			logger.V(logutil.DEFAULT).Info("EPP skipped response interception, routed request",
+				"targetEndpoint", reqCtx.TargetEndpoint,
+				"targetModel", reqCtx.TargetModelName)
 			// Gracefully close the gRPC stream to stop external processing for this request.
 			// This ensures Envoy continues with the request without calling further phases.
 			// See: https://github.com/envoyproxy/envoy/blob/0533de0acca281110945e5726bbb306fbb12bde5/api/envoy/service/ext_proc/v3/external_processor.proto#L40-L41
@@ -529,7 +538,7 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 		})
 	}
 
-	// Handle skip — send response with fallback routing to the proxy.
+	// Handle skip — send response with the director's routing decision to the proxy.
 	if r.RequestState == RequestSkipped {
 		if r.reqHeaderResp != nil {
 			if err := srv.Send(r.reqHeaderResp); err != nil {

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -402,7 +402,12 @@ type mockParser struct {
 
 func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
 	if m.skip {
-		return &fwkrh.ParseResult{SkipResponseProcessing: true, Body: nil}, nil
+		return &fwkrh.ParseResult{
+			SkipResponseProcessing: true,
+			Body: &fwkrh.InferenceRequestBody{
+				Payload: fwkrh.RawPayload(body),
+			},
+		}, nil
 	}
 	return &fwkrh.ParseResult{SkipResponseProcessing: false, Body: &fwkrh.InferenceRequestBody{}}, nil
 }

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -347,10 +347,12 @@ func recvResponseTrailers(stream pb.ExternalProcessor_ProcessClient) error {
 type testDirector struct {
 	requestHeaders                   map[string]string
 	handleResponseBodyEndStreamCount int
+	lastInferenceRequestBody         *fwkrh.InferenceRequestBody
 }
 
 func (ts *testDirector) HandleRequest(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (*handlers.RequestContext, error) {
 	ts.requestHeaders = reqCtx.Request.Headers
+	ts.lastInferenceRequestBody = inferenceRequestBody
 
 	bodyMap := make(map[string]any)
 	if err := json.Unmarshal(reqCtx.Request.RawBody, &bodyMap); err != nil {
@@ -399,7 +401,10 @@ type mockParser struct {
 }
 
 func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
-	return &fwkrh.ParseResult{Skip: m.skip, Body: &fwkrh.InferenceRequestBody{}}, nil
+	if m.skip {
+		return &fwkrh.ParseResult{Skip: true, Body: nil}, nil
+	}
+	return &fwkrh.ParseResult{Skip: false, Body: &fwkrh.InferenceRequestBody{}}, nil
 }
 
 func (m *mockParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*fwkrh.ParsedResponse, error) {
@@ -478,6 +483,13 @@ func TestServer_Skip(t *testing.T) {
 	// Verify that the director's HandleRequest was called even for skipped request
 	require.NotEmpty(t, director.requestHeaders, "HandleRequest should have been called for skipped request")
 	require.Equal(t, "test-request-id", director.requestHeaders["x-request-id"])
+
+	// Verify that the body was forced to have RawPayload
+	require.NotNil(t, director.lastInferenceRequestBody, "InferenceRequestBody should be non-nil")
+	require.NotNil(t, director.lastInferenceRequestBody.Payload, "Payload should be non-nil")
+	rawPayload, ok := director.lastInferenceRequestBody.Payload.(fwkrh.RawPayload)
+	require.True(t, ok, "Payload should be RawPayload")
+	require.Equal(t, []byte(`{"model":"test"}`), []byte(rawPayload), "Payload should match raw body")
 
 	cancel()
 	<-errChan

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -475,6 +475,10 @@ func TestServer_Skip(t *testing.T) {
 	_, err = process.Recv()
 	require.Error(t, err, "Expected error or EOF when receiving after skip")
 
+	// Verify that the director's HandleRequest was called even for skipped request
+	require.NotEmpty(t, director.requestHeaders, "HandleRequest should have been called for skipped request")
+	require.Equal(t, "test-request-id", director.requestHeaders["x-request-id"])
+
 	cancel()
 	<-errChan
 	testListener.Close()

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -402,9 +402,9 @@ type mockParser struct {
 
 func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
 	if m.skip {
-		return &fwkrh.ParseResult{Skip: true, Body: nil}, nil
+		return &fwkrh.ParseResult{SkipResponseProcessing: true, Body: nil}, nil
 	}
-	return &fwkrh.ParseResult{Skip: false, Body: &fwkrh.InferenceRequestBody{}}, nil
+	return &fwkrh.ParseResult{SkipResponseProcessing: false, Body: &fwkrh.InferenceRequestBody{}}, nil
 }
 
 func (m *mockParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*fwkrh.ParsedResponse, error) {


### PR DESCRIPTION
Currently, skipped requests (e.g. due to unsupported paths) immediately fall back to a random endpoint, bypassing the scheduling director completely. This PR routes skipped requests through the director so they can be scheduled via profiles to optimal endpoints.

### Changes
* **handlers/server**: Route skipped requests through `director.HandleRequest` instead of falling back immediately; mark `RequestState` as `RequestSkipped` at the end. And force skip==true ParseResult setting with RawPayload/
* **server_test**: Add assertions to `TestServer_Skip` to verify `HandleRequest` is called for skipped requests.