### PR TITLE
fix: don't abort kind-dev-env.sh on macOS when PROM_ENABLED=true

### DIFF
--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -200,7 +200,10 @@ done
 
 # Prometheus config-reloader needs sufficient inotify resources
 if [ "${PROM_ENABLED}" == "true" ]; then
-  INOTIFY_INSTANCES=$(cat /proc/sys/fs/inotify/max_user_instances)
+  # On non-Linux hosts (e.g. macOS) /proc does not exist and the kind pods run in
+  # the container-runtime VM, not the host, so fall back to a passing value rather
+  # than letting the failed read abort the script under `set -e`.
+  INOTIFY_INSTANCES=$(cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || echo 512)
   if [ "${INOTIFY_INSTANCES}" -lt 512 ]; then
     echo "Error: fs.inotify.max_user_instances is ${INOTIFY_INSTANCES} (need >= 512) for Prometheus."
     echo ""


### PR DESCRIPTION
## What this does

Stops `PROM_ENABLED=true make env-dev-kind` from aborting on macOS.

The Prometheus pre-flight check in `scripts/kind-dev-env.sh` reads
`/proc/sys/fs/inotify/max_user_instances`, a Linux-only path. On macOS that
read fails and, under `set -eo pipefail`, the failed `cat` kills the whole
script before the cluster is ever created.

This falls back to a passing value when the path is absent, so the host-side
check degrades gracefully off-Linux. On Linux the behavior is unchanged.

```diff
 if [ "${PROM_ENABLED}" == "true" ]; then
-  INOTIFY_INSTANCES=$(cat /proc/sys/fs/inotify/max_user_instances)
+  INOTIFY_INSTANCES=$(cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || echo 512)