### PR TITLE
feat(prefixcacheaffinity): derive TTFT gate from peak prefill throughput

### DIFF
--- a/config/charts/routerlib/templates/_config.yaml
+++ b/config/charts/routerlib/templates/_config.yaml
@@ -46,10 +46,12 @@ data:
       type: prefix-cache-affinity-filter
       parameters:
         affinityThreshold: 0.99
+        ttftSource: latencyPredictor
     - name: loose-affinity-filter
       type: prefix-cache-affinity-filter
       parameters:
         affinityThreshold: 0.80
+        ttftSource: latencyPredictor
     - type: latency-scorer
     - type: weighted-random-picker
     - type: slo-headroom-tier-filter

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -59,9 +59,10 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 - With probability `explorationProbability` (default 1%), skip the gate entirely for exploration
 - TTFT load gate: if best sticky endpoint's TTFT exceeds best non-sticky by more than
   `maxTTFTPenaltyMs`, break stickiness and keep all endpoints (0 = always stick). The
-  per-endpoint TTFT comes from the latency predictor when `ttftSource` is
-  `latencyPredictor` (default), or is estimated from in-flight tokens as
-  `inFlightTokens / peakPrefillThroughput * 1000` (ms) when `ttftSource` is `prefillThroughput`
+  per-endpoint TTFT is estimated from in-flight tokens as
+  `inFlightTokens / peakPrefillThroughput * 1000` (ms) when `ttftSource` is
+  `prefillThroughput` (default), or comes from the latency predictor when `ttftSource`
+  is `latencyPredictor`
 - If no endpoints have the TTFT source attribute (`LatencyPredictionInfo` or `InFlightLoad`),
   the TTFT load gate is skipped. If no endpoints have `PrefixCacheMatchInfo`, all prefix
   scores default to 0 and no endpoints pass the affinity threshold, so all are kept (no-op)
@@ -73,7 +74,7 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
 | `explorationProbability` | `float64` | No | `0.01` | Probability of skipping the gate |
 | `maxTTFTPenaltyMs` | `float64` | No | `5000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
-| `ttftSource` | `string` | No | `latencyPredictor` | TTFT source for the load gate: `latencyPredictor` or `prefillThroughput` |
+| `ttftSource` | `string` | No | `prefillThroughput` | TTFT source for the load gate: `prefillThroughput` or `latencyPredictor` |
 | `peakPrefillThroughput` | `float64` | No | `15928` | Peak prefill throughput (tokens/sec), used to estimate TTFT when `ttftSource` is `prefillThroughput` |
 
 The `peakPrefillThroughput` default of `15928` tokens/sec is calibrated for Qwen 32B on
@@ -85,8 +86,8 @@ to `latencyPredictor` to source TTFT from the latency predictor instead.
 ## Dependencies
 
 - Reads `PrefixCacheMatchInfo` from endpoint attributes (from `prefix-cache-scorer`)
-- Reads `LatencyPredictionInfo` for the TTFT load gate when `ttftSource` is `latencyPredictor` (from `predicted-latency-producer`)
 - Reads `InFlightLoad` for the TTFT load gate when `ttftSource` is `prefillThroughput` (from `in-flight-load-producer`)
+- Reads `LatencyPredictionInfo` for the TTFT load gate when `ttftSource` is `latencyPredictor` (from `predicted-latency-producer`)
 
 **Configuration Example:**
 ```yaml
@@ -97,7 +98,7 @@ plugins:
       affinityThreshold: 0.80
       explorationProbability: 0.01
       maxTTFTPenaltyMs: 5000
-      ttftSource: latencyPredictor
+      ttftSource: prefillThroughput
 schedulingProfiles:
   - name: default
     plugins:

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -59,9 +59,9 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 - With probability `explorationProbability` (default 1%), skip the gate entirely for exploration
 - TTFT load gate: if best sticky endpoint's TTFT exceeds best non-sticky by more than
   `maxTTFTPenaltyMs`, break stickiness and keep all endpoints (0 = always stick). The
-  per-endpoint TTFT comes from the latency predictor when `useLatencyPredictor` is true
-  (default), or is estimated from in-flight tokens as
-  `inFlightTokens / peakPrefillThroughput * 1000` (ms) when false
+  per-endpoint TTFT comes from the latency predictor when `ttftSource` is
+  `latencyPredictor` (default), or is estimated from in-flight tokens as
+  `inFlightTokens / peakPrefillThroughput * 1000` (ms) when `ttftSource` is `prefillThroughput`
 - If no endpoints have the TTFT source attribute (`LatencyPredictionInfo` or `InFlightLoad`),
   the TTFT load gate is skipped. If no endpoints have `PrefixCacheMatchInfo`, all prefix
   scores default to 0 and no endpoints pass the affinity threshold, so all are kept (no-op)
