### PR TITLE
epp: improve configuration logging formatting

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -1044,8 +1044,16 @@ func toRawMap(cfg *configapi.EndpointPickerConfig) map[string]any {
 		return nil
 	}
 	var rawMap map[string]any
-	if bytes, err := json.Marshal(cfg); err == nil {
-		_ = json.Unmarshal(bytes, &rawMap)
+	bytes, err := json.Marshal(cfg)
+	if err != nil {
+		return map[string]any{
+			"error": fmt.Sprintf("failed to marshal raw config: %v", err),
+		}
+	}
+	if err := json.Unmarshal(bytes, &rawMap); err != nil {
+		return map[string]any{
+			"error": fmt.Sprintf("failed to unmarshal raw config map: %v", err),
+		}
 	}
 	return rawMap
 }

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -284,7 +285,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		setupLog.Error(err, "Failed to parse configuration")
 		return nil, nil, err
 	}
-	setupLog.Info("Raw config after phase one", "config", rawConfig)
+	setupLog.Info("Raw config after phase one", "config", toRawMap(rawConfig))
 
 	useNewMetrics := !r.featureGates[datalayer.EnableLegacyMetricsFeatureGate]
 	epf := r.setupMetricsCollection(useNewMetrics, opts, pmc)
@@ -1036,4 +1037,15 @@ func serveMetrics(ctx context.Context, port int, enablePprof bool) error {
 		return fmt.Errorf("metrics server: %w", err)
 	}
 	return nil
+}
+
+func toRawMap(cfg *configapi.EndpointPickerConfig) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+	var rawMap map[string]any
+	if bytes, err := json.Marshal(cfg); err == nil {
+		_ = json.Unmarshal(bytes, &rawMap)
+	}
+	return rawMap
 }

--- a/pkg/epp/config/config.go
+++ b/pkg/epp/config/config.go
@@ -39,10 +39,9 @@ func (c *Config) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp Config
 	return fmt.Sprintf("%+v", temp(*c))
 }
-

--- a/pkg/epp/config/config.go
+++ b/pkg/epp/config/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol"
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
@@ -32,3 +34,15 @@ type Config struct {
 	FlowControlConfig  *flowcontrol.Config
 	ParserConfig       *handlers.Config
 }
+
+func (c *Config) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp Config
+	return fmt.Sprintf("%+v", temp(*c))
+}
+

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -34,7 +34,7 @@ func (c *Config) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp Config
@@ -52,10 +52,9 @@ type DataSourceConfig struct {
 }
 
 func (dsc DataSourceConfig) String() string {
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp DataSourceConfig
 	return fmt.Sprintf("%+v", temp(dsc))
 }
-

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package datalayer
 
 import (
+	"fmt"
+
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
@@ -28,6 +30,17 @@ type Config struct {
 	Sources []DataSourceConfig // the data sources configured in the data layer
 }
 
+func (c *Config) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp Config
+	return fmt.Sprintf("%+v", temp(*c))
+}
+
 // DataSourceConfig defines the configuration of a specific DataSource.
 // Plugin may be a DataSource (notification, endpoint) or a PollingDispatcher;
 // the framework type-asserts to the right variant at Configure time.
@@ -37,3 +50,12 @@ type DataSourceConfig struct {
 	Plugin     plugin.Plugin   // the source plugin instance (DataSource or PollingDispatcher)
 	Extractors []plugin.Plugin // extractors defined for the data source
 }
+
+func (dsc DataSourceConfig) String() string {
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp DataSourceConfig
+	return fmt.Sprintf("%+v", temp(dsc))
+}
+

--- a/pkg/epp/flowcontrol/config.go
+++ b/pkg/epp/flowcontrol/config.go
@@ -41,13 +41,12 @@ func (c *Config) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp Config
 	return fmt.Sprintf("%+v", temp(*c))
 }
-
 
 // NewConfigFromAPI creates a new Config by translating the top-level API configuration.
 func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig, handle plugin.Handle) (*Config, error) {

--- a/pkg/epp/flowcontrol/config.go
+++ b/pkg/epp/flowcontrol/config.go
@@ -37,6 +37,18 @@ type Config struct {
 	UsageLimitPolicy flowcontrol.UsageLimitPolicy
 }
 
+func (c *Config) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp Config
+	return fmt.Sprintf("%+v", temp(*c))
+}
+
+
 // NewConfigFromAPI creates a new Config by translating the top-level API configuration.
 func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig, handle plugin.Handle) (*Config, error) {
 	registryConfig, err := registry.NewConfigFromAPI(apiConfig, handle)

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -52,13 +52,12 @@ func (c *Config) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp Config
 	return fmt.Sprintf("%+v", temp(*c))
 }
