### PR TITLE
fix(epp): support legacy inference API group in cache configuration

### DIFF
--- a/pkg/epp/server/controller_config.go
+++ b/pkg/epp/server/controller_config.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
 )
@@ -37,6 +38,8 @@ type ControllerConfig struct {
 	startCrdReconcilers       bool
 	hasInferenceObjective     bool
 	hasInferenceModelRewrites bool
+	InferenceObjectiveGV      schema.GroupVersion
+	InferenceModelRewriteGV   schema.GroupVersion
 }
 
 func NewControllerConfig(startCrdReconcilers bool) ControllerConfig {
@@ -58,17 +61,31 @@ func (cc *ControllerConfig) PopulateControllerConfig(cfg *rest.Config) error {
 }
 
 func (cc *ControllerConfig) populateWithDiscovery(dc discovery.DiscoveryInterface) {
-	cc.hasInferenceObjective = kindExistsInAnyGroupVersion(dc, "InferenceObjective", supportedInferenceAPIGVs)
-	cc.hasInferenceModelRewrites = kindExistsInAnyGroupVersion(dc, "InferenceModelRewrite", supportedInferenceAPIGVs)
-}
+	log := ctrl.Log.WithName("controllerConfig")
 
-func kindExistsInAnyGroupVersion(dc discovery.DiscoveryInterface, kind string, groupVersions []schema.GroupVersion) bool {
-	for _, gv := range groupVersions {
-		if gvkExists(dc, gv.WithKind(kind)) {
-			return true
+	if gv, found := findGroupVersion(dc, "InferenceObjective", supportedInferenceAPIGVs); found {
+		cc.hasInferenceObjective = true
+		cc.InferenceObjectiveGV = gv
+		if gv == inferenceAPIGV && gvkExists(dc, legacyInferenceAPIGV.WithKind("InferenceObjective")) {
+			log.Info("Warning: Both legacy (inference.networking.x-k8s.io) and new (llm-d.ai) InferenceObjective CRDs are installed. EPP will prefer the new group and IGNORE legacy resources.")
 		}
 	}
-	return false
+	if gv, found := findGroupVersion(dc, "InferenceModelRewrite", supportedInferenceAPIGVs); found {
+		cc.hasInferenceModelRewrites = true
+		cc.InferenceModelRewriteGV = gv
+		if gv == inferenceAPIGV && gvkExists(dc, legacyInferenceAPIGV.WithKind("InferenceModelRewrite")) {
+			log.Info("Warning: Both legacy (inference.networking.x-k8s.io) and new (llm-d.ai) InferenceModelRewrite CRDs are installed. EPP will prefer the new group and IGNORE legacy resources.")
+		}
+	}
+}
+
+func findGroupVersion(dc discovery.DiscoveryInterface, kind string, groupVersions []schema.GroupVersion) (schema.GroupVersion, bool) {
+	for _, gv := range groupVersions {
+		if gvkExists(dc, gv.WithKind(kind)) {
+			return gv, true
+		}
+	}
+	return schema.GroupVersion{}, false
 }
 
 func gvkExists(dc discovery.DiscoveryInterface, gvk schema.GroupVersionKind) bool {

--- a/pkg/epp/server/controller_config_test.go
+++ b/pkg/epp/server/controller_config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery/fake"
 	k8stesting "k8s.io/client-go/testing"
 
@@ -40,10 +41,12 @@ func TestNewControllerConfig(t *testing.T) {
 
 func TestPopulateWithDiscovery(t *testing.T) {
 	tests := []struct {
-		name                      string
-		apiResourceLists          []*metav1.APIResourceList
-		wantInferenceObjective    bool
-		wantInferenceModelRewrite bool
+		name                        string
+		apiResourceLists            []*metav1.APIResourceList
+		wantInferenceObjective      bool
+		wantInferenceModelRewrite   bool
+		wantInferenceObjectiveGV    schema.GroupVersion
+		wantInferenceModelRewriteGV schema.GroupVersion
 	}{
 		{
 			name: "Both resources exist in llm-d group",
@@ -56,8 +59,10 @@ func TestPopulateWithDiscovery(t *testing.T) {
 					},
 				},
 			},
-			wantInferenceObjective:    true,
-			wantInferenceModelRewrite: true,
+			wantInferenceObjective:      true,
+			wantInferenceModelRewrite:   true,
+			wantInferenceObjectiveGV:    inferenceAPIGV,
+			wantInferenceModelRewriteGV: inferenceAPIGV,
 		},
 		{
 			name: "Both resources exist in legacy group",
@@ -70,8 +75,10 @@ func TestPopulateWithDiscovery(t *testing.T) {
 					},
 				},
 			},
-			wantInferenceObjective:    true,
-			wantInferenceModelRewrite: true,
+			wantInferenceObjective:      true,
+			wantInferenceModelRewrite:   true,
+			wantInferenceObjectiveGV:    legacyInferenceAPIGV,
+			wantInferenceModelRewriteGV: legacyInferenceAPIGV,
 		},
 		{
 			name: "Resources do not exist",
@@ -85,8 +92,10 @@ func TestPopulateWithDiscovery(t *testing.T) {
 					APIResources: []metav1.APIResource{},
 				},
 			},
-			wantInferenceObjective:    false,
-			wantInferenceModelRewrite: false,
+			wantInferenceObjective:      false,
+			wantInferenceModelRewrite:   false,
+			wantInferenceObjectiveGV:    schema.GroupVersion{},
+			wantInferenceModelRewriteGV: schema.GroupVersion{},
 		},
 		{
 			name: "Only InferenceObjective exists in llm-d group",
@@ -98,8 +107,10 @@ func TestPopulateWithDiscovery(t *testing.T) {
 					},
 				},
 			},
-			wantInferenceObjective:    true,
-			wantInferenceModelRewrite: false,
+			wantInferenceObjective:      true,
+			wantInferenceModelRewrite:   false,
+			wantInferenceObjectiveGV:    inferenceAPIGV,
+			wantInferenceModelRewriteGV: schema.GroupVersion{},
 		},
 		{
 			name: "Resources exist across supported groups",
@@ -117,8 +128,10 @@ func TestPopulateWithDiscovery(t *testing.T) {
 					},
 				},
 			},
