### PR TITLE
metrics: Add plugin name and type labels to EPP metrics

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
@@ -33,14 +33,18 @@ type indexer struct {
 	hashToPods     map[blockHash]podSet                         // the lookup data structure to find pods that have the blockHash cached
 	podToLRU       map[ServerID]*lru.Cache[blockHash, struct{}] // key is pod namespacedName, value is an LRU cache
 	defaultLRUSize int
+	pluginName     string
+	pluginType     string
 }
 
 // newIndexer initializes an indexer with size limits and starts cache size reporting.
-func newIndexer(ctx context.Context, defaultLRUSize int) indexerInterface {
+func newIndexer(ctx context.Context, defaultLRUSize int, pluginName, pluginType string) indexerInterface {
 	i := &indexer{
 		hashToPods:     make(map[blockHash]podSet),
 		podToLRU:       make(map[ServerID]*lru.Cache[blockHash, struct{}]),
 		defaultLRUSize: defaultLRUSize,
+		pluginName:     pluginName,
+		pluginType:     pluginType,
 	}
 
 	go i.reportLRUSize(ctx, time.Second)
@@ -150,7 +154,7 @@ func (i *indexer) reportOnce(ctx context.Context) {
 		avg = float64(totalEntries) / float64(numPods)
 	}
 
-	recordPrefixCacheSize(int64(totalEntries))
+	recordPrefixCacheSize(i.pluginName, i.pluginType, int64(totalEntries))
 
 	log.FromContext(ctx).V(logutil.TRACE).Info("Prefix cache state",
 		"total entries", totalEntries,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
@@ -29,7 +29,7 @@ func TestIndexer_AddAndGet(t *testing.T) {
 		ServerID:       ServerID{Namespace: "default", Name: "server1"},
 		NumOfGPUBlocks: 2,
 	}
-	i := newIndexer(context.Background(), 3).(*indexer) // Initialize with an lruSize greater than server.numOfGPUBlocks to verify server-defined limits take precedence.
+	i := newIndexer(context.Background(), 3, "test-name", "test-type").(*indexer) // Initialize with an lruSize greater than server.numOfGPUBlocks to verify server-defined limits take precedence.
 
 	hash1 := blockHash(1)
 	// Add an entry to the cache
@@ -55,7 +55,7 @@ func TestIndexer_AddAndGet(t *testing.T) {
 func TestIndexer_RemovePodAndEviction(t *testing.T) {
 	const indexerSize = 10
 
-	i := newIndexer(context.Background(), indexerSize).(*indexer)
+	i := newIndexer(context.Background(), indexerSize, "test-name", "test-type").(*indexer)
 
 	server1 := server{ServerID: ServerID{Namespace: "default", Name: "server1"}}
 	server2 := server{ServerID: ServerID{Namespace: "default", Name: "server2"}}
@@ -115,7 +115,7 @@ func TestIndexer_RemovePodAndEviction(t *testing.T) {
 func TestIndexer_ConcurrentAddRemovePod(t *testing.T) {
 	lruSize := 10
 	for iter := range 100 {
-		i := newIndexer(context.Background(), lruSize).(*indexer)
+		i := newIndexer(context.Background(), lruSize, "test-name", "test-type").(*indexer)
 		pod := server{ServerID: ServerID{Namespace: "default", Name: "pod1"}}
 
 		var wg sync.WaitGroup

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics.go
@@ -43,7 +43,7 @@ var (
 			Name:      "prefix_indexer_size",
 			Help:      metricsutil.HelpMsgWithStability("Size of the prefix indexer.", compbasemetrics.ALPHA),
 		},
-		[]string{},
+		[]string{"plugin_name", "plugin_type"},
 	)
 
 	prefixCacheHitRatio = prometheus.NewHistogramVec(
@@ -63,7 +63,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Ratio of prefix length matched to total prefix length in the cache lookup.", compbasemetrics.ALPHA),
 			Buckets:   []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
 		},
-		[]string{},
+		[]string{"plugin_name", "plugin_type"},
 	)
 
 	prefixCacheHitLength = prometheus.NewHistogramVec(
@@ -83,7 +83,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Length of the prefix match in number of bytes in the cache lookup.", compbasemetrics.ALPHA),
 			Buckets:   []float64{0, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
 		},
-		[]string{},
+		[]string{"plugin_name", "plugin_type"},
 	)
 )
 
@@ -111,20 +111,20 @@ func registerMetrics(registerer prometheus.Registerer) error {
 }
 
 // recordPrefixCacheSize records the size of the prefix indexer in megabytes.
-func recordPrefixCacheSize(size int64) {
+func recordPrefixCacheSize(pluginName, pluginType string, size int64) {
 	prefixCacheSize.WithLabelValues().Set(float64(size))
-	llmdPrefixCacheSize.WithLabelValues().Set(float64(size))
+	llmdPrefixCacheSize.WithLabelValues(pluginName, pluginType).Set(float64(size))
 }
 
 // recordPrefixCacheMatch records both the hit ratio and hit length for a prefix indexer match.
 // matchedLength is the number of characters that matched, and totalLength is the total prefix length.
-func recordPrefixCacheMatch(matchedLength, totalLength int) {
+func recordPrefixCacheMatch(pluginName, pluginType string, matchedLength, totalLength int) {
 	prefixCacheHitLength.WithLabelValues().Observe(float64(matchedLength))
-	llmdPrefixCacheHitLength.WithLabelValues().Observe(float64(matchedLength))
+	llmdPrefixCacheHitLength.WithLabelValues(pluginName, pluginType).Observe(float64(matchedLength))
 
 	if totalLength > 0 {
 		ratio := float64(matchedLength) / float64(totalLength)
 		prefixCacheHitRatio.WithLabelValues().Observe(ratio)
-		llmdPrefixCacheHitRatio.WithLabelValues().Observe(ratio)
+		llmdPrefixCacheHitRatio.WithLabelValues(pluginName, pluginType).Observe(ratio)
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics_test.go
@@ -38,25 +38,36 @@ func TestRecordPrefixCacheMetrics(t *testing.T) {
 	resetMetrics()
 	t.Cleanup(resetMetrics)
 
-	recordPrefixCacheSize(4096)
-	recordPrefixCacheMatch(10, 20)
-	recordPrefixCacheMatch(0, 0)
+	recordPrefixCacheSize("test-plugin", "test-type", 4096)
+	recordPrefixCacheMatch("test-plugin", "test-type", 10, 20)
+	recordPrefixCacheMatch("test-plugin", "test-type", 0, 0)
 
 	require.Equal(t, float64(4096), testutil.ToFloat64(prefixCacheSize.WithLabelValues()))
+	require.Equal(t, float64(4096), testutil.ToFloat64(llmdPrefixCacheSize.WithLabelValues("test-plugin", "test-type")))
 
 	hitRatio, err := getHistogram(prefixCacheHitRatio)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), hitRatio.GetSampleCount())
 	require.Equal(t, 0.5, hitRatio.GetSampleSum())
 
+	llmdHitRatio, err := getHistogram(llmdPrefixCacheHitRatio, "test-plugin", "test-type")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), llmdHitRatio.GetSampleCount())
+	require.Equal(t, 0.5, llmdHitRatio.GetSampleSum())
+
 	hitLength, err := getHistogram(prefixCacheHitLength)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), hitLength.GetSampleCount())
 	require.Equal(t, float64(10), hitLength.GetSampleSum())
+
+	llmdHitLength, err := getHistogram(llmdPrefixCacheHitLength, "test-plugin", "test-type")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), llmdHitLength.GetSampleCount())
+	require.Equal(t, float64(10), llmdHitLength.GetSampleSum())
 }
 
-func getHistogram(histogram *prometheus.HistogramVec) (*dto.Histogram, error) {
-	metric, err := histogram.GetMetricWithLabelValues()
+func getHistogram(histogram *prometheus.HistogramVec, labelValues ...string) (*dto.Histogram, error) {
+	metric, err := histogram.GetMetricWithLabelValues(labelValues...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -94,7 +94,6 @@ func newDataProducer(ctx context.Context, name string, config config, handle plu
 	if err := registerMetrics(handle.Metrics()); err != nil {
 		return nil, err
 	}
-
 	// Surface the override to the operator so a too-small configured value is
 	// not silently swallowed. The clamp itself happens at request time in
 	// GetBlockSize and applies uniformly across endpoint metric, autotune
@@ -108,7 +107,7 @@ func newDataProducer(ctx context.Context, name string, config config, handle plu
 		)
 	}
 
-	indexer := newIndexer(ctx, config.LRUCapacityPerServer)
+	indexer := newIndexer(ctx, config.LRUCapacityPerServer, name, ApproxPrefixCachePluginType)
 
 	p := &dataProducer{
 		typedName: plugin.TypedName{
@@ -230,7 +229,7 @@ func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.Inferen
 	matchLen := state.PrefixCacheServers[ServerID(targetEndpoint.GetMetadata().NamespacedName)]
 	blockSize := p.GetBlockSize(primaryProfileResult.TargetEndpoints)
 	avgChars := averageCharactersPerToken
-	recordPrefixCacheMatch(matchLen*blockSize*avgChars, total*blockSize*avgChars)
+	recordPrefixCacheMatch(p.typedName.Name, p.typedName.Type, matchLen*blockSize*avgChars, total*blockSize*avgChars)
 }
 
 func (p *dataProducer) makeserver(targetEndpoint fwksched.Endpoint) server {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics.go
@@ -79,7 +79,7 @@ var (
 			Name:      "inference_request_metric",
 			Help:      metricsutil.HelpMsgWithStability("Consolidated gauge for various inference request metrics including TTFT, TPOT, SLOs, and prediction durations.", compbasemetrics.ALPHA),
 		},
-		modelTypeLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name", "type"},
 	)
 
 	requestTTFT = prometheus.NewHistogramVec(
@@ -99,7 +99,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Inference model TTFT distribution in seconds for each model and target model.", compbasemetrics.ALPHA),
 			Buckets:   generalLatencyBuckets,
 		},
-		modelLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name"},
 	)
 
 	requestPredictedTTFT = prometheus.NewHistogramVec(
@@ -119,7 +119,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Inference model Predicted TTFT distribution in seconds for each model and target model.", compbasemetrics.ALPHA),
 			Buckets:   generalLatencyBuckets,
 		},
-		modelLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name"},
 	)
 
 	requestTTFTPredictionDuration = prometheus.NewHistogramVec(
@@ -139,7 +139,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Duration taken to generate TTFT predictions in seconds for each model and target model.", compbasemetrics.ALPHA),
 			Buckets:   predictionLatencyBuckets,
 		},
-		modelLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name"},
 	)
 
 	requestTPOT = prometheus.NewHistogramVec(
@@ -159,7 +159,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Inference model TPOT distribution in seconds for each model and target model.", compbasemetrics.ALPHA),
 			Buckets:   tpotBuckets,
 		},
-		modelLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name"},
 	)
 
 	requestPredictedTPOT = prometheus.NewHistogramVec(
@@ -179,7 +179,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Inference model Predicted TPOT distribution in seconds for each model and target model.", compbasemetrics.ALPHA),
 			Buckets:   tpotBuckets,
 		},
-		modelLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name"},
 	)
 
 	requestTPOTPredictionDuration = prometheus.NewHistogramVec(
@@ -199,7 +199,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Duration taken to generate TPOT predictions in seconds for each model and target model.", compbasemetrics.ALPHA),
 			Buckets:   predictionLatencyBuckets,
 		},