@@ -73,20 +73,20 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
 | `explorationProbability` | `float64` | No | `0.01` | Probability of skipping the gate |
 | `maxTTFTPenaltyMs` | `float64` | No | `5000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
-| `useLatencyPredictor` | `bool` | No | `true` | TTFT source: latency predictor (true) or peak prefill throughput (false) |
-| `peakPrefillThroughput` | `float64` | No | `15928` | Peak prefill throughput (tokens/sec), used to estimate TTFT when `useLatencyPredictor` is false |
+| `ttftSource` | `string` | No | `latencyPredictor` | TTFT source for the load gate: `latencyPredictor` or `prefillThroughput` |
+| `peakPrefillThroughput` | `float64` | No | `15928` | Peak prefill throughput (tokens/sec), used to estimate TTFT when `ttftSource` is `prefillThroughput` |
 
 The `peakPrefillThroughput` default of `15928` tokens/sec is calibrated for Qwen 32B on
 2x H100 80GB (TP=2) with vLLM 0.19, measured as the prefill throughput of a single
 unloaded chunk of `max_num_batched_tokens` (8192) tokens. It is hardware-, model-, and
-serving-stack-specific; retune it for a different deployment, or set `useLatencyPredictor`
-to `true` to source TTFT from the latency predictor instead.
+serving-stack-specific; retune it for a different deployment, or set `ttftSource`
+to `latencyPredictor` to source TTFT from the latency predictor instead.
 
 ## Dependencies
 
 - Reads `PrefixCacheMatchInfo` from endpoint attributes (from `prefix-cache-scorer`)
-- Reads `LatencyPredictionInfo` for the TTFT load gate when `useLatencyPredictor` is true (from `predicted-latency-producer`)
-- Reads `InFlightLoad` for the TTFT load gate when `useLatencyPredictor` is false (from `in-flight-load-producer`)
+- Reads `LatencyPredictionInfo` for the TTFT load gate when `ttftSource` is `latencyPredictor` (from `predicted-latency-producer`)
+- Reads `InFlightLoad` for the TTFT load gate when `ttftSource` is `prefillThroughput` (from `in-flight-load-producer`)
 
 **Configuration Example:**
 ```yaml
@@ -97,7 +97,7 @@ plugins:
       affinityThreshold: 0.80
       explorationProbability: 0.01
       maxTTFTPenaltyMs: 5000
-      useLatencyPredictor: true
+      ttftSource: latencyPredictor
 schedulingProfiles:
   - name: default
     plugins:

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -35,10 +35,10 @@ This filter resolves the trade-off by operating as a **pre-filter** rather than 
 It narrows the candidate set to only the sticky endpoints (those above `affinityThreshold`),
 then passes them to downstream plugins. When paired with `weighted-random-picker`, requests
 are spread across the sticky set — maintaining cache affinity while distributing load. The
-load gates (`maxTTFTPenaltyMs` and `maxTokensInFlightPenalty`) add automatic back-off: if
-sticky endpoints become overloaded and their predicted TTFT or in-flight tokens exceed
-non-sticky endpoints by more than the configured penalty, the filter breaks stickiness and
-opens up all endpoints, preventing the hot-spotting problem. The exploration mechanism (`explorationProbability`) seeds cache state on other
+TTFT load gate (`maxTTFTPenaltyMs`) adds automatic back-off: if sticky endpoints become
+overloaded and their TTFT exceeds non-sticky endpoints by more than the configured penalty,
+the filter breaks stickiness and opens up all endpoints, preventing the hot-spotting problem.
+The exploration mechanism (`explorationProbability`) seeds cache state on other
 endpoints over time, preventing permanent stickiness to a fixed subset.
 
 ## Overview
@@ -57,13 +57,14 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 - Keep only endpoints with prefix cache score >= `affinityThreshold`
 - If no endpoints pass, all are kept (no-op)
 - With probability `explorationProbability` (default 1%), skip the gate entirely for exploration
-- TTFT load gate: if best sticky endpoint's predicted TTFT exceeds best non-sticky by
-  more than `maxTTFTPenaltyMs`, break stickiness and keep all endpoints
-- In-flight tokens load gate: if best sticky endpoint's in-flight tokens exceed best non-sticky
-  by more than `maxTokensInFlightPenalty`, break stickiness and keep all endpoints (if > 0)
-- If no endpoints have `LatencyPredictionInfo` (predictions absent), the TTFT load gate
-  is skipped. If no endpoints have `PrefixCacheMatchInfo`, all prefix scores default to 0
-  and no endpoints pass the affinity threshold, so all are kept (no-op)
+- TTFT load gate: if best sticky endpoint's TTFT exceeds best non-sticky by more than
+  `maxTTFTPenaltyMs`, break stickiness and keep all endpoints (0 = always stick). The
+  per-endpoint TTFT comes from the latency predictor when `useLatencyPredictor` is true
+  (default), or is estimated from in-flight tokens as
+  `inFlightTokens / peakPrefillThroughput * 1000` (ms) when false
+- If no endpoints have the TTFT source attribute (`LatencyPredictionInfo` or `InFlightLoad`),
+  the TTFT load gate is skipped. If no endpoints have `PrefixCacheMatchInfo`, all prefix
+  scores default to 0 and no endpoints pass the affinity threshold, so all are kept (no-op)
 
 ## Config
 
@@ -72,13 +73,20 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
 | `explorationProbability` | `float64` | No | `0.01` | Probability of skipping the gate |
 | `maxTTFTPenaltyMs` | `float64` | No | `5000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
-| `maxTokensInFlightPenalty` | `int64` | No | `0` | Max in-flight tokens penalty before breaking stickiness. 0 = disabled |
+| `useLatencyPredictor` | `bool` | No | `true` | TTFT source: latency predictor (true) or peak prefill throughput (false) |
+| `peakPrefillThroughput` | `float64` | No | `15928` | Peak prefill throughput (tokens/sec), used to estimate TTFT when `useLatencyPredictor` is false |
+
+The `peakPrefillThroughput` default of `15928` tokens/sec is calibrated for Qwen 32B on
+2x H100 80GB (TP=2) with vLLM 0.19, measured as the prefill throughput of a single
+unloaded chunk of `max_num_batched_tokens` (8192) tokens. It is hardware-, model-, and
+serving-stack-specific; retune it for a different deployment, or set `useLatencyPredictor`
+to `true` to source TTFT from the latency predictor instead.
 
 ## Dependencies
 
 - Reads `PrefixCacheMatchInfo` from endpoint attributes (from `prefix-cache-scorer`)
-- Reads `LatencyPredictionInfo` for TTFT load gate (from `predicted-latency-producer`)
-- Reads `InFlightLoad` for in-flight tokens load gate (from `in-flight-load-producer`)
+- Reads `LatencyPredictionInfo` for the TTFT load gate when `useLatencyPredictor` is true (from `predicted-latency-producer`)
+- Reads `InFlightLoad` for the TTFT load gate when `useLatencyPredictor` is false (from `in-flight-load-producer`)
 
 **Configuration Example:**
 ```yaml
