### PR TITLE
feat(metrics): add core TTFT and stream-aware TPOT metrics

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -79,7 +79,7 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		metrics.RecordResponseSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.ResponseSize)
 		fairnessID := reqCtx.SchedulingRequest.FairnessID
 		priority := strconv.Itoa(reqCtx.Priority)
-		metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp)
+		metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.modelServerStreaming, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp)
 		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 	}
 	return s.director.HandleResponseBody(ctx, reqCtx, endOfStream)

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -49,6 +50,10 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 
 	reqCtx.ResponseSize += len(responseBytes)
 
+	if reqCtx.FirstTokenTimestamp.IsZero() && len(responseBytes) > 0 {
+		reqCtx.FirstTokenTimestamp = time.Now()
+	}
+
 	var parsedResp *fwkrh.ParsedResponse
 	parser, err := s.getOrResolveParser(ctx, reqCtx)
 	if err != nil {
@@ -71,6 +76,8 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		metrics.RecordNormalizedTimePerOutputToken(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 		metrics.RecordRequestLatencies(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)
 		metrics.RecordResponseSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.ResponseSize)
+		metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp)
+		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 	}
 	return s.director.HandleResponseBody(ctx, reqCtx, endOfStream)
 }

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -76,8 +77,10 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		metrics.RecordNormalizedTimePerOutputToken(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 		metrics.RecordRequestLatencies(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)
 		metrics.RecordResponseSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.ResponseSize)
-		metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp)
-		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
+		fairnessID := reqCtx.SchedulingRequest.FairnessID
+		priority := strconv.Itoa(reqCtx.Priority)
+		metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp)
+		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 	}
 	return s.director.HandleResponseBody(ctx, reqCtx, endOfStream)
 }

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -29,6 +29,7 @@ import (
 	envoy "github.com/llm-d/llm-d-router/pkg/common/envoy"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/util/request"
 )
@@ -77,7 +78,10 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		metrics.RecordNormalizedTimePerOutputToken(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 		metrics.RecordRequestLatencies(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)
 		metrics.RecordResponseSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.ResponseSize)
-		fairnessID := reqCtx.SchedulingRequest.FairnessID
+		fairnessID := metadata.DefaultFairnessID
+		if reqCtx.SchedulingRequest != nil {
+			fairnessID = reqCtx.SchedulingRequest.FairnessID
+		}
 		priority := strconv.Itoa(reqCtx.Priority)
 		metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.modelServerStreaming, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp)
 		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -29,6 +29,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
@@ -195,7 +196,8 @@ func TestHandleResponseBody(t *testing.T) {
 			reqCtx := test.reqCtx
 			if reqCtx == nil {
 				reqCtx = &RequestContext{
-					Response: &Response{},
+					Response:          &Response{},
+					SchedulingRequest: &fwksched.InferenceRequest{FairnessID: metadata.DefaultFairnessID},
 				}
 			}
 			server.HandleResponseBody(ctx, reqCtx, test.body, true)
@@ -257,6 +259,7 @@ func TestHandleStreamedResponseBody(t *testing.T) {
 						"content-type": "text/event-stream; charset=utf-8",
 					},
 				},
+				SchedulingRequest: &fwksched.InferenceRequest{FairnessID: metadata.DefaultFairnessID},
 			}
 			server.HandleResponseBody(ctx, reqCtx, test.body, true) // Hard coded to true since openAIParser does not endOfStream to switch logic.
 
@@ -328,6 +331,7 @@ func TestHandleResponseBodyModelStreaming_TokenAccumulation(t *testing.T) {
 						"content-type": "text/event-stream",
 					},
 				},