-		modelLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name"},
 	)
 
 	sloViolationCounter = prometheus.NewCounterVec(
@@ -217,7 +217,7 @@ var (
 			Name:      "request_slo_violation_total",
 			Help:      metricsutil.HelpMsgWithStability("Counter of SLO violations for each model, target model, and violation type.", compbasemetrics.ALPHA),
 		},
-		modelTypeLabels,
+		[]string{"plugin_name", "plugin_type", "model_name", "target_model_name", "type"},
 	)
 )
 
@@ -254,20 +254,20 @@ func registerMetrics(registerer prometheus.Registerer) error {
 	return nil
 }
 
-func recordRequestTPOT(ctx context.Context, modelName, targetModelName string, tpot float64) bool {
+func recordRequestTPOT(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, tpot float64) bool {
 	if tpot < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "TPOT value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "tpot", tpot)
 		return false
 	}
 	requestTPOT.WithLabelValues(modelName, targetModelName).Observe(tpot)
-	llmdRequestTPOT.WithLabelValues(modelName, targetModelName).Observe(tpot)
+	llmdRequestTPOT.WithLabelValues(pluginName, pluginType, modelName, targetModelName).Observe(tpot)
 	inferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOT).Set(tpot)
-	llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOT).Set(tpot)
+	llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTPOT).Set(tpot)
 	return true
 }
 
