### PR TITLE
fix: disagg multi-modal input content

### DIFF
--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -445,7 +445,7 @@ The `always-disagg-multimodal-decider` triggers encode disaggregation whenever t
 > [!NOTE]
 > This plugin accepts no parameters.
 
-It checks for the presence of `image_url`, `video_url`, or `input_audio` content blocks in the chat-completions request body. If any multimodal content is found, the encode stage is activated.
+It checks for the presence of `image_url`, `audio_url`, `video_url`, or `input_audio` content blocks in the chat-completions request body. If any multimodal content is found, the encode stage is activated.
 
 ---
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -148,7 +148,16 @@ func TestHasMultimodalContent(t *testing.T) {
 		{"text only", chatRequest(false, false, false), false},
 		{"image", chatRequest(true, false, false), true},
 		{"video", chatRequest(false, true, false), true},
-		{"audio", chatRequest(false, false, true), true},
+		{"audio input_audio", chatRequest(false, false, true), true},
+		{"audio audio_url", &scheduling.InferenceRequest{
+			Body: &fwkrh.InferenceRequestBody{
+				ChatCompletions: &fwkrh.ChatCompletionsRequest{
+					Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{
+						Structured: []fwkrh.ContentBlock{{Type: "audio_url"}},
+					}}},
+				},
+			},
+		}, true},
 		{"all types", chatRequest(true, true, true), true},
 	}
 	for _, tt := range tests {

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/multimodal_helpers.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/multimodal_helpers.go
@@ -12,7 +12,8 @@ func hasMultimodalContent(request *scheduling.InferenceRequest) bool {
 	for _, msg := range request.Body.ChatCompletions.Messages {
 		// See https://github.com/vllm-project/vllm/blob/main/docs/features/multimodal_inputs.md#online-serving
 		for _, block := range msg.Content.Structured {
-			if block.Type == "image_url" || block.Type == "video_url" || block.Type == "input_audio" {
+			if block.Type == "image_url" || block.Type == "video_url" ||
+				block.Type == "input_audio" || block.Type == "audio_url" {
 				return true
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`hasMultimodalContent()` was missing `"audio_url"` from its content-type check. vLLM supports two distinct audio input formats:
- `input_audio` — OpenAI-style inline base64 audio
- `audio_url` — URL-based audio, analogous to `image_url`

Without this fix, requests using `audio_url` silently bypass the encode stage: `hasMultimodalContent()` returns `false`, so `always-disagg-multimodal-decider` skips the encode worker entirely.
- ref: https://github.com/vllm-project/vllm/blob/main/docs/features/multimodal_inputs.md

**Which issue(s) this PR fixes**: related to #608

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fix encode disaggregation not triggering for `audio_url` content type requests
```