@@ -89,7 +97,7 @@ plugins:
       affinityThreshold: 0.80
       explorationProbability: 0.01
       maxTTFTPenaltyMs: 5000
-      maxTokensInFlightPenalty: 1000
+      useLatencyPredictor: true
 schedulingProfiles:
   - name: default
     plugins:

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -74,9 +74,9 @@ type Config struct {
 	MaxTTFTPenaltyMs float64 `json:"maxTTFTPenaltyMs,omitempty"`
 
 	// TTFTSource selects where the load gate reads per-endpoint TTFT from.
-	// TTFTSourceLatencyPredictor (default) reads predicted TTFT from the latency
-	// predictor; TTFTSourcePrefillThroughput estimates it from in-flight tokens
-	// and PeakPrefillThroughput.
+	// TTFTSourcePrefillThroughput (default) estimates it from in-flight tokens and
+	// PeakPrefillThroughput; TTFTSourceLatencyPredictor reads predicted TTFT from
+	// the latency predictor.
 	TTFTSource TTFTSource `json:"ttftSource,omitempty"`
 
 	// PeakPrefillThroughput is the peak prefill throughput in tokens/sec, used to
@@ -94,7 +94,7 @@ var DefaultConfig = Config{
 	AffinityThreshold:      0.80,
 	ExplorationProbability: 0.01,
 	MaxTTFTPenaltyMs:       5000,
-	TTFTSource:             TTFTSourceLatencyPredictor,
+	TTFTSource:             TTFTSourcePrefillThroughput,
 
 	// Calibrated for Qwen 32B on 2x H100 80GB (TP=2), vLLM 0.19; see README.
 	PeakPrefillThroughput: 15928,
@@ -141,7 +141,7 @@ func (c *Config) validate() error {
 		return fmt.Errorf("peakPrefillThroughput must be >= 0, got %f", c.PeakPrefillThroughput)
 	}
 	switch c.TTFTSource {
-	case "", TTFTSourceLatencyPredictor, TTFTSourcePrefillThroughput:
+	case TTFTSourceLatencyPredictor, TTFTSourcePrefillThroughput:
 	default:
 		return fmt.Errorf("ttftSource must be %q or %q, got %q", TTFTSourceLatencyPredictor, TTFTSourcePrefillThroughput, c.TTFTSource)
 	}
@@ -152,10 +152,10 @@ func (c *Config) validate() error {
 }
 
 // usesLatencyPredictor reports whether the load gate sources TTFT from the
-// latency predictor. The predictor is the default; only an explicit
-// prefillThroughput selects the in-flight-token estimate.
+// latency predictor. Throughput is the default; only an explicit
+// latencyPredictor selects the predictor.
 func (c *Config) usesLatencyPredictor() bool {
-	return c.TTFTSource != TTFTSourcePrefillThroughput
+	return c.TTFTSource == TTFTSourceLatencyPredictor
 }
 
 func (p *Plugin) TypedName() fwkplugin.TypedName {

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -23,6 +23,7 @@ package prefixcacheaffinity
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -53,16 +54,21 @@ type Config struct {
 	ExplorationProbability float64 `json:"explorationProbability,omitempty"`
 
 	// MaxTTFTPenaltyMs is the max TTFT penalty (ms) before breaking stickiness.
-	// If the best sticky endpoint's predicted TTFT exceeds the best non-sticky
-	// endpoint's predicted TTFT by more than this value, all endpoints are kept.
-	// Set to 0 to always stick. Default: 5000.
+	// If the best sticky endpoint's TTFT exceeds the best non-sticky endpoint's
+	// TTFT by more than this value, all endpoints are kept. Set to 0 to always
+	// stick. Default: 5000.
 	MaxTTFTPenaltyMs float64 `json:"maxTTFTPenaltyMs,omitempty"`
 
-	// MaxTokensInFlightPenalty is the max in-flight token penalty before breaking
-	// stickiness. If the best sticky endpoint's in-flight tokens exceed the best
-	// non-sticky endpoint's in-flight tokens by more than this value, all endpoints
-	// are kept. Set to 0 to disable this gate. Default: 0 (disabled).
-	MaxTokensInFlightPenalty int64 `json:"maxTokensInFlightPenalty,omitempty"`
+	// UseLatencyPredictor selects the TTFT source for the load gate. When true
+	// (default), per-endpoint TTFT is read from the latency predictor. When
+	// false, TTFT is estimated from in-flight tokens and PeakPrefillThroughput.
+	UseLatencyPredictor bool `json:"useLatencyPredictor,omitempty"`
+
+	// PeakPrefillThroughput is the peak prefill throughput in tokens/sec, used to
+	// estimate TTFT from in-flight tokens when UseLatencyPredictor is false:
+	//   TTFT_ms = inFlightTokens / PeakPrefillThroughput * 1000
+	// (tokens / (tokens/sec) * 1000 = ms). Default: 15928.
+	PeakPrefillThroughput float64 `json:"peakPrefillThroughput,omitempty"`
 
 	PrefixMatchInfoProducerName       string `json:"prefixMatchInfoProducerName,omitempty"`
 	LatencyPredictionInfoProducerName string `json:"latencyPredictionInfoProducerName,omitempty"`
@@ -73,6 +79,8 @@ var DefaultConfig = Config{
 	AffinityThreshold:      0.80,
 	ExplorationProbability: 0.01,
 	MaxTTFTPenaltyMs:       5000,
+	UseLatencyPredictor:    true,
+	PeakPrefillThroughput:  15928,
 }
 
 type Plugin struct {
@@ -112,8 +120,11 @@ func (c *Config) validate() error {
 	if c.MaxTTFTPenaltyMs < 0 {
 		return fmt.Errorf("maxTTFTPenaltyMs must be >= 0, got %f", c.MaxTTFTPenaltyMs)
 	}
-	if c.MaxTokensInFlightPenalty < 0 {
-		return fmt.Errorf("maxTokensInFlightPenalty must be >= 0, got %d", c.MaxTokensInFlightPenalty)
+	if c.PeakPrefillThroughput < 0 {
+		return fmt.Errorf("peakPrefillThroughput must be >= 0, got %f", c.PeakPrefillThroughput)
+	}
+	if !c.UseLatencyPredictor && c.MaxTTFTPenaltyMs > 0 && c.PeakPrefillThroughput == 0 {
+		return errors.New("peakPrefillThroughput must be > 0 when useLatencyPredictor is false")
 	}
 	return nil
 }
@@ -165,18 +176,6 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 		}
 	}
 
-	// In-flight tokens load gate: break stickiness if sticky endpoints are too loaded.
-	if p.config.MaxTokensInFlightPenalty > 0 && len(nonSticky) > 0 {
-		bestStickyTokens := p.bestInFlightTokens(sticky)
-		bestNonStickyTokens := p.bestInFlightTokens(nonSticky)
-		if bestStickyTokens-bestNonStickyTokens > p.config.MaxTokensInFlightPenalty {
-			logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: in-flight tokens load gate broken",
-				"bestStickyTokens", bestStickyTokens, "bestNonStickyTokens", bestNonStickyTokens,
-				"penalty", bestStickyTokens-bestNonStickyTokens, "maxPenalty", p.config.MaxTokensInFlightPenalty)
-			return endpoints
-		}
-	}
-
 	logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: narrowed to sticky",
 		"affinityThreshold", p.config.AffinityThreshold, "sticky", len(sticky), "total", len(endpoints))
 	return sticky
@@ -187,10 +186,11 @@ func (p *Plugin) Consumes() fwkplugin.DataDependencies {
 		p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{},
 	}
 	if p.config.MaxTTFTPenaltyMs > 0 {
-		required[p.latencyPredictionInfoDataKey] = attrlatency.LatencyPredictionInfo{}
-	}
-	if p.config.MaxTokensInFlightPenalty > 0 {
-		required[p.inFlightLoadDataKey] = attrconcurrency.InFlightLoad{}
+		if p.config.UseLatencyPredictor {
+			required[p.latencyPredictionInfoDataKey] = attrlatency.LatencyPredictionInfo{}
+		} else {
+			required[p.inFlightLoadDataKey] = attrconcurrency.InFlightLoad{}
+		}
 	}
 	return fwkplugin.DataDependencies{Required: required}
 }
@@ -208,33 +208,40 @@ func (p *Plugin) prefixCacheScore(ep fwksched.Endpoint) float64 {
 	return 0
 }
 
+// bestTTFT returns the lowest per-endpoint TTFT (ms) across endpoints.
 func (p *Plugin) bestTTFT(endpoints []fwksched.Endpoint) float64 {
 	best := math.MaxFloat64
 	for _, ep := range endpoints {
-		if raw, ok := ep.Get(p.latencyPredictionInfoDataKey.String()); ok {
-			info := raw.(*attrlatency.LatencyPredictionInfo)
-			if info.TTFT() < best {
-				best = info.TTFT()
-			}
+		if ttft := p.endpointTTFT(ep); ttft < best {
+			best = ttft
 		}
 	}
 	return best
 }
 
-// bestInFlightTokens returns the lowest in-flight token count across endpoints.
-// Endpoints without the attribute are treated as 0 (no observed load).
-func (p *Plugin) bestInFlightTokens(endpoints []fwksched.Endpoint) int64 {
-	best := int64(math.MaxInt64)
-	for _, ep := range endpoints {
-		var tokens int64
-		if raw, ok := ep.Get(p.inFlightLoadDataKey.String()); ok {
-			if load, ok := raw.(*attrconcurrency.InFlightLoad); ok && load != nil {
-				tokens = load.Tokens
-			}
+// endpointTTFT returns the predicted TTFT (ms) for an endpoint, either from the
+// latency predictor or estimated from in-flight tokens and peak prefill
+// throughput. Endpoints missing the required attribute contribute no signal:
+// MaxFloat64 on the predictor path (never the fastest), 0 in-flight tokens on
+// the throughput path (no observed load).
+func (p *Plugin) endpointTTFT(ep fwksched.Endpoint) float64 {
+	if p.config.UseLatencyPredictor {
+		if raw, ok := ep.Get(p.latencyPredictionInfoDataKey.String()); ok {
+			info := raw.(*attrlatency.LatencyPredictionInfo)
+			return info.TTFT()
 		}
-		if tokens < best {
-			best = tokens
+		return math.MaxFloat64
+	}
+	return float64(p.inFlightTokens(ep)) / p.config.PeakPrefillThroughput * 1000
+}
+
+// inFlightTokens returns an endpoint's in-flight token count, or 0 when the
+// attribute is absent (no observed load).
+func (p *Plugin) inFlightTokens(ep fwksched.Endpoint) int64 {
+	if raw, ok := ep.Get(p.inFlightLoadDataKey.String()); ok {
+		if load, ok := raw.(*attrconcurrency.InFlightLoad); ok && load != nil {
+			return load.Tokens
 		}
 	}
-	return best
+	return 0
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -44,6 +44,20 @@ const (
 
 var _ fwksched.Filter = &Plugin{}
 
+// TTFTSource selects the per-endpoint TTFT signal used by the load gate. The
+// choice also determines which producer attribute the filter consumes.
+type TTFTSource string
+
+const (
+	// TTFTSourceLatencyPredictor reads predicted TTFT from LatencyPredictionInfo
+	// (produced by the predicted-latency-producer).
+	TTFTSourceLatencyPredictor TTFTSource = "latencyPredictor"
+	// TTFTSourcePrefillThroughput estimates TTFT from in-flight tokens and
+	// PeakPrefillThroughput, reading InFlightLoad (produced by the
+	// in-flight-load-producer).
+	TTFTSourcePrefillThroughput TTFTSource = "prefillThroughput"
+)
+
 type Config struct {
 	// AffinityThreshold is the prefix cache score threshold. Endpoints with
 	// score >= this value are considered "sticky" (prompt is cached). Default: 0.80.
@@ -59,13 +73,14 @@ type Config struct {
 	// stick. Default: 5000.
 	MaxTTFTPenaltyMs float64 `json:"maxTTFTPenaltyMs,omitempty"`
 
-	// UseLatencyPredictor selects the TTFT source for the load gate. When true
-	// (default), per-endpoint TTFT is read from the latency predictor. When
-	// false, TTFT is estimated from in-flight tokens and PeakPrefillThroughput.
-	UseLatencyPredictor bool `json:"useLatencyPredictor,omitempty"`
+	// TTFTSource selects where the load gate reads per-endpoint TTFT from.
+	// TTFTSourceLatencyPredictor (default) reads predicted TTFT from the latency
+	// predictor; TTFTSourcePrefillThroughput estimates it from in-flight tokens
+	// and PeakPrefillThroughput.
+	TTFTSource TTFTSource `json:"ttftSource,omitempty"`
 
 	// PeakPrefillThroughput is the peak prefill throughput in tokens/sec, used to
-	// estimate TTFT from in-flight tokens when UseLatencyPredictor is false:
+	// estimate TTFT from in-flight tokens when TTFTSource is prefillThroughput:
 	//   TTFT_ms = inFlightTokens / PeakPrefillThroughput * 1000
 	// (tokens / (tokens/sec) * 1000 = ms). Default: 15928.
 	PeakPrefillThroughput float64 `json:"peakPrefillThroughput,omitempty"`
@@ -79,8 +94,10 @@ var DefaultConfig = Config{
 	AffinityThreshold:      0.80,
 	ExplorationProbability: 0.01,
 	MaxTTFTPenaltyMs:       5000,
-	UseLatencyPredictor:    true,
-	PeakPrefillThroughput:  15928,
+	TTFTSource:             TTFTSourceLatencyPredictor,
+
+	// Calibrated for Qwen 32B on 2x H100 80GB (TP=2), vLLM 0.19; see README.
+	PeakPrefillThroughput: 15928,
 }
 
 type Plugin struct {
@@ -123,10 +140,22 @@ func (c *Config) validate() error {
 	if c.PeakPrefillThroughput < 0 {
 		return fmt.Errorf("peakPrefillThroughput must be >= 0, got %f", c.PeakPrefillThroughput)
 	}
-	if !c.UseLatencyPredictor && c.MaxTTFTPenaltyMs > 0 && c.PeakPrefillThroughput == 0 {
-		return errors.New("peakPrefillThroughput must be > 0 when useLatencyPredictor is false")
+	switch c.TTFTSource {
+	case "", TTFTSourceLatencyPredictor, TTFTSourcePrefillThroughput:
+	default:
+		return fmt.Errorf("ttftSource must be %q or %q, got %q", TTFTSourceLatencyPredictor, TTFTSourcePrefillThroughput, c.TTFTSource)
+	}
+	if !c.usesLatencyPredictor() && c.MaxTTFTPenaltyMs > 0 && c.PeakPrefillThroughput == 0 {
+		return errors.New("peakPrefillThroughput must be > 0 when ttftSource is prefillThroughput")
 	}
 	return nil
+}
+
+// usesLatencyPredictor reports whether the load gate sources TTFT from the
+// latency predictor. The predictor is the default; only an explicit
+// prefillThroughput selects the in-flight-token estimate.
+func (c *Config) usesLatencyPredictor() bool {
+	return c.TTFTSource != TTFTSourcePrefillThroughput
 }
 
 func (p *Plugin) TypedName() fwkplugin.TypedName {
@@ -186,7 +215,7 @@ func (p *Plugin) Consumes() fwkplugin.DataDependencies {
 		p.prefixMatchDataKey: attrprefix.PrefixCacheMatchInfo{},
 	}
 	if p.config.MaxTTFTPenaltyMs > 0 {
-		if p.config.UseLatencyPredictor {
+		if p.config.usesLatencyPredictor() {
 			required[p.latencyPredictionInfoDataKey] = attrlatency.LatencyPredictionInfo{}
 		} else {
 			required[p.inFlightLoadDataKey] = attrconcurrency.InFlightLoad{}
@@ -225,7 +254,7 @@ func (p *Plugin) bestTTFT(endpoints []fwksched.Endpoint) float64 {
 // MaxFloat64 on the predictor path (never the fastest), 0 in-flight tokens on
 // the throughput path (no observed load).
 func (p *Plugin) endpointTTFT(ep fwksched.Endpoint) float64 {
-	if p.config.UseLatencyPredictor {
+	if p.config.usesLatencyPredictor() {
 		if raw, ok := ep.Get(p.latencyPredictionInfoDataKey.String()); ok {
 			info := raw.(*attrlatency.LatencyPredictionInfo)
 			return info.TTFT()

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -89,7 +89,7 @@ func TestFilter_NoStickyEndpoints(t *testing.T) {
 }
 
 func TestFilter_NarrowToSticky(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 5000, UseLatencyPredictor: true})
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 5000, TTFTSource: TTFTSourceLatencyPredictor})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 100, 0),
 		makeEndpoint("b", 85, 120, 0),
@@ -100,7 +100,7 @@ func TestFilter_NarrowToSticky(t *testing.T) {
 }
 
 func TestFilter_TTFTPenaltyBreaksStickiness(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100, UseLatencyPredictor: true})
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourceLatencyPredictor})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 500, 0),
 		makeEndpoint("b", 10, 50, 0),
@@ -112,7 +112,7 @@ func TestFilter_TTFTPenaltyBreaksStickiness(t *testing.T) {
 // With PeakPrefillThroughput=1000 tokens/sec, in-flight tokens map to TTFT as
 // tokens/1000*1000 = tokens ms: endpoint "a" -> 500ms, "b" -> 50ms.
 func TestFilter_ThroughputTTFTBreaksStickiness(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100, PeakPrefillThroughput: 1000})
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourcePrefillThroughput, PeakPrefillThroughput: 1000})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 10, 500),
 		makeEndpoint("b", 10, 10, 50),
@@ -122,7 +122,7 @@ func TestFilter_ThroughputTTFTBreaksStickiness(t *testing.T) {
 }
 
 func TestFilter_ThroughputTTFTWithinThreshold(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 1000, PeakPrefillThroughput: 1000})
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 1000, TTFTSource: TTFTSourcePrefillThroughput, PeakPrefillThroughput: 1000})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 10, 500),
 		makeEndpoint("b", 10, 10, 50),
@@ -133,7 +133,7 @@ func TestFilter_ThroughputTTFTWithinThreshold(t *testing.T) {
 }
 
 func TestFilter_TTFTPenaltyDisabled(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 0, PeakPrefillThroughput: 1000})
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 0, TTFTSource: TTFTSourcePrefillThroughput, PeakPrefillThroughput: 1000})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 10, 5000), // Huge load
 		makeEndpoint("b", 10, 10, 50),
@@ -163,7 +163,7 @@ func TestConsumes_ConditionalAttributes(t *testing.T) {
 	assert.False(t, ok, "LatencyPredictionInfoDataKey should not be consumed when the gate is disabled")
 
 	// Gate using the latency predictor.
-	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, UseLatencyPredictor: true})
+	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, TTFTSource: TTFTSourceLatencyPredictor})
 	consumed = p.Consumes()
 	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
 	assert.True(t, ok)
