### PR TITLE
fix(tracing): unify tracer scope and version metadata

### DIFF
--- a/pkg/common/observability/tracing/telemetry.go
+++ b/pkg/common/observability/tracing/telemetry.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
@@ -132,7 +133,19 @@ func initTraceExporter(ctx context.Context, logger logr.Logger) (sdktrace.SpanEx
 
 const instrumentationName = "llm-d-router"
 
-// Tracer returns a tracer for the llm-d router.
-func Tracer() trace.Tracer {
-	return otel.Tracer(instrumentationName)
+// Tracer returns a tracer for the given instrumentation scope, defaulting to
+// "llm-d-router". Build version and commit SHA are attached so every span in a
+// trace carries consistent scope metadata.
+func Tracer(scope ...string) trace.Tracer {
+	name := instrumentationName
+	if len(scope) > 0 && scope[0] != "" {
+		name = scope[0]
+	}
+	return otel.Tracer(
+		name,
+		trace.WithInstrumentationVersion(version.BuildRef),
+		trace.WithInstrumentationAttributes(
+			attribute.String("commit-sha", version.CommitSHA),
+		),
+	)
 }

--- a/pkg/common/observability/tracing/telemetry_test.go
+++ b/pkg/common/observability/tracing/telemetry_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/llm-d/llm-d-router/version"
+)
+
+func TestTracer(t *testing.T) {
+	const (
+		testBuildRef  = "test-build-ref"
+		testCommitSHA = "test-commit-sha"
+	)
+
+	origBuildRef, origCommitSHA := version.BuildRef, version.CommitSHA
+	version.BuildRef, version.CommitSHA = testBuildRef, testCommitSHA
+	t.Cleanup(func() {
+		version.BuildRef, version.CommitSHA = origBuildRef, origCommitSHA
+	})
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	origTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(origTP) })
+
+	tests := []struct {
+		name      string
+		scope     []string
+		wantScope string
+	}{
+		{name: "default scope", scope: nil, wantScope: instrumentationName},
+		{name: "custom scope", scope: []string{"llm-d-router/epp/extproc"}, wantScope: "llm-d-router/epp/extproc"},
+		{name: "empty scope falls back to default", scope: []string{""}, wantScope: instrumentationName},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder.Reset()
+
+			_, span := Tracer(tc.scope...).Start(context.Background(), "test-span")
+			span.End()
+
+			ended := recorder.Ended()
+			if len(ended) != 1 {
+				t.Fatalf("expected 1 recorded span, got %d", len(ended))
+			}
+
+			scope := ended[0].InstrumentationScope()
+			if scope.Name != tc.wantScope {
+				t.Errorf("scope name = %q, want %q", scope.Name, tc.wantScope)
+			}
+			if scope.Version != testBuildRef {
+				t.Errorf("scope version = %q, want %q", scope.Version, testBuildRef)
+			}
+
+			commitSHA, ok := scope.Attributes.Value(attribute.Key("commit-sha"))
+			if !ok {
+				t.Fatal("commit-sha scope attribute not set")
+			}
+			if commitSHA.AsString() != testCommitSHA {
+				t.Errorf("commit-sha = %q, want %q", commitSHA.AsString(), testCommitSHA)
+			}
+		})
+	}
+}

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -30,7 +30,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
@@ -41,6 +40,7 @@ import (
 	envoy "github.com/llm-d/llm-d-router/pkg/common/envoy"
 	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwkrequest "github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
@@ -48,7 +48,6 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
-	"github.com/llm-d/llm-d-router/version"
 )
 
 // EvictChannelLookup is an optional interface for looking up eviction channels by request ID.
@@ -220,13 +219,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 	ctx := srv.Context()
 
 	// Start tracing span for the request
-	tracer := otel.Tracer(
-		"llm-d-router/epp/extproc",
-		trace.WithInstrumentationVersion(version.BuildRef),
-		trace.WithInstrumentationAttributes(
-			attribute.String("commit-sha", version.CommitSHA),
-		),
-	)
+	tracer := tracing.Tracer("llm-d-router/epp/extproc")
 	// The server span is started in the RequestHeaders branch, once the upstream
 	// trace context carried in the incoming headers is available, so the EPP span
 	// joins the caller's trace instead of starting a disconnected root.

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,6 +37,7 @@ import (
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
 	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
@@ -231,7 +231,7 @@ func (d *Director) getInferenceObjective(ctx context.Context, reqCtx *handlers.R
 // HandleRequest orchestrates the request lifecycle.
 // It always returns the requestContext even in the error case, as the request context is used in error handling.
 func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (*handlers.RequestContext, error) {
-	tracer := otel.Tracer("llm-d-router")
+	tracer := tracing.Tracer()
 	ctx, span := tracer.Start(ctx, "gateway.request_orchestration", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind bug

**What this PR does / why we need it**:

EPP created tracers in three inconsistent ways: the `tracing.Tracer()` helper used scope `llm-d-router` with no version, `server.go` hand-rolled`llm-d-router/epp/extproc` with the build ref and commit SHA, and `director.go` hand-rolled `llm-d-router` with no version. 

The OTel instrumentation scope (name + version + attributes) is stamped onto every span, so within a single
trace some spans carried build/version metadata and others did not, and `director.go` duplicated the scope name literal instead of going through the helper.

This routes all tracer creation through `tracing.Tracer()`:

- `Tracer()` takes an optional scope name (defaulting to `llm-d-router`) and always attaches `version.BuildRef` and the `commit-sha` attribute.
- `server.go` uses `Tracer("llm-d-router/epp/extproc")`, preserving the per-component scope name while getting version metadata from the helper.
- `director.go` uses `Tracer()`, dropping the duplicated literal and the direct `otel.Tracer` call.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1538 

/cc @ahg-g 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP trace spans now consistently carry the build version and commit SHA across all instrumentation scopes, so a full request trace can be attributed to a single build.
```
