### PR TITLE
feat(metrics): extract configured custom metrics

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+
+// ScalarMetricValue is a numeric endpoint attribute extracted from a configured scalar metric.
+type ScalarMetricValue float64
+
+func (v ScalarMetricValue) Clone() fwkdl.Cloneable {
+	return v
+}
+
+func ReadScalarMetricValue(attrs fwkdl.AttributeMap, key string) (ScalarMetricValue, bool) {
+	return fwkdl.ReadAttribute[ScalarMetricValue](attrs, key)
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
@@ -41,6 +41,8 @@ The plugin config supports:
     but will be removed in a future release.
 -   `defaultEngine`: The engine type to use if the label is missing. Defaults to `vllm`.
 -   `engineConfigs`: A list of engine-specific metric specifications.
+    Each engine config can also include `customMetrics` entries. Each entry
+    maps a scalar metric selector to an endpoint attribute key.
 
 ### Built-in Engine Configurations
 
@@ -70,6 +72,9 @@ parameters:
       queuedRequestsSpec: "custom_queue_size{status=waiting}"
       runningRequestsSpec: "custom_running_size"
       kvUsageSpec: "custom_cache_utilization"
+      customMetrics:
+        - attributeKey: "custom.queue_depth"
+          metricSpec: "custom_queue_depth{tier=gold}"
 ```
 
 and the model server deployment Pods should have the label:
@@ -82,4 +87,3 @@ metadata:
 ```
 
 ```
-

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -30,6 +30,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
@@ -169,6 +170,16 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 			clone.CacheNumBlocks = int(extractValue(metric))
 			updated = true
 		}
+	}
+
+	for _, custom := range mapping.CustomMetrics {
+		metric, err := custom.Spec.getLatestMetric(families)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("custom metric %q: %w", custom.AttributeKey, err))
+			continue
+		}
+		ep.GetAttributes().Put(custom.AttributeKey, attrmetrics.ScalarMetricValue(extractValue(metric)))
+		updated = true
 	}
 
 	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().NamespacedName)

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -39,6 +39,7 @@ const (
 	defaultKvCacheUsagePercentageMetric = "vllm:kv_cache_usage_perc"
 	defaultLoraInfoMetric               = "vllm:lora_requests_info"
 	defaultCacheInfoMetric              = "vllm:cache_config_info"
+	customMetricsConfigKey              = "customMetrics"
 )
 
 func TestExtractorExtract(t *testing.T) {
@@ -500,6 +501,59 @@ func TestCoreMetricsExtractorFactoryDefaultEngine(t *testing.T) {
 			},
 			wantErr:      false,
 			checkDefault: "custom",
+		},
+		{
+			name: "custom engineConfigs with custom metrics",
+			params: map[string]any{
+				"defaultEngine": "custom",
+				"engineConfigs": []map[string]any{
+					{
+						"name": "custom",
+						customMetricsConfigKey: []map[string]any{
+							{
+								"attributeKey": "custom.queue_depth",
+								"metricSpec":   "custom_queue_depth{tier=gold}",
+							},
+						},
+					},
+				},
+			},
+			wantErr:      false,
+			checkDefault: "custom",
+		},
+		{
+			name: "custom metric attributeKey is required",
+			params: map[string]any{
+				"engineConfigs": []map[string]any{
+					{
+						"name": "custom",
+						customMetricsConfigKey: []map[string]any{
+							{
+								"metricSpec": "custom_queue_depth",
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "attributeKey cannot be empty",
+		},
+		{
+			name: "custom metric spec is required",
+			params: map[string]any{
+				"engineConfigs": []map[string]any{
+					{
+						"name": "custom",
+						customMetricsConfigKey: []map[string]any{
+							{
+								"attributeKey": "custom.queue_depth",
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "spec cannot be empty",
 		},
 		{
 			name: "custom engineConfigs auto-appends vllm sglang trtllm-serve and triton-tensorrt-llm",

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -60,6 +60,15 @@ type (
 		// CacheNumBlocksSpec defines the metric specification string for retrieving num GPU blocks directly
 		// as a gauge value (alternative to CacheInfoSpec labels). Used by engines like Triton TRT-LLM.
 		CacheNumBlocksSpec string `json:"cacheNumBlocksSpec,omitempty"`
+		// CustomMetrics defines engine-specific scalar metrics to extract as endpoint attributes.
+		CustomMetrics []customMetricConfigParams `json:"customMetrics,omitempty"`
+	}
+
+	customMetricConfigParams struct {
+		// AttributeKey is the endpoint attribute key where the scalar value is stored.
+		AttributeKey string `json:"attributeKey"`
+		// MetricSpec defines the source metric specification string.
+		MetricSpec string `json:"metricSpec"`
 	}
 
 	// modelServerExtractorParams holds the configuration parameters for the core metrics extractor plugin.
@@ -197,6 +206,11 @@ func newCoreMetricsExtractorPlugin(ctx context.Context, name string, params *mod
 			return nil, fmt.Errorf("engine config name cannot be %q (reserved)", DefaultEngineType)
 		}
 
+		customMetrics, customMetricErrs := customMetricConfigs(engineConfig.CustomMetrics)
+		if len(customMetricErrs) != 0 {
+			return nil, fmt.Errorf("failed to create mapping for engine %q: %w", engineConfig.Name, errors.Join(customMetricErrs...))
+		}
+
 		mapping, err := NewMappingFromConfig(MappingConfig{
 			Queue:               engineConfig.QueuedRequestsSpec,
 			Running:             engineConfig.RunningRequestsSpec,
@@ -207,6 +221,7 @@ func newCoreMetricsExtractorPlugin(ctx context.Context, name string, params *mod
 			CacheNumBlocksLabel: engineConfig.CacheNumBlocksLabelName,
 			CacheBlockSize:      engineConfig.CacheBlockSizeSpec,
 			CacheNumBlocks:      engineConfig.CacheNumBlocksSpec,
+			CustomMetrics:       customMetrics,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create mapping for engine %q: %w", engineConfig.Name, err)
@@ -239,6 +254,23 @@ func newCoreMetricsExtractorPlugin(ctx context.Context, name string, params *mod
 	}
 	extractor.typedName.Name = name
 	return extractor, nil
+}
+
+func customMetricConfigs(configs []customMetricConfigParams) ([]CustomMetric, []error) {
+	custom := make([]CustomMetric, 0, len(configs))
+	var errs []error
+	for _, cfg := range configs {
+		spec, err := parseStringToSpec(cfg.MetricSpec)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("custom metric %q: %w", cfg.AttributeKey, err))
+			continue
+		}
+		custom = append(custom, CustomMetric{
+			AttributeKey: cfg.AttributeKey,
+			Spec:         spec,
+		})
+	}
+	return custom, errs
 }
 
 func defaultExtractorParams() *modelServerExtractorParams {

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -42,9 +42,10 @@ type Mapping struct {
 	// (e.g. Triton TRT-LLM).
 	CacheBlockSize *Spec
 	CacheNumBlocks *Spec
+	CustomMetrics  []CustomMetric
 }
 
-// MappingConfig holds the string-based configuration used to build a Mapping.
+// MappingConfig holds configuration used to build a Mapping.
 type MappingConfig struct {
 	Queue               string
 	Running             string
@@ -55,6 +56,12 @@ type MappingConfig struct {
 	CacheNumBlocksLabel string
 	CacheBlockSize      string
 	CacheNumBlocks      string
+	CustomMetrics       []CustomMetric
+}
+
+type CustomMetric struct {
+	AttributeKey string
+	Spec         *Spec
 }
 
 type namedSpec struct {
@@ -68,13 +75,22 @@ func (m *Mapping) specs() []namedSpec {
 	if m.LoraRequestInfo != nil {
 		loraSpec = m.LoraRequestInfo.Spec
 	}
-	return []namedSpec{
-		{"queue", m.TotalQueuedRequests, m.TotalQueuedRequests != nil},
-		{"running", m.TotalRunningRequests, m.TotalRunningRequests != nil},
-		{"kv", m.KVCacheUtilization, m.KVCacheUtilization != nil},
-		{"lora", loraSpec, m.LoraRequestInfo != nil},
-		{"cacheInfo", m.CacheInfo, m.CacheInfo != nil},
+	specs := make([]namedSpec, 0, 5+len(m.CustomMetrics))
+	specs = append(specs,
+		namedSpec{"queue", m.TotalQueuedRequests, m.TotalQueuedRequests != nil},
+		namedSpec{"running", m.TotalRunningRequests, m.TotalRunningRequests != nil},
+		namedSpec{"kv", m.KVCacheUtilization, m.KVCacheUtilization != nil},
+		namedSpec{"lora", loraSpec, m.LoraRequestInfo != nil},
+		namedSpec{"cacheInfo", m.CacheInfo, m.CacheInfo != nil},
+	)
+	for _, custom := range m.CustomMetrics {
+		specs = append(specs, namedSpec{
+			name:    custom.AttributeKey,
+			spec:    custom.Spec,
+			enabled: custom.Spec != nil,
+		})
 	}
+	return specs
 }
 
 // String returns a human-readable representation of the Mapping, listing which specs are disabled (nil).
@@ -145,6 +161,8 @@ func NewMappingFromConfig(cfg MappingConfig) (*Mapping, error) {
 	if err != nil {
 		errs = append(errs, err)
 	}
+	customMetrics, customErrs := parseCustomMetrics(cfg.CustomMetrics)
+	errs = append(errs, customErrs...)
 
 	if len(errs) != 0 {
 		return nil, errors.Join(errs...)
@@ -159,5 +177,32 @@ func NewMappingFromConfig(cfg MappingConfig) (*Mapping, error) {
 		CacheNumBlocksLabel:  cfg.CacheNumBlocksLabel,
 		CacheBlockSize:       cacheBlockSizeSpec,
 		CacheNumBlocks:       cacheNumBlocksSpec,
+		CustomMetrics:        customMetrics,
 	}, nil
+}
+
+func parseCustomMetrics(configs []CustomMetric) ([]CustomMetric, []error) {
+	metrics := make([]CustomMetric, 0, len(configs))
+	var errs []error
+	seenKeys := make(map[string]struct{}, len(configs))
+	for _, cfg := range configs {
+		if cfg.AttributeKey == "" {
+			errs = append(errs, errors.New("custom metric attributeKey cannot be empty"))
+			continue
+		}
+		if _, ok := seenKeys[cfg.AttributeKey]; ok {
+			errs = append(errs, fmt.Errorf("custom metric attributeKey %q is duplicated", cfg.AttributeKey))
+			continue
+		}
+		seenKeys[cfg.AttributeKey] = struct{}{}
+		if cfg.Spec == nil {
+			errs = append(errs, fmt.Errorf("custom metric %q spec cannot be empty", cfg.AttributeKey))
+			continue
+		}
+		metrics = append(metrics, CustomMetric{
+			AttributeKey: cfg.AttributeKey,
+			Spec:         cfg.Spec,
+		})
+	}
+	return metrics, errs
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -38,10 +38,13 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
 	sourcehttp "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
@@ -336,6 +339,89 @@ func TestMetricsExtractionDisabledSpecNoError(t *testing.T) {
 	})
 
 	assert.NoError(t, p.Poll(ctx, ep))
+}
+
+func TestMetricsExtractionCustomScalarFromConfig(t *testing.T) {
+	const attributeKey = "custom.queue_depth"
+
+	srv := createMockServer([]MetricMock{
+		{
+			Name:  "custom_queue_depth",
+			Value: 42.5,
+			Labels: map[string]string{
+				"tier": "gold",
+			},
+		},
+	})
+	defer srv.Close()
+
+	params := &modelServerExtractorParams{
+		EngineConfigs: []engineConfigParams{
+			{
+				Name: "vllm",
+				CustomMetrics: []customMetricConfigParams{
+					{
+						AttributeKey: attributeKey,
+						MetricSpec:   "custom_queue_depth{tier=gold}",
+					},
+				},
+			},
+		},
+	}
+
+	p, err := buildPipeline(t, srv.URL, params)
+	require.NoError(t, err)
+
+	ep := newEndpointAt(mustHost(t, srv.URL), map[string]string{
+		DefaultEngineTypeLabelKey: "vllm",
+	})
+
+	require.NoError(t, p.Poll(context.Background(), ep))
+
+	got, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), attributeKey)
+	require.True(t, ok, "custom scalar metric should be stored as an endpoint attribute")
+	assert.InDelta(t, 42.5, float64(got), 0.001)
+	assert.Zero(t, ep.GetMetrics().WaitingQueueSize)
+	assert.Zero(t, ep.GetMetrics().RunningRequestsSize)
+	assert.Zero(t, ep.GetMetrics().KVCacheUsagePercent)
+}
+
+func TestMetricsExtractionCustomCounterFromConfig(t *testing.T) {
+	const attributeKey = "custom.total_requests"
+
+	ext := buildExtractor(t, &modelServerExtractorParams{
+		EngineConfigs: []engineConfigParams{
+			{
+				Name: "vllm",
+				CustomMetrics: []customMetricConfigParams{
+					{
+						AttributeKey: attributeKey,
+						MetricSpec:   "custom_total_requests",
+					},
+				},
+			},
+		},
+	})
+
+	ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		Labels: map[string]string{DefaultEngineTypeLabelKey: "vllm"},
+	}, nil)
+	err := ext.Extract(context.Background(), fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{
+		Endpoint: ep,
+		Payload: sourcemetrics.PrometheusMetricMap{
+			"custom_total_requests": {
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{Counter: &dto.Counter{Value: ptr.To(12.0)}},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	got, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), attributeKey)
+	require.True(t, ok, "custom counter should be stored as an endpoint attribute")
+	assert.InDelta(t, 12.0, float64(got), 0.001)
 }
 
 // TestMetricsExtractionServerError verifies that an HTTP error from the server propagates as a Poll error.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for configured custom gauge metrics in the core metrics extractor.

Engine configs can now map a Prometheus gauge metric selector to an endpoint attribute key. The extractor reads the matching gauge value and stores it as a cloneable endpoint attribute, without adding new fixed fields to the core `Metrics` struct.

This provides the extraction/storage layer for custom numeric routing signals. Consuming those attributes in scorers or filters is left for follow-up work.

**Which issue(s) this PR fixes**:

Fixes #1454

**Release note**:

```release-note
Support configured custom gauge metrics in the core metrics extractor.