### PR TITLE
fix(approximate prefix): include tools in approximate prefix-cache estimator for chatCompletion and messages

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -115,18 +115,12 @@ func (b estimateBackend) estimateBytes(ctx context.Context, body *fwkrh.Inferenc
 func (b estimateBackend) chatCompletionsBytes(chat *fwkrh.ChatCompletionsRequest) ([]byte, []fwkrh.MultiModalFeature) {
 	var out []byte
 	var features []fwkrh.MultiModalFeature
-	// Tools render inside the system block after the system content in most templates.
-	start := 0
-	if len(chat.Messages) > 0 && chat.Messages[0].Role == "system" {
-		out, features = b.appendChatMessage(out, features, chat.Messages[0])
-		start = 1
-	}
 	if len(chat.Tools) > 0 {
 		if raw, err := json.Marshal(chat.Tools); err == nil {
 			out = append(out, raw...)
 		}
 	}
-	for _, msg := range chat.Messages[start:] {
+	for _, msg := range chat.Messages {
 		out, features = b.appendChatMessage(out, features, msg)
 	}
 	return out, features
@@ -163,6 +157,11 @@ func (b estimateBackend) appendChatMessage(out []byte, features []fwkrh.MultiMod
 func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fwkrh.MultiModalFeature) {
 	var out []byte
 	var features []fwkrh.MultiModalFeature
+	if len(req.Tools) > 0 {
+		if raw, err := json.Marshal(req.Tools); err == nil {
+			out = append(out, raw...)
+		}
+	}
 	// The system field accepts only text -- a string or an array of text blocks.
 	// See https://docs.anthropic.com/en/api/messages#body-system.
 	if req.System.Raw != "" {
@@ -172,12 +171,6 @@ func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fw
 			if block.Type == blockTypeText {
 				out = append(out, []byte(block.Text)...)
 			}
-		}
-	}
-	// Tools follow the system block, matching chatCompletionsBytes.
-	if len(req.Tools) > 0 {
-		if raw, err := json.Marshal(req.Tools); err == nil {
-			out = append(out, raw...)
 		}
 	}
 	for _, msg := range req.Messages {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -59,39 +59,34 @@ func (b estimateBackend) produce(ctx context.Context, body *fwkrh.InferenceReque
 		return &fwkrh.TokenizedPrompt{TokenIDs: body.Embeddings.Input.TokenIDs}, nil
 	}
 
-	// Chat and Anthropic messages fold multimodal placeholders into the stream
-	// and report them as features.
-	if body.ChatCompletions != nil {
-		raw, features := b.chatCompletionsBytes(body.ChatCompletions)
-		return &fwkrh.TokenizedPrompt{TokenIDs: packBytes(raw), MultiModalFeatures: features}, nil
-	}
-	if body.Messages != nil {
-		raw, features := b.messagesBytes(body.Messages)
-		tokens := packBytes(raw)
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Anthropic messages prefix-cache estimation",
-			"messageCount", len(body.Messages.Messages),
-			"rawBytes", len(raw),
-			"tokenCount", len(tokens),
-			"mmFeatureCount", len(features),
-			"mmFeatures", features,
-		)
-		return &fwkrh.TokenizedPrompt{TokenIDs: tokens, MultiModalFeatures: features}, nil
-	}
-
-	raw, err := estimateBytes(body)
+	raw, features, err := b.estimateBytes(ctx, body)
 	if err != nil {
 		return nil, err
 	}
-	return &fwkrh.TokenizedPrompt{TokenIDs: packBytes(raw)}, nil
+	return &fwkrh.TokenizedPrompt{TokenIDs: packBytes(raw), MultiModalFeatures: features}, nil
 }
 
-// estimateBytes serializes the user input of a non-chat request body to a byte
-// stream. Coverage matches the protocols the approximate prefix-cache scorer
-// handles. The chat path is handled separately to emit multimodal features.
-func estimateBytes(body *fwkrh.InferenceRequestBody) ([]byte, error) {
+// estimateBytes serializes a non-pre-tokenized request body to a byte stream
+// and, for protocols that carry multimodal assets, the features that describe
+// them. Coverage matches the protocols the approximate prefix-cache scorer
+// handles.
+func (b estimateBackend) estimateBytes(ctx context.Context, body *fwkrh.InferenceRequestBody) ([]byte, []fwkrh.MultiModalFeature, error) {
 	switch {
+	case body.ChatCompletions != nil:
+		raw, features := b.chatCompletionsBytes(body.ChatCompletions)
+		return raw, features, nil
+	case body.Messages != nil:
+		raw, features := b.messagesBytes(body.Messages)
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Anthropic messages prefix-cache estimation",
+			"messageCount", len(body.Messages.Messages),
+			"rawBytes", len(raw),
+			"mmFeatureCount", len(features),
+			"mmFeatures", features,
+		)
+		return raw, features, nil
 	case body.Conversations != nil:
-		return json.Marshal(body.Conversations.Items)
+		raw, err := json.Marshal(body.Conversations.Items)
+		return raw, nil, err
 	case body.Responses != nil:
 		var combined []map[string]any
 		if body.Responses.Instructions != nil {
@@ -101,13 +96,15 @@ func estimateBytes(body *fwkrh.InferenceRequestBody) ([]byte, error) {
 			combined = append(combined, map[string]any{"tools": body.Responses.Tools})
 		}
 		combined = append(combined, map[string]any{"input": body.Responses.Input})
-		return json.Marshal(combined)
+		raw, err := json.Marshal(combined)
+		return raw, nil, err
 	case body.Completions != nil:
-		return []byte(body.Completions.Prompt.PlainText()), nil
+		return []byte(body.Completions.Prompt.PlainText()), nil, nil
 	case body.Embeddings != nil:
-		return json.Marshal(body.Embeddings.Input)
+		raw, err := json.Marshal(body.Embeddings.Input)
+		return raw, nil, err
 	default:
-		return nil, errors.New("unsupported request body type, skipping estimation")
+		return nil, nil, errors.New("unsupported request body type, skipping estimation")
 	}
 }
 
@@ -118,26 +115,44 @@ func estimateBytes(body *fwkrh.InferenceRequestBody) ([]byte, error) {
 func (b estimateBackend) chatCompletionsBytes(chat *fwkrh.ChatCompletionsRequest) ([]byte, []fwkrh.MultiModalFeature) {
 	var out []byte
 	var features []fwkrh.MultiModalFeature
-	for _, msg := range chat.Messages {
-		if msg.Role != "" {
-			out = append(out, []byte(msg.Role)...)
+	// Tools render inside the system block after the system content in most templates.
+	start := 0
+	if len(chat.Messages) > 0 && chat.Messages[0].Role == "system" {
+		out, features = b.appendChatMessage(out, features, chat.Messages[0])
+		start = 1
+	}
+	if len(chat.Tools) > 0 {
+		if raw, err := json.Marshal(chat.Tools); err == nil {
+			out = append(out, raw...)
 		}
-		if msg.Content.Raw != "" {
-			out = append(out, []byte(msg.Content.Raw)...)
-			continue
-		}
-		for _, block := range msg.Content.Structured {
-			switch block.Type {
-			case blockTypeText:
-				out = append(out, []byte(block.Text)...)
-			case "image_url":
-				out, features = appendMMAsset(out, features, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
-			case "video_url":
-				out, features = appendMMAsset(out, features, block.VideoURL.URL, assetPlaceholderCount(len(block.VideoURL.URL)))
-			case "input_audio", "audio_url":
-				data := block.InputAudio.Data + block.InputAudio.Format
-				out, features = appendMMAsset(out, features, data, assetPlaceholderCount(len(data)))
-			}
+	}
+	for _, msg := range chat.Messages[start:] {
+		out, features = b.appendChatMessage(out, features, msg)
+	}
+	return out, features
+}
+
+// appendChatMessage flattens a single chat-completions message into the byte
+// stream, recording multimodal placeholders on aligned boundaries.
+func (b estimateBackend) appendChatMessage(out []byte, features []fwkrh.MultiModalFeature, msg fwkrh.Message) ([]byte, []fwkrh.MultiModalFeature) {
+	if msg.Role != "" {
+		out = append(out, []byte(msg.Role)...)
+	}
+	if msg.Content.Raw != "" {
+		out = append(out, []byte(msg.Content.Raw)...)
+		return out, features
+	}
+	for _, block := range msg.Content.Structured {
+		switch block.Type {
+		case blockTypeText:
+			out = append(out, []byte(block.Text)...)
+		case "image_url":
+			out, features = appendMMAsset(out, features, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
+		case "video_url":
+			out, features = appendMMAsset(out, features, block.VideoURL.URL, assetPlaceholderCount(len(block.VideoURL.URL)))
+		case "input_audio", "audio_url":
+			data := block.InputAudio.Data + block.InputAudio.Format
+			out, features = appendMMAsset(out, features, data, assetPlaceholderCount(len(data)))
 		}
 	}
 	return out, features
@@ -157,6 +172,12 @@ func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fw
 			if block.Type == blockTypeText {
 				out = append(out, []byte(block.Text)...)
 			}
+		}
+	}
+	// Tools follow the system block, matching chatCompletionsBytes.
+	if len(req.Tools) > 0 {
+		if raw, err := json.Marshal(req.Tools); err == nil {
+			out = append(out, raw...)
 		}
 	}
 	for _, msg := range req.Messages {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -366,6 +366,151 @@ func TestEstimateBackend_MessagesDeterministic(t *testing.T) {
 	}
 }
 
+// TestEstimateBackend_ChatSystemBeforeTools asserts a leading system message is
+// emitted before tools, so requests sharing the system but differing in tools
+// share their leading tokens.
+func TestEstimateBackend_ChatSystemBeforeTools(t *testing.T) {
+	systemContent := "you are a helpful assistant that should generate a long enough leading byte segment for this ordering test"
+	// -1 skips the token straddling the system/tools byte boundary.
+	sharedTokens := (len("system")+len(systemContent))/bytesPerToken - 1
+	chat := func(toolName string) *fwkrh.InferenceRequestBody {
+		return &fwkrh.InferenceRequestBody{ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{
+				{Role: "system", Content: fwkrh.Content{Raw: systemContent}},
+				{Role: "user", Content: fwkrh.Content{Raw: "hi"}},
+			},
+			Tools: []any{map[string]any{"name": toolName}},
+		}}
+	}
+	a, err := estimateBackend{}.produce(context.Background(), chat("alpha"))
+	if err != nil {
+		t.Fatalf("produce alpha: %v", err)
+	}
+	b, err := estimateBackend{}.produce(context.Background(), chat("beta"))
+	if err != nil {
+		t.Fatalf("produce beta: %v", err)
+	}
+	if hashTokens(a.TokenIDs) == hashTokens(b.TokenIDs) {
+		t.Fatal("streams identical, tools were not applied")
+	}
+	for i := 0; i < sharedTokens; i++ {
+		if a.TokenIDs[i] != b.TokenIDs[i] {
+			t.Errorf("token %d differs: system content should seed the prefix before tools", i)
+		}
+	}
+}
+
+// TestEstimateBackend_MessagesSystemBeforeTools is the /v1/messages analog of
+// TestEstimateBackend_ChatSystemBeforeTools.
+func TestEstimateBackend_MessagesSystemBeforeTools(t *testing.T) {
+	systemContent := "you are a helpful assistant that should generate a long enough leading byte segment for this ordering test"
+	// System is emitted without a role prefix; -1 skips the boundary token.
+	sharedTokens := len(systemContent)/bytesPerToken - 1
+	build := func(toolName string) *fwkrh.InferenceRequestBody {
+		return &fwkrh.InferenceRequestBody{Messages: &fwkrh.MessagesRequest{
+			System: fwkrh.AnthropicContent{Raw: systemContent},
+			Messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{Raw: "hi"}},
+			},
+			Tools: []any{map[string]any{"name": toolName}},
+		}}
+	}
+	a, err := estimateBackend{}.produce(context.Background(), build("alpha"))
+	if err != nil {
+		t.Fatalf("produce alpha: %v", err)
+	}
+	b, err := estimateBackend{}.produce(context.Background(), build("beta"))
+	if err != nil {
+		t.Fatalf("produce beta: %v", err)
+	}
+	if hashTokens(a.TokenIDs) == hashTokens(b.TokenIDs) {
+		t.Fatal("streams identical, tools were not applied")
+	}
+	for i := 0; i < sharedTokens; i++ {
+		if a.TokenIDs[i] != b.TokenIDs[i] {
+			t.Errorf("token %d differs: system content should seed the prefix before tools", i)
+		}
+	}
+}
+
+// TestEstimateBackend_ChatToolsAffectPrefix asserts the tools list participates
+// in the prefix stream so distinct tool sets do not collide on the same key.
+func TestEstimateBackend_ChatToolsAffectPrefix(t *testing.T) {
+	chat := func(tools []any) *fwkrh.InferenceRequestBody {
+		return &fwkrh.InferenceRequestBody{ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello world"}}},
+			Tools:    tools,
+		}}
+	}
+	noTools, err := estimateBackend{}.produce(context.Background(), chat(nil))
+	if err != nil {
+		t.Fatalf("produce no-tools: %v", err)
+	}
+	weather := []any{map[string]any{
+		"type":     "function",
+		"function": map[string]any{"name": "get_weather"},
+	}}
+	withTools, err := estimateBackend{}.produce(context.Background(), chat(weather))
+	if err != nil {
+		t.Fatalf("produce with-tools: %v", err)
+	}
+	if hashTokens(noTools.TokenIDs) == hashTokens(withTools.TokenIDs) {
+		t.Error("tools list was ignored by the prefix estimator")
+	}
+	stock := []any{map[string]any{
+		"type":     "function",
+		"function": map[string]any{"name": "get_stock_price"},
+	}}
+	otherTools, err := estimateBackend{}.produce(context.Background(), chat(stock))
+	if err != nil {
+		t.Fatalf("produce other-tools: %v", err)
+	}
+	if hashTokens(withTools.TokenIDs) == hashTokens(otherTools.TokenIDs) {
+		t.Error("different tools lists produced identical tokens")
+	}
+}
+
+// TestEstimateBackend_MessagesToolsAffectPrefix is the /v1/messages analog of
+// TestEstimateBackend_ChatToolsAffectPrefix.
+func TestEstimateBackend_MessagesToolsAffectPrefix(t *testing.T) {
+	build := func(tools []any) *fwkrh.InferenceRequestBody {
+		return &fwkrh.InferenceRequestBody{Messages: &fwkrh.MessagesRequest{
+			Messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{Raw: "hello world"}},
+			},
+			Tools: tools,
+		}}
+	}
+	noTools, err := estimateBackend{}.produce(context.Background(), build(nil))
+	if err != nil {
+		t.Fatalf("produce no-tools: %v", err)
+	}
+	weather := []any{map[string]any{
+		"name":         "get_weather",
+		"description":  "Get the current weather",
+		"input_schema": map[string]any{"type": "object"},
+	}}
+	withTools, err := estimateBackend{}.produce(context.Background(), build(weather))
+	if err != nil {
+		t.Fatalf("produce with-tools: %v", err)
+	}
+	if hashTokens(noTools.TokenIDs) == hashTokens(withTools.TokenIDs) {
+		t.Error("tools list was ignored by the messages prefix estimator")
+	}
+	stock := []any{map[string]any{
+		"name":         "get_stock_price",
+		"description":  "Get a stock price",
+		"input_schema": map[string]any{"type": "object"},
+	}}
+	otherTools, err := estimateBackend{}.produce(context.Background(), build(stock))
+	if err != nil {
+		t.Fatalf("produce other-tools: %v", err)
+	}
+	if hashTokens(withTools.TokenIDs) == hashTokens(otherTools.TokenIDs) {
+		t.Error("different tools lists produced identical tokens")
+	}
+}
+
 // TestEstimateBackend_NonChatNoFeatures asserts non-chat protocols carry no
 // multimodal features.
 func TestEstimateBackend_NonChatNoFeatures(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -18,11 +18,14 @@ package tokenizer
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"testing"
 	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
@@ -40,16 +43,10 @@ func hashTokens(t []uint32) uint64 {
 // hashing, so the scorer's cache keys are unchanged.
 func TestPackBytes_KeyPreserving(t *testing.T) {
 	raw := []byte("the quick brown fox jumps over!!") // len 32, 4-byte aligned
-	if len(raw)%bytesPerToken != 0 {
-		t.Fatalf("fixture must be %d-byte aligned, got len %d", bytesPerToken, len(raw))
-	}
+	require.Zero(t, len(raw)%bytesPerToken, "fixture must be %d-byte aligned, got len %d", bytesPerToken, len(raw))
 	tokens := packBytes(raw)
-	if got, want := len(tokens), len(raw)/bytesPerToken; got != want {
-		t.Fatalf("token count: got %d, want %d", got, want)
-	}
-	if hashTokens(tokens) != xxhash.Sum64(raw) {
-		t.Errorf("packed-token hash != raw-byte hash; estimate path is not key-preserving")
-	}
+	require.Len(t, tokens, len(raw)/bytesPerToken)
+	assert.Equal(t, xxhash.Sum64(raw), hashTokens(tokens), "packed-token hash != raw-byte hash; estimate path is not key-preserving")
 }
 
 // TestEstimateBackend_GeneratePassthrough asserts pre-tokenized input is kept
@@ -59,17 +56,8 @@ func TestEstimateBackend_GeneratePassthrough(t *testing.T) {
 	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
 		Generate: &fwkrh.GenerateRequest{TokenIDs: in},
 	})
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if len(tp.TokenIDs) != len(in) {
-		t.Fatalf("got %d tokens, want %d", len(tp.TokenIDs), len(in))
-	}
-	for i := range in {
-		if tp.TokenIDs[i] != in[i] {
-			t.Errorf("token %d: got %d, want %d", i, tp.TokenIDs[i], in[i])
-		}
-	}
+	require.NoError(t, err)
+	assert.Equal(t, in, tp.TokenIDs)
 }
 
 // TestEstimateBackend_CompletionsTokenIDsPassthrough asserts token-ID completions
@@ -79,17 +67,8 @@ func TestEstimateBackend_CompletionsTokenIDsPassthrough(t *testing.T) {
 	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
 		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: in}},
 	})
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if len(tp.TokenIDs) != len(in) {
-		t.Fatalf("got %d tokens, want %d (token IDs must pass through, not be byte-estimated)", len(tp.TokenIDs), len(in))
-	}
-	for i := range in {
-		if tp.TokenIDs[i] != in[i] {
-			t.Errorf("token %d: got %d, want %d", i, tp.TokenIDs[i], in[i])
-		}
-	}
+	require.NoError(t, err)
+	assert.Equal(t, in, tp.TokenIDs, "token IDs must pass through, not be byte-estimated")
 }
 
 // TestEstimateBackend_EmbeddingsTokenIDsPassthrough asserts token-ID embeddings
