### PR TITLE
feat(metrics): add inter-token latency (ITL) metric

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -56,6 +56,15 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		reqCtx.FirstTokenTimestamp = time.Now()
 	}
 
+	if reqCtx.modelServerStreaming && len(responseBytes) > 0 {
+		now := time.Now()
+		if !reqCtx.LastChunkReceivedTimestamp.IsZero() {
+			itl := now.Sub(reqCtx.LastChunkReceivedTimestamp).Seconds()
+			metrics.RecordInterTokenLatency(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, itl)
+		}
+		reqCtx.LastChunkReceivedTimestamp = now
+	}
+
 	var parsedResp *fwkrh.ParsedResponse
 	parser, err := s.getOrResolveParser(ctx, reqCtx)
 	if err != nil {

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -59,8 +59,12 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 	if reqCtx.modelServerStreaming && len(responseBytes) > 0 {
 		now := time.Now()
 		if !reqCtx.LastChunkReceivedTimestamp.IsZero() {
+			fairnessID := metadata.DefaultFairnessID
+			if reqCtx.SchedulingRequest != nil {
+				fairnessID = reqCtx.SchedulingRequest.FairnessID
+			}
 			itl := now.Sub(reqCtx.LastChunkReceivedTimestamp).Seconds()
-			metrics.RecordInterTokenLatency(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, itl)
+			metrics.RecordInterTokenLatency(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, strconv.Itoa(reqCtx.Priority), itl)
 		}
 		reqCtx.LastChunkReceivedTimestamp = now
 	}

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -106,24 +106,25 @@ type StreamingServer struct {
 // Refactor this monolithic struct. Fields related to the Envoy ext-proc protocol should be decoupled from the internal
 // request lifecycle state.
 type RequestContext struct {
-	TargetPod                 *fwkdl.EndpointMetadata
-	TargetEndpoint            string
-	IncomingModelName         string
-	TargetModelName           string
-	ObjectiveKey              string
-	Priority                  int
-	RequestReceivedTimestamp  time.Time
-	FirstTokenTimestamp       time.Time
-	ResponseCompleteTimestamp time.Time
-	RequestSize               int
-	Usage                     fwkrh.Usage
-	ResponseSize              int
-	ResponseBodyStarted       bool
-	ResponseComplete          bool
-	ResponseStatusCode        string
-	RequestRunning            bool
-	Request                   *Request
-	Parser                    fwkrh.Parser
+	TargetPod                  *fwkdl.EndpointMetadata
+	TargetEndpoint             string
+	IncomingModelName          string
+	TargetModelName            string
+	ObjectiveKey               string
+	Priority                   int
+	RequestReceivedTimestamp   time.Time
+	FirstTokenTimestamp        time.Time
+	ResponseCompleteTimestamp  time.Time
+	LastChunkReceivedTimestamp time.Time
+	RequestSize                int
+	Usage                      fwkrh.Usage
+	ResponseSize               int
+	ResponseBodyStarted        bool
+	ResponseComplete           bool
+	ResponseStatusCode         string
+	RequestRunning             bool
+	Request                    *Request
+	Parser                     fwkrh.Parser
 
 	SchedulingRequest *fwksched.InferenceRequest
 

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -175,7 +175,7 @@ var (
 				0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.15, 0.2, 0.3, 0.5, 0.75, 1, 2,
 			},
 		},
-		modelLabels,
+		append(append([]string{}, modelLabels...), "fairness_id", "priority"),
 	)
 )
 

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -165,6 +165,18 @@ var (
 		},
 		modelLabelsWithFairnessPriority,
 	)
+
+	llmdInterTokenLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "streaming_inter_token_latency_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Inter-token latency in seconds for streaming requests, measured as the time between consecutive response body chunks.", compbasemetrics.ALPHA),
+			Buckets: []float64{
+				0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.15, 0.2, 0.3, 0.5, 0.75, 1, 2,
+			},
+		},
+		modelLabels,
+	)
 )
 
 // --- llm-d Inference Pool Metrics ---

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -659,6 +659,9 @@ func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairness
 	ttftSeconds := firstToken.Sub(received).Seconds()
 	tpotSeconds := (e2eSeconds - ttftSeconds) / float64(outputTokenCount-1)
 	llmdRequestTPOT.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(tpotSeconds)
