### PR TITLE
epp: add opt-in ext_proc gRPC stream metrics

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -400,6 +400,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		PriorityBandControlPlane:         priorityBandControlPlane,
 		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
 		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
+		EnableGRPCStreamMetrics:          opts.EnableGRPCStreamMetrics,
 	}
 
 	if err := serverRunner.SetupWithManager(mgr); err != nil {
@@ -943,6 +944,7 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 		SaturationDetector:               eppConfig.SaturationDetector,
 		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
 		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
+		EnableGRPCStreamMetrics:          opts.EnableGRPCStreamMetrics,
 	}
 
 	r.customCollectors = append(r.customCollectors, collectors.NewInferencePoolMetricsCollector(ds))

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,3 +41,30 @@ Metrics defined by llm-d Router are in addition to Inference Gateway metrics. Fo
 > [!NOTE]
 > This metric is maintained for backward compatibility with the deprecated
 > `pd-profile-handler`. New deployments should use `disagg_decision_total`.
+
+## Opt-in ext_proc Stream Metrics
+
+Three metrics covering ext_proc gRPC stream lifecycle. Disabled by default; enable with `--enable-grpc-stream-metrics`. All carry the `llm_d_router_epp_` prefix.
+
+### `extproc_streams_inflight`
+
+*   **Type:** Gauge
+*   **Release Stage:** ALPHA
+*   **Description:** Number of ext_proc gRPC streams currently open.
+*   **Usage:** Sized at one stream per Envoy worker per EPP backend. A persistent increase under steady load indicates streams are being opened faster than they close.
+
+### `extproc_stream_duration_seconds`
+
+*   **Type:** Histogram
+*   **Release Stage:** ALPHA
+*   **Description:** Duration an ext_proc gRPC stream stays open, in seconds.
+*   **Usage:** Long-lived streams are normal; the histogram surfaces the distribution. A sudden shift toward short durations can indicate Envoy reconnecting due to handler errors.
+
+### `extproc_streams_total`
+
+*   **Type:** Counter
+*   **Labels:**
+    *   `code`: string — the gRPC status code at stream close (`OK`, `Canceled`, `DeadlineExceeded`, `Internal`, ...). Bare `context.Canceled` and `context.DeadlineExceeded` are classified to their canonical codes rather than collapsing into `Unknown`.
+*   **Release Stage:** ALPHA
+*   **Description:** Total ext_proc gRPC streams completed, by gRPC status code.
+*   **Usage:** Rate of `code="OK"` is the healthy stream-completion rate. A rising rate of `code="Internal"` or `code="Unknown"` indicates handler errors. `code="Canceled"` is expected on Envoy restarts and rolling EPP updates.

--- a/pkg/epp/metrics/grpc_stream_metrics.go
+++ b/pkg/epp/metrics/grpc_stream_metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metrics
 
 import (

--- a/pkg/epp/metrics/grpc_stream_metrics.go
+++ b/pkg/epp/metrics/grpc_stream_metrics.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	compbasemetrics "k8s.io/component-base/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
+)
+
+// Opt-in ext_proc gRPC stream metrics (see --enable-grpc-stream-metrics).
+var (
+	extProcStreamsInflight = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "extproc_streams_inflight",
+			Help:      metricsutil.HelpMsgWithStability("Number of ext_proc gRPC streams currently open.", compbasemetrics.ALPHA),
+		},
+	)
+
+	extProcStreamDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "extproc_stream_duration_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Duration an ext_proc gRPC stream stays open, in seconds.", compbasemetrics.ALPHA),
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 120, 300, 600},
+		},
+	)
+
+	extProcStreamsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "extproc_streams_total",
+			Help:      metricsutil.HelpMsgWithStability("Total ext_proc gRPC streams completed, by gRPC status code.", compbasemetrics.ALPHA),
+		},
+		[]string{"code"},
+	)
+)
+
+var registerGRPCStreamMetricsOnce sync.Once
+
+// RegisterGRPCStreamMetrics registers the ext_proc stream metrics; called only when enabled.
+func RegisterGRPCStreamMetrics() {
+	registerGRPCStreamMetricsOnce.Do(func() {
+		metrics.Registry.MustRegister(extProcStreamsInflight)
+		metrics.Registry.MustRegister(extProcStreamDuration)
+		metrics.Registry.MustRegister(extProcStreamsTotal)
+	})
+}
+
+// ExtProcStreamStarted records an ext_proc stream open.
+func ExtProcStreamStarted() {
+	extProcStreamsInflight.Inc()
+}
+
+// ExtProcStreamFinished records an ext_proc stream close with its status and duration.
+func ExtProcStreamFinished(code string, seconds float64) {
+	extProcStreamsInflight.Dec()
+	extProcStreamDuration.Observe(seconds)
+	extProcStreamsTotal.WithLabelValues(code).Inc()
+}

