### PR TITLE
fix(epd): add missing video_url to sidecar mmTypes after EPP encode routing

### DIFF
--- a/pkg/sidecar/proxy/connector_epd_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_epd_shared_storage.go
@@ -30,6 +30,7 @@ import (
 var mmTypes = map[string]bool{
 	"image_url":   true,
 	"audio_url":   true,
+	"video_url":   true,
 	"input_audio": true,
 }
 
@@ -112,6 +113,12 @@ func mmItemURL(item map[string]any) string {
 		}
 	case "audio_url":
 		if m, ok := item["audio_url"].(map[string]any); ok {
+			if u, ok := m["url"].(string); ok {
+				return u
+			}
+		}
+	case "video_url":
+		if m, ok := item["video_url"].(map[string]any); ok {
 			if u, ok := m["url"].(string); ok {
 				return u
 			}

--- a/pkg/sidecar/proxy/connector_epd_shared_storage_test.go
+++ b/pkg/sidecar/proxy/connector_epd_shared_storage_test.go
@@ -117,6 +117,25 @@ func TestExtractMMItems(t *testing.T) {
 			},
 			expected: 1,
 		},
+		{
+			name: "single video item",
+			request: map[string]any{
+				"messages": []any{
+					map[string]any{
+						"role": "user",
+						"content": []any{
+							map[string]any{
+								"type": "video_url",
+								"video_url": map[string]any{
+									"url": "https://example.com/video.mp4",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -204,6 +223,16 @@ func TestMMItemURL(t *testing.T) {
 			expected: "https://example.com/audio.mp3",
 		},
 		{
+			name: "video_url with url",
+			item: map[string]any{
+				"type": "video_url",
+				"video_url": map[string]any{
+					"url": "https://example.com/video.mp4",
+				},
+			},
+			expected: "https://example.com/video.mp4",
+		},
+		{
 			name: "input_audio has no url",
 			item: map[string]any{
 				"type": "input_audio",
@@ -239,6 +268,11 @@ func TestMMItemURL(t *testing.T) {
 // imageURLItem builds an image_url content item.
 func imageURLItem(url string) map[string]any {
 	return map[string]any{"type": "image_url", "image_url": map[string]any{"url": url}}
+}
+
+// videoURLItem builds a video_url content item.
+func videoURLItem(url string) map[string]any {
+	return map[string]any{"type": "video_url", "video_url": map[string]any{"url": url}}
 }
 
 // inlineAudioItem builds an input_audio content item.
@@ -289,6 +323,11 @@ func TestFanoutEncoderPrimerDeduplication(t *testing.T) {
 		{
 			name:          "duplicate image URLs — second is skipped",
 			request:       userMessageRequest(imageURLItem("https://example.com/same.jpg"), imageURLItem("https://example.com/same.jpg")),
+			expectedCalls: 1,
+		},
+		{
+			name:          "duplicate video URLs — second is skipped",
+			request:       userMessageRequest(videoURLItem("https://example.com/same.mp4"), videoURLItem("https://example.com/same.mp4")),
 			expectedCalls: 1,
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
 
/kind bug
 

**What this PR does / why we need it**:


Issue:
  User submits multi-modal Chat Completions request containing  video_url  block. EPP routes request to sidecar
  with encoder endpoints.
  Video disaggregated encoding fails to execute. Request bypasses encoder stage, going directly to
  prefill/decoder stages without video embeddings, breaking disaggregated inference.

Root Cause:
Prior work (#732, #777, docs) established that video_url should trigger encode disaggregation in E/PD, but no PR implemented Sidecar handling.
On the E/PD encode path, the sidecar’s mmTypes map in connector_epd_shared_storage.go does not include  "video_url"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
