### PR TITLE
feat(sidecar): remove deprecated --inference-pool-name and --inference-pool-namespace flags

### DIFF
--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -64,13 +64,9 @@ const (
 	encoderUseTLS                  = "UseTLSForEncoder"
 	prefillerTLSInsecureSkipVerify = "prefiller-tls-insecure-skip-verify"
 	decoderTLSInsecureSkipVerify   = "decoder-tls-insecure-skip-verify"
-	inferencePoolNamespace         = "inference-pool-namespace"
-	inferencePoolName              = "inference-pool-name"
 
 	// Environment variables
 	envInferencePool           = "INFERENCE_POOL"
-	envInferencePoolNamespace  = "INFERENCE_POOL_NAMESPACE"
-	envInferencePoolName       = "INFERENCE_POOL_NAME"
 	envEnablePrefillerSampling = "ENABLE_PREFILLER_SAMPLING"
 
 	// Defaults
@@ -179,8 +175,6 @@ func NewOptions() *Options {
 			EnablePrefillerSampling: enablePrefillerSampling,
 			MaxIdleConnsPerHost:     defaultMaxIdleConnsPerHost,
 			PoolGroup:               routing.InferencePoolAPIGroup,
-			InferencePoolNamespace:  os.Getenv(envInferencePoolNamespace),
-			InferencePoolName:       os.Getenv(envInferencePoolName),
 			DecodeChunkSize:         0,
 		},
 		vllmPort:      defaultVLLMPort,
@@ -231,10 +225,6 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.decoderInsecureSkipVerify, decoderTLSInsecureSkipVerify, opts.decoderInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=decoder instead. Skip TLS verification for requests to decoder.")
 	_ = fs.MarkDeprecated(decoderTLSInsecureSkipVerify, "use --tls-insecure-skip-verify=decoder instead")
 
-	fs.StringVar(&opts.InferencePoolNamespace, inferencePoolNamespace, opts.InferencePoolNamespace, "Deprecated: use --inference-pool instead. The Kubernetes namespace for the InferencePool (defaults to INFERENCE_POOL_NAMESPACE env var)")
-	_ = fs.MarkDeprecated(inferencePoolNamespace, "use --inference-pool instead")
-	fs.StringVar(&opts.InferencePoolName, inferencePoolName, opts.InferencePoolName, "Deprecated: use --inference-pool instead. The specific InferencePool name (defaults to INFERENCE_POOL_NAME env var)")
-	_ = fs.MarkDeprecated(inferencePoolName, "use --inference-pool instead")
 	fs.IntVar(&opts.MaxIdleConnsPerHost, "max-idle-conns-per-host", opts.MaxIdleConnsPerHost, "max idle keep-alive connections per host for reverse proxy transports; set to at least the expected concurrency")
 	fs.StringVar(&opts.inlineConfiguration, inlineConfiguration, "", "Sidecar configuration in YAML provided as inline specification. Example `--configuration={port: 8085, vllm-port: 8203}. Inline configuration and file configuration are mutually exclusive.`")
 	fs.StringVar(&opts.fileConfiguration, configurationFile, "", "Path to file which contains sidecar configuration in YAML. Example `--configuration-file=/etc/config/sidecar-config.yaml`. Inline configuration and file configuration are mutually exclusive.")
@@ -264,7 +254,7 @@ func (opts *Options) Complete() error {
 		opts.KVConnector = opts.connector
 	}
 
-	// Parse inferencePool field (namespace/name or just name), overriding deprecated separate flags
+	// Parse inferencePool field (namespace/name or just name) into Config.
 	if opts.inferencePool != "" {
 		parts := strings.SplitN(opts.inferencePool, "/", 2)
 		if len(parts) == 2 {
@@ -362,11 +352,8 @@ func (opts *Options) Validate() error {
 
 	// Validate SSRF protection requirements
 	if opts.EnableSSRFProtection {
-		if opts.InferencePoolNamespace == "" {
-			return errors.New("--inference-pool, --inference-pool-namespace, INFERENCE_POOL, or INFERENCE_POOL_NAMESPACE environment variable is required when --enable-ssrf-protection is true")
-		}
-		if opts.InferencePoolName == "" {
-			return errors.New("--inference-pool, --inference-pool-name, INFERENCE_POOL, or INFERENCE_POOL_NAME environment variable is required when --enable-ssrf-protection is true")
+		if opts.InferencePoolNamespace == "" || opts.InferencePoolName == "" {
+			return errors.New("--inference-pool flag or INFERENCE_POOL environment variable is required when --enable-ssrf-protection is true")
 		}
 	}
 

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -431,8 +431,8 @@ func compareOptions(t *testing.T, expected, actual *Options) {
 	assertEqual(secureServing, expected.SecureServing, actual.SecureServing)
 
 	assertEqual(inferencePool, expected.inferencePool, actual.inferencePool)
-	assertEqual(inferencePoolNamespace, expected.InferencePoolNamespace, actual.InferencePoolNamespace)
-	assertEqual(inferencePoolName, expected.InferencePoolName, actual.InferencePoolName)
+	assertEqual("InferencePoolNamespace", expected.InferencePoolNamespace, actual.InferencePoolNamespace)
+	assertEqual("InferencePoolName", expected.InferencePoolName, actual.InferencePoolName)
 	assertEqual(poolGroup, expected.PoolGroup, actual.PoolGroup)
 
 	assertEqual(decodeChunkSize, expected.DecodeChunkSize, actual.DecodeChunkSize)
@@ -531,11 +531,11 @@ func compareSlices(expected, got []string) (bool, []string, []string) {
 
 func TestNewOptionsWithEnvVars(t *testing.T) {
 	// Set environment variables - t.Setenv automatically handles cleanup
-	t.Setenv("INFERENCE_POOL_NAMESPACE", "test-namespace")
-	t.Setenv("INFERENCE_POOL_NAME", "test-pool")
+	t.Setenv("INFERENCE_POOL", "test-namespace/test-pool")
 	t.Setenv("ENABLE_PREFILLER_SAMPLING", "true")
 
 	opts := NewOptions()
+	require.NoError(t, opts.Complete())
 
 	if opts.InferencePoolNamespace != "test-namespace" {
 		t.Errorf("Expected InferencePoolNamespace to be 'test-namespace', got '%s'", opts.InferencePoolNamespace)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Removes the deprecated sidecar CLI flags `--inference-pool-name` and `--inference-pool-namespace` and their backing environment variables. The pre-existing `--inference-pool` flag (and `INFERENCE_POOL` env var) accepts
`namespace/name` (or just `name`) and has been the recommended way to select the InferencePool since the deprecation landed; this PR makes it the only way.

The SSRF-protection error message that referenced all four flag/env combinations is collapsed to mention only `--inference-pool` / `INFERENCE_POOL`. The env-var unit test is updated accordingly.

No new flags or environment variables are introduced.

**Which issue(s) this PR fixes**:

Refs #965

**Release note**:
```release-note
Removed deprecated sidecar flags `--inference-pool-name` and `--inference-pool-namespace`, and their environment variables `INFERENCE_POOL_NAME` and `INFERENCE_POOL_NAMESPACE`. Use the existing `--inference-pool` flag (or `INFERENCE_POOL` environment variable) with a `namespace/name` or `name` value instead.
```