### PR TITLE
feat(prefixcacheaffinity): raise MaxTTFTPenaltyMs default to 18000

### DIFF
--- a/config/charts/routerlib/templates/_config.yaml
+++ b/config/charts/routerlib/templates/_config.yaml
@@ -47,11 +47,13 @@ data:
       parameters:
         affinityThreshold: 0.99
         ttftSource: latencyPredictor
+        maxTTFTPenaltyMs: 5000
     - name: loose-affinity-filter
       type: prefix-cache-affinity-filter
       parameters:
         affinityThreshold: 0.80
         ttftSource: latencyPredictor
+        maxTTFTPenaltyMs: 5000
     - type: latency-scorer
     - type: weighted-random-picker
     - type: slo-headroom-tier-filter

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -73,7 +73,7 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 |-----------|------|----------|---------|-------------|
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
 | `explorationProbability` | `float64` | No | `0.01` | Probability of skipping the gate |
-| `maxTTFTPenaltyMs` | `float64` | No | `5000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
+| `maxTTFTPenaltyMs` | `float64` | No | `18000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
 | `ttftSource` | `string` | No | `prefillThroughput` | TTFT source for the load gate: `prefillThroughput` or `latencyPredictor` |
 | `peakPrefillThroughput` | `float64` | No | `15928` | Peak prefill throughput (tokens/sec), used to estimate TTFT when `ttftSource` is `prefillThroughput` |
 

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -70,7 +70,7 @@ type Config struct {
 	// MaxTTFTPenaltyMs is the max TTFT penalty (ms) before breaking stickiness.
 	// If the best sticky endpoint's TTFT exceeds the best non-sticky endpoint's
 	// TTFT by more than this value, all endpoints are kept. Set to 0 to always
-	// stick. Default: 5000.
+	// stick. Default: 18000.
 	MaxTTFTPenaltyMs float64 `json:"maxTTFTPenaltyMs,omitempty"`
 
 	// TTFTSource selects where the load gate reads per-endpoint TTFT from.
@@ -93,7 +93,7 @@ type Config struct {
 var DefaultConfig = Config{
 	AffinityThreshold:      0.80,
 	ExplorationProbability: 0.01,
-	MaxTTFTPenaltyMs:       5000,
+	MaxTTFTPenaltyMs:       18000,
 	TTFTSource:             TTFTSourcePrefillThroughput,
 
 	// Calibrated for Qwen 32B on 2x H100 80GB (TP=2), vLLM 0.19; see README.


### PR DESCRIPTION
## What

Tune the `maxTTFTPenaltyMs` load-gate threshold in the prefix-cache-affinity
filter for each TTFT source:

- **Code default** (`prefillThroughput` source): raise from `5000` → `18000`
  in `DefaultConfig` and the README.
- **routerlib helm config** (`latencyPredictor` source): set an explicit
  `maxTTFTPenaltyMs: 5000` on both the strict (0.99) and loose (0.80)
  prefix-cache-affinity filters.

## Why

`maxTTFTPenaltyMs` controls how much extra TTFT we tolerate on the best sticky
(cache-hit) endpoint over the best non-sticky endpoint before the gate breaks
stickiness and opens up all endpoints. The right threshold depends on which
TTFT signal the gate reads, because the two sources are on different scales:

- `prefillThroughput` estimates TTFT as `uncachedInFlightTokens /
  peakPrefillThroughput`. This is a coarse, aggregate prefill-backlog
  drain-time proxy computed against *peak* throughput, so its sticky−nonsticky
  spread runs large. It needs a wider budget (18000) to express a sane
  latency-vs-cache-hit tradeoff and avoid abandoning cache hits under normal
  load.
- `latencyPredictor` predicts the marginal actual TTFT for the request, so a
  difference in ms maps directly to real first-token latency. A tighter
  threshold (5000) is meaningful and correct there.

The helm config uses `latencyPredictor`, so it pins 5000; the in-code default
targets `prefillThroughput`, so it moves to 18000. The values are calibrated
for the Qwen-32B / 2×H100 (TP=2), vLLM 0.19 setup noted in `DefaultConfig`.

## Changes

- `pkg/.../prefixcacheaffinity/plugin.go` — `DefaultConfig.MaxTTFTPenaltyMs` 5000 → 18000
- `pkg/.../prefixcacheaffinity/README.md` — document the new default
- `config/charts/routerlib/templates/_config.yaml` — explicit `maxTTFTPenaltyMs: 5000` on both affinity filters

## Test plan

- [ ] Existing unit tests pass (`go test ./pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/...`)
- [ ] Helm template renders (`helm template config/charts/routerlib`)
