### PR TITLE
make EPP gRPC healthCheck configurable in helm

### DIFF
--- a/config/charts/llm-d-router-gateway/templates/gke.yaml
+++ b/config/charts/llm-d-router-gateway/templates/gke.yaml
@@ -35,6 +35,30 @@ spec:
         port: {{ $port }}
         grpcServiceName: "/vllm.grpc.engine.VllmEngine/HealthCheck"
     {{- end }}
+{{- $eppHealthPort := int (.Values.router.epp.grpcHealthPort | default 9003) }}
+{{- /* The GKE gateway controller health-checks the EPP backend on gRPC port
+9003 by default, so an explicit HealthCheckPolicy is only needed for other ports. */}}
+{{- if ne $eppHealthPort 9003 }}
+---
+kind: HealthCheckPolicy
+apiVersion: networking.gke.io/v1
+metadata:
+  name: {{ .Release.Name }}-epp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "llm-d-router.name" . }}
+  default:
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        portSpecification: "USE_FIXED_PORT"
+        port: {{ $eppHealthPort }}
+{{- end }}
 ---
 apiVersion: networking.gke.io/v1
 kind: GCPBackendPolicy

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -132,6 +132,9 @@ spec:
           {{- if gt (.Values.router.epp.replicas | int) 1 }}
               - --ha-enable-leader-election
           {{- end }}
+          {{- $grpcHealthPort := .Values.router.epp.grpcHealthPort | default 9003 }}
+              - --grpc-health-port
+              - "{{ $grpcHealthPort }}"
               # Pass additional flags via the router.epp.flags field in values.yaml.
               # Render them as --flag=value so boolean values are parsed correctly.
           {{- range $key, $value := $eppFlags }}
@@ -153,7 +156,7 @@ spec:
             - name: grpc
               containerPort: 9002
             - name: grpc-health
-              containerPort: 9003
+              containerPort: {{ $grpcHealthPort }}
             - name: metrics
               containerPort: 9090
         {{- if .Values.router.epp.extraContainerPorts }}
@@ -162,11 +165,11 @@ spec:
           livenessProbe:
           {{- if gt (.Values.router.epp.replicas | int) 1 }}
             grpc:
-              port: 9003
+              port: {{ $grpcHealthPort }}
               service: liveness
           {{- else }}
             grpc:
-              port: 9003
+              port: {{ $grpcHealthPort }}
               service: inference-extension
           {{- end }}
             initialDelaySeconds: 5
@@ -174,11 +177,11 @@ spec:
           readinessProbe:
           {{- if gt (.Values.router.epp.replicas | int) 1 }}
             grpc:
-              port: 9003
+              port: {{ $grpcHealthPort }}
               service: readiness
           {{- else }}
             grpc:
-              port: 9003
+              port: {{ $grpcHealthPort }}
               service: inference-extension
           {{- end }}
             periodSeconds: 2

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -11,7 +11,9 @@ epp:
     tag: main
     pullPolicy: Always
   extProcPort: 9002
-  
+  # gRPC port serving EPP liveness and readiness checks, 9003 if unset.
+  # grpcHealthPort: 9003
+
   parsers: [] # e.g. ["openai-parser", "anthropic-parser"], or empty for auto-selection
 
   # Metrics DataSource Configuration


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Makes the EPP gRPC health check port configurable via a single chart value, `router.epp.grpcHealthPort` (optional, defaults to 9003).

The port was previously hardcoded in five places in the EPP deployment template (the `grpc-health` container port and the liveness/readiness probe ports) and the `--grpc-health-port` flag was never passed to the EPP binary, so the port could not be changed coherently. The value now drives the flag, the container port, and the probe ports together, so the binary, pod spec, and probes can never drift apart.

On GKE, when the port is set to anything other than 9003, the chart renders a `HealthCheckPolicy` targeting the EPP Service with a gRPC check on that port. With the default 9003 no policy is rendered, since the GKE gateway controller already health-checks the EPP backend on gRPC 9003, keeping the rendered output identical to before this change.

**How it was verified**:

`make verify-helm-charts` passes. With `grpcHealthPort` unset the rendered output is byte-identical to before this change.

End to end on a GKE cluster with a `gke-l7-regional-external-managed` Gateway and `llm-d-inference-sim` as the model server:

```
helm upgrade --install vllm-sim ./config/charts/llm-d-router-gateway \
  --set provider.name=gke \
  --set httpRoute.create=true \
  --set router.modelServers.matchLabels.app=vllm-sim \
  --set router.epp.grpcHealthPort=9113
```

After the upgrade, the EPP pod restarts and becomes Ready, confirming the binary and the probes moved to 9113 together, and the `vllm-sim-epp` `HealthCheckPolicy` is created targeting the EPP Service. The load balancer health check can be observed with `gcloud compute health-checks list --filter="type=GRPC"`.

<img width="2452" height="300" alt="image" src="https://github.com/user-attachments/assets/e4447cc3-e0f0-4e7a-bef0-17a6a6d7561c" />


**Which issue(s) this PR fixes**:
Fixes #1604

**Release note**:
```release-note
The EPP gRPC health check port is configurable via `router.epp.grpcHealthPort` (default 9003). 
```
