### PR TITLE
feat: replace UDS support in Helm chart with new tokenizer render

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -347,6 +347,8 @@ router:
           secretKeyRef:
             name: my-hf-token-secret
             key: token
+      - name: HF_HOME
+          value: /models
     resources:
       requests:
         cpu: "4"

--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -303,31 +303,44 @@ router:
 
 ### 5. Sidecar Tokenizer Configuration (`router.tokenizer.*`)
 
-Runs a tokenizer sidecar container to expose a Unix Domain Socket (UDS) to EPP, allowing EPP to tokenize incoming requests and enable precise, token-count-aware routing policies (e.g., precise prefix-cache matching).
+Runs a tokenizer sidecar that EPP queries to tokenize incoming requests, enabling precise, token-count-aware routing policies (e.g., precise prefix-cache matching).
+
+The sidecar runs vLLM's `vllm launch render <modelName>` and exposes `/v1/completions/render` and `/v1/chat/completions/render` over loopback HTTP. Wire EPP to it via `router.epp.pluginsCustomConfig` with `type: token-producer` and `vllm:`.
 
 #### Tokenizer Sidecar Parameters
 
 | **Parameter Name** | **Description** | **Default** |
 | :--- | :--- | :--- |
-| `router.tokenizer.enabled` | Enable a tokenizer UDS sidecar container in the EPP deployment. | `false` |
-| `router.tokenizer.image.registry` | Tokenizer container image registry. | `ghcr.io/llm-d` |
-| `router.tokenizer.image.repository` | Tokenizer container image repository. | `llm-d-uds-tokenizer` |
-| `router.tokenizer.image.tag` | Tokenizer container image tag. | `vllm-v0.19.1` |
+| `router.tokenizer.enabled` | Enable the vLLM `/render` tokenizer sidecar in the EPP deployment. | `false` |
+| `router.tokenizer.modelName` | **REQUIRED** when enabled. Model name passed as the first positional arg to the sidecar's `vllm launch render` command. | `""` |
+| `router.tokenizer.image.registry` | Tokenizer container image registry. | `docker.io` |
+| `router.tokenizer.image.repository` | Tokenizer container image repository. | `vllm/vllm-openai-cpu` |
+| `router.tokenizer.image.tag` | Tokenizer container image tag. | `v0.19.1` |
 | `router.tokenizer.image.pullPolicy` | Tokenizer container image pull policy. | `IfNotPresent` |
-| `router.tokenizer.env` | Extra environment variables for the tokenizer container (e.g., HuggingFace token). `TOKENIZERS_DIR` and `HF_HOME` are templated automatically. | `[HF_TOKEN]` |
-| `router.tokenizer.resources` | Tokenizer container resource requests and limits. | `requests.cpu: "8"`, `requests.memory: 8Gi` |
-| `router.tokenizer.volumeMounts` | Extra volume mounts for the tokenizer container (e.g., for model files). | `[]` |
+| `router.tokenizer.port` | Container port the sidecar listens on. | `8000` |
+| `router.tokenizer.command` | Override container command. Empty renders `["vllm", "launch", "render"]`. | `[]` |
+| `router.tokenizer.args` | Override container args. Empty renders `["<modelName>", "--port=<port>"]`. | `[]` |
+| `router.tokenizer.env` | Extra environment variables (e.g., HuggingFace token). | `[HF_TOKEN]` |
+| `router.tokenizer.resources` | Tokenizer container resource requests and limits. | `requests.cpu: "4"`, `requests.memory: 8Gi` |
+| `router.tokenizer.volumeMounts` | Extra volume mounts for the tokenizer container. | `[]` |
+| `router.tokenizer.readinessProbe` | Readiness probe spec. | `httpGet /health on the render-http named port` |
 
