### PR TITLE
Enable all HTTP parsers by default in EPP

### DIFF
--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vertexai"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
@@ -513,15 +514,19 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			},
 		},
 		{
-			name:       "Success - Config without parser and a default openai parser is injected",
+			name:       "Success - Config without parser and default parsers are injected",
 			configText: successWithNoParserConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
 				require.NotNil(t, cfg.ParserRegistry, "Parser registry should be loaded")
 				parsers := cfg.ParserRegistry.Parsers()
-				require.Len(t, parsers, 1, "Should have one parser")
-				require.Equal(t, "openai-parser", parsers[0].TypedName().Name, "Should have openai parser name")
-				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type, "Should contain openai parser type")
+				require.Len(t, parsers, 3, "Should have three default parsers")
+				require.Equal(t, "openai-parser", parsers[0].TypedName().Name)
+				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type)
+				require.Equal(t, "anthropic-parser", parsers[1].TypedName().Name)
+				require.Equal(t, anthropic.AnthropicParserType, parsers[1].TypedName().Type)
+				require.Equal(t, "vllmhttp-parser", parsers[2].TypedName().Name)
+				require.Equal(t, vllmhttp.VllmHTTPParserType, parsers[2].TypedName().Type)
 			},
 		},
 		{
@@ -922,6 +927,7 @@ func registerTestPlugins(t *testing.T) {
 	fwkplugin.Register(openai.OpenAIParserType, openai.OpenAIParserPluginFactory)
 	fwkplugin.Register(vertexai.VertexAIParserType, vertexai.VertexAIParserPluginFactory)
 	fwkplugin.Register(anthropic.AnthropicParserType, anthropic.AnthropicParserPluginFactory)
+	fwkplugin.Register(vllmhttp.VllmHTTPParserType, vllmhttp.VllmHTTPParserPluginFactory)
 	fwkplugin.Register(usagelimits.StaticUsageLimitPolicyType, usagelimits.StaticPolicyFactory)
 	fwkplugin.Register(prefix.PrefixCacheScorerPluginType, prefix.PrefixCachePluginFactory)
 	fwkplugin.Register(reqdataprodprefix.ApproxPrefixCachePluginType, reqdataprodprefix.ApproxPrefixCacheFactory)

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -28,7 +28,9 @@ import (
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
@@ -248,6 +250,8 @@ func ensureParsers(
 	if len(cfg.RequestHandler.Parsers) == 0 {
 		cfg.RequestHandler.Parsers = []configapi.ParserConfig{
 			{PluginRef: openai.OpenAIParserType},
+			{PluginRef: anthropic.AnthropicParserType},
+			{PluginRef: vllmhttp.VllmHTTPParserType},
 		}
 	}
 	for _, pc := range cfg.RequestHandler.Parsers {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -29,6 +29,8 @@ import (
 	"fmt"
 	"strings"
 
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
@@ -82,13 +84,9 @@ func (p *VllmHTTPParser) WithName(name string) *VllmHTTPParser {
 }
 
 func (p *VllmHTTPParser) Claims() fwkrh.Claims {
-	openaiClaims := p.openai.Claims()
-	paths := make([]string, 0, 1+len(openaiClaims.Paths))
-	paths = append(paths, generatePathSuffix)
-	paths = append(paths, openaiClaims.Paths...)
 	return fwkrh.Claims{
-		Paths:     paths,
-		Protocols: openaiClaims.Protocols,
+		Paths:     []string{generatePathSuffix},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
 }
 
@@ -98,7 +96,7 @@ func (p *VllmHTTPParser) ParseRequest(ctx context.Context, body []byte, headers 
 	if strings.HasSuffix(request.GetRequestPath(headers), generatePathSuffix) {
 		return p.parseGenerateRequest(body)
 	}
-	return p.openai.ParseRequest(ctx, body, headers)
+	return nil, fmt.Errorf("unsupported path: %s", request.GetRequestPath(headers))
 }
 
 // ParseResponse delegates to the OpenAI parser. /inference/v1/generate

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
@@ -253,36 +254,29 @@ func TestVllmHTTPParser_ParseRequest_GenerateErrorPaths(t *testing.T) {
 	}
 }
 
-// TestVllmHTTPParser_DelegatesToOpenAI confirms that non-generate paths flow
-// through the embedded OpenAI parser.
-func TestVllmHTTPParser_DelegatesToOpenAI(t *testing.T) {
+// TestVllmHTTPParser_RejectsNonGeneratePaths confirms that non-generate paths
+// are rejected with an error.
+func TestVllmHTTPParser_RejectsNonGeneratePaths(t *testing.T) {
 	parser := NewVllmHTTPParser()
 
 	body, _ := json.Marshal(map[string]any{
 		"prompt": "hello world",
 	})
-	got, err := parser.ParseRequest(context.Background(), body, map[string]string{":path": "/v1/completions"})
-	if err != nil {
-		t.Fatalf("ParseRequest() unexpected error: %v", err)
+	_, err := parser.ParseRequest(context.Background(), body, map[string]string{":path": "/v1/completions"})
+	if err == nil {
+		t.Fatal("ParseRequest() expected error for non-generate path, got nil")
 	}
-	if got.Body == nil || got.Body.Completions == nil {
-		t.Fatalf("expected Completions body via OpenAI delegation, got %+v", got)
-	}
-	if got.Body.Completions.Prompt.Raw != "hello world" {
-		t.Errorf("Completions.Prompt.Raw = %q, want %q", got.Body.Completions.Prompt.Raw, "hello world")
+	if !strings.Contains(err.Error(), "unsupported path") {
+		t.Errorf("expected error to contain 'unsupported path', got: %v", err)
 	}
 }
 
 func TestVllmHTTPParser_Claims(t *testing.T) {
 	parser := NewVllmHTTPParser()
 	got := parser.Claims()
-	openaiClaims := parser.openai.Claims()
-	wantPaths := make([]string, 0, 1+len(openaiClaims.Paths))
-	wantPaths = append(wantPaths, generatePathSuffix)
-	wantPaths = append(wantPaths, openaiClaims.Paths...)
 	want := fwkrh.Claims{
-		Paths:     wantPaths,
-		Protocols: openaiClaims.Protocols,
+		Paths:     []string{generatePathSuffix},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables all available HTTP endpoint parsers (`openai-parser`, `anthropic-parser`, and `vllmhttp-parser`) by default in the Endpoint Picker (EPP). This allows EPP to route requests for these APIs without requiring explicit parser configuration.

Additionally, refactors `vllmhttp-parser` to remove the delegation to `openai-parser`. It now strictly handles only `/inference/v1/generate` requests, avoiding overlapping path claims when both parsers are enabled.

**Which issue(s) this PR fixes**:
Fixes #1487

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Enable openai, anthropic, and vllmhttp parsers by default in EPP.
```