-
 
 // ConfigOption is a functional option for configuring the FlowController.
 type ConfigOption func(*Config)

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -48,6 +48,18 @@ type Config struct {
 	EnqueueChannelBufferSize int
 }
 
+func (c *Config) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp Config
+	return fmt.Sprintf("%+v", temp(*c))
+}
+
+
 // ConfigOption is a functional option for configuring the FlowController.
 type ConfigOption func(*Config)
 

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -151,7 +151,7 @@ func (c *Config) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp Config
@@ -198,13 +198,12 @@ func (p *PriorityBandConfig) String() string {
 	if p == nil {
 		return "<nil>"
 	}
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp PriorityBandConfig
 	return fmt.Sprintf("%+v", temp(*p))
 }
-
 
 // --- Config Functional Options ---
 

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -147,9 +147,20 @@ type Config struct {
 	PriorityBandGCTimeout time.Duration
 }
 
+func (c *Config) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp Config
+	return fmt.Sprintf("%+v", temp(*c))
+}
+
 // PriorityBandConfig defines the configuration template for a single priority band.
 // A "Band" is defined as the collection (or range) of all flows having the same priority level.
-// It establishes the default behaviors (such as queueing and dispatch policies) and total capacity limits for all flows
+// It establishes the default behaviors (such as queueing and dispatch behaviors) and total capacity limits for all flows
 // that operate at this priority level.
 type PriorityBandConfig struct {
 	// Priority is the unique numerical priority level for this band.
@@ -182,6 +193,18 @@ type PriorityBandConfig struct {
 	// Optional: Defaults to defaultPriorityBandMaxRequests (5000).
 	MaxRequests uint64
 }
+
+func (p *PriorityBandConfig) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp PriorityBandConfig
+	return fmt.Sprintf("%+v", temp(*p))
+}
+
 
 // --- Config Functional Options ---
 

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -22,7 +22,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
-// Config holds the configuration for the SaturationDetector.
+// Config holds the configuration for the Parser.
 type Config struct {
 	Parser fwkrh.Parser
 }
