### PR TITLE
Session affinity filter/scorer can optionally pick the scheduling profile to inject the routed endpoint from. This enables P/D disaggregation support.

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/README.md
@@ -7,16 +7,40 @@ Pins subsequent requests in a session to the same pod the first request was sent
 The session is carried in a request header whose value is the base64-encoded `namespace/name` of the previously selected pod. As a [`ResponseHeaderProcessor`](../../../../interface/requestcontrol/plugins.go), the filter writes that same header on the response so the client can echo it back on the next request.
 
 ## Parameters
-
+ 
 | Name | Type | Default | Description |
 |---|---|---|---|
 | `headerName` | string | `x-session-token` | Request and response header carrying the session token. When set, only this header is read; the default is ignored. |
+| `profileName` | string | | The name of the profile this instance is associated with. When set (e.g. `prefill`), the plugin looks up the target pod from the results of that profile in `SchedulingResult` during the response received phase. When empty, it defaults to the primary (decode) pod. |
+
+### Default Configuration (without PD disaggregation)
 
 ```yaml
 - type: session-affinity-filter
   parameters:
     headerName: x-session-token
 ```
+
+### PD Disaggregation Configuration
+
+To support session affinity with PD disaggregation, configure two separate instances of the filter: one for decode and one for prefill.
+
+```yaml
+# Instance for the decode profile (pins decode requests)
+- name: session-affinity-decode
+  type: session-affinity-filter
+  parameters:
+    headerName: x-session-token
+
+# Instance for the prefill profile (pins prefill requests)
+- name: session-affinity-prefill
+  type: session-affinity-filter
+  parameters:
+    headerName: x-session-token-prefill
+    profileName: prefill
+```
+
+The decode instance uses the default behavior (writing the decode pod to `x-session-token`). The prefill instance uses `profileName: prefill` to look up the prefill pod from the scheduling results and write it to `x-session-token-prefill`. This ensures that subsequent requests in the same session target both the same prefill pod and the same decode pod.
 
 ## Relationship to the session affinity scorer
 

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -107,13 +107,6 @@ func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.Infere
 
 // ResponseHeader sets the session header on the response sent to the client.
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	podToWrite := targetPod
-	if s.profileName != "" && request != nil && request.SchedulingResult != nil {
-		if result := request.SchedulingResult.ProfileResults[s.profileName]; result != nil && len(result.TargetEndpoints) > 0 && result.TargetEndpoints[0] != nil {
-			if md := result.TargetEndpoints[0].GetMetadata(); md != nil {
-				podToWrite = md
-			}
-		}
-	}
+	podToWrite := sessionutil.ResolvePodToWrite(request, s.profileName, targetPod)
 	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, podToWrite)
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -38,7 +38,8 @@ type parameters struct {
 	// HeaderName overrides the default x-session-token header used to read and
 	// write the session token. When empty the default is used.
 	HeaderName string `json:"headerName"`
-	// ProfileName is the name of the profile this instance is associated with.
+	// ProfileName is the name of the profile this instance is associated with (optional).
+	// When empty, the plugin defaults to the primary (decode) pod.
 	// Used in ResponseHeader to look up the correct target pod from SchedulingResult.
 	ProfileName string `json:"profileName"`
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -109,8 +109,10 @@ func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.Infere
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
 	podToWrite := targetPod
 	if s.profileName != "" && request != nil && request.SchedulingResult != nil {
-		if result, ok := request.SchedulingResult.ProfileResults[s.profileName]; ok && len(result.TargetEndpoints) > 0 {
-			podToWrite = result.TargetEndpoints[0].GetMetadata()
+		if result := request.SchedulingResult.ProfileResults[s.profileName]; result != nil && len(result.TargetEndpoints) > 0 && result.TargetEndpoints[0] != nil {
+			if md := result.TargetEndpoints[0].GetMetadata(); md != nil {
+				podToWrite = md
+			}
 		}
 	}
 	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, podToWrite)

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -38,6 +38,9 @@ type parameters struct {
 	// HeaderName overrides the default x-session-token header used to read and
 	// write the session token. When empty the default is used.
 	HeaderName string `json:"headerName"`
+	// ProfileName is the name of the profile this instance is associated with.
+	// Used in ResponseHeader to look up the correct target pod from SchedulingResult.
+	ProfileName string `json:"profileName"`
 }
 
 // compile-time type assertion
@@ -53,15 +56,16 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 		}
 	}
 
