### PR TITLE
Pin :latest image tags and enable strict presubmit check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ check-latest-tags-strict: ## Check ':latest' image tags in YAML (strict; fails o
 
 .PHONY: presubmit
 presubmit: LINT_NEW_ONLY=true
-presubmit: git-branch-check signed-commits-check go-mod-check format lint vulncheck check-latest-tags
+presubmit: git-branch-check signed-commits-check go-mod-check format lint vulncheck check-latest-tags-strict
 
 .PHONY: git-branch-check
 git-branch-check:

--- a/config/manifests/sglang/gpu-deployment.yaml
+++ b/config/manifests/sglang/gpu-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: sglang
-          image: lmsysorg/sglang:latest
+          image: lmsysorg/sglang:v0.5.12
           command: ["python3", "-m", "sglang.launch_server"]
           args:
             - "--model-path=Qwen/Qwen3-32B"

--- a/config/manifests/vllm/gpu-deployment.yaml
+++ b/config/manifests/vllm/gpu-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: "vllm/vllm-openai:latest"
+          image: "vllm/vllm-openai:v0.21.0"
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/config/manifests/vllm/gpu-grpc-deployment.yaml
+++ b/config/manifests/vllm/gpu-grpc-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm-server
-          image: vllm/vllm-openai:latest
+          image: vllm/vllm-openai:v0.21.0
           command: ["python3", "-m", "vllm.entrypoints.grpc_server"]
           args:
           - "--model"

--- a/config/manifests/vllm/gpu-multilora-deployment.yaml
+++ b/config/manifests/vllm/gpu-multilora-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: "vllm/vllm-openai:latest"
+          image: "vllm/vllm-openai:v0.21.0"
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/config/manifests/vllm/gpu-prefix-cache-deployment.yaml
+++ b/config/manifests/vllm/gpu-prefix-cache-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: "vllm/vllm-openai:latest"
+          image: "vllm/vllm-openai:v0.21.0"
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/scripts/check-latest-tags.sh
+++ b/scripts/check-latest-tags.sh
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Check that YAML files do not use the ':latest' image tag.
-# Container images should be pinned to a specific version so that builds
-# and tests are reproducible.
+# Check that external container images in YAML files do not use the ':latest'
+# tag. Images for components outside the llm-d project are pinned to a specific
+# version so that builds and tests are reproducible and not broken by upstream
+# API or behavior changes. Images owned by the llm-d project are allowed to
+# track ':latest' on main so cross-component regressions surface early.
 #
 # Usage:
 #   ./scripts/check-latest-tags.sh [--warn] [DIR ...]
@@ -31,6 +33,9 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Images under these llm-d-owned registries may use ':latest'.
+OWNED_IMAGE_RE='image:[[:space:]]*"?(ghcr\.io|quay\.io)/llm-d/'
 
 WARN_ONLY=false
 
@@ -70,6 +75,7 @@ for dir in "${SCAN_DIRS[@]}"; do
     | grep -v ':latest-' \
     | grep -v 'description:' \
     | grep -v '<your-registry>' \
+    | grep -vE "$OWNED_IMAGE_RE" \
     | awk -F: '{content = substr($0, index($0,$3)); if (content !~ /^[[:space:]]*#/) print}' \
     || true)"
 
@@ -79,16 +85,16 @@ for dir in "${SCAN_DIRS[@]}"; do
 done
 
 if [[ -z "$violations" ]]; then
-  echo "No ':latest' image tags found in YAML files."
+  echo "No ':latest' image tags found for external images in YAML files."
   exit 0
 fi
 
 if [[ "$WARN_ONLY" == true ]]; then
-  echo "WARNING: The following YAML files use the ':latest' image tag."
+  echo "WARNING: The following YAML files use the ':latest' tag for an external image."
 else
-  echo "ERROR: The following YAML files use the ':latest' image tag."
+  echo "ERROR: The following YAML files use the ':latest' tag for an external image."
 fi
-echo "Pin images to a specific version for reproducible builds."
+echo "Pin external images to a specific version for reproducible builds."
 echo ""
 echo "$violations"
 

--- a/scripts/check-latest-tags.sh
+++ b/scripts/check-latest-tags.sh
@@ -58,14 +58,15 @@ for dir in "${SCAN_DIRS[@]}"; do
   # Find YAML files, pruning .git and vendor trees for speed.
   # Use grep -Hn (force filenames, no recursion) since find already
   # supplies explicit paths. Match "image:" as a YAML key (leading
-  # whitespace) to avoid substring hits in unrelated fields.
+  # whitespace, or column 0 after the grep line-number prefix) to
+  # avoid substring hits in unrelated fields.
   matches="$(find "$dir" \
     -path '*/.git' -prune -o \
     -path '*/vendor' -prune -o \
     -path '*/node_modules' -prune -o \
     -type f \( -name '*.yaml' -o -name '*.yml' \) -print0 \
     | xargs -0 grep -Hn ':latest' \
-    | grep '[[:space:]]image:' \
+    | grep -E '([[:space:]]image:|:[0-9]+:image:)' \
     | grep -v ':latest-' \
     | grep -v 'description:' \
     | grep -v '<your-registry>' \


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**

Follow-up from #1457 (per elevran's review).

1. Pins GPU manifest images to specific versions:
   - `vllm/vllm-openai:latest` to `vllm/vllm-openai:v0.21.0` (4 manifests)
   - `lmsysorg/sglang:latest` to `lmsysorg/sglang:v0.5.12` (1 manifest)
2. Flips the `presubmit` target from `check-latest-tags` (warn-only) to `check-latest-tags-strict` so `:latest` regressions block merge.
3. Fixes the grep pattern in `check-latest-tags.sh` to detect `image:` at column 0 (the previous pattern required leading whitespace).

**Which issue(s) this PR fixes:**

Resolves #1568

**Does this PR introduce a user-facing change?**

No.

**How has this been tested?**

Ran `./scripts/check-latest-tags.sh` in strict mode and confirmed zero violations. Verified column 0 detection with a test YAML file containing `image: foo/bar:latest` at column 0.