### PR TITLE
[Helm] Support agentgateway in standalone service mode

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -53,8 +53,6 @@ helm install my-standalone-router ./config/charts/llm-d-router-standalone \
   --set router.proxy.replicas=3
 ```
 
-Service mode works with `proxyType=agentgateway` too; add `--set router.proxy.mode=service` to the agentgateway install below to run the agentgateway proxy as its own service.
-
 ---
 
 ### 2. Gateway Mode (`llm-d-router-gateway`)
@@ -524,7 +522,7 @@ Configures EPP to run with a proxy (Envoy proxy or Agentgateway proxy) that inte
 | :--- | :--- | :--- |
 | `router.proxy.enabled` | Enable the proxy (Envoy or Agentgateway) in front of EPP. | `false` |
 | `router.proxy.proxyType` | Type of proxy. Options: `[envoy, agentgateway]`. | `envoy` |
-| `router.proxy.mode` | Proxy deployment mode. `sidecar` runs the proxy in the EPP pod; `service` runs it as its own horizontally scalable Deployment and Service reaching EPP over the EPP Service. Supported for both Envoy and Agentgateway. | `sidecar` |
+| `router.proxy.mode` | Proxy deployment mode. `sidecar` runs the proxy in the EPP pod; `service` runs it as its own horizontally scalable Deployment and Service reaching EPP over the EPP Service. | `sidecar` |
 | `router.proxy.replicas` | Replica count for the proxy Deployment when `mode=service`. | `2` |
 | `router.proxy.failOpen` | Whether the proxy passes traffic through (fail-open) when EPP is unreachable. Applies to `proxyType=envoy` only; Agentgateway exposes no fail-open setting and rejects requests (fails closed) when EPP is unreachable. | `true` |
 | `router.proxy.name` | Name of the sidecar container. | `""` |

--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -52,6 +52,9 @@ helm install my-standalone-router ./config/charts/llm-d-router-standalone \
   --set router.proxy.mode=service \
   --set router.proxy.replicas=3
 ```
+
+Service mode works with `proxyType=agentgateway` too; add `--set router.proxy.mode=service` to the agentgateway install below to run the agentgateway proxy as its own service.
+
 ---
 
 ### 2. Gateway Mode (`llm-d-router-gateway`)
@@ -513,7 +516,7 @@ httpRoute:
 
 ### Standalone Mode Configuration
 
-Configures EPP to run with a proxy (Envoy proxy or Agentgateway proxy) that intercepts and routes client traffic directly to model servers (exclusive to `llm-d-router-standalone`). The proxy runs as a sidecar in the EPP pod by default, or as a separate horizontally scalable service when `router.proxy.mode=service` (Envoy only).
+Configures EPP to run with a proxy (Envoy proxy or Agentgateway proxy) that intercepts and routes client traffic directly to model servers (exclusive to `llm-d-router-standalone`). The proxy runs as a sidecar in the EPP pod by default, or as a separate horizontally scalable service when `router.proxy.mode=service`.
 
 #### Proxy Sidecar Parameters
 
@@ -521,9 +524,9 @@ Configures EPP to run with a proxy (Envoy proxy or Agentgateway proxy) that inte
 | :--- | :--- | :--- |
 | `router.proxy.enabled` | Enable the proxy (Envoy or Agentgateway) in front of EPP. | `false` |
 | `router.proxy.proxyType` | Type of proxy. Options: `[envoy, agentgateway]`. | `envoy` |
-| `router.proxy.mode` | Proxy deployment mode. `sidecar` runs the proxy in the EPP pod; `service` runs it as its own horizontally scalable Deployment and Service reaching EPP over the EPP Service (Envoy only). | `sidecar` |
+| `router.proxy.mode` | Proxy deployment mode. `sidecar` runs the proxy in the EPP pod; `service` runs it as its own horizontally scalable Deployment and Service reaching EPP over the EPP Service. Supported for both Envoy and Agentgateway. | `sidecar` |
 | `router.proxy.replicas` | Replica count for the proxy Deployment when `mode=service`. | `2` |
-| `router.proxy.failOpen` | Whether the proxy passes traffic through (fail-open) when EPP is unreachable. | `true` |
+| `router.proxy.failOpen` | Whether the proxy passes traffic through (fail-open) when EPP is unreachable. Applies to `proxyType=envoy` only; Agentgateway exposes no fail-open setting and rejects requests (fails closed) when EPP is unreachable. | `true` |
 | `router.proxy.name` | Name of the sidecar container. | `""` |
 | `router.proxy.image` | Sidecar container image. | `""` |
 | `router.proxy.imagePullPolicy` | Sidecar container image pull policy. | `IfNotPresent` |

