### PR TITLE
Set session affinity token in response headers

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -23,7 +23,7 @@ const (
 
 // compile-time type assertion
 var _ scheduling.Scorer = &SessionAffinity{}
-var _ requestcontrol.ResponseBodyProcessor = &SessionAffinity{}
+var _ requestcontrol.ResponseHeaderProcessor = &SessionAffinity{}
 
 // Factory defines the factory function for SessionAffinity scorer.
 func Factory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
@@ -85,20 +85,17 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 	return scoredEndpoints
 }
 
-// ResponseBody sets the session header on the response sent to the client
+// ResponseHeader sets the session header on the response sent to the client.
 // TODO: this should be using a cookie and ensure not overriding any other
 // cookie values if present.
 // Tracked in https://github.com/llm-d/llm-d-router/issues/28
-func (s *SessionAffinity) ResponseBody(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	if !response.EndOfStream {
-		return
-	}
+func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
 	if response == nil || targetPod == nil {
 		reqID := "undefined"
 		if response != nil {
 			reqID = response.RequestID
 		}
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Session affinity scorer - skip post response because one of response, targetPod is nil", "req id", reqID)
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Session affinity scorer - skip response header because response or targetPod is nil", "req id", reqID)
 		return
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -95,8 +95,7 @@ func TestSessionAffinity_Score(t *testing.T) {
 	}
 }
 
-func TestSessionAffinity_ResponseBody(t *testing.T) {
-
+func TestSessionAffinity_ResponseHeader(t *testing.T) {
 	targetEndpoint := &fwkdl.EndpointMetadata{
 		NamespacedName: k8stypes.NamespacedName{Name: "pod1"},
 		Address:        "1.2.3.4",
@@ -113,27 +112,26 @@ func TestSessionAffinity_ResponseBody(t *testing.T) {
 	}{
 		{
 			name:            "standard case with existing headers map",
-			initialResponse: &requestcontrol.Response{RequestID: "req-1", Headers: make(map[string]string), EndOfStream: true},
+			initialResponse: &requestcontrol.Response{RequestID: "req-1", Headers: make(map[string]string)},
 			targetPod:       targetEndpoint,
 			wantHeaders:     map[string]string{"x-session-token": wantToken},
 		},
 		{
 			name:            "response with nil headers map",
-			initialResponse: &requestcontrol.Response{RequestID: "req-2", Headers: nil, EndOfStream: true},
+			initialResponse: &requestcontrol.Response{RequestID: "req-2", Headers: nil},
 			targetPod:       targetEndpoint,
 			wantHeaders:     map[string]string{"x-session-token": wantToken},
 		},
 		{
 			name:            "nil targetPod should do nothing",
-			initialResponse: &requestcontrol.Response{RequestID: "req-3", Headers: make(map[string]string), EndOfStream: true},
+			initialResponse: &requestcontrol.Response{RequestID: "req-3", Headers: make(map[string]string)},
 			targetPod:       nil,
 			wantHeaders:     map[string]string{},
 		},
 		{
-			name:            "incomplete response should do nothing (EndOfStream=false)",
-			initialResponse: &requestcontrol.Response{RequestID: "req-4", Headers: make(map[string]string), EndOfStream: false},
+			name:            "nil response should do nothing",
+			initialResponse: nil,
 			targetPod:       targetEndpoint,
-			wantHeaders:     map[string]string{},
 		},
 	}
 
@@ -142,7 +140,11 @@ func TestSessionAffinity_ResponseBody(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s.ResponseBody(ctx, nil, test.initialResponse, test.targetPod)
+			s.ResponseHeader(ctx, nil, test.initialResponse, test.targetPod)
+
+			if test.initialResponse == nil {
+				return
+			}
 
 			if diff := cmp.Diff(test.wantHeaders, test.initialResponse.Headers); diff != "" {
 				t.Errorf("Unexpected output (-want +got): %v", diff)


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind bug

**What this PR does / why we need it**:

The session affinity scorer sets x-session-token so clients can send it on later requests and be routed back to the same pod. Response headers are already sent to Envoy before response body processing runs, so setting the token from ResponseBody does not reliably include it in the client response. This change registers the scorer as a ResponseHeaderProcessor and sets the token while response headers are still mutable.

The tests are updated to cover the response header hook, nil header maps, nil target pods, and nil responses.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