@@ -171,7 +171,7 @@ func TestConsumes_ConditionalAttributes(t *testing.T) {
 	assert.False(t, ok)
 
 	// Gate using peak prefill throughput.
-	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, UseLatencyPredictor: false, PeakPrefillThroughput: 1000})
+	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, TTFTSource: TTFTSourcePrefillThroughput, PeakPrefillThroughput: 1000})
 	consumed = p.Consumes()
 	_, ok = consumed.Required[p.inFlightLoadDataKey]
 	assert.True(t, ok)
@@ -210,7 +210,7 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfig.AffinityThreshold, p.config.AffinityThreshold)
 	assert.Equal(t, DefaultConfig.ExplorationProbability, p.config.ExplorationProbability)
 	assert.Equal(t, float64(10000), p.config.MaxTTFTPenaltyMs)
-	assert.Equal(t, DefaultConfig.UseLatencyPredictor, p.config.UseLatencyPredictor)
+	assert.Equal(t, DefaultConfig.TTFTSource, p.config.TTFTSource)
 	assert.Equal(t, DefaultConfig.PeakPrefillThroughput, p.config.PeakPrefillThroughput)
 }
 
@@ -233,29 +233,37 @@ func TestFactory_InvalidPeakPrefillThroughput(t *testing.T) {
 }
 
 // The throughput TTFT source needs a non-zero divisor: with the gate enabled