@@ -99,17 +78,8 @@ func TestEstimateBackend_EmbeddingsTokenIDsPassthrough(t *testing.T) {
 	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
 		Embeddings: &fwkrh.EmbeddingsRequest{Input: fwkrh.EmbeddingsInput{TokenIDs: in}},
 	})
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if len(tp.TokenIDs) != len(in) {
-		t.Fatalf("got %d tokens, want %d", len(tp.TokenIDs), len(in))
-	}
-	for i := range in {
-		if tp.TokenIDs[i] != in[i] {
-			t.Errorf("token %d: got %d, want %d", i, tp.TokenIDs[i], in[i])
-		}
-	}
+	require.NoError(t, err)
+	assert.Equal(t, in, tp.TokenIDs)
 }
 
 // TestEstimateBackend_CompletionsDeterministic asserts the same prompt produces
@@ -119,28 +89,18 @@ func TestEstimateBackend_CompletionsDeterministic(t *testing.T) {
 		return &fwkrh.InferenceRequestBody{Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: s}}}
 	}
 	a, err := estimateBackend{}.produce(context.Background(), body("hello world"))
-	if err != nil {
-		t.Fatalf("produce a: %v", err)
-	}
+	require.NoError(t, err)
 	b, err := estimateBackend{}.produce(context.Background(), body("hello world"))