+				SchedulingRequest: &fwksched.InferenceRequest{FairnessID: metadata.DefaultFairnessID},
 			}
 
 			for _, chunk := range tc.chunks {
@@ -482,6 +486,7 @@ func TestResponseSizeAccumulation(t *testing.T) {
 				Response: &Response{
 					Headers: map[string]string{},
 				},
+				SchedulingRequest: &fwksched.InferenceRequest{FairnessID: metadata.DefaultFairnessID},
 			}
 			for i, chunk := range tt.chunks {
 				endOfStream := i == len(tt.chunks)-1

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -113,7 +113,7 @@ type RequestContext struct {
 	ObjectiveKey              string
 	Priority                  int
 	RequestReceivedTimestamp  time.Time
-	FirstTokenTimestamp      time.Time
+	FirstTokenTimestamp       time.Time
 	ResponseCompleteTimestamp time.Time
 	RequestSize               int
 	Usage                     fwkrh.Usage

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -113,6 +113,7 @@ type RequestContext struct {
 	ObjectiveKey              string
 	Priority                  int
 	RequestReceivedTimestamp  time.Time
+	FirstTokenTimestamp      time.Time
 	ResponseCompleteTimestamp time.Time
 	RequestSize               int
 	Usage                     fwkrh.Usage

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -148,7 +148,7 @@ var (
 				8, 10, 15, 20, 30, 45, 60, 120,
 			},
 		},
-		modelLabels,
+		append(append([]string{}, modelLabels...), "fairness_id", "priority"),
 	)
 
 	llmdRequestTPOT = prometheus.NewHistogramVec(
@@ -161,7 +161,7 @@ var (
 				0.3, 0.4, 0.5, 0.6, 0.8, 1, 2,
 			},
 		},
-		modelLabels,
+		append(append([]string{}, modelLabels...), "fairness_id", "priority"),
 	)
 )
 

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -137,6 +137,34 @@ var (
 		},
 		modelLabels,
 	)
+
+	llmdRequestTTFT = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "request_ttft_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Time to first token in seconds, measured from request received to first response byte.", compbasemetrics.ALPHA),
+			Buckets: []float64{
+				0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6,
+				8, 10, 15, 20, 30, 45, 60, 120, 180, 240, 300, 360, 480, 600, 900, 1200,
+				1800, 2700, 3600,
+			},
+		},
+		modelLabels,
+	)
+
+	llmdRequestTPOT = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "request_tpot_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Average time per output token in seconds, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
+			Buckets: []float64{
+				0.0005, 0.00205, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.125, 0.15, 0.2,
+				0.3, 0.4, 0.5, 0.6, 0.8, 1, 1.5, 2, 3, 4.5, 6, 12, 18, 24, 30, 36, 48, 60,
+				90, 120, 180, 270, 360,
+			},
+		},
+		modelLabels,
+	)
 )
 
 // --- llm-d Inference Pool Metrics ---

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -148,7 +148,7 @@ var (
 				8, 10, 15, 20, 30, 45, 60, 120,
 			},
 		},