-// (maxTTFTPenaltyMs defaults to 5000) and useLatencyPredictor=false,
+// (maxTTFTPenaltyMs defaults to 5000) and ttftSource=prefillThroughput,
 // peakPrefillThroughput=0 must be rejected.
 func TestFactory_ThroughputModeRequiresPeakPrefillThroughput(t *testing.T) {
-	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"useLatencyPredictor": false, "peakPrefillThroughput": 0}`)), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"ttftSource": "prefillThroughput", "peakPrefillThroughput": 0}`)), nil)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "peakPrefillThroughput must be > 0 when useLatencyPredictor is false")
+	assert.Contains(t, err.Error(), "peakPrefillThroughput must be > 0 when ttftSource is prefillThroughput")
 }
 
 func TestFactory_ThroughputModeValid(t *testing.T) {
-	plugin, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"useLatencyPredictor": false, "peakPrefillThroughput": 1000}`)), nil)
+	plugin, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"ttftSource": "prefillThroughput", "peakPrefillThroughput": 1000}`)), nil)
 	assert.NoError(t, err)
 	p := plugin.(*Plugin)
-	assert.False(t, p.config.UseLatencyPredictor)
+	assert.Equal(t, TTFTSourcePrefillThroughput, p.config.TTFTSource)
 	assert.Equal(t, float64(1000), p.config.PeakPrefillThroughput)