-	if err != nil {
-		t.Fatalf("produce b: %v", err)
-	}
-	if hashTokens(a.TokenIDs) != hashTokens(b.TokenIDs) {
-		t.Error("same prompt produced different tokens")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, hashTokens(a.TokenIDs), hashTokens(b.TokenIDs), "same prompt produced different tokens")
 	c, err := estimateBackend{}.produce(context.Background(), body("hello there"))
-	if err != nil {
-		t.Fatalf("produce c: %v", err)
-	}
-	if hashTokens(a.TokenIDs) == hashTokens(c.TokenIDs) {
-		t.Error("distinct prompts produced identical tokens")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(a.TokenIDs), hashTokens(c.TokenIDs), "distinct prompts produced identical tokens")
 }
 
 // pngBase64Raw is a 64x32 RGBA PNG (bare base64 payload), yielding
 // 64*32/imageTokenFactor = 2 placeholder tokens under the dynamic estimator.
-const pngBase64Raw = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAgCAIAAAAt/+nTAAAARUlEQVR4nOzP0QnAUAzDwBSy/8zlTSECdxj/a2fmu7x9d5mAmoCagJqAmoCagJqAmoCagJqAmoCagJqAmoCagNofAAD//57WAN8yR4QZAAAAAElFTkSuQmCC"
+const pngBase64Raw = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAgCAIAAAAt/+nTAAAARUlEQVR4nOzP0QnAUAzDwBSy/8zlTSECdxj/a2fmu7x9d5mAmoCagJqAmoCagJqAmoCagJqAmoCagJqAmoCagJqAmoCagNofAAD//57WAN8yR4QZAAAAAElFTkSuQmCC"
 const pngBase64DataURL = "data:image/png;base64," + pngBase64Raw
 
 // TestEstimateBackend_ChatImageFeature asserts a chat image emits a multimodal
