### PR TITLE
increase lychee link-checker timeout to 60s

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -4,10 +4,15 @@ exclude = [
   "^https://www.envoyproxy.io/"
 ]
 
-# Timeout in seconds
-timeout = 20
+# Per-request timeout in seconds. Sized for slow upstream docs sites
+# (e.g. sigs.k8s.io subdomains under load); 20s was tight enough to fire
+# spurious timeouts on otherwise-reachable links.
+timeout = 60
 
-# Retry failed links (helpful for flaky sites)
+# Retry failed links (helpful for flaky sites). Combined with the longer
+# timeout, this covers both transient connection failures and slow
+# responses without ballooning total runtime: worst-case per-link wait
+# is roughly timeout * (max_retries + 1) + max_retries * retry_wait_time.
 max_retries = 5
 retry_wait_time = 2
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -9,11 +9,15 @@ exclude = [
 # spurious timeouts on otherwise-reachable links.
 timeout = 60
 
-# Retry failed links (helpful for flaky sites). Combined with the longer
-# timeout, this covers both transient connection failures and slow
-# responses without ballooning total runtime: worst-case per-link wait
-# is roughly timeout * (max_retries + 1) + max_retries * retry_wait_time.
-max_retries = 5
+# Retry settings. Lychee retries on connection errors and timeouts.
+# Worst-case per dead link with these values:
+#   timeout * (max_retries + 1) + max_retries * retry_wait_time
+#   = 60 * 3 + 2 * 2 = 184s.
+# Lychee runs link checks concurrently (default 128 parallel), so total
+# wall-clock is bounded by the slowest single link, not the sum across
+# all links. Two retries is enough to ride out brief connection resets
+# or 503s without piling extra waits on a truly-dead host.
+max_retries = 2
 retry_wait_time = 2
 
 # Accept non-200 status codes (429: rate limits)


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:
The Markdown Link Checker workflow has been failing intermittently with
TIMEOUT for upstream docs sites (notably sigs.k8s.io subdomains) that
respond slower than 20s under load. Five retries at the same 20s ceiling
do not help because the same request times out each round.

Raise the per-request timeout to 60s. Retry settings are lowered from 5 to 2.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1521 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
