### PR TITLE
Fix race condition in logger test

### DIFF
--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"bytes"
 	"context"
+	"string"
 	"sync"
 	"testing"
 	"time"
@@ -73,6 +74,13 @@ func TestLogger(t *testing.T) {
 
 	time.Sleep(6 * time.Second)
 	cancel()
+
+	// Wait for goroutines to log shutdown message to avoid race condition with subsequent tests
+	assert.Eventually(t, func() bool {
+		logOutput := b.read()
+		return strings.Contains(logOutput, "Shutting down prometheus metrics thread") &&
+			strings.Contains(logOutput, "Shutting down metrics logger thread")
+	}, 1*time.Second, 10*time.Millisecond)
 
 	logOutput := b.read()
 	assert.Contains(t, logOutput, "Refreshing Prometheus Metrics	{\"ReadyPods\": 2}")

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -19,7 +19,7 @@ package logger
 import (
 	"bytes"
 	"context"
-	"string"
+	"strings"
 	"sync"
 	"testing"
 	"time"


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind test

**What this PR does / why we need it**:
This is a race condition I discovered in the GAIE cleanup: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2959. Both TestLogger and TestRefreshPrometheusMetricsAvgValues interact with a global Prometheus metrics registry and we didn't fully wait for the metrics thread to shutdown before starting the next test.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
