### PR TITLE
Fix/inflight token dependency

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -48,6 +48,11 @@ type Config struct {
 	// AddEstimatedOutputTokens controls whether estimated output tokens are added to
 	// the in-flight token counter. Defaults to false.
 	AddEstimatedOutputTokens bool `json:"addEstimatedOutputTokens"`
+	// PrefixMatchInfoProducerName selects which prefix-cache producer's
+	// PrefixCacheMatchInfo to read for the cached-prefix discount. Empty defaults
+	// to the approximate-prefix producer; set it to a precise-prefix-cache
+	// producer's instance name to discount against precise cache state instead.
+	PrefixMatchInfoProducerName string `json:"prefixMatchInfoProducerName,omitempty"`
 }
 
 func defaultConfig() Config {
@@ -77,6 +82,7 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 		tokenEstimator:           NewSimpleTokenEstimator(),
 		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
 		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		prefixMatchInfoDK:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
 		PluginState:              fwkplugin.NewPluginState(ctx),
 	}, nil
 }
@@ -98,6 +104,7 @@ type InFlightLoadProducer struct {
 	addEstimatedOutputTokens bool
 	PluginState              *fwkplugin.PluginState
 	dk                       fwkplugin.DataKey
+	prefixMatchInfoDK        fwkplugin.DataKey
 }
 
 // addedTokensEntry tracks a request's contribution to the global token and