-			wantInferenceObjective:    true,
-			wantInferenceModelRewrite: true,
+			wantInferenceObjective:      true,
+			wantInferenceModelRewrite:   true,
+			wantInferenceObjectiveGV:    inferenceAPIGV,
+			wantInferenceModelRewriteGV: legacyInferenceAPIGV,
 		},
 		{
 			name: "Only InferenceModelRewrite exists in legacy group",
@@ -130,8 +143,10 @@ func TestPopulateWithDiscovery(t *testing.T) {
 					},
 				},
 			},
-			wantInferenceObjective:    false,
-			wantInferenceModelRewrite: true,
+			wantInferenceObjective:      false,
+			wantInferenceModelRewrite:   true,
+			wantInferenceObjectiveGV:    schema.GroupVersion{},
+			wantInferenceModelRewriteGV: legacyInferenceAPIGV,
 		},
 	}
 
@@ -148,8 +163,14 @@ func TestPopulateWithDiscovery(t *testing.T) {
 			if cc.hasInferenceObjective != tt.wantInferenceObjective {
 				t.Errorf("populateWithDiscovery() hasInferenceObjective = %v, want %v", cc.hasInferenceObjective, tt.wantInferenceObjective)
 			}
+			if cc.InferenceObjectiveGV != tt.wantInferenceObjectiveGV {
+				t.Errorf("populateWithDiscovery() InferenceObjectiveGV = %v, want %v", cc.InferenceObjectiveGV, tt.wantInferenceObjectiveGV)
+			}
 			if cc.hasInferenceModelRewrites != tt.wantInferenceModelRewrite {
 				t.Errorf("populateWithDiscovery() hasInferenceModelRewrites = %v, want %v", cc.hasInferenceModelRewrites, tt.wantInferenceModelRewrite)
+			}
+			if cc.InferenceModelRewriteGV != tt.wantInferenceModelRewriteGV {
+				t.Errorf("populateWithDiscovery() InferenceModelRewriteGV = %v, want %v", cc.InferenceModelRewriteGV, tt.wantInferenceModelRewriteGV)
 			}
 		})
 	}

--- a/pkg/epp/server/controller_manager.go
+++ b/pkg/epp/server/controller_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -35,16 +36,33 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common"
 )
 