-	return NewSessionAffinity(name, params.HeaderName), nil
+	return NewSessionAffinity(name, params.HeaderName, params.ProfileName), nil
 }
 
 // NewSessionAffinity returns a filter. When sessionHeader is empty the default
 // x-session-token header is used.
-func NewSessionAffinity(name, sessionHeader string) *SessionAffinity {
+func NewSessionAffinity(name, sessionHeader, profileName string) *SessionAffinity {
 	return &SessionAffinity{
 		typedName:     plugin.TypedName{Type: SessionAffinityType, Name: name},
 		sessionHeader: sessionutil.NormalizeHeader(sessionHeader),
+		profileName:   profileName,
 	}
 }
 
@@ -74,6 +78,8 @@ type SessionAffinity struct {
 	typedName plugin.TypedName
 	// sessionHeader is the request/response header carrying the session token.
 	sessionHeader string
+	// profileName is the name of the profile this instance is associated with.
+	profileName string
 }
 
 // TypedName returns the typed name of the plugin.
@@ -99,6 +105,12 @@ func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.Infere
 }
 
 // ResponseHeader sets the session header on the response sent to the client.
-func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
+func (s *SessionAffinity) ResponseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
+	podToWrite := targetPod
+	if s.profileName != "" && request != nil && request.SchedulingResult != nil {
+		if result, ok := request.SchedulingResult.ProfileResults[s.profileName]; ok && len(result.TargetEndpoints) > 0 {
+			podToWrite = result.TargetEndpoints[0].GetMetadata()
+		}
+	}
+	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, podToWrite)
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
@@ -211,6 +211,54 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 			},
 			wantHeaders: map[string]string{"x-session-token-prefill": base64.StdEncoding.EncodeToString([]byte("default/prefill-pod"))},
 		},
