### PR TITLE
Fixes for CI after latest vulnerability fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,6 @@ updates:
     commit-message:
       prefix: "deps(docker)"
     ignore:
-      # Major/minor upgrades are handled intentionally via `make upgrade-deps`; dependabot covers patches only
+      # ßdependabot covers patches only
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,7 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps(docker)"
+    ignore:
+      # Major/minor upgrades are handled intentionally via `make upgrade-deps`; dependabot covers patches only
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,6 @@ updates:
     commit-message:
       prefix: "deps(docker)"
     ignore:
-      # ßdependabot covers patches only
+      # dependabot covers patches only
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,10 +1,4 @@
-FROM quay.io/projectquay/golang:1.25
-
-# Upgrade Go to 1.25.11 to fix standard library vulnerabilities (CVEs)
-RUN ARCH=$(uname -m) && \
-    GOARCH=$(echo ${ARCH} | sed 's/x86_64/amd64/; s/aarch64/arm64/') && \
-    rm -rf /usr/local/go && \
-    curl -sSfL "https://go.dev/dl/go1.25.11.linux-${GOARCH}.tar.gz" | tar -C /usr/local -xzf -
+FROM golang:1.25.11
 
 RUN mkdir /app
 WORKDIR /app
@@ -20,7 +14,7 @@ ARG ENVTEST_VERSION=release-0.19
 ARG ENVTEST_K8S_VERSION=1.31.0
 ARG GOVULNCHECK_VERSION=v1.3.0
 
-RUN dnf install -y podman gcc-toolset-12 && dnf clean all
+RUN apt-get update && apt-get install -y podman gcc-12 && apt-get clean all
 
 # The base image ships GCC 8 (RHEL 8 default), which lacks the ARM64 LSE
 # atomic emulation helpers (__aarch64_ldadd8_sync etc.) required by Go's

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -14,15 +14,6 @@ ARG ENVTEST_VERSION=release-0.19
 ARG ENVTEST_K8S_VERSION=1.31.0
 ARG GOVULNCHECK_VERSION=v1.3.0
 
-RUN apt-get update && apt-get install -y podman gcc-12 && apt-get clean all
-
-# The base image ships GCC 8 (RHEL 8 default), which lacks the ARM64 LSE
-# atomic emulation helpers (__aarch64_ldadd8_sync etc.) required by Go's
-# race detector. gcc-toolset-12 provides GCC 12 which includes them.
-# TODO: remove gcc-toolset-12 once this base image is updated to RHEL 9
-#       (GCC 11+ ships natively there and includes the helpers).
-ENV PATH=/opt/rh/gcc-toolset-12/root/usr/bin:$PATH
-
 # Install docker CLI and buildx plugin
 RUN ARCH=$(uname -m) && \
     GOARCH=$(echo ${ARCH} | sed 's/x86_64/amd64/; s/aarch64/arm64/') && \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR changes the builder image to use the docker provided golang image, rather than the one from quay.io. The issue with the image on quay.io is that the tags only have major and minor making it difficult to automate updates.

In addition the is PR configures dependabopt to not make major or minor semver updates of images.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
