### PR TITLE
fix(chart): qualify latency predictor uvicorn module path

### DIFF
--- a/config/charts/routerlib/templates/_latency-predictor.tpl
+++ b/config/charts/routerlib/templates/_latency-predictor.tpl
@@ -55,7 +55,7 @@ Latency Predictor Sidecar Containers
   image: {{ $.Values.router.latencyPredictor.predictionServers.image.registry }}/{{ $.Values.router.latencyPredictor.predictionServers.image.repository }}:{{ $.Values.router.latencyPredictor.predictionServers.image.tag }}
   imagePullPolicy: {{ $.Values.router.latencyPredictor.predictionServers.image.pullPolicy }}
   command: ["uvicorn"]
-  args: ["prediction_server:app", "--host", "0.0.0.0", "--port", "{{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}"]
+  args: ["llm_d_latency_predictor.prediction_server:app", "--host", "0.0.0.0", "--port", "{{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}"]
   ports:
   - containerPort: {{ add $.Values.router.latencyPredictor.predictionServers.startPort $i }}
     name: predict-port-{{ add $i 1 }}


### PR DESCRIPTION
## What
Update the latency-predictor Helm template to launch uvicorn with the
fully-qualified module path `llm_d_latency_predictor.prediction_server:app`.

## Why
The updated latency predictor image ships the prediction server as the
`llm_d_latency_predictor` package, matching the benchmark setup. Without the
package qualifier, uvicorn can't import the app on the new image.

## Changes
- `config/charts/routerlib/templates/_latency-predictor.tpl`: `prediction_server:app` -> `llm_d_latency_predictor.prediction_server:app`
