### PR TITLE
feat(prefixcacheaffinity): default explorationProbability to 0

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -56,7 +56,7 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 
 - Keep only endpoints with prefix cache score >= `affinityThreshold`
 - If no endpoints pass, all are kept (no-op)
-- With probability `explorationProbability` (default 1%), skip the gate entirely for exploration
+- With probability `explorationProbability` (default 0, disabled), skip the gate entirely for exploration
 - TTFT load gate: if best sticky endpoint's TTFT exceeds best non-sticky by more than
   `maxTTFTPenaltyMs`, break stickiness and keep all endpoints (0 = always stick). The
   per-endpoint TTFT is estimated from in-flight tokens as
@@ -72,7 +72,7 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
-| `explorationProbability` | `float64` | No | `0.01` | Probability of skipping the gate |
+| `explorationProbability` | `float64` | No | `0` | Probability of skipping the gate |
 | `maxTTFTPenaltyMs` | `float64` | No | `18000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
 | `ttftSource` | `string` | No | `prefillThroughput` | TTFT source for the load gate: `prefillThroughput` or `latencyPredictor` |
 | `peakPrefillThroughput` | `float64` | No | `15928` | Peak prefill throughput (tokens/sec), used to estimate TTFT when `ttftSource` is `prefillThroughput` |

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -64,7 +64,7 @@ type Config struct {
 	AffinityThreshold float64 `json:"affinityThreshold,omitempty"`
 
 	// ExplorationProbability is the probability of skipping the gate entirely,
-	// keeping all endpoints for exploration. Range: [0, 1]. Default: 0.01.
+	// keeping all endpoints for exploration. Range: [0, 1]. Default: 0.
 	ExplorationProbability float64 `json:"explorationProbability,omitempty"`
 
 	// MaxTTFTPenaltyMs is the max TTFT penalty (ms) before breaking stickiness.
@@ -92,7 +92,7 @@ type Config struct {
 
 var DefaultConfig = Config{
 	AffinityThreshold:      0.80,
-	ExplorationProbability: 0.01,
+	ExplorationProbability: 0,
 	MaxTTFTPenaltyMs:       18000,
 	TTFTSource:             TTFTSourcePrefillThroughput,
 


### PR DESCRIPTION
With the prefix affinity gate in place, randomly skipping it for exploration is mostly unnecessary, so disable it by default.
