### PR TITLE
update(GHA): to scan image before push out

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -2,8 +2,17 @@ name: Trivy Scan
 description: Scan container image with official Aqua Security Trivy action
 inputs:
   image:
-    required: true
-    description: "Image to scan (e.g., 'my-repo/my-image:latest')"
+    required: false
+    default: ''
+    description: "Image reference to scan (e.g., 'my-repo/my-image:latest'). Mutually exclusive with 'tarball'."
+  tarball:
+    required: false
+    default: ''
+    description: "Path to a local image tarball to scan (e.g. /tmp/image.tar from buildx type=docker,dest=...). Mutually exclusive with 'image'."
+  severity:
+    required: false
+    default: 'HIGH,CRITICAL'
+    description: "Comma-separated severities that fail the scan (e.g. 'CRITICAL' or 'MEDIUM,HIGH,CRITICAL')."
 
 runs:
   using: "composite"
@@ -12,9 +21,10 @@ runs:
       uses: aquasecurity/trivy-action@v0.36.0 # v0.36.0 ed142fd0673e97e23eac54620cfb913e5ce36c25
       with:
         image-ref: ${{ inputs.image }}
+        input: ${{ inputs.tarball }}
         format: 'sarif'
         output: 'trivy-results.sarif'
-        severity: 'HIGH,CRITICAL'
+        severity: ${{ inputs.severity }}
         exit-code: '1'
 
     - name: Upload Trivy SARIF to Security tab

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -42,7 +42,7 @@ jobs:
           push: 'false'
           buildx-outputs: type=docker,dest=/tmp/epp-image.tar
 
-      # Gate the push on the scan: a HIGH/CRITICAL by default when not set but configable
+      # Gate the push on the scan: a HIGH/CRITICAL by default when not set but configurable
       - name: Run Trivy scan for EPP on AMD64
         uses: ./.github/actions/trivy-scan
         with:

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -32,7 +32,24 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Build and push EPP image
+      - name: Build AMD64 EPP image (no push)
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: Dockerfile.epp
+          tag: ${{ inputs.tag }}
+          image-name: ${{ inputs.epp-image-name }}
+          registry: ghcr.io/llm-d
+          push: 'false'
+          buildx-outputs: type=docker,dest=/tmp/epp-image.tar
+
+      # Gate the push on the scan: a HIGH/CRITICAL by default when not set but configable
+      - name: Run Trivy scan for EPP on AMD64
+        uses: ./.github/actions/trivy-scan
+        with:
+          tarball: /tmp/epp-image.tar
+
+      # Re-run the build with push enabled with: cache-to/cache-from type=gha
+      - name: Push EPP image for both AMD64 and ARM64
         uses: ./.github/actions/docker-build-and-push
         with:
           docker-file: Dockerfile.epp
@@ -42,11 +59,7 @@ jobs:
           github-token: ${{ github.token }}
           prerelease: ${{ inputs.prerelease }}
           commit-sha: ${{ github.sha }}
-
-      - name: Run Trivy scan on EPP image
-        uses: ./.github/actions/trivy-scan
-        with:
-          image: ghcr.io/llm-d/${{ inputs.epp-image-name }}:${{ inputs.tag }}
+          push: 'true'
 
   build-sidecar:
     runs-on: ubuntu-latest
@@ -54,7 +67,22 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Build and push sidecar image
+      - name: Build sidecar AMD64 image (no push)
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: Dockerfile.sidecar
+          tag: ${{ inputs.tag }}
+          image-name: ${{ inputs.sidecar-image-name }}
+          registry: ghcr.io/llm-d
+          push: 'false'
+          buildx-outputs: type=docker,dest=/tmp/sidecar-image.tar
+
+      - name: Run Trivy scan on sidecar image on AMD64
+        uses: ./.github/actions/trivy-scan
+        with:
+          tarball: /tmp/sidecar-image.tar
+
+      - name: Push sidecar image for both AMD64 and ARM64
         uses: ./.github/actions/docker-build-and-push
         with:
           docker-file: Dockerfile.sidecar
@@ -64,11 +92,7 @@ jobs:
           github-token: ${{ github.token }}
           prerelease: ${{ inputs.prerelease }}
           commit-sha: ${{ github.sha }}
-
-      - name: Run Trivy scan on sidecar image
-        uses: ./.github/actions/trivy-scan
-        with:
-          image: ghcr.io/llm-d/${{ inputs.sidecar-image-name }}:${{ inputs.tag }}
+          push: 'true'
 
   push-helm-charts:
     needs: [build-epp, build-sidecar]


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
- steps: build amd64 image, generate tarball to scan, gate on high or critical
- if passed: build amd64 and arm64, push to registry
- make severity configable by default is on high or critical

**Which issue(s) this PR fixes**:
per discussion https://llm-d.slack.com/archives/C08SBNRRSBD/p1780345117131489

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
