### PR TITLE
fix(requestcontrol): let data producers override the execution timeout

### DIFF
--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -75,10 +75,9 @@ type DataProducer interface {
 
 // TimeoutAwareProducer is an optional interface a DataProducer may implement to
 // raise the data-producer execution deadline above the director's default. A
-// producer whose work can legitimately exceed it (e.g. tokenization or
-// multimodal input download) returns the timeout it already manages internally;
-// the director uses the largest value declared across producers. A non-positive
-// value keeps the default.
+// producer whose work can legitimately exceed it. returns the timeout it already
+// manages internally; the director uses the largest value declared across producers.
+// A non-positive value keeps the default.
 type TimeoutAwareProducer interface {
 	ProduceTimeout() time.Duration
 }

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -74,10 +74,8 @@ type DataProducer interface {
 }
 
 // TimeoutAwareProducer is an optional interface a DataProducer may implement to
-// raise the data-producer execution deadline above the director's default. A
-// producer whose work can legitimately exceed it. returns the timeout it already
-// manages internally; the director uses the largest value declared across producers.
-// A non-positive value keeps the default.
+// declare its own execution timeout, overriding the default. A non-positive
+// value selects the default.
 type TimeoutAwareProducer interface {
 	ProduceTimeout() time.Duration
 }

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -18,6 +18,7 @@ package requestcontrol
 
 import (
 	"context"
+	"time"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
@@ -70,6 +71,16 @@ type ResponseBodyProcessor interface {
 type DataProducer interface {
 	plugin.ProducerPlugin
 	Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error
+}
+
+// TimeoutAwareProducer is an optional interface a DataProducer may implement to
+// raise the data-producer execution deadline above the director's default. A
+// producer whose work can legitimately exceed it (e.g. tokenization or
+// multimodal input download) returns the timeout it already manages internally;
+// the director uses the largest value declared across producers. A non-positive
+// value keeps the default.
+type TimeoutAwareProducer interface {
+	ProduceTimeout() time.Duration
 }
 
 // Admitter is called by the director after the data producer and before scheduling.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -22,6 +22,9 @@ import (
 	"fmt"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
@@ -44,6 +47,53 @@ func (b renderBackend) produceTimeout() time.Duration {
 		return ta.produceTimeout()
 	}
 	return 0
+}
+
+const (
+	// warmupImage is a 1x1 PNG data URL used to prime the multimodal processor.
+	warmupImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+	warmupAttempts      = 24
+	warmupRetryInterval = 5 * time.Second
+)
+
+// warmer is implemented by backends that prime themselves at load time.
+type warmer interface {
+	warmup(ctx context.Context)
+}
+
+// warmup primes the render path so the first request does not pay the cold-start
+// cost. It retries a text render until the backend responds, then issues a
+// best-effort multimodal render. It returns on success, on the attempt cap, or
+// on context cancellation.
+func (b renderBackend) warmup(ctx context.Context) {
+	logger := log.FromContext(ctx).V(logutil.DEBUG)
+	for i := 0; i < warmupAttempts; i++ {
+		if _, err := b.produce(ctx, warmupChat()); err == nil {
+			_, _ = b.produce(ctx, warmupChat(warmupImage))
+			logger.Info("token-producer backend warmed up", "attempts", i+1)
+			return
+		}
+		select {
+		case <-time.After(warmupRetryInterval):
+		case <-ctx.Done():
+			return
+		}
+	}
+	logger.Info("token-producer backend warmup did not complete")
+}
+
+// warmupChat builds a single-message chat body carrying the given image URLs.
+func warmupChat(imageURLs ...string) *fwkrh.InferenceRequestBody {
+	blocks := []fwkrh.ContentBlock{{Type: "text", Text: "warmup"}}
+	for _, url := range imageURLs {
+		blocks = append(blocks, fwkrh.ContentBlock{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: url}})
+	}
+	return &fwkrh.InferenceRequestBody{
+		ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Structured: blocks}}},
+		},
+	}
 }
 
 // renderBackend produces real token IDs and owns protocol dispatch, including

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
@@ -28,6 +29,21 @@ import (
 // in fidelity (render vs estimate); callers never branch on which produced it.
 type tokenInputProducer interface {
 	produce(ctx context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedPrompt, error)
+}
+
+// timeoutAware is implemented by backends (and the tokenizers they wrap) whose
+// produce step can exceed the default data-producer timeout and that manage
+// their own. The plugin surfaces it so the director extends its budget.
+type timeoutAware interface {
+	produceTimeout() time.Duration
+}
+
+// produceTimeout reports the wrapped tokenizer's timeout when it manages one.
+func (b renderBackend) produceTimeout() time.Duration {
+	if ta, ok := b.tk.(timeoutAware); ok {
+		return ta.produceTimeout()
+	}
+	return 0
 }
 
 // renderBackend produces real token IDs and owns protocol dispatch, including

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -85,7 +85,8 @@ func (b renderBackend) warmup(ctx context.Context) {
 
 // warmupChat builds a single-message chat body carrying the given image URLs.
 func warmupChat(imageURLs ...string) *fwkrh.InferenceRequestBody {
-	blocks := []fwkrh.ContentBlock{{Type: "text", Text: "warmup"}}
+	blocks := make([]fwkrh.ContentBlock, 0, 1+len(imageURLs))
+	blocks = append(blocks, fwkrh.ContentBlock{Type: "text", Text: "warmup"})
 	for _, url := range imageURLs {
 		blocks = append(blocks, fwkrh.ContentBlock{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: url}})
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -196,11 +196,15 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 		backend = estimateBackend{img: newImageEstimator(config.Estimate)}
 	}
 
-	return &Plugin{
+	p := &Plugin{
 		typedName: plugin.TypedName{Type: PluginType, Name: name},
 		backend:   backend,
 		dk:        TokenizedPromptDataKey.WithNonEmptyProducerName(name),
-	}, nil
+	}
+	if w, ok := backend.(warmer); ok {
+		go w.warmup(ctx)
+	}
+	return p, nil
 }
 
 // Plugin tokenizes the prompt in the incoming request and writes the result to

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
@@ -210,8 +211,11 @@ type Plugin struct {
 	dk        plugin.DataKey
 }
 
-// compile-time assertion.
-var _ requestcontrol.DataProducer = &Plugin{}
+// compile-time assertions.
+var (
+	_ requestcontrol.DataProducer         = &Plugin{}
+	_ requestcontrol.TimeoutAwareProducer = &Plugin{}
+)
 
 // TypedName returns the typed name of the plugin.
 func (p *Plugin) TypedName() plugin.TypedName {
@@ -221,6 +225,16 @@ func (p *Plugin) TypedName() plugin.TypedName {
 // Produces returns the data keys this plugin produces.
 func (p *Plugin) Produces() map[plugin.DataKey]any {
 	return map[plugin.DataKey]any{p.dk: fwkrh.TokenizedPrompt{}}
+}
+
+// ProduceTimeout surfaces the backend's render timeout when it manages one, so
+// the director extends the data-producer budget past its default. Returns 0 to
+// keep the default (e.g. the estimate backend, which is in-memory).
+func (p *Plugin) ProduceTimeout() time.Duration {
+	if ta, ok := p.backend.(timeoutAware); ok {
+		return ta.produceTimeout()
+	}
+	return 0
 }
 
 // Produce derives the request's TokenizedPrompt via the configured backend and

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
@@ -51,6 +52,28 @@ func newTestPlugin(tok tokenizer) *Plugin {
 		typedName: plugin.TypedName{Type: PluginType, Name: "test"},
 		backend:   renderBackend{tk: tok},
 	}
+}
+
+func TestProduceTimeout(t *testing.T) {
+	ctx := context.Background()
+
+	// vLLM backend surfaces its configured render timeout (default mmTimeout).
+	vp, err := NewPlugin(ctx, "tok", &tokenizerPluginConfig{ModelName: "m", VLLM: &vllmConfig{}})
+	require.NoError(t, err)
+	assert.Equal(t, defaultHTTPRenderMMTimeout, vp.ProduceTimeout())
+
+	// The override value is the plugin's own configurable timeout.
+	vp2, err := NewPlugin(ctx, "tok", &tokenizerPluginConfig{ModelName: "m", VLLM: &vllmConfig{MMTimeout: "45s"}})
+	require.NoError(t, err)
+	assert.Equal(t, 45*time.Second, vp2.ProduceTimeout())
+
+	// Estimate backend declares none, so the director keeps its default.
+	ep, err := NewPlugin(ctx, "tok", &tokenizerPluginConfig{Estimate: &estimateConfig{}})
+	require.NoError(t, err)
+	assert.Zero(t, ep.ProduceTimeout())
+
+	// A render backend whose tokenizer manages no timeout (e.g. UDS) keeps the default.
+	assert.Zero(t, newTestPlugin(&mockTokenizer{}).ProduceTimeout())
 }
 
 func TestPluginFactory_Validation(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -152,6 +152,15 @@ func (r *vllmHTTPRenderer) chatTimeout(req *tokenizerTypes.RenderChatRequest) ti
 	return r.timeout
 }
 
+// produceTimeout returns the worst-case configured render timeout (multimodal),
+// surfaced so the data-producer executor extends its budget past the default.
+func (r *vllmHTTPRenderer) produceTimeout() time.Duration {
+	if r.mmTimeout > r.timeout {
+		return r.mmTimeout
+	}
+	return r.timeout
+}
+
 // completionsRenderRequest is the wire body for POST /v1/completions/render.
 type completionsRenderRequest struct {
 	Model  string `json:"model"`

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -54,9 +54,8 @@ import (
 )
 
 const (
-	// dataProducerTimeout is the default budget for running all DataProducer
-	// plugins. A producer whose work has a higher latency profile overrides it
-	// by implementing requestcontrol.TimeoutAwareProducer.
+	// dataProducerTimeout is the default per-producer execution timeout. A
+	// producer overrides it by implementing requestcontrol.TimeoutAwareProducer.
 	dataProducerTimeout       = 400 * time.Millisecond
 	responseBodyQueueCapacity = 100
 )
@@ -607,7 +606,14 @@ func (d *Director) runDataProducerPlugins(ctx context.Context,
 	if len(plugins) == 0 {
 		return nil
 	}
-	return dataProducerPluginsWithTimeout(ctx, effectiveDataProducerTimeout(plugins), plugins, request, endpoints)
+	// Each producer runs under its own timeout so a slow one does not extend the
+	// budget of the others.
+	for _, p := range plugins {
+		if err := dataProducerPluginsWithTimeout(ctx, producerTimeout(p), []fwkrc.DataProducer{p}, request, endpoints); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (d *Director) runAdmissionPlugins(ctx context.Context,

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -54,9 +54,9 @@ import (
 )
 
 const (
-	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2081):
-	// Make this timeout configurable per-plugin or globally via the Director configuration to support plugins with
-	// varying latency profiles.
+	// dataProducerTimeout is the default budget for running all DataProducer
+	// plugins. A producer whose work has a higher latency profile overrides it
+	// by implementing requestcontrol.TimeoutAwareProducer.
 	dataProducerTimeout       = 400 * time.Millisecond
 	responseBodyQueueCapacity = 100
 )
@@ -603,10 +603,11 @@ func (d *Director) runPreAdmissionPlugins(ctx context.Context, request *fwksched
 
 func (d *Director) runDataProducerPlugins(ctx context.Context,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
-	if len(d.requestControlPlugins.dataProducerPlugins) == 0 {
+	plugins := d.requestControlPlugins.dataProducerPlugins
+	if len(plugins) == 0 {
 		return nil
 	}
-	return dataProducerPluginsWithTimeout(ctx, dataProducerTimeout, d.requestControlPlugins.dataProducerPlugins, request, endpoints)
+	return dataProducerPluginsWithTimeout(ctx, effectiveDataProducerTimeout(plugins), plugins, request, endpoints)
 }
 
 func (d *Director) runAdmissionPlugins(ctx context.Context,

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -38,21 +38,15 @@ func executePluginsAsDAG(ctx context.Context, plugins []fwkrc.DataProducer, requ
 	return nil
 }
 
-// effectiveDataProducerTimeout returns the default data-producer budget
-// (dataProducerTimeout), raised to the largest timeout any producer declares
-// via TimeoutAwareProducer. A producer whose work has a higher latency profile
-// (e.g. the token-producer's render/tokenize, including multimodal input
-// download) thus overrides the default for the whole batch.
-func effectiveDataProducerTimeout(plugins []fwkrc.DataProducer) time.Duration {
-	timeout := dataProducerTimeout
-	for _, p := range plugins {
-		if tp, ok := p.(fwkrc.TimeoutAwareProducer); ok {
-			if pt := tp.ProduceTimeout(); pt > timeout {
-				timeout = pt
-			}
+// producerTimeout returns the producer's declared timeout when it implements
+// TimeoutAwareProducer with a positive value, otherwise dataProducerTimeout.
+func producerTimeout(p fwkrc.DataProducer) time.Duration {
+	if tp, ok := p.(fwkrc.TimeoutAwareProducer); ok {
+		if t := tp.ProduceTimeout(); t > 0 {
+			return t
 		}
 	}
-	return timeout
+	return dataProducerTimeout
 }
 
 // dataProducerPluginsWithTimeout executes DataProducer plugins with a timeout.

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -38,6 +38,23 @@ func executePluginsAsDAG(ctx context.Context, plugins []fwkrc.DataProducer, requ
 	return nil
 }
 
+// effectiveDataProducerTimeout returns the default data-producer budget
+// (dataProducerTimeout), raised to the largest timeout any producer declares
+// via TimeoutAwareProducer. A producer whose work has a higher latency profile
+// (e.g. the token-producer's render/tokenize, including multimodal input
+// download) thus overrides the default for the whole batch.
+func effectiveDataProducerTimeout(plugins []fwkrc.DataProducer) time.Duration {
+	timeout := dataProducerTimeout
+	for _, p := range plugins {
+		if tp, ok := p.(fwkrc.TimeoutAwareProducer); ok {
+			if pt := tp.ProduceTimeout(); pt > timeout {
+				timeout = pt
+			}
+		}
+	}
+	return timeout
+}
+
 // dataProducerPluginsWithTimeout executes DataProducer plugins with a timeout.
 // The child context is cancelled when the timeout fires so plugins can observe cancellation
 // (e.g. abort outbound HTTP calls) and avoid committing state after the director has moved on.

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -360,49 +360,32 @@ type timeoutAwareMockPlugin struct {
 
 func (p *timeoutAwareMockPlugin) ProduceTimeout() time.Duration { return p.timeout }
 
-func TestEffectiveDataProducerTimeout(t *testing.T) {
+func TestProducerTimeout(t *testing.T) {
 	testCases := []struct {
-		name    string
-		plugins []fwkrc.DataProducer
-		want    time.Duration
+		name string
+		p    fwkrc.DataProducer
+		want time.Duration
 	}{
 		{
-			name: "no producers uses default",
+			name: "producer without timeout awareness uses default",
+			p:    &executorMockDataProducerPlugin{name: "p1"},
 			want: dataProducerTimeout,
 		},
 		{
-			name:    "producer without timeout awareness uses default",
-			plugins: []fwkrc.DataProducer{&executorMockDataProducerPlugin{name: "p1"}},
-			want:    dataProducerTimeout,
-		},
-		{
-			name: "aware producer with a longer timeout overrides the default",
-			plugins: []fwkrc.DataProducer{
-				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "tok"}, timeout: 30 * time.Second},
-			},
+			name: "declared timeout overrides the default",
+			p:    &timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "tok"}, timeout: 30 * time.Second},
 			want: 30 * time.Second,
 		},
 		{
-			name: "aware producer with a shorter timeout does not lower the default",
-			plugins: []fwkrc.DataProducer{
-				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "fast"}, timeout: 10 * time.Millisecond},
-			},
+			name: "non-positive declared timeout uses default",
+			p:    &timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "zero"}, timeout: 0},
 			want: dataProducerTimeout,
-		},
-		{
-			name: "largest declared timeout wins across producers",
-			plugins: []fwkrc.DataProducer{
-				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "a"}, timeout: 5 * time.Second},
-				&executorMockDataProducerPlugin{name: "b"},
-				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "c"}, timeout: 30 * time.Second},
-			},
-			want: 30 * time.Second,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, effectiveDataProducerTimeout(tc.plugins))
+			assert.Equal(t, tc.want, producerTimeout(tc.p))
 		})
 	}
 }

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -349,3 +349,60 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 		})
 	}
 }
