### PR TITLE
metrics: use centralized LLMDRouterEndpointPickerSubsystem in mm cache producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/metrics.go
@@ -24,15 +24,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
+	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
-
-const llmdSubsystem = "llm_d_router_epp"
 
 var (
 	// encoderCacheQueriesTotal counts every multimodal item hash lookup against the LRU.
 	encoderCacheQueriesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: llmdSubsystem,
+			Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
 			Name:      "encoder_cache_queries_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups made against the encoder-cache affinity LRU.", compbasemetrics.ALPHA),
 		},
@@ -44,7 +43,7 @@ var (
 	// Divide by queries_total for hit rate.
 	encoderCacheHitsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: llmdSubsystem,
+			Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
 			Name:      "encoder_cache_hits_total",
 			Help:      metricsutil.HelpMsgWithStability("Total number of multimodal item hash lookups that found a match in the encoder-cache affinity LRU, by endpoint.", compbasemetrics.ALPHA),
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The multimodal encoder-cache producer defines its own `llmdSubsystem` constant set to `"llm_d_router_epp"`, duplicating `eppmetrics.LLMDRouterEndpointPickerSubsystem` in `pkg/epp/metrics`. The two have identical values today; importing the centralized constant removes the drift risk and matches the pattern already used by `approximateprefix/metrics.go` and `predictedlatency/metrics.go`.

No metric name or label change.

**Which issue(s) this PR fixes**:

NONE

**Release note**:
```release-note
NONE
```