### PR TITLE
Add session-affinity filter and configurable header for session affinity

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -99,6 +99,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity"
+	sessionaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/random"
@@ -483,6 +484,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(bylabel.EncodeRoleType, bylabel.EncodeRoleFactory)
 	fwkplugin.Register(bylabel.DecodeRoleType, bylabel.DecodeRoleFactory)
 	fwkplugin.Register(bylabel.PrefillRoleType, bylabel.PrefillRoleFactory)
+	fwkplugin.Register(sessionaffinityfilter.SessionAffinityType, sessionaffinityfilter.Factory)
 
 	// dataparallel profile handler
 	fwkplugin.Register(dataparallel.DataParallelProfileHandlerType, dataparallel.ProfileHandlerFactory)

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/README.md
@@ -1,0 +1,30 @@
+# Session Affinity Filter
+
+**Type:** `session-affinity-filter`
+
+Pins subsequent requests in a session to the same pod the first request was sent to, as a hard constraint. When the session pod is among the candidates the filter returns it as the sole endpoint; when there is no session, the token cannot be decoded, or the session pod is no longer a candidate, the filter returns all candidates unchanged so downstream filters and scorers decide.
+
+The session is carried in a request header whose value is the base64-encoded `namespace/name` of the previously selected pod. As a [`ResponseHeaderProcessor`](../../../../interface/requestcontrol/plugins.go), the filter writes that same header on the response so the client can echo it back on the next request.
+
+## Parameters
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `headerName` | string | `x-session-token` | Request and response header carrying the session token. When set, only this header is read; the default is ignored. |
+
+```yaml
+- type: session-affinity-filter
+  parameters:
+    headerName: x-session-token
+```
+
+## Relationship to the session affinity scorer
+
+The [session affinity scorer](../../scorer/sessionaffinity/README.md) (`session-affinity-scorer`) provides the same affinity behavior as a soft preference and writes the same response header.
+
+Configuring both the filter and the scorer is unnecessary:
+
+- If they use the **same** `headerName`, the configuration is redundant: both read and write the identical header, and the filter already restricts candidates to the session pod, so the scorer's contribution is moot.
+- If they use **different** `headerName` values, the configuration is misleading: the response carries the same token under two different headers (both encode the chosen pod), so the client cannot tell which header to echo back.
+
+Choose one: the filter for a hard pin, or the scorer for a soft preference that can be outweighed by other scorers.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package sessionaffinity provides a session affinity filter plugin for the epp.
 package sessionaffinity

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
@@ -1,0 +1,2 @@
+// Package sessionaffinity provides a session affinity filter plugin for the epp.
+package sessionaffinity

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sessionaffinity
 
 import (
@@ -9,7 +25,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	sessiontoken "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/sessionaffinity"
+	sessionutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/sessionaffinity"
 )
 
 const (
@@ -37,15 +53,15 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 		}
 	}
 
-	return NewSessionAffinity(params.HeaderName).WithName(name), nil
+	return NewSessionAffinity(name, params.HeaderName), nil
 }
 
 // NewSessionAffinity returns a filter. When sessionHeader is empty the default
 // x-session-token header is used.