+
+var _ fwkrc.TimeoutAwareProducer = &timeoutAwareMockPlugin{}
+
+// timeoutAwareMockPlugin is a DataProducer that declares its own timeout.
+type timeoutAwareMockPlugin struct {
+	executorMockDataProducerPlugin
+	timeout time.Duration
+}
+
+func (p *timeoutAwareMockPlugin) ProduceTimeout() time.Duration { return p.timeout }
+
+func TestEffectiveDataProducerTimeout(t *testing.T) {
+	testCases := []struct {
+		name    string
+		plugins []fwkrc.DataProducer
+		want    time.Duration
+	}{
+		{
+			name: "no producers uses default",
+			want: dataProducerTimeout,
+		},
+		{
+			name:    "producer without timeout awareness uses default",
+			plugins: []fwkrc.DataProducer{&executorMockDataProducerPlugin{name: "p1"}},
+			want:    dataProducerTimeout,
+		},
+		{
+			name: "aware producer with a longer timeout overrides the default",
+			plugins: []fwkrc.DataProducer{
+				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "tok"}, timeout: 30 * time.Second},
+			},
+			want: 30 * time.Second,
+		},
+		{
+			name: "aware producer with a shorter timeout does not lower the default",
+			plugins: []fwkrc.DataProducer{
+				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "fast"}, timeout: 10 * time.Millisecond},
+			},
+			want: dataProducerTimeout,
+		},
+		{
+			name: "largest declared timeout wins across producers",
+			plugins: []fwkrc.DataProducer{
+				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "a"}, timeout: 5 * time.Second},
+				&executorMockDataProducerPlugin{name: "b"},
+				&timeoutAwareMockPlugin{executorMockDataProducerPlugin: executorMockDataProducerPlugin{name: "c"}, timeout: 30 * time.Second},
+			},
+			want: 30 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, effectiveDataProducerTimeout(tc.plugins))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The hardcoded `dataProducerTimeout = 400ms` wraps every DataProducer, clamping the
token-producer's vLLM `/render` call — its own `vllm.timeout`/`mmTimeout` are ignored
because the 400ms parent context wins (`context.WithTimeout` takes the minimum). Cold
multimodal renders (e.g. Qwen3-VL) take 2–5s and fail with `DataProducer execution
timed out`, which collapses prefix-cache scoring to 0.

This keeps 400ms as the default budget but lets a producer that already manages its own
timeout raise it: a new optional interface `requestcontrol.TimeoutAwareProducer
{ ProduceTimeout() time.Duration }`, with the director using `max(default, max declared)`.
The token-producer surfaces its configured vLLM render timeout (`max(timeout, mmTimeout)`);
the estimate and UDS backends declare none and keep the default. No new config — operators
tune the existing `vllm.mmTimeout`.

Supersedes the global `requestControl.dataProducerTimeout` knob proposed in #1190: the
plugin that owns the latency surfaces the timeout it already declares, rather than adding a
generic framework-level timeout.

**Which issue(s) this PR fixes**:

- Fixes #1501 
- Fixes #1190 

**Release note**:

```release-note
NONE
```