### PR TITLE
Allow multiple Parsers by adding match interface and building routing based on it

### DIFF
--- a/cmd/epp/runner/health.go
+++ b/cmd/epp/runner/health.go
@@ -26,14 +26,14 @@ import (
 	"google.golang.org/grpc/codes"
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
-	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
 type appProtocolSupporter interface {
-	SupportedAppProtocols() []v1.AppProtocol
+	Match() fwkrh.Match
 }
 
 type healthServer struct {
@@ -120,7 +120,7 @@ func (s *healthServer) checkProtocolSupport(isLive bool) bool {
 		if supporter == nil {
 			continue
 		}
-		supported := supporter.SupportedAppProtocols()
+		supported := supporter.Match().Protocols
 		if len(supported) == 0 {
 			continue
 		}

--- a/cmd/epp/runner/health.go
+++ b/cmd/epp/runner/health.go
@@ -33,7 +33,7 @@ import (
 )
 
 type appProtocolSupporter interface {
-	Match() fwkrh.Match
+	Claims() fwkrh.Claims
 }
 
 type healthServer struct {
@@ -120,7 +120,7 @@ func (s *healthServer) checkProtocolSupport(isLive bool) bool {
 		if supporter == nil {
 			continue
 		}
-		supported := supporter.Match().Protocols
+		supported := supporter.Claims().Protocols
 		if len(supported) == 0 {
 			continue
 		}

--- a/cmd/epp/runner/health_test.go
+++ b/cmd/epp/runner/health_test.go
@@ -52,8 +52,8 @@ type mockSupporter struct {
 	protocols []v1.AppProtocol
 }
 
-func (m *mockSupporter) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (m *mockSupporter) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Protocols: m.protocols,
 	}
 }

--- a/cmd/epp/runner/health_test.go
+++ b/cmd/epp/runner/health_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
 // Mock Datastore
@@ -51,8 +52,10 @@ type mockSupporter struct {
 	protocols []v1.AppProtocol
 }
 
-func (m *mockSupporter) SupportedAppProtocols() []v1.AppProtocol {
-	return m.protocols
+func (m *mockSupporter) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Protocols: m.protocols,
+	}
 }
 
 func TestHealthServer_Check(t *testing.T) {

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -60,7 +60,6 @@ import (
 	fcregistry "github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
-	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/models"
@@ -159,7 +158,7 @@ type Runner struct {
 	requestControlConfig *requestcontrol.Config
 	schedulerConfig      *scheduling.SchedulerConfig
 	customCollectors     []prometheus.Collector
-	parsers              []fwkrh.Parser
+	parserDispatcher     *handlers.ParserDispatcher
 	dlRuntime            *datalayer.Runtime
 	PluginHandle         fwkplugin.Handle
 	// rawConfig caches the result of parseConfigurationPhaseOne.
@@ -382,7 +381,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
 		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
 		Director:                         director,
-		Parsers:                          r.parsers,
+		ParserDispatcher:                 r.parserDispatcher,
 		SaturationDetector:               eppConfig.SaturationDetector,
 		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
 		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
@@ -395,8 +394,9 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 	// --- Add Runnables to Manager ---
 	// Register health server.
-	supporters := make([]appProtocolSupporter, len(r.parsers))
-	for i, p := range r.parsers {
+	parsers := r.parserDispatcher.Parsers()
+	supporters := make([]appProtocolSupporter, len(parsers))
+	for i, p := range parsers {
 		supporters[i] = p
 	}
 	if err := registerHealthServer(mgr, ctrl.Log.WithName("health"), ds, opts.GRPCHealthPort, isLeader, opts.EnableLeaderElection, supporters); err != nil {
@@ -661,7 +661,7 @@ func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *conf
 	// The plugins will be executed in topologically sorted order to ensure that data is produced before it is consumed.
 	r.requestControlConfig.OrderDataProducerPlugins(dag)
 
-	r.parsers = handlers.NewParsers(cfg.ParserConfig)
+	r.parserDispatcher = cfg.ParserDispatcher
 	logger.Info("loaded configuration from file/text successfully")
 
 	return cfg, nil
@@ -922,7 +922,7 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
 		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
 		Director:                         director,
-		Parsers:                          r.parsers,
+		ParserDispatcher:                 r.parserDispatcher,
 		SaturationDetector:               eppConfig.SaturationDetector,
 		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
 		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
@@ -942,8 +942,9 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	isLeader.Store(true)
 
 	healthSrv := grpc.NewServer()
-	ps := make([]appProtocolSupporter, len(r.parsers))
-	for i, p := range r.parsers {
+	parsers := r.parserDispatcher.Parsers()
+	ps := make([]appProtocolSupporter, len(parsers))
+	for i, p := range parsers {
 		ps[i] = p
 	}
 	healthPb.RegisterHealthServer(healthSrv, &healthServer{

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -158,7 +158,7 @@ type Runner struct {
 	requestControlConfig *requestcontrol.Config
 	schedulerConfig      *scheduling.SchedulerConfig
 	customCollectors     []prometheus.Collector
-	parserDispatcher     *handlers.ParserDispatcher
+	parserRegistry       *handlers.ParserRegistry
 	dlRuntime            *datalayer.Runtime
 	PluginHandle         fwkplugin.Handle
 	// rawConfig caches the result of parseConfigurationPhaseOne.
@@ -381,7 +381,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
 		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
 		Director:                         director,
-		ParserDispatcher:                 r.parserDispatcher,
+		ParserRegistry:                   r.parserRegistry,
 		SaturationDetector:               eppConfig.SaturationDetector,
 		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
 		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
@@ -394,7 +394,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 	// --- Add Runnables to Manager ---
 	// Register health server.
-	parsers := r.parserDispatcher.Parsers()
+	parsers := r.parserRegistry.Parsers()
 	supporters := make([]appProtocolSupporter, len(parsers))
 	for i, p := range parsers {
 		supporters[i] = p
@@ -661,7 +661,7 @@ func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *conf
 	// The plugins will be executed in topologically sorted order to ensure that data is produced before it is consumed.
 	r.requestControlConfig.OrderDataProducerPlugins(dag)
 
-	r.parserDispatcher = cfg.ParserDispatcher
+	r.parserRegistry = cfg.ParserRegistry
 	logger.Info("loaded configuration from file/text successfully")
 
 	return cfg, nil
@@ -922,7 +922,7 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
 		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
 		Director:                         director,
-		ParserDispatcher:                 r.parserDispatcher,
+		ParserRegistry:                   r.parserRegistry,
 		SaturationDetector:               eppConfig.SaturationDetector,
 		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
 		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
@@ -942,7 +942,7 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	isLeader.Store(true)
 
 	healthSrv := grpc.NewServer()
-	parsers := r.parserDispatcher.Parsers()
+	parsers := r.parserRegistry.Parsers()
 	ps := make([]appProtocolSupporter, len(parsers))
 	for i, p := range parsers {
 		ps[i] = p

--- a/pkg/epp/config/config.go
+++ b/pkg/epp/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	SaturationDetector fwkfc.SaturationDetector
 	DataConfig         *datalayer.Config
 	FlowControlConfig  *flowcontrol.Config
-	ParserConfig       *handlers.Config
+	ParserDispatcher   *handlers.ParserDispatcher
 }
 
 func (c *Config) String() string {

--- a/pkg/epp/config/config.go
+++ b/pkg/epp/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	SaturationDetector fwkfc.SaturationDetector
 	DataConfig         *datalayer.Config
 	FlowControlConfig  *flowcontrol.Config
-	ParserDispatcher   *handlers.ParserDispatcher
+	ParserRegistry     *handlers.ParserRegistry
 }
 
 func (c *Config) String() string {

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -180,7 +180,7 @@ func InstantiateAndConfigure(
 		}
 	}
 
-	parserRegistry, err := buildParserRegistry(rawConfig.RequestHandler.Parsers, handle)
+	parserRegistry, err := buildParserRegistry(rawConfig.RequestHandler.Parsers, handle, logger)
 	if err != nil {
 		return nil, fmt.Errorf("parser registry build failed: %w", err)
 	}
@@ -307,7 +307,7 @@ func loadFeatureConfig(gates configapi.FeatureGates) map[string]bool {
 	return config
 }
 
-func buildParserRegistry(rawParserConfigs []configapi.ParserConfig, handle fwkplugin.Handle) (*handlers.ParserRegistry, error) {
+func buildParserRegistry(rawParserConfigs []configapi.ParserConfig, handle fwkplugin.Handle, logger logr.Logger) (*handlers.ParserRegistry, error) {
 	if len(rawParserConfigs) == 0 {
 		return nil, errors.New("no parsers configured")
 	}
@@ -324,7 +324,7 @@ func buildParserRegistry(rawParserConfigs []configapi.ParserConfig, handle fwkpl
 		}
 		parsers = append(parsers, v)
 	}
-	return handlers.NewParserRegistry(parsers), nil
+	return handlers.NewParserRegistry(parsers, logger), nil
 }
 
 func buildDataLayerConfig(rawDataConfig *configapi.DataLayerConfig, handle fwkplugin.Handle) (*datalayer.Config, error) {

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -180,9 +180,9 @@ func InstantiateAndConfigure(
 		}
 	}
 
-	parserDispatcher, err := buildParserDispatcher(rawConfig.RequestHandler.Parsers, handle)
+	parserRegistry, err := buildParserRegistry(rawConfig.RequestHandler.Parsers, handle)
 	if err != nil {
-		return nil, fmt.Errorf("parser dispatcher build failed: %w", err)
+		return nil, fmt.Errorf("parser registry build failed: %w", err)
 	}
 
 	plugin, ok := handle.GetAllPluginsWithNames()[rawConfig.FlowControl.SaturationDetector.PluginRef]
@@ -199,7 +199,7 @@ func InstantiateAndConfigure(
 		SaturationDetector: saturationDetector,
 		DataConfig:         dataConfig,
 		FlowControlConfig:  flowControlConfig,
-		ParserDispatcher:   parserDispatcher,
+		ParserRegistry:     parserRegistry,
 	}, nil
 }
 
@@ -307,7 +307,7 @@ func loadFeatureConfig(gates configapi.FeatureGates) map[string]bool {
 	return config
 }
 
-func buildParserDispatcher(rawParserConfigs []configapi.ParserConfig, handle fwkplugin.Handle) (*handlers.ParserDispatcher, error) {
+func buildParserRegistry(rawParserConfigs []configapi.ParserConfig, handle fwkplugin.Handle) (*handlers.ParserRegistry, error) {
 	if len(rawParserConfigs) == 0 {
 		return nil, errors.New("no parsers configured")
 	}
@@ -324,7 +324,7 @@ func buildParserDispatcher(rawParserConfigs []configapi.ParserConfig, handle fwk
 		}
 		parsers = append(parsers, v)
 	}
-	return handlers.NewParserDispatcher(parsers), nil
+	return handlers.NewParserRegistry(parsers), nil
 }
 
 func buildDataLayerConfig(rawDataConfig *configapi.DataLayerConfig, handle fwkplugin.Handle) (*datalayer.Config, error) {

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -180,9 +180,9 @@ func InstantiateAndConfigure(
 		}
 	}
 
-	parserConfig, err := buildParsersConfig(rawConfig.RequestHandler.Parsers, handle)
+	parserDispatcher, err := buildParserDispatcher(rawConfig.RequestHandler.Parsers, handle)
 	if err != nil {
-		return nil, fmt.Errorf("parsers config build failed: %w", err)
+		return nil, fmt.Errorf("parser dispatcher build failed: %w", err)
 	}
 
 	plugin, ok := handle.GetAllPluginsWithNames()[rawConfig.FlowControl.SaturationDetector.PluginRef]
@@ -199,7 +199,7 @@ func InstantiateAndConfigure(
 		SaturationDetector: saturationDetector,
 		DataConfig:         dataConfig,
 		FlowControlConfig:  flowControlConfig,
-		ParserConfig:       parserConfig,
+		ParserDispatcher:   parserDispatcher,
 	}, nil
 }
 
@@ -307,7 +307,7 @@ func loadFeatureConfig(gates configapi.FeatureGates) map[string]bool {
 	return config
 }
 
-func buildParsersConfig(rawParserConfigs []configapi.ParserConfig, handle fwkplugin.Handle) (*handlers.Config, error) {
+func buildParserDispatcher(rawParserConfigs []configapi.ParserConfig, handle fwkplugin.Handle) (*handlers.ParserDispatcher, error) {
 	if len(rawParserConfigs) == 0 {
 		return nil, errors.New("no parsers configured")
 	}
@@ -324,9 +324,7 @@ func buildParsersConfig(rawParserConfigs []configapi.ParserConfig, handle fwkplu
 		}
 		parsers = append(parsers, v)
 	}
-	return &handlers.Config{
-		Parsers: parsers,
-	}, nil
+	return handlers.NewParserDispatcher(parsers), nil
 }
 
 func buildDataLayerConfig(rawDataConfig *configapi.DataLayerConfig, handle fwkplugin.Handle) (*datalayer.Config, error) {

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
 	reqdataprodprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vertexai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
@@ -503,8 +504,8 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successParserConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
-				parsers := cfg.ParserDispatcher.Parsers()
+				require.NotNil(t, cfg.ParserRegistry, "Parser registry should be loaded")
+				parsers := cfg.ParserRegistry.Parsers()
 				require.Len(t, parsers, 1, "Should have one parser")
 				require.Equal(t, "openai-parser", parsers[0].TypedName().Name, "Should have openai parser name")
 				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type, "Should contain openai parser type")
@@ -515,8 +516,8 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successWithNoParserConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
-				parsers := cfg.ParserDispatcher.Parsers()
+				require.NotNil(t, cfg.ParserRegistry, "Parser registry should be loaded")
+				parsers := cfg.ParserRegistry.Parsers()
 				require.Len(t, parsers, 1, "Should have one parser")
 				require.Equal(t, "openai-parser", parsers[0].TypedName().Name, "Should have openai parser name")
 				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type, "Should contain openai parser type")
@@ -527,8 +528,8 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successParserWithNameConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
-				parsers := cfg.ParserDispatcher.Parsers()
+				require.NotNil(t, cfg.ParserRegistry, "Parser registry should be loaded")
+				parsers := cfg.ParserRegistry.Parsers()
 				require.Len(t, parsers, 1, "Should have one parser")
 				require.Equal(t, "openaiParser", parsers[0].TypedName().Name, "Should have openai parser name")
 				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type, "Should contain openai parser type")
@@ -539,8 +540,8 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successMultipleParsersConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
-				parsers := cfg.ParserDispatcher.Parsers()
+				require.NotNil(t, cfg.ParserRegistry, "Parser registry should be loaded")
+				parsers := cfg.ParserRegistry.Parsers()
 				require.Len(t, parsers, 2, "Should have two parsers")
 				require.Equal(t, "openai-parser", parsers[0].TypedName().Name, "First parser should be openai-parser")
 				require.Equal(t, "secondParser", parsers[1].TypedName().Name, "Second parser should be secondParser")
@@ -561,8 +562,8 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successDeprecatedTopLevelParserText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserDispatcher, "ParserDispatcher should be loaded")
-				parsers := cfg.ParserDispatcher.Parsers()
+				require.NotNil(t, cfg.ParserRegistry, "ParserRegistry should be loaded")
+				parsers := cfg.ParserRegistry.Parsers()
 				require.Len(t, parsers, 1, "Should have one parser")
 				require.Equal(t, "openai-parser", parsers[0].TypedName().Name)
 			},
@@ -918,6 +919,7 @@ func registerTestPlugins(t *testing.T) {
 	fwkplugin.Register(maxscore.MaxScorePickerType, maxscore.MaxScorePickerFactory)
 	fwkplugin.Register(single.SingleProfileHandlerType, single.SingleProfileHandlerFactory)
 	fwkplugin.Register(openai.OpenAIParserType, openai.OpenAIParserPluginFactory)
+	fwkplugin.Register(vertexai.VertexAIParserType, vertexai.VertexAIParserPluginFactory)
 	fwkplugin.Register(usagelimits.StaticUsageLimitPolicyType, usagelimits.StaticPolicyFactory)
 	fwkplugin.Register(prefix.PrefixCacheScorerPluginType, prefix.PrefixCachePluginFactory)
 	fwkplugin.Register(reqdataprodprefix.ApproxPrefixCachePluginType, reqdataprodprefix.ApproxPrefixCacheFactory)

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -503,10 +503,11 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successParserConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserConfig, "Parser config should be loaded")
-				require.Len(t, cfg.ParserConfig.Parsers, 1, "Should have one parser")
-				require.Equal(t, "openai-parser", cfg.ParserConfig.Parsers[0].TypedName().Name, "Should have openai parser name")
-				require.Equal(t, openai.OpenAIParserType, cfg.ParserConfig.Parsers[0].TypedName().Type, "Should contain openai parser type")
+				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
+				parsers := cfg.ParserDispatcher.Parsers()
+				require.Len(t, parsers, 1, "Should have one parser")
+				require.Equal(t, "openai-parser", parsers[0].TypedName().Name, "Should have openai parser name")
+				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type, "Should contain openai parser type")
 			},
 		},
 		{
@@ -514,10 +515,11 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successWithNoParserConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserConfig, "Parser config should be loaded")
-				require.Len(t, cfg.ParserConfig.Parsers, 1, "Should have one parser")
-				require.Equal(t, "openai-parser", cfg.ParserConfig.Parsers[0].TypedName().Name, "Should have openai parser name")
-				require.Equal(t, openai.OpenAIParserType, cfg.ParserConfig.Parsers[0].TypedName().Type, "Should contain openai parser type")
+				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
+				parsers := cfg.ParserDispatcher.Parsers()
+				require.Len(t, parsers, 1, "Should have one parser")
+				require.Equal(t, "openai-parser", parsers[0].TypedName().Name, "Should have openai parser name")
+				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type, "Should contain openai parser type")
 			},
 		},
 		{
@@ -525,10 +527,11 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successParserWithNameConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserConfig, "Parser config should be loaded")
-				require.Len(t, cfg.ParserConfig.Parsers, 1, "Should have one parser")
-				require.Equal(t, "openaiParser", cfg.ParserConfig.Parsers[0].TypedName().Name, "Should have openai parser name")
-				require.Equal(t, openai.OpenAIParserType, cfg.ParserConfig.Parsers[0].TypedName().Type, "Should contain openai parser type")
+				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
+				parsers := cfg.ParserDispatcher.Parsers()
+				require.Len(t, parsers, 1, "Should have one parser")
+				require.Equal(t, "openaiParser", parsers[0].TypedName().Name, "Should have openai parser name")
+				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type, "Should contain openai parser type")
 			},
 		},
 		{
@@ -536,10 +539,11 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successMultipleParsersConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserConfig, "Parser config should be loaded")
-				require.Len(t, cfg.ParserConfig.Parsers, 2, "Should have two parsers")
-				require.Equal(t, "openai-parser", cfg.ParserConfig.Parsers[0].TypedName().Name, "First parser should be openai-parser")
-				require.Equal(t, "secondParser", cfg.ParserConfig.Parsers[1].TypedName().Name, "Second parser should be secondParser")
+				require.NotNil(t, cfg.ParserDispatcher, "Parser dispatcher should be loaded")
+				parsers := cfg.ParserDispatcher.Parsers()
+				require.Len(t, parsers, 2, "Should have two parsers")
+				require.Equal(t, "openai-parser", parsers[0].TypedName().Name, "First parser should be openai-parser")
+				require.Equal(t, "secondParser", parsers[1].TypedName().Name, "Second parser should be secondParser")
 			},
 		},
 