-		append(append([]string{}, modelLabels...), "fairness_id", "priority"),
+		append(append([]string{}, modelLabels...), "fairness_id", "priority", "streaming"),
 	)
 
 	llmdRequestTPOT = prometheus.NewHistogramVec(

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -142,7 +142,7 @@ var (
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
 			Name:      "service_level_ttft_seconds",
-			Help:      metricsutil.HelpMsgWithStability("Service-level time to first token in seconds, measured from request received to first response byte.", compbasemetrics.ALPHA),
+			Help:      metricsutil.HelpMsgWithStability("Service-level time to first token in seconds, measured from request received to first response byte. For non-streaming requests, this equals total request duration.", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6,
 				8, 10, 15, 20, 30, 45, 60, 120,

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -145,8 +145,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Service-level time to first token in seconds, measured from request received to first response byte.", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6,
-				8, 10, 15, 20, 30, 45, 60, 120, 180, 240, 300, 360, 480, 600, 900, 1200,
-				1800, 2700, 3600,
+				8, 10, 15, 20, 30, 45, 60, 120,
 			},
 		},
 		modelLabels,

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -154,8 +154,8 @@ var (
 	llmdRequestTPOT = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
-			Name:      "service_level_tpot_seconds",
-			Help:      metricsutil.HelpMsgWithStability("Service-level average time per output token in seconds, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
+			Name:      "service_level_streaming_tpot_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Service-level average time per output token in seconds for streaming requests, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.0005, 0.00205, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.125, 0.15, 0.2,
 				0.3, 0.4, 0.5, 0.6, 0.8, 1, 2,

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -158,8 +158,7 @@ var (
 			Help:      metricsutil.HelpMsgWithStability("Service-level average time per output token in seconds, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.0005, 0.00205, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.125, 0.15, 0.2,
-				0.3, 0.4, 0.5, 0.6, 0.8, 1, 1.5, 2, 3, 4.5, 6, 12, 18, 24, 30, 36, 48, 60,
-				90, 120, 180, 270, 360,
+				0.3, 0.4, 0.5, 0.6, 0.8, 1, 2,
 			},
 		},
 		modelLabels,

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -141,8 +141,8 @@ var (
 	llmdRequestTTFT = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
-			Name:      "service_level_ttft_seconds",
-			Help:      metricsutil.HelpMsgWithStability("Service-level time to first token in seconds, measured from request received to first response byte. For non-streaming requests, this equals total request duration.", compbasemetrics.ALPHA),
+			Name:      "ttft_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Time to first token in seconds, measured from request received to first response byte. For non-streaming requests, this equals total request duration.", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6,
 				8, 10, 15, 20, 30, 45, 60, 120,
@@ -154,8 +154,8 @@ var (
 	llmdRequestTPOT = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
-			Name:      "service_level_streaming_tpot_seconds",
-			Help:      metricsutil.HelpMsgWithStability("Service-level average time per output token in seconds for streaming requests, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
+			Name:      "streaming_tpot_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Average time per output token in seconds for streaming requests, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.0005, 0.00205, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.125, 0.15, 0.2,
 				0.3, 0.4, 0.5, 0.6, 0.8, 1, 2,

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -141,8 +141,8 @@ var (
 	llmdRequestTTFT = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
-			Name:      "request_ttft_seconds",
-			Help:      metricsutil.HelpMsgWithStability("Time to first token in seconds, measured from request received to first response byte.", compbasemetrics.ALPHA),
+			Name:      "service_level_ttft_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Service-level time to first token in seconds, measured from request received to first response byte.", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6,
 				8, 10, 15, 20, 30, 45, 60, 120, 180, 240, 300, 360, 480, 600, 900, 1200,
@@ -155,8 +155,8 @@ var (
 	llmdRequestTPOT = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
-			Name:      "request_tpot_seconds",
-			Help:      metricsutil.HelpMsgWithStability("Average time per output token in seconds, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
+			Name:      "service_level_tpot_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Service-level average time per output token in seconds, computed as (e2e - TTFT) / (output_tokens - 1).", compbasemetrics.ALPHA),
 			Buckets: []float64{
 				0.0005, 0.00205, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.125, 0.15, 0.2,
 				0.3, 0.4, 0.5, 0.6, 0.8, 1, 1.5, 2, 3, 4.5, 6, 12, 18, 24, 30, 36, 48, 60,

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -622,7 +622,7 @@ func RecordNormalizedTimePerOutputToken(ctx context.Context, modelName, targetMo
 }
 
 // RecordRequestTTFT records the time to first token.
-func RecordRequestTTFT(ctx context.Context, modelName, targetModelName string, received time.Time, firstToken time.Time) bool {
+func RecordRequestTTFT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, received time.Time, firstToken time.Time) bool {
 	if firstToken.IsZero() {
 		return false
 	}
@@ -632,12 +632,12 @@ func RecordRequestTTFT(ctx context.Context, modelName, targetModelName string, r
 		return false
 	}
 	ttftSeconds := firstToken.Sub(received).Seconds()
-	llmdRequestTTFT.WithLabelValues(modelName, targetModelName).Observe(ttftSeconds)
+	llmdRequestTTFT.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(ttftSeconds)
 	return true
 }
 
 // RecordRequestTPOT records the average time per output token.
-func RecordRequestTPOT(ctx context.Context, modelName, targetModelName string, received time.Time, firstToken time.Time, complete time.Time, outputTokenCount int) bool {
+func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, received time.Time, firstToken time.Time, complete time.Time, outputTokenCount int) bool {
 	if firstToken.IsZero() || outputTokenCount <= 1 {
 		return false
 	}
@@ -650,7 +650,7 @@ func RecordRequestTPOT(ctx context.Context, modelName, targetModelName string, r
 	e2eSeconds := complete.Sub(received).Seconds()
 	ttftSeconds := firstToken.Sub(received).Seconds()
 	tpotSeconds := (e2eSeconds - ttftSeconds) / float64(outputTokenCount-1)
-	llmdRequestTPOT.WithLabelValues(modelName, targetModelName).Observe(tpotSeconds)
+	llmdRequestTPOT.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(tpotSeconds)
 	return true
 }
 

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -438,6 +438,8 @@ func Register(customCollectors ...prometheus.Collector) {
 		metrics.Registry.MustRegister(llmdRunningRequests)
 		metrics.Registry.MustRegister(normalizedTimePerOutputToken)
 		metrics.Registry.MustRegister(llmdNormalizedTimePerOutputToken)
+		metrics.Registry.MustRegister(llmdRequestTTFT)
+		metrics.Registry.MustRegister(llmdRequestTPOT)
 		metrics.Registry.MustRegister(inferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(inferencePoolAvgQueueSize)
@@ -501,6 +503,8 @@ func Reset() {
 	llmdRunningRequests.Reset()
 	normalizedTimePerOutputToken.Reset()
 	llmdNormalizedTimePerOutputToken.Reset()
+	llmdRequestTTFT.Reset()
+	llmdRequestTPOT.Reset()
 	inferencePoolAvgKVCache.Reset()
 	llmdInferencePoolAvgKVCache.Reset()
 	inferencePoolAvgQueueSize.Reset()
@@ -614,6 +618,39 @@ func RecordNormalizedTimePerOutputToken(ctx context.Context, modelName, targetMo
 
 	normalizedTimePerOutputToken.WithLabelValues(modelName, targetModelName).Observe(secondsPerToken)
 	llmdNormalizedTimePerOutputToken.WithLabelValues(modelName, targetModelName).Observe(secondsPerToken)
+	return true
+}
+
+// RecordRequestTTFT records the time to first token.
+func RecordRequestTTFT(ctx context.Context, modelName, targetModelName string, received time.Time, firstToken time.Time) bool {
+	if firstToken.IsZero() {
+		return false
+	}
+	if !firstToken.After(received) {
+		log.FromContext(ctx).Error(nil, "Request latency values are invalid for TTFT calculation",
+			"modelName", modelName, "targetModelName", targetModelName, "firstTokenTime", firstToken, "receivedTime", received)
+		return false
+	}
+	ttftSeconds := firstToken.Sub(received).Seconds()
+	llmdRequestTTFT.WithLabelValues(modelName, targetModelName).Observe(ttftSeconds)
+	return true
+}
+
+// RecordRequestTPOT records the average time per output token.
+func RecordRequestTPOT(ctx context.Context, modelName, targetModelName string, received time.Time, firstToken time.Time, complete time.Time, outputTokenCount int) bool {
+	if firstToken.IsZero() || outputTokenCount <= 1 {
+		return false
+	}
+	if !firstToken.After(received) || !complete.After(firstToken) {
+		log.FromContext(ctx).Error(nil, "Request latency values are invalid for TPOT calculation",
+			"modelName", modelName, "targetModelName", targetModelName,
+			"receivedTime", received, "firstTokenTime", firstToken, "completeTime", complete)
+		return false
+	}
+	e2eSeconds := complete.Sub(received).Seconds()
+	ttftSeconds := firstToken.Sub(received).Seconds()
+	tpotSeconds := (e2eSeconds - ttftSeconds) / float64(outputTokenCount-1)
+	llmdRequestTPOT.WithLabelValues(modelName, targetModelName).Observe(tpotSeconds)
 	return true
 }
 

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -622,7 +622,7 @@ func RecordNormalizedTimePerOutputToken(ctx context.Context, modelName, targetMo
 }
 
 // RecordRequestTTFT records the time to first token.
-func RecordRequestTTFT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, received time.Time, firstToken time.Time) bool {
+func RecordRequestTTFT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, streaming bool, received time.Time, firstToken time.Time) bool {
 	if firstToken.IsZero() {
 		return false
 	}
@@ -632,7 +632,11 @@ func RecordRequestTTFT(ctx context.Context, modelName, targetModelName, fairness
 		return false
 	}
 	ttftSeconds := firstToken.Sub(received).Seconds()
-	llmdRequestTTFT.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(ttftSeconds)
+	streamingLabel := "false"
+	if streaming {
+		streamingLabel = "true"
+	}
+	llmdRequestTTFT.WithLabelValues(modelName, targetModelName, fairnessID, priority, streamingLabel).Observe(ttftSeconds)
 	return true
 }
 

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1243,6 +1243,75 @@ func TestFlowControlPoolSaturationMetric(t *testing.T) {
 	require.Equal(t, 0.5, valNew)
 }
 
+func TestRecordRequestTTFT(t *testing.T) {
+	Reset()
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	timeBaseline := time.Now()
+
+	t.Run("valid requests", func(t *testing.T) {
+		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(10*time.Millisecond)))
+		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(1600*time.Millisecond)))
+		require.True(t, RecordRequestTTFT(ctx, "m20", "t20", timeBaseline, timeBaseline.Add(120*time.Millisecond)))
+
+		h, err := getHistogramVecLabelValues(t, llmdRequestTTFT, "m10", "t10")
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), h.GetSampleCount())
+		require.InDelta(t, 1.61, h.GetSampleSum(), 0.001)
+
+		h, err = getHistogramVecLabelValues(t, llmdRequestTTFT, "m20", "t20")
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), h.GetSampleCount())
+		require.InDelta(t, 0.12, h.GetSampleSum(), 0.001)
+	})
+
+	t.Run("zero first token timestamp", func(t *testing.T) {
+		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline, time.Time{}))
+	})
+
+	t.Run("first token before received", func(t *testing.T) {
+		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline.Add(10*time.Millisecond), timeBaseline))
+	})
+}
+
+func TestRecordRequestTPOT(t *testing.T) {
+	Reset()
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	timeBaseline := time.Now()
+
+	t.Run("valid multi-token request", func(t *testing.T) {
+		// e2e = 2s, ttft = 0.5s, tokens = 11 → tpot = (2 - 0.5) / 10 = 0.15s
+		received := timeBaseline
+		firstToken := timeBaseline.Add(500 * time.Millisecond)
+		complete := timeBaseline.Add(2000 * time.Millisecond)
+		require.True(t, RecordRequestTPOT(ctx, "m10", "t10", received, firstToken, complete, 11))
+
+		h, err := getHistogramVecLabelValues(t, llmdRequestTPOT, "m10", "t10")
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), h.GetSampleCount())
+		require.InDelta(t, 0.15, h.GetSampleSum(), 0.001)
+	})
+
+	t.Run("single token skipped", func(t *testing.T) {
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 1))
+	})
+
+	t.Run("zero tokens skipped", func(t *testing.T) {
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 0))
+	})
+
+	t.Run("zero first token timestamp", func(t *testing.T) {
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, time.Time{}, timeBaseline.Add(200*time.Millisecond), 10))
+	})
+
+	t.Run("first token before received", func(t *testing.T) {
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline.Add(100*time.Millisecond), timeBaseline, timeBaseline.Add(200*time.Millisecond), 10))
+	})
+
+	t.Run("complete before first token", func(t *testing.T) {
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(200*time.Millisecond), timeBaseline.Add(100*time.Millisecond), 10))
+	})
+}
+
 func TestInferenceModelRewriteDecisionsTotalMetric(t *testing.T) {
 	Reset()
 

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1249,27 +1249,27 @@ func TestRecordRequestTTFT(t *testing.T) {
 	timeBaseline := time.Now()
 
 	t.Run("valid requests", func(t *testing.T) {
-		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(10*time.Millisecond)))
-		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(1600*time.Millisecond)))
-		require.True(t, RecordRequestTTFT(ctx, "m20", "t20", timeBaseline, timeBaseline.Add(120*time.Millisecond)))
+		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(10*time.Millisecond)))
+		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(1600*time.Millisecond)))
+		require.True(t, RecordRequestTTFT(ctx, "m20", "t20", "tenant-b", "5", timeBaseline, timeBaseline.Add(120*time.Millisecond)))
 
