### PR TITLE
test(flowcontrol): harden and reorganize the flow-control benchmark suite

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -113,6 +113,16 @@ jobs:
           GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
         run: make test-unit
 
+      # Anti-rot: execute the benchmark bodies once so runtime breakage (panics,
+      # deadlocks) is caught. `go test` only compiles benchmarks; it never runs
+      # them without -bench.
+      - name: Run benchmark smoke
+        shell: bash
+        env:
+          GO_MOD_CACHE_VOL: ${{ steps.go-cache.outputs.mod }}
+          GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
+        run: make bench-smoke
+
       - name: Run hermetic integration tests
         shell: bash
         env:

--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,11 @@ bench-tokenizer: image-build-builder ## Run external tokenizer + scorer benchmar
 	@printf "Run 'EXTERNAL_TOKENIZER_ENABLED=true KV_CACHE_ENABLED=true make env-dev-kind' first.\n\n"
 	$(BUILDER_RUN_CLUSTER) 'go test -bench=. -benchmem -count=5 -timeout=5m ./test/profiling/tokenizerbench/'
 
+.PHONY: bench-smoke
+bench-smoke: image-build-builder ## Smoke-run the flowcontrol benchmarks once (-benchtime=1x) to catch runtime rot
+	@printf "\033[33;1m==== Running Flow Control Benchmark Smoke ====\033[0m\n"
+	$(BUILDER_RUN) 'go test -run=^$$ -bench=. -benchtime=1x -timeout=5m ./pkg/epp/flowcontrol/benchmark/...'
+
 .PHONY: post-deploy-test
 post-deploy-test: ## Run post deployment tests
 	@echo "Success!"

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -304,9 +304,10 @@ func BenchmarkFlowController_FullPath(b *testing.B) {
 
 	telemetry := newBenchmarkTelemetry()
 
-	// Concurrency-gated: each dispatched request consumes a detector slot and
-	// releases it after ResponseBody, so W workers > L limit sustains backpressure
-	// and forces real queuing in the dispatch cycle.
+	// Concurrency-gated by the real detector: each dispatched request records in-flight load (via
+	// PreRequest) and releases it after ResponseBody. Load is held only briefly, so this measures
+	// free-flowing dispatch plus the detector's per-cycle DynamicAttribute read cost rather than
+	// sustained W>L queuing.
 	var globalReqID atomic.Uint64
 
 	b.ResetTimer()

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -27,29 +27,17 @@ import (
 	"testing"
 	"time"
 
-	k8stypes "k8s.io/apimachinery/pkg/types"
-
-	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/controller"
-	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/types"
-	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
-	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	requesthandling "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload"
-	igwtestutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
 // BenchmarkFlowController_PerformanceMatrix evaluates throughput across a matrix of variables.
-// It systematically evaluates the impact of strict egress limits, data parallelism, priority
-// levels, flow density, and concurrent connections.
+// It systematically evaluates the impact of strict egress limits, priority levels, flow density,
+// and concurrent connections.
 func BenchmarkFlowController_PerformanceMatrix(b *testing.B) {
 	if testing.Short() {
 		b.Skip("skipping PerformanceMatrix in short mode")
@@ -87,8 +75,12 @@ func runMatrixCoordinate(b *testing.B, m benchMatrix) {
 
 	fc, detector := setupBenchmarkHarness(ctx, b, m.priorities, m.limit, nil, nil)
 
-	// Yield briefly to allow the background supervisor to bootstrap the data plane.
-	time.Sleep(10 * time.Millisecond)
+	// Warm up: block on one request until it's dispatched, proving the dispatch loop is live before
+	// timing. Release the slot per the loop's immediate-drain protocol.
+	warmup := &benchRequest{key: flowcontrol.FlowKey{ID: "warmup", Priority: 0}, byteSize: 1024}
+	if outcome, _ := fc.EnqueueAndWait(ctx, warmup); outcome == types.QueueOutcomeDispatched && m.limit > 0 {
+		detector.Release()
+	}
 
 	reqs := make([]*benchRequest, m.flows)
 	for i := 0; i < int(m.flows); i++ {
@@ -282,123 +274,27 @@ func BenchmarkFlowController_MassCancellation(b *testing.B) {
 	}
 }
 
-// fullPathBenchHarness holds shared setup state for full-path benchmarks that
-// wire a real InFlightLoadProducer, real concurrency detector, and real
-// persistent endpoints into the FlowController.
-type fullPathBenchHarness struct {
-	fc       *controller.FlowController
-	producer *inflightload.InFlightLoadProducer
-	epMeta   *fwkdl.EndpointMetadata
-	schedEp  scheduling.Endpoint
-}
-
-// setupFullPathBenchmark creates the shared harness for benchmarks that exercise
-// the complete flow control data path: producer -> detector -> controller -> cleanup.
-func setupFullPathBenchmark(ctx context.Context, b *testing.B, name string, numPriorities int) *fullPathBenchHarness {
-	b.Helper()
-	if numPriorities < 1 {
-		numPriorities = 1
-	}
-	handle := igwtestutils.NewTestHandle(ctx)
-
-	producerName := name + "-producer"
-	producerPlugin, err := inflightload.InFlightLoadProducerFactory(
-		producerName, fwkplugin.StrictDecoder([]byte(`{}`)), handle,
-	)
-	if err != nil {
-		b.Fatal(err)
-	}
-	producer := producerPlugin.(*inflightload.InFlightLoadProducer)
-
-	detectorPlugin, err := concurrency.ConcurrencyDetectorFactory(
-		name+"-detector",
-		fwkplugin.StrictDecoder([]byte(fmt.Sprintf(
-			`{"maxConcurrency": 100, "inFlightLoadProducerName": %q}`, producerName,
-		))),
-		handle,
-	)
-	if err != nil {
-		b.Fatal(err)
-	}
-	realDetector := detectorPlugin.(flowcontrol.SaturationDetector)
-
-	epMeta := &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "default"},
-	}
-	ep := fwkdl.NewEndpoint(epMeta, fwkdl.NewMetrics())
-	if err := producer.Extract(ctx, fwkdl.EndpointEvent{
-		Type: fwkdl.EventAddOrUpdate, Endpoint: ep,
-	}); err != nil {
-		b.Fatal(err)
-	}
-
-	fPolicy, err := globalstrict.GlobalStrictFairnessPolicyFactory(registry.DefaultFairnessPolicyRef, nil, handle)
-	if err != nil {
-		b.Fatal(err)
-	}
-	handle.AddPlugin(registry.DefaultFairnessPolicyRef, fPolicy)
-
-	oPolicy, err := fcfs.FCFSOrderingPolicyFactory(registry.DefaultOrderingPolicyRef, nil, handle)
-	if err != nil {
-		b.Fatal(err)
-	}
-	handle.AddPlugin(registry.DefaultOrderingPolicyRef, oPolicy)
-
-	defaults := registry.PriorityBandPolicyDefaults{
-		OrderingPolicy: oPolicy.(flowcontrol.OrderingPolicy),
-		FairnessPolicy: fPolicy.(flowcontrol.FairnessPolicy),
-	}
-	reg := setupRegistry(b, defaults, priorityLevels(numPriorities))
-
-	fc := controller.NewFlowController(ctx, name+"-bench", &controller.Config{
-		DefaultRequestTTL:        5 * time.Minute,
-		ExpiryCleanupInterval:    1 * time.Hour,
-		EnqueueChannelBufferSize: 2000,
-	}, controller.Deps{
-		Registry:           reg,
-		SaturationDetector: realDetector,
-		EndpointCandidates: &mocks.MockEndpointCandidates{Candidates: []fwkdl.Endpoint{ep}},
-		UsageLimitPolicy:   usagelimits.DefaultPolicy(),
-	})
-
-	time.Sleep(10 * time.Millisecond)
-
-	schedEp := scheduling.NewEndpoint(epMeta, fwkdl.NewMetrics(), nil)
-
-	return &fullPathBenchHarness{
-		fc:       fc,
-		producer: producer,
-		epMeta:   epMeta,
-		schedEp:  schedEp,
-	}
-}
-
-// BenchmarkFlowController_FullPathStress exercises the complete flow control
-// data path under realistic production conditions: real InFlightLoadProducer,
-// real concurrency detector reading DynamicAttributes from persistent endpoints,
-// real FlowController with backpressure from a concurrency-gated detector,
-// multiple priority bands, concurrent workers creating unique flows (agentic
-// churn), and the full PreRequest -> dispatch -> StartOfStream -> EndOfStream
-// lifecycle per request.
+// BenchmarkFlowController_FullPath measures dispatch throughput and allocation overhead of the
+// complete flow-control data path using REAL components: a real InFlightLoadProducer feeding a real
+// concurrency SaturationDetector, which gates a real FlowController. Unlike the throughput
+// microbenchmarks (which use the mock benchDetector), this captures the cost of the detector's
+// per-dispatch DynamicAttribute reads against live producer state in the hot path.
 //
-// What it catches:
-//   - PluginState entry leaks (addedTokensEntry not cleaned up by OnEvicted)
-//   - DynamicAttribute closure leaks (producer tracker never decremented)
-//   - Cross-band counter drift (stats routed to wrong priority band)
-//   - Registry flow infrastructure leaks under concurrent churn
-//   - Contention-induced allocation growth (lock convoy, sync.Map thrashing)
+// Each iteration runs the full request lifecycle: EnqueueAndWait (admission) -> PreRequest
+// (producer records in-flight load) -> ResponseBody StartOfStream / EndOfStream (producer releases
+// it). Workers spread across priority bands and mint a unique flow per request for registry churn.
 //
 // Run with:
 //
-//	go test -bench=FullPathStress -benchtime=5000x -count=3 -run=^$ ./pkg/epp/flowcontrol/benchmark/
+//	go test -bench=FullPath -run=^$ ./pkg/epp/flowcontrol/benchmark/
 //
-// Stable B/op across runs = no leak. Counter assertion at the end catches
-// tracker drift that B/op alone would miss.
-func BenchmarkFlowController_FullPathStress(b *testing.B) {
+// Reports d/s (dispatch throughput). Producer-level leak correctness is covered by the inflightload
+// producer's own unit tests, not here.
+func BenchmarkFlowController_FullPath(b *testing.B) {
 	const numPriorities = 4
 
 	ctx := b.Context()
-	h := setupFullPathBenchmark(ctx, b, "stress", numPriorities)
+	h := setupFullPathBenchmark(ctx, b, "fullpath", numPriorities)
 
 	sosResp := &requestcontrol.Response{StartOfStream: true}
 	eosResp := &requestcontrol.Response{EndOfStream: true}
@@ -406,9 +302,11 @@ func BenchmarkFlowController_FullPathStress(b *testing.B) {
 		"decode": {TargetEndpoints: []scheduling.Endpoint{h.schedEp}},
 	}
 
-	// Concurrency-gated: each dispatched request consumes a slot. Workers
-	// release immediately after ResponseBody, creating sustained backpressure
-	// (W workers > L limit). This forces real queuing in the dispatch cycle.
+	telemetry := newBenchmarkTelemetry()
+
+	// Concurrency-gated: each dispatched request consumes a detector slot and
+	// releases it after ResponseBody, so W workers > L limit sustains backpressure
+	// and forces real queuing in the dispatch cycle.
 	var globalReqID atomic.Uint64
 
 	b.ResetTimer()
@@ -416,6 +314,7 @@ func BenchmarkFlowController_FullPathStress(b *testing.B) {
 	b.SetParallelism(max(100/runtime.GOMAXPROCS(0), 1))
 
 	b.RunParallel(func(pb *testing.PB) {
+		var local threadTelemetry
 		for pb.Next() {
 			id := globalReqID.Add(1)
 			reqID := fmt.Sprintf("req-%d", id)
@@ -427,12 +326,14 @@ func BenchmarkFlowController_FullPathStress(b *testing.B) {
 				byteSize: 512,
 			}
 			outcome, _ := h.fc.EnqueueAndWait(ctx, fcReq)
-
 			if outcome != types.QueueOutcomeDispatched {
-				b.Fatalf("request %s was not dispatched: %v", reqID, outcome)
+				telemetry.recordReject(&local)
+				continue
 			}
+			telemetry.recordDispatch(&local)
 
-			// 2. Post-scheduling: producer tracks the request on the endpoint.
+			// 2. Post-scheduling: producer records in-flight load on the endpoint, which the
+			//    detector reads to compute saturation.
 			infReq := &scheduling.InferenceRequest{
 				RequestID: reqID,
 				Body:      &requesthandling.InferenceRequestBody{TokenizedPrompt: &requesthandling.TokenizedPrompt{PerPromptTokens: [][]uint32{benchTokenIDs}}},
@@ -440,21 +341,22 @@ func BenchmarkFlowController_FullPathStress(b *testing.B) {
 			schedResult := &scheduling.SchedulingResult{ProfileResults: profileResults}
 			h.producer.PreRequest(ctx, infReq, schedResult)
 
-			// 3. Response lifecycle: release counters.
+			// 3. Response lifecycle: release the in-flight load.
 			infReq.SchedulingResult = schedResult
 			h.producer.ResponseBody(ctx, infReq, sosResp, h.epMeta)
 			h.producer.ResponseBody(ctx, infReq, eosResp, h.epMeta)
 		}
+		telemetry.commit(&local)
 	})
 
 	b.StopTimer()
-	b.ReportMetric(float64(globalReqID.Load()), "total-requests")
+	telemetry.report(b, b.Elapsed().Seconds())
 
-	finalRequests := h.producer.GetRequests(h.epMeta.NamespacedName.String())
-	finalTokens := h.producer.GetTokens(h.epMeta.NamespacedName.String())
-	if finalRequests != 0 || finalTokens != 0 {
-		b.Errorf("counter leak detected after %d requests across %d priorities: requests=%d, tokens=%d",
-			globalReqID.Load(), numPriorities, finalRequests, finalTokens)
+	// A fully saturated full-path run must dispatch every request; a rejection
+	// means the throughput numbers are skewed. Assert on the benchmark goroutine
+	// (never inside RunParallel, where FailNow is invalid).
+	if rejects := telemetry.rejectCount.Load(); rejects > 0 {
+		b.Fatalf("full-path benchmark saw %d rejected requests; throughput numbers are unreliable", rejects)
 	}
 }
 

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -72,15 +72,17 @@ func BenchmarkFlowController_PerformanceMatrix(b *testing.B) {
 // runMatrixCoordinate executes a single coordinate of the performance hypercube.
 func runMatrixCoordinate(b *testing.B, m benchMatrix) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure SUT goroutines are torn down even when the coordinate fails fatally.
 
 	fc, detector := setupBenchmarkHarness(ctx, b, m.priorities, m.limit, nil, nil)
 
 	// Warm up: block on one request until it's dispatched, proving the dispatch loop is live before
-	// timing. Release the slot per the loop's immediate-drain protocol.
+	// timing. Release the slot per the loop's immediate-drain protocol (a no-op under free-flow).
 	warmup := &benchRequest{key: flowcontrol.FlowKey{ID: "warmup", Priority: 0}, byteSize: 1024}
-	if outcome, _ := fc.EnqueueAndWait(ctx, warmup); outcome == types.QueueOutcomeDispatched && m.limit > 0 {
-		detector.Release()
+	if outcome, err := fc.EnqueueAndWait(ctx, warmup); outcome != types.QueueOutcomeDispatched {
+		b.Fatalf("warmup request was not dispatched: outcome=%v, err=%v", outcome, err)
 	}
+	detector.Release()
 
 	reqs := make([]*benchRequest, m.flows)
 	for i := 0; i < int(m.flows); i++ {
@@ -165,6 +167,13 @@ func runMatrixCoordinate(b *testing.B, m benchMatrix) {
 	b.StopTimer()
 	elapsed := b.Elapsed().Seconds()
 	telemetry.report(b, elapsed)
+
+	// Every coordinate expects flow (W>L or free-flow), so zero dispatches means the dispatch path
+	// wedged mid-run: fail loudly instead of publishing plausible-looking zero rows. Assert on the
+	// benchmark goroutine (never inside RunParallel, where FailNow is invalid).
+	if telemetry.dispatchCount.Load() == 0 {
+		b.Fatalf("coordinate %s dispatched zero requests; the dispatch path is wedged", m.name())
+	}
 
 	cancel()                          // Graceful teardown to prevent async skewing of subsequent coordinates.
 	time.Sleep(50 * time.Millisecond) // Wait for SUT background goroutines to terminate.

--- a/pkg/epp/flowcontrol/benchmark/detector_test.go
+++ b/pkg/epp/flowcontrol/benchmark/detector_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/benchmark/detector_test.go
+++ b/pkg/epp/flowcontrol/benchmark/detector_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"context"
+	"testing"
+)
+
+// TestBenchDetector_NoLeakOnNonDispatchingCycles verifies the detector self-heals empty-queue idle
+// grants: the processor's dispatchCycle evaluates Saturation on a 1ms ticker even when the queue is
+// empty, so those grants never dispatch and are never Released. The detector may report saturated
+// briefly but must never latch -- grants keep recurring and no saturated run exceeds the stuck
+// threshold.
+func TestBenchDetector_NoLeakOnNonDispatchingCycles(t *testing.T) {
+	d := &benchDetector{}
+	d.concurrencyLimit.Store(1)
+
+	grants, run, maxRun := 0, 0, 0
+	for i := 0; i < 100; i++ {
+		if d.Saturation(context.Background(), nil) < 1.0 {
+			grants++
+			run = 0
+		} else {
+			run++
+			if run > maxRun {
+				maxRun = run
+			}
+		}
+	}
+	if grants == 0 {
+		t.Fatal("detector latched saturated across all idle cycles (permanent leak)")
+	}
+	if maxRun > stuckReadThreshold {
+		t.Fatalf("idle saturated run = %d, want <= %d (self-heal should reclaim)", maxRun, stuckReadThreshold)
+	}
+}
+
+// TestBenchDetector_SaturatesAtLimit asserts the W>L backpressure the PerformanceMatrix sweep exists
+// to measure: with the limit reached by in-flight (un-Released) grants, the next Saturation must
+// report saturated.
+func TestBenchDetector_SaturatesAtLimit(t *testing.T) {
+	d := &benchDetector{}
+	d.concurrencyLimit.Store(2)
+
+	// Two grants whose requests are still in flight (not yet Released) occupy both slots.
+	for i := 0; i < 2; i++ {
+		if got := d.Saturation(context.Background(), nil); got >= 1.0 {
+			t.Fatalf("grant %d within limit must not be saturated: got %v", i, got)
+		}
+	}
+	if got := d.Saturation(context.Background(), nil); got < 1.0 {
+		t.Fatalf("over-limit Saturation must report saturated: got %v, want >= 1.0", got)
+	}
+}
+
+// TestBenchDetector_GrantReleaseBalanced verifies the common path: a cycle grants
+// a permit, the dispatched request releases it, and in-flight returns to zero.
+func TestBenchDetector_GrantReleaseBalanced(t *testing.T) {
+	d := &benchDetector{}
+	d.concurrencyLimit.Store(1)
+
+	if got := d.Saturation(context.Background(), nil); got >= 1.0 {
+		t.Fatalf("first grant must not be saturated: got %v", got)
+	}
+	d.Release()
+	if got := d.inFlight.Load(); got != 0 {
+		t.Fatalf("inFlight = %d after release, want 0", got)
+	}
+	// The freed permit must be grantable again.
+	if got := d.Saturation(context.Background(), nil); got >= 1.0 {
+		t.Fatalf("grant after release must not be saturated: got %v", got)
+	}
+}
+
+// TestBenchDetector_ReleaseRecoversCapacity verifies the steady-state load path: grants fill the
+// limit and report saturated, Releases free the slots back to zero, and freed capacity is grantable
+// again -- the conserve-count property under sustained dispatch.
+func TestBenchDetector_ReleaseRecoversCapacity(t *testing.T) {
+	d := &benchDetector{}
+	d.concurrencyLimit.Store(2)
+
+	d.Saturation(context.Background(), nil) // grant 1 (in flight)
+	d.Saturation(context.Background(), nil) // grant 2 (in flight) -> at limit
+	if got := d.Saturation(context.Background(), nil); got < 1.0 {
+		t.Fatalf("at-limit Saturation must be saturated: got %v, want >= 1.0", got)
+	}
+
+	d.Release() // both in-flight requests complete
+	d.Release()
+	if got := d.inFlight.Load(); got != 0 {
+		t.Fatalf("inFlight = %d after releasing all grants, want 0", got)
+	}
+
+	if got := d.Saturation(context.Background(), nil); got >= 1.0 {
+		t.Fatalf("grant after releases must not be saturated: got %v", got)
+	}
+}
+
+// TestBenchDetector_FreeFlow confirms that a non-positive limit is pure free-flow
+// with no bookkeeping side effects.
+func TestBenchDetector_FreeFlow(t *testing.T) {
+	d := &benchDetector{} // limit defaults to 0
+	if got := d.Saturation(context.Background(), nil); got != 0.0 {
+		t.Fatalf("free-flow Saturation = %v, want 0.0", got)
+	}
+	d.Release() // must be a no-op
+	if got := d.inFlight.Load(); got != 0 {
+		t.Fatalf("inFlight = %d under free-flow, want 0", got)
+	}
+}

--- a/pkg/epp/flowcontrol/benchmark/doc.go
+++ b/pkg/epp/flowcontrol/benchmark/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/benchmark/doc.go
+++ b/pkg/epp/flowcontrol/benchmark/doc.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package benchmark load-tests the Flow Control layer. It contains two families of benchmarks that
+// trade off isolation against realism.
+//
+// # Throughput microbenchmarks (mock detector)
+//
+// PerformanceMatrix, TopologyChurn, and MassCancellation isolate the FlowController's CPU cost
+// using a mock SaturationDetector and a synchronous, sleep-free pipeline. Simulating downstream
+// inference latency with sleeps would park goroutines and measure Go scheduler overhead rather
+// than computational throughput, so the harness avoids it:
+//
+//  1. Intentional Backpressure (W > L): Ingress Concurrency (W) is driven higher than the Capacity
+//     Limit (L), forcing requests to queue.
+//  2. Strict Capacity Checking: the mock SaturationDetector atomically grants capacity only when
+//     evaluated, preventing races where dispatch outruns clients.
+//  3. Immediate Draining: when a client unblocks it immediately frees its capacity slot, triggering
+//     the next dispatch and keeping the system active.
+//  4. Consistent Queue Depth: a fixed, deep queue forces continuous evaluation of fairness and
+//     ordering policies at limits, isolating CPU performance.
+//
+// # Full-path benchmark (real components)
+//
+// FullPath measures the complete data path with the REAL InFlightLoadProducer and concurrency
+// SaturationDetector wired into the FlowController, capturing the cost of the detector's
+// per-dispatch DynamicAttribute reads against live producer state. It complements the
+// microbenchmarks: they isolate flow-control CPU; it prices realistic saturation detection.
+// Producer-level leak correctness is covered by the inflightload producer's own unit tests, not
+// here.
+//
+// # Interpreting Metrics in b.RunParallel
+//
+// In a highly concurrent queuing system, standard Go benchmark metrics require care to interpret:
+//
+//  1. ns/op (system-wide amortized time): because these use b.RunParallel, ns/op represents inverse
+//     throughput, not latency. The d/s custom metric converts it to dispatches per second.
+//  2. ops: one "op" is the complete lifecycle of a single simulated request: ingress, queuing,
+//     policy evaluation, and egress.
+//  3. allocs/op and B/op (GC pressure): high allocations per request mean the garbage collector
+//     thrashes under load, causing latency jitter.
+//  4. Saturated Coordinates (W > L): when Concurrency exceeds Capacity, EnqueueAndWait blocks;
+//     because capacity is released immediately upon dispatch, an "op" is governed by the Flow
+//     Control layer's CPU overhead.
+//
+// # Custom Metrics Reported
+//
+//   - d/s:       (Dispatches/sec) the primary throughput metric (PerformanceMatrix, TopologyChurn,
+//     FullPath).
+//   - r/s:       (Rejects/sec) rate of requests rejected due to capacity or timeouts.
+//   - errors:    total unexpected runtime errors encountered.
+//   - zombies/s: rate of requests hitting context deadlines/TTLs (MassCancellation).
+package benchmark

--- a/pkg/epp/flowcontrol/benchmark/helpers_test.go
+++ b/pkg/epp/flowcontrol/benchmark/helpers_test.go
@@ -14,47 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package benchmark implements a synchronous steady-state pipeline for load-testing the Flow
-// Control layer.
-//
-// Benchmarking Flow Control is challenging. Data plane routing is fast, while downstream inference
-// is slow. Simulating downstream latency with thread sleeps skews CPU profiles by parking
-// goroutines, which measures Go scheduler overhead rather than computational throughput.
-//
-// This harness avoids sleeps by using a synchronous pipeline:
-//
-//  1. Intentional Backpressure (W > L): Ingress Concurrency (W) is driven higher than the Capacity
-//     Limit (L), forcing requests to queue.
-//  2. Strict Capacity Checking: A mock SaturationDetector atomically grants capacity only when
-//     evaluated, preventing race conditions where dispatch outruns clients.
-//  3. Immediate Draining: When a client unblocks, it immediately frees its capacity slot,
-//     triggering the next dispatch and keeping the system continuously active.
-//  4. Consistent Queue Depth: Maintaining a fixed, deep queue forces continuous evaluation of
-//     fairness and ordering policies at limits, isolating CPU performance.
-//
-// # Interpreting Metrics in b.RunParallel
-//
-// In a highly concurrent queuing system, standard Go benchmark metrics require careful
-// interpretation:
-//
-//  1. ns/op (system-wide amortized time): Because this uses b.RunParallel, ns/op represents inverse
-//     throughput, not latency. If the system processes 1,000,000 requests in 1 second, it reports
-//     1,000,000 ns/op. (The d/s custom metric converts this to RPS automatically).
-//  2. ops (the definition of an operation): One "op" is the complete lifecycle of a single
-//     simulated request: Ingress, queuing, policy evaluation, and egress.
-//  3. allocs/op and B/op (GC Pressure): High allocations per request mean the Go Garbage Collector
-//     will thrash under load, causing latency jitter.
-//  4. Saturated Coordinates (W > L): When Concurrency (W) exceeds Capacity (L), EnqueueAndWait
-//     blocks. Because we immediately release capacity upon dispatch, the duration of an "op" is
-//     strictly governed by the Flow Control layer's CPU overhead.
-//
-// # Custom Metrics Reported
-//
-//   - d/s:                  (Dispatches/sec) The primary throughput metric.
-//   - r/s:                  (Rejects/sec) Rate of requests rejected due to capacity or timeouts.
-//   - errors:               Total unexpected runtime errors encountered.
-//   - zombies/s:            Rate of requests hitting context deadlines/TTLs.
-//   - burst_dispatches/sec: Drain rate when capacity is instantaneously freed.
 package benchmark
 
 import (
@@ -68,16 +27,22 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/controller"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/registry"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/types"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload"
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -120,37 +85,84 @@ type testDetector interface {
 	Release()
 }
 
-// benchDetector models target saturation based strictly on active request counts.
+// benchDetector is a mock SaturationDetector that models a strict concurrency limit (L) without
+// parking goroutines. The processor's dispatch loop calls Saturation once per cycle and then
+// dispatches at most one item; the benchmark worker calls Release after that item is dispatched.
+//
+// Saturation optimistically reserves a permit (inFlight++); Release frees it. Under the matrix's
+// W>L load the queue is always full, so every grant leads to a dispatch and a Release: inFlight
+// accumulates to L and Saturation reports 1.0 once exceeded, which is the backpressure the matrix
+// measures.
+//
+// The complication: the processor also runs dispatchCycle on a 1ms ticker when the queue is EMPTY
+// (notably at startup). Those idle grants never dispatch and so are never Released; a naive detector
+// would latch saturated forever and deadlock every request until its TTL. We distinguish leaked
+// idle grants from genuine load saturation with releaseCount: while releases are
+// flowing the saturation is real; if two consecutive saturated reads see zero releases between them
+// the outstanding grants are leaked idle permits, so we reclaim one. The 1.0/0.99 split sits below
+// usagelimits.DefaultPolicy's 1.0 ceiling, so a grant never trips head-of-line gating.
+//
+// stuckReads and lastReleaseCount are touched only by the single-threaded dispatch loop (Saturation)
+// and so need no synchronization; inFlight and releaseCount are atomic (Release runs on workers).
 type benchDetector struct {
 	flowcontrol.SaturationDetector
 	concurrencyLimit atomic.Int64
-	// _ prevents false sharing between atomic counters on multicore CPU cache lines.
-	_        [56]byte
-	inFlight atomic.Int64
+	// _ prevents false sharing between concurrencyLimit and the hot atomic counters below.
+	_            [48]byte
+	inFlight     atomic.Int64
+	releaseCount atomic.Int64
+
+	stuckReads       int
+	lastReleaseCount int64
 }
 
-// Release frees one unit of capacity.
+// stuckReadThreshold is the number of consecutive saturated reads with zero intervening releases
+// after which the detector treats the outstanding grants as leaked idle permits and reclaims one.
+// >1 so that a single slow Release under load does not cause a spurious reclaim.
+const stuckReadThreshold = 2
+
+// Release frees the permit held by the dispatch that just completed.
 func (d *benchDetector) Release() {
-	if d.concurrencyLimit.Load() > 0 {
-		d.inFlight.Add(-1)
+	if d.concurrencyLimit.Load() <= 0 {
+		return
 	}
+	d.inFlight.Add(-1)
+	d.releaseCount.Add(1)
 }
 
-// Saturation reserves a concurrency slot atomically to guarantee the queues remain strictly at the
-// target depth.
+// Saturation reserves a permit for this cycle, reporting saturated once the limit is exceeded and
+// self-healing leaked idle grants (see the type doc).
 func (d *benchDetector) Saturation(ctx context.Context, candidates []fwkdl.Endpoint) float64 {
 	limit := d.concurrencyLimit.Load()
 	if limit <= 0 {
 		return 0.0 // Free-flow
 	}
 
-	// Optimistic increment to reserve a slot
+	// Optimistically reserve a permit for this cycle.
 	if d.inFlight.Add(1) <= limit {
+		d.stuckReads = 0
 		return 0.99 // Return < 1.0 so the dispatcher proceeds.
 	}
 
-	// Capacity exceeded; rollback the optimistic increment.
+	// Capacity exceeded; roll back the speculative reservation.
 	d.inFlight.Add(-1)
+
+	rc := d.releaseCount.Load()
+	if rc != d.lastReleaseCount {
+		// Releases are flowing: this is genuine load saturation, not a leak.
+		d.lastReleaseCount = rc
+		d.stuckReads = 0
+		return 1.0
+	}
+
+	// No releases since the last saturated read. After a couple of these the outstanding grants must
+	// be leaked idle permits (an empty-queue dispatch tick reserved but never dispatched), so reclaim
+	// one to keep the detector from latching.
+	d.stuckReads++
+	if d.stuckReads >= stuckReadThreshold {
+		d.inFlight.Add(-1)
+		d.stuckReads = 0
+	}
 	return 1.0 // Saturated - forces the Flow Control layer to hold the item.
 }
 
@@ -218,17 +230,15 @@ func setupRegistry(
 	return reg
 }
 
-// setupBenchmarkHarness creates the standard SUT environment.
-func setupBenchmarkHarness(
-	ctx context.Context,
+// setupRegistryWithDefaultPolicies registers the default FCFS ordering and global-strict fairness
+// policies on the handle, then provisions a FlowRegistry with `p` priority bands using them as the
+// per-band defaults. Shared by every benchmark harness so the policy wiring lives in one place.
+func setupRegistryWithDefaultPolicies(
 	b *testing.B,
+	handle fwkplugin.Handle,
 	p priorityLevels,
-	limit egressConcurrencyLimit,
-	customDetector testDetector,
-	customCfg *controller.Config,
-) (*controller.FlowController, testDetector) {
+) contracts.FlowRegistry {
 	b.Helper()
-	handle := testutils.NewTestHandle(ctx)
 
 	fPolicy, err := globalstrict.GlobalStrictFairnessPolicyFactory(registry.DefaultFairnessPolicyRef, nil, handle)
 	if err != nil {
@@ -247,7 +257,22 @@ func setupBenchmarkHarness(
 		FairnessPolicy: fPolicy.(flowcontrol.FairnessPolicy),
 	}
 
-	reg := setupRegistry(b, defaults, p)
+	return setupRegistry(b, defaults, p)
+}
+
+// setupBenchmarkHarness creates the standard SUT environment.
+func setupBenchmarkHarness(
+	ctx context.Context,
+	b *testing.B,
+	p priorityLevels,
+	limit egressConcurrencyLimit,
+	customDetector testDetector,
+	customCfg *controller.Config,
+) (*controller.FlowController, testDetector) {
+	b.Helper()
+	handle := testutils.NewTestHandle(ctx)
+
+	reg := setupRegistryWithDefaultPolicies(b, handle, p)
 
 	detector := customDetector
 	if detector == nil {
@@ -275,8 +300,89 @@ func setupBenchmarkHarness(
 	return fc, detector
 }
 
-// benchmarkTelemetry aggregates benchmark statistics lock-free.
-// Threads mutate local structs and commit totals once at the end.
+// fullPathBenchHarness holds shared setup state for full-path benchmarks that wire a real
+// InFlightLoadProducer, real concurrency detector, and real persistent endpoints into the
+// FlowController.
+type fullPathBenchHarness struct {
+	fc       *controller.FlowController
+	producer *inflightload.InFlightLoadProducer
+	epMeta   *fwkdl.EndpointMetadata
+	schedEp  scheduling.Endpoint
+}
+
+// setupFullPathBenchmark creates the shared harness for benchmarks that exercise
+// the complete flow control data path: producer -> detector -> controller -> cleanup.
+func setupFullPathBenchmark(ctx context.Context, b *testing.B, name string, numPriorities int) *fullPathBenchHarness {
+	b.Helper()
+	if numPriorities < 1 {
+		numPriorities = 1
+	}
+	handle := testutils.NewTestHandle(ctx)
+
+	producerName := name + "-producer"
+	producerPlugin, err := inflightload.InFlightLoadProducerFactory(
+		producerName, fwkplugin.StrictDecoder([]byte(`{}`)), handle,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	producer := producerPlugin.(*inflightload.InFlightLoadProducer)
+
+	detectorPlugin, err := concurrency.ConcurrencyDetectorFactory(
+		name+"-detector",
+		fwkplugin.StrictDecoder([]byte(fmt.Sprintf(
+			`{"maxConcurrency": 100, "inFlightLoadProducerName": %q}`, producerName,
+		))),
+		handle,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	realDetector := detectorPlugin.(flowcontrol.SaturationDetector)
+
+	epMeta := &fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "default"},
+	}
+	ep := fwkdl.NewEndpoint(epMeta, fwkdl.NewMetrics())
+	if err := producer.Extract(ctx, fwkdl.EndpointEvent{
+		Type: fwkdl.EventAddOrUpdate, Endpoint: ep,
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	reg := setupRegistryWithDefaultPolicies(b, handle, priorityLevels(numPriorities))
+
+	fc := controller.NewFlowController(ctx, name+"-bench", &controller.Config{
+		DefaultRequestTTL:        5 * time.Minute,
+		ExpiryCleanupInterval:    1 * time.Hour,
+		EnqueueChannelBufferSize: 2000,
+	}, controller.Deps{
+		Registry:           reg,
+		SaturationDetector: realDetector,
+		EndpointCandidates: &mocks.MockEndpointCandidates{Candidates: []fwkdl.Endpoint{ep}},
+		UsageLimitPolicy:   usagelimits.DefaultPolicy(),
+	})
+
+	schedEp := scheduling.NewEndpoint(epMeta, fwkdl.NewMetrics(), nil)
+
+	// Warm up: block on one request until it's dispatched, proving the dispatch loop is live before
+	// timing. It exercises only the FlowController, not the producer, so no in-flight load is left
+	// behind.
+	warmup := &benchRequest{key: flowcontrol.FlowKey{ID: "warmup", Priority: 0}, byteSize: 512}
+	if outcome, _ := fc.EnqueueAndWait(ctx, warmup); outcome != types.QueueOutcomeDispatched {
+		b.Fatalf("full-path warmup did not dispatch: %v", outcome)
+	}
+
+	return &fullPathBenchHarness{
+		fc:       fc,
+		producer: producer,
+		epMeta:   epMeta,
+		schedEp:  schedEp,
+	}
+}
+
+// benchmarkTelemetry aggregates benchmark statistics lock-free: threads mutate local structs and
+// commit totals once at the end.
 type benchmarkTelemetry struct {
 	errorCount    atomic.Int64
 	dispatchCount atomic.Int64
@@ -323,8 +429,7 @@ func (t *benchmarkTelemetry) commit(local *threadTelemetry) {
 	}
 }
 
-// report aggregates the committed globals and issues standard b.ReportMetric calls into the Go
-// benchmarking framework.
+// report aggregates the committed globals and issues the standard b.ReportMetric calls.
 func (t *benchmarkTelemetry) report(b *testing.B, elapsed float64) {
 	if elapsed <= 0 {
 		return

--- a/pkg/epp/flowcontrol/benchmark/helpers_test.go
+++ b/pkg/epp/flowcontrol/benchmark/helpers_test.go
@@ -119,6 +119,12 @@ type benchDetector struct {
 // stuckReadThreshold is the number of consecutive saturated reads with zero intervening releases
 // after which the detector treats the outstanding grants as leaked idle permits and reclaims one.
 // >1 so that a single slow Release under load does not cause a spurious reclaim.
+//
+// The heuristic is deliberately biased toward liveness: if a genuine holder's Release stalls past
+// the threshold (e.g. its worker goroutine is descheduled), the reclaim transiently over-admits
+// beyond L rather than risking a latched-saturated deadlock. For a CPU-cost benchmark that is the
+// right trade: true queueing still reports saturated (1.0) while releases flow, and a slightly
+// loose L only shifts the coordinate's operating point, whereas a latch would hang the run.
 const stuckReadThreshold = 2
 
 // Release frees the permit held by the dispatch that just completed.
@@ -284,7 +290,10 @@ func setupBenchmarkHarness(
 	cfg := customCfg
 	if cfg == nil {
 		cfg = &controller.Config{
-			DefaultRequestTTL:        5 * time.Minute,
+			// Nothing in a throughput benchmark legitimately waits minutes: the worst observed
+			// steady-state queue wait is ~10s (L=1, W=5000). A tight TTL bounds the cost of a wedged
+			// coordinate to seconds of CI time instead of minutes per cell.
+			DefaultRequestTTL:        30 * time.Second,
 			ExpiryCleanupInterval:    1 * time.Hour, // Effectively disabled
 			EnqueueChannelBufferSize: 2000,
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind test
/kind cleanup

**What this PR does / why we need it**:

Hardens and clarifies the flow-control benchmark suite (`pkg/epp/flowcontrol/benchmark`). Test-only; no production code changes.

- Re-scope the full-path benchmark (`FullPathStress` → `FullPath`) to what it uniquely measures: dispatch throughput and allocation overhead through the *real* producer → concurrency detector → controller path. Drops an off-layer producer leak-counter assertion (covered by the inflightload producer's own unit tests), reports `d/s` like the other benchmarks, and fixes a `b.Fatalf` called from inside `RunParallel` (invalid off the benchmark goroutine).
- Fix the mock `benchDetector` so the `PerformanceMatrix` L sweep is meaningful: it accumulates in-flight up to the limit and reports saturated once exceeded (real W>L backpressure), while self-healing the empty-queue idle grants the processor's 1 ms dispatch ticker would otherwise leak. Previously this latched and hung at L=1. Adds detector unit tests for saturation-at-limit and self-heal.
- Replace fixed bootstrap `time.Sleep`s with a warmup request that blocks until dispatch for deterministic readiness instead of arbitrary timing.
- Reorganize into `doc.go` (two-family overview) + `helpers_test.go` + `benchmark_test.go`, and dedup the shared registry/policy setup.
- Add a `bench-smoke` make target + CI step (`go test -bench=. -benchtime=1x`) so benchmark bodies execute on every PR; `go test` only compiles them otherwise, letting runtime breakage (panics, deadlocks) go undetected.

**Which issue(s) this PR fixes**:

N/A -- expanding upon the work in #1543

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
NONE
```