### PR TITLE
fix: allow model rewrite rules to fill missing model field

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -79,6 +79,9 @@ type Datastore interface {
 	// InferenceModelRewrite operations
 	ModelRewriteSet(infModelRewrite *v1alpha2.InferenceModelRewrite)
 	ModelRewriteDelete(namespacedName types.NamespacedName)
+	// ModelRewriteGet returns the highest-precedence rewrite rule for a given
+	// model name (prioritizing exact matches over generic wildcard rules) and
+	// the name of the InferenceModelRewrite object.
 	ModelRewriteGet(modelName string) (*v1alpha2.InferenceModelRewriteRule, string)
 	ModelRewriteGetAll() []*v1alpha2.InferenceModelRewrite
 

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -358,16 +358,14 @@ func (d *Director) modelRewriteIfNeeded(ctx context.Context, reqCtx *handlers.Re
 }
 
 func (d *Director) mutateModel(ctx context.Context, reqCtx *handlers.RequestContext, bodyMap map[string]any) (*handlers.RequestContext, error) {
-	var ok bool
-	reqCtx.IncomingModelName, ok = bodyMap["model"].(string)
-	if !ok {
-		return reqCtx, errcommon.Error{Code: errcommon.BadRequest, Msg: "model not found in request body"}
-	}
+	reqCtx.IncomingModelName, _ = bodyMap["model"].(string)
 	if reqCtx.TargetModelName == "" {
-		// Default to incoming model name
 		reqCtx.TargetModelName = reqCtx.IncomingModelName
 	}
 	d.applyWeightedModelRewrite(ctx, reqCtx)
+	if reqCtx.TargetModelName == "" {
+		return reqCtx, errcommon.Error{Code: errcommon.BadRequest, Msg: "model not found in request body"}
+	}
 	bodyMap["model"] = reqCtx.TargetModelName
 	return reqCtx, nil
 }

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -110,7 +110,9 @@ type Datastore interface {
 	PoolGet() (*datalayer.EndpointPool, error)
 	ObjectiveGet(objectiveName string) *v1alpha2.InferenceObjective
 	PodList(predicate func(fwkdl.Endpoint) bool) []fwkdl.Endpoint
-	// ModelRewriteGet returns the rewrite rule for a given model name and the name of the InferenceModelRewrite object.
+	// ModelRewriteGet returns the highest-precedence rewrite rule for a given
+	// model name (prioritizing exact matches over generic wildcard rules) and
+	// the name of the InferenceModelRewrite object.
 	ModelRewriteGet(modelName string) (*v1alpha2.InferenceModelRewriteRule, string)
 }
 

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -189,10 +189,16 @@ func (m mockProducedDataType) Clone() fwkdl.Cloneable {
 
 func (ds *mockDatastore) ModelRewriteGet(modelName string) (*v1alpha2.InferenceModelRewriteRule, string) {
 	// This mock implementation simulates the precedence logic for simplicity.
-	// It finds the oldest rewrite that has a rule matching the modelName.
+	// It finds the oldest rewrite that has a rule matching the modelName,
+	// prioritizing exact matches over generic (empty Matches) rules.
 	var matchingRewrites []*v1alpha2.InferenceModelRewrite
+	var genericRewrites []*v1alpha2.InferenceModelRewrite
 	for _, r := range ds.rewrites {
 		for _, rule := range r.Spec.Rules {
+			if len(rule.Matches) == 0 {
+				genericRewrites = append(genericRewrites, r)
+				continue
+			}
 			for _, match := range rule.Matches {
 				if match.Model != nil && match.Model.Value == modelName {
 					matchingRewrites = append(matchingRewrites, r)
@@ -202,17 +208,23 @@ func (ds *mockDatastore) ModelRewriteGet(modelName string) (*v1alpha2.InferenceM
 		}
 	}
 
-	if len(matchingRewrites) == 0 {
+	if len(matchingRewrites) == 0 && len(genericRewrites) == 0 {
 		return nil, ""
 	}
 
+	// Exact matches take precedence; fall back to generic rules.
+	candidates := matchingRewrites
+	if len(candidates) == 0 {
+		candidates = genericRewrites
+	}
+
 	// Sort by timestamp to find the oldest.
-	sort.Slice(matchingRewrites, func(i, j int) bool {
-		return matchingRewrites[i].CreationTimestamp.Before(&matchingRewrites[j].CreationTimestamp)
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].CreationTimestamp.Before(&candidates[j].CreationTimestamp)
 	})
 
 	// Return the first rule from the oldest rewrite.
-	return &matchingRewrites[0].Spec.Rules[0], matchingRewrites[0].Name
+	return &candidates[0].Spec.Rules[0], candidates[0].Name
 }
 
 func TestDirector_HandleRequest(t *testing.T) {
@@ -261,6 +273,26 @@ func TestDirector_HandleRequest(t *testing.T) {
 						{
 							ModelRewrite: modelRewritten,
 							Weight:       ptr.To[int32](100),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	genericRewriteTarget := "generic-target-model"
+	genericRewrite := &v1alpha2.InferenceModelRewrite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "generic-rewrite-rule",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1alpha2.InferenceModelRewriteSpec{
+			Rules: []v1alpha2.InferenceModelRewriteRule{
+				{
+					Targets: []v1alpha2.TargetModel{
+						{
+							ModelRewrite: genericRewriteTarget,
+							Weight:       100,
 						},
 					},
 				},
@@ -697,6 +729,28 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantErrCode:             errcommon.BadRequest,
 		},
 		{
+			name:                    "missing model field resolved by generic rewrite",
+			reqBodyMap:              map[string]any{"prompt": "p"},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			wantReqCtx: &handlers.RequestContext{
+				TargetModelName: genericRewriteTarget,
+				TargetPod: &fwkdl.EndpointMetadata{
+					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:        "192.168.1.100",
+					Port:           "8000",
+					MetricsHost:    "192.168.1.100:8000",
+				},
+				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
+			},
+			wantMutatedBody: map[string]any{
+				"model":  genericRewriteTarget,
+				"prompt": "p",
+			},
+		},
+		{
 			name:        "prompt or messages not found, expect err",
 			reqBodyMap:  map[string]any{"model": model},
 			wantErrCode: errcommon.BadRequest,
@@ -796,6 +850,14 @@ func TestDirector_HandleRequest(t *testing.T) {
 					mockDs := &mockDatastore{
 						pods:     ds.PodList(datastore.AllPodsPredicate),
 						rewrites: []*v1alpha2.InferenceModelRewrite{rewrite},
+					}
+					director.datastore = mockDs
+					director.endpointCandidates = NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(mockDs), time.Minute)
+				}
+				if test.name == "missing model field resolved by generic rewrite" {
+					mockDs := &mockDatastore{
+						pods:     ds.PodList(datastore.AllPodsPredicate),
+						rewrites: []*v1alpha2.InferenceModelRewrite{genericRewrite},
 					}
 					director.datastore = mockDs
 					director.endpointCandidates = NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(mockDs), time.Minute)

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -292,7 +292,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 					Targets: []v1alpha2.TargetModel{
 						{
 							ModelRewrite: genericRewriteTarget,
-							Weight:       100,
+							Weight:       ptr.To[int32](100),
 						},
 					},
 				},
@@ -363,6 +363,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		wantMutatedBody         map[string]any
 		fairnessIDHeader        string // If non-empty, set as metadata.FlowFairnessIDKey on the incoming request.
 		wantFairnessID          string // If non-empty, asserted against returnedReqCtx.SchedulingRequest.FairnessID.
+		rewrites                []*v1alpha2.InferenceModelRewrite
 	}{
 		{
 			name: "successful completions request",
@@ -484,6 +485,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				"prompt": "some prompt",
 			},
 			inferenceObjectiveName: model,
+			rewrites:               []*v1alpha2.InferenceModelRewrite{rewrite},
 		}, {
 			name: "successful chat completions request",
 			reqBodyMap: map[string]any{
@@ -749,6 +751,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				"model":  genericRewriteTarget,
 				"prompt": "p",
 			},
+			rewrites: []*v1alpha2.InferenceModelRewrite{genericRewrite},
 		},
 		{
 			name:        "prompt or messages not found, expect err",
@@ -846,18 +849,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 
 				endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(ds), time.Minute)
 				director := NewDirectorWithConfig(ds, mockSched, test.mockAdmissionController, endpointCandidates, config)
-				if test.name == "successful request with model rewrite" {
+				if len(test.rewrites) > 0 {
 					mockDs := &mockDatastore{
 						pods:     ds.PodList(datastore.AllPodsPredicate),
-						rewrites: []*v1alpha2.InferenceModelRewrite{rewrite},
-					}
-					director.datastore = mockDs
-					director.endpointCandidates = NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(mockDs), time.Minute)
-				}
-				if test.name == "missing model field resolved by generic rewrite" {
-					mockDs := &mockDatastore{
-						pods:     ds.PodList(datastore.AllPodsPredicate),
-						rewrites: []*v1alpha2.InferenceModelRewrite{genericRewrite},
+						rewrites: test.rewrites,
 					}
 					director.datastore = mockDs
 					director.endpointCandidates = NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(mockDs), time.Minute)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Reorders `mutateModel` so that `applyWeightedModelRewrite` runs before the model-existence check. Previously, requests without a `model` field in the body were rejected with `BadRequest` immediately, before rewrite rules had a chance to provide a default model name via generic (wildcard) `InferenceModelRewrite` rules.

This broke the [wildcard rewrite pattern](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencemodelrewrite/#generic-wildcard-rewrites) documented in the Gateway API Inference Extension spec.

**Which issue(s) this PR fixes**:

Fixes #1359

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Requests that omit the model field can now be handled by generic InferenceModelRewrite rules instead of being rejected with BadRequest.
```

**How has this been tested?**

- Existing test "model not found, expect err" still passes (no generic rewrite configured, same behavior as before)
- New test "missing model field resolved by generic rewrite" verifies that a generic rewrite rule fills in the missing model
- `go test ./pkg/epp/requestcontrol/...` passes