### PR TITLE
fix(epp/metrics): treat absent vllm:lora_requests_info as no LoRA loaded

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -129,10 +129,7 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 	}
 
 	if spec := mapping.LoraRequestInfo; spec != nil { // extract LoRA-specific metrics
-		metric, err := spec.getLatestMetric(families)
-		if err != nil {
-			errs = append(errs, err)
-		} else if metric != nil {
+		if metric := spec.getLatestMetric(families); metric != nil {
 			populateLoRAMetrics(clone, metric, &errs)
 			updated = true
 		}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/loraspec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/loraspec.go
@@ -17,8 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"fmt"
-
 	dto "github.com/prometheus/client_model/go"
 
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
@@ -50,10 +48,16 @@ func parseStringToLoRASpec(spec string) (*LoRASpec, error) {
 // generates new series and only most recent should be used. The value of each
 // series is its creation timestamp so we can retrieve the latest by sorting on
 // that the value first.
-func (spec *LoRASpec) getLatestMetric(families sourcemetrics.PrometheusMetricMap) (*dto.Metric, error) {
-	family, err := extractFamily(spec.Spec, families)
-	if err != nil {
-		return nil, err
+//
+// vLLM only emits vllm:lora_requests_info once an adapter has been loaded, so a
+// vanilla deployment scrape legitimately has no family present. Both "family
+// missing" and "family present but no matching labels" are reported as a nil
+// metric so the extractor can skip the LoRA section silently rather than
+// incrementing DataLayerExtractErrorsTotal on every poll (#926).
+func (spec *LoRASpec) getLatestMetric(families sourcemetrics.PrometheusMetricMap) *dto.Metric {
+	family, exists := families[spec.Name]
+	if !exists || len(family.GetMetric()) == 0 {
+		return nil
 	}
 
 	var latest *dto.Metric
@@ -69,9 +73,5 @@ func (spec *LoRASpec) getLatestMetric(families sourcemetrics.PrometheusMetricMap
 		}
 	}
 
-	if latest == nil {
-		return nil, fmt.Errorf("no matching lora metric found for %q with labels %v", spec.Name, spec.Labels)
-	}
-
-	return latest, nil
+	return latest
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -219,30 +219,19 @@ func TestMetricsExtractionLoRADisabledViaConfig(t *testing.T) {
 }
 
 // TestMetricsExtractionMissingMetricFamilyReturnsError verifies the error-path behavior:
-// when the server does not serve a metric that the extractor is configured to collect,
-// Poll returns an error whose message names the missing metric family.
+// when the server does not serve a required metric that the extractor is configured to
+// collect, Poll returns an error whose message names the missing metric family.
+//
+// LoRA is excluded because vLLM only emits vllm:lora_requests_info once an adapter has
+// been loaded, so the absent family is a legitimate "no adapters" signal rather than
+// an error (#926). The LoRA-tolerance case is asserted by
+// TestMetricsExtractionLoRAFamilyAbsentNoError.
 func TestMetricsExtractionMissingMetricFamilyReturnsError(t *testing.T) {
 	tests := []struct {
-		name                   string
-		served                 []MetricMock
-		wantErrContain         string
-		wantWaitingQueueSize   int
-		wantRunningRequestSize int
-		wantKVCachePercent     float64
+		name           string
+		served         []MetricMock
+		wantErrContain string
 	}{
-		{
-			name: "LoRA family absent - other metrics still extracted",
-			served: []MetricMock{
-				{Name: WaitingMetric, Value: 4},
-				{Name: RunningMetric, Value: 1},
-				{Name: KVCacheMetric, Value: 0.2},
-				// LoRA and CacheInfo deliberately not served
-			},
-			wantErrContain:         "lora_requests_info",
-			wantWaitingQueueSize:   4,
-			wantRunningRequestSize: 1,
-			wantKVCachePercent:     0.2,
-		},
 		{
 			name:           "all metric families absent",
 			served:         []MetricMock{},
@@ -274,13 +263,49 @@ func TestMetricsExtractionMissingMetricFamilyReturnsError(t *testing.T) {
 			require.Error(t, pollErr, "expected error for missing metric family")
 			assert.True(t, strings.Contains(pollErr.Error(), tc.wantErrContain),
 				"error %q should contain %q", pollErr.Error(), tc.wantErrContain)
-
-			m := ep.GetMetrics()
-			assert.Equal(t, tc.wantWaitingQueueSize, m.WaitingQueueSize, "WaitingQueueSize")
-			assert.Equal(t, tc.wantRunningRequestSize, m.RunningRequestsSize, "RunningRequestsSize")
-			assert.InDelta(t, tc.wantKVCachePercent, m.KVCacheUsagePercent, 0.001, "KVCacheUsagePercent")
 		})
 	}
+}
+
+// TestMetricsExtractionLoRAFamilyAbsentNoError asserts the #926 fix end-to-end:
+// when vLLM has loaded no LoRA adapters and therefore emits no
+// vllm:lora_requests_info family, Extract returns no error and still populates
+// the other (required) metrics. Before the fix the extractor would return an
+// "lora_requests_info not found" error and the EPP would increment
+// DataLayerExtractErrorsTotal on every poll of any vanilla deployment.
+func TestMetricsExtractionLoRAFamilyAbsentNoError(t *testing.T) {
+	srv := createMockServer([]MetricMock{
+		{Name: WaitingMetric, Value: 4},
+		{Name: RunningMetric, Value: 1},
+		{Name: KVCacheMetric, Value: 0.2},
+		{
+			Name:  CacheConfigMetric,
+			Value: 1,
+			Labels: map[string]string{
+				CacheConfigBlockSizeInfoMetricName: "16",
+				CacheConfigNumGPUBlocksMetricName:  "512",
+			},
+		},
+	})
+	defer srv.Close()
+
+	p, err := buildPipeline(t, srv.URL, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ep := newEndpointAt(mustHost(t, srv.URL), map[string]string{
+		DefaultEngineTypeLabelKey: "vllm",
+	})
+
+	data, err := p.source.Poll(ctx, ep)
+	require.NoError(t, err)
+	require.NoError(t, p.ext.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep}),
+		"missing optional LoRA family must not be an extraction error")
+
+	m := ep.GetMetrics()
+	assert.Equal(t, 4, m.WaitingQueueSize, "WaitingQueueSize")
+	assert.Equal(t, 1, m.RunningRequestsSize, "RunningRequestsSize")
+	assert.InDelta(t, 0.2, m.KVCacheUsagePercent, 0.001, "KVCacheUsagePercent")
 }
 
 // TestMetricsExtractionDisabledSpecNoError verifies that when all metric specs are

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"errors"
 	"strconv"
 	"strings"
 	"testing"
@@ -338,19 +337,22 @@ func TestGetLoRAMetric(t *testing.T) {
 		metricFamilies   sourcemetrics.PrometheusMetricMap
 		expectedAdapters map[string]int
 		expectedMax      int
-		expectedErr      error
 		spec             *LoRASpec
 	}{
 		{
-			name: "no lora metrics",
+			// vLLM only emits vllm:lora_requests_info once at least one LoRA
+			// adapter has been loaded. A vanilla deployment with no LoRA must
+			// be treated as "no adapters" rather than a scrape error so the
+			// EPP doesn't spam DataLayerExtractErrorsTotal on every poll
+			// (#926).
+			name: "missing family treated as no adapters",
 			metricFamilies: sourcemetrics.PrometheusMetricMap{
 				"some_other_metric": makeMetricFamily("some_other_metric",
 					makeMetric(nil, 1.0, 1000),
 				),
 			},
-			expectedAdapters: map[string]int{},
+			expectedAdapters: nil,
 			expectedMax:      0,
-			expectedErr:      errors.New("metric family \"vllm:lora_requests_info\" not found"), // Expect an error because the family is missing
 			spec:             loraSpec,
 		},
 		{
@@ -364,7 +366,6 @@ func TestGetLoRAMetric(t *testing.T) {
 			},
 			expectedAdapters: map[string]int{"lora1": 0},
 			expectedMax:      2,
-			expectedErr:      nil,
 			spec:             loraSpec,
 		},
 		{
@@ -376,22 +377,13 @@ func TestGetLoRAMetric(t *testing.T) {
 			},
 			expectedAdapters: map[string]int{},
 			expectedMax:      0,
-			expectedErr:      nil, // Expect *no* error; just no adapters found
 			spec:             loraSpec,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			metric, err := tc.spec.getLatestMetric(tc.metricFamilies)
-
-			if tc.expectedErr != nil {
-				assert.Error(t, err)
-				assert.EqualError(t, err, tc.expectedErr.Error())
-				return
-			}
-
-			require.NoError(t, err)
+			metric := tc.spec.getLatestMetric(tc.metricFamilies)
 
 			if tc.spec == nil {
 				assert.Nil(t, metric)


### PR DESCRIPTION
## Summary

Fixes #926. vLLM only emits `vllm:lora_requests_info` once at least one LoRA adapter has been loaded. A vanilla deployment with no LoRA legitimately serves no such metric family, but `LoRASpec.getLatestMetric` was treating the absent family as an extraction error. Every scrape of any non-LoRA endpoint logged `"extract failed ... metric family vllm:lora_requests_info not found"` and incremented `DataLayerExtractErrorsTotal` — masking real extraction failures.

`LoRASpec.getLatestMetric` now returns `(nil, nil)` when the family is absent or has no metrics, matching the existing semantics for "family present but no matching labels". The upstream extractor already short-circuits on `metric == nil` via `else if metric != nil`, so no caller change is needed. Standard `Spec` (used for required metrics) keeps its strict not-found behavior.

## Verified locally
- Updated `TestGetLoRAMetric/missing_family_treated_as_no_adapters` expects `(nil, nil)`.
- New `TestMetricsExtractionLoRAFamilyAbsentNoError` exercises the end-to-end Extract path with no LoRA family served and asserts no error + required metrics still populated.
- `make test-unit-epp` and `make presubmit` green locally.

## Test plan
- [x] `go test ./pkg/epp/framework/plugins/datalayer/extractor/metrics/...`
- [x] `make test-unit-epp`
- [x] `make presubmit` (DCO, signed commits, go-mod-check, format, lint, govulncheck)