### PR TITLE
ci: drop redundant pull_request trigger from auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,8 +1,6 @@
 name: Auto Assign Reviewers
 
 on:
-  pull_request:
-    types: [opened]
   pull_request_target:
     types: [opened]
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Use `pull_request_target` to assign reviewers for PRs from forks.

The workflow declared both `pull_request` and `pull_request_target`, producing two runs per PR. Auto-assign needs `pull-requests: write` to request reviewers; `pull_request` does not grant that permission for fork PRs, so its run no-ops on forks and only duplicates the privileged run on own-repo PRs. `pull_request_target` covers both cases.

**Release note**:
```release-note
NONE
```