@@ -557,9 +561,10 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			configText: successDeprecatedTopLevelParserText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
-				require.NotNil(t, cfg.ParserConfig, "ParserConfig should be loaded")
-				require.Len(t, cfg.ParserConfig.Parsers, 1, "Should have one parser")
-				require.Equal(t, "openai-parser", cfg.ParserConfig.Parsers[0].TypedName().Name)
+				require.NotNil(t, cfg.ParserDispatcher, "ParserDispatcher should be loaded")
+				parsers := cfg.ParserDispatcher.Parsers()
+				require.Len(t, parsers, 1, "Should have one parser")
+				require.Equal(t, "openai-parser", parsers[0].TypedName().Name)
 			},
 		},
 		// --- Instantiation Errors ---

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
 	reqdataprodprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vertexai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
@@ -920,6 +921,7 @@ func registerTestPlugins(t *testing.T) {
 	fwkplugin.Register(single.SingleProfileHandlerType, single.SingleProfileHandlerFactory)
 	fwkplugin.Register(openai.OpenAIParserType, openai.OpenAIParserPluginFactory)
 	fwkplugin.Register(vertexai.VertexAIParserType, vertexai.VertexAIParserPluginFactory)
+	fwkplugin.Register(anthropic.AnthropicParserType, anthropic.AnthropicParserPluginFactory)
 	fwkplugin.Register(usagelimits.StaticUsageLimitPolicyType, usagelimits.StaticPolicyFactory)
 	fwkplugin.Register(prefix.PrefixCacheScorerPluginType, prefix.PrefixCachePluginFactory)
 	fwkplugin.Register(reqdataprodprefix.ApproxPrefixCachePluginType, reqdataprodprefix.ApproxPrefixCacheFactory)

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -288,7 +288,7 @@ plugins:
   type: max-score-picker
 - type: openai-parser
 - name: secondParser
-  type: vertexai-parser
+  type: anthropic-parser
 schedulingProfiles:
 - name: default
   plugins:

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -288,7 +288,7 @@ plugins:
   type: max-score-picker
 - type: openai-parser
 - name: secondParser
-  type: openai-parser
+  type: vertexai-parser
 schedulingProfiles:
 - name: default
   plugins:

--- a/pkg/epp/framework/common/request/headers.go
+++ b/pkg/epp/framework/common/request/headers.go
@@ -31,3 +31,25 @@ func GetHeader(headers map[string]string, key string) string {
 	}
 	return ""
 }
+
+// GetRequestPath extracts the request path from headers with fallback priority.
+func GetRequestPath(headers map[string]string) string {
+	if path := headers[":path"]; path != "" {
+		return path
+	}
+	if path := headers["x-original-path"]; path != "" {
+		return path
+	}
+	if path := headers["x-forwarded-path"]; path != "" {
+		return path
+	}
+	// Default to completions API for backward compatibility with existing clients and integration tests
+	return "/v1/completions"
+}
+
+// MatchPathSuffix checks if the path matches the suffix.
+func MatchPathSuffix(path, suffix string) bool {
+	path = strings.TrimSuffix(strings.TrimSpace(path), "/")
+	suffix = strings.Trim(strings.TrimSpace(suffix), "/")
+	return strings.HasSuffix(path, suffix)
+}

--- a/pkg/epp/framework/common/request/headers_test.go
+++ b/pkg/epp/framework/common/request/headers_test.go
@@ -29,3 +29,112 @@ func TestGetHeader(t *testing.T) {
 	assert.Equal(t, "", GetHeader(headers, "missing"))
 	assert.Equal(t, "", GetHeader(nil, "k"))
 }
