### PR TITLE
ci: propagate HF_TOKEN to e2e tests to avoid HF Hub rate limits

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -363,6 +363,7 @@ jobs:
           E2E_LABEL_FILTER: ${{ matrix.suite.label-filter }}
           PULL_SIDECAR_IMAGE: "false"
           PULL_VLLM_RENDER_IMAGE: "false"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make test-e2e-gaie-run
 
   e2e-router:
@@ -450,4 +451,5 @@ jobs:
           E2E_LABEL_FILTER: ${{ matrix.suite.label-filter }}
           LOAD_VLLM_RENDER_IMAGE: ${{ matrix.suite.needs-renderer }}
           PULL_VLLM_RENDER_IMAGE: "false"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make test-e2e-router-run

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ endif
 # Should we pass ALL env vars here?
 E2E_ENV_VARS = EPP_IMAGE VLLM_IMAGE SIDECAR_IMAGE VLLM_RENDER_IMAGE \
                E2E_KEEP_CLUSTER_ON_FAILURE E2E_PORT E2E_METRICS_PORT K8S_CONTEXT READY_TIMEOUT \
-               E2E_LABEL_FILTER LOAD_VLLM_RENDER_IMAGE
+               E2E_LABEL_FILTER LOAD_VLLM_RENDER_IMAGE HF_TOKEN
 BUILDER_E2E_ENV_FLAGS = $(foreach v,$(E2E_ENV_VARS),$(if $($(v)),-e '$(v)=$($(v))'))
 ifneq ($(filter command line environment,$(origin NAMESPACE)),)
 BUILDER_E2E_ENV_FLAGS += -e NAMESPACE=$(NAMESPACE)

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -31,7 +32,7 @@ func createModelServersFromKustomize(kustomizeDir string, extra map[string]strin
 		"${DECODE_ROLE}":             "",
 		"${EPP_NAME}":                "e2e-epp",
 		"${NAMESPACE}":               nsName,
-		"${HF_TOKEN}":                "",
+		"${HF_TOKEN}":                os.Getenv("HF_TOKEN"),
 		"${VLLM_EXTRA_ARGS_E}":       "",
 		"${VLLM_EXTRA_ARGS_P}":       "",
 		"${VLLM_EXTRA_ARGS_D}":       "",

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -193,9 +194,15 @@ func removeEmptyLabels(inputs []string) []string {
 }
 
 func isModelReal(modelName string) bool {
-	url := "https://huggingface.co/api/models/" + modelName
+	req, err := http.NewRequest("GET", "https://huggingface.co/api/models/"+modelName, nil)
+	if err != nil {
+		return false
+	}
+	if token := os.Getenv("HF_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
-	resp, err := http.Get(url)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Summary
- Propagate `HF_TOKEN` from a GitHub repo secret into e2e test containers so vllm-render and model-existence checks authenticate against HF Hub
- Authenticated requests have a substantially higher rate limit than anonymous ones, addressing the 429 flakes described in #1527
- If the secret is not configured, behavior is unchanged (empty token, anonymous requests)

### Changes
- **Makefile**: add `HF_TOKEN` to `E2E_ENV_VARS` forwarding list
- **test/e2e/setup_test.go**: read `HF_TOKEN` from env instead of hardcoding empty string
- **test/e2e/utils_test.go**: attach Bearer token header to the `isModelReal` HF API call
- **ci-pr-checks.yaml**: pass `secrets.HF_TOKEN` in both `e2e-gaie` and `e2e-router` job steps

### Prerequisites
A repo admin must create the `HF_TOKEN` repository secret with a valid HuggingFace access token (a free account token is sufficient for the models used in CI).

Closes #1527

```release-note
NONE
```