### PR TITLE
feat: add OpenTelemetry spans to scheduling scorer pipeline

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -300,7 +300,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		setupLog.Error(err, "Failed to setup datastore")
 		return nil, nil, err
 	}
-	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds, opts.Tracing)
 	if err != nil {
 		setupLog.Error(err, "Failed to parse configuration")
 		return nil, nil, err
@@ -625,14 +625,14 @@ func makePodListFunc(ds datastore.Datastore) func() []types.NamespacedName {
 	}
 }
 
-func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *configapi.EndpointPickerConfig, ds datastore.Datastore) (*config.Config, error) {
+func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *configapi.EndpointPickerConfig, ds datastore.Datastore, traceScorers bool) (*config.Config, error) {
 	logger := log.FromContext(ctx)
 
 	applyDeprecatedEnvFeatureGate(enableExperimentalFlowControlLayer, "Flow Control layer", flowcontrol.FeatureGate, rawConfig)
 
 	handle := fwkplugin.NewEppHandle(ctx, makePodListFunc(ds), fwkplugin.WithMetricsRecorder(ctrlmetrics.Registry))
 	r.PluginHandle = handle
-	cfg, err := loader.InstantiateAndConfigure(rawConfig, handle, logger)
+	cfg, err := loader.InstantiateAndConfigure(rawConfig, handle, logger, loader.WithScorerTracing(traceScorers))
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to load the configuration - %w", err)
@@ -879,7 +879,7 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 		"(InferenceModelRewrite, InferenceObjective reconciler, and any " +
 		"k8s-notification-source data layer plugins); see docs/discovery.md")
 