+
+func TestGetRequestPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name:    "primary path header",
+			headers: map[string]string{":path": "/foo"},
+			want:    "/foo",
+		},
+		{
+			name:    "x-original-path header",
+			headers: map[string]string{"x-original-path": "/bar"},
+			want:    "/bar",
+		},
+		{
+			name:    "x-forwarded-path header",
+			headers: map[string]string{"x-forwarded-path": "/baz"},
+			want:    "/baz",
+		},
+		{
+			name:    "fallback to completions",
+			headers: map[string]string{},
+			want:    "/v1/completions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetRequestPath(tt.headers); got != tt.want {
+				t.Errorf("GetRequestPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchPathSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		suffix string
+		want   bool
+	}{
+		{
+			name:   "exact match",
+			path:   "chat/completions",
+			suffix: "chat/completions",
+			want:   true,
+		},
+		{
+			name:   "exact match with leading slash in path",
+			path:   "/chat/completions",
+			suffix: "chat/completions",
+			want:   true,
+		},
+		{
+			name:   "exact match with leading slash in suffix",
+			path:   "chat/completions",
+			suffix: "/chat/completions",
+			want:   true,
+		},
+		{
+			name:   "exact match with leading slash in both",
+			path:   "/chat/completions",
+			suffix: "/chat/completions",
+			want:   true,
+		},
+		{
+			name:   "suffix match with slash boundary",
+			path:   "/v1/chat/completions",
+			suffix: "chat/completions",
+			want:   true,
+		},
+		{
+			name:   "suffix match with dot boundary (gRPC)",
+			path:   "/google.cloud.aiplatform.v1beta1.PredictionService/ChatCompletions",
+			suffix: "PredictionService/ChatCompletions",
+			want:   true,
+		},
+		{
+			name:   "no match",
+			path:   "/v1/chat/completions",
+			suffix: "embeddings",
+			want:   false,
+		},
+		{
+			name:   "trailing slash in path",
+			path:   "/v1/chat/completions/",
+			suffix: "chat/completions",
+			want:   true,
+		},
+		{
+			name:   "trailing slash in suffix",
+			path:   "/v1/chat/completions",
+			suffix: "chat/completions/",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MatchPathSuffix(tt.path, tt.suffix); got != tt.want {
+				t.Errorf("MatchPathSuffix(%q, %q) = %v, want %v", tt.path, tt.suffix, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -43,12 +43,12 @@ type Parser interface {
 	// buffered response body and 'endOfStream' set to true.
 	ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*ParsedResponse, error)
 
-	// Match returns the matching criteria (paths and protocols) for this parser.
-	Match() Match
+	// Claims returns the paths and protocols claimed by this parser.
+	Claims() Claims
 }
 
-// Match defines the matching criteria for a parser.
-type Match struct {
+// Claims defines the matching criteria for a parser.
+type Claims struct {
 	Paths     []string         // path patterns this parser claims (e.g., "chat/completions")
 	Protocols []v1.AppProtocol // protocols this parser supports (e.g., "h2c")
 }

--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -43,9 +43,14 @@ type Parser interface {
 	// buffered response body and 'endOfStream' set to true.
 	ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*ParsedResponse, error)
 
-	// SupportedAppProtocols returns the list of supported protocols.
-	// Returning an empty list means it supports all protocols.
-	SupportedAppProtocols() []v1.AppProtocol
+	// Match returns the matching criteria (paths and protocols) for this parser.
+	Match() Match
+}
+
+// Match defines the matching criteria for a parser.
+type Match struct {
+	Paths     []string         // path patterns this parser claims (e.g., "chat/completions")
+	Protocols []v1.AppProtocol // protocols this parser supports (e.g., "h2c")
 }
 
 // ParseResult contains the result of parsing the request.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -61,8 +61,11 @@ func (p *AnthropicParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *AnthropicParser) SupportedAppProtocols() []v1.AppProtocol {
-	return []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP}
+func (p *AnthropicParser) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Paths:     []string{messagesAPI},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
+	}
 }
 
 func AnthropicParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -61,8 +61,8 @@ func (p *AnthropicParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *AnthropicParser) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (p *AnthropicParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Paths:     []string{messagesAPI},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -611,12 +611,15 @@ func TestAnthropicParser_ParseResponse_Streaming(t *testing.T) {
 	}
 }
 
-func TestAnthropicParser_SupportedAppProtocols(t *testing.T) {
+func TestAnthropicParser_Match(t *testing.T) {
 	parser := NewAnthropicParser()
-	supported := parser.SupportedAppProtocols()
-	want := []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP}
+	got := parser.Match()
+	want := fwkrh.Match{
+		Paths:     []string{messagesAPI},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
+	}
 
-	if diff := cmp.Diff(want, supported); diff != "" {
-		t.Errorf("SupportedAppProtocols() mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -611,15 +611,15 @@ func TestAnthropicParser_ParseResponse_Streaming(t *testing.T) {
 	}
 }
 
-func TestAnthropicParser_Match(t *testing.T) {
+func TestAnthropicParser_Claims(t *testing.T) {
 	parser := NewAnthropicParser()
-	got := parser.Match()
-	want := fwkrh.Match{
+	got := parser.Claims()
+	want := fwkrh.Claims{
 		Paths:     []string{messagesAPI},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
+		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -26,9 +26,9 @@ import (
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers"
 )
 
 const (
@@ -83,8 +83,17 @@ func (p *OpenAIParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *OpenAIParser) SupportedAppProtocols() []v1.AppProtocol {
-	return []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP}
+func (p *OpenAIParser) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Paths: []string{
+			chatCompletionsAPI,
+			completionsAPI,
+			embeddingsAPI,
+			responsesAPI,
+			conversationsAPI,
+		},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
+	}
 }
 
 func OpenAIParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -147,26 +156,6 @@ func (p *OpenAIParser) parseStreamResponse(chunk []byte) (*fwkrh.ParsedResponse,
 	}, nil
 }
 
-// GetRequestPath extracts the request path from headers with fallback priority
-func GetRequestPath(headers map[string]string) string {
-	// Try primary path header
-	if path := headers[parsers.MethodPathKey]; path != "" {
-		return path
-	}
-
-	// Try fallback headers
-	if path := headers["x-original-path"]; path != "" {
-		return path
-	}
-
-	if path := headers["x-forwarded-path"]; path != "" {
-		return path
-	}
-
-	// Default to completions API for backward compatibility with existing clients and integration tests
-	return "/v1/completions"
-}
-
 // determineAPITypeFromPath determines the API type based on the request path.
 // Note: path strings have already been cleaned and normalized by the gateway/proxy layer
 // (no trailing slashes, query parameters, or additional suffix strings at this point).
@@ -196,7 +185,7 @@ func determineAPITypeFromPath(path string) string {
 // extractRequestBody extracts the InferenceRequestBody from the given request body map using path-based detection.
 func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.InferenceRequestBody, error) {
 	// Determine API type from request path
-	path := GetRequestPath(headers)
+	path := request.GetRequestPath(headers)
 	apiType := determineAPITypeFromPath(path)
 
 	switch apiType {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -83,8 +83,8 @@ func (p *OpenAIParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *OpenAIParser) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (p *OpenAIParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Paths: []string{
 			chatCompletionsAPI,
 			completionsAPI,

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1057,13 +1057,22 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 	}
 }
 
-func TestOpenAIParser_SupportedAppProtocols(t *testing.T) {
+func TestOpenAIParser_Match(t *testing.T) {
 	parser := NewOpenAIParser()
-	supported := parser.SupportedAppProtocols()
-	want := []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP}
+	got := parser.Match()
+	want := fwkrh.Match{
+		Paths: []string{
+			chatCompletionsAPI,
+			completionsAPI,
+			embeddingsAPI,
+			responsesAPI,
+			conversationsAPI,
+		},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
+	}
 
-	if diff := cmp.Diff(want, supported); diff != "" {
-		t.Errorf("SupportedAppProtocols() mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1057,10 +1057,10 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 	}
 }
 
-func TestOpenAIParser_Match(t *testing.T) {
+func TestOpenAIParser_Claims(t *testing.T) {
 	parser := NewOpenAIParser()
-	got := parser.Match()
-	want := fwkrh.Match{
+	got := parser.Claims()
+	want := fwkrh.Claims{
 		Paths: []string{
 			chatCompletionsAPI,
 			completionsAPI,
@@ -1072,7 +1072,7 @@ func TestOpenAIParser_Match(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
+		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -53,8 +53,11 @@ func (p *PassthroughParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *PassthroughParser) SupportedAppProtocols() []v1.AppProtocol {
-	return []v1.AppProtocol{}
+func (p *PassthroughParser) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Paths:     nil,
+		Protocols: []v1.AppProtocol{},
+	}
 }
 
 func PassthroughParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -53,8 +53,8 @@ func (p *PassthroughParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *PassthroughParser) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (p *PassthroughParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Paths:     nil,
 		Protocols: []v1.AppProtocol{},
 	}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
@@ -82,10 +83,15 @@ func TestPassthroughParser_ParseResponse(t *testing.T) {
 	}
 }
 
-func TestPassthroughParser_SupportedAppProtocols(t *testing.T) {
+func TestPassthroughParser_Match(t *testing.T) {
 	parser := NewPassthroughParser()
-	supported := parser.SupportedAppProtocols()
-	if len(supported) != 0 {
-		t.Errorf("SupportedAppProtocols() = %v, want empty non-nil list", supported)
+	got := parser.Match()
+	want := fwkrh.Match{
+		Paths:     nil,
+		Protocols: []v1.AppProtocol{},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
@@ -83,15 +83,15 @@ func TestPassthroughParser_ParseResponse(t *testing.T) {
 	}
 }
 
-func TestPassthroughParser_Match(t *testing.T) {
+func TestPassthroughParser_Claims(t *testing.T) {
 	parser := NewPassthroughParser()
-	got := parser.Match()
-	want := fwkrh.Match{
+	got := parser.Claims()
+	want := fwkrh.Claims{
 		Paths:     nil,
 		Protocols: []v1.AppProtocol{},
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
+		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -82,8 +82,8 @@ func (p *VertexAIParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *VertexAIParser) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (p *VertexAIParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Paths: []string{
 			chatCompletionsMethod,
 			streamRawPredictServiceMethod,

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -82,8 +82,15 @@ func (p *VertexAIParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *VertexAIParser) SupportedAppProtocols() []v1.AppProtocol {
-	return []v1.AppProtocol{v1.AppProtocolH2C}
+func (p *VertexAIParser) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Paths: []string{
+			chatCompletionsMethod,
+			streamRawPredictServiceMethod,
+			rawPredictServiceMethod,
+		},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C},
+	}
 }
 
 func VertexAIParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -290,8 +290,8 @@ func TestVertexAIParser_Metadata(t *testing.T) {
 		t.Errorf("Expected name %s, got %s", VertexAIParserType, typedName.Name)
 	}
 
-	got := parser.Match()
-	want := fwkrh.Match{
+	got := parser.Claims()
+	want := fwkrh.Claims{
 		Paths: []string{
 			chatCompletionsMethod,
 			streamRawPredictServiceMethod,
@@ -301,7 +301,7 @@ func TestVertexAIParser_Metadata(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
+		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -290,9 +290,18 @@ func TestVertexAIParser_Metadata(t *testing.T) {
 		t.Errorf("Expected name %s, got %s", VertexAIParserType, typedName.Name)
 	}
 
-	protocols := parser.SupportedAppProtocols()
-	if len(protocols) != 1 || protocols[0] != v1.AppProtocolH2C {
-		t.Errorf("Expected protocols [h2c], got %v", protocols)
+	got := parser.Match()
+	want := fwkrh.Match{
+		Paths: []string{
+			chatCompletionsMethod,
+			streamRawPredictServiceMethod,
+			rawPredictServiceMethod,
+		},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,8 +38,8 @@ import (
 const (
 	VllmGRPCParserType = "vllmgrpc-parser"
 
-	vllmGeneratePath = "/vllm.grpc.engine.VllmEngine/Generate"
-	vllmEmbedPath    = "/vllm.grpc.engine.VllmEngine/Embed"
+	vllmGeneratePath = "vllm.grpc.engine.VllmEngine/Generate"
+	vllmEmbedPath    = "vllm.grpc.engine.VllmEngine/Embed"
 )
 
 // compile-time type validation
@@ -73,8 +74,14 @@ func (p *VllmGRPCParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *VllmGRPCParser) SupportedAppProtocols() []v1.AppProtocol {
-	return []v1.AppProtocol{v1.AppProtocolH2C}
+func (p *VllmGRPCParser) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Paths: []string{
+			vllmGeneratePath,
+			vllmEmbedPath,
+		},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C},
+	}
 }
 
 // ParseRequest parses the gRPC request body and headers and returns an InferenceRequestBody.
@@ -87,8 +94,8 @@ func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers 
 	}
 
 	path := headers[parsers.MethodPathKey]
-	switch path {
-	case vllmEmbedPath:
+	switch {
+	case strings.HasSuffix(path, vllmEmbedPath):
 		var req pb.EmbedRequest
 		if err := proto.Unmarshal(parsedPayload, &req); err != nil {
 			return nil, fmt.Errorf("unmarshaling EmbedRequest: %w", err)
@@ -100,7 +107,7 @@ func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers 
 		logger.V(logutil.TRACE).Info("parsed EmbedRequest")
 		return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
 
-	case vllmGeneratePath:
+	case strings.HasSuffix(path, vllmGeneratePath):
 		var req pb.GenerateRequest
 		if err := proto.Unmarshal(parsedPayload, &req); err != nil {
 			return nil, fmt.Errorf("unmarshaling GenerateRequest: %w", err)

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -74,8 +74,8 @@ func (p *VllmGRPCParser) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *VllmGRPCParser) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (p *VllmGRPCParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Paths: []string{
 			vllmGeneratePath,
 			vllmEmbedPath,

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -505,10 +505,10 @@ func TestVllmGRPCParser_ParseResponse(t *testing.T) {
 	}
 }
 
-func TestVllmGRPCParser_Match(t *testing.T) {
+func TestVllmGRPCParser_Claims(t *testing.T) {
 	parser := NewVllmGRPCParser()
-	got := parser.Match()
-	want := fwkrh.Match{
+	got := parser.Claims()
+	want := fwkrh.Claims{
 		Paths: []string{
 			vllmGeneratePath,
 			vllmEmbedPath,
@@ -517,6 +517,6 @@ func TestVllmGRPCParser_Match(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
+		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -505,13 +505,18 @@ func TestVllmGRPCParser_ParseResponse(t *testing.T) {
 	}
 }
 
-func TestVllmGRPCParser_SupportedAppProtocols(t *testing.T) {
+func TestVllmGRPCParser_Match(t *testing.T) {
 	parser := NewVllmGRPCParser()
+	got := parser.Match()
+	want := fwkrh.Match{
+		Paths: []string{
+			vllmGeneratePath,
+			vllmEmbedPath,
+		},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C},
+	}
 
-	supported := parser.SupportedAppProtocols()
-	want := []v1.AppProtocol{v1.AppProtocolH2C}
-
-	if diff := cmp.Diff(want, supported); diff != "" {
-		t.Errorf("SupportedAppProtocols() mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -81,14 +81,14 @@ func (p *VllmHTTPParser) WithName(name string) *VllmHTTPParser {
 	return p
 }
 
-func (p *VllmHTTPParser) Match() fwkrh.Match {
-	openaiMatch := p.openai.Match()
-	paths := make([]string, 0, 1+len(openaiMatch.Paths))
+func (p *VllmHTTPParser) Claims() fwkrh.Claims {
+	openaiClaims := p.openai.Claims()
+	paths := make([]string, 0, 1+len(openaiClaims.Paths))
 	paths = append(paths, generatePathSuffix)
-	paths = append(paths, openaiMatch.Paths...)
-	return fwkrh.Match{
+	paths = append(paths, openaiClaims.Paths...)
+	return fwkrh.Claims{
 		Paths:     paths,
-		Protocols: openaiMatch.Protocols,
+		Protocols: openaiClaims.Protocols,
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -29,8 +29,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
-
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
@@ -41,7 +40,7 @@ const (
 	VllmHTTPParserType = "vllmhttp-parser"
 
 	// generatePathSuffix is the vLLM disaggregated Prefill/Decode API path.
-	generatePathSuffix = "/inference/v1/generate"
+	generatePathSuffix = "inference/v1/generate"
 )
 
 // compile-time type validation
@@ -82,15 +81,21 @@ func (p *VllmHTTPParser) WithName(name string) *VllmHTTPParser {
 	return p
 }
 
-// SupportedAppProtocols mirrors the OpenAI parser; we accept the same HTTP-style transports.
-func (p *VllmHTTPParser) SupportedAppProtocols() []v1.AppProtocol {
-	return p.openai.SupportedAppProtocols()
+func (p *VllmHTTPParser) Match() fwkrh.Match {
+	openaiMatch := p.openai.Match()
+	paths := make([]string, 0, 1+len(openaiMatch.Paths))
+	paths = append(paths, generatePathSuffix)
+	paths = append(paths, openaiMatch.Paths...)
+	return fwkrh.Match{
+		Paths:     paths,
+		Protocols: openaiMatch.Protocols,
+	}
 }
 
 // ParseRequest handles /inference/v1/generate locally and delegates everything
 // else to the embedded OpenAI parser.
 func (p *VllmHTTPParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
-	if strings.HasSuffix(openai.GetRequestPath(headers), generatePathSuffix) {
+	if strings.HasSuffix(request.GetRequestPath(headers), generatePathSuffix) {
 		return p.parseGenerateRequest(body)
 	}
 	return p.openai.ParseRequest(ctx, body, headers)

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -273,19 +273,19 @@ func TestVllmHTTPParser_DelegatesToOpenAI(t *testing.T) {
 	}
 }
 
-func TestVllmHTTPParser_Match(t *testing.T) {
+func TestVllmHTTPParser_Claims(t *testing.T) {
 	parser := NewVllmHTTPParser()
-	got := parser.Match()
-	openaiMatch := parser.openai.Match()
-	wantPaths := make([]string, 0, 1+len(openaiMatch.Paths))
+	got := parser.Claims()
+	openaiClaims := parser.openai.Claims()
+	wantPaths := make([]string, 0, 1+len(openaiClaims.Paths))
 	wantPaths = append(wantPaths, generatePathSuffix)
-	wantPaths = append(wantPaths, openaiMatch.Paths...)
-	want := fwkrh.Match{
+	wantPaths = append(wantPaths, openaiClaims.Paths...)
+	want := fwkrh.Claims{
 		Paths:     wantPaths,
-		Protocols: openaiMatch.Protocols,
+		Protocols: openaiClaims.Protocols,
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
+		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -272,3 +272,20 @@ func TestVllmHTTPParser_DelegatesToOpenAI(t *testing.T) {
 		t.Errorf("Completions.Prompt.Raw = %q, want %q", got.Body.Completions.Prompt.Raw, "hello world")
 	}
 }
+
+func TestVllmHTTPParser_Match(t *testing.T) {
+	parser := NewVllmHTTPParser()
+	got := parser.Match()
+	openaiMatch := parser.openai.Match()
+	wantPaths := make([]string, 0, 1+len(openaiMatch.Paths))
+	wantPaths = append(wantPaths, generatePathSuffix)
+	wantPaths = append(wantPaths, openaiMatch.Paths...)
+	want := fwkrh.Match{
+		Paths:     wantPaths,
+		Protocols: openaiMatch.Protocols,
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Match() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -22,63 +22,80 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// ParserDispatcher handles the routing of incoming requests to the appropriate Parser.
-type ParserDispatcher struct {
-	routes         map[string]fwkrh.Parser
+type parserEntry struct {
+	parser          fwkrh.Parser
+	normalizedPaths []string
+}
+
+// ParserRegistry handles the routing of incoming requests to the appropriate Parser.
+type ParserRegistry struct {
+	entries        []parserEntry
 	fallbackParser fwkrh.Parser
 	parsers        []fwkrh.Parser
 }
 
-// NewParserDispatcher builds a central routing table from a list of active parsers.
-// The order of the input parsers determines the priority (first match wins for identical suffixes).
-func NewParserDispatcher(parsers []fwkrh.Parser) *ParserDispatcher {
-	dispatcher := &ParserDispatcher{
-		routes: make(map[string]fwkrh.Parser),
-	}
-	seen := make(map[fwkrh.Parser]bool)
-	for _, parser := range parsers {
-		if !seen[parser] {
-			seen[parser] = true
-			dispatcher.parsers = append(dispatcher.parsers, parser)
-		}
+// NewParserRegistry builds a central routing table from a list of active parsers.
+// The order of the input parsers determines the priority (first match wins).
+func NewParserRegistry(parsers []fwkrh.Parser) *ParserRegistry {
+	registry := &ParserRegistry{}
+	seenTypes := make(map[string]bool)
+	logger := log.Log.WithName("ParserRegistry")
 
+	for i, parser := range parsers {
 		paths := parser.Claims().Paths
+		typeName := parser.TypedName().Type
 		if len(paths) == 0 {
 			// A parser with no paths acts as a fallback. Stop processing subsequent
 			// parsers once a fallback is registered, as it will capture all remaining traffic.
-			if dispatcher.fallbackParser == nil {
-				dispatcher.fallbackParser = parser
+			registry.fallbackParser = parser
+			if !seenTypes[typeName] {
+				seenTypes[typeName] = true
+				registry.parsers = append(registry.parsers, parser)
+			} else {
+				logger.Info("Parser type is already registered, skipping duplicate type configuration", "type", typeName, "parser", parser.TypedName().Name)
+			}
+			for _, skipped := range parsers[i+1:] {
+				logger.Info("Parser is skipped because it is configured after fallback parser", "skippedParser", skipped.TypedName().Name, "fallbackParser", parser.TypedName().Name)
 			}
 			break
 		}
-		for _, suffix := range paths {
-			normalized := normalizeSuffix(suffix)
-			// First-wins priority for duplicate suffixes
-			if _, exists := dispatcher.routes[normalized]; !exists {
-				dispatcher.routes[normalized] = parser
+		if !seenTypes[typeName] {
+			seenTypes[typeName] = true
+			registry.parsers = append(registry.parsers, parser)
+			normalizedPaths := make([]string, 0, len(paths))
+			for _, suffix := range paths {
+				normalizedPaths = append(normalizedPaths, normalizeSuffix(suffix))
+			}
+			registry.entries = append(registry.entries, parserEntry{
+				parser:          parser,
+				normalizedPaths: normalizedPaths,
+			})
+		} else {
+			logger.Info("Parser type is already registered, skipping duplicate type configuration", "type", typeName, "parser", parser.TypedName().Name)
+		}
+	}
+	return registry
+}
+
+// Parsers returns all unique active parsers registered in the registry.
+func (pr *ParserRegistry) Parsers() []fwkrh.Parser {
+	return pr.parsers
+}
+
+// Resolve resolves an incoming request path to the matching Parser using suffix matching.
+func (pr *ParserRegistry) Resolve(path string) (fwkrh.Parser, error) {
+	for _, entry := range pr.entries {
+		for _, suffix := range entry.normalizedPaths {
+			if request.MatchPathSuffix(path, suffix) {
+				return entry.parser, nil
 			}
 		}
 	}
-
-	return dispatcher
-}
-
-// Parsers returns all unique active parsers registered in the dispatcher.
-func (pd *ParserDispatcher) Parsers() []fwkrh.Parser {
-	return pd.parsers
-}
-
-// Dispatch resolves an incoming request path to the matching Parser using suffix matching.
-func (pd *ParserDispatcher) Dispatch(path string) (fwkrh.Parser, error) {
-	for suffix, parser := range pd.routes {
-		if request.MatchPathSuffix(path, suffix) {
-			return parser, nil
-		}
-	}
-	if pd.fallbackParser != nil {
-		return pd.fallbackParser, nil
+	if pr.fallbackParser != nil {
+		return pr.fallbackParser, nil
 	}
 
 	return nil, fmt.Errorf("no parser registered matching path suffix for: %s", path)

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -18,7 +18,9 @@ package handlers
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
@@ -41,4 +43,58 @@ func (c *Config) String() string {
 // NewParsers returns the configured parsers.
 func NewParsers(config *Config) []fwkrh.Parser {
 	return config.Parsers
+}
+
+// ParserRouter handles the routing of incoming requests to the appropriate Parser.
+type ParserRouter struct {
+	routes         map[string]fwkrh.Parser
+	fallbackParser fwkrh.Parser
+}
+
+// NewParserRouter builds a central routing table from a list of active parsers.
+// The order of the input parsers determines the priority (first match wins for identical suffixes).
+func NewParserRouter(parsers []fwkrh.Parser) *ParserRouter {
+	router := &ParserRouter{
+		routes: make(map[string]fwkrh.Parser),
+	}
+
+	for _, parser := range parsers {
+		paths := parser.Match().Paths
+		if len(paths) == 0 {
+			// A parser with no paths acts as a fallback. Stop processing subsequent
+			// parsers once a fallback is registered, as it will capture all remaining traffic.
+			if router.fallbackParser == nil {
+				router.fallbackParser = parser
+			}
+			break
+		}
+		for _, suffix := range paths {
+			normalized := normalizeSuffix(suffix)
+			// First-wins priority for duplicate suffixes
+			if _, exists := router.routes[normalized]; !exists {
+				router.routes[normalized] = parser
+			}
+		}
+	}
+
+	return router
+}
+
+// Route resolves an incoming request path to the matching Parser using suffix matching.
+func (pr *ParserRouter) Route(path string) (fwkrh.Parser, error) {
+	for suffix, parser := range pr.routes {
+		if request.MatchPathSuffix(path, suffix) {
+			return parser, nil
+		}
+	}
+	if pr.fallbackParser != nil {
+		return pr.fallbackParser, nil
+	}
+
+	return nil, fmt.Errorf("no parser registered matching path suffix for: %s", path)
+}
+
+// normalizeSuffix cleans up a suffix by removing leading and trailing slashes.
+func normalizeSuffix(suffix string) string {
+	return strings.Trim(strings.TrimSpace(suffix), "/")
 }

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type parserEntry struct {
@@ -30,19 +30,19 @@ type parserEntry struct {
 	normalizedPaths []string
 }
 
-// ParserRegistry handles the routing of incoming requests to the appropriate Parser.
+// ParserRegistry handles the resolution of incoming requests to the appropriate Parser.
 type ParserRegistry struct {
 	entries        []parserEntry
 	fallbackParser fwkrh.Parser
 	parsers        []fwkrh.Parser
 }
 
-// NewParserRegistry builds a central routing table from a list of active parsers.
+// NewParserRegistry builds a central resolution table from a list of active parsers.
 // The order of the input parsers determines the priority (first match wins).
-func NewParserRegistry(parsers []fwkrh.Parser) *ParserRegistry {
+func NewParserRegistry(parsers []fwkrh.Parser, logger logr.Logger) *ParserRegistry {
 	registry := &ParserRegistry{}
 	seenTypes := make(map[string]bool)
-	logger := log.Log.WithName("ParserRegistry")
+	logger = logger.WithName("ParserRegistry")
 
 	for i, parser := range parsers {
 		paths := parser.Claims().Paths
@@ -55,10 +55,10 @@ func NewParserRegistry(parsers []fwkrh.Parser) *ParserRegistry {
 				seenTypes[typeName] = true
 				registry.parsers = append(registry.parsers, parser)
 			} else {
-				logger.Info("Parser type is already registered, skipping duplicate type configuration", "type", typeName, "parser", parser.TypedName().Name)
+				logger.Info("Parser type is already registered, skipping duplicate type configuration", "severity", "warning", "type", typeName, "parser", parser.TypedName().Name)
 			}
 			for _, skipped := range parsers[i+1:] {
-				logger.Info("Parser is skipped because it is configured after fallback parser", "skippedParser", skipped.TypedName().Name, "fallbackParser", parser.TypedName().Name)
+				logger.Info("Parser is skipped because it is configured after fallback parser", "severity", "warning", "skippedParser", skipped.TypedName().Name, "fallbackParser", parser.TypedName().Name)
 			}
 			break
 		}
@@ -74,7 +74,7 @@ func NewParserRegistry(parsers []fwkrh.Parser) *ParserRegistry {
 				normalizedPaths: normalizedPaths,
 			})
 		} else {
-			logger.Info("Parser type is already registered, skipping duplicate type configuration", "type", typeName, "parser", parser.TypedName().Name)
+			logger.Info("Parser type is already registered, skipping duplicate type configuration", "severity", "warning", "type", typeName, "parser", parser.TypedName().Name)
 		}
 	}
 	return registry

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -24,71 +24,61 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
-// Config holds the configuration for the Parser.
-type Config struct {
-	Parsers []fwkrh.Parser
-}
-
-func (c *Config) String() string {
-	if c == nil {
-		return "<nil>"
-	}
-	// Define a local type definition to prevent infinite recursion when calling Sprintf("%+v").
-	// A new type definition inherits the struct fields but does not copy its methods,
-	// bypassing the Stringer check and allowing a safe reflection-based field dump.
-	type temp Config
-	return fmt.Sprintf("%+v", temp(*c))
-}
-
-// NewParsers returns the configured parsers.
-func NewParsers(config *Config) []fwkrh.Parser {
-	return config.Parsers
-}
-
-// ParserRouter handles the routing of incoming requests to the appropriate Parser.
-type ParserRouter struct {
+// ParserDispatcher handles the routing of incoming requests to the appropriate Parser.
+type ParserDispatcher struct {
 	routes         map[string]fwkrh.Parser
 	fallbackParser fwkrh.Parser
+	parsers        []fwkrh.Parser
 }
 
-// NewParserRouter builds a central routing table from a list of active parsers.
+// NewParserDispatcher builds a central routing table from a list of active parsers.
 // The order of the input parsers determines the priority (first match wins for identical suffixes).
-func NewParserRouter(parsers []fwkrh.Parser) *ParserRouter {
-	router := &ParserRouter{
+func NewParserDispatcher(parsers []fwkrh.Parser) *ParserDispatcher {
+	dispatcher := &ParserDispatcher{
 		routes: make(map[string]fwkrh.Parser),
 	}
-
+	seen := make(map[fwkrh.Parser]bool)
 	for _, parser := range parsers {
-		paths := parser.Match().Paths
+		if !seen[parser] {
+			seen[parser] = true
+			dispatcher.parsers = append(dispatcher.parsers, parser)
+		}
+
+		paths := parser.Claims().Paths
 		if len(paths) == 0 {
 			// A parser with no paths acts as a fallback. Stop processing subsequent
 			// parsers once a fallback is registered, as it will capture all remaining traffic.
-			if router.fallbackParser == nil {
-				router.fallbackParser = parser
+			if dispatcher.fallbackParser == nil {
+				dispatcher.fallbackParser = parser
 			}
 			break
 		}
 		for _, suffix := range paths {
 			normalized := normalizeSuffix(suffix)
 			// First-wins priority for duplicate suffixes
-			if _, exists := router.routes[normalized]; !exists {
-				router.routes[normalized] = parser
+			if _, exists := dispatcher.routes[normalized]; !exists {
+				dispatcher.routes[normalized] = parser
 			}
 		}
 	}
 
-	return router
+	return dispatcher
 }
 
-// Route resolves an incoming request path to the matching Parser using suffix matching.
-func (pr *ParserRouter) Route(path string) (fwkrh.Parser, error) {
-	for suffix, parser := range pr.routes {
+// Parsers returns all unique active parsers registered in the dispatcher.
+func (pd *ParserDispatcher) Parsers() []fwkrh.Parser {
+	return pd.parsers
+}
+
+// Dispatch resolves an incoming request path to the matching Parser using suffix matching.
+func (pd *ParserDispatcher) Dispatch(path string) (fwkrh.Parser, error) {
+	for suffix, parser := range pd.routes {
 		if request.MatchPathSuffix(path, suffix) {
 			return parser, nil
 		}
 	}
-	if pr.fallbackParser != nil {
-		return pr.fallbackParser, nil
+	if pd.fallbackParser != nil {
+		return pd.fallbackParser, nil
 	}
 
 	return nil, fmt.Errorf("no parser registered matching path suffix for: %s", path)

--- a/pkg/epp/handlers/parsers_test.go
+++ b/pkg/epp/handlers/parsers_test.go
@@ -33,8 +33,8 @@ type testParser struct {
 func (tp *testParser) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: tp.name, Name: tp.name}
 }
-func (tp *testParser) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (tp *testParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Paths:     tp.paths,
 		Protocols: nil,
 	}
@@ -46,11 +46,11 @@ func (tp *testParser) ParseResponse(ctx context.Context, body []byte, headers ma
 	return nil, nil //nolint:nilnil
 }
 
-func TestParserRouter(t *testing.T) {
+func TestParserDispatcher(t *testing.T) {
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
 	anthropic := &testParser{name: "anthropic", paths: []string{"v1/messages"}}
 	vertex := &testParser{name: "vertex", paths: []string{"PredictionService/ChatCompletions"}}
-	router := NewParserRouter([]fwkrh.Parser{openai, anthropic, vertex})
+	dispatcher := NewParserDispatcher([]fwkrh.Parser{openai, anthropic, vertex})
 
 	tests := []struct {
 		name        string
@@ -92,29 +92,29 @@ func TestParserRouter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser, err := router.Route(tt.requestPath)
+			parser, err := dispatcher.Dispatch(tt.requestPath)
 			if (err != nil) != tt.expectError {
-				t.Errorf("Route(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
+				t.Errorf("Dispatch(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
 				return
 			}
 			if tt.expectError {
 				return
 			}
 			if parser.TypedName().Name != tt.wantParser {
-				t.Errorf("Route(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
+				t.Errorf("Dispatch(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
 			}
 		})
 	}
 }
 
-func TestParserRouterPriority(t *testing.T) {
+func TestParserDispatcherPriority(t *testing.T) {
 	// Both plugins claim `v1/chat/completions`
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions"}}
 	custom := &testParser{name: "custom", paths: []string{"v1/chat/completions"}}
 
 	// 1. OpenAI configured first
-	router1 := NewParserRouter([]fwkrh.Parser{openai, custom})
-	parser1, err := router1.Route("/v1/chat/completions")
+	dispatcher1 := NewParserDispatcher([]fwkrh.Parser{openai, custom})
+	parser1, err := dispatcher1.Dispatch("/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,8 +123,8 @@ func TestParserRouterPriority(t *testing.T) {
 	}
 
 	// 2. Custom configured first
-	router2 := NewParserRouter([]fwkrh.Parser{custom, openai})
-	parser2, err := router2.Route("/v1/chat/completions")
+	dispatcher2 := NewParserDispatcher([]fwkrh.Parser{custom, openai})
+	parser2, err := dispatcher2.Dispatch("/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,10 +133,10 @@ func TestParserRouterPriority(t *testing.T) {
 	}
 }
 
-func TestParserRouterWithWildcard(t *testing.T) {
+func TestParserDispatcherWithWildcard(t *testing.T) {
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
 	wildcard := &testParser{name: "wildcard", paths: nil}
-	router := NewParserRouter([]fwkrh.Parser{openai, wildcard})
+	dispatcher := NewParserDispatcher([]fwkrh.Parser{openai, wildcard})
 
 	tests := []struct {
 		name        string
@@ -158,16 +158,16 @@ func TestParserRouterWithWildcard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser, err := router.Route(tt.requestPath)
+			parser, err := dispatcher.Dispatch(tt.requestPath)
 			if (err != nil) != tt.expectError {
-				t.Errorf("Route(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
+				t.Errorf("Dispatch(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
 				return
 			}
 			if tt.expectError {
 				return
 			}
 			if parser.TypedName().Name != tt.wantParser {
-				t.Errorf("Route(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
+				t.Errorf("Dispatch(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
 			}
 		})
 	}

--- a/pkg/epp/handlers/parsers_test.go
+++ b/pkg/epp/handlers/parsers_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
@@ -50,7 +51,7 @@ func TestParserRegistry(t *testing.T) {
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
 	anthropic := &testParser{name: "anthropic", paths: []string{"v1/messages"}}
 	vertex := &testParser{name: "vertex", paths: []string{"PredictionService/ChatCompletions"}}
-	registry := NewParserRegistry([]fwkrh.Parser{openai, anthropic, vertex})
+	registry := NewParserRegistry([]fwkrh.Parser{openai, anthropic, vertex}, logr.Discard())
 
 	tests := []struct {
 		name        string
@@ -113,7 +114,7 @@ func TestParserRegistryPriority(t *testing.T) {
 	custom := &testParser{name: "custom", paths: []string{"v1/chat/completions"}}
 
 	// 1. OpenAI configured first
-	registry1 := NewParserRegistry([]fwkrh.Parser{openai, custom})
+	registry1 := NewParserRegistry([]fwkrh.Parser{openai, custom}, logr.Discard())
 	parser1, err := registry1.Resolve("/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -123,7 +124,7 @@ func TestParserRegistryPriority(t *testing.T) {
 	}
 
 	// 2. Custom configured first
-	registry2 := NewParserRegistry([]fwkrh.Parser{custom, openai})
+	registry2 := NewParserRegistry([]fwkrh.Parser{custom, openai}, logr.Discard())
 	parser2, err := registry2.Resolve("/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -136,7 +137,7 @@ func TestParserRegistryPriority(t *testing.T) {
 func TestParserRegistryWithPassthrough(t *testing.T) {
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
 	passthrough := &testParser{name: "passthrough", paths: nil}
-	registry := NewParserRegistry([]fwkrh.Parser{openai, passthrough})
+	registry := NewParserRegistry([]fwkrh.Parser{openai, passthrough}, logr.Discard())
 
 	tests := []struct {
 		name        string
@@ -177,7 +178,7 @@ func TestParserRegistryDuplicateTypes(t *testing.T) {
 	p1 := &testParser{name: "openai", paths: []string{"v1/chat/completions"}}
 	p2 := &testParser{name: "openai", paths: []string{"v1/completions"}}
 
-	registry := NewParserRegistry([]fwkrh.Parser{p1, p2})
+	registry := NewParserRegistry([]fwkrh.Parser{p1, p2}, logr.Discard())
 	parsers := registry.Parsers()
 	if len(parsers) != 1 {
 		t.Errorf("expected 1 parser after skipping duplicate type, got %d", len(parsers))

--- a/pkg/epp/handlers/parsers_test.go
+++ b/pkg/epp/handlers/parsers_test.go
@@ -46,11 +46,11 @@ func (tp *testParser) ParseResponse(ctx context.Context, body []byte, headers ma
 	return nil, nil //nolint:nilnil
 }
 
-func TestParserDispatcher(t *testing.T) {
+func TestParserRegistry(t *testing.T) {
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
 	anthropic := &testParser{name: "anthropic", paths: []string{"v1/messages"}}
 	vertex := &testParser{name: "vertex", paths: []string{"PredictionService/ChatCompletions"}}
-	dispatcher := NewParserDispatcher([]fwkrh.Parser{openai, anthropic, vertex})
+	registry := NewParserRegistry([]fwkrh.Parser{openai, anthropic, vertex})
 
 	tests := []struct {
 		name        string
@@ -92,29 +92,29 @@ func TestParserDispatcher(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser, err := dispatcher.Dispatch(tt.requestPath)
+			parser, err := registry.Resolve(tt.requestPath)
 			if (err != nil) != tt.expectError {
-				t.Errorf("Dispatch(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
+				t.Errorf("Resolve(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
 				return
 			}
 			if tt.expectError {
 				return
 			}
 			if parser.TypedName().Name != tt.wantParser {
-				t.Errorf("Dispatch(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
+				t.Errorf("Resolve(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
 			}
 		})
 	}
 }
 
-func TestParserDispatcherPriority(t *testing.T) {
+func TestParserRegistryPriority(t *testing.T) {
 	// Both plugins claim `v1/chat/completions`
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions"}}
 	custom := &testParser{name: "custom", paths: []string{"v1/chat/completions"}}
 
 	// 1. OpenAI configured first
-	dispatcher1 := NewParserDispatcher([]fwkrh.Parser{openai, custom})
-	parser1, err := dispatcher1.Dispatch("/v1/chat/completions")
+	registry1 := NewParserRegistry([]fwkrh.Parser{openai, custom})
+	parser1, err := registry1.Resolve("/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,8 +123,8 @@ func TestParserDispatcherPriority(t *testing.T) {
 	}
 
 	// 2. Custom configured first
-	dispatcher2 := NewParserDispatcher([]fwkrh.Parser{custom, openai})
-	parser2, err := dispatcher2.Dispatch("/v1/chat/completions")
+	registry2 := NewParserRegistry([]fwkrh.Parser{custom, openai})
+	parser2, err := registry2.Resolve("/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,10 +133,10 @@ func TestParserDispatcherPriority(t *testing.T) {
 	}
 }
 
-func TestParserDispatcherWithWildcard(t *testing.T) {
+func TestParserRegistryWithPassthrough(t *testing.T) {
 	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
-	wildcard := &testParser{name: "wildcard", paths: nil}
-	dispatcher := NewParserDispatcher([]fwkrh.Parser{openai, wildcard})
+	passthrough := &testParser{name: "passthrough", paths: nil}
+	registry := NewParserRegistry([]fwkrh.Parser{openai, passthrough})
 
 	tests := []struct {
 		name        string
@@ -145,30 +145,49 @@ func TestParserDispatcherWithWildcard(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name:        "specific match wins over wildcard",
+			name:        "specific match wins over passthrough",
 			requestPath: "/v1/completions",
 			wantParser:  "openai",
 		},
 		{
-			name:        "wildcard match",
+			name:        "passthrough match",
 			requestPath: "/unknown/path",
-			wantParser:  "wildcard",
+			wantParser:  "passthrough",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser, err := dispatcher.Dispatch(tt.requestPath)
+			parser, err := registry.Resolve(tt.requestPath)
 			if (err != nil) != tt.expectError {
-				t.Errorf("Dispatch(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
+				t.Errorf("Resolve(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
 				return
 			}
 			if tt.expectError {
 				return
 			}
 			if parser.TypedName().Name != tt.wantParser {
-				t.Errorf("Dispatch(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
+				t.Errorf("Resolve(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
 			}
 		})
+	}
+}
+
+func TestParserRegistryDuplicateTypes(t *testing.T) {
+	p1 := &testParser{name: "openai", paths: []string{"v1/chat/completions"}}
+	p2 := &testParser{name: "openai", paths: []string{"v1/completions"}}
+
+	registry := NewParserRegistry([]fwkrh.Parser{p1, p2})
+	parsers := registry.Parsers()
+	if len(parsers) != 1 {
+		t.Errorf("expected 1 parser after skipping duplicate type, got %d", len(parsers))
+	}
+	if parsers[0] != p1 {
+		t.Errorf("expected first parser to be kept, got %v", parsers[0])
+	}
+
+	_, err := registry.Resolve("/v1/completions")
+	if err == nil {
+		t.Error("expected error resolving path for skipped parser type, but succeeded")
 	}
 }

--- a/pkg/epp/handlers/parsers_test.go
+++ b/pkg/epp/handlers/parsers_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+// testParser is a simple mock parser for testing routing logic.
+type testParser struct {
+	name  string
+	paths []string
+}
+
+func (tp *testParser) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: tp.name, Name: tp.name}
+}
+func (tp *testParser) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Paths:     tp.paths,
+		Protocols: nil,
+	}
+}
+func (tp *testParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
+	return nil, nil //nolint:nilnil
+}
+func (tp *testParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*fwkrh.ParsedResponse, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func TestParserRouter(t *testing.T) {
+	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
+	anthropic := &testParser{name: "anthropic", paths: []string{"v1/messages"}}
+	vertex := &testParser{name: "vertex", paths: []string{"PredictionService/ChatCompletions"}}
+	router := NewParserRouter([]fwkrh.Parser{openai, anthropic, vertex})
+
+	tests := []struct {
+		name        string
+		requestPath string
+		wantParser  string
+		expectError bool
+	}{
+		{
+			name:        "exact match openai chat completions",
+			requestPath: "/v1/chat/completions",
+			wantParser:  "openai",
+		},
+		{
+			name:        "exact match anthropic messages",
+			requestPath: "/v1/messages",
+			wantParser:  "anthropic",
+		},
+		{
+			name:        "suffix match vertex chat completions",
+			requestPath: "/google.cloud.aiplatform.v1beta1.PredictionService/ChatCompletions",
+			wantParser:  "vertex",
+		},
+		{
+			name:        "suffix match vertex chat completions different version",
+			requestPath: "/google.cloud.aiplatform.v1.PredictionService/ChatCompletions",
+			wantParser:  "vertex",
+		},
+		{
+			name:        "path with trailing slash normalize match",
+			requestPath: "/v1/messages/",
+			wantParser:  "anthropic",
+		},
+		{
+			name:        "no suffix match returns error",
+			requestPath: "/unknown/path",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser, err := router.Route(tt.requestPath)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Route(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
+				return
+			}
+			if tt.expectError {
+				return
+			}
+			if parser.TypedName().Name != tt.wantParser {
+				t.Errorf("Route(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
+			}
+		})
+	}
+}
+
+func TestParserRouterPriority(t *testing.T) {
+	// Both plugins claim `v1/chat/completions`
+	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions"}}
+	custom := &testParser{name: "custom", paths: []string{"v1/chat/completions"}}
+
+	// 1. OpenAI configured first
+	router1 := NewParserRouter([]fwkrh.Parser{openai, custom})
+	parser1, err := router1.Route("/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parser1.TypedName().Name != "openai" {
+		t.Errorf("expected openai to take precedence, got %s", parser1.TypedName().Name)
+	}
+
+	// 2. Custom configured first
+	router2 := NewParserRouter([]fwkrh.Parser{custom, openai})
+	parser2, err := router2.Route("/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parser2.TypedName().Name != "custom" {
+		t.Errorf("expected custom to take precedence, got %s", parser2.TypedName().Name)
+	}
+}
+
+func TestParserRouterWithWildcard(t *testing.T) {
+	openai := &testParser{name: "openai", paths: []string{"v1/chat/completions", "v1/completions"}}
+	wildcard := &testParser{name: "wildcard", paths: nil}
+	router := NewParserRouter([]fwkrh.Parser{openai, wildcard})
+
+	tests := []struct {
+		name        string
+		requestPath string
+		wantParser  string
+		expectError bool
+	}{
+		{
+			name:        "specific match wins over wildcard",
+			requestPath: "/v1/completions",
+			wantParser:  "openai",
+		},
+		{
+			name:        "wildcard match",
+			requestPath: "/unknown/path",
+			wantParser:  "wildcard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser, err := router.Route(tt.requestPath)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Route(%q) error = %v, expectError %v", tt.requestPath, err, tt.expectError)
+				return
+			}
+			if tt.expectError {
+				return
+			}
+			if parser.TypedName().Name != tt.wantParser {
+				t.Errorf("Route(%q) resolved parser = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
+			}
+		})
+	}
+}

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -26,6 +26,7 @@ import (
 
 	envoy "github.com/llm-d/llm-d-router/pkg/common/envoy"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/util/request"
 )
@@ -48,10 +49,17 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 
 	reqCtx.ResponseSize += len(responseBytes)
 
-	parsedResp, err := s.parsers[0].ParseResponse(ctx, responseBytes, reqCtx.Response.Headers, endOfStream)
+	var parsedResp *fwkrh.ParsedResponse
+	parser, err := s.getOrResolveParser(ctx, reqCtx)
 	if err != nil {
-		logger.Error(err, "parsing response")
-	} else if parsedResp != nil && parsedResp.Usage != nil {
+		logger.Error(err, "parsing response: failed to resolve parser")
+	} else {
+		parsedResp, err = parser.ParseResponse(ctx, responseBytes, reqCtx.Response.Headers, endOfStream)
+		if err != nil {
+			logger.Error(err, "parsing response")
+		}
+	}
+	if parsedResp != nil && parsedResp.Usage != nil {
 		reqCtx.Usage = *parsedResp.Usage
 		metrics.RecordInputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Usage.PromptTokens)
 		metrics.RecordOutputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Usage.CompletionTokens)

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -188,7 +188,7 @@ func TestHandleResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
 			}
 			server.director = &mockDirector{}
 			reqCtx := test.reqCtx
@@ -247,7 +247,7 @@ func TestHandleStreamedResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
 			}
 			server.director = &mockDirector{}
 			reqCtx := &RequestContext{
@@ -318,8 +318,8 @@ func TestHandleResponseBodyModelStreaming_TokenAccumulation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
-				director:         &mockDirector{},
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				director:       &mockDirector{},
 			}
 			reqCtx := &RequestContext{
 				Response: &Response{
@@ -474,8 +474,8 @@ func TestResponseSizeAccumulation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
-				director:         &mockDirector{},
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				director:       &mockDirector{},
 			}
 			reqCtx := &RequestContext{
 				Response: &Response{

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -188,7 +188,7 @@ func TestHandleResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parsers: []fwkrh.Parser{openai.NewOpenAIParser()},
+				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
 			}
 			server.director = &mockDirector{}
 			reqCtx := test.reqCtx
@@ -247,7 +247,7 @@ func TestHandleStreamedResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parsers: []fwkrh.Parser{openai.NewOpenAIParser()},
+				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
 			}
 			server.director = &mockDirector{}
 			reqCtx := &RequestContext{
@@ -318,8 +318,8 @@ func TestHandleResponseBodyModelStreaming_TokenAccumulation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parsers:  []fwkrh.Parser{openai.NewOpenAIParser()},
-				director: &mockDirector{},
+				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				director:     &mockDirector{},
 			}
 			reqCtx := &RequestContext{
 				Response: &Response{
@@ -474,8 +474,8 @@ func TestResponseSizeAccumulation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parsers:  []fwkrh.Parser{openai.NewOpenAIParser()},
-				director: &mockDirector{},
+				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				director:     &mockDirector{},
 			}
 			reqCtx := &RequestContext{
 				Response: &Response{

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/go-logr/logr"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
@@ -188,7 +189,7 @@ func TestHandleResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}, logr.Discard()),
 			}
 			server.director = &mockDirector{}
 			reqCtx := test.reqCtx
@@ -247,7 +248,7 @@ func TestHandleStreamedResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}, logr.Discard()),
 			}
 			server.director = &mockDirector{}
 			reqCtx := &RequestContext{
@@ -318,7 +319,7 @@ func TestHandleResponseBodyModelStreaming_TokenAccumulation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}, logr.Discard()),
 				director:       &mockDirector{},
 			}
 			reqCtx := &RequestContext{
@@ -474,7 +475,7 @@ func TestResponseSizeAccumulation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}, logr.Discard()),
 				director:       &mockDirector{},
 			}
 			reqCtx := &RequestContext{

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -188,7 +188,7 @@ func TestHandleResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
 			}
 			server.director = &mockDirector{}
 			reqCtx := test.reqCtx
@@ -247,7 +247,7 @@ func TestHandleStreamedResponseBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
 			}
 			server.director = &mockDirector{}
 			reqCtx := &RequestContext{
@@ -318,8 +318,8 @@ func TestHandleResponseBodyModelStreaming_TokenAccumulation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
-				director:     &mockDirector{},
+				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				director:         &mockDirector{},
 			}
 			reqCtx := &RequestContext{
 				Response: &Response{
@@ -474,8 +474,8 @@ func TestResponseSizeAccumulation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &StreamingServer{
-				parserRouter: NewParserRouter([]fwkrh.Parser{openai.NewOpenAIParser()}),
-				director:     &mockDirector{},
+				parserDispatcher: NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}),
+				director:         &mockDirector{},
 			}
 			reqCtx := &RequestContext{
 				Response: &Response{

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -59,11 +59,11 @@ type EvictChannelLookup interface {
 	Deregister(requestID string)
 }
 
-func NewStreamingServer(datastore Datastore, director Director, parsers []fwkrh.Parser, maxPoolBufferSize int) *StreamingServer {
+func NewStreamingServer(datastore Datastore, director Director, parserDispatcher *ParserDispatcher, maxPoolBufferSize int) *StreamingServer {
 	return &StreamingServer{
 		director:          director,
 		datastore:         datastore,
-		parserRouter:      NewParserRouter(parsers),
+		parserDispatcher:  parserDispatcher,
 		maxPoolBufferSize: maxPoolBufferSize,
 		bufferPool: sync.Pool{
 			New: func() any {
@@ -94,7 +94,7 @@ type Datastore interface {
 type StreamingServer struct {
 	datastore         Datastore
 	director          Director
-	parserRouter      *ParserRouter
+	parserDispatcher  *ParserDispatcher
 	evictionLookup    EvictChannelLookup // optional, set for eviction support
 	bufferPool        sync.Pool
 	maxPoolBufferSize int
@@ -187,7 +187,7 @@ func (s *StreamingServer) getOrResolveParser(ctx context.Context, reqCtx *Reques
 		headers = reqCtx.Request.Headers
 	}
 	path := fwkrequest.GetRequestPath(headers)
-	resolvedParser, err := s.parserRouter.Route(path)
+	resolvedParser, err := s.parserDispatcher.Dispatch(path)
 	if err != nil {
 		logger.Error(err, "Error resolving parser for path", "path", path)
 		return nil, err

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -59,11 +59,11 @@ type EvictChannelLookup interface {
 	Deregister(requestID string)
 }
 
-func NewStreamingServer(datastore Datastore, director Director, parserDispatcher *ParserDispatcher, maxPoolBufferSize int) *StreamingServer {
+func NewStreamingServer(datastore Datastore, director Director, parserRegistry *ParserRegistry, maxPoolBufferSize int) *StreamingServer {
 	return &StreamingServer{
 		director:          director,
 		datastore:         datastore,
-		parserDispatcher:  parserDispatcher,
+		parserRegistry:    parserRegistry,
 		maxPoolBufferSize: maxPoolBufferSize,
 		bufferPool: sync.Pool{
 			New: func() any {
@@ -94,7 +94,7 @@ type Datastore interface {
 type StreamingServer struct {
 	datastore         Datastore
 	director          Director
-	parserDispatcher  *ParserDispatcher
+	parserRegistry    *ParserRegistry
 	evictionLookup    EvictChannelLookup // optional, set for eviction support
 	bufferPool        sync.Pool
 	maxPoolBufferSize int
@@ -122,7 +122,7 @@ type RequestContext struct {
 	ResponseStatusCode        string
 	RequestRunning            bool
 	Request                   *Request
-	ResolvedParser            fwkrh.Parser
+	Parser                    fwkrh.Parser
 
 	SchedulingRequest *fwksched.InferenceRequest
 
@@ -177,8 +177,8 @@ type recvResult struct {
 }
 
 func (s *StreamingServer) getOrResolveParser(ctx context.Context, reqCtx *RequestContext) (fwkrh.Parser, error) {
-	if reqCtx.ResolvedParser != nil {
-		return reqCtx.ResolvedParser, nil
+	if reqCtx.Parser != nil {
+		return reqCtx.Parser, nil
 	}
 
 	logger := log.FromContext(ctx)
@@ -187,14 +187,14 @@ func (s *StreamingServer) getOrResolveParser(ctx context.Context, reqCtx *Reques
 		headers = reqCtx.Request.Headers
 	}
 	path := fwkrequest.GetRequestPath(headers)
-	resolvedParser, err := s.parserDispatcher.Dispatch(path)
+	parser, err := s.parserRegistry.Resolve(path)
 	if err != nil {
 		logger.Error(err, "Error resolving parser for path", "path", path)
 		return nil, err
 	}
 
-	reqCtx.ResolvedParser = resolvedParser
-	return resolvedParser, nil
+	reqCtx.Parser = parser
+	return parser, nil
 }
 
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -42,6 +42,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
+	fwkrequest "github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
@@ -62,7 +63,7 @@ func NewStreamingServer(datastore Datastore, director Director, parsers []fwkrh.
 	return &StreamingServer{
 		director:          director,
 		datastore:         datastore,
-		parsers:           parsers,
+		parserRouter:      NewParserRouter(parsers),
 		maxPoolBufferSize: maxPoolBufferSize,
 		bufferPool: sync.Pool{
 			New: func() any {
@@ -93,7 +94,7 @@ type Datastore interface {
 type StreamingServer struct {
 	datastore         Datastore
 	director          Director
-	parsers           []fwkrh.Parser
+	parserRouter      *ParserRouter
 	evictionLookup    EvictChannelLookup // optional, set for eviction support
 	bufferPool        sync.Pool
 	maxPoolBufferSize int
@@ -121,6 +122,7 @@ type RequestContext struct {
 	ResponseStatusCode        string
 	RequestRunning            bool
 	Request                   *Request
+	ResolvedParser            fwkrh.Parser
 
 	SchedulingRequest *fwksched.InferenceRequest
 
@@ -172,6 +174,27 @@ const (
 type recvResult struct {
 	req *extProcPb.ProcessingRequest
 	err error
+}
+
+func (s *StreamingServer) getOrResolveParser(ctx context.Context, reqCtx *RequestContext) (fwkrh.Parser, error) {
+	if reqCtx.ResolvedParser != nil {
+		return reqCtx.ResolvedParser, nil
+	}
+
+	logger := log.FromContext(ctx)
+	var headers map[string]string
+	if reqCtx.Request != nil {
+		headers = reqCtx.Request.Headers
+	}
+	path := fwkrequest.GetRequestPath(headers)
+	resolvedParser, err := s.parserRouter.Route(path)
+	if err != nil {
+		logger.Error(err, "Error resolving parser for path", "path", path)
+		return nil, err
+	}
+
+	reqCtx.ResolvedParser = resolvedParser
+	return resolvedParser, nil
 }
 
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
@@ -343,7 +366,13 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				reqCtx.RequestSize = buf.Len()
 				buf.Reset()
 
-				parseResult, parseErr := s.parsers[0].ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
+				parser, resolveErr := s.getOrResolveParser(ctx, reqCtx)
+				if resolveErr != nil {
+					err = errcommon.Error{Code: errcommon.BadRequest, Msg: resolveErr.Error()}
+					logger.Error(err, "Error resolving parser for request body")
+					break
+				}
+				parseResult, parseErr := parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 				if parseErr != nil {
 					err = errcommon.Error{Code: errcommon.BadRequest, Msg: parseErr.Error()}
 					logger.Error(err, "Error parsing request")

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -58,7 +58,7 @@ type ExtProcServerRunner struct {
 	RefreshPrometheusMetricsInterval time.Duration
 	MetricsStalenessThreshold        time.Duration
 	Director                         *requestcontrol.Director
-	ParserDispatcher                 *handlers.ParserDispatcher
+	ParserRegistry                   *handlers.ParserRegistry
 	SaturationDetector               fwkfc.SaturationDetector
 	GRPCMaxRecvMsgSize               int
 	GRPCMaxSendMsgSize               int
@@ -197,7 +197,7 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 		if poolCap == 0 {
 			poolCap = 4 * 1024 * 1024 // gRPC default 4MB
 		}
-		extProcServer := handlers.NewStreamingServer(r.Datastore, r.Director, r.ParserDispatcher, poolCap)
+		extProcServer := handlers.NewStreamingServer(r.Datastore, r.Director, r.ParserRegistry, poolCap)
 		extProcPb.RegisterExternalProcessorServer(srv, extProcServer)
 
 		if r.HealthChecking {

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -41,7 +41,6 @@ import (
 	datalayerlogger "github.com/llm-d/llm-d-router/pkg/epp/datalayer/logger"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
-	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-router/pkg/epp/requestcontrol"
 )
@@ -59,7 +58,7 @@ type ExtProcServerRunner struct {
 	RefreshPrometheusMetricsInterval time.Duration
 	MetricsStalenessThreshold        time.Duration
 	Director                         *requestcontrol.Director
-	Parsers                          []fwkrh.Parser
+	ParserDispatcher                 *handlers.ParserDispatcher
 	SaturationDetector               fwkfc.SaturationDetector
 	GRPCMaxRecvMsgSize               int
 	GRPCMaxSendMsgSize               int
@@ -198,7 +197,7 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 		if poolCap == 0 {
 			poolCap = 4 * 1024 * 1024 // gRPC default 4MB
 		}
-		extProcServer := handlers.NewStreamingServer(r.Datastore, r.Director, r.Parsers, poolCap)
+		extProcServer := handlers.NewStreamingServer(r.Datastore, r.Director, r.ParserDispatcher, poolCap)
 		extProcPb.RegisterExternalProcessorServer(srv, extProcServer)
 
 		if r.HealthChecking {

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -134,7 +134,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 	director := &testDirector{}
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
-	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
@@ -436,7 +436,7 @@ func TestServer_Skip(t *testing.T) {
 
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
-	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserDispatcher([]fwkrh.Parser{mockPar}), 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{mockPar}), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
@@ -513,7 +513,7 @@ func TestServer_GRPCReceiveLimit(t *testing.T) {
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
 
-	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,7 +135,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 	director := &testDirector{}
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
-	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}, logr.Discard()), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
@@ -436,7 +437,7 @@ func TestServer_Skip(t *testing.T) {
 
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
-	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{mockPar}), 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{mockPar}, logr.Discard()), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
@@ -513,7 +514,7 @@ func TestServer_GRPCReceiveLimit(t *testing.T) {
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
 
-	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}, logr.Discard()), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -134,7 +134,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 	director := &testDirector{}
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
-	streamingServer := handlers.NewStreamingServer(ds, director, []fwkrh.Parser{openai.NewOpenAIParser()}, 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
@@ -414,8 +414,8 @@ func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[
 func (m *mockParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*fwkrh.ParsedResponse, error) {
 	return nil, errors.New("sentinel error for mock parser")
 }
-func (m *mockParser) Match() fwkrh.Match {
-	return fwkrh.Match{
+func (m *mockParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
 		Paths:     []string{"completions"},
 		Protocols: nil,
 	}
@@ -436,7 +436,7 @@ func TestServer_Skip(t *testing.T) {
 
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
-	streamingServer := handlers.NewStreamingServer(ds, director, []fwkrh.Parser{mockPar}, 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserDispatcher([]fwkrh.Parser{mockPar}), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)
@@ -513,7 +513,7 @@ func TestServer_GRPCReceiveLimit(t *testing.T) {
 	ctx, cancel, ds := igwtestutils.PrepareForTestStreamingServer(t, []*v1alpha2.InferenceObjective{model},
 		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
 
-	streamingServer := handlers.NewStreamingServer(ds, director, []fwkrh.Parser{openai.NewOpenAIParser()}, 0)
+	streamingServer := handlers.NewStreamingServer(ds, director, handlers.NewParserDispatcher([]fwkrh.Parser{openai.NewOpenAIParser()}), 0)
 
 	testListener, errChan := igwtestutils.SetupTestStreamingServer(ctx, t, streamingServer)
 	process, conn := igwtestutils.GetStreamingServerClient(ctx, t)

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	extv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
@@ -415,9 +414,11 @@ func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[
 func (m *mockParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*fwkrh.ParsedResponse, error) {
 	return nil, errors.New("sentinel error for mock parser")
 }
-
-func (m *mockParser) SupportedAppProtocols() []extv1.AppProtocol {
-	return nil
+func (m *mockParser) Match() fwkrh.Match {
+	return fwkrh.Match{
+		Paths:     []string{"completions"},
+		Protocols: nil,
+	}
 }
 
 func (m *mockParser) TypedName() fwkplugin.TypedName {

--- a/test/integration/epp/common_tests.go
+++ b/test/integration/epp/common_tests.go
@@ -86,16 +86,25 @@ func ReqResponseOnly(
 	return reqs
 }
 
-// ReqResponseGRPCWithTailer creates a sequence simulating only the response phase from Envoy while passing gRPC payload.
-// It also generate a response trailer.
-// It skips the RequestHeaders phase entirely.
-func ReqResponseGRPCWithTailer(
+// ReqRequestHeadersAndResponseGRPC creates a sequence that starts with request headers (to resolve parser)
+// followed by response phase.
+func ReqRequestHeadersAndResponseGRPC(
+	reqHeaders map[string]string,
 	respHeaders map[string]string,
 	bodyChunks ...[]byte,
 ) []*extProcPb.ProcessingRequest {
-	reqs := make([]*extProcPb.ProcessingRequest, 0, 1+len(bodyChunks))
+	reqs := make([]*extProcPb.ProcessingRequest, 0, 2+len(bodyChunks))
 
-	// 1. Response Headers
+	// 1. Request Headers
+	reqs = append(reqs, &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &envoyCorev3.HeaderMap{Headers: buildEnvoyHeaders(reqHeaders)},
+			},
+		},
+	})
+
+	// 2. Response Headers
 	reqs = append(reqs, &extProcPb.ProcessingRequest{
 		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
 			ResponseHeaders: &extProcPb.HttpHeaders{
@@ -104,7 +113,7 @@ func ReqResponseGRPCWithTailer(
 		},
 	})
 
-	// 2. Response Body Chunks
+	// 3. Response Body Chunks
 	for _, chunk := range bodyChunks {
 		reqs = append(reqs, &extProcPb.ProcessingRequest{
 			Request: &extProcPb.ProcessingRequest_ResponseBody{
@@ -116,7 +125,7 @@ func ReqResponseGRPCWithTailer(
 		})
 	}
 
-	// 3. Response Trailer
+	// 4. Response Trailer
 	reqs = append(reqs, &extProcPb.ProcessingRequest{
 		Request: &extProcPb.ProcessingRequest_ResponseTrailers{
 			ResponseTrailers: &extProcPb.HttpTrailers{},

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -220,7 +220,8 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 					},
 				}
 				gRPCPayload, _ := integration.CreateGrpcPayload(resp)
-				return ReqResponseGRPCWithTailer(
+				return ReqRequestHeadersAndResponseGRPC(
+					map[string]string{":path": integration.GenerateGRPCMethodName},
 					map[string]string{"content-type": "application/grpc"},
 					gRPCPayload[:len(gRPCPayload)/2],
 					gRPCPayload[len(gRPCPayload)/2:],
@@ -241,7 +242,8 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 		},
 		{
 			name: "response buffering: invalid gRPC",
-			requests: ReqResponseGRPCWithTailer(
+			requests: ReqRequestHeadersAndResponseGRPC(
+				map[string]string{":path": integration.GenerateGRPCMethodName},
 				map[string]string{"content-type": "application/grpc"},
 				[]byte("no healthy upstream"),
 			),
@@ -260,7 +262,8 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 					},
 				}
 				gRPCPayload, _ := integration.CreateGrpcPayload(resp)
-				return ReqResponseGRPCWithTailer(
+				return ReqRequestHeadersAndResponseGRPC(
+					map[string]string{":path": integration.GenerateGRPCMethodName},
 					map[string]string{"content-type": "application/grpc"},
 					gRPCPayload[:len(gRPCPayload)/2],
 					gRPCPayload[len(gRPCPayload)/2:],


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR refactors the parser routing logic to support multiple concurrent parsers:
1. Adds the `Claims` interface to parsers which returns the supported path and protocol `Claims` information.
2. Uses the `parserRouter` to register the routing table and resolve the correct parser for incoming requests.

**Parser Selection & Context Lifecycle**:
- **Selection**: When request header and body are received, the EPP extracts the request path (checking `:path`, `x-original-path`, or `x-forwarded-path` headers) and uses `ParserRouter` to match it against the paths registered by active parsers.
  - If multiple parsers support the same path, the first parser configured in the list takes precedence (first match wins).
- The resolved parser is stored in `RequestContext.ResolvedParser`.
- Response Phase: During the response body processing phase, the server retrieves the `ResolvedParser` from the `RequestContext` to ensure the same parser is used to parse response usage metrics.

**Configuration Example**:
You can now configure multiple parsers in the `EndpointPickerConfig` as follows:
```yaml
apiVersion: inference.networking.x-k8s.io/v1alpha1
kind: EndpointPickerConfig
...
requestHandler:
  parsers:
  - pluginRef: openai-parser
  - pluginRef: anthropic-parser
```
Priority is determined by the order of the configuration (first match wins for duplicate paths).

This work is built on top of #1448.

**Which issue(s) this PR fixes**:
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP now supports configuring multiple parsers under `requestHandler.parsers` in the `EndpointPickerConfig`. The router matches the request path suffix to select the appropriate parser (first match wins for duplicate parsers supporting suffix match).
```
