### PR TITLE
fix(concurrency-detector): report zero saturation for endpoints with nil metadata

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -137,6 +137,8 @@ func (d *detector) Saturation(_ context.Context, endpoints []datalayer.Endpoint)
 			totalCapacity += d.config.maxConcurrency
 		}
 
+		// nil metadata = endpoint not yet populated by this EPP instance
+		// (fresh or passive); counts as idle capacity with zero in-flight load.
 		if e.GetMetadata() == nil {
 			continue
 		}
@@ -148,6 +150,10 @@ func (d *detector) Saturation(_ context.Context, endpoints []datalayer.Endpoint)
 		} else {
 			totalInflight += load.Requests
 		}
+	}
+
+	if totalCapacity == 0 {
+		return 1.0
 	}
 
 	return float64(totalInflight) / float64(totalCapacity)

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -125,8 +125,18 @@ func (d *detector) getLoad(m datalayer.AttributeMap) *attrconcurrency.InFlightLo
 //
 //	Saturation = Total Inflight Requests / Total MaxConcurrency Capacity.
 func (d *detector) Saturation(_ context.Context, endpoints []datalayer.Endpoint) float64 {
+	if len(endpoints) == 0 {
+		return 1.0
+	}
+
 	var totalInflight, totalCapacity int64
 	for _, e := range endpoints {
+		if d.config.mode == modeTokens {
+			totalCapacity += d.config.maxTokenConcurrency
+		} else {
+			totalCapacity += d.config.maxConcurrency
+		}
+
 		if e.GetMetadata() == nil {
 			continue
 		}
@@ -135,15 +145,9 @@ func (d *detector) Saturation(_ context.Context, endpoints []datalayer.Endpoint)
 
 		if d.config.mode == modeTokens {
 			totalInflight += load.Tokens
-			totalCapacity += d.config.maxTokenConcurrency
 		} else {
 			totalInflight += load.Requests
-			totalCapacity += d.config.maxConcurrency
 		}
-	}
-
-	if totalCapacity == 0 {
-		return 1.0
 	}
 
 	return float64(totalInflight) / float64(totalCapacity)

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -534,6 +534,34 @@ func TestDetector_ConcurrencyStress(t *testing.T) {
 	require.Equal(t, int64(0), reg.get(fullID).Requests)
 }
 
+// TestDetector_NilMetadataEndpoint verifies that endpoints with nil metadata
+// are counted toward pool capacity with zero in-flight load, not skipped.
+func TestDetector_NilMetadataEndpoint(t *testing.T) {
+	t.Parallel()
+
+	detector := newDetector("test-detector", config{mode: modeRequests, maxConcurrency: 10}, logr.Discard())
+	ctx := context.Background()
+
+	t.Run("all_nil_metadata_returns_zero", func(t *testing.T) {
+		t.Parallel()
+		candidates := []datalayer.Endpoint{&nilMetadataEndpoint{}, &nilMetadataEndpoint{}}
+		got := detector.Saturation(ctx, candidates)
+		require.InDelta(t, 0.0, got, 1e-6, "endpoints with nil metadata should report zero saturation")
+	})
+
+	t.Run("mixed_nil_and_loaded", func(t *testing.T) {
+		t.Parallel()
+		reg := newLocalRegistry()
+		driveLoad(ctx, reg, detector, "loaded", 10)
+		candidates := []datalayer.Endpoint{
+			newFakeEndpoint(reg, "loaded"),
+			&nilMetadataEndpoint{},
+		}
+		got := detector.Saturation(ctx, candidates)
+		require.InDelta(t, 0.5, got, 1e-6, "10 inflight / (10+10) capacity = 0.5")
+	})
+}
+
 // --- Test Helpers & Mocks ---
 
 func simulatePreRequest(_ context.Context, reg *localRegistry, req *fwksched.InferenceRequest, result *fwksched.SchedulingResult) {
@@ -673,3 +701,18 @@ func makeTokenRequest(requestID string, inputTokens int) *fwksched.InferenceRequ
 		},
 	}
 }
+
+// nilMetadataEndpoint simulates a freshly registered endpoint whose metadata
+// has not been populated yet.
+type nilMetadataEndpoint struct{}
+
+func (e *nilMetadataEndpoint) GetMetadata() *datalayer.EndpointMetadata     { return nil }
+func (e *nilMetadataEndpoint) UpdateMetadata(m *datalayer.EndpointMetadata) {}
+func (e *nilMetadataEndpoint) GetAttributes() datalayer.AttributeMap        { return e }
+func (e *nilMetadataEndpoint) GetMetrics() *datalayer.Metrics               { return nil }
+func (e *nilMetadataEndpoint) UpdateMetrics(*datalayer.Metrics)             {}
+func (e *nilMetadataEndpoint) String() string                               { return "nil-metadata" }
+func (e *nilMetadataEndpoint) Get(string) (datalayer.Cloneable, bool)       { return nil, false }
+func (e *nilMetadataEndpoint) Put(string, datalayer.Cloneable)              {}
+func (e *nilMetadataEndpoint) Keys() []string                               { return nil }
+func (e *nilMetadataEndpoint) Clone() datalayer.AttributeMap                { return e }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

The concurrency-detector's `Saturation()` method skipped endpoints with nil metadata, excluding them from both the inflight and capacity totals. When all endpoints lacked metadata (freshly provisioned pods or passive HA pods), `totalCapacity` stayed zero and the method returned 1.0, incorrectly signalling full saturation.

This caused autoscaling events to trigger immediately after cluster provisioning, and the passive pod in an HA setup permanently reported saturation as 1 instead of 0.

The fix moves capacity accumulation before the nil-metadata guard. Every endpoint in the candidate list contributes its configured max concurrency to the denominator. Endpoints with nil metadata contribute zero inflight load to the numerator. An empty candidate list still returns 1.0 (fail-closed).

The utilization-detector does not have this problem because it reads metrics from the model servers directly (which always report their resource usage), while the concurrency-detector relies on in-flight load data that only gets populated after the EPP processes traffic.

**Which issue(s) this PR fixes:**

Resolves #1495

**Does this PR introduce a user-facing change?**

Yes. Freshly provisioned pods and passive HA pods now report saturation as 0 instead of 1 when the concurrency-detector plugin is active.

**How has this been tested?**

Added `TestDetector_NilMetadataEndpoint` covering:
- All endpoints with nil metadata returns saturation 0.0
- Mixed nil metadata and loaded endpoints returns correct ratio (e.g., 10 inflight / 20 capacity = 0.5)

All existing tests continue to pass.