### PR TITLE
ci(e2e): pull kindest/node from mirror.gcr.io instead of docker.io

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -22,6 +22,7 @@ EPP_IMAGE="${EPP_IMAGE:-ghcr.io/llm-d/llm-d-router-endpoint-picker:dev}"
 SIM_IMAGE="${VLLM_IMAGE:-ghcr.io/llm-d/llm-d-inference-sim:v0.9.0}"
 MANIFEST_PATH="${MANIFEST_PATH:-${DIR}/../test/testdata/sim-deployment.yaml}"
 USE_KIND="${USE_KIND:-true}"
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-mirror.gcr.io/kindest/node:v1.32.2}"
 
 KIND_CLUSTER_NAME="inference-e2e"
 
@@ -76,7 +77,7 @@ if [ "${USE_KIND}" = "true" ]; then
       kubectl config use-context "kind-${KIND_CLUSTER_NAME}"
     else
       echo "Creating new kind cluster '${KIND_CLUSTER_NAME}' for running the tests..."
-      kind create cluster --name "${KIND_CLUSTER_NAME}"
+      kind create cluster --name "${KIND_CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}"
       CREATED_CLUSTER="${KIND_CLUSTER_NAME}"
     fi
     load_images "${KIND_CLUSTER_NAME}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Pull `kindest/node` from `mirror.gcr.io` instead of Docker Hub so `hack/test-e2e.sh` no longer hits the `docker.io` rate-limit / connection-timeout flake documented in #1525. `mirror.gcr.io` serves the same kindest/node SHAs Docker Hub publishes; the kind cluster contract is unchanged.

`KIND_NODE_IMAGE` stays overridable via env, so anyone with a different registry pinning policy can target docker.io or a corporate mirror without further code changes.

The pattern is already used across the K8s ecosystem, Kuadrant operator, oracle/oci-service-operator, ansible/aap-dev, and others all pull `kindest/node` from `mirror.gcr.io`.

**Which issue(s) this PR fixes**:

Fixes #1525

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
NONE
```