-#### Complete Tokenizer Sidecar Example
+#### Complete Tokenizer Render Sidecar Example
 
 ```yaml
 router:
+  epp:
+    volumes:
+      - name: model-cache-volume
+        persistentVolumeClaim:
+          claimName: pvc-model-cache
   tokenizer:
     enabled: true
+    modelName: "Qwen/Qwen3-32B"
     image:
-      registry: ghcr.io/llm-d
-      repository: llm-d-uds-tokenizer
-      tag: vllm-v0.19.1
+      registry: docker.io
+      repository: vllm/vllm-openai-cpu
+      tag: v0.19.1
     env:
       - name: HF_TOKEN
         valueFrom:
@@ -336,7 +349,7 @@ router:
             key: token
     resources:
       requests:
-        cpu: "8"
+        cpu: "4"
         memory: 8Gi
       limits:
         memory: 16Gi
@@ -344,12 +357,71 @@ router:
       # If pre-loading models from an external volume:
       - mountPath: /models
         name: model-cache-volume
-  volumes:
-    - name: model-cache-volume
-      persistentVolumeClaim:
-        claimName: pvc-model-cache
 ```
 
+#### UDS Tokenizer Backend (deprecated)
+
+The `llm-d-uds-tokenizer` sidecar (gRPC over a Unix Domain Socket) is no longer
+templated by this chart; the render backend above supersedes it. If you still
+need it during migration, set it up in two steps.
+
+**Step 1 — inject the sidecar into the EPP deployment.** The chart does not
+render it, so patch it in yourself (e.g. via kustomize). The EPP container must
+mount the shared socket volume so it can reach the tokenizer:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+        # Existing EPP container — add the shared socket mount.
+        - name: epp
+          volumeMounts:
+            - name: tokenizer-uds
+              mountPath: /tmp/tokenizer
+        # The deprecated sidecar.
+        - name: tokenizer-uds
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:vllm-v0.19.1
+          env:
+            - name: TOKENIZERS_DIR
+              value: /tokenizers
+            - name: HF_HOME
+              value: /tokenizers
+            # Required for gated/private tokenizers on HuggingFace.
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          volumeMounts:
+            - name: tokenizers
+              mountPath: /tokenizers
+            - name: tokenizer-uds
+              mountPath: /tmp/tokenizer
+      volumes:
+        - name: tokenizers
+          emptyDir: {}
+        - name: tokenizer-uds
+          emptyDir: {}
+```
+
+**Step 2 — point EPP at the socket.** Configure the tokenizer plugin via
+`router.epp.pluginsCustomConfig` (the chart writes this into the EPP config
+mounted at `/config`). Select the deprecated UDS backend with
+`udsTokenizerConfig`:
+
+```yaml
+router:
+  epp:
+    pluginsCustomConfig:
+      custom-plugins.yaml: |
+        plugins:
+          - type: token-producer
+            parameters:
+              modelName: "Qwen/Qwen3-32B"
+              udsTokenizerConfig:
+                socketFile: /tmp/tokenizer/tokenizer-uds.socket
+```
 ---
 
 ### 6. Sidecar Latency Predictor Configuration (`router.latencyPredictor.*`)

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -259,32 +259,46 @@ spec:
         {{- toYaml .Values.router.epp.volumeMounts | nindent 12 }}
         {{- end }}
         {{- if .Values.router.tokenizer.enabled }}
-            - name: tokenizer-uds
-              mountPath: /tmp/tokenizer
-        {{- end }}
-        {{- if .Values.router.tokenizer.enabled }}
-        - name: tokenizer-uds
-          image: {{ .Values.router.tokenizer.image.registry }}/{{ .Values.router.tokenizer.image.repository }}:{{ .Values.router.tokenizer.image.tag }}
-          imagePullPolicy: {{ .Values.router.tokenizer.image.pullPolicy | default "IfNotPresent" }}
+        {{- $tokenizer := .Values.router.tokenizer }}
+        {{- $renderPort := $tokenizer.port | default 8000 | int }}
+        - name: vllm-render
+          image: {{ $tokenizer.image.registry }}/{{ $tokenizer.image.repository }}:{{ $tokenizer.image.tag }}
+          imagePullPolicy: {{ $tokenizer.image.pullPolicy | default "IfNotPresent" }}
+          command:
+          {{- if $tokenizer.command }}
+          {{- toYaml $tokenizer.command | nindent 12 }}
+          {{- else }}
+            - vllm
+            - launch
+            - render
+          {{- end }}
+          args:
+          {{- if $tokenizer.args }}
+          {{- toYaml $tokenizer.args | nindent 12 }}
+          {{- else }}
+            - {{ $tokenizer.modelName | quote }}
+            - {{ printf "--port=%d" $renderPort | quote }}
+          {{- end }}
+          ports:
+            - name: render-http
+              containerPort: {{ $renderPort }}
+          {{- with $tokenizer.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $tokenizer.env }}
           env:
-            - name: TOKENIZERS_DIR
-              value: /tokenizers
-            - name: HF_HOME
-              value: /tokenizers
-            {{- if .Values.router.tokenizer.env }}
-            {{- toYaml .Values.router.tokenizer.env | nindent 12 }}
-            {{- end }}
-          {{- if .Values.router.tokenizer.resources }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $tokenizer.resources }}
           resources:
-            {{- toYaml .Values.router.tokenizer.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /tokenizers
-              name: tokenizers
-            - mountPath: /tmp/tokenizer
-              name: tokenizer-uds
-            {{- if .Values.router.tokenizer.volumeMounts }}
-            {{- toYaml .Values.router.tokenizer.volumeMounts | nindent 12 }}
+            - mountPath: /root/.cache/huggingface
+              name: model-cache
+            {{- with $tokenizer.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- end }}
       {{- include "llm-d-router.latencyPredictor.containers" . | nindent 8 }}
@@ -293,9 +307,7 @@ spec:
       {{- toYaml .Values.router.epp.volumes | nindent 8 }}
       {{- end }}
       {{- if .Values.router.tokenizer.enabled }}
-        - name: tokenizers
-          emptyDir: {}
-        - name: tokenizer-uds
+        - name: model-cache
           emptyDir: {}
       {{- end }}
       {{- if and $proxy.enabled (eq $proxyType "agentgateway") $proxyConfigMapName }}

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -333,6 +333,17 @@ EPP generic validations
 {{- include "llm-d-router.validations.deprecations" . }}
 {{- include "llm-d-router.validations.epp.resources" . }}
 {{- include "llm-d-router.validations.epp.inferenceObjectives" . }}
+{{- include "llm-d-router.validations.epp.tokenizer" . }}
+{{- end -}}
+
+{{/*
+Tokenizer validations: require modelName for the render sidecar's command args.
+*/}}
+{{- define "llm-d-router.validations.epp.tokenizer" -}}
+{{- $tokenizer := .Values.router.tokenizer | default dict }}
+{{- if and (dig "enabled" false $tokenizer) (not (dig "modelName" "" $tokenizer)) }}
+{{- fail ".Values.router.tokenizer.modelName is required when the tokenizer is enabled." }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -66,14 +66,21 @@ epp:
 proxy:
   enabled: false    
 
-# Tokenizer sidecar configuration
+# Tokenizer sidecar. Runs vLLM's `vllm launch render <modelName>` and exposes
+# `/render` over loopback HTTP to EPP. modelName is passed as the first
+# positional arg to the render command (required when enabled). EPP is wired to
+# the sidecar via `router.epp.pluginsCustomConfig`.
 tokenizer:
   enabled: false
+  modelName: ""
   image:
-    registry: ghcr.io/llm-d
-    repository: llm-d-uds-tokenizer
-    tag: vllm-v0.19.1
+    registry: docker.io
+    repository: vllm/vllm-openai-cpu
+    tag: v0.19.1
     pullPolicy: IfNotPresent
+  port: 8000
+  command: []
+  args: []
   env:
     - name: HF_TOKEN
       valueFrom:
@@ -82,9 +89,18 @@ tokenizer:
           key: HF_TOKEN
   resources:
     requests:
-      cpu: "8"
+      cpu: "4"
       memory: 8Gi
-    
+  volumeMounts: []
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: render-http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 60
+
 # Monitoring configuration for EPP
 monitoring:
   interval: "10s"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- replace old UDS with new render with 
```
tokenizer:
  enabled: false
  modelName: ""
  image:
    registry: docker.io
    repository: vllm/vllm-openai-cpu
    tag: v0.19.1
....
``` 
in values.yaml
- add example in  README if user wanna old UDS 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
