### PR TITLE
Fix/flowcontrol band gc desired

### DIFF
--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -282,6 +282,12 @@ func (fc *FlowController) EnqueueAndWait(
 
 // fallbackRequest wraps a FlowControlRequest to override its flow key, so a request that falls back to a different
 // priority is enqueued under the band that was actually leased rather than its original (unprovisioned) band.
+//
+// Trade-off: downstream consumers see this wrapper, so item.OriginalRequest().FlowKey() reports the fallback
+// priority rather than the requested one — despite the method name. This is intentional, since the item must be
+// leased, distributed, and enqueued consistently at the fallback priority. The originally requested priority
+// therefore survives only in the withConnectionWithFallback log; surfacing it in metrics is left as a follow-up
+// (a dedicated fallback counter labeled with the original priority).
 type fallbackRequest struct {
 	flowcontrol.FlowControlRequest
 	key flowcontrol.FlowKey

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -239,7 +239,7 @@ func (fc *FlowController) EnqueueAndWait(
 
 	// 2. Acquire a lease for the Flow.
 	// We hold this lease for the entire duration of the request (Distribution + Queueing).
-	err := fc.withConnectionWithDemotion(flowKey, func(conn contracts.ActiveFlowConnection) error {
+	err := fc.withConnectionWithDemotion(req, func(conn contracts.ActiveFlowConnection, effectiveReq flowcontrol.FlowControlRequest) error {
 
 		select { // Non-blocking check on controller lifecycle.
 		case <-fc.parentCtx.Done():
@@ -249,7 +249,9 @@ func (fc *FlowController) EnqueueAndWait(
 		}
 
 		// Attempt to distribute the request once, passing the active connection.
-		item, err := fc.tryDistribution(reqCtx, req, enqueueTime, conn)
+		// effectiveReq carries the demoted flow key when the requested band was not provisioned, so the
+		// item is enqueued under the band that was actually leased.
+		item, err := fc.tryDistribution(reqCtx, effectiveReq, enqueueTime, conn)
 		if err != nil {
 			// Distribution failed terminally (e.g., context cancelled during blocking submit).
 			// The item has already been finalized by tryDistribution.
@@ -278,12 +280,26 @@ func (fc *FlowController) EnqueueAndWait(
 	return finalOutcome, err
 }
 
-// withConnectionWithDemotion acquires a flow connection, demoting to priority 0 when the requested band is not yet provisioned.
+// demotedRequest wraps a FlowControlRequest to override its flow key, so a request demoted to a fallback
+// priority is enqueued under the band that was actually leased rather than its original (unprovisioned) band.
+type demotedRequest struct {
+	flowcontrol.FlowControlRequest
+	key flowcontrol.FlowKey
+}
+
+func (d demotedRequest) FlowKey() flowcontrol.FlowKey { return d.key }
+
+// withConnectionWithDemotion acquires a flow connection, demoting to priority 0 when the requested band is not yet
+// provisioned. On demotion, the callback receives a request whose FlowKey reports the demoted priority, ensuring the
+// item is leased, distributed, and enqueued consistently under priority 0; otherwise it receives the original request.
 func (fc *FlowController) withConnectionWithDemotion(
-	key flowcontrol.FlowKey,
-	fn func(conn contracts.ActiveFlowConnection) error,
+	req flowcontrol.FlowControlRequest,
+	fn func(conn contracts.ActiveFlowConnection, effectiveReq flowcontrol.FlowControlRequest) error,
 ) error {
-	err := fc.registry.WithConnection(key, fn)
+	key := req.FlowKey()
+	err := fc.registry.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
+		return fn(conn, req)
+	})
 	if err == nil || !errors.Is(err, contracts.ErrPriorityBandNotFound) || key.Priority == 0 {
 		return err
 	}
@@ -295,7 +311,10 @@ func (fc *FlowController) withConnectionWithDemotion(
 	)
 	demotedKey := key
 	demotedKey.Priority = 0
-	return fc.registry.WithConnection(demotedKey, fn)
+	demoted := demotedRequest{FlowControlRequest: req, key: demotedKey}
+	return fc.registry.WithConnection(demotedKey, func(conn contracts.ActiveFlowConnection) error {
+		return fn(conn, demoted)
+	})
 }
 
 // tryDistribution handles a single attempt to select a shard and submit a request.

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -239,7 +239,7 @@ func (fc *FlowController) EnqueueAndWait(
 
 	// 2. Acquire a lease for the Flow.
 	// We hold this lease for the entire duration of the request (Distribution + Queueing).
-	err := fc.withConnectionWithDemotion(req, func(conn contracts.ActiveFlowConnection, effectiveReq flowcontrol.FlowControlRequest) error {
+	err := fc.withConnectionWithFallback(req, func(conn contracts.ActiveFlowConnection, effectiveReq flowcontrol.FlowControlRequest) error {
 
 		select { // Non-blocking check on controller lifecycle.
 		case <-fc.parentCtx.Done():
@@ -249,7 +249,7 @@ func (fc *FlowController) EnqueueAndWait(
 		}
 
 		// Attempt to distribute the request once, passing the active connection.
-		// effectiveReq carries the demoted flow key when the requested band was not provisioned, so the
+		// effectiveReq carries the fallback flow key when the requested band was not provisioned, so the
 		// item is enqueued under the band that was actually leased.
 		item, err := fc.tryDistribution(reqCtx, effectiveReq, enqueueTime, conn)
 		if err != nil {
@@ -280,19 +280,22 @@ func (fc *FlowController) EnqueueAndWait(
 	return finalOutcome, err
 }
 
-// demotedRequest wraps a FlowControlRequest to override its flow key, so a request demoted to a fallback
+// fallbackRequest wraps a FlowControlRequest to override its flow key, so a request that falls back to a different
 // priority is enqueued under the band that was actually leased rather than its original (unprovisioned) band.
-type demotedRequest struct {
+type fallbackRequest struct {
 	flowcontrol.FlowControlRequest
 	key flowcontrol.FlowKey
 }
 
-func (d demotedRequest) FlowKey() flowcontrol.FlowKey { return d.key }
+func (r fallbackRequest) FlowKey() flowcontrol.FlowKey { return r.key }
 
-// withConnectionWithDemotion acquires a flow connection, demoting to priority 0 when the requested band is not yet
-// provisioned. On demotion, the callback receives a request whose FlowKey reports the demoted priority, ensuring the
-// item is leased, distributed, and enqueued consistently under priority 0; otherwise it receives the original request.
-func (fc *FlowController) withConnectionWithDemotion(
+// withConnectionWithFallback acquires a flow connection, falling back to priority 0 when the requested band is not yet
+// provisioned. On fallback, the callback receives a request whose FlowKey reports priority 0, ensuring the item is
+// leased, distributed, and enqueued consistently under priority 0; otherwise it receives the original request.
+//
+// Note: relative to the requested priority this is a demotion for positive priorities but a promotion for negative
+// ones. It is an availability-first fallback for the brief window before the control plane provisions the band.
+func (fc *FlowController) withConnectionWithFallback(
 	req flowcontrol.FlowControlRequest,
 	fn func(conn contracts.ActiveFlowConnection, effectiveReq flowcontrol.FlowControlRequest) error,
 ) error {
@@ -305,15 +308,15 @@ func (fc *FlowController) withConnectionWithDemotion(
 	}
 
 	fc.logger.V(logutil.DEFAULT).Info(
-		"Priority band not provisioned, demoting request to priority 0",
+		"Priority band not provisioned, falling back to priority 0",
 		"originalPriority", key.Priority,
 		"flowID", key.ID,
 	)
-	demotedKey := key
-	demotedKey.Priority = 0
-	demoted := demotedRequest{FlowControlRequest: req, key: demotedKey}
-	return fc.registry.WithConnection(demotedKey, func(conn contracts.ActiveFlowConnection) error {
-		return fn(conn, demoted)
+	fallbackKey := key
+	fallbackKey.Priority = 0
+	fallback := fallbackRequest{FlowControlRequest: req, key: fallbackKey}
+	return fc.registry.WithConnection(fallbackKey, func(conn contracts.ActiveFlowConnection) error {
+		return fn(conn, fallback)
 	})
 }
 

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -1070,3 +1070,44 @@ func TestFlowController_Concurrency_Backpressure(t *testing.T) {
 	require.Equal(t, numRequests, successCount,
 		"all concurrent requests should be dispatched successfully even under high contention and zero buffer capacity")
 }
+
+// TestFlowController_EnqueueAndWait_DemotionRewritesItemPriority verifies that when the requested priority band is not
+// provisioned, the request is not only leased at the fallback priority (0) but also enqueued there: the FlowItem handed
+// to the processor must report the demoted flow key, not the original (unprovisioned) priority. Without this, the
+// processor looks up a managed queue at the missing band and rejects the demoted request.
+func TestFlowController_EnqueueAndWait_DemotionRewritesItemPriority(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const originalPriority = 100
+
+	var capturedKey flowcontrol.FlowKey
+	processor := &mockProcessor{
+		SubmitFunc: func(item *internal.FlowItem) error {
+			capturedKey = item.OriginalRequest().FlowKey()
+			go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+			return nil
+		},
+	}
+
+	registry := &mockRegistryClient{FlowRegistryDataPlane: &mocks.MockRegistryDataPlane{}}
+	registry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(conn contracts.ActiveFlowConnection) error) error {
+		// Only priority 0 is provisioned; any other band is rejected, forcing demotion.
+		if key.Priority != 0 {
+			return fmt.Errorf("band %d: %w", key.Priority, contracts.ErrPriorityBandNotFound)
+		}
+		return fn(&mockActiveFlowConnection{RegistryV: registry, FlowKeyV: key})
+	}
+
+	h := newUnitHarness(ctx, t, &Config{DefaultRequestTTL: time.Minute}, registry, processor)
+
+	outcome, err := h.fc.EnqueueAndWait(ctx, newTestRequest(flowcontrol.FlowKey{ID: "batch", Priority: originalPriority}))
+
+	require.NoError(t, err, "demoted request should be dispatched, not rejected")
+	assert.Equal(t, types.QueueOutcomeDispatched, outcome)
+	assert.Equal(t, 0, capturedKey.Priority,
+		"demoted request must be enqueued at priority 0, not its original unprovisioned priority")
+	assert.Equal(t, "batch", capturedKey.ID, "demotion must preserve the flow ID")
+}

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -1071,11 +1071,11 @@ func TestFlowController_Concurrency_Backpressure(t *testing.T) {
 		"all concurrent requests should be dispatched successfully even under high contention and zero buffer capacity")
 }
 
-// TestFlowController_EnqueueAndWait_DemotionRewritesItemPriority verifies that when the requested priority band is not
+// TestFlowController_EnqueueAndWait_FallbackRewritesItemPriority verifies that when the requested priority band is not
 // provisioned, the request is not only leased at the fallback priority (0) but also enqueued there: the FlowItem handed
-// to the processor must report the demoted flow key, not the original (unprovisioned) priority. Without this, the
-// processor looks up a managed queue at the missing band and rejects the demoted request.
-func TestFlowController_EnqueueAndWait_DemotionRewritesItemPriority(t *testing.T) {
+// to the processor must report the fallback flow key, not the original (unprovisioned) priority. Without this, the
+// processor looks up a managed queue at the missing band and rejects the request.
+func TestFlowController_EnqueueAndWait_FallbackRewritesItemPriority(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1094,7 +1094,7 @@ func TestFlowController_EnqueueAndWait_DemotionRewritesItemPriority(t *testing.T
 
 	registry := &mockRegistryClient{FlowRegistryDataPlane: &mocks.MockRegistryDataPlane{}}
 	registry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(conn contracts.ActiveFlowConnection) error) error {
-		// Only priority 0 is provisioned; any other band is rejected, forcing demotion.
+		// Only priority 0 is provisioned; any other band is rejected, forcing the fallback.
 		if key.Priority != 0 {
 			return fmt.Errorf("band %d: %w", key.Priority, contracts.ErrPriorityBandNotFound)
 		}
@@ -1105,9 +1105,9 @@ func TestFlowController_EnqueueAndWait_DemotionRewritesItemPriority(t *testing.T
 
 	outcome, err := h.fc.EnqueueAndWait(ctx, newTestRequest(flowcontrol.FlowKey{ID: "batch", Priority: originalPriority}))
 
-	require.NoError(t, err, "demoted request should be dispatched, not rejected")
+	require.NoError(t, err, "fallback request should be dispatched, not rejected")
 	assert.Equal(t, types.QueueOutcomeDispatched, outcome)
 	assert.Equal(t, 0, capturedKey.Priority,
-		"demoted request must be enqueued at priority 0, not its original unprovisioned priority")
-	assert.Equal(t, "batch", capturedKey.ID, "demotion must preserve the flow ID")
+		"fallback request must be enqueued at priority 0, not its original unprovisioned priority")
+	assert.Equal(t, "batch", capturedKey.ID, "fallback must preserve the flow ID")
 }

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -121,6 +121,11 @@ type FlowRegistry struct {
 	// These are never removed by control-plane sync or garbage collection.
 	initialPriorities map[int]struct{}
 
+	// desiredPriorities tracks the most recent set of priority bands the control plane wants provisioned
+	// (the last value applied via ApplyDesiredPriorities). Bands in this set are protected from garbage
+	// collection: a desired band that is merely idle (no live flows) must not be reaped.
+	desiredPriorities map[int]struct{}
+
 	// priorityBandUpdateCh carries desired priority topology updates from the control plane to the processor loop.
 	priorityBandUpdateCh chan map[int]struct{}
 }
@@ -151,6 +156,7 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 		config:               cfg,
 		logger:               logger.WithName("flow-registry"),
 		initialPriorities:    make(map[int]struct{}),
+		desiredPriorities:    make(map[int]struct{}),
 		priorityBandUpdateCh: make(chan map[int]struct{}, 1),
 	}
 
@@ -224,24 +230,27 @@ func (fr *FlowRegistry) FlowGCTimeout() time.Duration {
 // ApplyDesiredPriorities provisions missing priority bands and removes idle bands no longer desired.
 // It is invoked by the Processor maintenance loop.
 func (fr *FlowRegistry) ApplyDesiredPriorities(desired map[int]struct{}) {
-	if desired == nil {
-		desired = map[int]struct{}{}
-	}
-
 	fr.mu.Lock()
 	defer fr.mu.Unlock()
 
+	// Record the desired set so GC (and any other deletion path) does not reap a band the control plane
+	// still wants. Store a defensive copy: SubmitDesiredPriorities crosses goroutine boundaries and direct
+	// callers may retain or mutate their map after the call.
+	desiredCopy := make(map[int]struct{}, len(desired))
 	for priority := range desired {
+		desiredCopy[priority] = struct{}{}
+	}
+	fr.desiredPriorities = desiredCopy
+
+	for priority := range desiredCopy {
 		if _, ok := fr.config.PriorityBands[priority]; !ok {
 			fr.provisionPriorityBandLocked(priority)
 		}
 	}
 
+	// Remove bands that are no longer protected (neither static nor desired) once they are idle.
 	for priority := range fr.config.PriorityBands {
-		if _, static := fr.initialPriorities[priority]; static {
-			continue
-		}
-		if _, wanted := desired[priority]; wanted {
+		if fr.isBandProtectedLocked(priority) {
 			continue
 		}
 		if !fr.isPriorityBandIdle(priority) {
@@ -397,6 +406,18 @@ func (fr *FlowRegistry) isPriorityBandIdle(priority int) bool {
 	return !val.(*priorityBandState).isActive()
 }
 
+// isBandProtectedLocked reports whether a priority band must never be garbage collected.
+// A band is protected if it was provisioned at startup (initialPriorities) or is currently
+// desired by the control plane (desiredPriorities). Protected bands persist even while idle.
+// The caller must hold fr.mu.
+func (fr *FlowRegistry) isBandProtectedLocked(priority int) bool {
+	if _, static := fr.initialPriorities[priority]; static {
+		return true
+	}
+	_, desired := fr.desiredPriorities[priority]
+	return desired
+}
+
 // --- `contracts.FlowRegistryObserver` Implementation ---
 
 // Stats returns globally aggregated statistics for the entire `FlowRegistry`.
@@ -508,9 +529,10 @@ func (fr *FlowRegistry) cleanupPriorityBandResourcesLocked(priority int) {
 		return
 	}
 
-	// Bands provisioned at startup are never collected. The transient band state is already gone,
-	// leaving the band in its startup state.
-	if _, static := fr.initialPriorities[priority]; static {
+	// Protected bands (provisioned at startup or still desired by the control plane) are never collected.
+	// The transient band state is already gone, leaving the band in its provisioned state; a later request
+	// re-pins it. This is the single chokepoint that shields protected bands from every deletion path.
+	if fr.isBandProtectedLocked(priority) {
 		return
 	}
 

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -202,9 +202,9 @@ func (fr *FlowRegistry) SubmitDesiredPriorities(desired map[int]struct{}) {
 	if desired == nil {
 		desired = map[int]struct{}{}
 	}
-	copy := make(map[int]struct{}, len(desired))
+	desiredCopy := make(map[int]struct{}, len(desired))
 	for priority := range desired {
-		copy[priority] = struct{}{}
+		desiredCopy[priority] = struct{}{}
 	}
 
 	// Drain any stale pending update so only the latest state is queued.
@@ -214,7 +214,7 @@ func (fr *FlowRegistry) SubmitDesiredPriorities(desired map[int]struct{}) {
 	}
 
 	// After draining, the channel always has capacity; this send never blocks.
-	fr.priorityBandUpdateCh <- copy
+	fr.priorityBandUpdateCh <- desiredCopy
 }
 
 // PriorityBandUpdateChannel returns the channel carrying desired priority topology updates.
@@ -256,8 +256,10 @@ func (fr *FlowRegistry) ApplyDesiredPriorities(desired map[int]struct{}) {
 		if !fr.isPriorityBandIdle(priority) {
 			continue
 		}
-		// Re-verify under the lock: a concurrent request may have pinned the band
-		// in the window between isPriorityBandIdle and this check.
+		// Cheap best-effort guard against tearing down a band that just became active. Holding fr.mu does
+		// not actually exclude a concurrent pin: pinLeasedResource is lock-free and never takes fr.mu. The
+		// removal is safe regardless, since pinLeasedResource's stale-object protection backs off a racing
+		// pin and the priority-0 fallback plus the next reconcile/GC cycle self-heal.
 		if val, ok := fr.priorityBandStates.Load(priority); ok {
 			if val.(*priorityBandState).isActive() {
 				continue
@@ -342,14 +344,8 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 //
 // NOTE: The caller (WithConnection) must already hold a lease on the priority band to prevent GC during this operation.
 func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error {
-	fr.mu.RLock()
-	_, exists := fr.config.PriorityBands[key.Priority]
-	fr.mu.RUnlock()
-
-	if !exists {
-		return fmt.Errorf("priority band %d not found: %w", key.Priority, contracts.ErrPriorityBandNotFound)
-	}
-
+	// buildFlowComponents validates that the priority band exists (returning ErrPriorityBandNotFound if not)
+	// under the same read lock it uses to read the topology, so a single acquisition covers both.
 	fr.mu.RLock()
 	components, err := fr.buildFlowComponents(key)
 	fr.mu.RUnlock()

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -116,7 +116,10 @@ func (h *registryTestHarness) openConnectionOnFlow(key flowcontrol.FlowKey) {
 	_, exists := h.fr.config.PriorityBands[key.Priority]
 	h.fr.mu.RUnlock()
 	if !exists {
-		h.fr.ApplyDesiredPriorities(map[int]struct{}{key.Priority: {}})
+		// Provision the band without asserting it into the desired set, so GC tests exercise
+		// collection of idle, undesired bands. Tests that need a band protected from GC mark it
+		// desired explicitly via ApplyDesiredPriorities.
+		require.NoError(h.t, h.fr.ensurePriorityBand(key.Priority), "Provisioning band for flow %s should not fail", key)
 	}
 	err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
 	require.NoError(h.t, err, "Registering flow %s should not fail", key)
@@ -924,6 +927,41 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 			err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
 			assert.NoError(t, err, "Request at static priority %d should succeed after GC", priority)
 		}
+	})
+
+	t.Run("ShouldNotCollectControlPlaneDesiredBand_AfterInactivity", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
+
+		// A dynamically provisioned band (one the control plane desires but that is not in the static
+		// EPP config) must survive GC for as long as it stays desired — even after inactivity has
+		// collected all of its flows and left the band idle. Reaping an idle-but-desired band makes
+		// every request at that priority fail until the next reconcile re-provisions it. Regression: #1354.
+		const desiredPrio = -1
+		h.fr.ApplyDesiredPriorities(map[int]struct{}{desiredPrio: {}})
+
+		// A request arrives, creating then releasing a flow at the desired priority.
+		key := flowcontrol.FlowKey{ID: "batch-A", Priority: desiredPrio}
+		h.openConnectionOnFlow(key)
+
+		// Inactivity: the flow idles and is collected, dropping the band's lease to zero and
+		// making it a GC candidate, despite the control plane still desiring it.
+		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
+		h.fr.ExecuteGCCycle()
+		h.fakeClock.Step(h.config.PriorityBandGCTimeout + time.Second)
+		h.fr.ExecuteGCCycle()
+
+		h.fr.mu.RLock()
+		_, exists := h.fr.config.PriorityBands[desiredPrio]
+		h.fr.mu.RUnlock()
+		require.True(t, exists,
+			"Control-plane-desired band %d must survive GC after inactivity", desiredPrio)
+
+		// A follow-up request to the still-desired band must not be rejected/demoted.
+		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
+		require.NoError(t, err,
+			"Request to a still-desired band must succeed after inactivity")
+		assert.NotErrorIs(t, err, contracts.ErrPriorityBandNotFound)
 	})
 
 	t.Run("ShouldCollectMultipleBands_InOneCycle", func(t *testing.T) {

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -957,11 +957,10 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		require.True(t, exists,
 			"Control-plane-desired band %d must survive GC after inactivity", desiredPrio)
 
-		// A follow-up request to the still-desired band must not be rejected/demoted.
+		// A follow-up request to the still-desired band must not be rejected with ErrPriorityBandNotFound.
 		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
 		require.NoError(t, err,
 			"Request to a still-desired band must succeed after inactivity")
-		assert.NotErrorIs(t, err, contracts.ErrPriorityBandNotFound)
 	})
 
 	t.Run("ShouldCollectMultipleBands_InOneCycle", func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a regression from #1354 where a priority band defined only via an `InferenceObjective` (not present in the static EPP config) was garbage-collected after a period of inactivity. Nothing re-provisioned it until the next reconcile, so subsequent requests at that priority were rejected with `priority band not found`.

#1354 moved band provisioning to the control plane but left band *lifecycle* under the old idleness-GC model: the periodic GC only exempted startup bands and had no knowledge of the control plane's desired set, so it reaped still-desired bands once their flows drained.

Three commits:

1. **Retain control-plane-desired bands across GC.** The registry now tracks the last-applied desired set, and a band is protected from collection when it is either a startup band or currently desired (`initialPriorities ∪ desiredPriorities`). `ApplyDesiredPriorities` and the GC path share this predicate at the single physical-deletion chokepoint, so a band is removed only when it is unprotected and idle. Includes a regression test.

2. **Enqueue fallback requests at the fallback priority.** When the requested band is not provisioned, the request was leased at priority 0 but the `FlowItem` still carried the original priority, so the processor looked it up at the missing band and rejected it anyway. The effective (priority-0) request is now threaded through to item creation so the request is leased, distributed, and enqueued consistently at priority 0. Includes a controller regression test.

3. **Address non-blocking review feedback from #1354** (no functional change): collapse a redundant lock acquisition in `ensureFlowInfrastructure`, rename the priority-0 "demotion" to the more accurate "fallback" (it is a promotion for negative priorities), un-shadow the builtin `copy`, and reword a misleading concurrency comment.

Note for reviewers: commit 2 keeps the existing availability-first fallback behavior from #1354 — during the brief window before the control plane provisions a band, a request is served at priority 0 rather than its requested priority. This is only reachable in that warm-up window (priorities are sourced from provisioned objectives). The follow-up issue (#1606) tracks the residual creation race and the broader band-lifecycle simplification.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of #1606 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fixed a regression where a priority band defined only via an InferenceObjective (not in the static EPP config) could be garbage-collected after a period of inactivity, causing subsequent requests at that priority to be rejected with "priority band not found".
```
