### PR TITLE
fix(sidecar): take effect mooncake bootstrap port configured in yaml

### DIFF
--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -371,6 +371,11 @@ func (opts *Options) Validate() error {
 		return fmt.Errorf("--decode-chunk-size must be a non-negative integer (0 disables chunked decode), got %d", opts.DecodeChunkSize)
 	}
 
+	// Validate mooncake bootstrap port
+	if opts.MooncakeBootstrapPort < 1 || opts.MooncakeBootstrapPort > 65535 {
+		return fmt.Errorf("--mooncake-bootstrap-port must be between 1 and 65535, got %d", opts.MooncakeBootstrapPort)
+	}
+
 	// Validate SSRF protection requirements
 	if opts.EnableSSRFProtection {
 		if opts.InferencePoolNamespace == "" || opts.InferencePoolName == "" {
@@ -458,6 +463,9 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	}
 	if cfg.VLLMPort != 0 && !opts.isFlagSet(vllmPort) {
 		opts.vllmPort = strconv.Itoa(cfg.VLLMPort)
+	}
+	if cfg.MooncakeBootstrapPort != 0 && !opts.isFlagSet(mooncakeBootstrapPortFlag) {
+		opts.MooncakeBootstrapPort = cfg.MooncakeBootstrapPort
 	}
 	if cfg.DataParallelSize != 0 && !opts.isFlagSet(dataParallelSize) {
 		opts.DataParallelSize = cfg.DataParallelSize

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -62,6 +62,7 @@ inference-pool: "file-ns/inference-pool-file"
 pool-group: "pool-group-file"
 max-idle-conns-per-host: 300
 decode-chunk-size: 128
+mooncake-bootstrap-port: 9000
 tracing: true
 `, KVConnectorSGLang, KVConnectorNIXLV2, ECExampleConnector))
 }
@@ -105,6 +106,7 @@ func TestSidecarConfiguration(t *testing.T) {
 		pool-group: pool-group-inline,
 		max-idle-conns-per-host: 200,
 		decode-chunk-size: 256,
+		mooncake-bootstrap-port: 9001,
 		tracing: true
 	}`, KVConnectorSGLang, KVConnectorNIXLV2, ECExampleConnector)
 	invalidInlineYAML := "{port: 8200, invalid-yaml}"
@@ -131,6 +133,7 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.vllmPort = "8021"
 				o.DataParallelSize = 3
 				o.MaxIdleConnsPerHost = 200
+				o.MooncakeBootstrapPort = 9001
 
 				o.KVConnector = KVConnectorSGLang
 				o.connector = KVConnectorNIXLV2
@@ -175,6 +178,7 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.vllmPort = "8200"
 				o.DataParallelSize = 5
 				o.MaxIdleConnsPerHost = 300
+				o.MooncakeBootstrapPort = 9000
 
 				o.KVConnector = KVConnectorSGLang
 				o.ECConnector = ECExampleConnector
@@ -231,6 +235,7 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.vllmPort = "8222"
 				o.DataParallelSize = 2
 				o.MaxIdleConnsPerHost = 200
+				o.MooncakeBootstrapPort = 9001
 
 				o.KVConnector = KVConnectorSGLang
 				o.ECConnector = ECExampleConnector
@@ -279,27 +284,29 @@ func TestSidecarConfiguration(t *testing.T) {
 		{
 			name: "flags override file YAML",
 			inputFlags: map[string]any{
-				port:                    "8111",
-				vllmPort:                "8222",
-				dataParallelSize:        2,
-				kvConnector:             KVConnectorSGLang,
-				ecConnector:             ECExampleConnector,
-				enableSSRFProtection:    true,
-				enablePrefillerSampling: true,
-				enableTLS:               &[]string{prefillStage},
-				tlsInsecureSkipVerify:   &[]string{prefillStage},
-				secureServing:           false,
-				certPath:                "/etc/certificates",
-				inferencePool:           "ns/inference-pool",
-				poolGroup:               "pool-group",
-				configurationFile:       validYAMLPath,
-				maxIdleConnsPerHost:     400,
+				port:                      "8111",
+				vllmPort:                  "8222",
+				dataParallelSize:          2,
+				kvConnector:               KVConnectorSGLang,
+				ecConnector:               ECExampleConnector,
+				enableSSRFProtection:      true,
+				enablePrefillerSampling:   true,
+				enableTLS:                 &[]string{prefillStage},
+				tlsInsecureSkipVerify:     &[]string{prefillStage},
+				secureServing:             false,
+				certPath:                  "/etc/certificates",
+				inferencePool:             "ns/inference-pool",
+				poolGroup:                 "pool-group",
+				configurationFile:         validYAMLPath,
+				maxIdleConnsPerHost:       400,
+				mooncakeBootstrapPortFlag: 9002,
 			},
 			expected: func(o *Options) {
 				o.Port = "8111"
 				o.vllmPort = "8222"
 				o.DataParallelSize = 2
 				o.MaxIdleConnsPerHost = 400
+				o.MooncakeBootstrapPort = 9002
 
 				o.KVConnector = KVConnectorSGLang
 				o.ECConnector = ECExampleConnector


### PR DESCRIPTION
**What type of PR is this?**
 
/kind bug
 

**What this PR does / why we need it**:

Struct options.go defines JSON tag for  mooncake-bootstrap-port , 

``` yaml
type yamlConfiguration struct {
	Port                           int      `json:"port,omitempty"`
	VLLMPort                       int      `json:"vllm-port,omitempty"`
	MooncakeBootstrapPort          int      `json:"mooncake-bootstrap-port,omitempty"`
```

but options.go  lacks assignment logic to copy field into final options.go struct.

This may lead that  the mooncake-bootstrap-port  in YAML config file (via  --configuration-file  or  --configuration  flag) will not take effect as expected. 
  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
