### PR TITLE
fix(ci): exclude release-notes/* branches from release baseline lookup

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -126,7 +126,7 @@ jobs:
         run: |
           gh api "repos/${{ github.repository }}/branches" \
             --paginate \
-            --jq '[.[] | select(.name | startswith("release-")) | .name][]' \
+            --jq '[.[] | select(.name | test("^release-[0-9]")) | .name][]' \
             | sort -V | tail -1 > /tmp/release_branches.txt
           echo "Release branches found:"
           cat /tmp/release_branches.txt


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Changed the `jq` filter to `test("^release-[0-9]")` to match only semver-style release branches.

The `Find latest release branch` step used `startswith("release-")` to select release branches, which also matched the bot-created `release-notes/pr-*` branches. Then `gh run list --workflow ci-pr-checks.yaml --branch release-notes/pr-*` exits 1 because those branches have no CI - PR Checks runs; with `set -e` this failed the entire `test` job.

**Which issue(s) this PR fixes**:
NA

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