@@ -159,30 +119,17 @@ func TestEstimateBackend_ChatImageFeature(t *testing.T) {
 		},
 	}
 	tp, err := estimateBackend{}.produce(context.Background(), body)
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if len(tp.MultiModalFeatures) != 1 {
-		t.Fatalf("got %d features, want 1", len(tp.MultiModalFeatures))
-	}
+	require.NoError(t, err)
+	require.Len(t, tp.MultiModalFeatures, 1)
 	f := tp.MultiModalFeatures[0]
-	if f.Modality != fwkrh.ModalityImage {
-		t.Errorf("modality: got %q, want %q", f.Modality, fwkrh.ModalityImage)
-	}
-	if want := strconv.FormatUint(xxhash.Sum64String(pngBase64DataURL), 16); f.Hash != want {
-		t.Errorf("hash: got %q, want %q", f.Hash, want)
-	}
-	if f.Length <= 1 {
-		t.Errorf("image length: got %d, want > 1 (placeholder weighting)", f.Length)
-	}
-	if f.Offset < 0 || f.Offset+f.Length > len(tp.TokenIDs) {
-		t.Errorf("feature span [%d,%d) outside token stream of len %d", f.Offset, f.Offset+f.Length, len(tp.TokenIDs))
-	}
+	assert.Equal(t, fwkrh.ModalityImage, f.Modality)
+	assert.Equal(t, strconv.FormatUint(xxhash.Sum64String(pngBase64DataURL), 16), f.Hash)
+	assert.Greater(t, f.Length, 1, "image length must be > 1 (placeholder weighting)")
+	assert.GreaterOrEqual(t, f.Offset, 0)
+	assert.LessOrEqual(t, f.Offset+f.Length, len(tp.TokenIDs), "feature span [%d,%d) outside token stream of len %d", f.Offset, f.Offset+f.Length, len(tp.TokenIDs))
 	// Placeholder tokens are the URL hash repeated; verify the span carries weight.
 	for i := f.Offset; i < f.Offset+f.Length; i++ {
-		if tp.TokenIDs[i] != uint32(xxhash.Sum64String(pngBase64DataURL)) {
-			t.Errorf("token %d: got %d, want image placeholder token", i, tp.TokenIDs[i])
-		}
+		assert.Equal(t, uint32(xxhash.Sum64String(pngBase64DataURL)), tp.TokenIDs[i], "token %d: got %d, want image placeholder token", i, tp.TokenIDs[i])
 	}
 }
 
