### PR TITLE
standalone deployment with proxy as a separate service

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -44,7 +44,7 @@ helm install my-standalone-router ./config/charts/llm-d-router-standalone \
 ```
 
 #### Standalone with a Separate Proxy Service
-Deploys the Envoy proxy as its own horizontally scalable Deployment and Service instead of as a sidecar in the EPP pod. The proxy reaches EPP over the EPP Service and fails open if EPP is unreachable, so the data path stays available across EPP active/passive failover:
+Deploys the proxy as its own horizontally scalable Deployment and Service instead of as a sidecar in the EPP pod. The proxy reaches EPP over the EPP Service and fails open if EPP is unreachable, so the data path stays available across EPP active/passive failover:
 
 ```bash
 helm install my-standalone-router ./config/charts/llm-d-router-standalone \
@@ -126,6 +126,7 @@ Core settings for the Endpoint Picker Proxy (EPP) container and pod, including s
 | `router.epp.env` | Extra environment variables for EPP container. | `[]` |
 | `router.epp.extraContainerPorts` | Extra ports to expose on the EPP container. | `[]` |
 | `router.extraServicePorts` | Extra ports to expose on the EPP Service. | `[]` |
+| `router.clusterDomain` | Kubernetes cluster DNS domain used to build in-cluster Service FQDNs. | `cluster.local` |
 | `router.epp.flags` | Map of command-line flags passed directly to the EPP binary. | `{}` |
 | `router.epp.affinity` | Affinity rules for EPP pods. | `{}` |
 | `router.epp.tolerations` | Tolerations for EPP pods. | `[]` |
@@ -520,10 +521,10 @@ Configures EPP to run with a proxy (Envoy proxy or Agentgateway proxy) that inte
 | **Parameter Name** | **Description** | **Default** |
 | :--- | :--- | :--- |
 | `router.proxy.enabled` | Enable the proxy (Envoy or Agentgateway) in front of EPP. | `false` |
-| `router.proxy.proxyType` | **Standalone only**. Type of proxy. Options: `[envoy, agentgateway]`. | `envoy` |
-| `router.proxy.mode` | **Standalone only**. Proxy deployment mode. `sidecar` runs the proxy in the EPP pod; `service` runs it as its own horizontally scalable Deployment and Service reaching EPP over the EPP Service (Envoy only). | `sidecar` |
-| `router.proxy.replicas` | **Standalone only**. Replica count for the proxy Deployment when `mode=service`. | `2` |
-| `router.proxy.failOpen` | **Standalone only**. Whether the proxy passes traffic through when EPP is unreachable. Defaults to `true` in `service` mode, `false` in `sidecar` mode. | _(mode-derived)_ |
+| `router.proxy.proxyType` | Type of proxy. Options: `[envoy, agentgateway]`. | `envoy` |
+| `router.proxy.mode` | Proxy deployment mode. `sidecar` runs the proxy in the EPP pod; `service` runs it as its own horizontally scalable Deployment and Service reaching EPP over the EPP Service (Envoy only). | `sidecar` |
+| `router.proxy.replicas` | Replica count for the proxy Deployment when `mode=service`. | `2` |
+| `router.proxy.failOpen` | Whether the proxy passes traffic through (fail-open) when EPP is unreachable. | `true` |
 | `router.proxy.name` | Name of the sidecar container. | `""` |
 | `router.proxy.image` | Sidecar container image. | `""` |
 | `router.proxy.imagePullPolicy` | Sidecar container image pull policy. | `IfNotPresent` |

--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -7,7 +7,7 @@ This directory contains Helm charts for deploying the **llm-d Router** component
 We provide two charts depending on your deployment mode, both leveraging a shared core library chart (`routerlib`):
 
 *   **`llm-d-router-gateway`**: Used for **Gateway Mode**. It deploys EPP and creates an `InferencePool` resource. It integrates with the Kubernetes Gateway API (typically via `HTTPRoute` pointing to the `InferencePool`) for multi-pool, dynamic routing.
