### PR TITLE
fix: detect legacy inference CRDs at startup

### DIFF
--- a/pkg/epp/server/controller_config.go
+++ b/pkg/epp/server/controller_config.go
@@ -24,6 +24,15 @@ import (
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
 )
 
+var (
+	inferenceAPIGV           = schema.GroupVersion{Group: v1alpha2.GroupVersion.Group, Version: v1alpha2.GroupVersion.Version}
+	legacyInferenceAPIGV     = schema.GroupVersion{Group: "inference.networking.x-k8s.io", Version: v1alpha2.GroupVersion.Version}
+	supportedInferenceAPIGVs = []schema.GroupVersion{
+		inferenceAPIGV,
+		legacyInferenceAPIGV,
+	}
+)
+
 type ControllerConfig struct {
 	startCrdReconcilers       bool
 	hasInferenceObjective     bool
@@ -49,19 +58,17 @@ func (cc *ControllerConfig) PopulateControllerConfig(cfg *rest.Config) error {
 }
 
 func (cc *ControllerConfig) populateWithDiscovery(dc discovery.DiscoveryInterface) {
-	inferenceObjectiveGVK := schema.GroupVersionKind{
-		Group:   v1alpha2.GroupVersion.Group,
-		Version: v1alpha2.GroupVersion.Version,
-		Kind:    "InferenceObjective",
-	}
-	cc.hasInferenceObjective = gvkExists(dc, inferenceObjectiveGVK)
+	cc.hasInferenceObjective = kindExistsInAnyGroupVersion(dc, "InferenceObjective", supportedInferenceAPIGVs)
+	cc.hasInferenceModelRewrites = kindExistsInAnyGroupVersion(dc, "InferenceModelRewrite", supportedInferenceAPIGVs)
+}
 
-	inferenceModelRewriteGVK := schema.GroupVersionKind{
-		Group:   v1alpha2.GroupVersion.Group,
-		Version: v1alpha2.GroupVersion.Version,
-		Kind:    "InferenceModelRewrite",
+func kindExistsInAnyGroupVersion(dc discovery.DiscoveryInterface, kind string, groupVersions []schema.GroupVersion) bool {
+	for _, gv := range groupVersions {
+		if gvkExists(dc, gv.WithKind(kind)) {
+			return true
+		}
 	}
-	cc.hasInferenceModelRewrites = gvkExists(dc, inferenceModelRewriteGVK)
+	return false
 }
 
 func gvkExists(dc discovery.DiscoveryInterface, gvk schema.GroupVersionKind) bool {

--- a/pkg/epp/server/controller_config_test.go
+++ b/pkg/epp/server/controller_config_test.go
@@ -41,47 +41,106 @@ func TestNewControllerConfig(t *testing.T) {
 func TestPopulateWithDiscovery(t *testing.T) {
 	tests := []struct {
 		name                      string
-		apiResources              []metav1.APIResource
+		apiResourceLists          []*metav1.APIResourceList
 		wantInferenceObjective    bool
 		wantInferenceModelRewrite bool
 	}{
 		{
-			name: "Both resources exist",
-			apiResources: []metav1.APIResource{
-				{Kind: "InferenceObjective"},
-				{Kind: "InferenceModelRewrite"},
+			name: "Both resources exist in llm-d group",
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1alpha2.GroupVersion.String(),
+					APIResources: []metav1.APIResource{
+						{Kind: "InferenceObjective"},
+						{Kind: "InferenceModelRewrite"},
+					},
+				},
 			},
 			wantInferenceObjective:    true,
 			wantInferenceModelRewrite: true,
 		},
 		{
-			name:                      "Resources do not exist",
-			apiResources:              []metav1.APIResource{},
+			name: "Both resources exist in legacy group",
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: legacyInferenceAPIGV.String(),
+					APIResources: []metav1.APIResource{
+						{Kind: "InferenceObjective"},
+						{Kind: "InferenceModelRewrite"},
+					},
+				},
+			},
+			wantInferenceObjective:    true,
+			wantInferenceModelRewrite: true,
+		},
+		{
+			name: "Resources do not exist",
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1alpha2.GroupVersion.String(),
+					APIResources: []metav1.APIResource{},
+				},
+				{
+					GroupVersion: legacyInferenceAPIGV.String(),
+					APIResources: []metav1.APIResource{},
+				},
+			},
 			wantInferenceObjective:    false,
 			wantInferenceModelRewrite: false,
 		},
 		{
-			name: "Only InferenceObjective exists",
-			apiResources: []metav1.APIResource{
-				{Kind: "InferenceObjective"},
+			name: "Only InferenceObjective exists in llm-d group",
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1alpha2.GroupVersion.String(),
+					APIResources: []metav1.APIResource{
+						{Kind: "InferenceObjective"},
+					},
+				},
 			},
 			wantInferenceObjective:    true,
 			wantInferenceModelRewrite: false,
+		},
+		{
+			name: "Resources exist across supported groups",
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1alpha2.GroupVersion.String(),
+					APIResources: []metav1.APIResource{
+						{Kind: "InferenceObjective"},
+					},
+				},
+				{
+					GroupVersion: legacyInferenceAPIGV.String(),
+					APIResources: []metav1.APIResource{
+						{Kind: "InferenceModelRewrite"},
+					},
+				},
+			},
+			wantInferenceObjective:    true,
+			wantInferenceModelRewrite: true,
+		},
+		{
+			name: "Only InferenceModelRewrite exists in legacy group",
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: legacyInferenceAPIGV.String(),
+					APIResources: []metav1.APIResource{
+						{Kind: "InferenceModelRewrite"},
+					},
+				},
+			},
+			wantInferenceObjective:    false,
+			wantInferenceModelRewrite: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup fake discovery for this specific test case
 			fakeDiscovery := &fake.FakeDiscovery{
 				Fake: &k8stesting.Fake{},
 			}
-			fakeDiscovery.Resources = []*metav1.APIResourceList{
-				{
-					GroupVersion: v1alpha2.GroupVersion.String(),
-					APIResources: tt.apiResources,
-				},
-			}
+			fakeDiscovery.Resources = tt.apiResourceLists
 
 			cc := &ControllerConfig{}
 			cc.populateWithDiscovery(fakeDiscovery)


### PR DESCRIPTION
Start the InferenceObjective and InferenceModelRewrite reconcilers when either the llm-d.ai/v1alpha2 or legacy inference.networking.x-k8s.io/v1alpha2 resources are advertised by discovery.

Add discovery tests for the supported API groups and partial resource availability.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The InferenceObjective and InferenceModelRewrite reconcilers support both the llm-d.ai and legacy inference.networking.x-k8s.io API groups, but startup discovery only checked for the llm-d.ai/v1alpha2 resources.

This updates the startup discovery gate so those reconcilers are enabled when either supported API group is advertised by discovery.

**Which issue(s) this PR fixes**:
Fixes #1432

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE