### PR TITLE
feat(epp): add modality label to multimodal encoder-cache metrics

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/attribute/multimodal/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/multimodal/data_types.go
@@ -32,6 +32,8 @@ var (
 type MatchItem struct {
 	Hash string
 	Size int
+	// Modality is emitted as a metric label.
+	Modality string
 }
 
 // EncoderCacheMatchInfo carries endpoint-local multimodal cache match data.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
@@ -36,7 +36,7 @@ var (
 			Name:      "encoder_cache_queries_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups made against the encoder-cache affinity LRU.", compbasemetrics.ALPHA),
 		},
-		[]string{"plugin_type", "plugin_name"},
+		[]string{"plugin_type", "plugin_name", "modality"},
 	)
 
 	// encoderCacheHitsTotal counts the subset of encoder_cache_queries_total where
@@ -48,7 +48,7 @@ var (
 			Name:      "encoder_cache_hits_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups that found a match in the encoder-cache affinity LRU, by endpoint.", compbasemetrics.ALPHA),
 		},
-		[]string{"plugin_type", "plugin_name", "pod"},
+		[]string{"plugin_type", "plugin_name", "pod", "modality"},
 	)
 
 	registerOnce sync.Once

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	attrmm "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/multimodal"
 )
 
@@ -33,31 +34,32 @@ func TestRecordItemLookupsMetrics(t *testing.T) {
 
 	pod := k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"}
 	podKey := pod.String()
+	img := string(fwkrh.ModalityImage)
 
-	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName))
-	initialHits := testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey))
+	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName, img))
+	initialHits := testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey, img))
 
 	// Case 1: Cache Misses
 	items := []attrmm.MatchItem{
-		{Hash: "hash-1", Size: 1},
-		{Hash: "hash-2", Size: 1},
+		{Hash: "hash-1", Size: 1, Modality: img},
+		{Hash: "hash-2", Size: 1, Modality: img},
 	}
 	producer.recordItemLookups(items)
 
-	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName)))
-	assert.Equal(t, initialHits, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey)))
+	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName, img)))
+	assert.Equal(t, initialHits, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey, img)))
 
 	// Case 2: Cache Hits (add one to cache first)
 	producer.putCacheEntry("hash-1", pod)
 
 	items = []attrmm.MatchItem{
-		{Hash: "hash-1", Size: 1}, // Hit
-		{Hash: "hash-3", Size: 1}, // Miss
+		{Hash: "hash-1", Size: 1, Modality: img}, // Hit
+		{Hash: "hash-3", Size: 1, Modality: img}, // Miss
 	}
 	producer.recordItemLookups(items)
 
-	assert.Equal(t, initialQueries+4, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName)))
-	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey)))
+	assert.Equal(t, initialQueries+4, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName, img)))
+	assert.Equal(t, initialHits+1, testutil.ToFloat64(encoderCacheHitsTotal.WithLabelValues(ProducerType, testName, podKey, img)))
 }
 
 func TestRegisterEncoderCacheMetrics(t *testing.T) {
@@ -73,11 +75,12 @@ func TestRegisterEncoderCacheMetrics(t *testing.T) {
 func TestProduceRecordsMetrics(t *testing.T) {
 	producer := newTestProducer(t, nil, nil)
 	request := requestWithHashes("req-1", map[string]int{"hash-1": 1, "hash-2": 1})
+	img := string(fwkrh.ModalityImage)
 
-	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName))
+	initialQueries := testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName, img))
 
 	// Produce should call recordItemLookups
 	require.NoError(t, producer.Produce(context.Background(), request, nil))
 
-	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName)))
+	assert.Equal(t, initialQueries+2, testutil.ToFloat64(encoderCacheQueriesTotal.WithLabelValues(ProducerType, testName, img)))
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -232,13 +232,13 @@ func ExtractMMItems(request *scheduling.InferenceRequest) []attrmm.MatchItem {
 		if feature.Hash == "" {
 			continue
 		}
-		addItem(itemsByHash, feature.Hash)
+		addItem(itemsByHash, feature.Hash, string(feature.Modality))
 	}
 	return itemSlice(itemsByHash)
 }
 