-func recordRequestTPOTWithSLO(ctx context.Context, modelName, targetModelName string, tpot float64, sloThreshold float64) bool {
+func recordRequestTPOTWithSLO(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, tpot float64, sloThreshold float64) bool {
 	if tpot < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "TPOT value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "tpot", tpot)
@@ -276,59 +276,59 @@ func recordRequestTPOTWithSLO(ctx context.Context, modelName, targetModelName st
 
 	if tpot > sloThreshold {
 		inferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOTSLOViolation).Set(1)
-		llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOTSLOViolation).Set(1)
+		llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTPOTSLOViolation).Set(1)
 		sloViolationCounter.WithLabelValues(modelName, targetModelName, typeTPOT).Inc()
-		llmdSloViolationCounter.WithLabelValues(modelName, targetModelName, typeTPOT).Inc()
+		llmdSloViolationCounter.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTPOT).Inc()
 		log.FromContext(ctx).V(logutil.DEFAULT).Info("TPOT SLO violation detected",
 			"modelName", modelName, "targetModelName", targetModelName, "tpot", tpot, "threshold", sloThreshold)
 	} else {
 		inferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOTSLOViolation).Set(0)
-		llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOTSLOViolation).Set(0)
+		llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTPOTSLOViolation).Set(0)
 	}
 
 	return true
 }
 
-func recordRequestPredictedTPOT(ctx context.Context, modelName, targetModelName string, predictedTPOT float64) bool {
+func recordRequestPredictedTPOT(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, predictedTPOT float64) bool {
 	if predictedTPOT < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "Predicted TPOT value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "tpot", predictedTPOT)
 		return false
 	}
 	requestPredictedTPOT.WithLabelValues(modelName, targetModelName).Observe(predictedTPOT)
-	llmdRequestPredictedTPOT.WithLabelValues(modelName, targetModelName).Observe(predictedTPOT)
+	llmdRequestPredictedTPOT.WithLabelValues(pluginName, pluginType, modelName, targetModelName).Observe(predictedTPOT)
 	inferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTPOT).Set(predictedTPOT)
-	llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTPOT).Set(predictedTPOT)
+	llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typePredictedTPOT).Set(predictedTPOT)
 	return true
 }
 
-func recordRequestTPOTPredictionDuration(ctx context.Context, modelName, targetModelName string, duration float64) bool {
+func recordRequestTPOTPredictionDuration(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, duration float64) bool {
 	if duration < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "TPOT prediction duration must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "duration", duration)
 		return false
 	}
 	requestTPOTPredictionDuration.WithLabelValues(modelName, targetModelName).Observe(duration)
-	llmdRequestTPOTPredictionDuration.WithLabelValues(modelName, targetModelName).Observe(duration)
+	llmdRequestTPOTPredictionDuration.WithLabelValues(pluginName, pluginType, modelName, targetModelName).Observe(duration)
 	inferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOTPredictionDuration).Set(duration)
-	llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTPOTPredictionDuration).Set(duration)
+	llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTPOTPredictionDuration).Set(duration)
 	return true
 }
 
-func recordRequestTTFT(ctx context.Context, modelName, targetModelName string, ttft float64) bool {
+func recordRequestTTFT(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, ttft float64) bool {
 	if ttft < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "TTFT value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "ttft", ttft)
 		return false
 	}
 	requestTTFT.WithLabelValues(modelName, targetModelName).Observe(ttft)
-	llmdRequestTTFT.WithLabelValues(modelName, targetModelName).Observe(ttft)
+	llmdRequestTTFT.WithLabelValues(pluginName, pluginType, modelName, targetModelName).Observe(ttft)
 	inferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFT).Set(ttft)
-	llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFT).Set(ttft)
+	llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTTFT).Set(ttft)
 	return true
 }
 
-func recordRequestTTFTWithSLO(ctx context.Context, modelName, targetModelName string, ttft float64, sloThreshold float64) bool {
+func recordRequestTTFTWithSLO(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, ttft float64, sloThreshold float64) bool {
 	if ttft < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "TTFT value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "ttft", ttft)
@@ -337,41 +337,41 @@ func recordRequestTTFTWithSLO(ctx context.Context, modelName, targetModelName st
 
 	if ttft > sloThreshold {
 		inferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFTSLOViolation).Set(1)
-		llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFTSLOViolation).Set(1)
+		llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTTFTSLOViolation).Set(1)
 		sloViolationCounter.WithLabelValues(modelName, targetModelName, typeTTFT).Inc()
-		llmdSloViolationCounter.WithLabelValues(modelName, targetModelName, typeTTFT).Inc()
+		llmdSloViolationCounter.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTTFT).Inc()
 		log.FromContext(ctx).V(logutil.DEFAULT).Info("TTFT SLO violation detected",
 			"modelName", modelName, "targetModelName", targetModelName, "ttft", ttft, "threshold", sloThreshold)
 	} else {
 		inferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFTSLOViolation).Set(0)
-		llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFTSLOViolation).Set(0)
+		llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTTFTSLOViolation).Set(0)
 	}
 
 	return true
 }
 
