### PR TITLE
feat(approximate prefix): add Anthropic /v1/messages prefix-cache estimation

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -572,7 +572,7 @@ func (r *MessagesRequest) String() string {
 	}
 	messagesLen := 0
 	for _, msg := range r.Messages {
-		messagesLen += len(msg.Content.PlainText())
+		messagesLen += msg.Content.textLen()
 	}
 	return fmt.Sprintf("{MessagesLength: %d}", messagesLen)
 }
@@ -615,18 +615,17 @@ func (ac AnthropicContent) MarshalJSON() ([]byte, error) {
 	return json.Marshal("")
 }
 
-func (ac AnthropicContent) PlainText() string {
+func (ac AnthropicContent) textLen() int {
 	if ac.Raw != "" {
-		return ac.Raw
+		return len(ac.Raw)
 	}
-	var sb strings.Builder
+	n := 0
 	for _, block := range ac.Structured {
 		if block.Type == "text" {
-			sb.WriteString(block.Text)
-			sb.WriteString(" ")
+			n += len(block.Text)
 		}
 	}
-	return sb.String()
+	return n
 }
 
 type AnthropicContentBlock struct {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -148,8 +148,16 @@ func (b estimateBackend) chatCompletionsBytes(chat *fwkrh.ChatCompletionsRequest
 func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fwkrh.MultiModalFeature) {
 	var out []byte
 	var features []fwkrh.MultiModalFeature
-	if s := req.System.PlainText(); s != "" {
-		out = append(out, []byte(s)...)
+	// The system field accepts only text -- a string or an array of text blocks.
+	// See https://docs.anthropic.com/en/api/messages#body-system.
+	if req.System.Raw != "" {
+		out = append(out, []byte(req.System.Raw)...)
+	} else {
+		for _, block := range req.System.Structured {
+			if block.Type == blockTypeText {
+				out = append(out, []byte(block.Text)...)
+			}
+		}
 	}
 	for _, msg := range req.Messages {
 		if msg.Role != "" {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -24,13 +24,17 @@ import (
 	"strconv"
 
 	"github.com/cespare/xxhash/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
 // bytesPerToken matches the scorer's averageCharactersPerToken, so a block of N
 // pseudo-tokens covers the same input bytes as an N-token raw-byte block.
 const bytesPerToken = 4
+
+const blockTypeText = "text"
 
 // estimateBackend packs request bytes into pseudo-tokens with no real tokenizer.
 // The IDs suit content-locality hashing only; they never match engine KV blocks,
@@ -39,7 +43,7 @@ type estimateBackend struct {
 	img imageEstimator
 }
 
-func (b estimateBackend) produce(_ context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedPrompt, error) {
+func (b estimateBackend) produce(ctx context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedPrompt, error) {
 	// Pre-tokenized inputs are already real tokens; pass them through unchanged
 	// rather than byte-estimating. Token-ID inputs are valid for generate,
 	// /v1/completions, and /v1/embeddings.
@@ -55,11 +59,23 @@ func (b estimateBackend) produce(_ context.Context, body *fwkrh.InferenceRequest
 		return &fwkrh.TokenizedPrompt{TokenIDs: body.Embeddings.Input.TokenIDs}, nil
 	}
 
-	// The chat path folds multimodal placeholders into the stream and reports
-	// them as features; other protocols carry no multimodal content.
+	// Chat and Anthropic messages fold multimodal placeholders into the stream
+	// and report them as features.
 	if body.ChatCompletions != nil {
 		raw, features := b.chatCompletionsBytes(body.ChatCompletions)
 		return &fwkrh.TokenizedPrompt{TokenIDs: packBytes(raw), MultiModalFeatures: features}, nil
+	}
+	if body.Messages != nil {
+		raw, features := b.messagesBytes(body.Messages)
+		tokens := packBytes(raw)
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Anthropic messages prefix-cache estimation",
+			"messageCount", len(body.Messages.Messages),
+			"rawBytes", len(raw),
+			"tokenCount", len(tokens),
+			"mmFeatureCount", len(features),
+			"mmFeatures", features,
+		)
+		return &fwkrh.TokenizedPrompt{TokenIDs: tokens, MultiModalFeatures: features}, nil
 	}
 
 	raw, err := estimateBytes(body)
@@ -112,7 +128,7 @@ func (b estimateBackend) chatCompletionsBytes(chat *fwkrh.ChatCompletionsRequest
 		}
 		for _, block := range msg.Content.Structured {
 			switch block.Type {
-			case "text":
+			case blockTypeText:
 				out = append(out, []byte(block.Text)...)
 			case "image_url":
 				out, features = appendMMAsset(out, features, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
@@ -121,6 +137,36 @@ func (b estimateBackend) chatCompletionsBytes(chat *fwkrh.ChatCompletionsRequest
 			case "input_audio", "audio_url":
 				data := block.InputAudio.Data + block.InputAudio.Format
 				out, features = appendMMAsset(out, features, data, assetPlaceholderCount(len(data)))
+			}
+		}
+	}
+	return out, features
+}
+
+// messagesBytes flattens an Anthropic /v1/messages request into pseudo-token
+// bytes.
+func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fwkrh.MultiModalFeature) {
+	var out []byte
+	var features []fwkrh.MultiModalFeature
+	if s := req.System.PlainText(); s != "" {
+		out = append(out, []byte(s)...)
+	}
+	for _, msg := range req.Messages {
+		if msg.Role != "" {
+			out = append(out, []byte(msg.Role)...)
+		}
+		if msg.Content.Raw != "" {
+			out = append(out, []byte(msg.Content.Raw)...)
+			continue
+		}
+		for _, block := range msg.Content.Structured {
+			switch block.Type {
+			case blockTypeText:
+				out = append(out, []byte(block.Text)...)
+			case "image":
+				if content, count := b.img.placeholderForAnthropicImage(block.Source); content != "" {
+					out, features = appendMMAsset(out, features, content, count)
+				}
 			}
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -138,9 +138,10 @@ func TestEstimateBackend_CompletionsDeterministic(t *testing.T) {
 	}
 }
 
-// pngBase64DataURL is a 64x32 RGBA PNG, yielding 64*32/imageTokenFactor = 2
-// placeholder tokens under the dynamic estimator.
-const pngBase64DataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAAAgCAIAAAAt/+nTAAAARUlEQVR4nOzP0QnAUAzDwBSy/8zlTSECdxj/a2fmu7x9d5mAmoCagJqAmoCagJqAmoCagJqAmoCagJqAmoCagNofAAD//57WAN8yR4QZAAAAAElFTkSuQmCC"
+// pngBase64Raw is a 64x32 RGBA PNG (bare base64 payload), yielding
+// 64*32/imageTokenFactor = 2 placeholder tokens under the dynamic estimator.
+const pngBase64Raw = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAgCAIAAAAt/+nTAAAARUlEQVR4nOzP0QnAUAzDwBSy/8zlTSECdxj/a2fmu7x9d5mAmoCagJqAmoCagJqAmoCagJqAmoCagJqAmoCagNofAAD//57WAN8yR4QZAAAAAElFTkSuQmCC"
+const pngBase64DataURL = "data:image/png;base64," + pngBase64Raw
 
 // TestEstimateBackend_ChatImageFeature asserts a chat image emits a multimodal
 // feature with the image modality and the URL content hash, occupies more than
@@ -264,6 +265,104 @@ func TestImageEstimator_CustomDefaultResolution(t *testing.T) {
 	}
 	if got, want := tp.MultiModalFeatures[0].Length, (1024*1024)/imageTokenFactor; got != want {
 		t.Errorf("custom default-resolution length: got %d, want %d", got, want)
+	}
+}
+
+// TestEstimateBackend_MessagesImageFeature asserts an Anthropic messages image
+// emits a multimodal feature with image modality, a content-derived hash, and
+// span inside the token stream. The base64 source must hash by its raw payload.
+func TestEstimateBackend_MessagesImageFeature(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		Messages: &fwkrh.MessagesRequest{
+			Messages: []fwkrh.AnthropicMessage{{
+				Role: "user",
+				Content: fwkrh.AnthropicContent{Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "text", Text: "describe this"},
+					{Type: "image", Source: &fwkrh.AnthropicImageSource{
+						Type: "base64", MediaType: "image/png", Data: pngBase64Raw,
+					}},
+				}},
+			}},
+		},
+	}
+	tp, err := estimateBackend{}.produce(context.Background(), body)
+	if err != nil {
+		t.Fatalf("produce: %v", err)
+	}
+	if len(tp.MultiModalFeatures) != 1 {
+		t.Fatalf("got %d features, want 1", len(tp.MultiModalFeatures))
+	}
+	f := tp.MultiModalFeatures[0]
+	if f.Modality != fwkrh.ModalityImage {
+		t.Errorf("modality: got %q, want %q", f.Modality, fwkrh.ModalityImage)
+	}
+	if want := strconv.FormatUint(xxhash.Sum64String(pngBase64Raw), 16); f.Hash != want {
+		t.Errorf("hash: got %q, want %q (base64 source must hash by its raw payload)", f.Hash, want)
+	}
+	if f.Length <= 1 {
+		t.Errorf("image length: got %d, want > 1 (placeholder weighting)", f.Length)
+	}
+	if f.Offset < 0 || f.Offset+f.Length > len(tp.TokenIDs) {
+		t.Errorf("feature span [%d,%d) outside token stream of len %d", f.Offset, f.Offset+f.Length, len(tp.TokenIDs))
+	}
+}
+
+// TestEstimateBackend_MessagesURLImageKey asserts a url-typed source is hashed
+// by its URL unchanged (no synthesized data-URL prefix).
+func TestEstimateBackend_MessagesURLImageKey(t *testing.T) {
+	const url = "https://example.com/a.png"
+	body := &fwkrh.InferenceRequestBody{
+		Messages: &fwkrh.MessagesRequest{
+			Messages: []fwkrh.AnthropicMessage{{
+				Role: "user",
+				Content: fwkrh.AnthropicContent{Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "image", Source: &fwkrh.AnthropicImageSource{Type: "url", URL: url}},
+				}},
+			}},
+		},
+	}
+	tp, err := estimateBackend{}.produce(context.Background(), body)
+	if err != nil {
+		t.Fatalf("produce: %v", err)
+	}
+	if len(tp.MultiModalFeatures) != 1 {
+		t.Fatalf("got %d features, want 1", len(tp.MultiModalFeatures))
+	}
+	if want := strconv.FormatUint(xxhash.Sum64String(url), 16); tp.MultiModalFeatures[0].Hash != want {
+		t.Errorf("hash: got %q, want %q", tp.MultiModalFeatures[0].Hash, want)
+	}
+}
+
+// TestEstimateBackend_MessagesDeterministic asserts identical requests produce
+// identical tokens and that changing the system prompt changes the stream.
+// CacheSalt is intentionally NOT tested -- the approximateprefix layer mixes it
+// into the seed, not this estimator.
+func TestEstimateBackend_MessagesDeterministic(t *testing.T) {
+	build := func(system, userText string) *fwkrh.InferenceRequestBody {
+		return &fwkrh.InferenceRequestBody{Messages: &fwkrh.MessagesRequest{
+			System: fwkrh.AnthropicContent{Raw: system},
+			Messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{Raw: userText}},
+			},
+		}}
+	}
+	a, err := estimateBackend{}.produce(context.Background(), build("you are helpful", "hello world"))
+	if err != nil {
+		t.Fatalf("produce a: %v", err)
+	}
+	b, err := estimateBackend{}.produce(context.Background(), build("you are helpful", "hello world"))
+	if err != nil {
+		t.Fatalf("produce b: %v", err)
+	}
+	if hashTokens(a.TokenIDs) != hashTokens(b.TokenIDs) {
+		t.Error("identical messages requests produced different tokens")
+	}
+	c, err := estimateBackend{}.produce(context.Background(), build("you are concise", "hello world"))
+	if err != nil {
+		t.Fatalf("produce c: %v", err)
+	}
+	if hashTokens(a.TokenIDs) == hashTokens(c.TokenIDs) {
+		t.Error("different system prompts produced identical tokens")
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
@@ -26,6 +26,8 @@ import (
 	_ "image/gif"
 	_ "image/jpeg"
 	_ "image/png"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
 const (
@@ -71,11 +73,32 @@ func newImageEstimator(cfg *estimateConfig) imageEstimator {
 	return est
 }
 
-// placeholderCount estimates the number of placeholder tokens an image occupies.
-// Static mode returns a constant count; dynamic mode uses decoded pixel dimensions
-// (or the default resolution) divided by the factor. The result is always >= 1 so
-// an image contributes weight to the pseudo-token stream.
+// placeholderCount estimates placeholder tokens for an image URL. Data URLs
+// are decoded for dimensions; other URLs fall back to the default resolution.
 func (e imageEstimator) placeholderCount(url string) int {
+	w, h, ok := imageDimensionsFromBase64(url)
+	return e.countFromDims(w, h, ok)
+}
+
+// placeholderForAnthropicImage returns the content (URL or raw base64) and
+// placeholder count for an Anthropic image source. Empty content means skip.
+func (e imageEstimator) placeholderForAnthropicImage(src *fwkrh.AnthropicImageSource) (content string, count int) {
+	if src == nil {
+		return "", 0
+	}
+	if src.URL != "" {
+		return src.URL, e.placeholderCount(src.URL)
+	}
+	if src.Data != "" {
+		w, h, ok := imageDimensionsFromBase64Payload(src.Data)
+		return src.Data, e.countFromDims(w, h, ok)
+	}
+	return "", 0
+}
+
+// countFromDims returns the token count from decoded dimensions (decoded==true)
+// or the configured defaults. Always >= 1 so every image carries weight.
+func (e imageEstimator) countFromDims(decW, decH int, decoded bool) int {
 	if e.mode == imageModeStatic {
 		if e.staticToken > 0 {
 			return e.staticToken
@@ -89,8 +112,8 @@ func (e imageEstimator) placeholderCount(url string) int {
 	if h <= 0 {
 		h = defaultImageHeight
 	}
-	if rw, rh, ok := imageDimensionsFromBase64(url); ok {
-		w, h = rw, rh
+	if decoded {
+		w, h = decW, decH
 	}
 	factor := e.factor
 	if factor <= 0 {
@@ -109,7 +132,13 @@ func imageDimensionsFromBase64(url string) (width, height int, ok bool) {
 		return 0, 0, false
 	}
 	idx := strings.Index(url, "base64,")
-	decoded, err := base64.StdEncoding.DecodeString(url[idx+len("base64,"):])
+	return imageDimensionsFromBase64Payload(url[idx+len("base64,"):])
+}
+
+// imageDimensionsFromBase64Payload decodes a bare base64 image payload and
+// returns its pixel dimensions.
+func imageDimensionsFromBase64Payload(rawB64 string) (width, height int, ok bool) {
+	decoded, err := base64.StdEncoding.DecodeString(rawB64)
 	if err != nil {
 		return 0, 0, false
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds Anthropic `/v1/messages` support to the approximate prefix-cache token estimator. Before this change, requests with `body.Messages` fell through to `estimateBytes` and errored with `unsupported request body type`, leaving Anthropic traffic out of the prefix cache entirely.

The new branch in `estimateBackend.produce`:

- Flattens `MessagesRequest` (system + role + content) into the same pseudo-token byte stream pattern used by the chat-completions path.
- Folds multimodal `image` blocks into the stream as `MultiModalFeature`s. Each source hashes by its wire-form identity — URL for URL sources, the raw base64 payload for base64 sources.

**OpenAI vs Anthropic image format**

The two APIs carry image content in incompatible shapes, which is why the estimator can't reuse the chat-completions path:

| | OpenAI `/v1/chat/completions` | Anthropic `/v1/messages` |
|---|---|---|
| Block `type` | `image_url` | `image` |
| Carrier field | `image_url.url` (single string) | `source` (object with `type`, `media_type`, `data` or `url`) |
| Base64 form | Data URI: `data:image/jpeg;base64,/9j/4AAQ...` | Raw payload: `"/9j/4AAQ..."` + separate `media_type` field |
| URL form | Same `url` field, e.g. `https://...` | `source.type: "url"`, `source.url: https://...` |

**Which issue(s) this PR fixes**:
Fixes #1507

**Release note**:
```release-note
NONE
```