-func addItem(itemsByHash map[string]attrmm.MatchItem, hash string) {
-	itemsByHash[hash] = attrmm.MatchItem{Hash: hash, Size: 1}
+func addItem(itemsByHash map[string]attrmm.MatchItem, hash, modality string) {
+	itemsByHash[hash] = attrmm.MatchItem{Hash: hash, Size: 1, Modality: modality}
 }
 
 func itemSlice(itemsByHash map[string]attrmm.MatchItem) []attrmm.MatchItem {
@@ -260,10 +260,10 @@ func (p *Producer) recordItemLookups(items []attrmm.MatchItem) {
 	defer p.mutex.RUnlock()
 	pluginType, pluginName := p.typedName.Type, p.typedName.Name
 	for _, item := range items {
-		encoderCacheQueriesTotal.WithLabelValues(pluginType, pluginName).Inc()
+		encoderCacheQueriesTotal.WithLabelValues(pluginType, pluginName, item.Modality).Inc()
 		for pod, podCache := range p.caches {
 			if podCache.Contains(item.Hash) {
-				encoderCacheHitsTotal.WithLabelValues(pluginType, pluginName, pod).Inc()
+				encoderCacheHitsTotal.WithLabelValues(pluginType, pluginName, pod, item.Modality).Inc()
 			}
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -58,15 +58,18 @@ func TestExtractMMItemsFromTokenizedPrompt(t *testing.T) {
 		Body: &fwkrh.InferenceRequestBody{
 			TokenizedPrompt: &fwkrh.TokenizedPrompt{
 				MultiModalFeatures: []fwkrh.MultiModalFeature{
-					{Hash: "image-a", Length: 576},
-					{Hash: "image-b", Length: 0},
-					{Hash: "image-a", Length: 144},
+					{Modality: fwkrh.ModalityImage, Hash: "image-a", Length: 576},
+					{Modality: fwkrh.ModalityImage, Hash: "image-b", Length: 0},
+					{Modality: fwkrh.ModalityImage, Hash: "image-a", Length: 144},
 				},
 			},
 		},
 	})
 
-	assert.ElementsMatch(t, []attrmm.MatchItem{{Hash: "image-a", Size: 1}, {Hash: "image-b", Size: 1}}, items)
+	assert.ElementsMatch(t, []attrmm.MatchItem{
+		{Hash: "image-a", Size: 1, Modality: string(fwkrh.ModalityImage)},
+		{Hash: "image-b", Size: 1, Modality: string(fwkrh.ModalityImage)},
+	}, items)
 }
 
 func TestExtractMMItemsNilTokenizedPromptReturnsNil(t *testing.T) {
@@ -118,15 +121,16 @@ func TestProduceMatchesMultiplePodsAndPreRequestUpdatesPlacement(t *testing.T) {
 
 	require.NoError(t, producer.Produce(context.Background(), request, []scheduling.Endpoint{endpointA, endpointB, endpointC}))
 
+	img := string(fwkrh.ModalityImage)
 	assertMatchInfo(t, producer, endpointA,
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}},
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}, {Hash: "hash-c", Size: 1}})
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}},
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}, {Hash: "hash-c", Size: 1, Modality: img}})
 	assertMatchInfo(t, producer, endpointB,
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}},
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}, {Hash: "hash-c", Size: 1}})
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}},
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}, {Hash: "hash-c", Size: 1, Modality: img}})
 	assertMatchInfo(t, producer, endpointC,
 		nil,
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}, {Hash: "hash-c", Size: 1}})
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}, {Hash: "hash-c", Size: 1, Modality: img}})
 
 	producer.PreRequest(context.Background(), request, schedulingResult(endpointC))
 	producer.wg.Wait()
@@ -171,12 +175,13 @@ func TestStalePodCleanup(t *testing.T) {
 	endpointB := newEndpoint(podB)
 	require.NoError(t, producer.Produce(context.Background(), requestWithHashes("req", map[string]int{"hash-a": 1}), []scheduling.Endpoint{endpointA, endpointB}))
 
+	img := string(fwkrh.ModalityImage)
 	assertMatchInfo(t, producer, endpointA,
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}},
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}})
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}},
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}})
 	assertMatchInfo(t, producer, endpointB,
 		nil,
-		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1}})
+		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}})
 }
 
 func TestProducerEndpointExtractorInterfaceContract(t *testing.T) {
@@ -256,7 +261,7 @@ func newEndpoint(name k8stypes.NamespacedName) scheduling.Endpoint {
 func requestWithHashes(requestID string, hashToWeight map[string]int) *scheduling.InferenceRequest {
 	features := make([]fwkrh.MultiModalFeature, 0, len(hashToWeight))
 	for hash, weight := range hashToWeight {
-		features = append(features, fwkrh.MultiModalFeature{Hash: hash, Length: weight})
+		features = append(features, fwkrh.MultiModalFeature{Modality: fwkrh.ModalityImage, Hash: hash, Length: weight})
 	}
 	return &scheduling.InferenceRequest{
 		RequestID: requestID,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a `modality` label to `encoder_cache_queries_total` and `encoder_cache_hits_total`. Threads `MultiModalFeature.Modality` through `MatchItem` and `recordItemLookups`. Forward-compat: call sites currently hardcode `ModalityImage`; the label reads `image` until upstream sources it from vLLM's `/render` response keys.

Cardinality: `modality` is a closed enum (at most 3 values), so the multiplier on existing series is bounded at 3x.

**Which issue(s) this PR fixes**:

Fixes #1535

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP: added `modality` label to encoder_cache_queries_total and encoder_cache_hits_total.
```
