### PR TITLE
feat(observability): add mm.modality, mm.hash_count, mm.hit to EPP scheduler spans

### DIFF
--- a/pkg/epp/framework/observability/multimodal/multimodal.go
+++ b/pkg/epp/framework/observability/multimodal/multimodal.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package multimodal provides span-attribute helpers derived from a request's
+// multimodal features. It lives under pkg/epp so the sidecar build (which only
+// pulls pkg/common) does not pick up EPP-internal imports.
+package multimodal
+
+import (
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+// ModalityNone is the mm.modality value when no multimodal content is present.
+const ModalityNone = "none"
+
+// SpanAttributes derives mm.modality and mm.hash_count from req.
+func SpanAttributes(req *scheduling.InferenceRequest) []attribute.KeyValue {
+	modality, hashCount := Summary(req)
+	return []attribute.KeyValue{
+		attribute.String("mm.modality", modality),
+		attribute.Int("mm.hash_count", hashCount),
+	}
+}
+
+// Summary returns the modality string (sorted comma-joined, or "none") and
+// hash count derived from req.
+func Summary(req *scheduling.InferenceRequest) (modality string, hashCount int) {
+	features := requestMMFeatures(req)
+	if len(features) == 0 {
+		return ModalityNone, 0
+	}
+	seen := map[string]struct{}{}
+	for _, f := range features {
+		if f.Modality == "" {
+			continue
+		}
+		seen[string(f.Modality)] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return ModalityNone, len(features)
+	}
+	modalities := make([]string, 0, len(seen))
+	for m := range seen {
+		modalities = append(modalities, m)
+	}
+	sort.Strings(modalities)
+	return strings.Join(modalities, ","), len(features)
+}
+
+func requestMMFeatures(req *scheduling.InferenceRequest) []fwkrh.MultiModalFeature {
+	if req == nil || req.Body == nil || req.Body.TokenizedPrompt == nil {
+		return nil
+	}
+	return req.Body.TokenizedPrompt.MultiModalFeatures
+}

--- a/pkg/epp/framework/observability/multimodal/multimodal_test.go
+++ b/pkg/epp/framework/observability/multimodal/multimodal_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multimodal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+func TestSummary(t *testing.T) {
+	tests := []struct {
+		name          string
+		req           *scheduling.InferenceRequest
+		wantModality  string
+		wantHashCount int
+	}{
+		{
+			name:          "nil request",
+			req:           nil,
+			wantModality:  ModalityNone,
+			wantHashCount: 0,
+		},
+		{
+			name:          "nil body",
+			req:           &scheduling.InferenceRequest{Body: nil},
+			wantModality:  ModalityNone,
+			wantHashCount: 0,
+		},
+		{
+			name:          "no tokenized prompt",
+			req:           &scheduling.InferenceRequest{Body: &fwkrh.InferenceRequestBody{}},
+			wantModality:  ModalityNone,
+			wantHashCount: 0,
+		},
+		{
+			name:          "empty multimodal features",
+			req:           requestWith(),
+			wantModality:  ModalityNone,
+			wantHashCount: 0,
+		},
+		{
+			name: "image only",
+			req: requestWith(
+				fwkrh.MultiModalFeature{Modality: fwkrh.ModalityImage, Hash: "h1"},
+				fwkrh.MultiModalFeature{Modality: fwkrh.ModalityImage, Hash: "h2"},
+			),
+			wantModality:  "image",
+			wantHashCount: 2,
+		},
+		{
+			name: "mixed modalities sorted and comma-joined",
+			req: requestWith(
+				fwkrh.MultiModalFeature{Modality: "video", Hash: "v1"},
+				fwkrh.MultiModalFeature{Modality: fwkrh.ModalityImage, Hash: "i1"},
+				fwkrh.MultiModalFeature{Modality: "audio", Hash: "a1"},
+			),
+			wantModality:  "audio,image,video",
+			wantHashCount: 3,
+		},
+		{
+			name: "missing modality strings still count toward hash_count",
+			req: requestWith(
+				fwkrh.MultiModalFeature{Hash: "h1"},
+				fwkrh.MultiModalFeature{Hash: "h2"},
+			),
+			wantModality:  ModalityNone,
+			wantHashCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modality, hashCount := Summary(tt.req)
+			assert.Equal(t, tt.wantModality, modality)
+			assert.Equal(t, tt.wantHashCount, hashCount)
+		})
+	}
+}
+
+func TestSpanAttributes(t *testing.T) {
+	attrs := SpanAttributes(requestWith(
+		fwkrh.MultiModalFeature{Modality: fwkrh.ModalityImage, Hash: "h1"},
+	))
+	assert.Len(t, attrs, 2)
+	assert.Equal(t, "mm.modality", string(attrs[0].Key))
+	assert.Equal(t, "image", attrs[0].Value.AsString())
+	assert.Equal(t, "mm.hash_count", string(attrs[1].Key))
+	assert.Equal(t, int64(1), attrs[1].Value.AsInt64())
+}
+
+func requestWith(features ...fwkrh.MultiModalFeature) *scheduling.InferenceRequest {
+	return &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{
+				MultiModalFeatures: features,
+			},
+		},
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
@@ -77,7 +77,9 @@ func (p *PrefixCacheMatchInfo) WithCachedBlockCount(cachedBlockCount int) *Prefi
 	return p
 }
 