-		h, err := getHistogramVecLabelValues(t, llmdRequestTTFT, "m10", "t10")
+		h, err := getHistogramVecLabelValues(t, llmdRequestTTFT, "m10", "t10", "tenant-a", "3")
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), h.GetSampleCount())
 		require.InDelta(t, 1.61, h.GetSampleSum(), 0.001)
 
-		h, err = getHistogramVecLabelValues(t, llmdRequestTTFT, "m20", "t20")
+		h, err = getHistogramVecLabelValues(t, llmdRequestTTFT, "m20", "t20", "tenant-b", "5")
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), h.GetSampleCount())
 		require.InDelta(t, 0.12, h.GetSampleSum(), 0.001)
 	})
 
 	t.Run("zero first token timestamp", func(t *testing.T) {
-		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline, time.Time{}))
+		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, time.Time{}))
 	})
 
 	t.Run("first token before received", func(t *testing.T) {
-		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", timeBaseline.Add(10*time.Millisecond), timeBaseline))
+		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline.Add(10*time.Millisecond), timeBaseline))
 	})
 }
 
@@ -1283,32 +1283,32 @@ func TestRecordRequestTPOT(t *testing.T) {
 		received := timeBaseline
 		firstToken := timeBaseline.Add(500 * time.Millisecond)
 		complete := timeBaseline.Add(2000 * time.Millisecond)
-		require.True(t, RecordRequestTPOT(ctx, "m10", "t10", received, firstToken, complete, 11))
+		require.True(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", received, firstToken, complete, 11))
 
-		h, err := getHistogramVecLabelValues(t, llmdRequestTPOT, "m10", "t10")
+		h, err := getHistogramVecLabelValues(t, llmdRequestTPOT, "m10", "t10", "tenant-a", "3")
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), h.GetSampleCount())
 		require.InDelta(t, 0.15, h.GetSampleSum(), 0.001)
 	})
 
 	t.Run("single token skipped", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 1))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 1))
 	})
 
 	t.Run("zero tokens skipped", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 0))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 0))
 	})
 
 	t.Run("zero first token timestamp", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, time.Time{}, timeBaseline.Add(200*time.Millisecond), 10))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, time.Time{}, timeBaseline.Add(200*time.Millisecond), 10))
 	})
 
 	t.Run("first token before received", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline.Add(100*time.Millisecond), timeBaseline, timeBaseline.Add(200*time.Millisecond), 10))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline.Add(100*time.Millisecond), timeBaseline, timeBaseline.Add(200*time.Millisecond), 10))
 	})
 
 	t.Run("complete before first token", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", timeBaseline, timeBaseline.Add(200*time.Millisecond), timeBaseline.Add(100*time.Millisecond), 10))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(200*time.Millisecond), timeBaseline.Add(100*time.Millisecond), 10))
 	})
 }
 

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1248,28 +1248,28 @@ func TestRecordRequestTTFT(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	timeBaseline := time.Now()
 
-	t.Run("valid requests", func(t *testing.T) {
-		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(10*time.Millisecond)))
-		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(1600*time.Millisecond)))
-		require.True(t, RecordRequestTTFT(ctx, "m20", "t20", "tenant-b", "5", timeBaseline, timeBaseline.Add(120*time.Millisecond)))
+	t.Run("valid streaming requests", func(t *testing.T) {
+		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline, timeBaseline.Add(10*time.Millisecond)))
+		require.True(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline, timeBaseline.Add(1600*time.Millisecond)))
+		require.True(t, RecordRequestTTFT(ctx, "m20", "t20", "tenant-b", "5", false, timeBaseline, timeBaseline.Add(120*time.Millisecond)))
 