-	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds, opts.Tracing)
 	if err != nil {
 		setupLog.Error(err, "Failed to parse configuration")
 		return err

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -52,6 +52,20 @@ var (
 	deprecatedSchemeGroupVersion = schema.GroupVersion{Group: "inference.networking.x-k8s.io", Version: "v1alpha1"} // TODO: deprecated should be clean up
 )
 
+type instantiateOptions struct {
+	traceScorers bool
+}
+
+// InstantiateOption configures InstantiateAndConfigure.
+type InstantiateOption func(*instantiateOptions)
+
+// WithScorerTracing controls whether scheduler scorers are wrapped with tracing spans.
+func WithScorerTracing(enabled bool) InstantiateOption {
+	return func(options *instantiateOptions) {
+		options.traceScorers = enabled
+	}
+}
+
 func init() {
 	// Support deprecated pseudo config CRD
 	var builder runtime.SchemeBuilder
@@ -148,7 +162,12 @@ func InstantiateAndConfigure(
 	rawConfig *configapi.EndpointPickerConfig,
 	handle fwkplugin.Handle,
 	logger logr.Logger,
+	options ...InstantiateOption,
 ) (*config.Config, error) {
+	opts := instantiateOptions{}
+	for _, option := range options {
+		option(&opts)
+	}
 
 	if err := instantiatePlugins(rawConfig.Plugins, handle); err != nil {
 		return nil, fmt.Errorf("plugin instantiation failed: %w", err)
@@ -163,7 +182,7 @@ func InstantiateAndConfigure(
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
 	}
 
-	schedulerConfig, err := buildSchedulerConfig(rawConfig.SchedulingProfiles, handle)
+	schedulerConfig, err := buildSchedulerConfig(rawConfig.SchedulingProfiles, handle, opts.traceScorers)
 	if err != nil {
 		return nil, fmt.Errorf("scheduler config build failed: %w", err)
 	}
@@ -251,12 +270,13 @@ func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle fwkplug
 func buildSchedulerConfig(
 	configProfiles []configapi.SchedulingProfile,
 	handle fwkplugin.Handle,
+	traceScorers bool,
 ) (*scheduling.SchedulerConfig, error) {
 
 	profiles := make(map[string]fwksched.SchedulerProfile)
 
 	for _, cfgProfile := range configProfiles {
-		fwProfile := scheduling.NewSchedulerProfile()
+		fwProfile := scheduling.NewSchedulerProfile(scheduling.WithScorerTracing(traceScorers))
 
 		for _, pluginRef := range cfgProfile.Plugins {
 			plugin := handle.Plugin(pluginRef.PluginRef)

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -35,8 +35,6 @@ const (
 	scorerExtensionPoint                 = "Scorer"
 	pickerExtensionPoint                 = "Picker"
 	processProfilesResultsExtensionPoint = "ProcessProfilesResults"
-	schedulerInstrumentationName         = "llm-d-router"
-	scheduleSpanName                     = "llm_d.epp.schedule"
 )
 
 // NewSchedulerWithConfig returns a new scheduler with the given scheduler plugins configuration.

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -35,6 +35,8 @@ const (
 	scorerExtensionPoint                 = "Scorer"
 	pickerExtensionPoint                 = "Picker"
 	processProfilesResultsExtensionPoint = "ProcessProfilesResults"
+	schedulerInstrumentationName         = "llm-d-router"
+	scheduleSpanName                     = "llm_d.epp.schedule"
 )
 
 // NewSchedulerWithConfig returns a new scheduler with the given scheduler plugins configuration.

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -34,20 +34,35 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
 
+// SchedulerProfileOption configures a SchedulerProfile.
+type SchedulerProfileOption func(*SchedulerProfile)
+
+// WithScorerTracing controls whether scorer plugins are wrapped with tracing spans.
+func WithScorerTracing(enabled bool) SchedulerProfileOption {
+	return func(p *SchedulerProfile) {
+		p.traceScorers = enabled
+	}
+}
+
 // NewSchedulerProfile creates a new SchedulerProfile object and returns its pointer.
-func NewSchedulerProfile() *SchedulerProfile {
-	return &SchedulerProfile{
+func NewSchedulerProfile(options ...SchedulerProfileOption) *SchedulerProfile {
+	profile := &SchedulerProfile{
 		filters: []fwksched.Filter{},
 		scorers: []*WeightedScorer{},
 		// picker remains nil since profile doesn't support multiple pickers
 	}
+	for _, option := range options {
+		option(profile)
+	}
+	return profile
 }
 
 // SchedulerProfile provides a profile configuration for the scheduler which influence routing decisions.
 type SchedulerProfile struct {
-	filters []fwksched.Filter
-	scorers []*WeightedScorer
-	picker  fwksched.Picker
+	filters      []fwksched.Filter
+	scorers      []*WeightedScorer
+	picker       fwksched.Picker
+	traceScorers bool
 }
 
 // WithFilters sets the given filter plugins as the Filter plugins.
@@ -60,7 +75,10 @@ func (p *SchedulerProfile) WithFilters(filters ...fwksched.Filter) *SchedulerPro
 // WithScorers sets the given scorer plugins as the Scorer plugins.
 // if the SchedulerProfile has Scorer plugins, this call replaces the existing plugins with the given ones.
 func (p *SchedulerProfile) WithScorers(scorers ...*WeightedScorer) *SchedulerProfile {
-	p.scorers = scorers
+	p.scorers = make([]*WeightedScorer, 0, len(scorers))
+	for _, scorer := range scorers {
+		p.scorers = append(p.scorers, p.wrapScorer(scorer))
+	}
 	return p
 }
 
@@ -79,7 +97,7 @@ func (p *SchedulerProfile) WithPicker(picker fwksched.Picker) *SchedulerProfile 
 func (p *SchedulerProfile) AddPlugins(pluginObjects ...plugin.Plugin) error {
 	for _, plugin := range pluginObjects {
 		if weightedScorer, ok := plugin.(*WeightedScorer); ok {
-			p.scorers = append(p.scorers, weightedScorer)
+			p.scorers = append(p.scorers, p.wrapScorer(weightedScorer))
 			plugin = weightedScorer.Scorer // if we got WeightedScorer, unwrap the plugin
 		} else if scorer, ok := plugin.(fwksched.Scorer); ok { // if we got a Scorer instead of WeightedScorer that's an error.
 			return fmt.Errorf("failed to register scorer '%s' without a weight. follow function documentation to register a scorer", scorer.TypedName())
@@ -95,6 +113,16 @@ func (p *SchedulerProfile) AddPlugins(pluginObjects ...plugin.Plugin) error {
 		}
 	}
 	return nil
+}
+
+func (p *SchedulerProfile) wrapScorer(scorer *WeightedScorer) *WeightedScorer {
+	if scorer == nil || !p.traceScorers {
+		return scorer
+	}
+	if _, ok := scorer.Scorer.(*TracedScorer); ok {
+		return scorer
+	}
+	return NewWeightedScorer(NewTracedScorer(scorer.Scorer, scorer.Weight()), scorer.Weight())
 }
 
 func (p *SchedulerProfile) String() string {

--- a/pkg/epp/scheduling/traced_scorer.go
+++ b/pkg/epp/scheduling/traced_scorer.go
@@ -19,28 +19,24 @@ package scheduling
 import (
 	"context"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
 const (
-	scorerSpanNamePrefix        = "llm_d.epp.scorer."
-	scorerTypeAttribute         = "llm_d.scorer.type"
-	scorerNameAttribute         = "llm_d.scorer.name"
-	scorerWeightAttribute       = "llm_d.scorer.weight"
-	scorerCandidateAttribute    = "llm_d.scorer.candidate_count"
-	scorerEndpointsAttribute    = "llm_d.scorer.endpoints_scored"
-	scorerMaxScoreAttribute     = "llm_d.scorer.score.max"
-	scorerAverageScoreAttribute = "llm_d.scorer.score.avg"
+	scorerSpanName              = "score_endpoints"
+	scorerTypeAttribute         = "llm_d.epp.scorer.type"
+	scorerNameAttribute         = "llm_d.epp.scorer.name"
+	scorerWeightAttribute       = "llm_d.epp.scorer.weight"
+	scorerCandidateAttribute    = "llm_d.epp.scorer.candidate_endpoints"
+	scorerEndpointsAttribute    = "llm_d.epp.scorer.scored_endpoints"
+	scorerMaxScoreAttribute     = "llm_d.epp.scorer.max_score"
+	scorerAverageScoreAttribute = "llm_d.epp.scorer.average_score"
 )
-
-func schedulerTracer() trace.Tracer {
-	return otel.Tracer(schedulerInstrumentationName)
-}
 
 // TracedScorer decorates a scorer with request-local OpenTelemetry spans.
 type TracedScorer struct {
@@ -66,20 +62,30 @@ func (s *TracedScorer) Category() fwksched.ScorerCategory {
 
 func (s *TracedScorer) Score(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	typedName := s.TypedName()
-	ctx, span := schedulerTracer().Start(ctx, scorerSpanNamePrefix+typedName.Type,
+	attrs := []attribute.KeyValue{
+		attribute.String(scorerTypeAttribute, typedName.Type),
+		attribute.String(scorerNameAttribute, typedName.Name),
+		attribute.Float64(scorerWeightAttribute, s.weight),
+		attribute.Int(scorerCandidateAttribute, len(endpoints)),
+	}
+	if request != nil {
+		if request.TargetModel != "" {
+			attrs = append(attrs, attribute.String("gen_ai.request.model", request.TargetModel))
+		}
+		if request.RequestID != "" {
+			attrs = append(attrs, attribute.String("gen_ai.request.id", request.RequestID))
+		}
+	}
+
+	ctx, span := tracing.Tracer(TracerScope).Start(ctx, scorerSpanName,
 		trace.WithSpanKind(trace.SpanKindInternal),
-		trace.WithAttributes(
-			attribute.String(scorerTypeAttribute, typedName.Type),
-			attribute.String(scorerNameAttribute, typedName.Name),
-			attribute.Float64(scorerWeightAttribute, s.weight),
-			attribute.Int(scorerCandidateAttribute, len(endpoints)),
-		),
+		trace.WithAttributes(attrs...),
 	)
 	defer span.End()
 
 	scores := s.scorer.Score(ctx, request, endpoints)
 
-	attrs := []attribute.KeyValue{
+	attrs = []attribute.KeyValue{
 		attribute.Int(scorerEndpointsAttribute, len(scores)),
 	}
 	if len(scores) > 0 {

--- a/pkg/epp/scheduling/traced_scorer.go
+++ b/pkg/epp/scheduling/traced_scorer.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	scorerSpanNamePrefix        = "llm_d.epp.scorer."
+	scorerTypeAttribute         = "llm_d.scorer.type"
+	scorerNameAttribute         = "llm_d.scorer.name"
+	scorerWeightAttribute       = "llm_d.scorer.weight"
+	scorerCandidateAttribute    = "llm_d.scorer.candidate_count"
+	scorerEndpointsAttribute    = "llm_d.scorer.endpoints_scored"
+	scorerMaxScoreAttribute     = "llm_d.scorer.score.max"
+	scorerAverageScoreAttribute = "llm_d.scorer.score.avg"
+)
+
+func schedulerTracer() trace.Tracer {
+	return otel.Tracer(schedulerInstrumentationName)
+}
+
+// TracedScorer decorates a scorer with request-local OpenTelemetry spans.
+type TracedScorer struct {
+	scorer fwksched.Scorer
+	weight float64
+}
+
+// NewTracedScorer creates a tracing decorator for scorer.
+func NewTracedScorer(scorer fwksched.Scorer, weight float64) *TracedScorer {
+	return &TracedScorer{
+		scorer: scorer,
+		weight: weight,
+	}
+}
+
+func (s *TracedScorer) TypedName() fwkplugin.TypedName {
+	return s.scorer.TypedName()
+}
+
+func (s *TracedScorer) Category() fwksched.ScorerCategory {
+	return s.scorer.Category()
+}
+
+func (s *TracedScorer) Score(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	typedName := s.TypedName()
+	ctx, span := schedulerTracer().Start(ctx, scorerSpanNamePrefix+typedName.Type,
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String(scorerTypeAttribute, typedName.Type),
+			attribute.String(scorerNameAttribute, typedName.Name),
+			attribute.Float64(scorerWeightAttribute, s.weight),
+			attribute.Int(scorerCandidateAttribute, len(endpoints)),
+		),
+	)
+	defer span.End()
+
+	scores := s.scorer.Score(ctx, request, endpoints)
+
+	attrs := []attribute.KeyValue{
+		attribute.Int(scorerEndpointsAttribute, len(scores)),
+	}
+	if len(scores) > 0 {
+		var maxScore, totalScore float64
+		i := 0
+		for _, score := range scores {
+			if i == 0 || score > maxScore {
+				maxScore = score
+			}
+			totalScore += score
+			i++
+		}
+		attrs = append(attrs,
+			attribute.Float64(scorerMaxScoreAttribute, maxScore),
+			attribute.Float64(scorerAverageScoreAttribute, totalScore/float64(len(scores))),
+		)
+	}
+	span.SetAttributes(attrs...)
+
+	return scores
+}

--- a/pkg/epp/scheduling/traced_scorer_test.go
+++ b/pkg/epp/scheduling/traced_scorer_test.go
@@ -19,24 +19,21 @@ package scheduling
 import (
 	"context"
 	"math"
-	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
-func TestSchedulerProfileCreatesScheduleAndScorerSpans(t *testing.T) {
-	exporter := installTraceExporter(t)
+func TestSchedulerProfileCreatesScorerSpans(t *testing.T) {
+	recorder := setupSpanRecorder(t)
 
 	scorerA := &recordingScorer{
 		typedName: fwkplugin.TypedName{Type: "type-a", Name: "scorer-a"},
@@ -46,43 +43,52 @@ func TestSchedulerProfileCreatesScheduleAndScorerSpans(t *testing.T) {
 		typedName: fwkplugin.TypedName{Type: "type-b", Name: "scorer-b"},
 		scores:    []float64{0.5, 0.4},
 	}
-	profile := NewSchedulerProfile().
-		WithScorers(NewWeightedScorer(scorerA, 2), NewWeightedScorer(scorerB, 3)).
+	profile := NewSchedulerProfile(WithScorerTracing(true)).
 		WithPicker(&firstEndpointPicker{typedName: fwkplugin.TypedName{Type: "test-picker", Name: "picker"}})
+	if err := profile.AddPlugins(NewWeightedScorer(scorerA, 2), NewWeightedScorer(scorerB, 3)); err != nil {
+		t.Fatalf("AddPlugins() error = %v", err)
+	}
+	if _, ok := profile.scorers[0].Scorer.(*TracedScorer); !ok {
+		t.Fatal("profile scorer was not wrapped at profile creation")
+	}
+	if _, ok := profile.scorers[1].Scorer.(*TracedScorer); !ok {
+		t.Fatal("profile scorer was not wrapped at profile creation")
+	}
 
-	ctx, rootSpan := schedulerTracer().Start(context.Background(), "gateway.request_orchestration")
-	_, err := profile.Run(ctx, &fwksched.InferenceRequest{RequestID: "request-1", TargetModel: "model-a"}, testEndpoints())
+	ctx, rootSpan := tracing.Tracer(TracerScope).Start(context.Background(), "gateway_request_orchestration")
+	_, err := profile.Run(ctx, &fwksched.InferenceRequest{RequestID: "request-1", TargetModel: "model-a"}, newTestEndpoints("pod-a", "pod-b", "pod-c"))
 	rootSpan.End()
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	spans := exporter.GetSpans()
-	root := findSpan(t, spans, "gateway.request_orchestration")
-	schedule := findSpan(t, spans, scheduleSpanName)
-	scorerASpan := findSpan(t, spans, scorerSpanNamePrefix+"type-a")
-	scorerBSpan := findSpan(t, spans, scorerSpanNamePrefix+"type-b")
+	spans := recorder.Ended()
+	root := findSpan(t, spans, "gateway_request_orchestration")
+	scorerASpan := findScorerSpan(t, spans, "type-a", "scorer-a")
+	scorerBSpan := findScorerSpan(t, spans, "type-b", "scorer-b")
 
-	if schedule.Parent.SpanID() != root.SpanContext.SpanID() {
-		t.Fatalf("schedule span parent = %s, want %s", schedule.Parent.SpanID(), root.SpanContext.SpanID())
+	if scorerASpan.Parent().SpanID() != root.SpanContext().SpanID() {
+		t.Fatalf("scorer A span parent = %s, want %s", scorerASpan.Parent().SpanID(), root.SpanContext().SpanID())
 	}
-	if scorerASpan.Parent.SpanID() != schedule.SpanContext.SpanID() {
-		t.Fatalf("scorer A span parent = %s, want %s", scorerASpan.Parent.SpanID(), schedule.SpanContext.SpanID())
+	if scorerBSpan.Parent().SpanID() != root.SpanContext().SpanID() {
+		t.Fatalf("scorer B span parent = %s, want %s", scorerBSpan.Parent().SpanID(), root.SpanContext().SpanID())
 	}
-	if scorerBSpan.Parent.SpanID() != schedule.SpanContext.SpanID() {
-		t.Fatalf("scorer B span parent = %s, want %s", scorerBSpan.Parent.SpanID(), schedule.SpanContext.SpanID())
+	if scorerA.activeSpan.SpanID() != scorerASpan.SpanContext().SpanID() {
+		t.Fatalf("scorer A active span = %s, want %s", scorerA.activeSpan.SpanID(), scorerASpan.SpanContext().SpanID())
 	}
-	if scorerA.activeSpan.SpanID() != scorerASpan.SpanContext.SpanID() {
-		t.Fatalf("scorer A active span = %s, want %s", scorerA.activeSpan.SpanID(), scorerASpan.SpanContext.SpanID())
+	if scorerB.activeSpan.SpanID() != scorerBSpan.SpanContext().SpanID() {
+		t.Fatalf("scorer B active span = %s, want %s", scorerB.activeSpan.SpanID(), scorerBSpan.SpanContext().SpanID())
 	}
-	if scorerB.activeSpan.SpanID() != scorerBSpan.SpanContext.SpanID() {
-		t.Fatalf("scorer B active span = %s, want %s", scorerB.activeSpan.SpanID(), scorerBSpan.SpanContext.SpanID())
+	if scorerASpan.InstrumentationScope().Name != TracerScope {
+		t.Fatalf("scorer span scope = %q, want %q", scorerASpan.InstrumentationScope().Name, TracerScope)
 	}
 
 	attrsA := spanAttributes(scorerASpan)
 	assertStringAttribute(t, attrsA, scorerTypeAttribute, "type-a")
 	assertStringAttribute(t, attrsA, scorerNameAttribute, "scorer-a")
 	assertFloatAttribute(t, attrsA, scorerWeightAttribute, 2)
+	assertStringAttribute(t, attrsA, "gen_ai.request.model", "model-a")
+	assertStringAttribute(t, attrsA, "gen_ai.request.id", "request-1")
 
 	attrsB := spanAttributes(scorerBSpan)
 	assertStringAttribute(t, attrsB, scorerTypeAttribute, "type-b")
@@ -91,7 +97,7 @@ func TestSchedulerProfileCreatesScheduleAndScorerSpans(t *testing.T) {
 }
 
 func TestTracedScorerRecordsScoreAttributes(t *testing.T) {
-	exporter := installTraceExporter(t)
+	recorder := setupSpanRecorder(t)
 
 	scorer := &recordingScorer{
 		typedName: fwkplugin.TypedName{Type: "score-type", Name: "score-name"},
@@ -100,13 +106,13 @@ func TestTracedScorerRecordsScoreAttributes(t *testing.T) {
 	scores := NewTracedScorer(scorer, 4).Score(
 		context.Background(),
 		&fwksched.InferenceRequest{RequestID: "request-2", TargetModel: "model-b"},
-		testEndpoints(),
+		newTestEndpoints("pod-a", "pod-b", "pod-c"),
 	)
 	if len(scores) != 3 {
 		t.Fatalf("Score() returned %d scores, want 3", len(scores))
 	}
 
-	span := findSpan(t, exporter.GetSpans(), scorerSpanNamePrefix+"score-type")
+	span := findSpan(t, recorder.Ended(), scorerSpanName)
 	attrs := spanAttributes(span)
 
 	assertOnlyAttributes(t, span, []attribute.Key{
@@ -117,6 +123,8 @@ func TestTracedScorerRecordsScoreAttributes(t *testing.T) {
 		scorerEndpointsAttribute,
 		scorerMaxScoreAttribute,
 		scorerAverageScoreAttribute,
+		"gen_ai.request.model",
+		"gen_ai.request.id",
 	})
 	assertStringAttribute(t, attrs, scorerTypeAttribute, "score-type")
 	assertStringAttribute(t, attrs, scorerNameAttribute, "score-name")
@@ -125,14 +133,16 @@ func TestTracedScorerRecordsScoreAttributes(t *testing.T) {
 	assertIntAttribute(t, attrs, scorerEndpointsAttribute, 3)
 	assertFloatAttribute(t, attrs, scorerMaxScoreAttribute, 0.9)
 	assertFloatAttribute(t, attrs, scorerAverageScoreAttribute, 0.5)
+	assertStringAttribute(t, attrs, "gen_ai.request.model", "model-b")
+	assertStringAttribute(t, attrs, "gen_ai.request.id", "request-2")
 }
 
-func TestSchedulerProfileWithZeroScorersCreatesOnlyScheduleSpan(t *testing.T) {
-	exporter := installTraceExporter(t)
+func TestSchedulerProfileWithZeroScorersCreatesNoScorerSpans(t *testing.T) {
+	recorder := setupSpanRecorder(t)
 
-	profile := NewSchedulerProfile().
+	profile := NewSchedulerProfile(WithScorerTracing(true)).
 		WithPicker(&firstEndpointPicker{typedName: fwkplugin.TypedName{Type: "test-picker", Name: "picker"}})
-	endpoints := testEndpoints()[:2]
+	endpoints := newTestEndpoints("pod-a", "pod-b")
 
 	weightedScores := profile.runScorerPlugins(context.Background(), &fwksched.InferenceRequest{RequestID: "request-3"}, endpoints)
 	if len(weightedScores) != len(endpoints) {
@@ -148,13 +158,39 @@ func TestSchedulerProfileWithZeroScorersCreatesOnlyScheduleSpan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
+	if spans := findSpans(recorder.Ended(), scorerSpanName); len(spans) != 0 {
+		t.Fatalf("got %d scorer spans, want 0", len(spans))
+	}
+}
 
-	spans := exporter.GetSpans()
-	findSpan(t, spans, scheduleSpanName)
-	for _, span := range spans {
-		if strings.HasPrefix(span.Name, scorerSpanNamePrefix) {
-			t.Fatalf("unexpected scorer span %q", span.Name)
-		}
+func TestSchedulerProfileWithScorerTracingDisabledDoesNotWrapScorers(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+
+	scorer := &recordingScorer{
+		typedName: fwkplugin.TypedName{Type: "disabled-type", Name: "disabled-name"},
+		scores:    []float64{0.4},
+	}
+	profile := NewSchedulerProfile(WithScorerTracing(false)).
+		WithScorers(NewWeightedScorer(scorer, 2))
+	if _, ok := profile.scorers[0].Scorer.(*TracedScorer); ok {
+		t.Fatal("profile scorer was wrapped with tracing disabled")
+	}
+	endpoints := newTestEndpoints("pod-a")
+
+	ctx, rootSpan := otel.Tracer("test").Start(context.Background(), "root")
+	weightedScores := profile.runScorerPlugins(ctx, &fwksched.InferenceRequest{RequestID: "request-4"}, endpoints)
+	rootSpan.End()
+	if scorer.callCount != 1 {
+		t.Fatalf("Score() call count = %d, want 1", scorer.callCount)
+	}
+	if math.Abs(weightedScores[endpoints[0]]-0.8) > 1e-9 {
+		t.Fatalf("weighted score = %v, want 0.8", weightedScores[endpoints[0]])
+	}
+	if scorer.activeSpan.SpanID() != rootSpan.SpanContext().SpanID() {
+		t.Fatalf("scorer active span = %s, want root span %s", scorer.activeSpan.SpanID(), rootSpan.SpanContext().SpanID())
+	}
+	if spans := findSpans(recorder.Ended(), scorerSpanName); len(spans) != 0 {
+		t.Fatalf("got %d scorer spans, want 0", len(spans))
 	}
 }
 
@@ -169,11 +205,11 @@ func TestTracedScorerNoopTracerProvider(t *testing.T) {
 		typedName: fwkplugin.TypedName{Type: "noop-type", Name: "noop-name"},
 		scores:    []float64{0.4},
 	}
-	profile := NewSchedulerProfile().
+	profile := NewSchedulerProfile(WithScorerTracing(true)).
 		WithScorers(NewWeightedScorer(scorer, 2))
-	endpoints := testEndpoints()[:1]
+	endpoints := newTestEndpoints("pod-a")
 
-	weightedScores := profile.runScorerPlugins(context.Background(), &fwksched.InferenceRequest{RequestID: "request-4"}, endpoints)
+	weightedScores := profile.runScorerPlugins(context.Background(), &fwksched.InferenceRequest{RequestID: "request-5"}, endpoints)
 	if scorer.callCount != 1 {
 		t.Fatalf("Score() call count = %d, want 1", scorer.callCount)
 	}
@@ -224,66 +260,50 @@ func (p *firstEndpointPicker) Pick(_ context.Context, scoredEndpoints []*fwksche
 	return &fwksched.ProfileRunResult{TargetEndpoints: []fwksched.Endpoint{scoredEndpoints[0]}}
 }
 
-func testEndpoints() []fwksched.Endpoint {
-	return []fwksched.Endpoint{
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-a"}}, nil, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-b"}}, nil, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-c"}}, nil, nil),
-	}
-}
-
-func installTraceExporter(t *testing.T) *tracetest.InMemoryExporter {
+func findScorerSpan(t *testing.T, spans []sdktrace.ReadOnlySpan, scorerType, scorerName string) sdktrace.ReadOnlySpan {
 	t.Helper()
-	exporter := tracetest.NewInMemoryExporter()
-	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	previous := otel.GetTracerProvider()
-	otel.SetTracerProvider(provider)
-	t.Cleanup(func() {
-		_ = provider.Shutdown(context.Background())
-		otel.SetTracerProvider(previous)
-	})
-	return exporter
+	for _, span := range findSpans(spans, scorerSpanName) {
+		attrs := spanAttributes(span)
+		if attrs[scorerTypeAttribute].AsString() == scorerType && attrs[scorerNameAttribute].AsString() == scorerName {
+			return span
+		}
+	}
+	t.Fatalf("scorer span %q/%q not found in %v", scorerType, scorerName, spanNames(spans))
+	return nil
 }
 
-func findSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+func findSpan(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
 	t.Helper()
 	for _, span := range spans {
-		if span.Name == name {
+		if span.Name() == name {
 			return span
 		}
 	}
 	t.Fatalf("span %q not found in %v", name, spanNames(spans))
-	return tracetest.SpanStub{}
+	return nil
 }
 
-func spanNames(spans tracetest.SpanStubs) []string {
+func spanNames(spans []sdktrace.ReadOnlySpan) []string {
 	names := make([]string, 0, len(spans))
 	for _, span := range spans {
-		names = append(names, span.Name)
+		names = append(names, span.Name())
 	}
 	return names
 }
 
-func spanAttributes(span tracetest.SpanStub) map[attribute.Key]attribute.Value {
-	attrs := make(map[attribute.Key]attribute.Value, len(span.Attributes))
-	for _, attr := range span.Attributes {
-		attrs[attr.Key] = attr.Value
-	}
-	return attrs
-}
-
-func assertOnlyAttributes(t *testing.T, span tracetest.SpanStub, keys []attribute.Key) {
+func assertOnlyAttributes(t *testing.T, span sdktrace.ReadOnlySpan, keys []attribute.Key) {
 	t.Helper()
 	expected := make(map[attribute.Key]struct{}, len(keys))
 	for _, key := range keys {
 		expected[key] = struct{}{}
 	}
-	if len(span.Attributes) != len(expected) {
-		t.Fatalf("span %q has %d attributes, want %d: %v", span.Name, len(span.Attributes), len(expected), span.Attributes)
+	attrs := span.Attributes()
+	if len(attrs) != len(expected) {
+		t.Fatalf("span %q has %d attributes, want %d: %v", span.Name(), len(attrs), len(expected), attrs)
 	}
-	for _, attr := range span.Attributes {
+	for _, attr := range attrs {
 		if _, ok := expected[attr.Key]; !ok {
-			t.Fatalf("span %q has unexpected attribute %q", span.Name, attr.Key)
+			t.Fatalf("span %q has unexpected attribute %q", span.Name(), attr.Key)
 		}
 	}
 }

--- a/pkg/epp/scheduling/traced_scorer_test.go
+++ b/pkg/epp/scheduling/traced_scorer_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+func TestSchedulerProfileCreatesScheduleAndScorerSpans(t *testing.T) {
+	exporter := installTraceExporter(t)
+
+	scorerA := &recordingScorer{
+		typedName: fwkplugin.TypedName{Type: "type-a", Name: "scorer-a"},
+		scores:    []float64{0.25, 0.75},
+	}
+	scorerB := &recordingScorer{
+		typedName: fwkplugin.TypedName{Type: "type-b", Name: "scorer-b"},
+		scores:    []float64{0.5, 0.4},
+	}
+	profile := NewSchedulerProfile().
+		WithScorers(NewWeightedScorer(scorerA, 2), NewWeightedScorer(scorerB, 3)).
+		WithPicker(&firstEndpointPicker{typedName: fwkplugin.TypedName{Type: "test-picker", Name: "picker"}})
+
+	ctx, rootSpan := schedulerTracer().Start(context.Background(), "gateway.request_orchestration")
+	_, err := profile.Run(ctx, &fwksched.InferenceRequest{RequestID: "request-1", TargetModel: "model-a"}, testEndpoints())
+	rootSpan.End()
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	root := findSpan(t, spans, "gateway.request_orchestration")
+	schedule := findSpan(t, spans, scheduleSpanName)
+	scorerASpan := findSpan(t, spans, scorerSpanNamePrefix+"type-a")
+	scorerBSpan := findSpan(t, spans, scorerSpanNamePrefix+"type-b")
+
+	if schedule.Parent.SpanID() != root.SpanContext.SpanID() {
+		t.Fatalf("schedule span parent = %s, want %s", schedule.Parent.SpanID(), root.SpanContext.SpanID())
+	}
+	if scorerASpan.Parent.SpanID() != schedule.SpanContext.SpanID() {
+		t.Fatalf("scorer A span parent = %s, want %s", scorerASpan.Parent.SpanID(), schedule.SpanContext.SpanID())
+	}
+	if scorerBSpan.Parent.SpanID() != schedule.SpanContext.SpanID() {
+		t.Fatalf("scorer B span parent = %s, want %s", scorerBSpan.Parent.SpanID(), schedule.SpanContext.SpanID())
+	}
+	if scorerA.activeSpan.SpanID() != scorerASpan.SpanContext.SpanID() {
+		t.Fatalf("scorer A active span = %s, want %s", scorerA.activeSpan.SpanID(), scorerASpan.SpanContext.SpanID())
+	}
+	if scorerB.activeSpan.SpanID() != scorerBSpan.SpanContext.SpanID() {
+		t.Fatalf("scorer B active span = %s, want %s", scorerB.activeSpan.SpanID(), scorerBSpan.SpanContext.SpanID())
+	}
+
+	attrsA := spanAttributes(scorerASpan)
+	assertStringAttribute(t, attrsA, scorerTypeAttribute, "type-a")
+	assertStringAttribute(t, attrsA, scorerNameAttribute, "scorer-a")
+	assertFloatAttribute(t, attrsA, scorerWeightAttribute, 2)
+
+	attrsB := spanAttributes(scorerBSpan)
+	assertStringAttribute(t, attrsB, scorerTypeAttribute, "type-b")
+	assertStringAttribute(t, attrsB, scorerNameAttribute, "scorer-b")
+	assertFloatAttribute(t, attrsB, scorerWeightAttribute, 3)
+}
+
+func TestTracedScorerRecordsScoreAttributes(t *testing.T) {
+	exporter := installTraceExporter(t)
+
+	scorer := &recordingScorer{
+		typedName: fwkplugin.TypedName{Type: "score-type", Name: "score-name"},
+		scores:    []float64{0.1, 0.5, 0.9},
+	}
+	scores := NewTracedScorer(scorer, 4).Score(
+		context.Background(),
+		&fwksched.InferenceRequest{RequestID: "request-2", TargetModel: "model-b"},
+		testEndpoints(),
+	)
+	if len(scores) != 3 {
+		t.Fatalf("Score() returned %d scores, want 3", len(scores))
+	}
+
+	span := findSpan(t, exporter.GetSpans(), scorerSpanNamePrefix+"score-type")
+	attrs := spanAttributes(span)
+
+	assertOnlyAttributes(t, span, []attribute.Key{
+		scorerTypeAttribute,
+		scorerNameAttribute,
+		scorerWeightAttribute,
+		scorerCandidateAttribute,
+		scorerEndpointsAttribute,
+		scorerMaxScoreAttribute,
+		scorerAverageScoreAttribute,
+	})
+	assertStringAttribute(t, attrs, scorerTypeAttribute, "score-type")
+	assertStringAttribute(t, attrs, scorerNameAttribute, "score-name")
+	assertFloatAttribute(t, attrs, scorerWeightAttribute, 4)
+	assertIntAttribute(t, attrs, scorerCandidateAttribute, 3)
+	assertIntAttribute(t, attrs, scorerEndpointsAttribute, 3)
+	assertFloatAttribute(t, attrs, scorerMaxScoreAttribute, 0.9)
+	assertFloatAttribute(t, attrs, scorerAverageScoreAttribute, 0.5)
+}
+
+func TestSchedulerProfileWithZeroScorersCreatesOnlyScheduleSpan(t *testing.T) {
+	exporter := installTraceExporter(t)
+
+	profile := NewSchedulerProfile().
+		WithPicker(&firstEndpointPicker{typedName: fwkplugin.TypedName{Type: "test-picker", Name: "picker"}})
+	endpoints := testEndpoints()[:2]
+
+	weightedScores := profile.runScorerPlugins(context.Background(), &fwksched.InferenceRequest{RequestID: "request-3"}, endpoints)
+	if len(weightedScores) != len(endpoints) {
+		t.Fatalf("runScorerPlugins() returned %d endpoints, want %d", len(weightedScores), len(endpoints))
+	}
+	for _, endpoint := range endpoints {
+		if weightedScores[endpoint] != 0 {
+			t.Fatalf("runScorerPlugins() score = %v, want 0", weightedScores[endpoint])
+		}
+	}
+
+	_, err := profile.Run(context.Background(), &fwksched.InferenceRequest{RequestID: "request-3"}, endpoints)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	findSpan(t, spans, scheduleSpanName)
+	for _, span := range spans {
+		if strings.HasPrefix(span.Name, scorerSpanNamePrefix) {
+			t.Fatalf("unexpected scorer span %q", span.Name)
+		}
+	}
+}
+
+func TestTracedScorerNoopTracerProvider(t *testing.T) {
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+	})
+
+	scorer := &recordingScorer{
+		typedName: fwkplugin.TypedName{Type: "noop-type", Name: "noop-name"},
+		scores:    []float64{0.4},
+	}
+	profile := NewSchedulerProfile().
+		WithScorers(NewWeightedScorer(scorer, 2))
+	endpoints := testEndpoints()[:1]
+
+	weightedScores := profile.runScorerPlugins(context.Background(), &fwksched.InferenceRequest{RequestID: "request-4"}, endpoints)
+	if scorer.callCount != 1 {
+		t.Fatalf("Score() call count = %d, want 1", scorer.callCount)
+	}
+	if math.Abs(weightedScores[endpoints[0]]-0.8) > 1e-9 {
+		t.Fatalf("weighted score = %v, want 0.8", weightedScores[endpoints[0]])
+	}
+}
+
+type recordingScorer struct {
+	typedName  fwkplugin.TypedName
+	scores     []float64
+	callCount  int
+	activeSpan trace.SpanContext
+}
+
+func (s *recordingScorer) TypedName() fwkplugin.TypedName {
+	return s.typedName
+}
+
+func (s *recordingScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Distribution
+}
+
+func (s *recordingScorer) Score(ctx context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	s.callCount++
+	s.activeSpan = trace.SpanFromContext(ctx).SpanContext()
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
+	for i, endpoint := range endpoints {
+		if i < len(s.scores) {
+			scores[endpoint] = s.scores[i]
+		}
+	}
+	return scores
+}
+
+type firstEndpointPicker struct {
+	typedName fwkplugin.TypedName
+}
+
+func (p *firstEndpointPicker) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+func (p *firstEndpointPicker) Pick(_ context.Context, scoredEndpoints []*fwksched.ScoredEndpoint) *fwksched.ProfileRunResult {
+	if len(scoredEndpoints) == 0 {
+		return &fwksched.ProfileRunResult{}
+	}
+	return &fwksched.ProfileRunResult{TargetEndpoints: []fwksched.Endpoint{scoredEndpoints[0]}}
+}
+
+func testEndpoints() []fwksched.Endpoint {
+	return []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-a"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-b"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-c"}}, nil, nil),
+	}
+}
+
+func installTraceExporter(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previous)
+	})
+	return exporter
+}
+
+func findSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+	for _, span := range spans {
+		if span.Name == name {
+			return span
+		}
+	}
+	t.Fatalf("span %q not found in %v", name, spanNames(spans))
+	return tracetest.SpanStub{}
+}
+
+func spanNames(spans tracetest.SpanStubs) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name)
+	}
+	return names
+}
+
+func spanAttributes(span tracetest.SpanStub) map[attribute.Key]attribute.Value {
+	attrs := make(map[attribute.Key]attribute.Value, len(span.Attributes))
+	for _, attr := range span.Attributes {
+		attrs[attr.Key] = attr.Value
+	}
+	return attrs
+}
+
+func assertOnlyAttributes(t *testing.T, span tracetest.SpanStub, keys []attribute.Key) {
+	t.Helper()
+	expected := make(map[attribute.Key]struct{}, len(keys))
+	for _, key := range keys {
+		expected[key] = struct{}{}
+	}
+	if len(span.Attributes) != len(expected) {
+		t.Fatalf("span %q has %d attributes, want %d: %v", span.Name, len(span.Attributes), len(expected), span.Attributes)
+	}
+	for _, attr := range span.Attributes {
+		if _, ok := expected[attr.Key]; !ok {
+			t.Fatalf("span %q has unexpected attribute %q", span.Name, attr.Key)
+		}
+	}
+}
+
+func assertStringAttribute(t *testing.T, attrs map[attribute.Key]attribute.Value, key attribute.Key, want string) {
+	t.Helper()
+	value, ok := attrs[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	if got := value.AsString(); got != want {
+		t.Fatalf("attribute %q = %q, want %q", key, got, want)
+	}
+}
+
+func assertIntAttribute(t *testing.T, attrs map[attribute.Key]attribute.Value, key attribute.Key, want int64) {
+	t.Helper()
+	value, ok := attrs[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	if got := value.AsInt64(); got != want {
+		t.Fatalf("attribute %q = %d, want %d", key, got, want)
+	}
+}
+
+func assertFloatAttribute(t *testing.T, attrs map[attribute.Key]attribute.Value, key attribute.Key, want float64) {
+	t.Helper()
+	value, ok := attrs[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	if got := value.AsFloat64(); math.Abs(got-want) > 1e-9 {
+		t.Fatalf("attribute %q = %f, want %f", key, got, want)
+	}
+}


### PR DESCRIPTION
/kind feature

## Summary

Adds fine-grained OpenTelemetry spans to the EPP scheduling and scoring pipeline so operators can see per-scorer timing and the parent scheduling span in traces.

## Why this matters

Scheduling and scoring (`SchedulerProfile.Run` / `runScorerPlugins`) had no tracing, so per-scorer latency was invisible in traces (#1483). This wraps `SchedulerProfile.Run` in a parent scheduling span and adds a shared tracing wrapper (`traced_scorer.go`) that instruments each scorer plugin, reusing the existing OTel tracer that `director.go` already sets up for the `request_orchestration` span. It covers the parent scheduling span and the shared per-scorer wrapper (deliverables 1 and 2); migrating the existing prefix-cache span and ext_proc context propagation (3 and 4), plus the naming/flow-control question from the thread, are left as follow-ups.

## Testing

- Added `traced_scorer_test.go`; `go build ./pkg/epp/...` passes.

## Release note

```release-note
Add OpenTelemetry spans for the scheduling/scoring pipeline (parent scheduling span and per-scorer spans).
```

Refs #1483
