### PR TITLE
Bump default epp cpu 4->8

### DIFF
--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -57,7 +57,7 @@ epp:
   # EPP container resources: CPU limits unset for burst capacity, memory capped at 16Gi
   resources:
     requests:
-      cpu: "4"
+      cpu: "8"
       memory: 8Gi
     limits:
       memory: 16Gi


### PR DESCRIPTION
This change is triggered by:
1. Increase of the maxPrefixTokens in approximate prefix producer leading to potentially more compute cost for long inputs.
2. Recent refactor(multi-modal support, aligning on token format) added some overhead for better code readability
3. Based on test result in https://github.com/llm-d/llm-d-router/issues/1287#issuecomment-4666058475, this config can support ISL/OSL 100k/1k at 25 QPS with 25 model servers.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Default EPP CPU request is increased from 4 to 8 to accommodate longer prefix matching and other enhancements. 
```