+	return true
+}
+
 // RecordInterTokenLatency records the time between consecutive response body chunks for streaming requests.
 func RecordInterTokenLatency(ctx context.Context, modelName, targetModelName string, itlSeconds float64) bool {
 	if itlSeconds < 0 {

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -663,13 +663,13 @@ func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairness
 }
 
 // RecordInterTokenLatency records the time between consecutive response body chunks for streaming requests.
-func RecordInterTokenLatency(ctx context.Context, modelName, targetModelName string, itlSeconds float64) bool {
+func RecordInterTokenLatency(ctx context.Context, modelName, targetModelName, fairnessID, priority string, itlSeconds float64) bool {
 	if itlSeconds < 0 {
 		log.FromContext(ctx).Error(nil, "Inter-token latency value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "itlSeconds", itlSeconds)
 		return false
 	}
-	llmdInterTokenLatency.WithLabelValues(modelName, targetModelName).Observe(itlSeconds)
+	llmdInterTokenLatency.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(itlSeconds)
 	return true
 }
 

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -440,6 +440,7 @@ func Register(customCollectors ...prometheus.Collector) {
 		metrics.Registry.MustRegister(llmdNormalizedTimePerOutputToken)
 		metrics.Registry.MustRegister(llmdRequestTTFT)
 		metrics.Registry.MustRegister(llmdRequestTPOT)
+		metrics.Registry.MustRegister(llmdInterTokenLatency)
 		metrics.Registry.MustRegister(inferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(inferencePoolAvgQueueSize)
@@ -505,6 +506,7 @@ func Reset() {
 	llmdNormalizedTimePerOutputToken.Reset()
 	llmdRequestTTFT.Reset()
 	llmdRequestTPOT.Reset()
+	llmdInterTokenLatency.Reset()
 	inferencePoolAvgKVCache.Reset()
 	llmdInferencePoolAvgKVCache.Reset()
 	inferencePoolAvgQueueSize.Reset()
@@ -657,6 +659,14 @@ func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairness
 	ttftSeconds := firstToken.Sub(received).Seconds()
 	tpotSeconds := (e2eSeconds - ttftSeconds) / float64(outputTokenCount-1)
 	llmdRequestTPOT.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(tpotSeconds)
+// RecordInterTokenLatency records the time between consecutive response body chunks for streaming requests.
+func RecordInterTokenLatency(ctx context.Context, modelName, targetModelName string, itlSeconds float64) bool {
+	if itlSeconds < 0 {
+		log.FromContext(ctx).Error(nil, "Inter-token latency value must be non-negative",
+			"modelName", modelName, "targetModelName", targetModelName, "itlSeconds", itlSeconds)
+		return false
+	}
+	llmdInterTokenLatency.WithLabelValues(modelName, targetModelName).Observe(itlSeconds)
 	return true
 }
 

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1324,28 +1324,28 @@ func TestRecordInterTokenLatency(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
 	t.Run("valid observations", func(t *testing.T) {
-		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0.05))
-		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0.08))
-		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0.12))
-		require.True(t, RecordInterTokenLatency(ctx, "m20", "t20", 0.03))
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", "tenant-a", "3", 0.05))
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", "tenant-a", "3", 0.08))
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", "tenant-a", "3", 0.12))
+		require.True(t, RecordInterTokenLatency(ctx, "m20", "t20", "tenant-b", "5", 0.03))
 
-		h, err := getHistogramVecLabelValues(t, llmdInterTokenLatency, "m10", "t10")
+		h, err := getHistogramVecLabelValues(t, llmdInterTokenLatency, "m10", "t10", "tenant-a", "3")
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), h.GetSampleCount())
 		require.InDelta(t, 0.25, h.GetSampleSum(), 0.001)
 
-		h, err = getHistogramVecLabelValues(t, llmdInterTokenLatency, "m20", "t20")
+		h, err = getHistogramVecLabelValues(t, llmdInterTokenLatency, "m20", "t20", "tenant-b", "5")
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), h.GetSampleCount())
 		require.InDelta(t, 0.03, h.GetSampleSum(), 0.001)
 	})
 
 	t.Run("zero latency accepted", func(t *testing.T) {
-		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0))
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", "tenant-a", "3", 0))
 	})
 
 	t.Run("negative latency rejected", func(t *testing.T) {
-		require.False(t, RecordInterTokenLatency(ctx, "m10", "t10", -0.01))
+		require.False(t, RecordInterTokenLatency(ctx, "m10", "t10", "tenant-a", "3", -0.01))
 	})
 }
 

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1319,6 +1319,36 @@ func TestRecordRequestTPOT(t *testing.T) {
 	})
 }
 
+func TestRecordInterTokenLatency(t *testing.T) {
+	Reset()
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	t.Run("valid observations", func(t *testing.T) {
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0.05))
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0.08))
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0.12))
+		require.True(t, RecordInterTokenLatency(ctx, "m20", "t20", 0.03))
+
+		h, err := getHistogramVecLabelValues(t, llmdInterTokenLatency, "m10", "t10")
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), h.GetSampleCount())
+		require.InDelta(t, 0.25, h.GetSampleSum(), 0.001)
+
+		h, err = getHistogramVecLabelValues(t, llmdInterTokenLatency, "m20", "t20")
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), h.GetSampleCount())
+		require.InDelta(t, 0.03, h.GetSampleSum(), 0.001)
+	})
+
+	t.Run("zero latency accepted", func(t *testing.T) {
+		require.True(t, RecordInterTokenLatency(ctx, "m10", "t10", 0))
+	})
+
+	t.Run("negative latency rejected", func(t *testing.T) {
+		require.False(t, RecordInterTokenLatency(ctx, "m10", "t10", -0.01))
+	})
+}
+
 func TestInferenceModelRewriteDecisionsTotalMetric(t *testing.T) {
 	Reset()
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind feature

**What this PR does / why we need it**:

Adds a new always-on Prometheus histogram `lm_d_router_epp_streaming_inter_token_latency_seconds` that records the time between consecutive response body chunks in streaming responses. This complements the TTFT and TPOT metrics added in #1499.

TPOT averages per-token time across the full request, which masks decode lags. ITL records each inter-chunk (i.e., inter-token) interval individually, enabling P99 alerting on tail latency spikes that TPOT's averaging hides.
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1590.

**Release note** _(write `NONE` if no user-facing change)_:

Add streaming inter-token latency metric (llm_d_router_epp_streaming_inter_token_latency_seconds) to the response handler. Records the time between consecutive response body chunks for streaming requests, enabling per-interval decode latency monitoring. Not emitted for non-streaming requests.