+}
+
+// An unrecognized ttftSource value is rejected rather than silently treated as
+// the default.
+func TestFactory_InvalidTTFTSource(t *testing.T) {
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"ttftSource": "bogus"}`)), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ttftSource must be")
 }
 
 // peakPrefillThroughput=0 is valid as long as the throughput source is unused:
 // either the gate is disabled (maxTTFTPenaltyMs=0) or the latency predictor
 // supplies TTFT.
 func TestFactory_ZeroPeakPrefillThroughputAllowedWhenUnused(t *testing.T) {
-	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"maxTTFTPenaltyMs": 0, "useLatencyPredictor": false, "peakPrefillThroughput": 0}`)), nil)
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"maxTTFTPenaltyMs": 0, "ttftSource": "prefillThroughput", "peakPrefillThroughput": 0}`)), nil)
 	assert.NoError(t, err, "throughput source unused when the gate is disabled")
 
-	_, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"useLatencyPredictor": true, "peakPrefillThroughput": 0}`)), nil)
+	_, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"ttftSource": "latencyPredictor", "peakPrefillThroughput": 0}`)), nil)
 	assert.NoError(t, err, "throughput source unused when the latency predictor supplies TTFT")
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -257,6 +257,14 @@ func TestFactory_InvalidTTFTSource(t *testing.T) {
 	assert.Contains(t, err.Error(), "ttftSource must be")
 }
 
+// An empty ttftSource is rejected rather than silently defaulted: the default is
+// supplied by DefaultConfig, so an explicit empty value is a configuration error.
+func TestFactory_EmptyTTFTSourceRejected(t *testing.T) {
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"ttftSource": ""}`)), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ttftSource must be")
+}
+
 // peakPrefillThroughput=0 is valid as long as the throughput source is unused:
 // either the gate is disabled (maxTTFTPenaltyMs=0) or the latency predictor
 // supplies TTFT.
