### PR TITLE
fix(flowcontrol): map shutdown-drained requests to 503

### DIFF
--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -37,6 +37,7 @@ const (
 	RequestDroppedReasonSaturated        RequestDroppedReason = "rejected-saturated"
 	RequestDroppedReasonTTLExpired       RequestDroppedReason = "rejected-ttl-expired"
 	RequestDroppedReasonContextCancelled RequestDroppedReason = "rejected-context-cancelled"
+	RequestDroppedReasonShuttingDown     RequestDroppedReason = "rejected-shutting-down"
 
 	// Evicted — request was dispatched to an inference server and then killed.
 	// The generic "evicted" reason is the current default used by ImmediateResponseEvictor.Evict().

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -18,6 +18,7 @@ package requestcontrol
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -231,7 +232,9 @@ func translateFlowControlOutcome(outcome types.QueueOutcome, err error) error {
 	case types.QueueOutcomeEvictedContextCancelled:
 		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "client disconnected: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonContextCancelled)}}
 	case types.QueueOutcomeRejectedOther, types.QueueOutcomeEvictedOther:
-		// No x-removal-reason header: these are internal/unexpected failures, not a specific removal policy.
+		if errors.Is(err, types.ErrFlowControllerNotRunning) {
+			return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "flow controller shutting down: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonShuttingDown)}}
+		}
 		return errcommon.Error{Code: errcommon.Internal, Msg: "internal flow control error: " + msg}
 	default:
 		return errcommon.Error{Code: errcommon.Internal, Msg: "unhandled flow control outcome: " + msg}

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -301,3 +301,83 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslateFlowControlOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		outcome    fctypes.QueueOutcome
+		err        error
+		wantCode   string
+		wantReason string
+		wantNil    bool
+	}{
+		{
+			name:    "dispatched returns nil",
+			outcome: fctypes.QueueOutcomeDispatched,
+			err:     nil,
+			wantNil: true,
+		},
+		{
+			name:       "capacity rejection returns 429",
+			outcome:    fctypes.QueueOutcomeRejectedCapacity,
+			err:        fctypes.ErrQueueAtCapacity,
+			wantCode:   errcommon.ResourceExhausted,
+			wantReason: string(errcommon.RequestDroppedReasonSaturated),
+		},
+		{
+			name:       "TTL expiry returns 503",
+			outcome:    fctypes.QueueOutcomeEvictedTTL,
+			err:        fctypes.ErrTTLExpired,
+			wantCode:   errcommon.ServiceUnavailable,
+			wantReason: string(errcommon.RequestDroppedReasonTTLExpired),
+		},
+		{
+			name:       "context cancellation returns 503",
+			outcome:    fctypes.QueueOutcomeEvictedContextCancelled,
+			err:        fctypes.ErrContextCancelled,
+			wantCode:   errcommon.ServiceUnavailable,
+			wantReason: string(errcommon.RequestDroppedReasonContextCancelled),
+		},
+		{
+			name:       "shutdown eviction returns 503",
+			outcome:    fctypes.QueueOutcomeEvictedOther,
+			err:        fctypes.ErrFlowControllerNotRunning,
+			wantCode:   errcommon.ServiceUnavailable,
+			wantReason: string(errcommon.RequestDroppedReasonShuttingDown),
+		},
+		{
+			name:       "shutdown rejection returns 503",
+			outcome:    fctypes.QueueOutcomeRejectedOther,
+			err:        fctypes.ErrFlowControllerNotRunning,
+			wantCode:   errcommon.ServiceUnavailable,
+			wantReason: string(errcommon.RequestDroppedReasonShuttingDown),
+		},
+		{
+			name:     "internal error returns 500",
+			outcome:  fctypes.QueueOutcomeRejectedOther,
+			err:      errors.New("unexpected failure"),
+			wantCode: errcommon.Internal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := translateFlowControlOutcome(tt.outcome, tt.err)
+			if tt.wantNil {
+				require.NoError(t, result)
+				return
+			}
+			require.Error(t, result)
+			var e errcommon.Error
+			require.ErrorAs(t, result, &e)
+			assert.Equal(t, tt.wantCode, e.Code)
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, e.Headers[errcommon.RequestDroppedReasonHeaderKey],
+					"drop reason header should match")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Return ServiceUnavailable (503) instead of Internal (500) when requests are evicted or rejected due to `ErrFlowControllerNotRunning` during shutdown
- Add table test covering every `QueueOutcome` → HTTP status mapping

## Context
During a rolling update, `evictAll` finalizes queued requests as `EvictedOther` with `ErrFlowControllerNotRunning`. The previous mapping treated all `EvictedOther`/`RejectedOther` as `Internal` (500), which triggers false alerts. Shutdown-drained requests are transient unavailability, not internal errors.

## Test plan
- [x] Table test: dispatched→nil, capacity→429, TTL→503, cancel→503, shutdown→503, internal→500
- [x] Existing admission tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)