--- a/config/charts/llm-d-router-standalone/templates/_validations.tpl
+++ b/config/charts/llm-d-router-standalone/templates/_validations.tpl
@@ -33,10 +33,6 @@ standalone validations
   {{- if not $proxy.enabled -}}
     {{- fail ".Values.router.proxy.enabled must be true when .Values.router.proxy.mode=service" -}}
   {{- end -}}
-  {{- $proxyType := default "envoy" ($proxy.proxyType | default "envoy") | lower -}}
-  {{- if ne $proxyType "envoy" -}}
-    {{- fail (printf ".Values.router.proxy.mode=service currently supports only proxyType=envoy, got %q" $proxyType) -}}
-  {{- end -}}
   {{- $hasHTTP := false -}}
   {{- range $servicePort := (.Values.router.extraServicePorts | default (list)) -}}
     {{- if eq (toString (index $servicePort "name")) "http" -}}
@@ -62,7 +58,7 @@ standalone validations
     {{- $listenerPort := include "llm-d-router.standaloneProxyListenerPort" . -}}
     {{- $flags := .Values.router.epp.flags | default dict -}}
     {{- if and (hasKey $flags "secure-serving") (ne (toString (index $flags "secure-serving")) "false") -}}
-      {{- fail ".Values.router.epp.flags.secure-serving must be false when proxyType=agentgateway; standalone agentgateway uses plaintext gRPC to EPP over localhost" -}}
+      {{- fail ".Values.router.epp.flags.secure-serving must be false when proxyType=agentgateway; standalone agentgateway uses plaintext gRPC to EPP (over loopback in sidecar mode, or the EPP Service in service mode)" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -415,7 +415,7 @@ binds:
         policies:
           inferenceRouting:
             endpointPicker:
-              host: {{ printf "127.0.0.1:%v" (.Values.router.epp.extProcPort | default 9002) | quote }}
+              host: {{ printf "%s:%v" (include "llm-d-router.proxy.extProcHost" .) (.Values.router.epp.extProcPort | default 9002) | quote }}
             destinationMode: passthrough
 services:
 - name: {{ $serviceName | quote }}

--- a/config/charts/routerlib/templates/_proxy-deployment.yaml
+++ b/config/charts/routerlib/templates/_proxy-deployment.yaml
@@ -1,5 +1,8 @@
 {{- define "llm-d-epp.proxy-deployment" -}}
 {{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict -}}
+{{- $proxyType := include "llm-d-router.proxyType" . | trim -}}
+{{- $proxyConfigMap := index $proxy "configMap" | default dict -}}
+{{- $proxyConfigMapName := index $proxyConfigMap "name" | default "" -}}
 {{- if and $proxy.enabled (eq (include "llm-d-router.proxyMode" .) "service") -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -62,13 +65,30 @@ spec:
           resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with $proxy.volumeMounts }}
+        {{- if or (and (eq $proxyType "agentgateway") $proxyConfigMapName) $proxy.volumeMounts }}
           volumeMounts:
+          {{- if and (eq $proxyType "agentgateway") $proxyConfigMapName }}
+            - name: agentgateway-config-template
+              mountPath: /config
+              readOnly: true
+          {{- end }}
+          {{- with $proxy.volumeMounts }}
           {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
-      {{- with $proxy.volumes }}
+      {{- if or (and (eq $proxyType "agentgateway") $proxyConfigMapName) $proxy.volumes }}
       volumes:
+      {{- if and (eq $proxyType "agentgateway") $proxyConfigMapName }}
+        - name: agentgateway-config-template
+          configMap:
+            name: {{ $proxyConfigMapName }}
+            items:
+              - key: config.yaml
+                path: config.yaml
+      {{- end }}
+      {{- with $proxy.volumes }}
       {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- end }}
 ---
 {{- end -}}

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -116,6 +116,7 @@ test_cases_llm_d_router_standalone["latency-predictor"]="--set router.latencyPre
 test_cases_llm_d_router_standalone["llm-d-router-gateway"]="--set router.inferencePool.create=true --set router.modelServers.matchLabels.app=llm-instance-gateway"
 test_cases_llm_d_router_standalone["agentgateway"]="--set router.proxy.proxyType=agentgateway --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set 'router.modelServers.targetPorts[0].number=8000'"
 test_cases_llm_d_router_standalone["proxy-service"]="--set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set router.proxy.replicas=3"
+test_cases_llm_d_router_standalone["agentgateway-service"]="--set router.proxy.proxyType=agentgateway --set router.proxy.mode=service --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set 'router.modelServers.targetPorts[0].number=8000'"
 test_cases_llm_d_router_standalone["triton"]="--set router.modelServers.type=triton --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false"
 
 
@@ -187,13 +188,6 @@ mismatched_agentgateway_listener_target_port_command="${HELM} template ${SCRIPT_
 echo "Executing: ${mismatched_agentgateway_listener_target_port_command}"
 if eval "${mismatched_agentgateway_listener_target_port_command}"; then
   echo "Helm template unexpectedly succeeded for an agentgateway listener targetPort that does not match port"
-  exit 1
-fi
-
-unsupported_proxy_service_agentgateway_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set router.proxy.proxyType=agentgateway --set router.proxy.agentgateway.service.name=llm-instance-gateway --set 'router.proxy.agentgateway.service.ports[0]=8000' --set 'router.modelServers.targetPorts[0].number=8000' >/dev/null"
-echo "Executing: ${unsupported_proxy_service_agentgateway_command}"
-if eval "${unsupported_proxy_service_agentgateway_command}"; then
-  echo "Helm template unexpectedly succeeded for proxy mode=service with proxyType=agentgateway"
   exit 1
 fi
 
@@ -292,5 +286,35 @@ fi
 # The proxy Deployment selector/labels must be distinct from the EPP selector.
 if ! grep -q -- 'llm-d-router-proxy: proxy-svc-proxy' "${proxy_service_render_output}"; then
   echo "Proxy service mode did not render the dedicated proxy selector label"
+  exit 1
+fi
+
+echo "Verifying llm-d-router-standalone agentgateway in service mode reaches EPP over the Service..."
+agentgateway_service_mode_output="${TEMP_DIR}/llm-d-router-standalone-agentgateway-service-render.yaml"
+agentgateway_service_mode_command="${HELM} template ag-svc ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --namespace ag-ns --set router.proxy.proxyType=agentgateway --set router.proxy.mode=service --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set 'router.modelServers.targetPorts[0].number=8000' > ${agentgateway_service_mode_output}"
+echo "Executing: ${agentgateway_service_mode_command}"
+eval "${agentgateway_service_mode_command}"
+if ! grep -q -- 'name: ag-svc-proxy' "${agentgateway_service_mode_output}"; then
+  echo "Agentgateway service mode did not render the separate proxy Deployment/Service named ag-svc-proxy"
+  exit 1
+fi
+# The agentgateway container lives only in the standalone proxy Deployment, not the EPP pod.
+agentgateway_container_count=$(grep -c -- '- name: agentgateway-proxy$' "${agentgateway_service_mode_output}")
+if [ "${agentgateway_container_count}" -ne 1 ]; then
+  echo "Agentgateway service mode rendered ${agentgateway_container_count} agentgateway-proxy containers, expected exactly 1 (in the proxy Deployment)"
+  exit 1
+fi
+# endpointPicker must target the EPP Service FQDN, not loopback.
+if ! grep -q -- 'host: "ag-svc-epp.ag-ns.svc.cluster.local:9002"' "${agentgateway_service_mode_output}"; then
+  echo "Agentgateway service mode did not point endpointPicker.host at the EPP Service FQDN"
+  exit 1
+fi
+if grep -q -- 'host: "127.0.0.1:9002"' "${agentgateway_service_mode_output}"; then
+  echo "Agentgateway service mode still points endpointPicker.host at loopback"
+  exit 1
+fi
+# The agentgateway config must be mounted in the proxy Deployment.
+if ! grep -q -- 'agentgateway-config-template' "${agentgateway_service_mode_output}"; then
+  echo "Agentgateway service mode did not mount the agentgateway config in the proxy Deployment"
   exit 1
 fi


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
Extends `router.proxy.mode=service` to `proxyType=agentgateway` (was Envoy-only). The agentgateway proxy now runs as its own horizontally scalable Deployment + Service that reaches EPP over the EPP Service FQDN (instead of `127.0.0.1`).

Caveat: agentgateway's standalone config exposes no fail-open setting (`failureMode` is rejected by the binary) and fails closed when EPP is unreachable, so `router.proxy.failOpen` remains Envoy-only. Documented in the chart README. 
cc @ahg-g

Verified: `make verify-helm-charts` (new `agentgateway-service` case), the rendered config against the real agentgateway binary (`--validate-only`), and end-to-end on a kind cluster with vLLM on a GPU — request through the agentgateway proxy Service routed via EPP to vLLM (HTTP 200).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1610

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The standalone Helm chart now supports `proxyType=agentgateway` with `router.proxy.mode=service`, running the agentgateway proxy as a separate horizontally scalable Service that reaches EPP over the EPP Service. Fail-open (`router.proxy.failOpen`) remains Envoy-only.


```
