### PR TITLE
fix(sidecar): inject W3C trace context on outbound proxy requests

### DIFF
--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/go-logr/logr"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -400,10 +401,12 @@ func (s *Server) Clone() *Server {
 	}
 }
 
-// newProxyTransport returns an http.Transport cloned from the default with
-// connection-pool settings applied. If scheme is schemeHTTPS the transport's
-// TLSClientConfig is set accordingly.
-func (s *Server) newProxyTransport(scheme string, insecureSkipVerify bool) *http.Transport {
+// newProxyTransport returns an http.RoundTripper backed by an http.Transport
+// cloned from the default with connection-pool settings applied. If scheme is
+// schemeHTTPS the transport's TLSClientConfig is set accordingly. The transport
+// is wrapped with otelhttp so outbound requests carry W3C trace context,
+// keeping EPP, routing-proxy, and vLLM spans in a single trace.
+func (s *Server) newProxyTransport(scheme string, insecureSkipVerify bool) http.RoundTripper {
 	maxIdle := s.config.MaxIdleConnsPerHost
 	if maxIdle <= 0 {
 		maxIdle = defaultMaxIdleConnsPerHost
@@ -427,7 +430,7 @@ func (s *Server) newProxyTransport(scheme string, insecureSkipVerify bool) *http
 			},
 		}
 	}
-	return t
+	return otelhttp.NewTransport(t)
 }
 
 func (s *Server) setKVConnector() {

--- a/pkg/sidecar/proxy/transport_test.go
+++ b/pkg/sidecar/proxy/transport_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// newProxyTransport must inject W3C trace context into outbound requests so that
+// EPP -> routing-proxy -> vLLM share a single trace.
+func TestNewProxyTransportInjectsTraceContext(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+
+	var gotTraceparent string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	s := NewProxy(Config{})
+	client := &http.Client{Transport: s.newProxyTransport("http", false)}
+
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("parse trace ID: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("parse span ID: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, backend.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if gotTraceparent == "" {
+		t.Fatal("expected traceparent header to be injected into outbound request, got none")
+	}
+	if !strings.Contains(gotTraceparent, traceID.String()) {
+		t.Fatalf("expected outbound traceparent to carry trace ID %s, got %q", traceID, gotTraceparent)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind feature

**What this PR does / why we need it**:

The sidecar already extracts inbound trace context via `otelhttp.NewHandler` (`pkg/sidecar/proxy/proxy_helpers.go`), but its outbound calls went through a plain `http.Transport` cloned from the default, which never injects the propagator.

As a result vLLM's spans attached as unrelated traces in Jaeger instead of under the same trace as EPP and the routing proxy.

`newProxyTransport` is the single construction point for all three downstream reverse proxies (decoder, prefiller, encoder), so wrapping it once covers every outbound path. Injection uses the global propagator already configured in `pkg/common/observability/tracing` (W3C TraceContext + Baggage), so no per-call wiring is needed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Addresses gap 2 (trace propagation) of #1485.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fix P/D sidecar trace propagation so prefill, decode, and encoder requests inject W3C trace context, keeping EPP, routing-proxy, and vLLM spans in a single trace
```
