### PR TITLE
Export cache hit metrics for encoder cache data producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
@@ -50,6 +50,20 @@ var (
 		[]string{"plugin_type", "plugin_name", "pod", "modality"},
 	)
 
+	// encoderCacheHitRatio records, per endpoint and per request, the fraction of the
+	// request's multimodal items already present in that endpoint's LRU. The counters
+	// give an aggregate hit rate; this histogram exposes the distribution of
+	// per-endpoint hit ratios, which surfaces uneven cache locality across pods.
+	encoderCacheHitRatio = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
+			Name:      "encoder_cache_hit_ratio",
+			Help:      metricsutil.HelpMsgWithStability("Ratio of matched multimodal items to total items per endpoint in an encoder-cache lookup.", compbasemetrics.ALPHA),
+			Buckets:   []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
+		},
+		[]string{"plugin_type", "plugin_name"},
+	)
+
 	registerOnce sync.Once
 )
 
@@ -57,5 +71,6 @@ func registerEncoderCacheMetrics() {
 	registerOnce.Do(func() {
 		metrics.Registry.MustRegister(encoderCacheQueriesTotal)
 		metrics.Registry.MustRegister(encoderCacheHitsTotal)
+		metrics.Registry.MustRegister(encoderCacheHitRatio)
 	})
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -62,6 +64,23 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey, img)))
 }
 
+func TestRecordHitRatioMetrics(t *testing.T) {
+	producer := newTestProducer(t, nil, nil)
+
+	initial, err := hitRatioHistogram()
+	require.NoError(t, err)
+
+	producer.recordHitRatio(3, 5)
+	producer.recordHitRatio(0, 2)
+	producer.recordHitRatio(0, 0) // requests with no items are not observed
+
+	got, err := hitRatioHistogram()
+	require.NoError(t, err)
+
+	assert.Equal(t, initial.GetSampleCount()+2, got.GetSampleCount())
+	assert.InDelta(t, initial.GetSampleSum()+0.6, got.GetSampleSum(), 0.001)
+}
+
 func TestRegisterEncoderCacheMetrics(t *testing.T) {
 	// registerEncoderCacheMetrics uses sync.Once, so multiple calls are safe.
 	// We can't easily verify registration against a mock registry because it uses the global metrics.Registry.
@@ -83,4 +102,16 @@ func TestProduceRecordsMetrics(t *testing.T) {
 	require.NoError(t, producer.Produce(context.Background(), request, nil))
 
 	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName, img)))
+}
+
+func hitRatioHistogram() (*dto.Histogram, error) {
+	observer, err := encoderCacheHitRatio.GetMetricWithLabelValues(ProducerType, testName)
+	if err != nil {
+		return nil, err
+	}
+	metric := &dto.Metric{}
+	if err := observer.(prometheus.Histogram).Write(metric); err != nil {
+		return nil, err
+	}
+	return metric.GetHistogram(), nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -211,6 +211,7 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 			continue
 		}
 		matchedItems := p.matchedItemsForPod(metadata.NamespacedName.String(), requestItems)
+		p.recordHitRatio(len(matchedItems), len(requestItems))
 		endpoint.Put(p.dk.String(), attrmm.NewEncoderCacheMatchInfo(
 			matchedItems,
 			requestItems,
@@ -267,6 +268,17 @@ func (p *Producer) recordItemLookups(items []attrmm.MatchItem) {
 			}
 		}
 	}
+}
+
+// recordHitRatio observes the fraction of a request's multimodal items that
+// matched a single endpoint's LRU. A zero total is not a meaningful ratio and
+// is not observed.
+func (p *Producer) recordHitRatio(matchedItems, totalItems int) {
+	if totalItems == 0 {
+		return
+	}
+	ratio := float64(matchedItems) / float64(totalItems)
+	encoderCacheHitRatio.WithLabelValues(p.typedName.Type, p.typedName.Name).Observe(ratio)
 }
 
 func (p *Producer) matchedItemsForPod(pod string, requestItems []attrmm.MatchItem) []attrmm.MatchItem {


### PR DESCRIPTION
## Summary

- Add Prometheus metrics to the multimodal encoder-cache data producer plugin, following the pattern established by the approximate prefix cache plugin
- Three metrics exported under `llm_d_router_epp` subsystem: `encoder_cache_hit_ratio` (histogram), `encoder_cache_queries_total` (counter), `encoder_cache_hits_total` (counter)
- Metrics are recorded per endpoint in `Produce()` and registered via `handle.Metrics()` in `Factory()`

Closes #1384

## Details

The encoder cache data producer (`mm-embeddings-cache-producer`) tracks multimodal content hashes and their pod placements for cache-affinity routing. Previously, operators had no visibility into how effectively the cache was being utilized.

The three new metrics mirror what the approximate prefix cache plugin provides:

- `llm_d_router_epp_encoder_cache_hit_ratio`: Histogram (0.0 to 1.0 in 0.1 steps) of the ratio of matched multimodal items to total items per endpoint lookup. A ratio of 1.0 means all multimodal content in the request was found in that endpoint's encoder cache.
- `llm_d_router_epp_encoder_cache_queries_total`: Counter of total multimodal content items seen across all requests and endpoints.
- `llm_d_router_epp_encoder_cache_hits_total`: Counter of total cache hits (items that matched a pod's encoder cache entry).

The test handle in `producer_test.go` is updated to return a real `prometheus.Registry` instead of nil, matching the pattern used by the approximate prefix cache tests.

## Test plan

- [x] New `metrics_test.go` with tests for registration (including idempotent re-registration), recording with hits, recording with zero total
- [x] Existing `TestFactory` passes with metrics registration
- [x] All 16 tests in the multimodal package pass
- [x] `go build` clean


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Added `llm_d_router_epp_encoder_cache_hit_ratio` histogram metric.
```