+		{
+			name:            "profile set but absent from results (decode-only) writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-decode-only", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request: &scheduling.InferenceRequest{
+				RequestID: "req-decode-only",
+				SchedulingResult: &scheduling.SchedulingResult{
+					ProfileResults: map[string]*scheduling.ProfileRunResult{},
+				},
+			},
+			wantHeaders: map[string]string{},
+		},
+		{
+			name:            "profile set but TargetEndpoints empty writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-empty-ep", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request: &scheduling.InferenceRequest{
+				RequestID: "req-empty-ep",
+				SchedulingResult: &scheduling.SchedulingResult{
+					ProfileResults: map[string]*scheduling.ProfileRunResult{
+						"prefill": {TargetEndpoints: []scheduling.Endpoint{}},
+					},
+				},
+			},
+			wantHeaders: map[string]string{},
+		},
+		{
+			name:            "profile set but nil SchedulingResult writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-nil-sr", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request:         &scheduling.InferenceRequest{RequestID: "req-nil-sr"},
+			wantHeaders:     map[string]string{},
+		},
+		{
+			name:            "profile set but nil request writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-nil-req", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request:         nil,
+			wantHeaders:     map[string]string{},
+		},
 	}
 
 	ctx := utils.NewTestContext(t)

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
@@ -51,8 +51,8 @@ func TestSessionAffinity_Filter(t *testing.T) {
 	// valid token whose pod is not among the candidates
 	tokenForMissingPod := base64.StdEncoding.EncodeToString([]byte("pod-missing"))
 
-	sessionAffinityFilter := sessionaffinity.NewSessionAffinity("test-filter", "")
-	customHeaderFilter := sessionaffinity.NewSessionAffinity("test-filter", "x-custom-session")
+	sessionAffinityFilter := sessionaffinity.NewSessionAffinity("test-filter", "", "")
+	customHeaderFilter := sessionaffinity.NewSessionAffinity("test-filter", "x-custom-session", "")
 
 	tests := []struct {
 		name     string
@@ -141,7 +141,7 @@ func TestSessionAffinity_Filter(t *testing.T) {
 
 func TestSessionAffinity_ResponseHeader(t *testing.T) {
 	targetEndpoint := &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: "pod1"},
+		NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "pod1"},
 		Address:        "1.2.3.4",
 	}
 
@@ -151,8 +151,10 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 	tests := []struct {
 		name            string
 		sessionHeader   string
+		profileName     string
 		initialResponse *requestcontrol.Response
 		targetPod       *fwkdl.EndpointMetadata
+		request         *scheduling.InferenceRequest
 		wantHeaders     map[string]string
 	}{
 		{
@@ -185,14 +187,38 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 			initialResponse: nil,
 			targetPod:       targetEndpoint,
 		},
+		{
+			name:            "prefill profile lookup",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-prefill", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint, // passed targetPod is decode pod, should be ignored
+			request: &scheduling.InferenceRequest{
+				RequestID: "req-prefill",
+				SchedulingResult: &scheduling.SchedulingResult{
+					ProfileResults: map[string]*scheduling.ProfileRunResult{
+						"prefill": {
+							TargetEndpoints: []scheduling.Endpoint{
+								scheduling.NewEndpoint(
+									&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"}},
+									&fwkdl.Metrics{},
+									nil,
+								),
+							},
+						},
+					},
+				},
+			},
+			wantHeaders: map[string]string{"x-session-token-prefill": base64.StdEncoding.EncodeToString([]byte("default/prefill-pod"))},
+		},
 	}
 
 	ctx := utils.NewTestContext(t)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := sessionaffinity.NewSessionAffinity("test-filter", test.sessionHeader)
-			s.ResponseHeader(ctx, nil, test.initialResponse, test.targetPod)
+			s := sessionaffinity.NewSessionAffinity("test-filter", test.sessionHeader, test.profileName)
+			s.ResponseHeader(ctx, test.request, test.initialResponse, test.targetPod)
 
 			if test.initialResponse == nil {
 				return

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/README.md
@@ -11,12 +11,36 @@ The session is carried in a request header whose value is the base64-encoded `na
 | Name | Type | Default | Description |
 |---|---|---|---|
 | `headerName` | string | `x-session-token` | Request and response header carrying the session token. When set, only this header is read; the default is ignored. |
+| `profileName` | string | | The name of the profile this instance is associated with. When set (e.g. `prefill`), the plugin looks up the target pod from the results of that profile in `SchedulingResult` during the response received phase. When empty, it defaults to the primary (decode) pod. |
+
+### Default Configuration (without PD disaggregation)
 
 ```yaml
 - type: session-affinity-scorer
   parameters:
     headerName: x-session-token
 ```
+
+### PD Disaggregation Configuration
+
+To support session affinity with PD disaggregation, configure two separate instances of the scorer: one for decode and one for prefill.
+
+```yaml
+# Instance for the decode profile (pins decode requests)
+- name: session-affinity-decode
+  type: session-affinity-scorer
+  parameters:
+    headerName: x-session-token
+
+# Instance for the prefill profile (pins prefill requests)
+- name: session-affinity-prefill
+  type: session-affinity-scorer
+  parameters:
+    headerName: x-session-token-prefill
+    profileName: prefill
+```
+
+The decode instance uses the default behavior (writing the decode pod to `x-session-token`). The prefill instance uses `profileName: prefill` to look up the prefill pod from the scheduling results and write it to `x-session-token-prefill`. This ensures that subsequent requests in the same session target both the same prefill pod and the same decode pod.
 
 ## Relationship to the session affinity filter
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -109,13 +109,6 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 
 // ResponseHeader sets the session header on the response sent to the client.
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	podToWrite := targetPod
-	if s.profileName != "" && request != nil && request.SchedulingResult != nil {
-		if result := request.SchedulingResult.ProfileResults[s.profileName]; result != nil && len(result.TargetEndpoints) > 0 && result.TargetEndpoints[0] != nil {
-			if md := result.TargetEndpoints[0].GetMetadata(); md != nil {
-				podToWrite = md
-			}
-		}
-	}
+	podToWrite := sessionutil.ResolvePodToWrite(request, s.profileName, targetPod)
 	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, podToWrite)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -38,7 +38,8 @@ type parameters struct {
 	// HeaderName overrides the default x-session-token header used to read and
 	// write the session token. When empty the default is used.
 	HeaderName string `json:"headerName"`
-	// ProfileName is the name of the profile this instance is associated with.
+	// ProfileName is the name of the profile this instance is associated with (optional).
+	// When empty, the plugin defaults to the primary (decode) pod.
 	// Used in ResponseHeader to look up the correct target pod from SchedulingResult.
 	ProfileName string `json:"profileName"`
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -38,6 +38,9 @@ type parameters struct {
 	// HeaderName overrides the default x-session-token header used to read and
 	// write the session token. When empty the default is used.
 	HeaderName string `json:"headerName"`
+	// ProfileName is the name of the profile this instance is associated with.
+	// Used in ResponseHeader to look up the correct target pod from SchedulingResult.
+	ProfileName string `json:"profileName"`
 }
 
 // compile-time type assertion
@@ -53,15 +56,16 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 		}
 	}
 
-	return NewSessionAffinity(name, params.HeaderName), nil
+	return NewSessionAffinity(name, params.HeaderName, params.ProfileName), nil
 }
 
 // NewSessionAffinity returns a scorer. When sessionHeader is empty the default
 // x-session-token header is used.
-func NewSessionAffinity(name, sessionHeader string) *SessionAffinity {
+func NewSessionAffinity(name, sessionHeader, profileName string) *SessionAffinity {
 	return &SessionAffinity{
 		typedName:     plugin.TypedName{Type: SessionAffinityType, Name: name},
 		sessionHeader: sessionutil.NormalizeHeader(sessionHeader),
+		profileName:   profileName,
 	}
 }
 
@@ -73,6 +77,8 @@ type SessionAffinity struct {
 	typedName plugin.TypedName
 	// sessionHeader is the request/response header carrying the session token.
 	sessionHeader string
+	// profileName is the name of the profile this instance is associated with.
+	profileName string
 }
 
 // TypedName returns the typed name of the plugin.
@@ -101,6 +107,12 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 }
 
 // ResponseHeader sets the session header on the response sent to the client.
-func (s *SessionAffinity) ResponseHeader(ctx context.Context, _ *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
-	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, targetPod)
+func (s *SessionAffinity) ResponseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
+	podToWrite := targetPod
+	if s.profileName != "" && request != nil && request.SchedulingResult != nil {
+		if result, ok := request.SchedulingResult.ProfileResults[s.profileName]; ok && len(result.TargetEndpoints) > 0 {
+			podToWrite = result.TargetEndpoints[0].GetMetadata()
+		}
+	}
+	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, podToWrite)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -111,8 +111,10 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {
 	podToWrite := targetPod
 	if s.profileName != "" && request != nil && request.SchedulingResult != nil {
-		if result, ok := request.SchedulingResult.ProfileResults[s.profileName]; ok && len(result.TargetEndpoints) > 0 {
-			podToWrite = result.TargetEndpoints[0].GetMetadata()
+		if result := request.SchedulingResult.ProfileResults[s.profileName]; result != nil && len(result.TargetEndpoints) > 0 && result.TargetEndpoints[0] != nil {
+			if md := result.TargetEndpoints[0].GetMetadata(); md != nil {
+				podToWrite = md
+			}
 		}
 	}
 	sessionutil.WriteResponseHeader(ctx, SessionAffinityType, s.sessionHeader, response, podToWrite)

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -213,6 +213,54 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 			},
 			wantHeaders: map[string]string{"x-session-token-prefill": base64.StdEncoding.EncodeToString([]byte("default/prefill-pod"))},
 		},
+		{
+			name:            "profile set but absent from results (decode-only) writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-decode-only", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request: &scheduling.InferenceRequest{
+				RequestID: "req-decode-only",
+				SchedulingResult: &scheduling.SchedulingResult{
+					ProfileResults: map[string]*scheduling.ProfileRunResult{},
+				},
+			},
+			wantHeaders: map[string]string{},
+		},
+		{
+			name:            "profile set but TargetEndpoints empty writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-empty-ep", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request: &scheduling.InferenceRequest{
+				RequestID: "req-empty-ep",
+				SchedulingResult: &scheduling.SchedulingResult{
+					ProfileResults: map[string]*scheduling.ProfileRunResult{
+						"prefill": {TargetEndpoints: []scheduling.Endpoint{}},
+					},
+				},
+			},
+			wantHeaders: map[string]string{},
+		},
+		{
+			name:            "profile set but nil SchedulingResult writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-nil-sr", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request:         &scheduling.InferenceRequest{RequestID: "req-nil-sr"},
+			wantHeaders:     map[string]string{},
+		},
+		{
+			name:            "profile set but nil request writes no header",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-nil-req", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint,
+			request:         nil,
+			wantHeaders:     map[string]string{},
+		},
 	}
 
 	ctx := utils.NewTestContext(t)

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -48,8 +48,8 @@ func TestSessionAffinity_Score(t *testing.T) {
 	// valid session token for endpointB
 	validSessionTokenForEndpointB := base64.StdEncoding.EncodeToString([]byte(endpointB.GetMetadata().NamespacedName.String()))
 
-	sessionAffinityScorer := sessionaffinity.NewSessionAffinity("test-scorer", "")
-	customHeaderScorer := sessionaffinity.NewSessionAffinity("test-scorer", "x-custom-session")
+	sessionAffinityScorer := sessionaffinity.NewSessionAffinity("test-scorer", "", "")
+	customHeaderScorer := sessionaffinity.NewSessionAffinity("test-scorer", "x-custom-session", "")
 
 	tests := []struct {
 		name       string
@@ -143,7 +143,7 @@ func TestSessionAffinity_Score(t *testing.T) {
 
 func TestSessionAffinity_ResponseHeader(t *testing.T) {
 	targetEndpoint := &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: "pod1"},
+		NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "pod1"},
 		Address:        "1.2.3.4",
 	}
 
@@ -153,8 +153,10 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 	tests := []struct {
 		name            string
 		sessionHeader   string
+		profileName     string
 		initialResponse *requestcontrol.Response
 		targetPod       *fwkdl.EndpointMetadata
+		request         *scheduling.InferenceRequest
 		wantHeaders     map[string]string
 	}{
 		{
@@ -187,14 +189,38 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 			initialResponse: nil,
 			targetPod:       targetEndpoint,
 		},
+		{
+			name:            "prefill profile lookup",
+			sessionHeader:   "x-session-token-prefill",
+			profileName:     "prefill",
+			initialResponse: &requestcontrol.Response{RequestID: "req-prefill", Headers: make(map[string]string)},
+			targetPod:       targetEndpoint, // passed targetPod is decode pod, should be ignored
+			request: &scheduling.InferenceRequest{
+				RequestID: "req-prefill",
+				SchedulingResult: &scheduling.SchedulingResult{
+					ProfileResults: map[string]*scheduling.ProfileRunResult{
+						"prefill": {
+							TargetEndpoints: []scheduling.Endpoint{
+								scheduling.NewEndpoint(
+									&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"}},
+									&fwkdl.Metrics{},
+									nil,
+								),
+							},
+						},
+					},
+				},
+			},
+			wantHeaders: map[string]string{"x-session-token-prefill": base64.StdEncoding.EncodeToString([]byte("default/prefill-pod"))},
+		},
 	}
 
 	ctx := utils.NewTestContext(t)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := sessionaffinity.NewSessionAffinity("test-scorer", test.sessionHeader)
-			s.ResponseHeader(ctx, nil, test.initialResponse, test.targetPod)
+			s := sessionaffinity.NewSessionAffinity("test-scorer", test.sessionHeader, test.profileName)
+			s.ResponseHeader(ctx, test.request, test.initialResponse, test.targetPod)
 
 			if test.initialResponse == nil {
 				return

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
@@ -84,15 +84,19 @@ func WriteResponseHeader(ctx context.Context, pluginType, sessionHeader string, 
 }
 
 // ResolvePodToWrite looks up the target pod from the scheduling results if profileName is set.
-// It returns targetPod if profileName is empty or if the lookup fails.
+// When profileName is empty, targetPod (the primary/decode pod) is returned.
+// When profileName is set, the function returns the profile's endpoint or nil
+// if the profile was not scheduled (e.g. decode-only requests skip prefill).
 func ResolvePodToWrite(request *scheduling.InferenceRequest, profileName string, targetPod *datalayer.EndpointMetadata) *datalayer.EndpointMetadata {
-	podToWrite := targetPod
-	if profileName != "" && request != nil && request.SchedulingResult != nil {
+	if profileName == "" {
+		return targetPod
+	}
+	if request != nil && request.SchedulingResult != nil {
 		if result := request.SchedulingResult.ProfileResults[profileName]; result != nil && len(result.TargetEndpoints) > 0 && result.TargetEndpoints[0] != nil {
 			if md := result.TargetEndpoints[0].GetMetadata(); md != nil {
-				podToWrite = md
+				return md
 			}
 		}
 	}
-	return podToWrite
+	return nil
 }

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
@@ -28,6 +28,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
 // DefaultHeader is the default request/response header carrying the session
@@ -80,4 +81,18 @@ func WriteResponseHeader(ctx context.Context, pluginType, sessionHeader string, 
 	}
 
 	response.Headers[sessionHeader] = base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
+}
+
+// ResolvePodToWrite looks up the target pod from the scheduling results if profileName is set.
+// It returns targetPod if profileName is empty or if the lookup fails.
+func ResolvePodToWrite(request *scheduling.InferenceRequest, profileName string, targetPod *datalayer.EndpointMetadata) *datalayer.EndpointMetadata {
+	podToWrite := targetPod
+	if profileName != "" && request != nil && request.SchedulingResult != nil {
+		if result := request.SchedulingResult.ProfileResults[profileName]; result != nil && len(result.TargetEndpoints) > 0 && result.TargetEndpoints[0] != nil {
+			if md := result.TargetEndpoints[0].GetMetadata(); md != nil {
+				podToWrite = md
+			}
+		}
+	}
+	return podToWrite
 }

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1341,22 +1341,22 @@ func TestDirector_HandleResponseHeader_SessionAffinity(t *testing.T) {
 	}{
 		{
 			name:       "scorer with default header",
-			plugin:     sessionaffinityscorer.NewSessionAffinity("test-scorer", ""),
+			plugin:     sessionaffinityscorer.NewSessionAffinity("test-scorer", "", ""),
 			wantHeader: "x-session-token",
 		},
 		{
 			name:       "scorer with custom header",
-			plugin:     sessionaffinityscorer.NewSessionAffinity("test-scorer", "x-custom-session"),
+			plugin:     sessionaffinityscorer.NewSessionAffinity("test-scorer", "x-custom-session", ""),
 			wantHeader: "x-custom-session",
 		},
 		{
 			name:       "filter with default header",
-			plugin:     sessionaffinityfilter.NewSessionAffinity("test-filter", ""),
+			plugin:     sessionaffinityfilter.NewSessionAffinity("test-filter", "", ""),
 			wantHeader: "x-session-token",
 		},
 		{
 			name:       "filter with custom header",
-			plugin:     sessionaffinityfilter.NewSessionAffinity("test-filter", "x-custom-session"),
+			plugin:     sessionaffinityfilter.NewSessionAffinity("test-filter", "x-custom-session", ""),
 			wantHeader: "x-custom-session",
 		},
 	}

--- a/test/integration/epp/session_affinity_test.go
+++ b/test/integration/epp/session_affinity_test.go
@@ -120,16 +120,9 @@ func sendSessionRequest(t *testing.T, h *TestHarness, sessionToken string) (endp
 	return endpoint, token
 }
 
-// TestSessionAffinityFilter_PDFlow validates the session affinity flow in a
-// prefill/decode disaggregated setup: two session-affinity-filter instances
-// emit separate tokens for the decode and prefill endpoints. The test verifies
-// that on a second request both tokens pin to the same pods, and that on a
-// decode-only request (where the always-disagg decider still schedules prefill
-// because it always returns true) the prefill token is set correctly.
-func TestSessionAffinityFilter_PDFlow(t *testing.T) {
-	const prefillHeader = "x-session-token-prefill"
-
-	configText := `
+// pdConfigBase is the shared EPP config skeleton for PD session-affinity tests.
+// The caller must supply the disagg-profile-handler parameters block (%s).
+const pdConfigBase = `
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -137,8 +130,7 @@ plugins:
   - type: always-disagg-pd-decider
   - type: disagg-profile-handler
     parameters:
-      deciders:
-        prefill: always-disagg-pd-decider
+%s
   - type: prefill-filter
   - type: decode-filter
   - type: queue-scorer
@@ -172,11 +164,13 @@ schedulingProfiles:
     - pluginRef: session-affinity-decode
 `
 
+// setupPDHarness creates a test harness with prefill and decode pods for PD
+// session-affinity tests.
+func setupPDHarness(t *testing.T, configText string) *TestHarness {
+	t.Helper()
 	ctx := t.Context()
 	h := NewTestHarness(ctx, t, WithStandardMode(), WithConfigText(configText)).WithBaseResources()
 
-	// Create pods with role labels. The by-label filters need llm-d.ai/role to
-	// separate prefill and decode candidates.
 	metricsMap := make(map[types.NamespacedName]*fwkdl.Metrics)
 	type podDef struct {
 		index int
@@ -213,6 +207,18 @@ schedulingProfiles:
 	h.metricsBackend.SetPodMetrics(metricsMap)
 	h.WaitForSync(len(pods), modelMyModel)
 	h.WaitForReadyPodsMetric(len(pods))
+	return h
+}
+
+// TestSessionAffinityFilter_PDDisaggregated validates the session affinity flow
+// in a prefill/decode disaggregated setup where every request is disaggregated.
+// Two session-affinity-filter instances emit separate tokens for the decode and
+// prefill endpoints. The second request pins both profiles to the same pods.
+func TestSessionAffinityFilter_PDDisaggregated(t *testing.T) {
+	const prefillHeader = "x-session-token-prefill"
+
+	configText := fmt.Sprintf(pdConfigBase, "      deciders:\n        prefill: always-disagg-pd-decider")
+	h := setupPDHarness(t, configText)
 
 	// First request: no session headers.
 	firstDecodeEP, decodeToken := sendSessionRequest(t, h, "")
@@ -228,6 +234,27 @@ schedulingProfiles:
 
 	secondPrefillToken := sendSessionRequestGetHeader(t, h, decodeToken, firstPrefillToken, prefillHeader)
 	require.NotEmpty(t, secondPrefillToken, "second response must carry a prefill session token")
+}
+
+// TestSessionAffinityFilter_DecodeOnly validates that when the disagg profile
+// handler has no prefill decider configured, prefill is skipped and the
+// profile-scoped session-affinity-filter does NOT emit a prefill session token
+// (i.e. it does not fall back to the decode pod).
+func TestSessionAffinityFilter_DecodeOnly(t *testing.T) {
+	const prefillHeader = "x-session-token-prefill"
+
+	// No deciders block: disagg-profile-handler skips prefill entirely.
+	configText := fmt.Sprintf(pdConfigBase, "      {}")
+	h := setupPDHarness(t, configText)
+
+	// Request routed to decode only; decode token must be present, prefill
+	// token must be absent.
+	_, decodeToken := sendSessionRequest(t, h, "")
+	require.NotEmpty(t, decodeToken, "response must carry a decode session token")
+
+	prefillToken := sendSessionRequestGetHeader(t, h, "", "", prefillHeader)
+	require.Empty(t, prefillToken,
+		"decode-only response must NOT carry a prefill session token")
 }
 
 // sendSessionRequestGetHeader drives a request through the EPP and returns the

--- a/test/integration/epp/session_affinity_test.go
+++ b/test/integration/epp/session_affinity_test.go
@@ -17,15 +17,20 @@ limitations under the License.
 package epp
 
 import (
+	"fmt"
 	"testing"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	sessionutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
+	testutil "github.com/llm-d/llm-d-router/pkg/epp/util/testing"
 	integration "github.com/llm-d/llm-d-router/test/integration"
 )
 
@@ -113,6 +118,150 @@ func sendSessionRequest(t *testing.T, h *TestHarness, sessionToken string) (endp
 
 	token = headerValue(responses[2].GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), sessionutil.DefaultHeader)
 	return endpoint, token
+}
+
+// TestSessionAffinityFilter_PDFlow validates the session affinity flow in a
+// prefill/decode disaggregated setup: two session-affinity-filter instances
+// emit separate tokens for the decode and prefill endpoints. The test verifies
+// that on a second request both tokens pin to the same pods, and that on a
+// decode-only request (where the always-disagg decider still schedules prefill
+// because it always returns true) the prefill token is set correctly.
+func TestSessionAffinityFilter_PDFlow(t *testing.T) {
+	const prefillHeader = "x-session-token-prefill"
+
+	configText := `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: openai-parser
+  - type: always-disagg-pd-decider
+  - type: disagg-profile-handler
+    parameters:
+      deciders:
+        prefill: always-disagg-pd-decider
+  - type: prefill-filter
+  - type: decode-filter
+  - type: queue-scorer
+  - type: max-score-picker
+  - type: session-affinity-filter
+    name: session-affinity-decode
+  - type: session-affinity-filter
+    name: session-affinity-prefill
+    parameters:
+      headerName: x-session-token-prefill
+      profileName: prefill
+  - type: mock-metrics-source
+requestHandler:
+  parsers:
+  - pluginRef: openai-parser
+dataLayer:
+  sources:
+  - pluginRef: mock-metrics-source
+schedulingProfiles:
+  - name: prefill
+    plugins:
+    - pluginRef: prefill-filter
+    - pluginRef: queue-scorer
+    - pluginRef: max-score-picker
+    - pluginRef: session-affinity-prefill
+  - name: decode
+    plugins:
+    - pluginRef: decode-filter
+    - pluginRef: queue-scorer
+    - pluginRef: max-score-picker
+    - pluginRef: session-affinity-decode
+`
+
+	ctx := t.Context()
+	h := NewTestHarness(ctx, t, WithStandardMode(), WithConfigText(configText)).WithBaseResources()
+
+	// Create pods with role labels. The by-label filters need llm-d.ai/role to
+	// separate prefill and decode candidates.
+	metricsMap := make(map[types.NamespacedName]*fwkdl.Metrics)
+	type podDef struct {
+		index int
+		role  string
+	}
+	pods := []podDef{
+		{0, bylabel.RolePrefill},
+		{1, bylabel.RolePrefill},
+		{2, bylabel.RoleDecode},
+		{3, bylabel.RoleDecode},
+	}
+	for _, p := range pods {
+		name := fmt.Sprintf("pod-%d", p.index)
+		metricsMap[types.NamespacedName{Namespace: h.Namespace, Name: name + "-rank-0"}] = &fwkdl.Metrics{
+			ActiveModels:  map[string]int{modelMyModelTarget: 1},
+			WaitingModels: make(map[string]int),
+		}
+		pod := testutil.MakePod(name).
+			Namespace(h.Namespace).
+			ReadyCondition().
+			Labels(map[string]string{
+				"app":             testPoolName,
+				bylabel.RoleLabel: p.role,
+			}).
+			IP(fmt.Sprintf("192.168.1.%d", p.index+1)).
+			Complete().
+			ObjRef()
+
+		intendedStatus := pod.Status
+		require.NoError(t, k8sClient.Create(ctx, pod))
+		pod.Status = intendedStatus
+		require.NoError(t, k8sClient.Status().Update(ctx, pod))
+	}
+	h.metricsBackend.SetPodMetrics(metricsMap)
+	h.WaitForSync(len(pods), modelMyModel)
+	h.WaitForReadyPodsMetric(len(pods))
+
+	// First request: no session headers.
+	firstDecodeEP, decodeToken := sendSessionRequest(t, h, "")
+	require.NotEmpty(t, decodeToken, "first response must carry a decode session token")
+
+	firstPrefillToken := sendSessionRequestGetHeader(t, h, "", "", prefillHeader)
+	require.NotEmpty(t, firstPrefillToken, "first response must carry a prefill session token")
+
+	// Second request: echo both tokens back.
+	secondDecodeEP, _ := sendSessionRequest(t, h, decodeToken)
+	require.Equal(t, firstDecodeEP, secondDecodeEP,
+		"second request must pin to the same decode endpoint")
+
+	secondPrefillToken := sendSessionRequestGetHeader(t, h, decodeToken, firstPrefillToken, prefillHeader)
+	require.NotEmpty(t, secondPrefillToken, "second response must carry a prefill session token")
+}
+
+// sendSessionRequestGetHeader drives a request through the EPP and returns the
+// value of the named response header. It extends sendSessionRequest to support
+// the prefill session token header.
+func sendSessionRequestGetHeader(t *testing.T, h *TestHarness, decodeToken, prefillToken, headerKey string) string {
+	t.Helper()
+
+	reqHeaders := map[string]string{
+		metadata.ObjectiveKey:        modelMyModel,
+		metadata.ModelNameRewriteKey: modelMyModelTarget,
+		reqcommon.RequestIDHeaderKey: "session-pd-req",
+	}
+	if decodeToken != "" {
+		reqHeaders[sessionutil.DefaultHeader] = decodeToken
+	}
+	if prefillToken != "" {
+		reqHeaders["x-session-token-prefill"] = prefillToken
+	}
+
+	requests := integration.ReqRaw(reqHeaders, `{"model":"`+modelMyModel+`","prompt":"hello","max_tokens":10,"temperature":0}`)
+	requests = append(requests, ReqResponseOnly(
+		map[string]string{"content-type": "application/json", "status": "200"},
+		`{"choices":[{"finish_reason":"stop","index":0,"message":{"content":"hi","role":"assistant"}}],"model":"`+modelMyModelTarget+`","object":"chat.completion","usage":{"completion_tokens":2,"prompt_tokens":3,"total_tokens":5}}`,
+	)...)
+
+	client, err := extProcPb.NewExternalProcessorClient(h.grpcConn).Process(t.Context())
+	require.NoError(t, err)
+
+	responses, err := integration.StreamedRequest(t, client, requests, 4)
+	require.NoError(t, err)
+	require.Len(t, responses, 4)
+
+	return headerValue(responses[2].GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), headerKey)
 }
 
 // headerValue returns the value set for key among the given header mutations, or


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Session affinity filter/scorer can optionally pick the scheduling profile to inject the routed endpoint from. This enables P/D disaggregation support.
```