--- a/pkg/epp/metrics/grpc_stream_metrics_test.go
+++ b/pkg/epp/metrics/grpc_stream_metrics_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metrics
 
 import (

--- a/pkg/epp/metrics/grpc_stream_metrics_test.go
+++ b/pkg/epp/metrics/grpc_stream_metrics_test.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtProcStreamMetrics(t *testing.T) {
+	extProcStreamsInflight.Set(0)
+	extProcStreamsTotal.Reset()
+
+	require.Equal(t, 0.0, promtestutil.ToFloat64(extProcStreamsInflight))
+
+	// inflight tracks open streams; close decrements and counts by code.
+	ExtProcStreamStarted()
+	ExtProcStreamStarted()
+	require.Equal(t, 2.0, promtestutil.ToFloat64(extProcStreamsInflight))
+
+	ExtProcStreamFinished("OK", 0.42)
+	require.Equal(t, 1.0, promtestutil.ToFloat64(extProcStreamsInflight))
+	require.Equal(t, 1.0, promtestutil.ToFloat64(extProcStreamsTotal.WithLabelValues("OK")))
+
+	ExtProcStreamFinished("Internal", 0.1)
+	require.Equal(t, 0.0, promtestutil.ToFloat64(extProcStreamsInflight))
+	require.Equal(t, 1.0, promtestutil.ToFloat64(extProcStreamsTotal.WithLabelValues("Internal")))
+	require.Equal(t, 1, promtestutil.CollectAndCount(extProcStreamDuration))
+}

--- a/pkg/epp/server/grpc_stream_metrics.go
+++ b/pkg/epp/server/grpc_stream_metrics.go
@@ -5,6 +5,7 @@ import (
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
@@ -21,7 +22,12 @@ func streamMetricsInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamSe
 	var err error
 	// defer: grpc-go does not recover handler panics; keep the gauge balanced.
 	defer func() {
-		metrics.ExtProcStreamFinished(status.Code(err).String(), time.Since(start).Seconds())
+		// Classify bare ctx.Err() so cancel/deadline don't collapse to Unknown.
+		code := status.Code(err)
+		if code == codes.Unknown {
+			code = status.FromContextError(err).Code()
+		}
+		metrics.ExtProcStreamFinished(code.String(), time.Since(start).Seconds())
 	}()
 	err = handler(srv, ss)
 	return err

--- a/pkg/epp/server/grpc_stream_metrics.go
+++ b/pkg/epp/server/grpc_stream_metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (

--- a/pkg/epp/server/grpc_stream_metrics.go
+++ b/pkg/epp/server/grpc_stream_metrics.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"time"
+
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+// streamMetricsInterceptor records ext_proc stream count and hold duration.
+func streamMetricsInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	// Skip co-registered streams (health Watch, reflection).
+	if info.FullMethod != extProcPb.ExternalProcessor_Process_FullMethodName {
+		return handler(srv, ss)
+	}
+	metrics.ExtProcStreamStarted()
+	start := time.Now()
+	var err error
+	// defer: grpc-go does not recover handler panics; keep the gauge balanced.
+	defer func() {
+		metrics.ExtProcStreamFinished(status.Code(err).String(), time.Since(start).Seconds())
+	}()
+	err = handler(srv, ss)
+	return err
+}

--- a/pkg/epp/server/grpc_stream_metrics_test.go
+++ b/pkg/epp/server/grpc_stream_metrics_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+type fakeServerStream struct{ ctx context.Context }
+
+func (f *fakeServerStream) SetHeader(metadata.MD) error  { return nil }
+func (f *fakeServerStream) SendHeader(metadata.MD) error { return nil }
+func (f *fakeServerStream) SetTrailer(metadata.MD)       {}
+func (f *fakeServerStream) Context() context.Context     { return f.ctx }
+func (f *fakeServerStream) SendMsg(any) error            { return nil }
+func (f *fakeServerStream) RecvMsg(any) error            { return nil }
+
+func invoke(t *testing.T, method string, handlerErr error) error {
+	t.Helper()
+	called := false
+	handler := func(_ any, _ grpc.ServerStream) error {
+		called = true
+		return handlerErr
+	}
+	err := streamMetricsInterceptor(nil, &fakeServerStream{ctx: context.Background()},
+		&grpc.StreamServerInfo{FullMethod: method}, handler)
+	require.True(t, called, "handler must be invoked")
+	return err
+}
+
+// Handler error propagates verbatim and the code maps.
+func TestStreamMetricsInterceptor_Propagation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   error
+		code codes.Code
+	}{
+		{"ok", nil, codes.OK},
+		{"status error", status.Error(codes.Internal, "boom"), codes.Internal},
+		{"plain error", errors.New("x"), codes.Unknown},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := invoke(t, extProcPb.ExternalProcessor_Process_FullMethodName, tc.in)
+			require.Equal(t, tc.in, err, "handler error must propagate verbatim")
+			require.Equal(t, tc.code, status.Code(err))
+		})
+	}
+}
+
+// Only the ext_proc Process stream is recorded; health Watch passes through.
+func TestStreamMetricsInterceptor_MethodScope(t *testing.T) {
+	metrics.RegisterGRPCStreamMetrics()
+	const name = "llm_d_router_epp_extproc_streams_total"
+
+	before, err := promtestutil.GatherAndCount(ctrlmetrics.Registry, name)
+	require.NoError(t, err)
+
+	// Non-ext_proc method: served, not recorded.
+	require.NoError(t, invoke(t, "/grpc.health.v1.Health/Watch", nil))
+	mid, err := promtestutil.GatherAndCount(ctrlmetrics.Registry, name)
+	require.NoError(t, err)
+	require.Equal(t, before, mid, "health Watch must not be counted as an ext_proc stream")
+
+	// ext_proc stream with a code unused elsewhere → adds one series.
+	_ = invoke(t, extProcPb.ExternalProcessor_Process_FullMethodName, status.Error(codes.ResourceExhausted, "x"))
+	after, err := promtestutil.GatherAndCount(ctrlmetrics.Registry, name)
+	require.NoError(t, err)
+	require.Equal(t, mid+1, after, "ext_proc Process stream must add a new completion series")
+}

