### PR TITLE
fix: release images embed CommitSHA=unknown, breaking version traceability in logs, metrics, and traces

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -60,5 +60,6 @@ runs:
         build-args: |
           LDFLAGS=-s -w
           COMMIT_SHA=${{ inputs.commit-sha || 'unknown' }}
+          BUILD_REF=${{ inputs.tag || 'unknown' }}
         cache-from: type=gha,scope=${{ inputs.image-name }}
         cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -41,6 +41,7 @@ jobs:
           registry: ghcr.io/llm-d
           github-token: ${{ github.token }}
           prerelease: ${{ inputs.prerelease }}
+          commit-sha: ${{ github.sha }}
 
       - name: Run Trivy scan on EPP image
         uses: ./.github/actions/trivy-scan
@@ -62,6 +63,7 @@ jobs:
           registry: ghcr.io/llm-d
           github-token: ${{ github.token }}
           prerelease: ${{ inputs.prerelease }}
+          commit-sha: ${{ github.sha }}
 
       - name: Run Trivy scan on sidecar image
         uses: ./.github/actions/trivy-scan


### PR DESCRIPTION
…h action

 
/kind bug
 

**What this PR does / why we need it**:

## Trigger Scenario
Every official release image build triggered by ci-release.yaml (tag push or GitHub release published) flows through ci-build-images.yaml → docker-build-and-pushaction. Neither the release workflow nor the dev workflow passes commit-sha to the action, and the action never passed BUILD_REF as a Docker build arg at all.

## Fault Behavior
All officially published EPP and sidecar images are built with:

 CommitSHA = "unknown"
 BuildRef  = ""

These values are embedded at compile time via -ldflags and cannot be changed at runtime. Every release image carries wrong version metadata permanently.

## Expected Behavior
The Go codebase explicitly consumes both values in three production paths:
 - Startup log: cmd/epp/runner/runner.go, cmd/pd-sidecar/main.go
 - Prometheus info metric: metrics.RecordInferenceExtensionInfo()
 - OpenTelemetry tracing: semconv.ServiceVersionKey, attribute "commit-sha"

The Dockerfiles (Dockerfile.epp, Dockerfile.sidecar) already declare ARG COMMIT_SHA and ARG BUILD_REF and inject them via -ldflags. The local make image-build-epppath correctly passes both. CI should produce identical metadata.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
