### PR TITLE
fix(tokenizer): label estimate multimodal features by modality

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -34,8 +34,13 @@ const nilStr = "<nil>"
 // Modality identifies the type of multimodal content in a prompt.
 type Modality string
 
-// ModalityImage is the only currently supported modality.
-const ModalityImage Modality = "image"
+// Modality values match the model-server's multimodal hash keys so labels agree
+// across backends.
+const (
+	ModalityImage Modality = "image"
+	ModalityAudio Modality = "audio"
+	ModalityVideo Modality = "video"
+)
 
 // RequestPayload represents a strongly-typed unmarshaled request payload or raw bytes.
 type RequestPayload interface {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -157,12 +157,12 @@ func (b estimateBackend) appendChatMessage(out []byte, features []fwkrh.MultiMod
 		case blockTypeText:
 			out = append(out, []byte(block.Text)...)
 		case "image_url":
-			out, features = appendMMAsset(out, features, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
+			out, features = appendMMAsset(out, features, fwkrh.ModalityImage, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
 		case "video_url":
-			out, features = appendMMAsset(out, features, block.VideoURL.URL, assetPlaceholderCount(len(block.VideoURL.URL)))
+			out, features = appendMMAsset(out, features, fwkrh.ModalityVideo, block.VideoURL.URL, assetPlaceholderCount(len(block.VideoURL.URL)))
 		case "input_audio", "audio_url":
 			data := block.InputAudio.Data + block.InputAudio.Format
-			out, features = appendMMAsset(out, features, data, assetPlaceholderCount(len(data)))
+			out, features = appendMMAsset(out, features, fwkrh.ModalityAudio, data, assetPlaceholderCount(len(data)))
 		}
 	}
 	return out, features
@@ -203,7 +203,7 @@ func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fw
 				out = append(out, []byte(block.Text)...)
 			case "image":
 				if content, count := b.img.placeholderForAnthropicImage(block.Source); content != "" {
-					out, features = appendMMAsset(out, features, content, count)
+					out, features = appendMMAsset(out, features, fwkrh.ModalityImage, content, count)
 				}
 			}
 		}
@@ -213,9 +213,8 @@ func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fw
 
 // appendMMAsset aligns out to a token boundary, appends count placeholder
 // pseudo-tokens derived from a stable content hash, and records the matching
-// feature. Modality is always ModalityImage: it is the only defined modality
-// const, and detection/scoring need only a non-empty, stably-hashed feature.
-func appendMMAsset(out []byte, features []fwkrh.MultiModalFeature, content string, count int) ([]byte, []fwkrh.MultiModalFeature) {
+// feature under modality so labels agree with the vllm backend.
+func appendMMAsset(out []byte, features []fwkrh.MultiModalFeature, modality fwkrh.Modality, content string, count int) ([]byte, []fwkrh.MultiModalFeature) {
 	out = align(out)
 	offset := len(out) / bytesPerToken
 
@@ -227,7 +226,7 @@ func appendMMAsset(out []byte, features []fwkrh.MultiModalFeature, content strin
 	}
 
 	features = append(features, fwkrh.MultiModalFeature{
-		Modality: fwkrh.ModalityImage,
+		Modality: modality,
 		Hash:     strconv.FormatUint(sum, 16),
 		Offset:   offset,
 		Length:   count,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -134,6 +134,30 @@ func TestEstimateBackend_ChatImageFeature(t *testing.T) {
 	}
 }
 
+func TestEstimateBackend_ChatModalityLabels(t *testing.T) {
+	chat := func(block fwkrh.ContentBlock) *fwkrh.InferenceRequestBody {
+		return &fwkrh.InferenceRequestBody{ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Structured: []fwkrh.ContentBlock{block}}}},
+		}}
+	}
+	for _, tc := range []struct {
+		name  string
+		block fwkrh.ContentBlock
+		want  fwkrh.Modality
+	}{
+		{"image", fwkrh.ContentBlock{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://example.com/a.png"}}, fwkrh.ModalityImage},
+		{"audio", fwkrh.ContentBlock{Type: "input_audio", InputAudio: fwkrh.AudioBlock{Data: "AAAA", Format: "wav"}}, fwkrh.ModalityAudio},
+		{"video", fwkrh.ContentBlock{Type: "video_url", VideoURL: fwkrh.VideoBlock{URL: "https://example.com/clip.mp4"}}, fwkrh.ModalityVideo},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tp, err := estimateBackend{}.produce(context.Background(), chat(tc.block))
+			require.NoError(t, err)
+			require.Len(t, tp.MultiModalFeatures, 1)
+			require.Equal(t, tc.want, tp.MultiModalFeatures[0].Modality)
+		})
+	}
+}
+
 // TestEstimateBackend_ChatImageWeightingDistinct asserts two images with
 // different placeholder counts produce different token streams, so image
 // weighting affects locality keys.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The token-producer `estimate` backend hardcoded `ModalityImage` for every multimodal item, so audio and video were reported as `image` in `encoder_cache_queries_total` / `encoder_cache_hits_total` diverging from the vLLM `/render` backend, which carries the real modality. This threads the actual modality through `appendMMAsset` and adds `ModalityAudio`/`ModalityVideo` consts. Routing is unaffected (scoring keys on the content hash, not modality); this corrects per-modality cache observability.

**Which issue(s) this PR fixes**:

Fixes #1617

**Release note**:
```release-note
NONE
```