--- a/pkg/epp/server/grpc_stream_metrics_test.go
+++ b/pkg/epp/server/grpc_stream_metrics_test.go
@@ -59,6 +59,29 @@ func TestStreamMetricsInterceptor_Propagation(t *testing.T) {
 	}
 }
 
+// Bare ctx.Err() classifies as Canceled/DeadlineExceeded, not Unknown.
+func TestStreamMetricsInterceptor_ContextErrorClassification(t *testing.T) {
+	metrics.RegisterGRPCStreamMetrics()
+	const name = "llm_d_router_epp_extproc_streams_total"
+
+	for _, tc := range []struct {
+		in   error
+		code string
+	}{
+		{context.Canceled, codes.Canceled.String()},
+		{context.DeadlineExceeded, codes.DeadlineExceeded.String()},
+	} {
+		t.Run(tc.code, func(t *testing.T) {
+			before, err := promtestutil.GatherAndCount(ctrlmetrics.Registry, name)
+			require.NoError(t, err)
+			_ = invoke(t, extProcPb.ExternalProcessor_Process_FullMethodName, tc.in)
+			after, err := promtestutil.GatherAndCount(ctrlmetrics.Registry, name)
+			require.NoError(t, err)
+			require.Equal(t, before+1, after, "must record a new series under code=%q", tc.code)
+		})
+	}
+}
+
 // Only the ext_proc Process stream is recorded; health Watch passes through.
 func TestStreamMetricsInterceptor_MethodScope(t *testing.T) {
 	metrics.RegisterGRPCStreamMetrics()

--- a/pkg/epp/server/grpc_stream_metrics_test.go
+++ b/pkg/epp/server/grpc_stream_metrics_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -213,7 +213,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.EnableCertReload, "enable-cert-reload", opts.EnableCertReload,
 		"Enables certificate reloading of the certificates specified in --cert-path.")
 	fs.BoolVar(&opts.EnableGRPCStreamMetrics, "enable-grpc-stream-metrics", opts.EnableGRPCStreamMetrics,
-		"Enables ext_proc gRPC stream metrics (in-flight gauge + hold-duration histogram). Defaults to false.")
+		"Enables ext_proc gRPC stream metrics (in-flight gauge + hold-duration histogram).")
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing, "Enables secure serving.")
 	fs.BoolVar(&opts.MetricsEndpointAuth, "metrics-endpoint-auth", opts.MetricsEndpointAuth,
 		"Enables authentication and authorization of the metrics endpoint.")

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -103,7 +103,7 @@ type Options struct {
 	EnableCertReload        bool   // Enables certificate reloading of the certificates specified in --cert-path.
 	SecureServing           bool   // Enables secure serving.
 	MetricsEndpointAuth     bool   // Enables authentication and authorization of the metrics endpoint.
-	EnableGRPCStreamMetrics bool   // Enables ext_proc gRPC stream metrics (in-flight gauge + hold duration).
+	EnableGRPCStreamMetrics bool   // Enables ext_proc gRPC stream metrics (in-flight gauge, hold duration, completions counter by code).
 	//
 	// Configuration.
 	//
@@ -213,7 +213,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.EnableCertReload, "enable-cert-reload", opts.EnableCertReload,
 		"Enables certificate reloading of the certificates specified in --cert-path.")
 	fs.BoolVar(&opts.EnableGRPCStreamMetrics, "enable-grpc-stream-metrics", opts.EnableGRPCStreamMetrics,
-		"Enables ext_proc gRPC stream metrics (in-flight gauge + hold-duration histogram).")
+		"Enables ext_proc gRPC stream metrics (in-flight gauge, hold-duration histogram, completions counter by code).")
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing, "Enables secure serving.")
 	fs.BoolVar(&opts.MetricsEndpointAuth, "metrics-endpoint-auth", opts.MetricsEndpointAuth,
 		"Enables authentication and authorization of the metrics endpoint.")

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -93,16 +93,17 @@ type Options struct {
 	//
 	// Diagnostics.
 	//
-	logging.LoggingOptions        // Logging configuration.
-	Tracing                bool   // Enables emitting traces.
-	HealthChecking         bool   // Enables health checking.
-	MetricsPort            int    // The metrics port exposed by EPP. (TODO: uint16)
-	GRPCHealthPort         int    // The port used for gRPC liveness and readiness probes. (TODO: uint16)
-	EnablePprof            bool   // Enables pprof handlers.
-	CertPath               string // The path to the certificate for secure serving.
-	EnableCertReload       bool   // Enables certificate reloading of the certificates specified in --cert-path.
-	SecureServing          bool   // Enables secure serving.
-	MetricsEndpointAuth    bool   // Enables authentication and authorization of the metrics endpoint.
+	logging.LoggingOptions         // Logging configuration.
+	Tracing                 bool   // Enables emitting traces.
+	HealthChecking          bool   // Enables health checking.
+	MetricsPort             int    // The metrics port exposed by EPP. (TODO: uint16)
+	GRPCHealthPort          int    // The port used for gRPC liveness and readiness probes. (TODO: uint16)
+	EnablePprof             bool   // Enables pprof handlers.
+	CertPath                string // The path to the certificate for secure serving.
+	EnableCertReload        bool   // Enables certificate reloading of the certificates specified in --cert-path.
+	SecureServing           bool   // Enables secure serving.
+	MetricsEndpointAuth     bool   // Enables authentication and authorization of the metrics endpoint.
+	EnableGRPCStreamMetrics bool   // Enables ext_proc gRPC stream metrics (in-flight gauge + hold duration).
 	//
 	// Configuration.
 	//
@@ -211,6 +212,8 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 			"then a self-signed certificate is used.")
 	fs.BoolVar(&opts.EnableCertReload, "enable-cert-reload", opts.EnableCertReload,
 		"Enables certificate reloading of the certificates specified in --cert-path.")