@@ -199,19 +146,11 @@ func TestEstimateBackend_ChatImageWeightingDistinct(t *testing.T) {
 	}
 	// Non-decodable URL falls back to the default 640x360 resolution.
 	def, err := estimateBackend{}.produce(context.Background(), chat("https://example.com/a.png"))
-	if err != nil {
-		t.Fatalf("produce default: %v", err)
-	}
-	if got, want := def.MultiModalFeatures[0].Length, (defaultImageWidth*defaultImageHeight)/imageTokenFactor; got != want {
-		t.Errorf("default image length: got %d, want %d", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, (defaultImageWidth*defaultImageHeight)/imageTokenFactor, def.MultiModalFeatures[0].Length, "default image length")
 	small, err := estimateBackend{}.produce(context.Background(), chat(pngBase64DataURL))
-	if err != nil {
-		t.Fatalf("produce small: %v", err)
-	}
-	if def.MultiModalFeatures[0].Length == small.MultiModalFeatures[0].Length {
-		t.Error("different images yielded identical placeholder counts")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, def.MultiModalFeatures[0].Length, small.MultiModalFeatures[0].Length, "different images yielded identical placeholder counts")
 }
 
 // chatImageBody builds a chat request carrying a single image_url block.
@@ -228,15 +167,9 @@ func chatImageBody(url string) *fwkrh.InferenceRequestBody {
 func TestImageEstimator_StaticMode(t *testing.T) {
 	b := estimateBackend{img: newImageEstimator(&estimateConfig{Image: &imageEstimateConfig{Mode: imageModeStatic, Static: &staticImageConfig{StaticToken: 7}}})}
 	tp, err := b.produce(context.Background(), chatImageBody(pngBase64DataURL))
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if len(tp.MultiModalFeatures) != 1 {
-		t.Fatalf("got %d features, want 1", len(tp.MultiModalFeatures))
-	}
-	if got := tp.MultiModalFeatures[0].Length; got != 7 {
-		t.Errorf("static image length: got %d, want 7", got)
-	}
+	require.NoError(t, err)
+	require.Len(t, tp.MultiModalFeatures, 1)
+	assert.Equal(t, 7, tp.MultiModalFeatures[0].Length, "static image length")
 }
 
 // TestImageEstimator_CustomFactor asserts the dynamic factor knob changes the
@@ -245,12 +178,8 @@ func TestImageEstimator_CustomFactor(t *testing.T) {
 	b := estimateBackend{img: newImageEstimator(&estimateConfig{Image: &imageEstimateConfig{Dynamic: &dynamicImageConfig{Factor: 2048}}})}
 	// Non-decodable URL falls back to the default 640x360 resolution.
 	tp, err := b.produce(context.Background(), chatImageBody("https://example.com/a.png"))
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if got, want := tp.MultiModalFeatures[0].Length, (defaultImageWidth*defaultImageHeight)/2048; got != want {
-		t.Errorf("custom-factor image length: got %d, want %d", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, (defaultImageWidth*defaultImageHeight)/2048, tp.MultiModalFeatures[0].Length, "custom-factor image length")
 }
 
 // TestImageEstimator_CustomDefaultResolution asserts the default-resolution knob
@@ -260,12 +189,8 @@ func TestImageEstimator_CustomDefaultResolution(t *testing.T) {
 		DefaultResolution: &resolution{Width: 1024, Height: 1024},
 	}})}
 	tp, err := b.produce(context.Background(), chatImageBody("https://example.com/a.png"))
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if got, want := tp.MultiModalFeatures[0].Length, (1024*1024)/imageTokenFactor; got != want {
-		t.Errorf("custom default-resolution length: got %d, want %d", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, (1024*1024)/imageTokenFactor, tp.MultiModalFeatures[0].Length, "custom default-resolution length")
 }
 
 // TestEstimateBackend_MessagesImageFeature asserts an Anthropic messages image