@@ -266,4 +274,20 @@ func TestFactory_ZeroPeakPrefillThroughputAllowedWhenUnused(t *testing.T) {
 
 	_, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"ttftSource": "latencyPredictor", "peakPrefillThroughput": 0}`)), nil)
 	assert.NoError(t, err, "throughput source unused when the latency predictor supplies TTFT")
+}
+
+// The default TTFT source is prefillThroughput, so an unset ttftSource selects
+// the throughput estimate: it consumes InFlightLoad and requires a non-zero
+// peakPrefillThroughput when the gate is enabled.
+func TestFactory_DefaultsToPrefillThroughput(t *testing.T) {
+	assert.Equal(t, TTFTSourcePrefillThroughput, DefaultConfig.TTFTSource)
+
+	plugin, err := Factory("test", fwkplugin.StrictDecoder(nil), nil)
+	assert.NoError(t, err)
+	p := plugin.(*Plugin)
+	assert.Equal(t, TTFTSourcePrefillThroughput, p.config.TTFTSource)
+
+	_, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"peakPrefillThroughput": 0}`)), nil)
+	assert.Error(t, err, "default throughput source needs a non-zero peakPrefillThroughput")
+	assert.Contains(t, err.Error(), "peakPrefillThroughput must be > 0")
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -225,3 +225,37 @@ func TestFactory_InvalidExplorationProbability(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "explorationProbability must be in [0, 1]")
 }
+
+func TestFactory_InvalidPeakPrefillThroughput(t *testing.T) {
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"peakPrefillThroughput": -1}`)), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "peakPrefillThroughput must be >= 0")
+}
+
+// The throughput TTFT source needs a non-zero divisor: with the gate enabled
+// (maxTTFTPenaltyMs defaults to 5000) and useLatencyPredictor=false,
+// peakPrefillThroughput=0 must be rejected.
+func TestFactory_ThroughputModeRequiresPeakPrefillThroughput(t *testing.T) {
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"useLatencyPredictor": false, "peakPrefillThroughput": 0}`)), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "peakPrefillThroughput must be > 0 when useLatencyPredictor is false")
+}
+
+func TestFactory_ThroughputModeValid(t *testing.T) {
+	plugin, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"useLatencyPredictor": false, "peakPrefillThroughput": 1000}`)), nil)
+	assert.NoError(t, err)
+	p := plugin.(*Plugin)
+	assert.False(t, p.config.UseLatencyPredictor)
+	assert.Equal(t, float64(1000), p.config.PeakPrefillThroughput)
+}
+
+// peakPrefillThroughput=0 is valid as long as the throughput source is unused:
+// either the gate is disabled (maxTTFTPenaltyMs=0) or the latency predictor
+// supplies TTFT.
+func TestFactory_ZeroPeakPrefillThroughputAllowedWhenUnused(t *testing.T) {
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"maxTTFTPenaltyMs": 0, "useLatencyPredictor": false, "peakPrefillThroughput": 0}`)), nil)
+	assert.NoError(t, err, "throughput source unused when the gate is disabled")
+
+	_, err = Factory("test", fwkplugin.StrictDecoder([]byte(`{"useLatencyPredictor": true, "peakPrefillThroughput": 0}`)), nil)
+	assert.NoError(t, err, "throughput source unused when the latency predictor supplies TTFT")
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -89,7 +89,7 @@ func TestFilter_NoStickyEndpoints(t *testing.T) {
 }
 
 func TestFilter_NarrowToSticky(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 5000})
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 5000, UseLatencyPredictor: true})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 100, 0),
 		makeEndpoint("b", 85, 120, 0),
@@ -100,7 +100,7 @@ func TestFilter_NarrowToSticky(t *testing.T) {
 }
 
 func TestFilter_TTFTPenaltyBreaksStickiness(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100})
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100, UseLatencyPredictor: true})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 500, 0),
 		makeEndpoint("b", 10, 50, 0),
@@ -109,35 +109,37 @@ func TestFilter_TTFTPenaltyBreaksStickiness(t *testing.T) {
 	assert.Equal(t, 2, len(result), "TTFT penalty should break stickiness")
 }
 
