### PR TITLE
fix(epp): extract upstream traceparent and re-parent server span

### DIFF
--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -23,11 +23,76 @@ import (
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
+
+func TestExtractTraceContext(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	const (
+		traceID = "0af7651916cd43dd8448eb211c80319c"
+		spanID  = "b7ad6b7169203331"
+	)
+
+	tests := []struct {
+		name         string
+		headers      []*configPb.HeaderValue
+		wantTraceID  string
+		wantRemote   bool
+		wantHasTrace bool
+	}{
+		{
+			name: "extracts upstream traceparent",
+			headers: []*configPb.HeaderValue{
+				{Key: "traceparent", Value: "00-" + traceID + "-" + spanID + "-01"},
+			},
+			wantTraceID:  traceID,
+			wantRemote:   true,
+			wantHasTrace: true,
+		},
+		{
+			name: "case-insensitive header key",
+			headers: []*configPb.HeaderValue{
+				{Key: "TraceParent", RawValue: []byte("00-" + traceID + "-" + spanID + "-01")},
+			},
+			wantTraceID:  traceID,
+			wantRemote:   true,
+			wantHasTrace: true,
+		},
+		{
+			name: "no traceparent yields no remote span context",
+			headers: []*configPb.HeaderValue{
+				{Key: "x-test", Value: "val"},
+			},
+			wantHasTrace: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{
+					Headers: &configPb.HeaderMap{Headers: tc.headers},
+				},
+			}
+
+			ctx := extractTraceContext(context.Background(), req)
+			sc := trace.SpanContextFromContext(ctx)
+
+			assert.Equal(t, tc.wantHasTrace, sc.IsValid(), "span context validity should match")
+			if tc.wantHasTrace {
+				assert.Equal(t, tc.wantTraceID, sc.TraceID().String(), "trace ID should match upstream")
+				assert.Equal(t, tc.wantRemote, sc.IsRemote(), "span context should be remote")
+			}
+		})
+	}
+}
 
 func TestHandleRequestHeaders(t *testing.T) {
 	t.Parallel()

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -197,6 +198,24 @@ func (s *StreamingServer) getOrResolveParser(ctx context.Context, reqCtx *Reques
 	return parser, nil
 }
 
+// extractTraceContext returns ctx augmented with the upstream trace context
+// carried in the incoming Envoy request headers (e.g. the traceparent set by the
+// client or the Gateway), using the globally configured text map propagator.
+//
+// The header wire format is the W3C Trace Context spec:
+// https://www.w3.org/TR/trace-context/
+// Extraction uses OpenTelemetry context propagation:
+// https://opentelemetry.io/docs/concepts/context-propagation/
+func extractTraceContext(ctx context.Context, req *extProcPb.ProcessingRequest_RequestHeaders) context.Context {
+	carrier := make(propagation.MapCarrier)
+	if req != nil && req.RequestHeaders != nil && req.RequestHeaders.Headers != nil {
+		for _, header := range req.RequestHeaders.Headers.Headers {
+			carrier[strings.ToLower(header.Key)] = envoy.GetHeaderValue(header)
+		}
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
+}
+
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	ctx := srv.Context()
 
@@ -208,8 +227,15 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			attribute.String("commit-sha", version.CommitSHA),
 		),
 	)
-	ctx, span := tracer.Start(ctx, "gateway.request", trace.WithSpanKind(trace.SpanKindServer))
-	defer span.End()
+	// The server span is started in the RequestHeaders branch, once the upstream
+	// trace context carried in the incoming headers is available, so the EPP span
+	// joins the caller's trace instead of starting a disconnected root.
+	var span trace.Span
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
 
 	logger := log.FromContext(ctx)
 	loggerTrace := logger.V(logutil.TRACE)
@@ -349,6 +375,13 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			logger.V(logutil.DEFAULT).Info("EPP received request") // Request ID will be logged too as part of logger context values.
 			loggerTrace = logger.V(logutil.TRACE)
 			ctx = log.IntoContext(ctx, logger)
+
+			// Re-parent the server span to the upstream trace context (e.g. the
+			// traceparent set by the client or the Gateway) carried in the incoming
+			// headers, then start it. The headers are only available here, so the span
+			// cannot be started at the top of Process without orphaning the trace.
+			ctx = extractTraceContext(ctx, v)
+			ctx, span = tracer.Start(ctx, "gateway.request", trace.WithSpanKind(trace.SpanKindServer))
 
 			err = s.HandleRequestHeaders(ctx, reqCtx, v)
 		case *extProcPb.ProcessingRequest_RequestBody:


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind bug

**What this PR does / why we need it**:

EPP runs as an Envoy `ext_proc` filter. On every request Envoy forwards the incoming headers, including the upstream `traceparent` set by the client or the Gateway. However, EPP started its `gateway.request` server span at the very top of `Process()`, before the `RequestHeaders` message was received. Because the span was started before the headers were available, the upstream trace context was never extracted, so EPP began a brand new root trace for every request. The result was two disconnected traces in Jaeger (Gateway/Envoy and EPP), and operators could not follow a single end-to-end trace through the request path.

This PR fixed the issue as below:

- Defers the server span start out of the top of `Process()` to the `RequestHeaders` branch, where the incoming headers are first available.
- Extracts the upstream trace context from the Envoy header map using the globally configured propagator (`extractTraceContext`), then starts the span re-parented to it, so the EPP trace joins the caller's trace.
- Leaves the existing downstream `Inject` behavior in `generateHeaders` unchanged; this issue only covered the missing inbound extraction.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1502 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
