### PR TITLE
refactor(unifiedInferenceReqeustBody)[2.2/n]: migrate vllmhttp parser to unified fields

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -27,8 +27,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
@@ -119,11 +121,49 @@ func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResul
 	}
 
 	body := &fwkrh.InferenceRequestBody{
-		Generate: &generate,
-		Payload:  fwkrh.PayloadMap(bodyMap),
+		TokenInputs: []fwkrh.TokenizedInput{
+			{
+				TokenIDs:           generate.TokenIDs,
+				MultiModalFeatures: convertMMFeaturesToUpstream(generate.Features),
+			},
+		},
+		ExtractedCacheSalt: generate.CacheSalt,
+		Generate:           &generate,
+		Payload:            fwkrh.PayloadMap(bodyMap),
 	}
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		body.Stream = true
 	}
 	return &fwkrh.ParseResult{Body: body, Skip: false}, nil
+}
+
+func convertMMFeaturesToUpstream(src *tokenization.MultiModalFeatures) []fwkrh.MultiModalFeature {
+	if src == nil || len(src.MMHashes) == 0 {
+		return nil
+	}
+
+	var items []fwkrh.MultiModalFeature
+	for modality, hashes := range src.MMHashes {
+		ranges, ok := src.MMPlaceholders[modality]
+		if !ok {
+			continue
+		}
+		n := len(hashes)
+		if len(ranges) < n {
+			n = len(ranges)
+		}
+		for i := 0; i < n; i++ {
+			items = append(items, fwkrh.MultiModalFeature{
+				Modality: fwkrh.Modality(modality),
+				Hash:     hashes[i],
+				Offset:   ranges[i].Offset,
+				Length:   ranges[i].Length,
+			})
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Offset < items[j].Offset })
+	return items
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -55,6 +55,11 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 				"token_ids": []any{1, 2, 3},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{1, 2, 3},
+					},
+				},
 				Generate: &fwkrh.GenerateRequest{
 					TokenIDs: []uint32{1, 2, 3},
 				},
@@ -71,6 +76,12 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 				"cache_salt": "abc123",
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{10, 20, 30},
+					},
+				},
+				ExtractedCacheSalt: "abc123",
 				Generate: &fwkrh.GenerateRequest{
 					TokenIDs:  []uint32{10, 20, 30},
 					CacheSalt: "abc123",
@@ -93,6 +104,11 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 				"stream": true,
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{1, 2, 3},
+					},
+				},
 				Generate: &fwkrh.GenerateRequest{
 					TokenIDs: []uint32{1, 2, 3},
 				},
@@ -130,6 +146,11 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 				"token_ids": []any{5, 6, 7},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{5, 6, 7},
+					},
+				},
 				Generate: &fwkrh.GenerateRequest{
 					TokenIDs: []uint32{5, 6, 7},
 				},
@@ -156,6 +177,15 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 				},
 			},
 			want: &fwkrh.InferenceRequestBody{
+				TokenInputs: []fwkrh.TokenizedInput{
+					{
+						TokenIDs: []uint32{151644, 872, 198, 3838, 374, 279, 6722, 315, 9625, 30, 151645, 198, 151644, 77091, 198},
+						MultiModalFeatures: []fwkrh.MultiModalFeature{
+							{Modality: fwkrh.ModalityImage, Hash: "abc123hash", Offset: 1, Length: 3},
+							{Modality: fwkrh.ModalityImage, Hash: "def456hash", Offset: 4, Length: 3},
+						},
+					},
+				},
 				Generate: &fwkrh.GenerateRequest{
 					TokenIDs: []uint32{151644, 872, 198, 3838, 374, 279, 6722, 315, 9625, 30, 151645, 198, 151644, 77091, 198},
 					Features: &tokenization.MultiModalFeatures{


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
### Overview & Context

This PR implements **Stage 2.2: vLLM HTTP Parser Migration** of the **InferenceRequestBody Standardization Plan** (see (https://github.com/llm-d/llm-d-router/issues/1364#issuecomment-4560679710)).

The goal of this PR is to migrate EPP's vLLM HTTP request parser (`parsers/vllmhttp`) to populate the new standardized unified request-body fields (`TokenInputs`, `ExtractedCacheSalt`) alongside the legacy `Generate` fields. This enables downstream scheduling and request-control plugins to consume unified fields cleanly.

This PR implements **dual-write** to guarantee a safe rollout.

---

### Summary of Changes

1.  **vLLM HTTP Request Parser (`vllmhttp.go`)**:
    *   Updated `ParseRequest` to populate the new unified fields (`TokenInputs`, `ExtractedCacheSalt`) in `InferenceRequestBody` for the `/inference/v1/generate` API endpoint:
        *   Translates `TokenIDs` into `TokenInputs`.
        *   Maps `CacheSalt` to `ExtractedCacheSalt`.
        *   Implements `convertMMFeaturesToUpstream` to convert multimodal features from `GenerateRequest.Features` (`tokenization.MultiModalFeatures`) to unified `MultiModalFeature`s inside `TokenInputs`.
2.  **vLLM HTTP Parser Unit Tests (`vllmhttp_test.go`)**:
    *   Updated the test cases in `vllmhttp_test.go` to explicitly define the expected `TokenInputs` and `ExtractedCacheSalt` fields in `wantResult`, including strict verification of multimodal features mapping.


**Which issue(s) this PR fixes**:
Part of #1364

**Release note**:
```release-note
NONE
```
