### PR TITLE
bug: Added back podman client to builder image

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -14,6 +14,8 @@ ARG ENVTEST_VERSION=release-0.19
 ARG ENVTEST_K8S_VERSION=1.31.0
 ARG GOVULNCHECK_VERSION=v1.3.0
 
+RUN apt-get update && apt-get install -y podman && apt-get clean all
+
 # Install docker CLI and buildx plugin
 RUN ARCH=$(uname -m) && \
     GOARCH=$(echo ${ARCH} | sed 's/x86_64/amd64/; s/aarch64/arm64/') && \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
PR #1468 made changes to the builder container used to run the various tests. This included the removal of the podman client. This causes issues for people who's local setup that uses podman as the container runtime.

Note: This issue did not affect CI, which uses docker as it's container runtime.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