-*   **`llm-d-router-standalone`**: Used for **Standalone Mode** (Service-backed or direct pod routing). EPP can be deployed without creating an `InferencePool` resource (by setting `router.inferencePool.create=false`). It supports running EPP with a sidecar proxy (Envoy or Agentgateway) to intercept and route traffic.
+*   **`llm-d-router-standalone`**: Used for **Standalone Mode** (Service-backed or direct pod routing). EPP can be deployed without creating an `InferencePool` resource (by setting `router.inferencePool.create=false`). It supports running a proxy (Envoy or Agentgateway) to intercept and route traffic, either as a sidecar in the EPP pod or as a separate horizontally scalable service.
 *   **`routerlib` (Library Chart)**: Encapsulates the core templates and default configurations for EPP and `InferencePool`. It is not deployable on its own.
 
 ---
@@ -41,6 +41,17 @@ helm install my-standalone-router ./config/charts/llm-d-router-standalone \
   --set router.proxy.proxyType=agentgateway \
   --set router.proxy.agentgateway.service.name=my-model-service \
   --set router.proxy.agentgateway.service.ports="8000"
+```
+
+#### Standalone with a Separate Proxy Service
+Deploys the Envoy proxy as its own horizontally scalable Deployment and Service instead of as a sidecar in the EPP pod. The proxy reaches EPP over the EPP Service and fails open if EPP is unreachable, so the data path stays available across EPP active/passive failover:
+
+```bash
+helm install my-standalone-router ./config/charts/llm-d-router-standalone \
+  --set router.modelServers.matchLabels.app=my-vllm-service \
+  --set router.inferencePool.create=false \
+  --set router.proxy.mode=service \
+  --set router.proxy.replicas=3
 ```
 ---
 
@@ -502,14 +513,17 @@ httpRoute:
 
 ### Standalone Mode Configuration
 
-Configures EPP to run with a sidecar proxy container (Envoy proxy or Agentgateway proxy) to intercept and route client traffic directly to model servers (exclusive to `llm-d-router-standalone`).
+Configures EPP to run with a proxy (Envoy proxy or Agentgateway proxy) that intercepts and routes client traffic directly to model servers (exclusive to `llm-d-router-standalone`). The proxy runs as a sidecar in the EPP pod by default, or as a separate horizontally scalable service when `router.proxy.mode=service` (Envoy only).
 
 #### Proxy Sidecar Parameters
 
 | **Parameter Name** | **Description** | **Default** |
 | :--- | :--- | :--- |
-| `router.proxy.enabled` | Enable a sidecar proxy container in the EPP deployment. | `false` |
-| `router.proxy.proxyType` | **Standalone only**. Type of sidecar proxy. Options: `[envoy, agentgateway]`. | `envoy` |
+| `router.proxy.enabled` | Enable the proxy (Envoy or Agentgateway) in front of EPP. | `false` |
+| `router.proxy.proxyType` | **Standalone only**. Type of proxy. Options: `[envoy, agentgateway]`. | `envoy` |
+| `router.proxy.mode` | **Standalone only**. Proxy deployment mode. `sidecar` runs the proxy in the EPP pod; `service` runs it as its own horizontally scalable Deployment and Service reaching EPP over the EPP Service (Envoy only). | `sidecar` |
+| `router.proxy.replicas` | **Standalone only**. Replica count for the proxy Deployment when `mode=service`. | `2` |
+| `router.proxy.failOpen` | **Standalone only**. Whether the proxy passes traffic through when EPP is unreachable. Defaults to `true` in `service` mode, `false` in `sidecar` mode. | _(mode-derived)_ |
 | `router.proxy.name` | Name of the sidecar container. | `""` |
 | `router.proxy.image` | Sidecar container image. | `""` |
 | `router.proxy.imagePullPolicy` | Sidecar container image pull policy. | `IfNotPresent` |

--- a/config/charts/llm-d-router-standalone/templates/_validations.tpl
+++ b/config/charts/llm-d-router-standalone/templates/_validations.tpl
@@ -31,7 +31,7 @@ standalone validations
     {{- fail (printf ".Values.router.proxy.mode=service currently supports only proxyType=envoy, got %q" $proxyType) -}}
   {{- end -}}
   {{- $hasHTTP := false -}}
-  {{- range $servicePort := (.Values.router.extraServicePorts | default list) -}}
+  {{- range $servicePort := (.Values.router.extraServicePorts | default (list)) -}}
     {{- if eq (toString (index $servicePort "name")) "http" -}}
       {{- $hasHTTP = true -}}
     {{- end -}}

--- a/config/charts/llm-d-router-standalone/templates/_validations.tpl
+++ b/config/charts/llm-d-router-standalone/templates/_validations.tpl
@@ -14,9 +14,13 @@ standalone validations
 */}}
 {{- define "llm-d-router.validations.standalone" -}}
 {{- $proxy := .Values.router.proxy | default dict -}}
-{{- $proxyMode := default "sidecar" ($proxy.mode | default "sidecar") | lower -}}
+{{- $proxyMode := include "llm-d-router.proxyMode" . | trim -}}
 {{- if not (or (eq $proxyMode "sidecar") (eq $proxyMode "service")) -}}
   {{- fail (printf ".Values.router.proxy.mode must be one of [sidecar, service], got %q" $proxyMode) -}}
+{{- end -}}
+{{- $failOpen := index $proxy "failOpen" -}}
+{{- if and (not (kindIs "invalid" $failOpen)) (not (kindIs "bool" $failOpen)) -}}
+  {{- fail (printf ".Values.router.proxy.failOpen must be a boolean, got %q" (toString $failOpen)) -}}
 {{- end -}}
 {{- if eq $proxyMode "service" -}}
   {{- if not $proxy.enabled -}}

--- a/config/charts/llm-d-router-standalone/templates/_validations.tpl
+++ b/config/charts/llm-d-router-standalone/templates/_validations.tpl
@@ -14,6 +14,28 @@ standalone validations
 */}}
 {{- define "llm-d-router.validations.standalone" -}}
 {{- $proxy := .Values.router.proxy | default dict -}}
+{{- $proxyMode := default "sidecar" ($proxy.mode | default "sidecar") | lower -}}
+{{- if not (or (eq $proxyMode "sidecar") (eq $proxyMode "service")) -}}
+  {{- fail (printf ".Values.router.proxy.mode must be one of [sidecar, service], got %q" $proxyMode) -}}
+{{- end -}}
+{{- if eq $proxyMode "service" -}}
+  {{- if not $proxy.enabled -}}
+    {{- fail ".Values.router.proxy.enabled must be true when .Values.router.proxy.mode=service" -}}
+  {{- end -}}
+  {{- $proxyType := default "envoy" ($proxy.proxyType | default "envoy") | lower -}}
+  {{- if ne $proxyType "envoy" -}}
+    {{- fail (printf ".Values.router.proxy.mode=service currently supports only proxyType=envoy, got %q" $proxyType) -}}
+  {{- end -}}
+  {{- $hasHTTP := false -}}
+  {{- range $servicePort := (.Values.router.extraServicePorts | default list) -}}
+    {{- if eq (toString (index $servicePort "name")) "http" -}}
+      {{- $hasHTTP = true -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $hasHTTP -}}
+    {{- fail ".Values.router.extraServicePorts must contain a port named \"http\" for the proxy listener when .Values.router.proxy.mode=service" -}}
+  {{- end -}}
+{{- end -}}
 {{- if $proxy.enabled -}}
   {{- $proxyType := default "envoy" ($proxy.proxyType | default "envoy") | lower -}}
   {{- if not (or (eq $proxyType "envoy") (eq $proxyType "agentgateway")) -}}

--- a/config/charts/llm-d-router-standalone/templates/epp.yaml
+++ b/config/charts/llm-d-router-standalone/templates/epp.yaml
@@ -2,6 +2,8 @@
 {{ include "llm-d-router.validations.standalone" . }}
 {{ include "llm-d-epp.config" . }}
 {{ include "llm-d-epp.deployment" . }}
+{{ include "llm-d-epp.proxy-deployment" . }}
+{{ include "llm-d-epp.proxy-service" . }}
 {{ include "llm-d-router.gke" . }}
 {{ include "llm-d-epp.leader-election-rbac" . }}
 {{ include "llm-d-epp.sa-token-secret" . }}

--- a/config/charts/llm-d-router-standalone/values.yaml
+++ b/config/charts/llm-d-router-standalone/values.yaml
@@ -22,10 +22,9 @@ router:
     # Replica count for the proxy Deployment when mode=service.
     replicas: 2
 
-    # Whether the proxy passes traffic through when EPP is unreachable. When
-    # unset it defaults to true in service mode (active/passive resiliency) and
-    # false in sidecar mode.
-    # failOpen: true
+    # Whether the proxy passes traffic through (fail-open) when EPP is
+    # unreachable, for active/passive resiliency.
+    failOpen: true
 
     resources:
       requests:

--- a/config/charts/llm-d-router-standalone/values.yaml
+++ b/config/charts/llm-d-router-standalone/values.yaml
@@ -12,6 +12,21 @@ router:
   proxy:
     enabled: true
     proxyType: envoy
+
+    # Deployment mode for the proxy:
+    #   sidecar - proxy runs as a container in the EPP pod (default).
+    #   service - proxy runs as its own horizontally scalable Deployment and
+    #             Service, reaching EPP over the EPP Service. Envoy only.
+    mode: sidecar
+
+    # Replica count for the proxy Deployment when mode=service.
+    replicas: 2
+
+    # Whether the proxy passes traffic through when EPP is unreachable. When
+    # unset it defaults to true in service mode (active/passive resiliency) and
+    # false in sidecar mode.
+    # failOpen: true
+
     resources:
       requests:
         cpu: "4"
@@ -129,6 +144,7 @@ router:
                                 - name: envoy.filters.http.ext_proc
                                   typed_config:
                                     "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                                    failure_mode_allow: {{ include "llm-d-router.proxy.failOpen" . }}
                                     grpc_service:
                                       envoy_grpc:
                                         cluster_name: ext_proc
@@ -191,7 +207,7 @@ router:
                       use_http_header: true
                       http_header_name: x-gateway-destination-endpoint
                   - name: ext_proc
-                    type: STATIC
+                    type: {{ include "llm-d-router.proxy.extProcClusterType" . }}
                     connect_timeout: 86400s
                     lb_policy: LEAST_REQUEST
                     circuit_breakers:
@@ -232,7 +248,7 @@ router:
                             - endpoint:
                                 address:
                                   socket_address:
-                                    address: 127.0.0.1
+                                    address: {{ include "llm-d-router.proxy.extProcHost" . }}
                                     port_value: 9002
                               load_balancing_weight: 1
         name: envoy-proxy

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -28,6 +28,8 @@ spec:
     spec:
       {{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict }}
       {{- $proxyType := include "llm-d-router.proxyType" . | trim }}
+      {{- $proxyMode := include "llm-d-router.proxyMode" . | trim }}
+      {{- $proxySidecar := and $proxy.enabled (eq $proxyMode "sidecar") }}
       {{- $proxyConfigMap := index $proxy "configMap" | default dict }}
       {{- $proxyConfigMapName := index $proxyConfigMap "name" | default "" }}
       {{- $eppFlags := deepCopy (.Values.router.epp.flags | default dict) }}
@@ -38,7 +40,7 @@ spec:
       # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
       terminationGracePeriodSeconds: 130
       containers:
-      {{- if $proxy.enabled }}
+      {{- if $proxySidecar }}
         - name: {{ $proxy.name }}
           image: {{ $proxy.image }}
           imagePullPolicy: {{ $proxy.imagePullPolicy | default "IfNotPresent" }}
@@ -275,7 +277,7 @@ spec:
         - name: model-cache
           emptyDir: {}
       {{- end }}
-      {{- if and $proxy.enabled (eq $proxyType "agentgateway") $proxyConfigMapName }}
+      {{- if and $proxySidecar (eq $proxyType "agentgateway") $proxyConfigMapName }}
         - name: agentgateway-config-template
           configMap:
             name: {{ $proxyConfigMapName }}
@@ -283,8 +285,10 @@ spec:
               - key: config.yaml
                 path: config.yaml
       {{- end }}
+      {{- if $proxySidecar }}
       {{- with $proxy.volumes }}
       {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- end }}
         - name: plugins-config-volume
           configMap:

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -137,7 +137,8 @@ the EPP Service FQDN in service mode.
 */}}
 {{- define "llm-d-router.proxy.extProcHost" -}}
 {{- if eq (include "llm-d-router.proxyMode" .) "service" -}}
-{{- printf "%s.%s.svc.cluster.local" (include "llm-d-router.name" .) .Release.Namespace -}}
+{{- $domain := .Values.router.clusterDomain | default "cluster.local" -}}
+{{- printf "%s.%s.svc.%s" (include "llm-d-router.name" .) .Release.Namespace $domain -}}
 {{- else -}}
 127.0.0.1
 {{- end -}}
@@ -162,8 +163,9 @@ sidecar mode; overridable via router.proxy.failOpen.
 */}}
 {{- define "llm-d-router.proxy.failOpen" -}}
 {{- $proxy := .Values.router.proxy | default dict -}}
-{{- if hasKey $proxy "failOpen" -}}
-{{- toString $proxy.failOpen -}}
+{{- $failOpen := index $proxy "failOpen" -}}
+{{- if kindIs "bool" $failOpen -}}
+{{- $failOpen -}}
 {{- else if eq (include "llm-d-router.proxyMode" .) "service" -}}
 true
 {{- else -}}
@@ -317,12 +319,11 @@ Return the rendered proxy ConfigMap data.
     {{- $generated := dict "config.yaml" (include "llm-d-router.proxy.agentgatewayConfig" .) -}}
     {{- $data = mergeOverwrite $data $generated -}}
   {{- else if eq $proxyType "envoy" -}}
-    {{- /* Resolve the ext_proc target and fail-open directives embedded in the preset. */ -}}
-    {{- $rendered := dict -}}
-    {{- range $key, $value := $data -}}
-      {{- $_ := set $rendered $key (tpl (toString $value) $) -}}
+    {{- /* Render only the chart-owned envoy.yaml so the ext_proc target and
+           fail-open directives resolve; user-supplied keys stay literal. */ -}}
+    {{- if hasKey $data "envoy.yaml" -}}
+      {{- $_ := set $data "envoy.yaml" (tpl (toString (index $data "envoy.yaml")) $) -}}
     {{- end -}}
-    {{- $data = $rendered -}}
   {{- end -}}
 {{- end -}}
 {{- toYaml $data -}}

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -107,6 +107,71 @@ Return the standalone proxy type.
 {{- end -}}
 
 {{/*
+Return the standalone proxy deployment mode: "sidecar" (proxy runs in the EPP
+pod) or "service" (proxy runs as its own horizontally scalable Deployment).
+*/}}
+{{- define "llm-d-router.proxyMode" -}}
+{{- $proxy := .Values.router.proxy | default dict -}}
+{{- default "sidecar" ($proxy.mode | default "sidecar") | lower -}}
+{{- end -}}
+
+{{/*
+Name of the standalone proxy Deployment and Service used in service mode.
+*/}}
+{{- define "llm-d-router.proxyName" -}}
+{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 -}}
+{{ $base }}-proxy
+{{- end -}}
+
+{{/*
+Selector labels for the service-mode proxy Deployment and Service. Distinct
+from the EPP selector so the proxy and EPP pods are never co-selected.
+*/}}
+{{- define "llm-d-router.proxySelectorLabels" -}}
+llm-d-router-proxy: {{ include "llm-d-router.proxyName" . }}
+{{- end -}}
+
+{{/*
+ext_proc upstream host the proxy uses to reach EPP. Loopback in sidecar mode;
+the EPP Service FQDN in service mode.
+*/}}
+{{- define "llm-d-router.proxy.extProcHost" -}}
+{{- if eq (include "llm-d-router.proxyMode" .) "service" -}}
+{{- printf "%s.%s.svc.cluster.local" (include "llm-d-router.name" .) .Release.Namespace -}}
+{{- else -}}
+127.0.0.1
+{{- end -}}
+{{- end -}}
+
+{{/*
+ext_proc cluster discovery type. STATIC for the loopback sidecar; STRICT_DNS so
+the proxy resolves the EPP Service FQDN in service mode.
+*/}}
+{{- define "llm-d-router.proxy.extProcClusterType" -}}
+{{- if eq (include "llm-d-router.proxyMode" .) "service" -}}
+STRICT_DNS
+{{- else -}}
+STATIC
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the proxy fails open (passes traffic through) when EPP is unreachable.
+Defaults to true in service mode for active/passive resiliency, false in
+sidecar mode; overridable via router.proxy.failOpen.
+*/}}
+{{- define "llm-d-router.proxy.failOpen" -}}
+{{- $proxy := .Values.router.proxy | default dict -}}
+{{- if hasKey $proxy "failOpen" -}}
+{{- toString $proxy.failOpen -}}
+{{- else if eq (include "llm-d-router.proxyMode" .) "service" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Normalize a scalar, comma-separated string, or list of ports into a
 comma-separated numeric string.
 */}}
@@ -246,9 +311,19 @@ Return the rendered proxy ConfigMap data.
 {{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict -}}
 {{- $configMap := index $proxy "configMap" | default dict -}}
 {{- $data := deepCopy ((index $configMap "data") | default dict) -}}
-{{- if and (hasPrefix "llm-d-router-standalone" .Chart.Name) (eq (include "llm-d-router.proxyType" .) "agentgateway") -}}
-  {{- $generated := dict "config.yaml" (include "llm-d-router.proxy.agentgatewayConfig" .) -}}
-  {{- $data = mergeOverwrite $data $generated -}}
+{{- if hasPrefix "llm-d-router-standalone" .Chart.Name -}}
+  {{- $proxyType := include "llm-d-router.proxyType" . -}}
+  {{- if eq $proxyType "agentgateway" -}}
+    {{- $generated := dict "config.yaml" (include "llm-d-router.proxy.agentgatewayConfig" .) -}}
+    {{- $data = mergeOverwrite $data $generated -}}
+  {{- else if eq $proxyType "envoy" -}}
+    {{- /* Resolve the ext_proc target and fail-open directives embedded in the preset. */ -}}
+    {{- $rendered := dict -}}
+    {{- range $key, $value := $data -}}
+      {{- $_ := set $rendered $key (tpl (toString $value) $) -}}
+    {{- end -}}
+    {{- $data = $rendered -}}
+  {{- end -}}
 {{- end -}}
 {{- toYaml $data -}}
 {{- end -}}

--- a/config/charts/routerlib/templates/_proxy-deployment.yaml
+++ b/config/charts/routerlib/templates/_proxy-deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "llm-d-router.labels" . | nindent 8 }}
         {{- include "llm-d-router.proxySelectorLabels" . | nindent 8 }}
     spec:
       containers:

--- a/config/charts/routerlib/templates/_proxy-deployment.yaml
+++ b/config/charts/routerlib/templates/_proxy-deployment.yaml
@@ -1,0 +1,74 @@
+{{- define "llm-d-epp.proxy-deployment" -}}
+{{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict -}}
+{{- if and $proxy.enabled (eq (include "llm-d-router.proxyMode" .) "service") -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-d-router.proxyName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.proxySelectorLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.router.proxy.replicas | default 2 }}
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.proxySelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-router.proxySelectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ $proxy.name }}
+          image: {{ $proxy.image }}
+          imagePullPolicy: {{ $proxy.imagePullPolicy | default "IfNotPresent" }}
+        {{- with $proxy.command }}
+          command:
+            - {{ . | quote }}
+        {{- end }}
+        {{- with $proxy.args }}
+          args:
+          {{- range . }}
+            - {{ . | quote }}
+          {{- end }}
+        {{- end }}
+        {{- with $proxy.env }}
+          env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $proxy.ports }}
+          ports:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $proxy.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.startupProbe }}
+          startupProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.securityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $proxy.volumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+      {{- with $proxy.volumes }}
+      volumes:
+      {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+---
+{{- end -}}
+{{- end -}}

--- a/config/charts/routerlib/templates/_proxy-service.yaml
+++ b/config/charts/routerlib/templates/_proxy-service.yaml
@@ -1,0 +1,22 @@
+{{- define "llm-d-epp.proxy-service" -}}
+{{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict -}}
+{{- if and $proxy.enabled (eq (include "llm-d-router.proxyMode" .) "service") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llm-d-router.proxyName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.proxySelectorLabels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "llm-d-router.proxySelectorLabels" . | nindent 4 }}
+  ports:
+    {{- with .Values.router.extraServicePorts }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  type: ClusterIP
+---
+{{- end -}}
+{{- end -}}

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -1,5 +1,8 @@
 extraServicePorts: []
 
+# Kubernetes cluster DNS domain, used to build in-cluster Service FQDNs.
+clusterDomain: cluster.local
+
 epp:
   replicas: 1
   image:

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -197,6 +197,13 @@ if eval "${unsupported_proxy_service_agentgateway_command}"; then
   exit 1
 fi
 
+invalid_failopen_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.failOpen=notabool >/dev/null"
+echo "Executing: ${invalid_failopen_command}"
+if eval "${invalid_failopen_command}"; then
+  echo "Helm template unexpectedly succeeded for non-boolean router.proxy.failOpen"
+  exit 1
+fi
+
 echo "Verifying llm-d-router-standalone extra flags render as --flag=value..."
 flag_render_output="${TEMP_DIR}/llm-d-router-standalone-flag-render.yaml"
 flag_render_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set-string router.epp.flags.secure-serving=false > ${flag_render_output}"

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -115,6 +115,7 @@ test_cases_llm_d_router_standalone["gke-provider"]="--set provider.name=gke --se
 test_cases_llm_d_router_standalone["latency-predictor"]="--set router.latencyPredictor.enabled=true --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false"
 test_cases_llm_d_router_standalone["llm-d-router-gateway"]="--set router.inferencePool.create=true --set router.modelServers.matchLabels.app=llm-instance-gateway"
 test_cases_llm_d_router_standalone["agentgateway"]="--set router.proxy.proxyType=agentgateway --set router.proxy.agentgateway.service.name=llm-instance-gateway --set 'router.proxy.agentgateway.service.ports[0]=8000' --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set 'router.modelServers.targetPorts[0].number=8000'"
+test_cases_llm_d_router_standalone["proxy-service"]="--set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set router.proxy.replicas=3"
 test_cases_llm_d_router_standalone["triton"]="--set router.modelServers.type=triton --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false"
 
 
@@ -189,6 +190,13 @@ if eval "${mismatched_agentgateway_listener_target_port_command}"; then
   exit 1
 fi
 
+unsupported_proxy_service_agentgateway_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set router.proxy.proxyType=agentgateway --set router.proxy.agentgateway.service.name=llm-instance-gateway --set 'router.proxy.agentgateway.service.ports[0]=8000' --set 'router.modelServers.targetPorts[0].number=8000' >/dev/null"
+echo "Executing: ${unsupported_proxy_service_agentgateway_command}"
+if eval "${unsupported_proxy_service_agentgateway_command}"; then
+  echo "Helm template unexpectedly succeeded for proxy mode=service with proxyType=agentgateway"
+  exit 1
+fi
+
 echo "Verifying llm-d-router-standalone extra flags render as --flag=value..."
 flag_render_output="${TEMP_DIR}/llm-d-router-standalone-flag-render.yaml"
 flag_render_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set-string router.epp.flags.secure-serving=false > ${flag_render_output}"
@@ -239,5 +247,48 @@ if ! grep -Eq -- '^[[:space:]]+"?app"?:[[:space:]]+"?llm-instance-gateway"?[[:sp
 fi
 if grep -q -- 'app.kubernetes.io/name:' "${agentgateway_service_block}"; then
   echo "Agentgateway model Service rendered an app.kubernetes.io/name label"
+  exit 1
+fi
+
+echo "Verifying llm-d-router-standalone proxy mode=service renders a separate proxy Deployment and Service..."
+proxy_service_render_output="${TEMP_DIR}/llm-d-router-standalone-proxy-service-render.yaml"
+proxy_service_render_command="${HELM} template proxy-svc ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --namespace proxy-ns --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set router.proxy.replicas=3 > ${proxy_service_render_output}"
+echo "Executing: ${proxy_service_render_command}"
+eval "${proxy_service_render_command}"
+if ! grep -q -- 'name: proxy-svc-proxy' "${proxy_service_render_output}"; then
+  echo "Proxy service mode did not render the separate proxy Deployment/Service named proxy-svc-proxy"
+  exit 1
+fi
+if ! grep -q -- 'replicas: 3' "${proxy_service_render_output}"; then
+  echo "Proxy service mode did not honor router.proxy.replicas"
+  exit 1
+fi
+if ! grep -q -- 'type: STRICT_DNS' "${proxy_service_render_output}"; then
+  echo "Proxy service mode did not switch the ext_proc cluster to STRICT_DNS"
+  exit 1
+fi
+if ! grep -q -- 'address: proxy-svc-epp.proxy-ns.svc.cluster.local' "${proxy_service_render_output}"; then
+  echo "Proxy service mode did not point ext_proc at the EPP Service FQDN"
+  exit 1
+fi
+if ! grep -q -- 'failure_mode_allow: true' "${proxy_service_render_output}"; then
+  echo "Proxy service mode did not enable fail-open on the ext_proc filter"
+  exit 1
+fi
+# The proxy listener must be exposed by the separate proxy Service.
+if ! grep -q -- 'port: 8081' "${proxy_service_render_output}"; then
+  echo "Proxy service mode did not expose the proxy listener Service port"
+  exit 1
+fi
+# In service mode the envoy-proxy container lives only in the standalone proxy
+# Deployment, never as a sidecar in the EPP Deployment, so it appears once.
+proxy_container_count=$(grep -c -- '- name: envoy-proxy$' "${proxy_service_render_output}")
+if [ "${proxy_container_count}" -ne 1 ]; then
+  echo "Proxy service mode rendered ${proxy_container_count} envoy-proxy containers, expected exactly 1 (in the proxy Deployment)"
+  exit 1
+fi
+# The proxy Deployment selector/labels must be distinct from the EPP selector.
+if ! grep -q -- 'llm-d-router-proxy: proxy-svc-proxy' "${proxy_service_render_output}"; then
+  echo "Proxy service mode did not render the dedicated proxy selector label"
   exit 1
 fi


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
Adds a standalone deployment option where the proxy runs as an independent, horizontally scalable Service instead of an EPP sidecar.

A new router.proxy.mode toggle controls this:

- sidecar (default) — unchanged: proxy runs in the EPP pod.
- service — the Envoy proxy is rendered as its own Deployment (router.proxy.replicas) and Service, reaching EPP over the EPP Service (STRICT_DNS ext_proc) with fail-open (failure_mode_allow, driven by router.proxy.failOpen, default true in service mode) for active/passive resiliency.

Default behavior is preserved (sidecar renders the same aside from an explicit failure_mode_allow: false, which is Envoy's default). Scope is Envoy-only. Validation rejects mode=service with a non-Envoy proxy or without an http listener port.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1556

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The standalone Helm chart now supports `router.proxy.mode=service`, deploying the Envoy proxy as a separate horizontally scalable Service (instead of an EPP sidecar) that reaches EPP over the EPP Service with fail-open ext_proc for active/passive resiliency. Default remains `sidecar`.

```