-func TestFilter_InFlightTokenPenaltyBreaksStickiness(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTokensInFlightPenalty: 100})
+// With PeakPrefillThroughput=1000 tokens/sec, in-flight tokens map to TTFT as
+// tokens/1000*1000 = tokens ms: endpoint "a" -> 500ms, "b" -> 50ms.
+func TestFilter_ThroughputTTFTBreaksStickiness(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 100, PeakPrefillThroughput: 1000})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 10, 500),
 		makeEndpoint("b", 10, 10, 50),
 	}
 	result := p.Filter(context.Background(), nil, endpoints)
-	assert.Equal(t, 2, len(result), "In-flight token penalty should break stickiness")
+	assert.Equal(t, 2, len(result), "throughput-derived TTFT penalty should break stickiness")
 }
 
-func TestFilter_InFlightTokenPenaltyWithinThreshold(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTokensInFlightPenalty: 1000})
+func TestFilter_ThroughputTTFTWithinThreshold(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 1000, PeakPrefillThroughput: 1000})
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint("a", 90, 10, 500),
 		makeEndpoint("b", 10, 10, 50),
 	}
 	result := p.Filter(context.Background(), nil, endpoints)
-	assert.Equal(t, 1, len(result), "In-flight token penalty within threshold should NOT break stickiness")
+	assert.Equal(t, 1, len(result), "throughput-derived TTFT within threshold should NOT break stickiness")
 	assert.Equal(t, "a", result[0].GetMetadata().NamespacedName.Name)
 }
 
-func TestFilter_InFlightTokenPenaltyDisabled(t *testing.T) {
-	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTokensInFlightPenalty: 0})
+func TestFilter_TTFTPenaltyDisabled(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, ExplorationProbability: 0, MaxTTFTPenaltyMs: 0, PeakPrefillThroughput: 1000})
 	endpoints := []fwksched.Endpoint{
-		makeEndpoint("a", 90, 10, 5000), // Huge penalty
+		makeEndpoint("a", 90, 10, 5000), // Huge load
 		makeEndpoint("b", 10, 10, 50),
 	}
 	result := p.Filter(context.Background(), nil, endpoints)
-	assert.Equal(t, 1, len(result), "In-flight token penalty=0 should NOT break stickiness")
+	assert.Equal(t, 1, len(result), "maxTTFTPenaltyMs=0 should NOT break stickiness")
 	assert.Equal(t, "a", result[0].GetMetadata().NamespacedName.Name)
 }
 
@@ -152,37 +154,29 @@ func TestFilter_ExplorationProbability(t *testing.T) {
 }
 
 func TestConsumes_ConditionalAttributes(t *testing.T) {
-	// Everything disabled
-	p := newTestPlugin(Config{MaxTTFTPenaltyMs: 0, MaxTokensInFlightPenalty: 0})
+	// Gate disabled: neither TTFT source is consumed.
+	p := newTestPlugin(Config{MaxTTFTPenaltyMs: 0})
 	consumed := p.Consumes()
 	_, ok := consumed.Required[p.inFlightLoadDataKey]
-	assert.False(t, ok, "InFlightLoadDataKey should not be consumed when penalty is 0")
+	assert.False(t, ok, "InFlightLoadDataKey should not be consumed when the gate is disabled")
 	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
-	assert.False(t, ok, "LatencyPredictionInfoDataKey should not be consumed when penalty is 0")
+	assert.False(t, ok, "LatencyPredictionInfoDataKey should not be consumed when the gate is disabled")
 
-	// Only TTFT enabled
-	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, MaxTokensInFlightPenalty: 0})
+	// Gate using the latency predictor.
+	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, UseLatencyPredictor: true})
 	consumed = p.Consumes()
+	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
+	assert.True(t, ok)
 	_, ok = consumed.Required[p.inFlightLoadDataKey]
 	assert.False(t, ok)
-	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
-	assert.True(t, ok)
 
-	// Only In-flight enabled
-	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 0, MaxTokensInFlightPenalty: 100})
+	// Gate using peak prefill throughput.
+	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, UseLatencyPredictor: false, PeakPrefillThroughput: 1000})
 	consumed = p.Consumes()
 	_, ok = consumed.Required[p.inFlightLoadDataKey]
 	assert.True(t, ok)
 	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
 	assert.False(t, ok)
-
-	// Both enabled
-	p = newTestPlugin(Config{MaxTTFTPenaltyMs: 5000, MaxTokensInFlightPenalty: 100})
-	consumed = p.Consumes()
-	_, ok = consumed.Required[p.inFlightLoadDataKey]
-	assert.True(t, ok)
-	_, ok = consumed.Required[p.latencyPredictionInfoDataKey]
-	assert.True(t, ok)
 }
 
 func TestFactory_ValidConfig(t *testing.T) {
@@ -216,6 +210,8 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultConfig.AffinityThreshold, p.config.AffinityThreshold)
 	assert.Equal(t, DefaultConfig.ExplorationProbability, p.config.ExplorationProbability)
 	assert.Equal(t, float64(10000), p.config.MaxTTFTPenaltyMs)
+	assert.Equal(t, DefaultConfig.UseLatencyPredictor, p.config.UseLatencyPredictor)
+	assert.Equal(t, DefaultConfig.PeakPrefillThroughput, p.config.PeakPrefillThroughput)
 }
 
 func TestFactory_InvalidAffinityThreshold(t *testing.T) {


### PR DESCRIPTION
Consolidate the TTFT-penalty and in-flight-tokens gates into a single TTFT load gate with a configurable source. useLatencyPredictor (default true) reads TTFT from the latency predictor; when false, TTFT is estimated from in-flight tokens and peakPrefillThroughput (tokens/sec). Removes MaxTokensInFlightPenalty.
