### PR TITLE
fix(epp): route chat-completions sub-paths through the OpenAI parser

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -91,6 +91,8 @@ func (p *OpenAIParser) Claims() fwkrh.Claims {
 			embeddingsAPI,
 			responsesAPI,
 			conversationsAPI,
+			chatCompletionsAPI + "/render",
+			completionsAPI + "/render",
 		},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
@@ -157,24 +159,25 @@ func (p *OpenAIParser) parseStreamResponse(chunk []byte) (*fwkrh.ParsedResponse,
 }
 
 // determineAPITypeFromPath determines the API type based on the request path.
-// Note: path strings have already been cleaned and normalized by the gateway/proxy layer
-// (no trailing slashes, query parameters, or additional suffix strings at this point).
 // The suffix-based matching supports both standard OpenAI paths (e.g. /v1/chat/completions)
 // and provider-specific paths (e.g. Vertex AI's /v1/projects/.../chat/completions).
+// Sub-paths /render under chat-completions and completions share the parent's body schema.
 func determineAPITypeFromPath(path string) string {
-	if strings.HasSuffix(path, "/conversations") {
+	if request.MatchPathSuffix(path, "/conversations") {
 		return conversationsAPI
 	}
-	if strings.HasSuffix(path, "/responses") {
+	if request.MatchPathSuffix(path, "/responses") {
 		return responsesAPI
 	}
-	if strings.HasSuffix(path, "/chat/completions") {
+	if request.MatchPathSuffix(path, "/chat/completions") ||
+		request.MatchPathSuffix(path, "/chat/completions/render") {
 		return chatCompletionsAPI
 	}
-	if strings.HasSuffix(path, "/completions") {
+	if request.MatchPathSuffix(path, "/completions") ||
+		request.MatchPathSuffix(path, "/completions/render") {
 		return completionsAPI
 	}
-	if strings.HasSuffix(path, "/embeddings") {
+	if request.MatchPathSuffix(path, "/embeddings") {
 		return embeddingsAPI
 	}
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -231,6 +231,95 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
+			name:    "chat completions render sub-path",
+			headers: map[string]string{":path": "/v1/chat/completions/render"},
+			body: map[string]any{
+				"model":    "test",
+				"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				ChatCompletions: &fwkrh.ChatCompletionsRequest{
+					Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hi"}}},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model":    "test",
+					"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+				},
+			},
+		},
+		{
+			name:    "chat completions render sub-path with trailing slash",
+			headers: map[string]string{":path": "/v1/chat/completions/render/"},
+			body: map[string]any{
+				"model":    "test",
+				"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				ChatCompletions: &fwkrh.ChatCompletionsRequest{
+					Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hi"}}},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model":    "test",
+					"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+				},
+			},
+		},
+		{
+			name:    "completions render sub-path",
+			headers: map[string]string{":path": "/v1/completions/render"},
+			body: map[string]any{
+				"model":  "test",
+				"prompt": "render this",
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Completions: &fwkrh.CompletionsRequest{
+					Prompt: fwkrh.Prompt{Raw: "render this"},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model":  "test",
+					"prompt": "render this",
+				},
+			},
+		},
+		{
+			name:    "chat completions render sub-path with multimodal content",
+			headers: map[string]string{":path": "/v1/chat/completions/render"},
+			body: map[string]any{
+				"model": "test",
+				"messages": []any{
+					map[string]any{
+						"role": "user",
+						"content": []any{
+							map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,abc"}},
+							map[string]any{"type": "text", "text": "describe"},
+						},
+					},
+				},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				ChatCompletions: &fwkrh.ChatCompletionsRequest{
+					Messages: []fwkrh.Message{
+						{Role: "user", Content: fwkrh.Content{Structured: []fwkrh.ContentBlock{
+							{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "data:image/png;base64,abc"}},
+							{Type: "text", Text: "describe"},
+						}}},
+					},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model": "test",
+					"messages": []any{
+						map[string]any{
+							"role": "user",
+							"content": []any{
+								map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,abc"}},
+								map[string]any{"type": "text", "text": "describe"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:    "chat completions request body with multi-modal content",
 			headers: map[string]string{":path": "/v1/chat/completions"},
 			body: map[string]any{
@@ -1135,6 +1224,8 @@ func TestOpenAIParser_Claims(t *testing.T) {
 			embeddingsAPI,
 			responsesAPI,
 			conversationsAPI,
+			chatCompletionsAPI + "/render",
+			completionsAPI + "/render",
 		},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`determineAPITypeFromPath` uses `strings.HasSuffix` against the canonical endpoint names, so vLLM-served sub-paths under known endpoints even though their request bodies share the parent endpoint's schema fall through to "no parser registered matching path suffix" at `pkg/epp/handlers/parsers.go:101`:

```
POST /v1/chat/completions/render  → HTTP 400 BadRequest
POST /v1/completions/render       → HTTP 400 BadRequest
```

Fix: add the two sub-paths to `Claims().Paths` so the parser registry routes them to `OpenAIParser`, and to `determineAPITypeFromPath` so they map onto the existing `chatCompletionsAPI` / `completionsAPI` parsing case. Bodies pass through `ChatCompletionsToRenderChatRequest` unchanged.

Manually tested against `Qwen/Qwen2.5-Omni-7B` (vLLM 0.22.1, A5000), 4-modality matrix over `/v1/chat/completions/render`:

| modality | HTTP | mm_hash returned                            |
| -------- | ---- | ------------------------------------------- |
| text     | 200  | n/a                                         |
| image    | 200  | `06aac075…`                                 |
| audio    | 200  | `05d0e7f9…`                                 |
| video    | 200  | `2fe7c795…` (4784 video placeholder tokens) |

<details>
<summary>Sample response: <code>/v1/chat/completions/render</code> with a video URL (redacted: <code>token_ids</code> array of length 4806 omitted)</summary>

```json
{
  "request_id": "chatcmpl-94c42400c6b3aa1c",
  "token_count": 4806,
  "features": {
    "mm_hashes":      { "video": ["2fe7c795a1dba79a9292c7ba52ccf498f27922c245e5ed0614104a1f9a90919c"] },
    "mm_placeholders":{ "video": [{ "offset": 15, "length": 4784 }] }
  }
}
```

</details>

**Which issue(s) this PR fixes**:

Fixes #1516

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
EPP: route /v1/chat/completions/render and /v1/completions/render through the OpenAI parser.
```
