### PR TITLE
fix: isolate HTTP clients to prevent config pollution and secure TLS defaults

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/source/http/client.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/client.go
@@ -61,12 +61,6 @@ var (
 		MaxIdleConnsPerHost: maxIdleConnsPerHost,
 		// TODO: set additional timeouts, transport options, etc.
 	}
-	defaultClient = &client{
-		Client: http.Client{
-			Timeout:   timeout,
-			Transport: baseTransport,
-		},
-	}
 )
 
 type client struct {
@@ -79,7 +73,7 @@ func (cl *client) Get(ctx context.Context, target *url.URL, ep Addressable,
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
-	resp, err := defaultClient.Do(req)
+	resp, err := cl.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch data from %s: %w", ep.GetNamespacedName(), err)
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"reflect"
 	"runtime/debug"
@@ -65,16 +66,22 @@ func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
 	if scheme != "http" && scheme != "https" {
 		return nil, fmt.Errorf("unsupported scheme: %s", scheme)
 	}
+	cl := &client{
+		Client: http.Client{
+			Timeout:   timeout,
+			Transport: baseTransport,
+		},
+	}
 	if scheme == "https" {
 		httpsTransport := baseTransport.Clone()
 		httpsTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipCertVerification}
-		defaultClient.Transport = httpsTransport
+		cl.Transport = httpsTransport
 	}
 	return &HTTPDataSource[T]{
 		typedName: fwkplugin.TypedName{Type: pluginType, Name: pluginName},
 		scheme:    scheme,
 		path:      path,
-		client:    defaultClient,
+		client:    cl,
 		parser:    parser,
 	}, nil
 }

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+you may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPDataSource_ClientIsolation(t *testing.T) {
+	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
+
+	// Create first HTTPS datasource, insecureSkipVerify = false
+	ds1, err := NewHTTPDataSource[any]("https", "/metrics", false, "test-type", "ds1", parser)
+	assert.NoError(t, err)
+
+	// Create second HTTPS datasource, insecureSkipVerify = true
+	ds2, err := NewHTTPDataSource[any]("https", "/metrics", true, "test-type", "ds2", parser)
+	assert.NoError(t, err)
+
+	// Verify ds1 uses isolated transport config
+	cl1, ok := ds1.client.(*client)
+	assert.True(t, ok)
+	t1, ok := cl1.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.NotNil(t, t1.TLSClientConfig)
+	assert.False(t, t1.TLSClientConfig.InsecureSkipVerify)
+
+	// Verify ds2 uses isolated transport config and does not pollute ds1
+	cl2, ok := ds2.client.(*client)
+	assert.True(t, ok)
+	t2, ok := cl2.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.NotNil(t, t2.TLSClientConfig)
+	assert.True(t, t2.TLSClientConfig.InsecureSkipVerify)
+
+	// Verify ds1 remains false (no configuration pollution)
+	assert.False(t, t1.TLSClientConfig.InsecureSkipVerify)
+}


### PR DESCRIPTION
…defaults

**What type of PR is this?**
 
/kind bug
 

**What this PR does / why we need it**:

Issue Trigger Scenario
 Configuring multiple HTTPS  metrics-data-source  or  models-data-source  instances with different  insecureSkipVerify  values in same process.
example:

    apiVersion: llm-d.ai/v1alpha1
    kind: EndpointPickerConfig
    plugins:
      - type: metrics-data-source
        name: secure-metrics-source      
        parameters:
          scheme: https
          path: /metrics
          insecureSkipVerify: false      <-----

      - type: metrics-data-source
        name: dev-metrics-source        
        parameters:
          scheme: https
          path: /metrics
          insecureSkipVerify: true     <----

      - type: core-metrics-extractor
        name: core-metrics-extractor

    dataLayer:
      sources:
        - pluginRef: secure-metrics-source
          extractors:
            - pluginRef: core-metrics-extractor
        - pluginRef: dev-metrics-source
          extractors:
            - pluginRef: core-metrics-extractor
            
            
            
Symptoms
  • Data source TLS configurations overwrite each other.
  • Self-signed certificate endpoints fail handshakes due to enabled verification, or secure endpoints skip verification, raising security risks.
  • Router picker fails to collect pod metrics, degrading routing accuracy.

Root Cause
  • datasource.go mutates shared package-level  defaultClient.Transport .
             defaultClient.Transport = httpsTransport
             
  • client.go invokes shared  defaultClient.Do(req)  instead of method receiver  cl.Do(req) .


 How it is fixed:
   Instantiated separate  client  struct for each data source instance in  NewHTTPDataSource .



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