-func NewSessionAffinity(sessionHeader string) *SessionAffinity {
+func NewSessionAffinity(name, sessionHeader string) *SessionAffinity {
 	return &SessionAffinity{
-		typedName:     plugin.TypedName{Type: SessionAffinityType},
-		sessionHeader: sessiontoken.NormalizeHeader(sessionHeader),
+		typedName:     plugin.TypedName{Type: SessionAffinityType, Name: name},
+		sessionHeader: sessionutil.NormalizeHeader(sessionHeader),
 	}
 }
 
@@ -65,16 +81,10 @@ func (s *SessionAffinity) TypedName() plugin.TypedName {
 	return s.typedName
 }
 
-// WithName sets the name of the plugin.
-func (s *SessionAffinity) WithName(name string) *SessionAffinity {
-	s.typedName.Name = name
-	return s
-}
-
 // Filter returns the endpoint running the session when it is among the
 // candidates, otherwise all candidate endpoints.
 func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
-	podName := sessiontoken.DecodePodName(ctx, request.Headers[s.sessionHeader])
+	podName := sessionutil.DecodePodName(ctx, request.Headers[s.sessionHeader])
 	if podName == "" {
 		return endpoints
 	}
@@ -90,5 +100,5 @@ func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.Infere
 
 // ResponseHeader sets the session header on the response sent to the client.
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	sessiontoken.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
+	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -9,7 +9,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	sessionscorer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity"
+	sessiontoken "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/sessionaffinity"
 )
 
 const (
@@ -45,7 +45,7 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 func NewSessionAffinity(sessionHeader string) *SessionAffinity {
 	return &SessionAffinity{
 		typedName:     plugin.TypedName{Type: SessionAffinityType},
-		sessionHeader: sessionscorer.NormalizeHeader(sessionHeader),
+		sessionHeader: sessiontoken.NormalizeHeader(sessionHeader),
 	}
 }
 
@@ -74,7 +74,7 @@ func (s *SessionAffinity) WithName(name string) *SessionAffinity {
 // Filter returns the endpoint running the session when it is among the
 // candidates, otherwise all candidate endpoints.
 func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
-	podName := sessionscorer.DecodePodName(ctx, request.Headers[s.sessionHeader])
+	podName := sessiontoken.DecodePodName(ctx, request.Headers[s.sessionHeader])
 	if podName == "" {
 		return endpoints
 	}
@@ -90,5 +90,5 @@ func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.Infere
 
 // ResponseHeader sets the session header on the response sent to the client.
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	sessionscorer.WriteSessionResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
+	sessiontoken.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -1,0 +1,94 @@
+package sessionaffinity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	sessionscorer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity"
+)
+
+const (
+	// SessionAffinityType is the type of the SessionAffinity filter.
+	SessionAffinityType = "session-affinity-filter"
+)
+
+// parameters configures the SessionAffinity filter.
+type parameters struct {
+	// HeaderName overrides the default x-session-token header used to read and
+	// write the session token. When empty the default is used.
+	HeaderName string `json:"headerName"`
+}
+
+// compile-time type assertion
+var _ scheduling.Filter = &SessionAffinity{}
+var _ requestcontrol.ResponseHeaderProcessor = &SessionAffinity{}
+
+// Factory defines the factory function for the SessionAffinity filter.
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	params := parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", SessionAffinityType, err)
+		}
+	}
+
+	return NewSessionAffinity(params.HeaderName).WithName(name), nil
+}
+
+// NewSessionAffinity returns a filter. When sessionHeader is empty the default
+// x-session-token header is used.
+func NewSessionAffinity(sessionHeader string) *SessionAffinity {
+	return &SessionAffinity{
+		typedName:     plugin.TypedName{Type: SessionAffinityType},
+		sessionHeader: sessionscorer.NormalizeHeader(sessionHeader),
+	}
+}
+
+// SessionAffinity is a routing filter that pins subsequent requests in a
+// session to the same pod the first request in the session was sent to. When
+// the session pod is among the candidates it is returned as the sole endpoint;
+// otherwise all candidates are returned so downstream filters and scorers can
+// decide.
+type SessionAffinity struct {
+	typedName plugin.TypedName
+	// sessionHeader is the request/response header carrying the session token.
+	sessionHeader string
+}
+
+// TypedName returns the typed name of the plugin.
+func (s *SessionAffinity) TypedName() plugin.TypedName {
+	return s.typedName
+}
+
+// WithName sets the name of the plugin.
+func (s *SessionAffinity) WithName(name string) *SessionAffinity {
+	s.typedName.Name = name
+	return s
+}
+
+// Filter returns the endpoint running the session when it is among the
+// candidates, otherwise all candidate endpoints.
+func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
+	podName := sessionscorer.DecodePodName(ctx, request.Headers[s.sessionHeader])
+	if podName == "" {
+		return endpoints
+	}
+
+	for _, endpoint := range endpoints {
+		if endpoint.GetMetadata().NamespacedName.String() == podName {
+			return []scheduling.Endpoint{endpoint}
+		}
+	}
+
+	return endpoints
+}
+
+// ResponseHeader sets the session header on the response sent to the client.
+func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
+	sessionscorer.WriteSessionResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sessionaffinity_test
 
 import (
@@ -35,8 +51,8 @@ func TestSessionAffinity_Filter(t *testing.T) {
 	// valid token whose pod is not among the candidates
 	tokenForMissingPod := base64.StdEncoding.EncodeToString([]byte("pod-missing"))
 
-	sessionAffinityFilter := sessionaffinity.NewSessionAffinity("")
-	customHeaderFilter := sessionaffinity.NewSessionAffinity("x-custom-session")
+	sessionAffinityFilter := sessionaffinity.NewSessionAffinity("test-filter", "")
+	customHeaderFilter := sessionaffinity.NewSessionAffinity("test-filter", "x-custom-session")
 
 	tests := []struct {
 		name     string
@@ -175,7 +191,7 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := sessionaffinity.NewSessionAffinity(test.sessionHeader)
+			s := sessionaffinity.NewSessionAffinity("test-filter", test.sessionHeader)
 			s.ResponseHeader(ctx, nil, test.initialResponse, test.targetPod)
 
 			if test.initialResponse == nil {

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
@@ -6,16 +6,17 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	sessionaffinity "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity"
+	sessionaffinity "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
-func TestSessionAffinity_Score(t *testing.T) {
+func TestSessionAffinity_Filter(t *testing.T) {
 	endpointA := scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-a"}},
 		&fwkdl.Metrics{},
@@ -31,96 +32,93 @@ func TestSessionAffinity_Score(t *testing.T) {
 
 	// valid session token for endpointB
 	validSessionTokenForEndpointB := base64.StdEncoding.EncodeToString([]byte(endpointB.GetMetadata().NamespacedName.String()))
+	// valid token whose pod is not among the candidates
+	tokenForMissingPod := base64.StdEncoding.EncodeToString([]byte("pod-missing"))
 
-	sessionAffinityScorer := sessionaffinity.NewSessionAffinity("")
-	customHeaderScorer := sessionaffinity.NewSessionAffinity("x-custom-session")
+	sessionAffinityFilter := sessionaffinity.NewSessionAffinity("")
+	customHeaderFilter := sessionaffinity.NewSessionAffinity("x-custom-session")
 
 	tests := []struct {
-		name       string
-		scorer     *sessionaffinity.SessionAffinity
-		req        *scheduling.InferenceRequest
-		input      []scheduling.Endpoint
-		wantScores map[scheduling.Endpoint]float64
+		name     string
+		filter   *sessionaffinity.SessionAffinity
+		req      *scheduling.InferenceRequest
+		input    []scheduling.Endpoint
+		wantPods []string
 	}{
 		{
-			name:   "selects correct endpoint : endpointB",
-			scorer: sessionAffinityScorer,
+			name:   "selects the session endpoint : endpointB",
+			filter: sessionAffinityFilter,
 			req: &scheduling.InferenceRequest{
 				Headers: map[string]string{"x-session-token": validSessionTokenForEndpointB},
 			},
-			input: inputEndpoints,
-			wantScores: map[scheduling.Endpoint]float64{
-				endpointA: 0.0,
-				endpointB: 1.0,
-			},
+			input:    inputEndpoints,
+			wantPods: []string{"pod-b"},
 		},
 		{
-			name:   "custom header selects endpointB",
-			scorer: customHeaderScorer,
+			name:   "custom header selects the session endpoint : endpointB",
+			filter: customHeaderFilter,
 			req: &scheduling.InferenceRequest{
 				Headers: map[string]string{"x-custom-session": validSessionTokenForEndpointB},
 			},
-			input: inputEndpoints,
-			wantScores: map[scheduling.Endpoint]float64{
-				endpointA: 0.0,
-				endpointB: 1.0,
-			},
+			input:    inputEndpoints,
+			wantPods: []string{"pod-b"},
 		},
 		{
 			name:   "custom header ignores default header",
-			scorer: customHeaderScorer,
+			filter: customHeaderFilter,
 			req: &scheduling.InferenceRequest{
 				Headers: map[string]string{"x-session-token": validSessionTokenForEndpointB},
 			},
-			input: inputEndpoints,
-			wantScores: map[scheduling.Endpoint]float64{
-				endpointA: 0.0,
-				endpointB: 0.0,
-			},
+			input:    inputEndpoints,
+			wantPods: []string{"pod-a", "pod-b"},
 		},
 		{
-			name:   "no session token",
-			scorer: sessionAffinityScorer,
+			name:   "no session token returns all endpoints",
+			filter: sessionAffinityFilter,
 			req: &scheduling.InferenceRequest{
 				Headers: map[string]string{},
 			},
-			// both endpoints get score 0.0
-			input: inputEndpoints,
-			wantScores: map[scheduling.Endpoint]float64{
-				endpointA: 0.0,
-				endpointB: 0.0,
-			},
+			input:    inputEndpoints,
+			wantPods: []string{"pod-a", "pod-b"},
 		},
 		{
-			name:   "invalid session token",
-			scorer: sessionAffinityScorer,
+			name:   "invalid session token returns all endpoints",
+			filter: sessionAffinityFilter,
 			req: &scheduling.InferenceRequest{
 				Headers: map[string]string{"x-session-token": "garbage-token"},
 			},
-			// expect same behavior as no session token
-			input: inputEndpoints,
-			wantScores: map[scheduling.Endpoint]float64{
-				endpointA: 0.0,
-				endpointB: 0.0,
-			},
+			input:    inputEndpoints,
+			wantPods: []string{"pod-a", "pod-b"},
 		},
 		{
-			name:   "no endpoints available",
-			scorer: sessionAffinityScorer,
-			req:    &scheduling.InferenceRequest{},
-			input:  []scheduling.Endpoint{},
-			// returns empty score map
-			wantScores: map[scheduling.Endpoint]float64{},
+			name:   "session pod not among candidates returns all endpoints",
+			filter: sessionAffinityFilter,
+			req: &scheduling.InferenceRequest{
+				Headers: map[string]string{"x-session-token": tokenForMissingPod},
+			},
+			input:    inputEndpoints,
+			wantPods: []string{"pod-a", "pod-b"},
+		},
+		{
+			name:     "no endpoints available",
+			filter:   sessionAffinityFilter,
+			req:      &scheduling.InferenceRequest{Headers: map[string]string{"x-session-token": validSessionTokenForEndpointB}},
+			input:    []scheduling.Endpoint{},
+			wantPods: []string{},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotScores := test.scorer.Score(context.Background(), test.req, test.input)
+			got := test.filter.Filter(context.Background(), test.req, test.input)
 
-			if diff := cmp.Diff(test.wantScores, gotScores); diff != "" {
-				t.Errorf("Unexpected output (-want +got): %v", diff)
+			gotPods := make([]string, len(got))
+			for idx, endpoint := range got {
+				gotPods[idx] = endpoint.GetMetadata().NamespacedName.Name
 			}
+
+			assert.ElementsMatch(t, test.wantPods, gotPods, "filtered endpoints should match expected endpoints")
+			assert.Len(t, got, len(test.wantPods), "filtered endpoints count should match expected count")
 		})
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/README.md
@@ -2,6 +2,22 @@
 
 **Type:** `session-affinity-scorer`
 
-Scores candidate pods by giving a higher score to pods that were previously used for the same session. Enables sticky routing for stateful workloads where reusing the same pod reduces latency or preserves context.
+Scores candidate pods by giving a higher score to the pod that was previously used for the same session, and zero to the rest. Enables sticky routing for stateful workloads where reusing the same pod reduces latency or preserves context.
 
-**Parameters:** None.
+The session is carried in a request header whose value is the base64-encoded `namespace/name` of the previously selected pod. As a [`ResponseHeaderProcessor`](../../../../interface/requestcontrol/plugins.go), the scorer writes that same header on the response so the client can echo it back on the next request.
+
+## Parameters
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `headerName` | string | `x-session-token` | Request and response header carrying the session token. When set, only this header is read; the default is ignored. |
+
+```yaml
+- type: session-affinity-scorer
+  parameters:
+    headerName: x-session-token
+```
+
+## Relationship to the session affinity filter
+
+The [session affinity filter](../../filter/sessionaffinity/README.md) (`session-affinity-filter`) provides the same affinity behavior as a hard constraint and writes the same response header. Configuring both alongside the scorer is unnecessary and can be misleading; see [Relationship to the session affinity scorer](../../filter/sessionaffinity/README.md#relationship-to-the-session-affinity-scorer) for details. Use the scorer for a soft preference that can be outweighed by other scorers, or the filter for a hard pin.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package sessionaffinity provides a session affinity scorer plugin for the epp.
 package sessionaffinity

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -9,7 +9,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	sessiontoken "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/sessionaffinity"
+	sessionutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/sessionaffinity"
 )
 
 const (
@@ -37,15 +37,15 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 		}
 	}
 
-	return NewSessionAffinity(params.HeaderName).WithName(name), nil
+	return NewSessionAffinity(name, params.HeaderName), nil
 }
 
 // NewSessionAffinity returns a scorer. When sessionHeader is empty the default
 // x-session-token header is used.
-func NewSessionAffinity(sessionHeader string) *SessionAffinity {
+func NewSessionAffinity(name, sessionHeader string) *SessionAffinity {
 	return &SessionAffinity{
-		typedName:     plugin.TypedName{Type: SessionAffinityType},
-		sessionHeader: sessiontoken.NormalizeHeader(sessionHeader),
+		typedName:     plugin.TypedName{Type: SessionAffinityType, Name: name},
+		sessionHeader: sessionutil.NormalizeHeader(sessionHeader),
 	}
 }
 
@@ -64,12 +64,6 @@ func (s *SessionAffinity) TypedName() plugin.TypedName {
 	return s.typedName
 }
 
-// WithName sets the name of the plugin.
-func (s *SessionAffinity) WithName(name string) *SessionAffinity {
-	s.typedName.Name = name
-	return s
-}
-
 // Category returns the preference the scorer applies when scoring candidate endpoints.
 func (s *SessionAffinity) Category() scheduling.ScorerCategory {
 	return scheduling.Affinity
@@ -78,7 +72,7 @@ func (s *SessionAffinity) Category() scheduling.ScorerCategory {
 // Score assign a high score to the pod used in previous requests and zero to others
 func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
 	scoredEndpoints := make(map[scheduling.Endpoint]float64)
-	podName := sessiontoken.DecodePodName(ctx, request.Headers[s.sessionHeader])
+	podName := sessionutil.DecodePodName(ctx, request.Headers[s.sessionHeader])
 
 	for _, endpoint := range endpoints {
 		scoredEndpoints[endpoint] = 0.0 // initial value
@@ -92,5 +86,5 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 
 // ResponseHeader sets the session header on the response sent to the client.
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	sessiontoken.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
+	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -2,27 +2,19 @@ package sessionaffinity
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	sessiontoken "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/sessionaffinity"
 )
 
 const (
 	// SessionAffinityType is the type of the SessionAffinity scorer.
 	SessionAffinityType = "session-affinity-scorer"
-
-	// DefaultSessionTokenHeader is the default request/response header carrying
-	// the session token. It is shared by the session-affinity scorer and filter.
-	DefaultSessionTokenHeader = "x-session-token"
 )
 
 // parameters configures the SessionAffinity scorer.
@@ -30,55 +22,6 @@ type parameters struct {
 	// HeaderName overrides the default x-session-token header used to read and
 	// write the session token. When empty the default is used.
 	HeaderName string `json:"headerName"`
-}
-
-// NormalizeHeader lowercases and trims the configured session header name,
-// falling back to DefaultSessionTokenHeader when empty. It is shared by the
-// session-affinity scorer and filter.
-func NormalizeHeader(name string) string {
-	header := strings.ToLower(strings.TrimSpace(name))
-	if header == "" {
-		return DefaultSessionTokenHeader
-	}
-	return header
-}
-
-// DecodePodName decodes a base64-encoded session token into a pod
-// NamespacedName string. It returns "" when the token is empty or cannot be
-// decoded. It is shared by the session-affinity scorer and filter.
-func DecodePodName(ctx context.Context, token string) string {
-	if token == "" {
-		return ""
-	}
-	decoded, err := base64.StdEncoding.DecodeString(token)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "Error decoding session header")
-		return ""
-	}
-	return string(decoded)
-}
-
-// WriteSessionResponseHeader encodes targetPod into sessionHeader on the
-// response sent to the client. It is shared by the session-affinity scorer and
-// filter; pluginType labels the originating plugin in logs.
-// TODO: this should be using a cookie and ensure not overriding any other
-// cookie values if present.
-// Tracked in https://github.com/llm-d/llm-d-router/issues/28
-func WriteSessionResponseHeader(ctx context.Context, pluginType, sessionHeader string, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	if response == nil || targetPod == nil {
-		reqID := "undefined"
-		if response != nil {
-			reqID = response.RequestID
-		}
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Session affinity - skip response header because response or targetPod is nil", "plugin", pluginType, "req id", reqID)
-		return
-	}
-
-	if response.Headers == nil { // TODO should always be populated?
-		response.Headers = make(map[string]string)
-	}
-
-	response.Headers[sessionHeader] = base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
 }
 
 // compile-time type assertion
@@ -102,7 +45,7 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 func NewSessionAffinity(sessionHeader string) *SessionAffinity {
 	return &SessionAffinity{
 		typedName:     plugin.TypedName{Type: SessionAffinityType},
-		sessionHeader: NormalizeHeader(sessionHeader),
+		sessionHeader: sessiontoken.NormalizeHeader(sessionHeader),
 	}
 }
 
@@ -135,7 +78,7 @@ func (s *SessionAffinity) Category() scheduling.ScorerCategory {
 // Score assign a high score to the pod used in previous requests and zero to others
 func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
 	scoredEndpoints := make(map[scheduling.Endpoint]float64)
-	podName := DecodePodName(ctx, request.Headers[s.sessionHeader])
+	podName := sessiontoken.DecodePodName(ctx, request.Headers[s.sessionHeader])
 
 	for _, endpoint := range endpoints {
 		scoredEndpoints[endpoint] = 0.0 // initial value
@@ -149,5 +92,5 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 
 // ResponseHeader sets the session header on the response sent to the client.
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	WriteSessionResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
+	sessiontoken.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -18,22 +20,89 @@ const (
 	// SessionAffinityType is the type of the SessionAffinity scorer.
 	SessionAffinityType = "session-affinity-scorer"
 
-	sessionTokenHeader = "x-session-token" // name of the session header in request
+	// DefaultSessionTokenHeader is the default request/response header carrying
+	// the session token. It is shared by the session-affinity scorer and filter.
+	DefaultSessionTokenHeader = "x-session-token"
 )
+
+// parameters configures the SessionAffinity scorer.
+type parameters struct {
+	// HeaderName overrides the default x-session-token header used to read and
+	// write the session token. When empty the default is used.
+	HeaderName string `json:"headerName"`
+}
+
+// NormalizeHeader lowercases and trims the configured session header name,
+// falling back to DefaultSessionTokenHeader when empty. It is shared by the
+// session-affinity scorer and filter.
+func NormalizeHeader(name string) string {
+	header := strings.ToLower(strings.TrimSpace(name))
+	if header == "" {
+		return DefaultSessionTokenHeader
+	}
+	return header
+}
+
+// DecodePodName decodes a base64-encoded session token into a pod
+// NamespacedName string. It returns "" when the token is empty or cannot be
+// decoded. It is shared by the session-affinity scorer and filter.
+func DecodePodName(ctx context.Context, token string) string {
+	if token == "" {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error decoding session header")
+		return ""
+	}
+	return string(decoded)
+}
+
+// WriteSessionResponseHeader encodes targetPod into sessionHeader on the
+// response sent to the client. It is shared by the session-affinity scorer and
+// filter; pluginType labels the originating plugin in logs.
+// TODO: this should be using a cookie and ensure not overriding any other
+// cookie values if present.
+// Tracked in https://github.com/llm-d/llm-d-router/issues/28
+func WriteSessionResponseHeader(ctx context.Context, pluginType, sessionHeader string, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
+	if response == nil || targetPod == nil {
+		reqID := "undefined"
+		if response != nil {
+			reqID = response.RequestID
+		}
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Session affinity - skip response header because response or targetPod is nil", "plugin", pluginType, "req id", reqID)
+		return
+	}
+
+	if response.Headers == nil { // TODO should always be populated?
+		response.Headers = make(map[string]string)
+	}
+
+	response.Headers[sessionHeader] = base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
+}
 
 // compile-time type assertion
 var _ scheduling.Scorer = &SessionAffinity{}
 var _ requestcontrol.ResponseHeaderProcessor = &SessionAffinity{}
 
 // Factory defines the factory function for SessionAffinity scorer.
-func Factory(name string, _ *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
-	return NewSessionAffinity().WithName(name), nil
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	params := parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", SessionAffinityType, err)
+		}
+	}
+
+	return NewSessionAffinity(params.HeaderName).WithName(name), nil
 }
 
-// NewSessionAffinity returns a scorer
-func NewSessionAffinity() *SessionAffinity {
+// NewSessionAffinity returns a scorer. When sessionHeader is empty the default
+// x-session-token header is used.
+func NewSessionAffinity(sessionHeader string) *SessionAffinity {
 	return &SessionAffinity{
-		typedName: plugin.TypedName{Type: SessionAffinityType},
+		typedName:     plugin.TypedName{Type: SessionAffinityType},
+		sessionHeader: NormalizeHeader(sessionHeader),
 	}
 }
 
@@ -43,6 +112,8 @@ func NewSessionAffinity() *SessionAffinity {
 // zero score to the rest of the targets
 type SessionAffinity struct {
 	typedName plugin.TypedName
+	// sessionHeader is the request/response header carrying the session token.
+	sessionHeader string
 }
 
 // TypedName returns the typed name of the plugin.
@@ -64,17 +135,8 @@ func (s *SessionAffinity) Category() scheduling.ScorerCategory {
 // Score assign a high score to the pod used in previous requests and zero to others
 func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
 	scoredEndpoints := make(map[scheduling.Endpoint]float64)
-	sessionToken := request.Headers[sessionTokenHeader]
-	podName := ""
+	podName := DecodePodName(ctx, request.Headers[s.sessionHeader])
 
-	if sessionToken != "" {
-		decodedBytes, err := base64.StdEncoding.DecodeString(sessionToken)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "Error decoding session header")
-		} else {
-			podName = string(decodedBytes)
-		}
-	}
 	for _, endpoint := range endpoints {
 		scoredEndpoints[endpoint] = 0.0 // initial value
 		if endpoint.GetMetadata().NamespacedName.String() == podName {
@@ -86,22 +148,6 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 }
 
 // ResponseHeader sets the session header on the response sent to the client.
-// TODO: this should be using a cookie and ensure not overriding any other
-// cookie values if present.
-// Tracked in https://github.com/llm-d/llm-d-router/issues/28
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	if response == nil || targetPod == nil {
-		reqID := "undefined"
-		if response != nil {
-			reqID = response.RequestID
-		}
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Session affinity scorer - skip response header because response or targetPod is nil", "req id", reqID)
-		return
-	}
-
-	if response.Headers == nil { // TODO should always be populated?
-		response.Headers = make(map[string]string)
-	}
-
-	response.Headers[sessionTokenHeader] = base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
+	WriteSessionResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sessionaffinity
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -32,8 +32,8 @@ func TestSessionAffinity_Score(t *testing.T) {
 	// valid session token for endpointB
 	validSessionTokenForEndpointB := base64.StdEncoding.EncodeToString([]byte(endpointB.GetMetadata().NamespacedName.String()))
 
-	sessionAffinityScorer := sessionaffinity.NewSessionAffinity("")
-	customHeaderScorer := sessionaffinity.NewSessionAffinity("x-custom-session")
+	sessionAffinityScorer := sessionaffinity.NewSessionAffinity("test-scorer", "")
+	customHeaderScorer := sessionaffinity.NewSessionAffinity("test-scorer", "x-custom-session")
 
 	tests := []struct {
 		name       string
@@ -177,7 +177,7 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := sessionaffinity.NewSessionAffinity(test.sessionHeader)
+			s := sessionaffinity.NewSessionAffinity("test-scorer", test.sessionHeader)
 			s.ResponseHeader(ctx, nil, test.initialResponse, test.targetPod)
 
 			if test.initialResponse == nil {

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sessionaffinity_test
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/sessionaffinity/token.go
+++ b/pkg/epp/framework/plugins/scheduling/sessionaffinity/token.go
@@ -1,0 +1,67 @@
+// Package sessiontoken provides the session token header helpers shared by the
+// session-affinity scorer and filter plugins.
+package sessiontoken
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+)
+
+// DefaultHeader is the default request/response header carrying the session
+// token.
+const DefaultHeader = "x-session-token"
+
+// NormalizeHeader lowercases and trims the configured session header name,
+// falling back to DefaultHeader when empty. Request headers are lowercased at
+// ingestion, so the configured name must be lowercased to match.
+func NormalizeHeader(name string) string {
+	header := strings.ToLower(strings.TrimSpace(name))
+	if header == "" {
+		return DefaultHeader
+	}
+	return header
+}
+
+// DecodePodName decodes a base64-encoded session token into a pod
+// NamespacedName string. It returns "" when the token is empty or cannot be
+// decoded.
+func DecodePodName(ctx context.Context, token string) string {
+	if token == "" {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error decoding session header")
+		return ""
+	}
+	return string(decoded)
+}
+
+// WriteResponseHeader encodes targetPod into sessionHeader on the response sent
+// to the client; pluginType labels the originating plugin in logs.
+// TODO: this should be using a cookie and ensure not overriding any other
+// cookie values if present.
+// Tracked in https://github.com/llm-d/llm-d-router/issues/28
+func WriteResponseHeader(ctx context.Context, pluginType, sessionHeader string, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
+	if response == nil || targetPod == nil {
+		reqID := "undefined"
+		if response != nil {
+			reqID = response.RequestID
+		}
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Session affinity - skip response header because response or targetPod is nil", "plugin", pluginType, "req id", reqID)
+		return
+	}
+
+	if response.Headers == nil { // TODO should always be populated?
+		response.Headers = make(map[string]string)
+	}
+
+	response.Headers[sessionHeader] = base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
+}

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
@@ -1,6 +1,22 @@
-// Package sessiontoken provides the session token header helpers shared by the
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sessionaffinity provides the session header helpers shared by the
 // session-affinity scorer and filter plugins.
-package sessiontoken
+package sessionaffinity
 
 import (
 	"context"

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1341,22 +1341,22 @@ func TestDirector_HandleResponseHeader_SessionAffinity(t *testing.T) {
 	}{
 		{
 			name:       "scorer with default header",
-			plugin:     sessionaffinityscorer.NewSessionAffinity(""),
+			plugin:     sessionaffinityscorer.NewSessionAffinity("test-scorer", ""),
 			wantHeader: "x-session-token",
 		},
 		{
 			name:       "scorer with custom header",
-			plugin:     sessionaffinityscorer.NewSessionAffinity("x-custom-session"),
+			plugin:     sessionaffinityscorer.NewSessionAffinity("test-scorer", "x-custom-session"),
 			wantHeader: "x-custom-session",
 		},
 		{
 			name:       "filter with default header",
-			plugin:     sessionaffinityfilter.NewSessionAffinity(""),
+			plugin:     sessionaffinityfilter.NewSessionAffinity("test-filter", ""),
 			wantHeader: "x-session-token",
 		},
 		{
 			name:       "filter with custom header",
-			plugin:     sessionaffinityfilter.NewSessionAffinity("x-custom-session"),
+			plugin:     sessionaffinityfilter.NewSessionAffinity("test-filter", "x-custom-session"),
 			wantHeader: "x-custom-session",
 		},
 	}

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1328,8 +1328,8 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 }
 
 // TestDirector_HandleResponseHeader_SessionAffinity validates that the
-// session-affinity scorer and filter, wired into the director as
-// response-received plugins, set the session token header on the response.
+// session-affinity scorer and filter, registered as response-received plugins,
+// set the session token header when the director runs the response-header hook.
 func TestDirector_HandleResponseHeader_SessionAffinity(t *testing.T) {
 	targetPod := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}}
 	wantToken := base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -18,6 +18,7 @@ package requestcontrol
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -54,6 +55,8 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	sessionaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
+	sessionaffinityscorer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	poolutil "github.com/llm-d/llm-d-router/pkg/epp/util/pool"
@@ -1321,6 +1324,69 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 	}
 	if diff := cmp.Diff("namespace1/test-pod-name", pr1.lastTargetPodOnResponse); diff != "" {
 		t.Errorf("Scheduler.OnResponse TargetPodName mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestDirector_HandleResponseHeader_SessionAffinity validates that the
+// session-affinity scorer and filter, wired into the director as
+// response-received plugins, set the session token header on the response.
+func TestDirector_HandleResponseHeader_SessionAffinity(t *testing.T) {
+	targetPod := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}}
+	wantToken := base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
+
+	tests := []struct {
+		name       string
+		plugin     fwkrc.ResponseHeaderProcessor
+		wantHeader string
+	}{
+		{
+			name:       "scorer with default header",
+			plugin:     sessionaffinityscorer.NewSessionAffinity(""),
+			wantHeader: "x-session-token",
+		},
+		{
+			name:       "scorer with custom header",
+			plugin:     sessionaffinityscorer.NewSessionAffinity("x-custom-session"),
+			wantHeader: "x-custom-session",
+		},
+		{
+			name:       "filter with default header",
+			plugin:     sessionaffinityfilter.NewSessionAffinity(""),
+			wantHeader: "x-session-token",
+		},
+		{
+			name:       "filter with custom header",
+			plugin:     sessionaffinityfilter.NewSessionAffinity("x-custom-session"),
+			wantHeader: "x-custom-session",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := logutil.NewTestLoggerIntoContext(context.Background())
+			ds := datastore.NewDatastore(t.Context(), nil, 0)
+			endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(ds), time.Minute)
+			director := NewDirectorWithConfig(
+				ds,
+				&mockScheduler{},
+				&mockAdmissionController{},
+				endpointCandidates,
+				NewConfig().WithResponseReceivedPlugins(test.plugin),
+			)
+
+			reqCtx := &handlers.RequestContext{
+				Request: &handlers.Request{
+					Headers: map[string]string{reqcommon.RequestIDHeaderKey: "test-req-id"},
+				},
+				Response:  &handlers.Response{Headers: map[string]string{}},
+				TargetPod: targetPod,
+			}
+
+			director.HandleResponseHeader(ctx, reqCtx)
+
+			assert.Equal(t, wantToken, reqCtx.Response.Headers[test.wantHeader],
+				"session token should be set on the %q response header", test.wantHeader)
+		})
 	}
 }
 

--- a/test/integration/epp/session_affinity_test.go
+++ b/test/integration/epp/session_affinity_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/session_affinity_test.go
+++ b/test/integration/epp/session_affinity_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package epp
+
+import (
+	"testing"
+
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
+	integration "github.com/llm-d/llm-d-router/test/integration"
+)
+
+const sessionTokenHeader = "x-session-token"
+
+// TestSessionAffinityFilter_RequestFlow validates the end-to-end session
+// affinity flow against an EPP initialized from text config: the first request
+// (no session header) is routed and gets a session token on the response, and
+// the second request (carrying that token) is pinned to the same endpoint.
+func TestSessionAffinityFilter_RequestFlow(t *testing.T) {
+	configText := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: openai-parser
+  - type: queue-scorer
+  - type: session-affinity-filter
+  - type: mock-metrics-source
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: queue-scorer
+      - pluginRef: session-affinity-filter
+requestHandler:
+  parsers:
+  - pluginRef: openai-parser
+dataLayer:
+  sources:
+  - pluginRef: mock-metrics-source
+`
+
+	ctx := t.Context()
+	h := NewTestHarness(ctx, t, WithStandardMode(), WithConfigText(configText)).WithBaseResources()
+
+	// Two ready pods so the filter has a real choice to pin to.
+	pods := []PodState{
+		P(0, 0, 0.1, modelMyModelTarget),
+		P(1, 0, 0.1, modelMyModelTarget),
+	}
+	h.WithPods(pods).WaitForSync(len(pods), modelMyModel)
+	h.WaitForReadyPodsMetric(len(pods))
+
+	// First request: no session header. Read the routed endpoint and the
+	// session token the plugin writes on the response.
+	firstEndpoint, token := sendSessionRequest(t, h, "")
+	require.NotEmpty(t, token, "first response must carry a session token")
+
+	// Second request: echo the token back. It must pin to the same endpoint.
+	secondEndpoint, _ := sendSessionRequest(t, h, token)
+	require.Equal(t, firstEndpoint, secondEndpoint,
+		"second request carrying the session token must be pinned to the first request's endpoint")
+}
+
+// sendSessionRequest drives one full request/response transaction through the
+// EPP and returns the routed destination endpoint and the session token set on
+// the response headers. When sessionToken is non-empty it is sent as the
+// session header on the request.
+func sendSessionRequest(t *testing.T, h *TestHarness, sessionToken string) (endpoint, token string) {
+	t.Helper()
+
+	reqHeaders := map[string]string{
+		metadata.ObjectiveKey:        modelMyModel,
+		metadata.ModelNameRewriteKey: modelMyModelTarget,
+		reqcommon.RequestIDHeaderKey: "session-req",
+	}
+	if sessionToken != "" {
+		reqHeaders[sessionTokenHeader] = sessionToken
+	}
+
+	requests := integration.ReqRaw(reqHeaders, `{"model":"`+modelMyModel+`","prompt":"hello","max_tokens":10,"temperature":0}`)
+	requests = append(requests, ReqResponseOnly(
+		map[string]string{"content-type": "application/json", "status": "200"},
+		`{"choices":[{"finish_reason":"stop","index":0,"message":{"content":"hi","role":"assistant"}}],"model":"`+modelMyModelTarget+`","object":"chat.completion","usage":{"completion_tokens":2,"prompt_tokens":3,"total_tokens":5}}`,
+	)...)
+
+	// Each request is a distinct HTTP transaction, so open a fresh ext_proc stream.
+	client, err := extProcPb.NewExternalProcessorClient(h.grpcConn).Process(t.Context())
+	require.NoError(t, err)
+
+	// RequestHeaders + RequestBody + ResponseHeaders + ResponseBody -> 4 responses.
+	responses, err := integration.StreamedRequest(t, client, requests, 4)
+	require.NoError(t, err)
+	require.Len(t, responses, 4)
+
+	endpoint = headerValue(responses[0].GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), metadata.DestinationEndpointKey)
+	require.NotEmpty(t, endpoint, "request headers response must set the destination endpoint")
+
+	token = headerValue(responses[2].GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), sessionTokenHeader)
+	return endpoint, token
+}
+
+// headerValue returns the value set for key among the given header mutations, or
+// "" when absent.
+func headerValue(setHeaders []*configPb.HeaderValueOption, key string) string {
+	for _, h := range setHeaders {
+		if h.GetHeader().GetKey() == key {
+			if raw := h.GetHeader().GetRawValue(); len(raw) > 0 {
+				return string(raw)
+			}
+			return h.GetHeader().GetValue()
+		}
+	}
+	return ""
+}

--- a/test/integration/epp/session_affinity_test.go
+++ b/test/integration/epp/session_affinity_test.go
@@ -24,11 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	sessionutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	integration "github.com/llm-d/llm-d-router/test/integration"
 )
-
-const sessionTokenHeader = "x-session-token"
 
 // TestSessionAffinityFilter_RequestFlow validates the end-to-end session
 // affinity flow against an EPP initialized from text config: the first request
@@ -91,7 +90,7 @@ func sendSessionRequest(t *testing.T, h *TestHarness, sessionToken string) (endp
 		reqcommon.RequestIDHeaderKey: "session-req",
 	}
 	if sessionToken != "" {
-		reqHeaders[sessionTokenHeader] = sessionToken
+		reqHeaders[sessionutil.DefaultHeader] = sessionToken
 	}
 
 	requests := integration.ReqRaw(reqHeaders, `{"model":"`+modelMyModel+`","prompt":"hello","max_tokens":10,"temperature":0}`)
@@ -112,7 +111,7 @@ func sendSessionRequest(t *testing.T, h *TestHarness, sessionToken string) (endp
 	endpoint = headerValue(responses[0].GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), metadata.DestinationEndpointKey)
 	require.NotEmpty(t, endpoint, "request headers response must set the destination endpoint")
 
-	token = headerValue(responses[2].GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), sessionTokenHeader)
+	token = headerValue(responses[2].GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), sessionutil.DefaultHeader)
 	return endpoint, token
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds a `session-affinity-filter` scheduling plugin and makes the session
token header configurable on both the existing `session-affinity-scorer`
and the new filter.

The session-affinity scorer expresses affinity as a soft preference that
other scorers can outweigh. Some deployments need a hard pin: route a
session to its previously selected pod, or fall back to all candidates if
that pod is gone. The new filter provides that. Both plugins also gain an
optional `headerName` parameter so the session token can ride a
deployment-specific header instead of the fixed `x-session-token`.

**Note:** This PR is an extension of the current implementation and will be 
combined with #1396 for other session affinity implementations 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #815

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
- Add a new `session-affinity-filter` scheduling plugin: pins a session to its
  previously selected pod as a hard constraint, falling back to all
  candidates when that pod is no longer available. Complements the existing
  `session-affinity-scorer` (soft preference).
- `session-affinity-scorer` and `session-affinity-filter` now accept an
  optional `headerName` parameter to carry the session token on a custom
  request/response header instead of the default `x-session-token`.
```