@@ -286,25 +211,14 @@ func TestEstimateBackend_MessagesImageFeature(t *testing.T) {
 		},
 	}
 	tp, err := estimateBackend{}.produce(context.Background(), body)
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if len(tp.MultiModalFeatures) != 1 {
-		t.Fatalf("got %d features, want 1", len(tp.MultiModalFeatures))
-	}
+	require.NoError(t, err)
+	require.Len(t, tp.MultiModalFeatures, 1)
 	f := tp.MultiModalFeatures[0]
-	if f.Modality != fwkrh.ModalityImage {
-		t.Errorf("modality: got %q, want %q", f.Modality, fwkrh.ModalityImage)
-	}
-	if want := strconv.FormatUint(xxhash.Sum64String(pngBase64Raw), 16); f.Hash != want {
-		t.Errorf("hash: got %q, want %q (base64 source must hash by its raw payload)", f.Hash, want)
-	}
-	if f.Length <= 1 {
-		t.Errorf("image length: got %d, want > 1 (placeholder weighting)", f.Length)
-	}
-	if f.Offset < 0 || f.Offset+f.Length > len(tp.TokenIDs) {
-		t.Errorf("feature span [%d,%d) outside token stream of len %d", f.Offset, f.Offset+f.Length, len(tp.TokenIDs))
-	}
+	assert.Equal(t, fwkrh.ModalityImage, f.Modality)
+	assert.Equal(t, strconv.FormatUint(xxhash.Sum64String(pngBase64Raw), 16), f.Hash, "base64 source must hash by its raw payload")
+	assert.Greater(t, f.Length, 1, "image length must be > 1 (placeholder weighting)")
+	assert.GreaterOrEqual(t, f.Offset, 0)
+	assert.LessOrEqual(t, f.Offset+f.Length, len(tp.TokenIDs), "feature span [%d,%d) outside token stream of len %d", f.Offset, f.Offset+f.Length, len(tp.TokenIDs))
 }
 
 // TestEstimateBackend_MessagesURLImageKey asserts a url-typed source is hashed
@@ -322,15 +236,9 @@ func TestEstimateBackend_MessagesURLImageKey(t *testing.T) {
 		},
 	}
 	tp, err := estimateBackend{}.produce(context.Background(), body)
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if len(tp.MultiModalFeatures) != 1 {
-		t.Fatalf("got %d features, want 1", len(tp.MultiModalFeatures))
-	}
-	if want := strconv.FormatUint(xxhash.Sum64String(url), 16); tp.MultiModalFeatures[0].Hash != want {
-		t.Errorf("hash: got %q, want %q", tp.MultiModalFeatures[0].Hash, want)
-	}
+	require.NoError(t, err)
+	require.Len(t, tp.MultiModalFeatures, 1)
+	assert.Equal(t, strconv.FormatUint(xxhash.Sum64String(url), 16), tp.MultiModalFeatures[0].Hash)
 }
 
 // TestEstimateBackend_MessagesDeterministic asserts identical requests produce
@@ -347,89 +255,71 @@ func TestEstimateBackend_MessagesDeterministic(t *testing.T) {
 		}}
 	}
 	a, err := estimateBackend{}.produce(context.Background(), build("you are helpful", "hello world"))
-	if err != nil {
-		t.Fatalf("produce a: %v", err)
-	}
+	require.NoError(t, err)
 	b, err := estimateBackend{}.produce(context.Background(), build("you are helpful", "hello world"))
-	if err != nil {
-		t.Fatalf("produce b: %v", err)
-	}
-	if hashTokens(a.TokenIDs) != hashTokens(b.TokenIDs) {
-		t.Error("identical messages requests produced different tokens")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, hashTokens(a.TokenIDs), hashTokens(b.TokenIDs), "identical messages requests produced different tokens")
 	c, err := estimateBackend{}.produce(context.Background(), build("you are concise", "hello world"))
-	if err != nil {
-		t.Fatalf("produce c: %v", err)
-	}
-	if hashTokens(a.TokenIDs) == hashTokens(c.TokenIDs) {
-		t.Error("different system prompts produced identical tokens")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(a.TokenIDs), hashTokens(c.TokenIDs), "different system prompts produced identical tokens")
 }
 
