### PR TITLE
Reduce allocations in response usage parsing in openai parser

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -341,7 +341,7 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 		if !ok {
 			continue
 		}
-		// When the stream is terminated with [DONE] or there's not usage data, skip the line
+		// When the stream is terminated with [DONE] or there's not any usage data, skip the line
 		if content == "[DONE]" || !strings.Contains(content, "usage") {
 			continue
 		}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -48,7 +48,6 @@ const (
 	// to account for optional parameters like "; charset=utf-8" often appended by proxies.
 	eventStreamType = "text/event-stream"
 
-	usageField               = "usage"
 	promptTokensField        = "prompt_tokens"
 	inputTokensField         = "input_tokens"
 	completionTokensField    = "completion_tokens"
@@ -260,14 +259,14 @@ func toInt(v any) int {
 }
 
 func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
-	var responseErr error
-	var responseBody map[string]any
-	responseErr = json.Unmarshal(responseBytes, &responseBody)
-	if responseErr != nil {
-		return nil, responseErr
+	var responseBody struct {
+		Usage map[string]any `json:"usage"`
 	}
-	usg, ok := responseBody[usageField].(map[string]any)
-	if !ok {
+	err := json.Unmarshal(responseBytes, &responseBody)
+	if err != nil {
+		return nil, err
+	}
+	if responseBody.Usage == nil {
 		return nil, nil //nolint:nilnil
 	}
 
@@ -275,7 +274,7 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 
 	// Chat/Completions APIs use prompt_tokens. Responses/Conversations APIs use input_tokens.
 	for _, inputTokens := range []string{promptTokensField, inputTokensField} {
-		if v, ok := usg[inputTokens]; ok && v != nil {
+		if v, ok := responseBody.Usage[inputTokens]; ok && v != nil {
 			usage.PromptTokens = toInt(v)
 			break
 		}
@@ -283,7 +282,7 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 
 	// Chat/Completions APIs use completion_tokens. Responses/Conversations APIs use output_tokens.
 	for _, outputTokens := range []string{completionTokensField, outputTokensField} {
-		if v, ok := usg[outputTokens]; ok && v != nil {
+		if v, ok := responseBody.Usage[outputTokens]; ok && v != nil {
 			usage.CompletionTokens = toInt(v)
 			break
 		}
@@ -291,7 +290,7 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 
 	// Chat/Completions APIs use prompt_tokens_details. Responses/Conversations APIs use input_tokens_details.
 	for _, details := range []string{promptTokensDetailsField, inputTokensDetailsField} {
-		if detailsMap, ok := usg[details].(map[string]any); ok {
+		if detailsMap, ok := responseBody.Usage[details].(map[string]any); ok {
 			if cachedTokens, ok := detailsMap[cachedTokensField]; ok {
 				usage.PromptTokenDetails = &fwkrh.PromptTokenDetails{
 					CachedTokens: toInt(cachedTokens),
@@ -301,7 +300,7 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 	}
 
 	// total_tokens field name is consistent across all API types.
-	if v, ok := usg[totalTokensField]; ok && v != nil {
+	if v, ok := responseBody.Usage[totalTokensField]; ok && v != nil {
 		usage.TotalTokens = toInt(v)
 	}
 
@@ -331,22 +330,21 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 	var streamResponse struct {
 		Usage    *fwkrh.Usage `json:"usage"`
 		Response struct {
-			Usage  map[string]any `json:"usage"`
-			Object string         `json:"object"`
+			Usage json.RawMessage `json:"usage"` // Delay JSON decoding until we know we have usage data
 		} `json:"response"`
 		Type string `json:"type"`
 	}
 
 	lines := strings.SplitSeq(responseText, "\n")
 	for line := range lines {
-		if !strings.HasPrefix(line, streamingRespPrefix) {
+		content, ok := strings.CutPrefix(line, streamingRespPrefix)
+		if !ok {
 			continue
 		}
-		content := strings.TrimPrefix(line, streamingRespPrefix)
-		if content == "[DONE]" {
+		// When the stream is terminated with [DONE] or there's not usage data, skip the line
+		if content == "[DONE]" || !strings.Contains(content, "usage") {
 			continue
 		}
-
 		byteSlice := []byte(content)
 		if err := json.Unmarshal(byteSlice, &streamResponse); err != nil {
 			continue
@@ -356,11 +354,9 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 			return streamResponse.Usage
 		}
 		// Responses API streaming format
-		if streamResponse.Response.Usage != nil && streamResponse.Type == "response.completed" {
-			// Convert map[string]any to JSON and parse
+		if len(streamResponse.Response.Usage) > 0 && streamResponse.Type == "response.completed" {
 			jsonBytes, _ := json.Marshal(map[string]any{
-				"usage":  streamResponse.Response.Usage,
-				"object": streamResponse.Response.Object,
+				"usage": streamResponse.Response.Usage,
 			})
 			if usage, err := extractUsage(jsonBytes); err == nil && usage != nil {
 				return usage


### PR DESCRIPTION
Implementation of multiple performance optimizations in the response serialization:

- Use a typed struct instead of map[string]any for the unmarshal in extractUsage, avoiding a full map allocation for every response.
- In _extractUsageStreaming_, Use json.RawMessage to defer decoding of nested usage data
- Skip lines early with a string check for "usage" to prevent unnecessary deserialization
- Replace HasPrefix+TrimPrefix with CutPrefix

**What type of PR is this?**
/kind feature
/kind bug
## Benchmark results

  <details>
  <summary>Environment</summary>

  goos: linux
  goarch: amd64
  cpu: 11th Gen Intel Core i7-11850H @ 2.50GHz

  </details>



| Benchmark | Baseline ns/op | Patched ns/op | Δ time | Baseline B/op | Patched B/op | Δ bytes | Baseline allocs | Patched allocs | Δ allocs |                                                                                                              
  |---|---|---|---|---|---|---|---|---|---|                                                                                                                                                                                                                   
  | ExtractUsage/small | 1,821 | 1,571 | -13.7% | 1,024 | 768 | -25.0% | 21 | 22 | +4.8% |                                                                                                                                                                    
  | ExtractUsage/medium | 8,169 | 5,099 | -37.6% | 3,096 | 1,704 | -45.0% | 75 | 38 | -49.3% |                                 
  | ExtractUsage/large | 33,140 | 27,290 | -17.7% | 11,008 | 1,240 | -88.7% | 132 | 32 | -75.8% |                              
  | ExtractUsage/no_usage | 3,088 | 1,044 | -66.2% | 1,504 | 208 | -86.2% | 35 | 5 | -85.7% |                                                                                                                                                                 
  | ExtractUsage/responses_api | 3,246 | 2,141 | -34.0% | 1,192 | 760 | -36.2% | 37 | 22 | -40.5% |                                                                                                                                                           
  | ExtractUsageStreaming/few_lines_small_chunks | 5,221 | 1,832 | -64.9% | 1,360 | 472 | -65.3% | 24 | 9 | -62.5% |                                                                                                                                          
  | ExtractUsageStreaming/many_lines_small_chunks | 111,414 | 4,153 | -96.3% | 30,072 | 472 | -98.4% | 509 | 9 | -98.2% |                                                                                                                                     
  | ExtractUsageStreaming/many_lines_large_chunks | 262,397 | 5,143 | -98.0% | 55,688 | 488 | -99.1% | 509 | 9 | -98.2% |
  | ExtractUsageStreaming/responses_api_few_lines | 15,224 | 5,015 | -67.1% | 4,340 | 1,851 | -57.4% | 92 | 40 | -56.5% |                                                                                                                                     


Where the input data for ExtractUsage is:
| Case | Body size |
  |---|---|
  | `small` | ~70 B |
  | `medium` | ~540 B |
  | `large` | ~6 KB |
  | `responses_api` | ~140 B |
 
And for ExtractUsageStreaming
| Case | Chunk lines | Chunk size | Usage line | Total lines |
  |---|---|---|---|---|
  | `few_lines_small_chunks` | 3 | ~50 B | 1 | 5 |
  | `many_lines_small_chunks` | 100 | ~50 B | 1 | 102 |
  | `many_lines_large_chunks` | 100 | ~300 B | 1 | 102 |
  | `responses_api_few_lines` | 5 | ~50 B | 1 | 7 |



**Which issue(s) this PR fixes**:

- Fixes: #1578 