+	fs.BoolVar(&opts.EnableGRPCStreamMetrics, "enable-grpc-stream-metrics", opts.EnableGRPCStreamMetrics,
+		"Enables ext_proc gRPC stream metrics (in-flight gauge + hold-duration histogram). Defaults to false.")
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing, "Enables secure serving.")
 	fs.BoolVar(&opts.MetricsEndpointAuth, "metrics-endpoint-auth", opts.MetricsEndpointAuth,
 		"Enables authentication and authorization of the metrics endpoint.")

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -43,6 +43,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/requestcontrol"
 )
 
@@ -64,6 +65,7 @@ type ExtProcServerRunner struct {
 	PriorityBandControlPlane         contracts.PriorityBandControlPlane
 	GRPCMaxRecvMsgSize               int
 	GRPCMaxSendMsgSize               int
+	EnableGRPCStreamMetrics          bool
 }
 
 // NewDefaultExtProcServerRunner creates a runner with default values.
@@ -191,6 +193,10 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 		}
 		if r.GRPCMaxSendMsgSize > 0 {
 			grpcOpts = append(grpcOpts, grpc.MaxSendMsgSize(r.GRPCMaxSendMsgSize))
+		}
+		if r.EnableGRPCStreamMetrics {
+			metrics.RegisterGRPCStreamMetrics()
+			grpcOpts = append(grpcOpts, grpc.ChainStreamInterceptor(streamMetricsInterceptor))
 		}
 		// Note: gzip compressor is registered via blank import above.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an opt-in gRPC `StreamServerInterceptor` on the EPP ext_proc server, gated by `--enable-grpc-stream-metrics` (default off):