-// WithMM attaches MM tracking. Call even when MatchBlocks=0.
+// WithMM attaches MM tracking. Call only for requests that carry MM content
+// (MatchBlocks may be 0 on a miss); leave unset for text-only so MM() stays nil
+// and consumers can tell "no MM" from "MM, zero match".
 func (p *PrefixCacheMatchInfo) WithMM(mm MMMatchInfo) *PrefixCacheMatchInfo {
 	p.mm = &mm
 	return p

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
@@ -19,6 +19,8 @@ package prefix
 import (
 	"maps"
 
+	"k8s.io/utils/ptr"
+
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	approxprefixconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/constants"
@@ -51,9 +53,15 @@ type PrefixCacheMatchInfo struct {
 	// per tier. Speculative index entries count under SpeculativeTierKey.
 	// Nil when the producer supplies no tier data.
 	cachedBlocksByTier map[string]int
+	// optional multimodal block-match attribution
+	mm *MMMatchInfo
 }
 
-func NewPrefixCacheMatchInfo(matchBlocks int, totalBlocks int, blockSizeTokens int) *PrefixCacheMatchInfo {
+type MMMatchInfo struct {
+	MatchBlocks int
+}
+
+func NewPrefixCacheMatchInfo(matchBlocks, totalBlocks, blockSizeTokens int) *PrefixCacheMatchInfo {
 	return &PrefixCacheMatchInfo{
 		matchBlocks:      matchBlocks,
 		totalBlocks:      totalBlocks,
@@ -69,17 +77,16 @@ func (p *PrefixCacheMatchInfo) WithCachedBlockCount(cachedBlockCount int) *Prefi
 	return p
 }
 
-func (p *PrefixCacheMatchInfo) MatchBlocks() int {
-	return p.matchBlocks
+// WithMM attaches MM tracking. Call even when MatchBlocks=0.
+func (p *PrefixCacheMatchInfo) WithMM(mm MMMatchInfo) *PrefixCacheMatchInfo {
+	p.mm = &mm
+	return p
 }
 
-func (p *PrefixCacheMatchInfo) TotalBlocks() int {
-	return p.totalBlocks
-}
-
-func (p *PrefixCacheMatchInfo) BlockSizeTokens() int {
-	return p.blockSizeTokens
-}
+func (p *PrefixCacheMatchInfo) MatchBlocks() int     { return p.matchBlocks }
+func (p *PrefixCacheMatchInfo) TotalBlocks() int     { return p.totalBlocks }
+func (p *PrefixCacheMatchInfo) BlockSizeTokens() int { return p.blockSizeTokens }
+func (p *PrefixCacheMatchInfo) MM() *MMMatchInfo     { return p.mm }
 
 // CachedBlockCount returns the unweighted count of contiguous cached prefix
 // blocks on the endpoint.
@@ -103,11 +110,15 @@ func (p *PrefixCacheMatchInfo) CachedBlocksByTier() map[string]int {
 }
 
 func (p *PrefixCacheMatchInfo) Clone() fwkdl.Cloneable {
-	return &PrefixCacheMatchInfo{
+	clone := &PrefixCacheMatchInfo{
 		matchBlocks:        p.matchBlocks,
 		totalBlocks:        p.totalBlocks,
 		blockSizeTokens:    p.blockSizeTokens,
 		cachedBlockCount:   p.cachedBlockCount,
 		cachedBlocksByTier: maps.Clone(p.cachedBlocksByTier),
 	}
+	if p.mm != nil {
+		clone.mm = ptr.To(*p.mm)
+	}
+	return clone
 }

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
@@ -86,3 +86,49 @@ func TestPrefixCacheMatchInfo_CloneDeepCopiesCachedBlocksByTier(t *testing.T) {
 	require.True(t, ok)
 	assert.Nil(t, nilClone.CachedBlocksByTier())
 }
+
+func TestPrefixCacheMatchInfo_MM(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      *PrefixCacheMatchInfo
+		wantMatch int
+		wantTotal int
+		wantBlock int
+		wantMM    *MMMatchInfo
+	}{
+		{
+			name:      "constructor leaves mm nil",
+			info:      NewPrefixCacheMatchInfo(5, 10, 16),
+			wantMatch: 5, wantTotal: 10, wantBlock: 16, wantMM: nil,
+		},
+		{
+			name:      "WithMM attaches non-zero",
+			info:      NewPrefixCacheMatchInfo(5, 10, 16).WithMM(MMMatchInfo{MatchBlocks: 2}),
+			wantMatch: 5, wantTotal: 10, wantBlock: 16, wantMM: &MMMatchInfo{MatchBlocks: 2},
+		},
+		{
+			name:      "WithMM(zero) attaches present-but-zero",
+			info:      NewPrefixCacheMatchInfo(5, 10, 16).WithMM(MMMatchInfo{MatchBlocks: 0}),
+			wantMatch: 5, wantTotal: 10, wantBlock: 16, wantMM: &MMMatchInfo{MatchBlocks: 0},
+		},
+		{
+			name:      "clone preserves nil mm",
+			info:      NewPrefixCacheMatchInfo(5, 10, 16).Clone().(*PrefixCacheMatchInfo),
+			wantMatch: 5, wantTotal: 10, wantBlock: 16, wantMM: nil,
+		},
+		{
+			name:      "clone preserves mm",
+			info:      NewPrefixCacheMatchInfo(7, 12, 64).WithMM(MMMatchInfo{MatchBlocks: 3}).Clone().(*PrefixCacheMatchInfo),
+			wantMatch: 7, wantTotal: 12, wantBlock: 64, wantMM: &MMMatchInfo{MatchBlocks: 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMatch, tt.info.MatchBlocks())
+			assert.Equal(t, tt.wantTotal, tt.info.TotalBlocks())
+			assert.Equal(t, tt.wantBlock, tt.info.BlockSizeTokens())
+			assert.Equal(t, tt.wantMM, tt.info.MM())
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
@@ -18,6 +18,7 @@ package preciseprefixcache
 
 import (
 	"context"
+	"sort"
 
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
 
@@ -32,25 +33,23 @@ type kvCacheIndexer interface {
 	KVBlockIndex() kvblock.Index
 }
 
-// computeBlockKeys hashes the request's TokenizedPrompt into KV-block keys.
-// When PerPromptTokens has more than one entry (multi-prompt completions),
-// each prompt is hashed independently so cross-prompt block adjacency (which
-// never exists in the model server cache) is avoided. Single-prompt requests
-// produce a length-1 outer slice. A non-empty CacheSalt is folded into each
-// prompt's first block. Returns nil when the request carries no tokens or no
-// prompt produces full KV blocks.
+// computeBlockKeys hashes the request's TokenizedPrompt into per-prompt
+// KV-block keys, folding CacheSalt into each prompt's first block. MM features
+// apply only to single-prompt requests; mmBlockIndices (block indices spanned
+// by MM content) is populated only in that case for hit attribution.
 func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
 	request *scheduling.InferenceRequest, blockSizeTokens int,
-) ([][]kvblock.BlockHash, error) {
+) ([][]kvblock.BlockHash, []int, error) {
 	if request == nil || request.Body == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	tp := request.Body.TokenizedPrompt
 	if tp == nil || len(tp.PerPromptTokens) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	var result [][]kvblock.BlockHash
+	var mmBlockIndices []int
 	for _, tokens := range tp.PerPromptTokens {
 		if len(tokens) == 0 {
 			continue
@@ -61,29 +60,77 @@ func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
 		if len(tp.PerPromptTokens) == 1 {
 			mmf = tp.MultiModalFeatures
 		}
-		keys, err := computeBlockKeysForTokens(ctx, idx, tokens, mmf, tp.CacheSalt, request.TargetModel, blockSizeTokens)
+		keys, mmIdx, err := computeBlockKeysForTokens(ctx, idx, tokens, mmf, tp.CacheSalt, request.TargetModel, blockSizeTokens)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(keys) == 0 {
 			continue
 		}
 		result = append(result, keys)
+		if len(tp.PerPromptTokens) == 1 {
+			mmBlockIndices = mmIdx
+		}
 	}
-	return result, nil
+	return result, mmBlockIndices, nil
 }
 
 func computeBlockKeysForTokens(ctx context.Context, idx kvCacheIndexer,
 	tokens []uint32, mmFeatures []fwkrh.MultiModalFeature, cacheSalt, model string, blockSizeTokens int,
-) ([]kvblock.BlockHash, error) {
+) ([]kvblock.BlockHash, []int, error) {
 	var extraFeatures []*kvblock.BlockExtraFeatures
+	var mmBlockIndices []int
 	if len(mmFeatures) > 0 {
 		mmHashes, mmPlaceholders := tokenizer.ConvertMMFeaturesFromUpstream(mmFeatures)
 		extraFeatures = kvblock.ComputeBlockExtraFeatures(
 			mmHashes, mmPlaceholders, blockSizeTokens, len(tokens))
+		mmBlockIndices = multimodalBlockIndices(mmFeatures, blockSizeTokens)
 	}
 	extraFeatures = foldCacheSalt(extraFeatures, cacheSalt, len(tokens)/blockSizeTokens)
-	return idx.ComputeBlockKeysFromTokens(ctx, tokens, model, extraFeatures)
+	keys, err := idx.ComputeBlockKeysFromTokens(ctx, tokens, model, extraFeatures)
+	return keys, mmBlockIndices, err
+}
+
+// countMMMatchedBlocks counts entries in (sorted) mmBlockIndices that are
+// strictly less than matchLen.
+func countMMMatchedBlocks(mmBlockIndices []int, matchLen int) int {
+	if matchLen <= 0 || len(mmBlockIndices) == 0 {
+		return 0
+	}
+	for i, idx := range mmBlockIndices {
+		if idx >= matchLen {
+			return i
+		}
+	}
+	return len(mmBlockIndices)
+}
+
+// multimodalBlockIndices returns the sorted unique block indices spanned by
+// any of the given features.
+func multimodalBlockIndices(features []fwkrh.MultiModalFeature, blockSizeTokens int) []int {
+	if blockSizeTokens <= 0 || len(features) == 0 {
+		return nil
+	}
+	seen := map[int]struct{}{}
+	for _, f := range features {
+		if f.Length <= 0 {
+			continue
+		}
+		start := f.Offset / blockSizeTokens
+		end := (f.Offset + f.Length - 1) / blockSizeTokens
+		for i := start; i <= end; i++ {
+			seen[i] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]int, 0, len(seen))
+	for i := range seen {
+		out = append(out, i)
+	}
+	sort.Ints(out)
+	return out
 }
 
 // foldCacheSalt appends the cache salt to the first block's extra keys, after

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+func TestMultimodalBlockIndices(t *testing.T) {
+	tests := []struct {
+		name            string
+		features        []fwkrh.MultiModalFeature
+		blockSizeTokens int
+		want            []int
+	}{
+		{
+			name:            "empty features",
+			features:        nil,
+			blockSizeTokens: 16,
+			want:            nil,
+		},
+		{
+			name:            "zero block size",
+			features:        []fwkrh.MultiModalFeature{{Offset: 0, Length: 16}},
+			blockSizeTokens: 0,
+			want:            nil,
+		},
+		{
+			name: "single feature spanning one block",
+			features: []fwkrh.MultiModalFeature{
+				{Offset: 0, Length: 16},
+			},
+			blockSizeTokens: 16,
+			want:            []int{0},
+		},
+		{
+			name: "single feature spanning multiple blocks",
+			features: []fwkrh.MultiModalFeature{
+				{Offset: 8, Length: 40},
+			},
+			blockSizeTokens: 16,
+			want:            []int{0, 1, 2},
+		},
+		{
+			name: "multiple features deduplicated and sorted",
+			features: []fwkrh.MultiModalFeature{
+				{Offset: 32, Length: 16},
+				{Offset: 0, Length: 16},
+				{Offset: 16, Length: 16},
+			},
+			blockSizeTokens: 16,
+			want:            []int{0, 1, 2},
+		},
+		{
+			name: "zero-length feature skipped",
+			features: []fwkrh.MultiModalFeature{
+				{Offset: 0, Length: 0},
+				{Offset: 16, Length: 16},
+			},
+			blockSizeTokens: 16,
+			want:            []int{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := multimodalBlockIndices(tt.features, tt.blockSizeTokens)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCountMMMatchedBlocks(t *testing.T) {
+	tests := []struct {
+		name          string
+		mmBlockIdx    []int
+		matchLen      int
+		wantMMMatched int
+	}{
+		{name: "no mm indices", mmBlockIdx: nil, matchLen: 5, wantMMMatched: 0},
+		{name: "no match", mmBlockIdx: []int{0, 1, 2}, matchLen: 0, wantMMMatched: 0},
+		{name: "all mm indices matched", mmBlockIdx: []int{0, 1, 2}, matchLen: 3, wantMMMatched: 3},
+		{name: "partial mm match", mmBlockIdx: []int{0, 5, 10}, matchLen: 6, wantMMMatched: 2},
+		{name: "match boundary excludes index equal to matchLen", mmBlockIdx: []int{0, 3, 5}, matchLen: 3, wantMMMatched: 1},
+		{name: "no mm in matched range", mmBlockIdx: []int{10, 20}, matchLen: 5, wantMMMatched: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countMMMatchedBlocks(tt.mmBlockIdx, tt.matchLen)
+			assert.Equal(t, tt.wantMMMatched, got)
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -381,13 +381,13 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 				cachedBlocksByTier[tier] += count
 			}
 		}
-		// mmBlockIndices is nil for multi-prompt; mmMatch=0 in that case.
-		mmMatch := countMMMatchedBlocks(mmBlockIndices, cachedBlocks)
-		ep.Put(p.dk.String(),
-			attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens).
-				WithCachedBlockCount(cachedBlocks).
-				WithCachedBlocksByTier(cachedBlocksByTier).
-				WithMM(attrprefix.MMMatchInfo{MatchBlocks: mmMatch}))
+		info := attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens).
+			WithCachedBlockCount(cachedBlocks).
+			WithCachedBlocksByTier(cachedBlocksByTier)
+		if len(mmBlockIndices) > 0 {
+			info.WithMM(attrprefix.MMMatchInfo{MatchBlocks: countMMMatchedBlocks(mmBlockIndices, cachedBlocks)})
+		}
+		ep.Put(p.dk.String(), info)
 	}
 
 	if p.speculativeEnabled {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -316,7 +316,7 @@ func (p *Producer) Produce(ctx context.Context,
 		}
 	}
 
-	perPromptKeys, err := computeBlockKeys(ctx, p.kvCacheIndexer, request, p.blockSizeTokens)
+	perPromptKeys, mmBlockIndices, err := computeBlockKeys(ctx, p.kvCacheIndexer, request, p.blockSizeTokens)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("failed to compute block keys: %w", err)
@@ -326,12 +326,12 @@ func (p *Producer) Produce(ctx context.Context,
 		return nil
 	}
 
-	return p.produceFromBlockKeys(ctx, span, request, endpoints, perPromptKeys)
+	return p.produceFromBlockKeys(ctx, span, request, endpoints, perPromptKeys, mmBlockIndices)
 }
 
 func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 	request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint,
-	perPromptKeys [][]kvblock.BlockHash,
+	perPromptKeys [][]kvblock.BlockHash, mmBlockIndices []int,
 ) error {
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
 	endpointSet := extractEndpointSet(endpoints)
@@ -381,10 +381,13 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 				cachedBlocksByTier[tier] += count
 			}
 		}
+		// mmBlockIndices is nil for multi-prompt; mmMatch=0 in that case.
+		mmMatch := countMMMatchedBlocks(mmBlockIndices, cachedBlocks)
 		ep.Put(p.dk.String(),
 			attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens).
 				WithCachedBlockCount(cachedBlocks).
-				WithCachedBlocksByTier(cachedBlocksByTier))
+				WithCachedBlocksByTier(cachedBlocksByTier).
+				WithMM(attrprefix.MMMatchInfo{MatchBlocks: mmMatch}))
 	}
 
 	if p.speculativeEnabled {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -197,12 +197,14 @@ func TestProduce_UsesTokenizedPrompt(t *testing.T) {
 	assert.Equal(t, 1, info.MatchBlocks())
 	assert.Equal(t, 1, info.TotalBlocks())
 	assert.Equal(t, 16, info.BlockSizeTokens())
+	assert.Nil(t, info.MM(), "text-only request must leave MM untracked")
 
 	raw2, ok := testEndpoints[1].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test").String())
 	require.True(t, ok)
 	info2 := raw2.(*attrprefix.PrefixCacheMatchInfo)
 	assert.Equal(t, 0, info2.MatchBlocks())
 	assert.Equal(t, 1, info2.TotalBlocks())
+	assert.Nil(t, info2.MM(), "text-only request must leave MM untracked")
 }
 
 // No tokens → no-op (no prompt-string fallback).

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -441,6 +441,68 @@ func TestProduce_WritesCachedBlocksByTier(t *testing.T) {
 	assert.Empty(t, info.CachedBlocksByTier())
 }
 
+// MM match uses cachedBlocks (literal), not matchLen (tier-weighted score).
+func TestProduce_MMMatchUsesCachedBlocksNotWeightedScore(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	tokens := make([]uint32, 4*testBlockSize)
+	for i := range tokens {
+		tokens[i] = uint32(i)
+	}
+	keys := []kvblock.BlockHash{0xAA, 0xBB, 0xCC, 0xDD}
+	const addr = "10.0.0.1:8080"
+
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, _ []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			return keys, nil
+		},
+		index: &fakeKVBlockIndex{
+			lookup: func(_ context.Context, _ []kvblock.BlockHash, _ sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
+				out := map[kvblock.BlockHash][]kvblock.PodEntry{}
+				for _, k := range keys {
+					out[k] = []kvblock.PodEntry{{PodIdentifier: addr}}
+				}
+				return out, nil
+			},
+		},
+	}
+	// Weighted score 3.2 gives matchLen=3, while all 4 blocks are cached.
+	scorer := &fakeKVBlockScorer{
+		score: func(_ context.Context, _ []kvblock.BlockHash, _ map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error) {
+			return map[string]float64{addr: 3.2}, nil
+		},
+	}
+
+	p := newProducerWithIndexer(ctx, idx, scorer)
+	endpoints := freshEndpoints()
+
+	// MM at block index 3: caught by cachedBlocks=4, missed by matchLen=3.
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-mm-weighted",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{
+				PerPromptTokens: [][]uint32{tokens},
+				MultiModalFeatures: []fwkrh.MultiModalFeature{
+					{Modality: fwkrh.ModalityImage, Hash: "img", Offset: 48, Length: 16},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, p.Produce(ctx, req, endpoints))
+
+	raw, ok := endpoints[0].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test").String())
+	require.True(t, ok)
+	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
+	require.True(t, ok)
+
+	assert.Equal(t, 3, info.MatchBlocks())
+	assert.Equal(t, 4, info.CachedBlockCount())
+	require.NotNil(t, info.MM())
+	assert.Equal(t, 1, info.MM().MatchBlocks, "must use cachedBlocks, not matchLen")
+}
+
 // Multimodal features flow through to ComputeBlockKeysFromTokens.
 func TestProduce_PassesMMExtraFeatures(t *testing.T) {
 	ctx := utils.NewTestContext(t)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	mmobs "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/multimodal"
 	schedplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling"
 )
 
@@ -115,6 +116,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.Inf
 		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
 	}
 	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
+	span.SetAttributes(mmobs.SpanAttributes(request)...)
 
 	// Prefill header
 	delete(request.Headers, routing.PrefillEndpointHeader) // clear header, if already set

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	mmobs "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/multimodal"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	schedplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling"
@@ -291,6 +292,7 @@ func (h *Handler) Pick(ctx context.Context, request *scheduling.InferenceRequest
 		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
 	}
 	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
+	span.SetAttributes(mmobs.SpanAttributes(request)...)
 
 	// ── Stage 1: Decode ────────────────────────────────────────────────────
 	if _, executed := profileResults[h.decodeProfile]; !executed {
@@ -415,6 +417,7 @@ func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceR
 		span.SetAttributes(attribute.String("gen_ai.request.model", request.TargetModel))
 	}
 	span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
+	span.SetAttributes(mmobs.SpanAttributes(request)...)
 
 	// Prefill header
 	delete(request.Headers, routing.PrefillEndpointHeader)

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	mmobs "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/multimodal"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	schedplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling"
@@ -190,6 +191,7 @@ func (h *PdProfileHandler) Pick(ctx context.Context, request *scheduling.Inferen
 		if request.RequestID != "" {
 			span.SetAttributes(attribute.String("gen_ai.request.id", request.RequestID))
 		}
+		span.SetAttributes(mmobs.SpanAttributes(request)...)
 	}
 
 	if _, executed := profileResults[h.decodeProfile]; !executed {

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -36,6 +36,8 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	mmobs "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/multimodal"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	preciseproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache"
 	schedplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling"
 	prefixscorer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/prefix"
@@ -61,9 +63,10 @@ type PluginConfig struct {
 // Deprecated: configure precise-prefix-cache-producer and prefix-cache-scorer
 // directly.
 type Plugin struct {
-	typedName plugin.TypedName
-	producer  *legacyProducer
-	scorer    *prefixscorer.Plugin
+	typedName    plugin.TypedName
+	producer     *legacyProducer
+	scorer       *prefixscorer.Plugin
+	matchInfoKey string
 }
 
 var (
@@ -130,9 +133,10 @@ func PluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handl
 	}
 
 	return &Plugin{
-		typedName: plugin.TypedName{Type: PrecisePrefixCachePluginType, Name: name},
-		producer:  producer,
-		scorer:    scorer,
+		typedName:    plugin.TypedName{Type: PrecisePrefixCachePluginType, Name: name},
+		producer:     producer,
+		scorer:       scorer,
+		matchInfoKey: attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name).String(),
 	}, nil
 }
 
@@ -180,6 +184,7 @@ func (p *Plugin) Score(ctx context.Context,
 			span.SetAttributes(attribute.String("gen_ai.request.id", req.RequestID))
 		}
 	}
+	span.SetAttributes(mmobs.SpanAttributes(req)...)
 
 	scores := p.scorer.Score(ctx, req, endpoints)
 
@@ -198,7 +203,35 @@ func (p *Plugin) Score(ctx context.Context,
 		)
 	}
 
+	if hit, tracked := anyMMHit(endpoints, p.matchInfoKey); tracked {
+		span.SetAttributes(attribute.Bool("mm.hit", hit))
+	}
 	return scores
+}
+
+// anyMMHit returns (hit, tracked). When no endpoint had MM tracked, the
+// caller should omit mm.hit (OTel: don't emit attributes whose value is unknown).
+func anyMMHit(endpoints []scheduling.Endpoint, key string) (hit, tracked bool) {
+	for _, ep := range endpoints {
+		v, ok := ep.Get(key)
+		if !ok {
+			continue
+		}
+		info, ok := v.(*attrprefix.PrefixCacheMatchInfo)
+		if !ok {
+			continue
+		}
+		mm := info.MM()
+		if mm == nil {
+			continue
+		}
+		tracked = true
+		if mm.MatchBlocks > 0 {
+			hit = true
+			return
+		}
+	}
+	return
 }
 
 func (p *Plugin) Produces() map[plugin.DataKey]any { return p.producer.Produces() }

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -37,6 +37,65 @@ import (
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
+func TestAnyMMHit(t *testing.T) {
+	const producerName = "test-producer"
+	key := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(producerName).String()
+	makeEndpoint := func(name string, info *attrprefix.PrefixCacheMatchInfo) scheduling.Endpoint {
+		ep := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}}, fwkdl.NewMetrics(), nil)
+		if info != nil {
+			ep.Put(key, info)
+		}
+		return ep
+	}
+
+	tests := []struct {
+		name        string
+		endpoints   []scheduling.Endpoint
+		wantHit     bool
+		wantTracked bool
+	}{
+		{name: "no endpoints", endpoints: nil},
+		{
+			name: "no match info attached",
+			endpoints: []scheduling.Endpoint{
+				makeEndpoint("a", nil),
+				makeEndpoint("b", nil),
+			},
+		},
+		{
+			name: "no producer tracked mm",
+			endpoints: []scheduling.Endpoint{
+				makeEndpoint("a", attrprefix.NewPrefixCacheMatchInfo(5, 10, 16)),
+				makeEndpoint("b", attrprefix.NewPrefixCacheMatchInfo(8, 10, 16)),
+			},
+		},
+		{
+			name: "tracked but zero mm matches",
+			endpoints: []scheduling.Endpoint{
+				makeEndpoint("a", attrprefix.NewPrefixCacheMatchInfo(5, 10, 16)),
+				makeEndpoint("b", attrprefix.NewPrefixCacheMatchInfo(8, 10, 16).WithMM(attrprefix.MMMatchInfo{MatchBlocks: 0})),
+			},
+			wantTracked: true,
+		},
+		{
+			name: "one endpoint reports mm match",
+			endpoints: []scheduling.Endpoint{
+				makeEndpoint("a", attrprefix.NewPrefixCacheMatchInfo(5, 10, 16)),
+				makeEndpoint("b", attrprefix.NewPrefixCacheMatchInfo(8, 10, 16).WithMM(attrprefix.MMMatchInfo{MatchBlocks: 2})),
+			},
+			wantHit: true, wantTracked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hit, tracked := anyMMHit(tt.endpoints, key)
+			assert.Equal(t, tt.wantHit, hit, "hit")
+			assert.Equal(t, tt.wantTracked, tracked, "tracked")
+		})
+	}
+}
+
 // In self-host mode the plugin satisfies Scorer, DataProducer, PreRequest,
 // and EndpointExtractor.
 func TestPluginFactory_SelfHostInterfaces(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `mm.modality`, `mm.hash_count`, and `mm.hit` attributes to EPP scheduler spans so multimodal routing decisions are distinguishable from text-only ones in collected traces. Affected spans: `llm_d.epp.scorer.prefix_cache`, `llm_d.epp.disagg.profile_handler.pick`, `llm_d.epp.prerequest.disaggregation` (two call sites), `llm_d.epp.pd.profile_handler.pick`.

`mm.hit` is driven by real per-feature-type block-match attribution: `PrefixCacheMatchInfo` gains an `mmMatchBlocks` field that the precise-prefix-cache producer populates from `MultiModalFeature.Offset/Length` derived block indices. `mm.modality` and `mm.hash_count` are derived from the request's `TokenizedPrompt.MultiModalFeatures` via a shared helper in `pkg/common/observability/tracing`.

Schema coordination: the `mm.*` namespace prefix should align with the OTel naming standardization tracked in #1519 before this merges.

**Which issue(s) this PR fixes**:

Fixes #1542

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP scheduler spans now emit `mm.modality`, `mm.hash_count`, and `mm.hit` attributes for multimodal routing visibility.
```


## Test evidence

| Span | image request | text request |
|---|---|---|
| `llm_d.epp.scorer.prefix_cache` | `mm.modality=image, mm.hash_count=1, mm.hit=false` | `mm.modality=none, mm.hash_count=0, mm.hit=false` |
| `llm_d.epp.disagg.profile_handler.pick` | `mm.modality=image, mm.hash_count=1` | `mm.modality=none, mm.hash_count=0` |
| `llm_d.epp.prerequest.disaggregation` | `mm.modality=image, mm.hash_count=1` | `mm.modality=none, mm.hash_count=0` |

`llm_d.epp.pd.profile_handler.pick` not exercised — same instrumentation pattern, fires only under `pd-profile-handler`.

<img width="682" height="453" alt="image" src="https://github.com/user-attachments/assets/2f55e925-ca7c-4da5-9eb9-cb1bb467d525" />
