### PR TITLE
feat: switch latency predictor to llm-d dev-latest images

### DIFF
--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -155,10 +155,9 @@ latencyPredictor:
   # Training Server Configuration
   trainingServer:
     image:
-      # TODO: Update this default once llm-d owns and publishes this image.
-      registry: us-central1-docker.pkg.dev/k8s-staging-images
-      repository: gateway-api-inference-extension/latency-training-server
-      tag: main
+      registry: ghcr.io/llm-d
+      repository: llm-d-latency-predictor-training-server
+      tag: v0.1.0-rc.1
       pullPolicy: Always
     port: 8000
     resources:
@@ -197,10 +196,9 @@ latencyPredictor:
     count: 1
     startPort: 8001
     image:
-      # TODO: Update this default once llm-d owns and publishes this image.
-      registry: us-central1-docker.pkg.dev/k8s-staging-images
-      repository: gateway-api-inference-extension/latency-prediction-server
-      tag: main
+      registry: ghcr.io/llm-d
+      repository: llm-d-latency-predictor-prediction-server
+      tag: v0.1.0-rc.1
       pullPolicy: Always
     resources:
       requests:

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -156,8 +156,8 @@ latencyPredictor:
   trainingServer:
     image:
       registry: ghcr.io/llm-d
-      repository: llm-d-latency-predictor-training-server
-      tag: v0.1.0-rc.1
+      repository: llm-d-latency-predictor-training-server-dev
+      tag: latest
       pullPolicy: Always
     port: 8000
     resources:
@@ -197,8 +197,8 @@ latencyPredictor:
     startPort: 8001
     image:
       registry: ghcr.io/llm-d
-      repository: llm-d-latency-predictor-prediction-server
-      tag: v0.1.0-rc.1
+      repository: llm-d-latency-predictor-prediction-server-dev
+      tag: latest
       pullPolicy: Always
     resources:
       requests:

--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -26,7 +26,8 @@ IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/llm-d}
 AGENTGATEWAY_TAG=${AGENTGATEWAY_TAG:-${EXTRA_TAG}}
 CHART_SUFFIX=${CHART_SUFFIX:-""}
 EPP_RELEASE_IMAGE_REPOSITORY=${EPP_RELEASE_IMAGE_REPOSITORY:-llm-d-router-endpoint-picker}
-export EXTRA_TAG AGENTGATEWAY_TAG IMAGE_REGISTRY EPP_RELEASE_IMAGE_REPOSITORY CHART_SUFFIX
+LATENCY_PREDICTOR_TAG=${LATENCY_PREDICTOR_TAG:-latest}
+export EXTRA_TAG AGENTGATEWAY_TAG IMAGE_REGISTRY EPP_RELEASE_IMAGE_REPOSITORY LATENCY_PREDICTOR_TAG CHART_SUFFIX
 
 HELM_CHART_REPO=${HELM_CHART_REPO:-${IMAGE_REGISTRY}/charts}
 CHART=${CHART:-llm-d-router-gateway}
@@ -43,6 +44,20 @@ then
      .router.epp.image.repository=strenv(EPP_RELEASE_IMAGE_REPOSITORY) |
      .router.epp.image.tag=strenv(EXTRA_TAG) |
      .router.epp.image.pullPolicy="IfNotPresent"' \
+    config/charts/${CHART}/values.yaml
+  if [[ ! ${LATENCY_PREDICTOR_TAG} =~ ${semver_regex} ]]; then
+    echo "ERROR: LATENCY_PREDICTOR_TAG must be a semver value on a release branch, got '${LATENCY_PREDICTOR_TAG}'"
+    exit 1
+  fi
+  ${YQ} -i \
+    '.latencyPredictor.trainingServer.image.registry=strenv(IMAGE_REGISTRY) |
+     .latencyPredictor.trainingServer.image.repository="llm-d-latency-predictor-training-server" |
+     .latencyPredictor.trainingServer.image.tag=strenv(LATENCY_PREDICTOR_TAG) |
+     .latencyPredictor.trainingServer.image.pullPolicy="IfNotPresent" |
+     .latencyPredictor.predictionServers.image.registry=strenv(IMAGE_REGISTRY) |
+     .latencyPredictor.predictionServers.image.repository="llm-d-latency-predictor-prediction-server" |
+     .latencyPredictor.predictionServers.image.tag=strenv(LATENCY_PREDICTOR_TAG) |
+     .latencyPredictor.predictionServers.image.pullPolicy="IfNotPresent"' \
     config/charts/${CHART}/values.yaml
   if [[ ${CHART} == "llm-d-router-standalone" ]]; then
     ${YQ} -i \


### PR DESCRIPTION
  Switch latencyPredictor training and prediction server defaults from
  k8s-staging gateway-api-inference-extension :main images to dev-latest
  images built and published from llm-d/llm-d-latency-predictor.

  Fixes llm-d/llm-d-latency-predictor#20

  **What type of PR is this?**

  /kind feature

  **What this PR does / why we need it**:

  Updates the default latency predictor image references in the helm chart
  to use dev-latest images built and published from llm-d/llm-d-latency-predictor.

  Training server: `ghcr.io/llm-d/llm-d-latency-predictor-training-server-dev:latest`
  Prediction server: `ghcr.io/llm-d/llm-d-latency-predictor-prediction-server-dev:latest`

  Removes the TODO comments about updating defaults once llm-d owns the images.

  **Which issue(s) this PR fixes**:

  Fixes llm-d/llm-d-latency-predictor#20

  **Release note** _(write `NONE` if no user-facing change)_:
  ```release-note
  NONE