-		h, err := getHistogramVecLabelValues(t, llmdRequestTTFT, "m10", "t10", "tenant-a", "3")
+		h, err := getHistogramVecLabelValues(t, llmdRequestTTFT, "m10", "t10", "tenant-a", "3", "true")
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), h.GetSampleCount())
 		require.InDelta(t, 1.61, h.GetSampleSum(), 0.001)
 
-		h, err = getHistogramVecLabelValues(t, llmdRequestTTFT, "m20", "t20", "tenant-b", "5")
+		h, err = getHistogramVecLabelValues(t, llmdRequestTTFT, "m20", "t20", "tenant-b", "5", "false")
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), h.GetSampleCount())
 		require.InDelta(t, 0.12, h.GetSampleSum(), 0.001)
 	})
 
 	t.Run("zero first token timestamp", func(t *testing.T) {
-		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, time.Time{}))
+		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline, time.Time{}))
 	})
 
 	t.Run("first token before received", func(t *testing.T) {
-		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline.Add(10*time.Millisecond), timeBaseline))
+		require.False(t, RecordRequestTTFT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline.Add(10*time.Millisecond), timeBaseline))
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind feature

**What this PR does / why we need it**:
Adds two new always-on Prometheus histograms to the core response path:

  - `llm_d_router_epp_request_ttft_seconds` – Time to first token, measured from request received to first response byte
  - `llm_d_router_epp_request_tpot_seconds` – Average time per output token, computed as (e2e - TTFT) / (output_tokens - 1)

These formulas already exist in the predicted latency plugin (predictedlatency/requestcontrol_hooks.go), but are only available when that plugin is loaded. The existing core metric `normalized_time_per_output_token_seconds` divides total request duration (including queue wait and prefill) by raw token count – it doesn't reflect actual decode-phase throughput.

This PR promotes the plugin's stream-aware calculations to core metrics so they're available regardless of plugin configuration, supporting service-level SLI reporting.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1498.

**Release note** _(write `NONE` if no user-facing change)_:

Add core service-level TTFT and TPOT metrics (`llm_d_router_epp_service_level_ttft_seconds`, `llm_d_router_epp_service_level_tpot_seconds`) to the response handler, available without enabling the predicted latency plugin. TTFT measures wall-clock time from request received to first response byte. TPOT measures decode-phase throughput as (e2e - TTFT) / (output_tokens - 1). For non-streaming requests, TTFT equals total request duration and TPOT is not recorded.