### PR TITLE
Tag container images with commit SHA

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -57,6 +57,7 @@ runs:
         tags: |
           ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}
           ${{ inputs.push == 'true' && inputs.prerelease != 'true' && format('{0}/{1}:latest', inputs.registry, inputs.image-name) || '' }}
+          ${{ inputs.commit-sha != '' && format('{0}/{1}:{2}', inputs.registry, inputs.image-name, inputs.commit-sha) || '' }}
         build-args: |
           LDFLAGS=-s -w
           COMMIT_SHA=${{ inputs.commit-sha || 'unknown' }}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Dev images are currently tagged only with the branch name, which is mutable: every push to main overwrites the previous image. This makes it impossible to pin a deployment or test run to the exact code that produced the image.

Add the commit SHA as an additional image tag so each build is individually addressable and immutable.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add the commit SHA as an additional image tag so each build is individually addressable and immutable.
```
