### PR TITLE
feat(parser) add messages/count_tokens support in anthropic parser

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/README.md
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/README.md
@@ -4,7 +4,9 @@
 
 Parses HTTP/H2C requests and responses in the Anthropic Messages API format. Use this parser when the EPP fronts endpoints serving the Anthropic API.
 
-Supports the Messages API (`/v1/messages`) endpoint. Extracts message content and streaming mode from the request body. Tracks token usage including prompt tokens, completion tokens, and cached tokens (via `cache_read_input_tokens`) from both standard JSON responses and server-sent events (SSE) for streaming responses.
+Supported endpoints:
+- Messages API (`/v1/messages`): extracts message content and streaming mode from the request body. Tracks token usage including prompt tokens, completion tokens, and cached tokens (via `cache_read_input_tokens`) from both standard JSON responses and server-sent events (SSE) for streaming responses.
+- Token Counting API (`/v1/messages/count_tokens`)
 
 **Parameters:** None.
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -33,7 +33,8 @@ import (
 const (
 	AnthropicParserType = "anthropic-parser"
 
-	messagesAPI = "messages"
+	messagesAPI    = "messages"
+	countTokensAPI = "messages/count_tokens"
 
 	streamingRespPrefix = "data: "
 
@@ -63,7 +64,7 @@ func (p *AnthropicParser) TypedName() fwkplugin.TypedName {
 
 func (p *AnthropicParser) Claims() fwkrh.Claims {
 	return fwkrh.Claims{
-		Paths:     []string{messagesAPI},
+		Paths:     []string{messagesAPI, countTokensAPI},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
 }
@@ -78,14 +79,24 @@ func (p *AnthropicParser) WithName(name string) *AnthropicParser {
 }
 
 func (p *AnthropicParser) ParseRequest(_ context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
+	path := getRequestPath(headers)
+
+	// The count_tokens endpoint returns only a token count and gains nothing from
+	// structured parsing or response interception; forward the body unchanged.
+	if strings.HasSuffix(path, "/"+countTokensAPI) {
+		return &fwkrh.ParseResult{
+			Body:                   &fwkrh.InferenceRequestBody{Payload: fwkrh.RawPayload(body)},
+			SkipResponseProcessing: true,
+		}, nil
+	}
+
+	if !strings.HasSuffix(path, "/"+messagesAPI) {
+		return nil, fmt.Errorf("unsupported API endpoint: %s", path)
+	}
+
 	bodyMap := make(map[string]any)
 	if err := json.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request body: %w", err)
-	}
-
-	path := getRequestPath(headers)
-	if !strings.HasSuffix(path, "/"+messagesAPI) {
-		return nil, fmt.Errorf("unsupported API endpoint: %s", path)
 	}
 
 	var messagesReq fwkrh.MessagesRequest

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -615,11 +615,60 @@ func TestAnthropicParser_Claims(t *testing.T) {
 	parser := NewAnthropicParser()
 	got := parser.Claims()
 	want := fwkrh.Claims{
-		Paths:     []string{messagesAPI},
+		Paths:     []string{messagesAPI, countTokensAPI},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAnthropicParser_ParseRequest_CountTokens(t *testing.T) {
+	parser := NewAnthropicParser()
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		body    []byte
+	}{
+		{
+			name:    "valid count_tokens body forwarded as raw payload",
+			headers: map[string]string{":path": "/v1/messages/count_tokens"},
+			body: []byte(`{"model":"test-model",` +
+				`"system":"You are a helpful assistant.",` +
+				`"messages":[{"role":"user","content":"Hello"}]}`),
+		},
+		{
+			name:    "empty body still forwarded",
+			headers: map[string]string{":path": "/v1/messages/count_tokens"},
+			body:    []byte{},
+		},
+		{
+			name:    "non-JSON body still forwarded",
+			headers: map[string]string{":path": "/v1/messages/count_tokens"},
+			body:    []byte("not-json"),
+		},
+		{
+			name:    "path read from x-original-path header",
+			headers: map[string]string{"x-original-path": "/v1/messages/count_tokens"},
+			body:    []byte(`{}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.ParseRequest(context.Background(), tt.body, tt.headers)
+			if err != nil {
+				t.Fatalf("ParseRequest() error = %v", err)
+			}
+			if !got.SkipResponseProcessing {
+				t.Errorf("ParseRequest() SkipResponseProcessing = false, want true")
+			}
+			want := &fwkrh.InferenceRequestBody{Payload: fwkrh.RawPayload(tt.body)}
+			if diff := cmp.Diff(want, got.Body); diff != "" {
+				t.Errorf("ParseRequest() body mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Support `/v1/messages/count_tokens` in the Anthropic parser. The body is forwarded unchanged as a `RawPayload` and EPP response interception is skipped, since the response carries only `input_tokens` and yields no scheduling signal.

**Release note**:
```release-note
`anthropic-parser`: supports the `/v1/messages/count_tokens` endpoint; the body is forwarded unchanged as a raw payload.
```