### PR TITLE
routing sidecar support /v1/messages for pd

### DIFF
--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -45,6 +45,9 @@ const (
 	// ResponsesPath is the OpenAI Responses API path
 	ResponsesPath = "/v1/responses"
 
+	// MessagesPath is the Anthropic Messages API path
+	MessagesPath = "/v1/messages"
+
 	// GeneratePath is vLLM's token-in generate endpoint
 	GeneratePath = "/inference/v1/generate"
 )

--- a/pkg/sidecar/proxy/connector_nixlv2_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_test.go
@@ -243,6 +243,79 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		Expect(responseBody).To(ContainSubstring("data: [DONE]"))
 	})
 
+	// Messages API tests — verify /v1/messages routes through the disaggregation
+	// handler with the same token-limit fields as chat completions.
+
+	It("should successfully send messages API request to 1. prefill 2. decode with the correct fields", func() {
+		proxyBaseAddr := startProxy()
+
+		By("sending a /v1/messages request with prefill header")
+		body := `{
+				"model": "claude-3-5-sonnet-20241022",
+				"messages": [
+				  {"role": "user", "content": "Hello"}
+				],
+				"max_tokens": 50
+			}`
+
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+MessagesPath, bytes.NewReader([]byte(body)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+
+		responseBody, err := io.ReadAll(rp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rp.StatusCode).To(Equal(http.StatusOK), string(responseBody))
+
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+
+		Expect(testInfo.prefillHandler.CompletionRequests).To(HaveLen(1))
+		prq1 := testInfo.prefillHandler.CompletionRequests[0]
+
+		Expect(prq1).To(HaveKey(requestFieldKVTransferParams))
+		kvTransferParams, ok := prq1[requestFieldKVTransferParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+
+		Expect(kvTransferParams).To(HaveKeyWithValue(requestFieldDoRemoteDecode, true))
+		Expect(kvTransferParams).To(HaveKeyWithValue(requestFieldDoRemotePrefill, false))
+
+		Expect(prq1).To(HaveKeyWithValue("max_tokens", BeNumerically("==", 1)))
+		Expect(prq1).To(HaveKeyWithValue("stream", false))
+
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		Expect(testInfo.decodeHandler.CompletionRequests).To(HaveLen(1))
+	})
+
+	It("should pass through messages API request when no prefill header is set", func() {
+		proxyBaseAddr := startProxy()
+
+		By("sending a /v1/messages request without prefill header")
+		body := `{
+				"model": "claude-3-5-sonnet-20241022",
+				"messages": [
+				  {"role": "user", "content": "Hello"}
+				],
+				"max_tokens": 50
+			}`
+
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+MessagesPath, bytes.NewReader([]byte(body)))
+		Expect(err).ToNot(HaveOccurred())
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+
+		responseBody, err := io.ReadAll(rp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rp.StatusCode).To(Equal(http.StatusOK), string(responseBody))
+
+		Expect(testInfo.prefillHandler.RequestCount.Load()).To(BeNumerically("==", 0))
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+	})
+
 	// Responses API tests — exercise the same NIXL v2 connector with
 	// /v1/responses and the max_output_tokens field instead of max_tokens.
 

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -424,6 +424,7 @@ func (s *Server) createRoutes() *http.ServeMux {
 	})
 	mux.HandleFunc("POST "+ChatCompletionsPath, s.disaggregatedPrefillHandler(APITypeChatCompletions))
 	mux.HandleFunc("POST "+CompletionsPath, s.disaggregatedPrefillHandler(APITypeChatCompletions))
+	mux.HandleFunc("POST "+MessagesPath, s.disaggregatedPrefillHandler(APITypeChatCompletions))
 	mux.HandleFunc("POST "+ResponsesPath, s.disaggregatedPrefillHandler(APITypeResponses))
 	mux.HandleFunc("POST "+GeneratePath, s.disaggregatedPrefillHandler(APITypeGenerate))
 

--- a/pkg/sidecar/proxy/proxy_test.go
+++ b/pkg/sidecar/proxy/proxy_test.go
@@ -117,12 +117,14 @@ var _ = Describe("Reverse Proxy", func() {
 
 			Entry("when the path is /v1/chat/completions and secure proxy is false", "/v1/chat/completions", false),
 			Entry("when the path is /v1/completions and secure proxy is false", "/v1/completions", false),
+			Entry("when the path is /v1/messages and secure proxy is false", "/v1/messages", false),
 			Entry("when the path is /v1/embeddings and secure proxy is false", "/v1/embeddings", false),
 			Entry("when the path is /score and secure proxy is false", "/score", false),
 			Entry("when the path is /healthz and secure proxy is false", "/healthz", false),
 
 			Entry("when the path is /v1/chat/completions and secure proxy is true", "/v1/chat/completions", true),
 			Entry("when the path is /v1/completions and secure proxy is true", "/v1/completions", true),
+			Entry("when the path is /v1/messages and secure proxy is true", "/v1/messages", true),
 			Entry("when the path is /v1/embeddings and secure proxy is true", "/v1/embeddings", true),
 			Entry("when the path is /score and secure proxy is true", "/score", true),
 			Entry("when the path is /healthz and secure proxy is true", "/healthz", true),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

Sits somewhere between the two, follows on after #1088 

**What this PR does / why we need it**:

This will register the /v1/messages API in the sidecar for pd-support.

cc @tessapham @hexfusion @vMaroon 