-func recordRequestPredictedTTFT(ctx context.Context, modelName, targetModelName string, predictedTTFT float64) bool {
+func recordRequestPredictedTTFT(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, predictedTTFT float64) bool {
 	if predictedTTFT < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "Predicted TTFT value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "ttft", predictedTTFT)
 		return false
 	}
 	requestPredictedTTFT.WithLabelValues(modelName, targetModelName).Observe(predictedTTFT)
-	llmdRequestPredictedTTFT.WithLabelValues(modelName, targetModelName).Observe(predictedTTFT)
+	llmdRequestPredictedTTFT.WithLabelValues(pluginName, pluginType, modelName, targetModelName).Observe(predictedTTFT)
 	inferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTTFT).Set(predictedTTFT)
-	llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typePredictedTTFT).Set(predictedTTFT)
+	llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typePredictedTTFT).Set(predictedTTFT)
 	return true
 }
 
-func recordRequestTTFTPredictionDuration(ctx context.Context, modelName, targetModelName string, duration float64) bool {
+func recordRequestTTFTPredictionDuration(ctx context.Context, pluginName, pluginType, modelName, targetModelName string, duration float64) bool {
 	if duration < 0 {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "TTFT prediction duration must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "duration", duration)
 		return false
 	}
 	requestTTFTPredictionDuration.WithLabelValues(modelName, targetModelName).Observe(duration)
-	llmdRequestTTFTPredictionDuration.WithLabelValues(modelName, targetModelName).Observe(duration)
+	llmdRequestTTFTPredictionDuration.WithLabelValues(pluginName, pluginType, modelName, targetModelName).Observe(duration)
 	inferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFTPredictionDuration).Set(duration)
-	llmdInferenceGauges.WithLabelValues(modelName, targetModelName, typeTTFTPredictionDuration).Set(duration)
+	llmdInferenceGauges.WithLabelValues(pluginName, pluginType, modelName, targetModelName, typeTTFTPredictionDuration).Set(duration)
 	return true
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics_test.go
@@ -39,29 +39,44 @@ func TestRecordRequestLatencyMetrics(t *testing.T) {
 	t.Cleanup(resetMetrics)
 	ctx := t.Context()
 
-	require.True(t, recordRequestTTFT(ctx, "model", "target", 0.5))
-	require.True(t, recordRequestPredictedTTFT(ctx, "model", "target", 0.4))
-	require.True(t, recordRequestTTFTPredictionDuration(ctx, "model", "target", 0.1))
-	require.True(t, recordRequestTTFTWithSLO(ctx, "model", "target", 2, 1))
-	require.True(t, recordRequestTPOT(ctx, "model", "target", 0.05))
-	require.True(t, recordRequestPredictedTPOT(ctx, "model", "target", 0.04))
-	require.True(t, recordRequestTPOTPredictionDuration(ctx, "model", "target", 0.2))
-	require.True(t, recordRequestTPOTWithSLO(ctx, "model", "target", 3, 1))
+	require.True(t, recordRequestTTFT(ctx, "test-plugin", "test-type", "model", "target", 0.5))
+	require.True(t, recordRequestPredictedTTFT(ctx, "test-plugin", "test-type", "model", "target", 0.4))
+	require.True(t, recordRequestTTFTPredictionDuration(ctx, "test-plugin", "test-type", "model", "target", 0.1))
+	require.True(t, recordRequestTTFTWithSLO(ctx, "test-plugin", "test-type", "model", "target", 2, 1))
+	require.True(t, recordRequestTPOT(ctx, "test-plugin", "test-type", "model", "target", 0.05))
+	require.True(t, recordRequestPredictedTPOT(ctx, "test-plugin", "test-type", "model", "target", 0.04))
+	require.True(t, recordRequestTPOTPredictionDuration(ctx, "test-plugin", "test-type", "model", "target", 0.2))
+	require.True(t, recordRequestTPOTWithSLO(ctx, "test-plugin", "test-type", "model", "target", 3, 1))
 
 	ttft, err := getHistogram(requestTTFT, "model", "target")
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), ttft.GetSampleCount())
 	require.Equal(t, 0.5, ttft.GetSampleSum())
 
+	llmdTtft, err := getHistogram(llmdRequestTTFT, "test-plugin", "test-type", "model", "target")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), llmdTtft.GetSampleCount())
+	require.Equal(t, 0.5, llmdTtft.GetSampleSum())
+
 	tpot, err := getHistogram(requestTPOT, "model", "target")
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), tpot.GetSampleCount())
 	require.Equal(t, 0.05, tpot.GetSampleSum())
 
+	llmdTpot, err := getHistogram(llmdRequestTPOT, "test-plugin", "test-type", "model", "target")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), llmdTpot.GetSampleCount())
+	require.Equal(t, 0.05, llmdTpot.GetSampleSum())
+
 	require.Equal(t, 0.5, testutil.ToFloat64(inferenceGauges.WithLabelValues("model", "target", typeTTFT)))
 	require.Equal(t, 0.05, testutil.ToFloat64(inferenceGauges.WithLabelValues("model", "target", typeTPOT)))
 	require.Equal(t, float64(1), testutil.ToFloat64(sloViolationCounter.WithLabelValues("model", "target", typeTTFT)))
 	require.Equal(t, float64(1), testutil.ToFloat64(sloViolationCounter.WithLabelValues("model", "target", typeTPOT)))
