### PR TITLE
ci: rename lint-and-test job to test

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Run make verify-helm-charts
         run: make verify-helm-charts
 
-  lint-and-test:
+  test:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Renames the `lint-and-test` job in `ci-pr-checks.yaml` to `test`. The lint and govulncheck steps moved to the standalone `ci-lint.yaml` workflow in #1313, so the remaining job only runs unit, integration, and e2e tests. The old name no longer reflects what the job does.

No behavior change: same triggers, same steps, same `if` gating.

**Heads up for branch protection**: if `lint-and-test` is a required status check on `main`, the protection rule will need to be updated to `test` (or both names should be allowed during transition) so PRs do not block on a check that no longer reports.

**Which issue(s) this PR fixes**:

NONE

**Release note**:
```release-note
NONE
```