### PR TITLE
fix(preciseprefixcache): honor cache_salt in block hashing

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
@@ -30,7 +30,7 @@ upstream. No-op otherwise.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `tokenProcessorConfig` | object | `kvblock.DefaultTokenProcessorConfig()` | KV-block hashing (must match engine `blockSize`/`hashSeed`). |
+| `tokenProcessorConfig` | object | `kvblock.DefaultTokenProcessorConfig()` | KV-block hashing for the EPP-recomputed keys (block size, hash seed). |
 | `indexerConfig` | object | `kvcache.NewDefaultConfig()` | `kvcache.Indexer` config. |
 | `kvEventsConfig` | object | `kvevents.DefaultConfig()` | KV-events pool config. |
 | `speculativeIndexing` | bool | `false` | Seed predicted entries on routing decisions. |
@@ -38,3 +38,25 @@ upstream. No-op otherwise.
 
 See [llm-d-kv-cache/docs/configuration.md](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/configuration.md)
 for nested parameter details.
+
+## Engine compatibility
+
+Block keys are recomputed by the EPP from `TokenizedPrompt` (tokens, model,
+multimodal features, cache salt) on both the lookup path and the KV-event
+ingestion path, using this plugin's `tokenProcessorConfig`. The engine's own
+block hashes serve only as opaque keys for the engine-to-request mapping, so
+`blockSize`/`hashSeed` need not match the engine.
+
+The cross-engine requirement is that the engine emits, in its KV-events, the
+hash-affecting inputs the EPP hashes: `token_ids`, and `extra_keys` carrying
+multimodal identifiers and `cache_salt`. An input the engine omits from
+`extra_keys` is absent on the event side, so requests carrying it do not
+correlate.
+
+| Engine | `extra_keys` in KV-events | `cache_salt` |
+|--------|---------------------------|--------------|
+| vLLM | emitted | in block-0 `extra_keys`; salted prefixes isolated and precise-routed |
+| SGLang | not emitted | baked into engine block hashes but not surfaced; salted requests are precise-cache misses until SGLang emits `extra_keys` |
+
+Salt isolation is enforced by the engine regardless; the above affects only
+routing accuracy for salted requests.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
@@ -33,8 +33,9 @@ type kvCacheIndexer interface {
 
 // computeBlockKeys hashes the request's TokenizedPrompt into KV-block keys,
 // passing any multimodal features into the block-extra-features computation
-// so MM tokens land in the right blocks. Returns (nil, nil) when the request
-// carries no tokens.
+// so MM tokens land in the right blocks. A non-empty CacheSalt is folded into
+// the first block's extra keys so salted prompts get isolated keys. Returns
+// (nil, nil) when the request carries no tokens.
 func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
 	request *scheduling.InferenceRequest, blockSizeTokens int,
 ) ([]kvblock.BlockHash, error) {
@@ -51,5 +52,25 @@ func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
 		extraFeatures = kvblock.ComputeBlockExtraFeatures(
 			mmHashes, mmPlaceholders, blockSizeTokens, len(tp.TokenIDs))
 	}
+	extraFeatures = foldCacheSalt(extraFeatures, tp.CacheSalt, len(tp.TokenIDs)/blockSizeTokens)
 	return idx.ComputeBlockKeysFromTokens(ctx, tp.TokenIDs, request.TargetModel, extraFeatures)
+}
+
+// foldCacheSalt appends the cache salt to the first block's extra keys, after
+// any multimodal hashes. vLLM puts cache_salt in block 0's extra_keys, and
+// engine-side KV-event ingestion folds that salt string into the same per-block
+// hash list (kvblock.ParseRawExtraKeys); the request side must match for salted
+// keys to correlate. No-op without a salt or a full first block.
+func foldCacheSalt(extraFeatures []*kvblock.BlockExtraFeatures, salt string, numBlocks int) []*kvblock.BlockExtraFeatures {
+	if salt == "" || numBlocks == 0 {
+		return extraFeatures
+	}
+	if extraFeatures == nil {
+		extraFeatures = make([]*kvblock.BlockExtraFeatures, numBlocks)
+	}
+	if extraFeatures[0] == nil {
+		extraFeatures[0] = &kvblock.BlockExtraFeatures{}
+	}
+	extraFeatures[0].MMHashes = append(extraFeatures[0].MMHashes, kvblock.MMHash{Hash: salt})
+	return extraFeatures
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -265,6 +265,95 @@ func TestProduce_PassesMMExtraFeatures(t *testing.T) {
 	require.NotNil(t, captured)
 }
 
+// Cache salt is folded into the first block's extra keys, isolating salted
+// prompts. Mirrors engine-side ingestion, which folds vLLM's block-0 cache_salt
+// into the same per-block hash list.
+func TestProduce_FoldsCacheSalt(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	tokens := make([]uint32, 16)
+	for i := range tokens {
+		tokens[i] = uint32(i)
+	}
+
+	tests := []struct {
+		name string
+		mm   []fwkrh.MultiModalFeature
+		want []kvblock.MMHash
+	}{
+		{
+			name: "salt only",
+			want: []kvblock.MMHash{{Hash: "s3cr3t"}},
+		},
+		{
+			name: "salt appended after mm hash",
+			mm:   []fwkrh.MultiModalFeature{{Modality: fwkrh.ModalityImage, Hash: "abc", Offset: 2, Length: 4}},
+			want: []kvblock.MMHash{{Hash: "abc"}, {Hash: "s3cr3t"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []*kvblock.BlockExtraFeatures
+			idx := &fakeKVCacheIndexer{
+				computeFromTokens: func(_ context.Context, _ []uint32, _ string, extra []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+					captured = extra
+					return []kvblock.BlockHash{0xAA}, nil
+				},
+				index: &fakeKVBlockIndex{},
+			}
+			p := newProducerWithIndexer(ctx, idx, &fakeKVBlockScorer{})
+
+			req := &scheduling.InferenceRequest{
+				RequestID:   "req-salt",
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					TokenizedPrompt: &fwkrh.TokenizedPrompt{
+						TokenIDs:           tokens,
+						MultiModalFeatures: tc.mm,
+						CacheSalt:          "s3cr3t",
+					},
+				},
+			}
+
+			require.NoError(t, p.Produce(ctx, req, testEndpoints))
+			require.Len(t, captured, 1)
+			require.NotNil(t, captured[0])
+			require.Equal(t, tc.want, captured[0].MMHashes)
+		})
+	}
+}
+
+// No salt → extra features stay untouched (nil for a text-only prompt).
+func TestProduce_NoCacheSalt_NoExtraFeatures(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	tokens := make([]uint32, 16)
+	for i := range tokens {
+		tokens[i] = uint32(i)
+	}
+	captured := []*kvblock.BlockExtraFeatures{{}} // sentinel; expect overwrite to nil
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, _ []uint32, _ string, extra []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			captured = extra
+			return []kvblock.BlockHash{0xAA}, nil
+		},
+		index: &fakeKVBlockIndex{},
+	}
+	p := newProducerWithIndexer(ctx, idx, &fakeKVBlockScorer{})
+
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-nosalt",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{TokenIDs: tokens},
+		},
+	}
+
+	require.NoError(t, p.Produce(ctx, req, testEndpoints))
+	require.Nil(t, captured)
+}
+
 // nil request / empty body → don't touch the indexer.
 func TestProduce_NoOpPaths(t *testing.T) {
 	ctx := utils.NewTestContext(t)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -158,10 +158,10 @@ func chatPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 	return pm
 }
 