+
+	require.Equal(t, 0.5, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typeTTFT)))
+	require.Equal(t, 0.05, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typeTPOT)))
+	require.Equal(t, float64(1), testutil.ToFloat64(llmdSloViolationCounter.WithLabelValues("test-plugin", "test-type", "model", "target", typeTTFT)))
+	require.Equal(t, float64(1), testutil.ToFloat64(llmdSloViolationCounter.WithLabelValues("test-plugin", "test-type", "model", "target", typeTPOT)))
 }
 
 func TestRecordRequestLatencyMetricsRejectNegativeValues(t *testing.T) {
@@ -69,14 +84,14 @@ func TestRecordRequestLatencyMetricsRejectNegativeValues(t *testing.T) {
 	t.Cleanup(resetMetrics)
 	ctx := t.Context()
 
-	require.False(t, recordRequestTTFT(ctx, "model", "target", -1))
-	require.False(t, recordRequestPredictedTTFT(ctx, "model", "target", -1))
-	require.False(t, recordRequestTTFTPredictionDuration(ctx, "model", "target", -1))
-	require.False(t, recordRequestTTFTWithSLO(ctx, "model", "target", -1, 1))
-	require.False(t, recordRequestTPOT(ctx, "model", "target", -1))
-	require.False(t, recordRequestPredictedTPOT(ctx, "model", "target", -1))
-	require.False(t, recordRequestTPOTPredictionDuration(ctx, "model", "target", -1))
-	require.False(t, recordRequestTPOTWithSLO(ctx, "model", "target", -1, 1))
+	require.False(t, recordRequestTTFT(ctx, "test-plugin", "test-type", "model", "target", -1))
+	require.False(t, recordRequestPredictedTTFT(ctx, "test-plugin", "test-type", "model", "target", -1))
+	require.False(t, recordRequestTTFTPredictionDuration(ctx, "test-plugin", "test-type", "model", "target", -1))
+	require.False(t, recordRequestTTFTWithSLO(ctx, "test-plugin", "test-type", "model", "target", -1, 1))
+	require.False(t, recordRequestTPOT(ctx, "test-plugin", "test-type", "model", "target", -1))
+	require.False(t, recordRequestPredictedTPOT(ctx, "test-plugin", "test-type", "model", "target", -1))
+	require.False(t, recordRequestTPOTPredictionDuration(ctx, "test-plugin", "test-type", "model", "target", -1))
+	require.False(t, recordRequestTPOTWithSLO(ctx, "test-plugin", "test-type", "model", "target", -1, 1))
 }
 
 func getHistogram(histogram *prometheus.HistogramVec, labelValues ...string) (*dto.Histogram, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics_test.go
@@ -68,6 +68,26 @@ func TestRecordRequestLatencyMetrics(t *testing.T) {
 	require.Equal(t, uint64(1), llmdTpot.GetSampleCount())
 	require.Equal(t, 0.05, llmdTpot.GetSampleSum())
 
+	llmdPredictedTtft, err := getHistogram(llmdRequestPredictedTTFT, "test-plugin", "test-type", "model", "target")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), llmdPredictedTtft.GetSampleCount())
+	require.Equal(t, 0.4, llmdPredictedTtft.GetSampleSum())
+
+	llmdTtftDuration, err := getHistogram(llmdRequestTTFTPredictionDuration, "test-plugin", "test-type", "model", "target")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), llmdTtftDuration.GetSampleCount())
+	require.Equal(t, 0.1, llmdTtftDuration.GetSampleSum())
+
+	llmdPredictedTpot, err := getHistogram(llmdRequestPredictedTPOT, "test-plugin", "test-type", "model", "target")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), llmdPredictedTpot.GetSampleCount())
+	require.Equal(t, 0.04, llmdPredictedTpot.GetSampleSum())
+
+	llmdTpotDuration, err := getHistogram(llmdRequestTPOTPredictionDuration, "test-plugin", "test-type", "model", "target")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), llmdTpotDuration.GetSampleCount())
+	require.Equal(t, 0.2, llmdTpotDuration.GetSampleSum())
+
 	require.Equal(t, 0.5, testutil.ToFloat64(inferenceGauges.WithLabelValues("model", "target", typeTTFT)))
 	require.Equal(t, 0.05, testutil.ToFloat64(inferenceGauges.WithLabelValues("model", "target", typeTPOT)))
 	require.Equal(t, float64(1), testutil.ToFloat64(sloViolationCounter.WithLabelValues("model", "target", typeTTFT)))
@@ -75,6 +95,10 @@ func TestRecordRequestLatencyMetrics(t *testing.T) {
 
 	require.Equal(t, 0.5, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typeTTFT)))
 	require.Equal(t, 0.05, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typeTPOT)))
+	require.Equal(t, 0.4, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typePredictedTTFT)))
+	require.Equal(t, 0.1, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typeTTFTPredictionDuration)))
+	require.Equal(t, 0.04, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typePredictedTPOT)))
+	require.Equal(t, 0.2, testutil.ToFloat64(llmdInferenceGauges.WithLabelValues("test-plugin", "test-type", "model", "target", typeTPOTPredictionDuration)))
 	require.Equal(t, float64(1), testutil.ToFloat64(llmdSloViolationCounter.WithLabelValues("test-plugin", "test-type", "model", "target", typeTTFT)))
 	require.Equal(t, float64(1), testutil.ToFloat64(llmdSloViolationCounter.WithLabelValues("test-plugin", "test-type", "model", "target", typeTPOT)))
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
@@ -73,7 +73,7 @@ func (pl *PredictedLatency) generatePredictions(ctx context.Context, predictedLa
 	}
 
 	// Bulk predict
