### PR TITLE
feat(monitoring): ship default EPP Prometheus alerting rules

### DIFF
--- a/deploy/components/monitoring/epp-alerting-rules.yaml
+++ b/deploy/components/monitoring/epp-alerting-rules.yaml
@@ -1,0 +1,94 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: epp-alerting-rules
+  labels:
+    app: epp-metrics
+spec:
+  groups:
+  # ---------------------------------------------------------------------------
+  # Availability and errors
+  # ---------------------------------------------------------------------------
+  - name: epp.availability
+    rules:
+    - alert: EPPHighErrorRatio
+      # Fraction of EPP requests returning an error. 0/0 yields no value, so this
+      # stays silent when there is no traffic. If your workload is low-volume and
+      # you see flapping at startup, add a request-rate floor with `and ... > N`.
+      expr: |
+        sum(rate(llm_d_router_epp_request_error_total[5m]))
+          / sum(rate(llm_d_router_epp_request_total[5m]))
+          > 0.05
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP error ratio above 5%"
+        description: "EPP request error ratio has been above 5% for 10m (current {{ $value | humanizePercentage }})."
+    - alert: EPPCriticalErrorRatio
+      expr: |
+        sum(rate(llm_d_router_epp_request_error_total[5m]))
+          / sum(rate(llm_d_router_epp_request_total[5m]))
+          > 0.20
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "EPP error ratio above 20%"
+        description: "EPP request error ratio has been above 20% for 5m (current {{ $value | humanizePercentage }}). The inference path is likely degraded."
+    - alert: EPPNoReadyEndpoints
+      # The pool has zero ready endpoints, so the EPP cannot route any request.
+      expr: llm_d_router_epp_ready_endpoints == 0
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: "EPP pool {{ $labels.name }} has no ready endpoints"
+        description: "llm_d_router_epp_ready_endpoints has been 0 for pool {{ $labels.name }} for 2m. The pool is unroutable."
+    - alert: EPPMetricsAbsent
+      # ready_endpoints is emitted continuously by the pool collector regardless of
+      # traffic, so its disappearance means the EPP is down or the ServiceMonitor
+      # stopped scraping it (a silent observability gap).
+      expr: absent(llm_d_router_epp_ready_endpoints)
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "EPP metrics are not being scraped"
+        description: "No llm_d_router_epp_ready_endpoints samples for 5m. The EPP is down or its ServiceMonitor is broken."
+
+  # ---------------------------------------------------------------------------
+  # EPP self-health
+  # ---------------------------------------------------------------------------
+  - name: epp.selfhealth
+    rules:
+    - alert: EPPDataLayerPollErrors
+      # A data source failed to poll, so scheduling may be running on stale
+      # endpoint state. This is otherwise invisible.
+      expr: sum by (source_type) (rate(llm_d_router_epp_datalayer_poll_errors_total[5m])) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP data layer poll errors for source {{ $labels.source_type }}"
+        description: "llm_d_router_epp_datalayer_poll_errors_total is increasing for source {{ $labels.source_type }}. Scheduling may be using stale data."
+    - alert: EPPDataLayerExtractErrors
+      expr: sum by (source_type, extractor_type) (rate(llm_d_router_epp_datalayer_extract_errors_total[5m])) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP data layer extract errors ({{ $labels.source_type }}/{{ $labels.extractor_type }})"
+        description: "llm_d_router_epp_datalayer_extract_errors_total is increasing for {{ $labels.source_type }}/{{ $labels.extractor_type }}. Scheduling may be using stale data."
+    # ext_proc stream metrics are opt-in (EPP flag --enable-grpc-stream-metrics).
+    # When the flag is unset these series are absent and the alert below simply
+    # never fires. "Abnormal" excludes OK and Canceled (the latter is a normal
+    # client disconnect); tune the matcher for your environment.
+    - alert: EPPExtProcStreamErrors
+      expr: sum by (code) (rate(llm_d_router_epp_extproc_streams_total{code!~"OK|Canceled"}[5m])) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP ext_proc streams terminating with {{ $labels.code }}"
+        description: "ext_proc gRPC streams are completing with status {{ $labels.code }}. Envoy<->EPP request processing may be failing."

--- a/deploy/components/monitoring/kustomization.yaml
+++ b/deploy/components/monitoring/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
 - epp-service-monitor.yaml
+- epp-alerting-rules.yaml
 - vllm-sim-pod-monitor.yaml

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -451,6 +451,7 @@ if [ "${PROM_ENABLED}" == "true" ]; then
     --set kubeScheduler.enabled=false \
     --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
     --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
+    --set prometheus.prometheusSpec.ruleSelectorNilUsesHelmValues=false \
     --set prometheus.prometheusSpec.resources.requests.memory=512Mi \
     --set prometheus.prometheusSpec.resources.limits.memory=1Gi \
     --set prometheus.service.type=NodePort \


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Ships a default set of EPP Prometheus alerting rules as a `PrometheusRule` under
`deploy/components/monitoring/`, wired into the same kustomization as the existing
ServiceMonitor (same `${EPP_NAME}` path). The repo exposes a rich `llm_d_router_epp_*`
metric set but shipped no alerts, so every deployment had to hand-write them.

This is the first slice of #1635 — **availability/errors** and **EPP self-health** —
using metric names that are stable today. Latency SLO and flow-control saturation
alerts will follow as separate sub-task PRs, per the discussion on the issue.

**Alerts added**

`epp.availability`
- `EPPHighErrorRatio` / `EPPCriticalErrorRatio` — error ratio (warning 5%, critical 20%)
- `EPPNoReadyEndpoints` — `ready_endpoints == 0`, the pool is unroutable
- `EPPMetricsAbsent` — `absent(ready_endpoints)`, catches a dead EPP or broken ServiceMonitor

`epp.selfhealth`
- `EPPDataLayerPollErrors` / `EPPDataLayerExtractErrors` — scheduling running on stale data
- `EPPExtProcStreamErrors` — abnormal ext_proc stream terminations (opt-in metric)