-var scheme = runtime.NewScheme()
+// NewScheme creates a new runtime.Scheme and registers the types based on the config.
+func NewScheme(cfg ControllerConfig) *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(v1.Install(s))
 
-func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(v1alpha2.Install(scheme))
-	utilruntime.Must(v1.Install(scheme))
+	if cfg.startCrdReconcilers {
+		if cfg.hasInferenceObjective {
+			s.AddKnownTypes(cfg.InferenceObjectiveGV,
+				&v1alpha2.InferenceObjective{},
+				&v1alpha2.InferenceObjectiveList{},
+			)
+			metav1.AddToGroupVersion(s, cfg.InferenceObjectiveGV)
+		}
+		if cfg.hasInferenceModelRewrites {
+			s.AddKnownTypes(cfg.InferenceModelRewriteGV,
+				&v1alpha2.InferenceModelRewrite{},
+				&v1alpha2.InferenceModelRewriteList{},
+			)
+			metav1.AddToGroupVersion(s, cfg.InferenceModelRewriteGV)
+		}
+	}
+	return s
 }
 
 // defaultManagerOptions returns the default options used to create the manager.
-func defaultManagerOptions(cfg ControllerConfig, gknn common.GKNN, metricsServerOptions metricsserver.Options) ctrl.Options {
+func defaultManagerOptions(cfg ControllerConfig, gknn common.GKNN, metricsServerOptions metricsserver.Options, scheme *runtime.Scheme) ctrl.Options {
 	opt := ctrl.Options{
 		Scheme: scheme,
 		Cache: cache.Options{
@@ -86,7 +104,8 @@ func defaultManagerOptions(cfg ControllerConfig, gknn common.GKNN, metricsServer
 // NewDefaultManager creates a new controller manager with default configuration.
 // Optional override functions can be passed to customize the manager options (e.g., for testing).
 func NewDefaultManager(controllerCfg ControllerConfig, gknn common.GKNN, restConfig *rest.Config, metricsServerOptions metricsserver.Options, leaderElectionEnabled bool, overrides ...func(*ctrl.Options)) (ctrl.Manager, error) {
-	opt := defaultManagerOptions(controllerCfg, gknn, metricsServerOptions)
+	scheme := NewScheme(controllerCfg)
+	opt := defaultManagerOptions(controllerCfg, gknn, metricsServerOptions, scheme)
 	if leaderElectionEnabled {
 		opt.LeaderElection = true
 		opt.LeaderElectionResourceLock = "leases"

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -81,11 +81,17 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 		},
 	}
 	return &ExtProcServerRunner{
-		GrpcPort:                         opts.GRPCPort,
-		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
-		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
-		GKNN:                             gknn,
-		ControllerCfg:                    ControllerConfig{true, true, true},
+		GrpcPort:           opts.GRPCPort,
+		GRPCMaxRecvMsgSize: opts.GRPCMaxRecvMsgSize,
+		GRPCMaxSendMsgSize: opts.GRPCMaxSendMsgSize,
+		GKNN:               gknn,
+		ControllerCfg: ControllerConfig{
+			startCrdReconcilers:       true,
+			hasInferenceObjective:     true,
+			hasInferenceModelRewrites: true,
+			InferenceObjectiveGV:      inferenceAPIGV,
+			InferenceModelRewriteGV:   inferenceAPIGV,
+		},
 		SecureServing:                    opts.SecureServing,
 		HealthChecking:                   opts.HealthChecking,
 		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,


### PR DESCRIPTION
EPP cache configuration was hardcoded to use the new `llm-d.ai` API group for `InferenceObjective` and `InferenceModelRewrite` resources. This caused EPP to fail to start in clusters where only the legacy `inference.networking.x-k8s.io` CRDs were installed, even though the config loader detected them.

This change:
- Updates `ControllerConfig` to detect and store the actual `GroupVersion` found in the cluster.
- Dynamically constructs the manager's `Scheme` using the detected `GroupVersion`s.
- Configures the cache to watch the correct GVK dynamically.
- Adds warning logs if both legacy and new CRDs are present, noting that EPP will prefer the new group.

/kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/llm-d/llm-d-router/issues/1432

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
If both legacy (inference.networking.x-k8s.io) and new (llm-d.ai) InferenceObjective/InferenceModelRewrite CRDs are installed. EPP will only reconcile the new group and IGNORE legacy resources.
```