- `llm_d_router_epp_extproc_streams_inflight` (gauge) concurrent open ext_proc streams
- `llm_d_router_epp_extproc_stream_duration_seconds` (histogram) stream hold time
- `llm_d_router_epp_extproc_streams_total{code}` (counter) completions by gRPC status

ext_proc streams stay open for the whole response, so their concurrent count is what consumes the gateway's connection/circuit-breaker budget; the EPP exposes no signal for it today. Scoped to the ext_proc `Process` stream (health `Watch` not counted) and balanced via `defer` (grpc-go does not recover handler panics). Nothing is registered and no interceptor is installed when disabled.

```
# HELP llm_d_router_epp_extproc_stream_duration_seconds [ALPHA] Duration an ext_proc gRPC stream stays open, in seconds.
  # TYPE llm_d_router_epp_extproc_stream_duration_seconds histogram
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="0.001"} 0
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="0.005"} 0
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="0.01"} 0
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="0.05"} 1
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="0.1"} 1
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="0.5"} 1
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="1"} 1
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="5"} 2399
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="10"} 3250
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="30"} 3250
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="60"} 3250
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="120"} 3250
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="300"} 3250
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="600"} 3250
  llm_d_router_epp_extproc_stream_duration_seconds_bucket{le="+Inf"} 3250
  llm_d_router_epp_extproc_stream_duration_seconds_sum 11678.568641630993
  llm_d_router_epp_extproc_stream_duration_seconds_count 3250
  # HELP llm_d_router_epp_extproc_streams_inflight [ALPHA] Number of ext_proc gRPC streams currently open.
  # TYPE llm_d_router_epp_extproc_streams_inflight gauge
  llm_d_router_epp_extproc_streams_inflight 0
  # HELP llm_d_router_epp_extproc_streams_total [ALPHA] Total ext_proc gRPC streams completed, by gRPC status code.
  # TYPE llm_d_router_epp_extproc_streams_total counter
  llm_d_router_epp_extproc_streams_total{code="Unknown"} 3250
```

**Which issue(s) this PR fixes**:

Fixes #1602

**Release note**:
```release-note
Added an opt-in `--enable-grpc-stream-metrics` flag to the EPP exposing ext_proc gRPC stream metrics: in-flight stream count, hold duration, and completions by gRPC status code.
```