@@ -31,7 +31,7 @@ func (c *Config) String() string {
 	if c == nil {
 		return "<nil>"
 	}
-	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
 	// A new type definition inherits the struct fields but does not copy its methods,
 	// bypassing the Stringer check and allowing a safe reflection-based field dump.
 	type temp Config
@@ -41,4 +41,3 @@ func (c *Config) String() string {
 func NewParser(config *Config) fwkrh.Parser {
 	return config.Parser
 }
-

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package handlers
 
 import (
+	"fmt"
+
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
@@ -25,6 +27,18 @@ type Config struct {
 	Parser fwkrh.Parser
 }
 
+func (c *Config) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	// Define a local type alias to prevent infinite recursion when calling Sprintf("%+v").
+	// A new type definition inherits the struct fields but does not copy its methods,
+	// bypassing the Stringer check and allowing a safe reflection-based field dump.
+	type temp Config
+	return fmt.Sprintf("%+v", temp(*c))
+}
+
 func NewParser(config *Config) fwkrh.Parser {
 	return config.Parser
 }
+


### PR DESCRIPTION
Format rawConfig as unstructured map in Phase 1 log to bypass the runtime.Object check and output as structured JSON. For Phase 2, log eppConfig directly and implement custom String() methods 

Without these, the logs are basically empty, see below

Example phase 1 log without the fix:
```
{
  "insertId": "mdflv96bt0snwe3u",
  "jsonPayload": {
    "configError": "got runtime.Object without object metadata: {Plugins: [{Name: cpu-prefix-cache-producer, Type: approx-prefix-cache-producer, Parameters: {\"autoTune\":false,\"lruCapacityPerServer\":82000}} {Name: queue-scorer, Type: queue-scorer} {Name: kv-cache-utilization-scorer, Type: kv-cache-utilization-scorer} {Name: gpu-prefix-cache-scorer, Type: prefix-cache-scorer} {Name: cpu-prefix-cache-scorer, Type: prefix-cache-scorer, Parameters: {\"prefixMatchInfoProducerName\":\"cpu-prefix-cache-producer\"}}], SchedulingProfiles: [{Name: default, Plugins: [{PluginRef: queue-scorer, Weight: 2.00} {PluginRef: kv-cache-utilization-scorer, Weight: 2.00} {PluginRef: gpu-prefix-cache-scorer, Weight: 1.00} {PluginRef: cpu-prefix-cache-scorer, Weight: 1.00}]}]}",
    "caller": "runner/runner.go:287",
    "config": {
      "apiVersion": "llm-d.ai/v1alpha1",
      "kind": "EndpointPickerConfig"
    },
    "msg": "Raw config after phase one",
    "level": "info",
    "logger": "setup",
    "ts": 1779981926.4215925
  },
}
```

Example phase1 log after the fix:

```
2026-05-28T16:44:19Z    INFO    setup   Raw config after phase one    {"config": {"apiVersion":"llm-d.ai/v1alpha1","dataLayer":null,"kind":"EndpointPickerConfig","plugins":[{"name":"disagg-headers-handler","parameters":null,"type":"disagg-headers-handler\"},{\"name\":\"always-disagg-pd-decider\",\"parameters\":null,\"type\":\"always-disagg-pd-decider\"},{\"name\":\"disagg-profile-handler\",\"parameters\":{\"deciderPluginName\":\"always-disagg-pd-decider\"},\"type\":\"disagg-profile-handler\"},{\"name\":\"prefill-filter\",\"parameters\":null,\"type\":\"prefill-filter\"},{\"name\":\"decode-filter\",\"parameters\":null,\"type\":\"decode-filter\"},{\"name\":\"prefix-cache-scorer\",\"parameters\":null,\"type\":\"prefix-cache-scorer\"},{\"name\":\"queue-scorer\",\"parameters\":null,\"type\":\"queue-scorer\"},{\"name\":\"kv-cache-utilization-scorer\",\"parameters\":null,\"type\":\"kv-cache-utilization-scorer\"},{\"name\":\"active-request-scorer\",\"parameters\":null,\"type\":\"active-request-scorer\"},{\"name\":\"max-score-picker\",\"parameters\":null,\"type\":\"max-score-picker\"}],\"schedulingProfiles\":[{\"name\":\"prefill\",\"plugins\":[{\"pluginRef\":\"prefill-filter\",\"weight\":null},{\"pluginRef\":\"prefix-cache-scorer\",\"weight\":3},{\"pluginRef\":\"queue-scorer\",\"weight\":2},{\"pluginRef\":\"kv-cache-utilization-scorer\",\"weight\":2},{\"pluginRef\":\"max-score-picker\",\"weight\":null}]},{\"name\":\"decode\",\"plugins\":[{\"pluginRef\":\"decode-filter\",\"weight\":null},{\"pluginRef\":\"active-request-scorer\",\"weight\":2},{\"pluginRef\":\"prefix-cache-scorer\",\"weight\":null},{\"pluginRef\":\"max-score-picker\",\"weight\":null}]}]}}
```

Example phase 2 log without the fix:
```
Also fix this, you can see that the "config" log is empty.

{
  "insertId": "g8pwi3qvdjz9yxst",
  "jsonPayload": {
    "msg": "EPP config after phase two",
    "caller": "runner/runner.go:315",
    "config": {
      "SchedulerConfig": {},
      "DataConfig": {
        "Sources": [
          {
            "Plugin": {},
            "Extractors": [
              {}
            ]
          }
        ]
      },
      "SaturationDetector": {},
      "FlowControlConfig": null,
      "ParserConfig": {
        "Parser": {}
      }
    },
    "level": "info",
    "logger": "setup",
    "ts": 1779981926.6385272
  },
}
```

example log after fix:
```
2026-05-28T16:44:19Z    INFO    setup   EPP config after phase two    {"config": "{SchedulerConfig:{ProfileHandler: disagg-profile-handler/disagg-profile-handler, Profiles: map[decode:{Filters: [decode-filter/by-label], Scorers: [active-request-scorer/active-request-scorer: 2.000000, prefix-cache-scorer/prefix-cache-scorer: 1.000000], Picker: max-score-picker/max-score-picker} prefill:{Filters: [prefill-filter/by-label], Scorers: [prefix-cache-scorer/prefix-cache-scorer: 3.000000, queue-scorer/queue-scorer: 2.000000, kv-cache-utilization-scorer/kv-cache-utilization-scorer: 2.000000], Picker: max-score-picker/max-score-picker}]} SaturationDetector:0xc000c92e00 DataConfig:{Sources:[{Plugin:0xc00017f830 Extractors:[0xc000c93140]}]} FlowControlConfig:<nil> ParserConfig:{Parser:0xc000bb03e0}}\"}
```

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