-	bulkPredictions, err := bulkPredictWithMetrics(ctx, predictedLatencyCtx, pl.latencypredictor, metricsStates, pl.config.EndpointRoleLabel, targetEndpointsMetadatas, prompts, generatedTokenCounts, prefixCacheScores, prefillTokensInFlights)
+	bulkPredictions, err := bulkPredictWithMetrics(ctx, pl.typedName.Name, pl.typedName.Type, predictedLatencyCtx, pl.latencypredictor, metricsStates, pl.config.EndpointRoleLabel, targetEndpointsMetadatas, prompts, generatedTokenCounts, prefixCacheScores, prefillTokensInFlights)
 	if err != nil {
 		logger.V(logutil.DEBUG).Error(err, "Bulk prediction failed")
 		return nil, err

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -149,7 +149,7 @@ func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.
 			}
 		}
 	} else {
-		processTokenForLatencyPrediction(ctx, pl.latencypredictor, pl.config.EndpointRoleLabel, predictedLatencyCtx, targetMetadata, now, pl.config.SamplingMean, pl.config.MaxDecodeTokenSamplesForPrediction)
+		processTokenForLatencyPrediction(ctx, pl.typedName.Name, pl.typedName.Type, pl.latencypredictor, pl.config.EndpointRoleLabel, predictedLatencyCtx, targetMetadata, now, pl.config.SamplingMean, pl.config.MaxDecodeTokenSamplesForPrediction)
 	}
 
 	if response.EndOfStream {
@@ -161,10 +161,10 @@ func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.
 		if predictedLatencyCtx.ttft > 0 {
 			// In non-streaming mode, TTFT represents full e2e latency.
 			logger.V(logutil.TRACE).Info("Averages calculated", "avgActualTTFT", predictedLatencyCtx.ttft, "avgPredictedTTFT", predictedLatencyCtx.predictedTTFT)
-			recordRequestTTFT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.ttft/1000)
-			recordRequestPredictedTTFT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.predictedTTFT/1000)
+			recordRequestTTFT(ctx, pl.typedName.Name, pl.typedName.Type, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.ttft/1000)
+			recordRequestPredictedTTFT(ctx, pl.typedName.Name, pl.typedName.Type, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.predictedTTFT/1000)
 			if predictedLatencyCtx.ttftSLO > 0 {
-				recordRequestTTFTWithSLO(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.ttft, predictedLatencyCtx.ttftSLO)
+				recordRequestTTFTWithSLO(ctx, pl.typedName.Name, pl.typedName.Type, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.ttft, predictedLatencyCtx.ttftSLO)
 			}
 		}
 
@@ -175,10 +175,10 @@ func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.
 
 		if predictedLatencyCtx.avgTPOT > 0 {
 			logger.V(logutil.TRACE).Info("Averages calculated", "avgActualTPOT", predictedLatencyCtx.avgTPOT, "avgPredictedTPOT", predictedLatencyCtx.avgPredictedTPOT)
-			recordRequestTPOT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgTPOT/1000)
-			recordRequestPredictedTPOT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgPredictedTPOT/1000)
+			recordRequestTPOT(ctx, pl.typedName.Name, pl.typedName.Type, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgTPOT/1000)
+			recordRequestPredictedTPOT(ctx, pl.typedName.Name, pl.typedName.Type, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgPredictedTPOT/1000)
 			if predictedLatencyCtx.avgTPOTSLO > 0 {
-				recordRequestTPOTWithSLO(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgTPOT, predictedLatencyCtx.avgTPOTSLO)
+				recordRequestTPOTWithSLO(ctx, pl.typedName.Name, pl.typedName.Type, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgTPOT, predictedLatencyCtx.avgTPOTSLO)
 			}
 
 			if m, err := getLatestMetricsForProfile(predictedLatencyCtx, ""); err == nil {
@@ -322,6 +322,7 @@ func predictFirstTPOT(ctx context.Context, predictedLatencyCtx *predictedLatency
 // processTokenForLatencyPrediction records actual inter-token latency, sampled predictions, and advances timestamp.
 func processTokenForLatencyPrediction(
 	ctx context.Context,
+	pluginName, pluginType string,
 	predictor latencypredictor.PredictorInterface,
 	endpointRoleLabel string,
 	predictedLatencyCtx *predictedLatencyCtx,
@@ -377,7 +378,7 @@ func processTokenForLatencyPrediction(
 			predictedLatencyCtx.predictedTPOTObservations = append(predictedLatencyCtx.predictedTPOTObservations, p.TPOT)
 			predictedLatencyCtx.avgPredictedTPOT = calculateRunningAverage(predictedLatencyCtx.avgPredictedTPOT, p.TPOT, len(predictedLatencyCtx.predictedTPOTObservations))
 		}
-		recordRequestTPOTPredictionDuration(ctx, predictedLatencyCtx.schedulingRequest.TargetModel, predictedLatencyCtx.incomingModelName, dur.Seconds())
+		recordRequestTPOTPredictionDuration(ctx, pluginName, pluginType, predictedLatencyCtx.schedulingRequest.TargetModel, predictedLatencyCtx.incomingModelName, dur.Seconds())
 		predictedLatencyCtx.decodeTokenSampler.recordPrediction(predictedLatencyCtx.generatedTokenCount)
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
@@ -153,6 +153,7 @@ func getLatestMetricsForProfile(predictedLatencyCtx *predictedLatencyCtx, profil
 // bulkPredictWithMetrics performs bulk predictions for multiple pods using their metrics states.
 func bulkPredictWithMetrics(
 	ctx context.Context,
+	pluginName, pluginType string,
 	predictedLatencyContext *predictedLatencyCtx,
 	predictor latencypredictor.PredictorInterface,
 	metricsStates []*fwkdl.Metrics,
@@ -219,8 +220,8 @@ func bulkPredictWithMetrics(
 	}
 
 	if predictedLatencyContext != nil {
-		recordRequestTTFTPredictionDuration(ctx, predictedLatencyContext.schedulingRequest.TargetModel, predictedLatencyContext.incomingModelName, duration.Seconds())
-		recordRequestTPOTPredictionDuration(ctx, predictedLatencyContext.schedulingRequest.TargetModel, predictedLatencyContext.incomingModelName, duration.Seconds())
+		recordRequestTTFTPredictionDuration(ctx, pluginName, pluginType, predictedLatencyContext.schedulingRequest.TargetModel, predictedLatencyContext.incomingModelName, duration.Seconds())
+		recordRequestTPOTPredictionDuration(ctx, pluginName, pluginType, predictedLatencyContext.schedulingRequest.TargetModel, predictedLatencyContext.incomingModelName, duration.Seconds())
 	}
 
 	results := make([]*latencypredictor.PredictionResponse, len(bulkResponse.Predictions))

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -55,7 +55,7 @@ func TestBulkPredictWithMetrics(t *testing.T) {
 	generatedTokenCounts := []int{1, 1}
 	prefixCacheScores := []float64{0.0, 0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), "test-plugin", "test-type", nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
@@ -82,7 +82,7 @@ func TestBulkPredictWithMetrics_Error(t *testing.T) {
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), "test-plugin", "test-type", nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, results)
@@ -100,7 +100,7 @@ func TestBulkPredictWithMetrics_InputMismatch(t *testing.T) {
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), "test-plugin", "test-type", nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, results)
@@ -133,7 +133,7 @@ func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
 		incomingModelName: "incoming-model",
 	}
 
-	results, err := bulkPredictWithMetrics(context.Background(), plCtx, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), "test-plugin", "test-type", plCtx, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -164,7 +164,7 @@ func TestBulkPredictWithMetrics_ChatCompletionsPrompt(t *testing.T) {
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mp, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, []int64{0})
+	results, err := bulkPredictWithMetrics(context.Background(), "test-plugin", "test-type", nil, mp, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, []int64{0})
 
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -183,7 +183,7 @@ func TestBulkPredictWithMetrics_NilMetricsState(t *testing.T) {
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
 
-	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+	results, err := bulkPredictWithMetrics(context.Background(), "test-plugin", "test-type", nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, results)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -326,7 +326,7 @@ func (h *Handler) Pick(ctx context.Context, request *scheduling.InferenceRequest
 	prefillUsed := profileResults[h.prefillProfile] != nil
 
 	decision := DisaggDecisionType(encodeUsed, prefillUsed)
-	RecordDisaggDecision(request.TargetModel, decision)
+	RecordDisaggDecision(h.typedName.Name, h.typedName.Type, request.TargetModel, decision)
 	span.SetAttributes(attribute.String("llm_d.profile_handler.decision", "complete_"+decision))
 
 	return map[string]scheduling.SchedulerProfile{}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics.go
@@ -59,7 +59,7 @@ var (
 			Name:      "pd_decision_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of P/D disaggregation decisions made", compbasemetrics.ALPHA),
 		},
-		[]string{"model_name", "decision_type"},
+		[]string{"plugin_name", "plugin_type", "model_name", "decision_type"},
 	)
 
 	// SchedulerDisaggDecisionCount records disaggregation routing decisions,
@@ -83,7 +83,7 @@ var (
 			Name:      "disagg_decision_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of disaggregation routing decisions made", compbasemetrics.ALPHA),
 		},
-		[]string{"model_name", "decision_type"},
+		[]string{"plugin_name", "plugin_type", "model_name", "decision_type"},
 	)
 )
 