@@ -276,7 +283,7 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 }
 
 func (p *InFlightLoadProducer) estimateRequestTokens(endpoint fwksched.Endpoint, inputTokens int64) int64 {
-	adjustedInput := uncachedInputTokens(endpoint, inputTokens)
+	adjustedInput := uncachedInputTokens(endpoint, inputTokens, p.prefixMatchInfoDK.String())
 	tokens := adjustedInput
 	if p.addEstimatedOutputTokens {
 		// Output tokens are based on the full input, not the cached portion.
@@ -390,19 +397,20 @@ func addedTokensKey(endpointID, profileName string) string {
 // uncachedInputTokens returns the prompt tokens this endpoint must actually compute,
 // excluding any prefix already cached on it.
 //
-// When the approximate prefix producer has populated PrefixCacheMatchInfo on the
-// endpoint, the matched and total block counts are in real (tokenized) units, so
-// we use them directly: uncached = (TotalBlocks - MatchBlocks) * BlockSizeTokens.
-// For very long prompts where the prefix index is capped (MaxPrefixTokensToMatch),
-// any tail beyond the cap is added back from the (estimated) inputTokens so the
-// full prompt cost is still reflected.
+// When the configured prefix producer (approximate or precise) has populated
+// PrefixCacheMatchInfo on the endpoint under prefixMatchInfoKey, the matched and
+// total block counts are in real (tokenized) units, so we use them directly:
+// uncached = (TotalBlocks - MatchBlocks) * BlockSizeTokens. For very long prompts
+// where the prefix index is capped (MaxPrefixTokensToMatch), any tail beyond the
+// cap is added back from the (estimated) inputTokens so the full prompt cost is
+// still reflected.
 //
 // When the attribute is missing, we fall back to the estimated inputTokens.
-func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64) int64 {
+func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64, prefixMatchInfoKey string) int64 {
 	if endpoint == nil {
 		return nonNeg(inputTokens)
 	}
-	raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoDataKey.String())
+	raw, ok := endpoint.Get(prefixMatchInfoKey)
 	if !ok {
 		return nonNeg(inputTokens)
 	}
@@ -446,14 +454,15 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 // token-producer ahead of this producer and auto-creates one when none is
 // configured; without it the input-token estimate silently reads zero.
 // PrefixCacheMatchInfo is optional — used to discount the already-cached prompt
-// prefix when an approximate-prefix producer is present.
+// prefix from the prefix producer selected by prefixMatchInfoProducerName
+// (approximate by default, or a precise-prefix-cache producer).
 func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
 			tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedPrompt{},
 		},
 		Optional: map[fwkplugin.DataKey]any{
-			attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{},
+			p.prefixMatchInfoDK: attrprefix.PrefixCacheMatchInfo{},
 		},
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -445,14 +445,15 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 // Consumes declares TokenizedPrompt as required so the data-layer DAG orders a
 // token-producer ahead of this producer and auto-creates one when none is
 // configured; without it the input-token estimate silently reads zero.
-//
-// PrefixCacheMatchInfo is read opportunistically in uncachedInputTokens with a
-// graceful fallback and is intentionally not declared here: a missing prefix
-// producer is a valid configuration, not a degraded one.
+// PrefixCacheMatchInfo is optional — used to discount the already-cached prompt
+// prefix when an approximate-prefix producer is present.
 func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
 			tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedPrompt{},
+		},
+		Optional: map[fwkplugin.DataKey]any{
+			attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{},
 		},
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -35,6 +35,7 @@ import (
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 	inflightloadconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/constants"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
 const (
@@ -86,6 +87,7 @@ var (
 	_ requestcontrol.DataProducer          = &InFlightLoadProducer{}
 	_ datalayer.EndpointExtractor          = (*InFlightLoadProducer)(nil)
 	_ datalayer.Registrant                 = &InFlightLoadProducer{}
+	_ fwkplugin.ConsumerPlugin             = &InFlightLoadProducer{}
 )
 
 type InFlightLoadProducer struct {
@@ -440,9 +442,19 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 	}
 }
 
-func (p *InFlightLoadProducer) Consumes() map[string]any {
-	return map[string]any{
-		attrprefix.PrefixCacheMatchInfoDataKey.String(): (*attrprefix.PrefixCacheMatchInfo)(nil),
+// Consumes declares TokenizedPrompt as required so the data-layer DAG orders a
+// token-producer ahead of this producer and auto-creates one when none is
+// configured; without it the input-token estimate silently reads zero.
+// PrefixCacheMatchInfo is optional — used to discount the already-cached prompt
+// prefix when an approximate-prefix producer is present.
+func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedPrompt{},
+		},
+		Optional: map[fwkplugin.DataKey]any{
+			attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{},
+		},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -445,15 +445,14 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 // Consumes declares TokenizedPrompt as required so the data-layer DAG orders a
 // token-producer ahead of this producer and auto-creates one when none is
 // configured; without it the input-token estimate silently reads zero.
-// PrefixCacheMatchInfo is optional — used to discount the already-cached prompt
-// prefix when an approximate-prefix producer is present.
+//
+// PrefixCacheMatchInfo is read opportunistically in uncachedInputTokens with a
+// graceful fallback and is intentionally not declared here: a missing prefix
+// producer is a valid configuration, not a degraded one.
 func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
 			tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedPrompt{},
-		},
-		Optional: map[fwkplugin.DataKey]any{
-			attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{},
 		},
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -60,10 +60,45 @@ func TestInFlightLoadProducer_Consumes(t *testing.T) {
 	// token-producer and orders it ahead of this producer; without it the input
 	// token estimate silently reads zero.
 	require.Contains(t, deps.Required, tokenproducer.TokenizedPromptDataKey)
-	// PrefixCacheMatchInfo is optional: consumed for the cached-prefix discount
-	// when an approximate-prefix producer is present, absent otherwise.
+	// PrefixCacheMatchInfo is optional: consumed for the cached-prefix discount.
+	// With no prefixMatchInfoProducerName set, it defaults to the approximate
+	// producer's key.
 	require.Contains(t, deps.Optional, attrprefix.PrefixCacheMatchInfoDataKey)
 	require.NotContains(t, deps.Required, attrprefix.PrefixCacheMatchInfoDataKey)
+}
+
+// prefixMatchInfoProducerName selects which prefix producer (approximate or
+// precise) feeds the cached-prefix discount, by both the optional dependency key
+// and the runtime read.
+func TestInFlightLoadProducer_PrefixMatchInfoProducerName(t *testing.T) {
+	t.Parallel()
+
+	const preciseName = "precise-prefix-cache-producer"
+	raw, err := json.Marshal(Config{PrefixMatchInfoProducerName: preciseName})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	p, err := InFlightLoadProducerFactory("inflight-load-producer",
+		json.NewDecoder(bytes.NewReader(raw)), igwtestutils.NewTestHandle(ctx))
+	require.NoError(t, err)
+	producer := p.(*InFlightLoadProducer)
+
+	preciseKey := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(preciseName)
+
+	// The optional dependency points at the configured precise producer, not approx.
+	require.Contains(t, producer.Consumes().Optional, preciseKey)
+	require.NotContains(t, producer.Consumes().Optional, attrprefix.PrefixCacheMatchInfoDataKey)
+
+	// The discount reads PrefixCacheMatchInfo from the configured producer's key
+	// (indexed 2*4=8, matched 1*4=4 -> uncached 4).
+	hit := newStubSchedulingEndpoint("ep-hit")
+	hit.Put(preciseKey.String(), attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+	require.Equal(t, int64(4), producer.estimateRequestTokens(hit, 5))
+
+	// Data under the approx (default) key is ignored, so it falls back to inputTokens.
+	miss := newStubSchedulingEndpoint("ep-miss")
+	miss.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+	require.Equal(t, int64(5), producer.estimateRequestTokens(miss, 5))
 }
 
 func TestInFlightLoadProducer_Produce(t *testing.T) {
@@ -603,7 +638,7 @@ func TestUncachedInputTokens_Overestimate(t *testing.T) {
 
 	inputTokens := int64(5)
 
-	uncached := uncachedInputTokens(endpoint, inputTokens)
+	uncached := uncachedInputTokens(endpoint, inputTokens, attrprefix.PrefixCacheMatchInfoDataKey.String())
 
 	// When the prefix cache says 4 tokens are definitely uncached in the indexed portion (8-4),
 	// we trust that over the smaller (approximate) estimate of 5.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -35,6 +35,7 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	igwtestutils "github.com/llm-d/llm-d-router/test/utils/igw"
 )
 
@@ -48,6 +49,21 @@ func newTestProducer(t testing.TB) *InFlightLoadProducer {
 	p, err := InFlightLoadProducerFactory("inflight-load-producer", decoder, igwtestutils.NewTestHandle(ctx))
 	require.NoError(t, err)
 	return p.(*InFlightLoadProducer)
+}
+
+func TestInFlightLoadProducer_Consumes(t *testing.T) {
+	t.Parallel()
+
+	deps := newTestProducer(t).Consumes()
+
+	// TokenizedPrompt is required so the data-layer DAG auto-creates a
+	// token-producer and orders it ahead of this producer; without it the input
+	// token estimate silently reads zero.
+	require.Contains(t, deps.Required, tokenproducer.TokenizedPromptDataKey)
+	// PrefixCacheMatchInfo is optional: consumed for the cached-prefix discount
+	// when an approximate-prefix producer is present, absent otherwise.
+	require.Contains(t, deps.Optional, attrprefix.PrefixCacheMatchInfoDataKey)
+	require.NotContains(t, deps.Required, attrprefix.PrefixCacheMatchInfoDataKey)
 }
 
 func TestInFlightLoadProducer_Produce(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -60,11 +60,10 @@ func TestInFlightLoadProducer_Consumes(t *testing.T) {
 	// token-producer and orders it ahead of this producer; without it the input
 	// token estimate silently reads zero.
 	require.Contains(t, deps.Required, tokenproducer.TokenizedPromptDataKey)
-	// PrefixCacheMatchInfo is consumed opportunistically with a graceful fallback,
-	// so it is not declared as a dependency (which would force a prefix producer
-	// or emit a spurious "no producer" warning for prefix-less configs).
+	// PrefixCacheMatchInfo is optional: consumed for the cached-prefix discount
+	// when an approximate-prefix producer is present, absent otherwise.
+	require.Contains(t, deps.Optional, attrprefix.PrefixCacheMatchInfoDataKey)
 	require.NotContains(t, deps.Required, attrprefix.PrefixCacheMatchInfoDataKey)
-	require.NotContains(t, deps.Optional, attrprefix.PrefixCacheMatchInfoDataKey)
 }
 
 func TestInFlightLoadProducer_Produce(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -60,10 +60,11 @@ func TestInFlightLoadProducer_Consumes(t *testing.T) {
 	// token-producer and orders it ahead of this producer; without it the input
 	// token estimate silently reads zero.
 	require.Contains(t, deps.Required, tokenproducer.TokenizedPromptDataKey)
-	// PrefixCacheMatchInfo is optional: consumed for the cached-prefix discount
-	// when an approximate-prefix producer is present, absent otherwise.
-	require.Contains(t, deps.Optional, attrprefix.PrefixCacheMatchInfoDataKey)
+	// PrefixCacheMatchInfo is consumed opportunistically with a graceful fallback,
+	// so it is not declared as a dependency (which would force a prefix producer
+	// or emit a spurious "no producer" warning for prefix-less configs).
 	require.NotContains(t, deps.Required, attrprefix.PrefixCacheMatchInfoDataKey)
+	require.NotContains(t, deps.Optional, attrprefix.PrefixCacheMatchInfoDataKey)
 }
 
 func TestInFlightLoadProducer_Produce(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The inflight-load-producer reads request.Body.TokenizedPrompt for its input-token estimate, but declared its dependency through the legacy map-based Consumes(), which the data-layer DAG does not read. It was therefore never treated as a ConsumerPlugin: no token-producer was auto-created or ordered ahead of it, so EstimateInput silently returned 0 whenever nothing else pulled in a token-producer — the active-request/load scorers then weighted on request counts only, with no token signal.

This PR:

- Declares TokenizedPrompt as a typed required dependency, so the data-layer DAG auto-creates and orders a token-producer ahead of this producer.
- Declares PrefixCacheMatchInfo as an optional dependency — the endpoint attribute read for the cached-prefix discount. (Optional deps don't drive DAG ordering or auto-creation; this is declarative, the runtime read keeps its graceful fallback.)
- Adds a prefixMatchInfoProducerName parameter that selects which prefix-cache producer supplies that discount: empty keeps the approximate-prefix producer (default); set it to a precise-prefix-cache producer's instance name to discount against precise cache state instead. It drives both the runtime read and the optional dependency key, mirroring prefix-cache-scorer's field of the same name.

**Which issue(s) this PR fixes**:
Fixes #1492

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
`inflight-load-producer`: a new `prefixMatchInfoProducerName` parameter selects which prefix-cache producer supplies the cached-prefix discount - the approximate-prefix producer by default, or a precise-prefix-cache producer when set.
```