-// cacheSaltFromBody returns the cache salt from whichever protocol is populated.
-// The protocol switch lives in the producer so consumers read only
-// TokenizedPrompt.CacheSalt.
-func cacheSaltFromBody(body *fwkrh.InferenceRequestBody) string {
+// CacheSaltFromBody returns the cache salt from whichever protocol is populated.
+// The protocol switch lives here so producers populate TokenizedPrompt.CacheSalt
+// from one place and consumers read only that field.
+func CacheSaltFromBody(body *fwkrh.InferenceRequestBody) string {
 	switch {
 	case body.Conversations != nil:
 		return body.Conversations.CacheSalt

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -252,7 +252,7 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 		// A parser (e.g. vLLM gRPC) may pre-populate tokens without a salt;
 		// ensure cache-salt isolation still applies on the skip path.
 		if request.Body.TokenizedPrompt.CacheSalt == "" {
-			request.Body.TokenizedPrompt.CacheSalt = cacheSaltFromBody(request.Body)
+			request.Body.TokenizedPrompt.CacheSalt = CacheSaltFromBody(request.Body)
 		}
 		return nil
 	}
@@ -261,7 +261,7 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 	if err != nil {
 		return err
 	}
-	tp.CacheSalt = cacheSaltFromBody(request.Body)
+	tp.CacheSalt = CacheSaltFromBody(request.Body)
 
 	request.Body.TokenizedPrompt = tp
 	return nil

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/legacy_producer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/legacy_producer.go
@@ -133,6 +133,7 @@ func (lp *legacyProducer) tokenizeRequest(request *scheduling.InferenceRequest) 
 	request.Body.TokenizedPrompt = &fwkrh.TokenizedPrompt{
 		TokenIDs:           tokens,
 		MultiModalFeatures: flattenMMFeatures(mmFeatures),
+		CacheSalt:          tokenizer.CacheSaltFromBody(request.Body),
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -172,7 +172,10 @@ func TestLegacyProducer_TokenizesCompletionPromptViaPool(t *testing.T) {
 
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "hello world"}},
+			Completions: &fwkrh.CompletionsRequest{
+				Prompt:    fwkrh.Prompt{Raw: "hello world"},
+				CacheSalt: "leg-salt",
+			},
 		},
 	}
 	require.NoError(t, lp.Produce(ctx, req, nil))
@@ -181,6 +184,9 @@ func TestLegacyProducer_TokenizesCompletionPromptViaPool(t *testing.T) {
 	assert.Equal(t, "hello world", stub.lastRaw)
 	require.NotNil(t, req.Body.TokenizedPrompt)
 	assert.Equal(t, []uint32{1, 2, 3}, req.Body.TokenizedPrompt.TokenIDs)
+	// Wrapper-owned tokenization must still carry the cache salt so precise
+	// keys stay isolated on this path.
+	assert.Equal(t, "leg-salt", req.Body.TokenizedPrompt.CacheSalt)
 }
 
 // End-to-end: tokens from the pool flow into the embedded producer, get


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
The precise producer built block keys from tokens + model only, so cache_salt never isolated prefixes — salted requests collided and failed to correlate with the engine-side index, which already folds vLLM's block-0 cache_salt into the recomputed keys.

Fold TokenizedPrompt.CacheSalt into the first block's extra keys on both producer paths (token-producer and legacy tokenizersPoolConfig wrapper), matching vLLM's placement and the KV-event ingestion path.

**Which issue(s) this PR fixes**:
Fixes #1389

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