-// TestEstimateBackend_ChatSystemBeforeTools asserts a leading system message is
-// emitted before tools, so requests sharing the system but differing in tools
+// TestEstimateBackend_ChatToolsBeforeSystem asserts the tools list is emitted
+// before the system message, so requests sharing tools but differing in system
 // share their leading tokens.
-func TestEstimateBackend_ChatSystemBeforeTools(t *testing.T) {
-	systemContent := "you are a helpful assistant that should generate a long enough leading byte segment for this ordering test"
-	// -1 skips the token straddling the system/tools byte boundary.
-	sharedTokens := (len("system")+len(systemContent))/bytesPerToken - 1
-	chat := func(toolName string) *fwkrh.InferenceRequestBody {
+func TestEstimateBackend_ChatToolsBeforeSystem(t *testing.T) {
+	tools := []any{map[string]any{"name": "search_for_long_enough_byte_segment_for_this_ordering_test"}}
+	toolsJSON, err := json.Marshal(tools)
+	require.NoError(t, err)
+	// -1 skips the token straddling the tools/system byte boundary.
+	sharedTokens := len(toolsJSON)/bytesPerToken - 1
+	chat := func(systemContent string) *fwkrh.InferenceRequestBody {
 		return &fwkrh.InferenceRequestBody{ChatCompletions: &fwkrh.ChatCompletionsRequest{
 			Messages: []fwkrh.Message{
 				{Role: "system", Content: fwkrh.Content{Raw: systemContent}},
 				{Role: "user", Content: fwkrh.Content{Raw: "hi"}},
 			},
-			Tools: []any{map[string]any{"name": toolName}},
+			Tools: tools,
 		}}
 	}
-	a, err := estimateBackend{}.produce(context.Background(), chat("alpha"))
-	if err != nil {
-		t.Fatalf("produce alpha: %v", err)
-	}
-	b, err := estimateBackend{}.produce(context.Background(), chat("beta"))
-	if err != nil {
-		t.Fatalf("produce beta: %v", err)
-	}
-	if hashTokens(a.TokenIDs) == hashTokens(b.TokenIDs) {
-		t.Fatal("streams identical, tools were not applied")
-	}
+	a, err := estimateBackend{}.produce(context.Background(), chat("you are a helpful assistant"))
+	require.NoError(t, err)
+	b, err := estimateBackend{}.produce(context.Background(), chat("you are a concise assistant"))
+	require.NoError(t, err)
+	require.NotEqual(t, hashTokens(a.TokenIDs), hashTokens(b.TokenIDs), "streams identical, system was not applied")
 	for i := 0; i < sharedTokens; i++ {
-		if a.TokenIDs[i] != b.TokenIDs[i] {
-			t.Errorf("token %d differs: system content should seed the prefix before tools", i)
-		}
+		assert.Equal(t, a.TokenIDs[i], b.TokenIDs[i], "token %d differs: tools should seed the prefix before system", i)
 	}
 }
 
-// TestEstimateBackend_MessagesSystemBeforeTools is the /v1/messages analog of
-// TestEstimateBackend_ChatSystemBeforeTools.
-func TestEstimateBackend_MessagesSystemBeforeTools(t *testing.T) {
-	systemContent := "you are a helpful assistant that should generate a long enough leading byte segment for this ordering test"
-	// System is emitted without a role prefix; -1 skips the boundary token.
-	sharedTokens := len(systemContent)/bytesPerToken - 1
-	build := func(toolName string) *fwkrh.InferenceRequestBody {
+// TestEstimateBackend_MessagesToolsBeforeSystem is the /v1/messages analog of
+// TestEstimateBackend_ChatToolsBeforeSystem.
+func TestEstimateBackend_MessagesToolsBeforeSystem(t *testing.T) {
+	tools := []any{map[string]any{
+		"name":         "search_for_long_enough_byte_segment_for_this_ordering_test",
+		"description":  "ensures stable byte length",
+		"input_schema": map[string]any{"type": "object"},
+	}}
+	toolsJSON, err := json.Marshal(tools)
+	require.NoError(t, err)
+	// -1 skips the token straddling the tools/system byte boundary.
+	sharedTokens := len(toolsJSON)/bytesPerToken - 1
+	build := func(systemContent string) *fwkrh.InferenceRequestBody {
 		return &fwkrh.InferenceRequestBody{Messages: &fwkrh.MessagesRequest{
 			System: fwkrh.AnthropicContent{Raw: systemContent},
 			Messages: []fwkrh.AnthropicMessage{
 				{Role: "user", Content: fwkrh.AnthropicContent{Raw: "hi"}},
 			},
-			Tools: []any{map[string]any{"name": toolName}},
+			Tools: tools,
 		}}
 	}
-	a, err := estimateBackend{}.produce(context.Background(), build("alpha"))
-	if err != nil {
-		t.Fatalf("produce alpha: %v", err)
-	}
-	b, err := estimateBackend{}.produce(context.Background(), build("beta"))
-	if err != nil {
-		t.Fatalf("produce beta: %v", err)
-	}
-	if hashTokens(a.TokenIDs) == hashTokens(b.TokenIDs) {
-		t.Fatal("streams identical, tools were not applied")
-	}
+	a, err := estimateBackend{}.produce(context.Background(), build("you are a helpful assistant"))
+	require.NoError(t, err)
+	b, err := estimateBackend{}.produce(context.Background(), build("you are a concise assistant"))
+	require.NoError(t, err)
+	require.NotEqual(t, hashTokens(a.TokenIDs), hashTokens(b.TokenIDs), "streams identical, system was not applied")
 	for i := 0; i < sharedTokens; i++ {
-		if a.TokenIDs[i] != b.TokenIDs[i] {
-			t.Errorf("token %d differs: system content should seed the prefix before tools", i)
-		}
+		assert.Equal(t, a.TokenIDs[i], b.TokenIDs[i], "token %d differs: tools should seed the prefix before system", i)
 	}
 }
 
@@ -443,31 +333,21 @@ func TestEstimateBackend_ChatToolsAffectPrefix(t *testing.T) {
 		}}
 	}
 	noTools, err := estimateBackend{}.produce(context.Background(), chat(nil))
-	if err != nil {
-		t.Fatalf("produce no-tools: %v", err)
-	}
+	require.NoError(t, err)
 	weather := []any{map[string]any{
 		"type":     "function",
 		"function": map[string]any{"name": "get_weather"},
 	}}
 	withTools, err := estimateBackend{}.produce(context.Background(), chat(weather))
-	if err != nil {
-		t.Fatalf("produce with-tools: %v", err)
-	}
-	if hashTokens(noTools.TokenIDs) == hashTokens(withTools.TokenIDs) {
-		t.Error("tools list was ignored by the prefix estimator")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(noTools.TokenIDs), hashTokens(withTools.TokenIDs), "tools list was ignored by the prefix estimator")
 	stock := []any{map[string]any{
 		"type":     "function",
 		"function": map[string]any{"name": "get_stock_price"},
 	}}
 	otherTools, err := estimateBackend{}.produce(context.Background(), chat(stock))
-	if err != nil {
-		t.Fatalf("produce other-tools: %v", err)
-	}
-	if hashTokens(withTools.TokenIDs) == hashTokens(otherTools.TokenIDs) {
-		t.Error("different tools lists produced identical tokens")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(withTools.TokenIDs), hashTokens(otherTools.TokenIDs), "different tools lists produced identical tokens")
 }
 
 // TestEstimateBackend_MessagesToolsAffectPrefix is the /v1/messages analog of
@@ -482,33 +362,23 @@ func TestEstimateBackend_MessagesToolsAffectPrefix(t *testing.T) {
 		}}
 	}
 	noTools, err := estimateBackend{}.produce(context.Background(), build(nil))