@@ -111,24 +111,24 @@ func registerMetrics(registerer prometheus.Registerer) error {
 // RecordPDDecision increments the counter for a specific P/D routing decision.
 //
 // Deprecated: Use RecordDisaggDecision instead.
-func RecordPDDecision(modelName, decisionType string) {
+func RecordPDDecision(pluginName, pluginType, modelName, decisionType string) {
 	if modelName == "" {
 		modelName = "unknown"
 	}
 	SchedulerPDDecisionCount.WithLabelValues(modelName, decisionType).Inc()
-	LlmdPDDecisionCount.WithLabelValues(modelName, decisionType).Inc()
+	LlmdPDDecisionCount.WithLabelValues(pluginName, pluginType, modelName, decisionType).Inc()
 }
 
 // RecordDisaggDecision increments the counter for a disaggregation routing decision.
 // The decisionType must be one of the DecisionType* constants (DecisionTypeDecodeOnly,
 // DecisionTypePrefillDecode, DecisionTypeEncodeDecode, DecisionTypeEncodePrefillDecode).
 // The model parameter should be the target model name; if empty, "unknown" is used.
-func RecordDisaggDecision(modelName, decisionType string) {
+func RecordDisaggDecision(pluginName, pluginType, modelName, decisionType string) {
 	if modelName == "" {
 		modelName = "unknown"
 	}
 	SchedulerDisaggDecisionCount.WithLabelValues(modelName, decisionType).Inc()
-	LlmdDisaggDecisionCount.WithLabelValues(modelName, decisionType).Inc()
+	LlmdDisaggDecisionCount.WithLabelValues(pluginName, pluginType, modelName, decisionType).Inc()
 }
 
 // DisaggDecisionType returns the DecisionType* constant corresponding to which

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics_test.go
@@ -29,9 +29,9 @@ func TestSchedulerPDDecisionCount(t *testing.T) {
 
 	model := "test-model"
 
-	RecordPDDecision(model, DecisionTypePrefillDecode)
-	RecordPDDecision(model, DecisionTypeDecodeOnly)
-	RecordPDDecision(model, DecisionTypePrefillDecode)
+	RecordPDDecision("test-plugin", "test-type", model, DecisionTypePrefillDecode)
+	RecordPDDecision("test-plugin", "test-type", model, DecisionTypeDecodeOnly)
+	RecordPDDecision("test-plugin", "test-type", model, DecisionTypePrefillDecode)
 
 	expected := `
 		# HELP llm_d_inference_scheduler_pd_decision_total [ALPHA] [Deprecated: Use llm_d_router_epp_pd_decision_total] Total number of P/D disaggregation decisions made
@@ -48,8 +48,8 @@ func TestSchedulerPDDecisionCount(t *testing.T) {
 	expectedNew := `
 		# HELP llm_d_router_epp_pd_decision_total [ALPHA] Total number of P/D disaggregation decisions made
 		# TYPE llm_d_router_epp_pd_decision_total counter
-		llm_d_router_epp_pd_decision_total{decision_type="decode-only",model_name="test-model"} 1
-		llm_d_router_epp_pd_decision_total{decision_type="prefill-decode",model_name="test-model"} 2
+		llm_d_router_epp_pd_decision_total{decision_type="decode-only",model_name="test-model",plugin_name="test-plugin",plugin_type="test-type"} 1
+		llm_d_router_epp_pd_decision_total{decision_type="prefill-decode",model_name="test-model",plugin_name="test-plugin",plugin_type="test-type"} 2
 	`
 
 	if err := testutil.CollectAndCompare(LlmdPDDecisionCount, strings.NewReader(expectedNew),
@@ -64,13 +64,13 @@ func TestRecordDisaggDecision(t *testing.T) {
 	LlmdDisaggDecisionCount.Reset()
 
 	model := "test-model"
-	RecordDisaggDecision(model, DecisionTypeDecodeOnly)
-	RecordDisaggDecision(model, DecisionTypePrefillDecode)
-	RecordDisaggDecision(model, DecisionTypePrefillDecode)
-	RecordDisaggDecision(model, DecisionTypeEncodeDecode)
-	RecordDisaggDecision(model, DecisionTypeEncodePrefillDecode)
-	RecordDisaggDecision(model, DecisionTypeEncodePrefillDecode)
-	RecordDisaggDecision(model, DecisionTypeEncodePrefillDecode)
+	RecordDisaggDecision("test-plugin", "test-type", model, DecisionTypeDecodeOnly)
+	RecordDisaggDecision("test-plugin", "test-type", model, DecisionTypePrefillDecode)
+	RecordDisaggDecision("test-plugin", "test-type", model, DecisionTypePrefillDecode)
+	RecordDisaggDecision("test-plugin", "test-type", model, DecisionTypeEncodeDecode)
+	RecordDisaggDecision("test-plugin", "test-type", model, DecisionTypeEncodePrefillDecode)
+	RecordDisaggDecision("test-plugin", "test-type", model, DecisionTypeEncodePrefillDecode)
+	RecordDisaggDecision("test-plugin", "test-type", model, DecisionTypeEncodePrefillDecode)
 
 	expected := `
 		# HELP llm_d_inference_scheduler_disagg_decision_total [ALPHA] [Deprecated: Use llm_d_router_epp_disagg_decision_total] Total number of disaggregation routing decisions made
@@ -89,10 +89,10 @@ func TestRecordDisaggDecision(t *testing.T) {
 	expectedNew := `
 		# HELP llm_d_router_epp_disagg_decision_total [ALPHA] Total number of disaggregation routing decisions made
 		# TYPE llm_d_router_epp_disagg_decision_total counter
-		llm_d_router_epp_disagg_decision_total{decision_type="decode-only",model_name="test-model"} 1
-		llm_d_router_epp_disagg_decision_total{decision_type="encode-decode",model_name="test-model"} 1
-		llm_d_router_epp_disagg_decision_total{decision_type="encode-prefill-decode",model_name="test-model"} 3
-		llm_d_router_epp_disagg_decision_total{decision_type="prefill-decode",model_name="test-model"} 2
+		llm_d_router_epp_disagg_decision_total{decision_type="decode-only",model_name="test-model",plugin_name="test-plugin",plugin_type="test-type"} 1
+		llm_d_router_epp_disagg_decision_total{decision_type="encode-decode",model_name="test-model",plugin_name="test-plugin",plugin_type="test-type"} 1
+		llm_d_router_epp_disagg_decision_total{decision_type="encode-prefill-decode",model_name="test-model",plugin_name="test-plugin",plugin_type="test-type"} 3
+		llm_d_router_epp_disagg_decision_total{decision_type="prefill-decode",model_name="test-model",plugin_name="test-plugin",plugin_type="test-type"} 2
 	`
 
 	if err := testutil.CollectAndCompare(LlmdDisaggDecisionCount, strings.NewReader(expectedNew),
@@ -105,7 +105,7 @@ func TestRecordDisaggDecisionEmptyModel(t *testing.T) {
 	SchedulerDisaggDecisionCount.Reset()
 	LlmdDisaggDecisionCount.Reset()
 
-	RecordDisaggDecision("", DecisionTypeDecodeOnly)
+	RecordDisaggDecision("test-plugin", "test-type", "", DecisionTypeDecodeOnly)
 
 	expected := `
 		# HELP llm_d_inference_scheduler_disagg_decision_total [ALPHA] [Deprecated: Use llm_d_router_epp_disagg_decision_total] Total number of disaggregation routing decisions made
@@ -121,7 +121,7 @@ func TestRecordDisaggDecisionEmptyModel(t *testing.T) {
 	expectedNew := `
 		# HELP llm_d_router_epp_disagg_decision_total [ALPHA] Total number of disaggregation routing decisions made
 		# TYPE llm_d_router_epp_disagg_decision_total counter
-		llm_d_router_epp_disagg_decision_total{decision_type="decode-only",model_name="unknown"} 1
+		llm_d_router_epp_disagg_decision_total{decision_type="decode-only",model_name="unknown",plugin_name="test-plugin",plugin_type="test-type"} 1
 	`
 
 	if err := testutil.CollectAndCompare(LlmdDisaggDecisionCount, strings.NewReader(expectedNew),

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -199,7 +199,7 @@ func (h *PdProfileHandler) Pick(ctx context.Context, request *scheduling.Inferen
 	}
 
 	if h.decider != nil && h.decider.disaggregate(ctx, request, profileResults[h.decodeProfile].TargetEndpoints[0]) {
-		RecordPDDecision(request.TargetModel, DecisionTypePrefillDecode) //nolint:staticcheck // intentional: pd-profile-handler is itself deprecated
+		RecordPDDecision(h.typedName.Name, h.typedName.Type, request.TargetModel, DecisionTypePrefillDecode) //nolint:staticcheck // intentional: pd-profile-handler is itself deprecated
 		// run the prefill profile
 		span.SetAttributes(
 			attribute.String("llm_d.profile_handler.decision", "prefill_decode"),
@@ -210,7 +210,7 @@ func (h *PdProfileHandler) Pick(ctx context.Context, request *scheduling.Inferen
 		}
 	}
 
-	RecordPDDecision(request.TargetModel, DecisionTypeDecodeOnly) //nolint:staticcheck // intentional: pd-profile-handler is itself deprecated
+	RecordPDDecision(h.typedName.Name, h.typedName.Type, request.TargetModel, DecisionTypeDecodeOnly) //nolint:staticcheck // intentional: pd-profile-handler is itself deprecated
 	span.SetAttributes(
 		attribute.String("llm_d.profile_handler.decision", "decode_only"),
 	)


### PR DESCRIPTION
Introduce plugin_name and plugin_type labels for the new EPP metrics. This implements tracking of specific endpoint picker plugin details.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1243

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Metrics emitted by plugins will have `plugin_name` and `plugin_type` labels.
```