-	if err != nil {
-		t.Fatalf("produce no-tools: %v", err)
-	}
+	require.NoError(t, err)
 	weather := []any{map[string]any{
 		"name":         "get_weather",
 		"description":  "Get the current weather",
 		"input_schema": map[string]any{"type": "object"},
 	}}
 	withTools, err := estimateBackend{}.produce(context.Background(), build(weather))
-	if err != nil {
-		t.Fatalf("produce with-tools: %v", err)
-	}
-	if hashTokens(noTools.TokenIDs) == hashTokens(withTools.TokenIDs) {
-		t.Error("tools list was ignored by the messages prefix estimator")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(noTools.TokenIDs), hashTokens(withTools.TokenIDs), "tools list was ignored by the messages prefix estimator")
 	stock := []any{map[string]any{
 		"name":         "get_stock_price",
 		"description":  "Get a stock price",
 		"input_schema": map[string]any{"type": "object"},
 	}}
 	otherTools, err := estimateBackend{}.produce(context.Background(), build(stock))
-	if err != nil {
-		t.Fatalf("produce other-tools: %v", err)
-	}
-	if hashTokens(withTools.TokenIDs) == hashTokens(otherTools.TokenIDs) {
-		t.Error("different tools lists produced identical tokens")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(withTools.TokenIDs), hashTokens(otherTools.TokenIDs), "different tools lists produced identical tokens")
 }
 
 // TestEstimateBackend_NonChatNoFeatures asserts non-chat protocols carry no
@@ -517,10 +387,6 @@ func TestEstimateBackend_NonChatNoFeatures(t *testing.T) {
 	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
 		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "hello"}},
 	})
-	if err != nil {
-		t.Fatalf("produce: %v", err)
-	}
-	if tp.MultiModalFeatures != nil {
-		t.Errorf("non-chat features: got %v, want nil", tp.MultiModalFeatures)
-	}
+	require.NoError(t, err)
+	assert.Nil(t, tp.MultiModalFeatures, "non-chat features should be nil")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The estimate tokenizer backend drops `tools` from chat-completions and messages requests before producing the byte stream. This PR folds `tools` into the prefix stream for `/v1/chat/completions` and `/v1/messages`. **Tool is estimated first and other messages including system prompt is estimated after**.

vLLM tool chat templates on system-vs-tools ordering, so any single convention mismatches some templates. Reference (templates under https://github.com/vllm-project/vllm/tree/main/examples):

| Template | System vs tools |
|---|---|
| deepseekv3 | system → tools |
| deepseekv31 | system → tools |
| gemma4 | system → tools |
| internlm2_tool | system → tools |
| phi4_mini | system → tools |
| qwen3coder | system → tools |
| granite | tools → system |
| hermes | tools → system |
| hunyuan_a13b | tools → system |
| llama3.2_json | tools → system |
| llama4_json | tools → system |
| mistral | bundled at end (tools → system) |
| mistral_parallel | bundled at end (tools → system) |
| glm4 | user-supplied system content not emitted (tools only) |

**Which issue(s) this PR fixes**:
Fixes #1019

**Release note**:
```release-note
Approximate prefix cache affinity routing now considers tools
```