### PR TITLE
release: configure and pass LATENCY_PREDICTOR_TAG via Makefile

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -25,19 +25,26 @@ This document defines the process for releasing llm-d-router.
    `refs/tags/v*` restricts who can push release tags, which is what triggers
    the release build.
 
-1. Set the required environment variables based on the expected release number:
+1. Choose whether you are releasing a release candidate or an official release, and set the environment variables accordingly:
+
+   - For a **Release Candidate** (e.g. `v0.9.0-rc.1`):
+     ```shell
+     export VERSION=v0.9.0-rc.1
+     export BRANCH_VERSION=0.9
+     export REMOTE=origin
+     ```
+
+   - For an **Official Release** (e.g. `v0.9.0`):
+     ```shell
+     export VERSION=v0.9.0
+     export BRANCH_VERSION=0.9
+     export REMOTE=origin
+     ```
+
+1. (Optional) If the latency predictor release version does **not** align with the router version, also set the expected tag (refer to the [latency predictor releases] to find the latest valid release tag):
 
    ```shell
-   export MAJOR=0
-   export MINOR=1
-   export PATCH=0
-   export REMOTE=origin
-   ```
-
-1. If creating a release candidate, set the release candidate number.
-
-   ```shell
-   export RC=1
+   export LATENCY_PREDICTOR_TAG=v0.8.0-rc.1
    ```
 1. If needed, clone the llm-d-router [repo].
 
@@ -53,54 +60,46 @@ This document defines the process for releasing llm-d-router.
 
 1. Release Branch Handling:
    - For a Release Candidate:
-     Create a new release branch from the `main` branch. The branch should be named `release-${MAJOR}.${MINOR}`, for example, `release-0.1`:
+     Create a new release branch from the `main` branch. The branch should be named `release-${BRANCH_VERSION}`, for example, `release-0.9`:
 
      ```shell
-     git checkout -b release-${MAJOR}.${MINOR}
+     git checkout -b release-${BRANCH_VERSION}
      ```
 
    - For a Major, Minor or Patch Release:
      A release branch should already exist. In this case, check out the existing branch:
 
      ```shell
-     git checkout release-${MAJOR}.${MINOR} ${REMOTE}/release-${MAJOR}.${MINOR}
+     git checkout release-${BRANCH_VERSION} ${REMOTE}/release-${BRANCH_VERSION}
      ```
+
+1. By default, `LATENCY_PREDICTOR_TAG` in the `Makefile` automatically resolves to the router release version (`${BUILD_REF}`). If the latency predictor tag does **not** align with the router version, update the default value of `LATENCY_PREDICTOR_TAG` in the `Makefile` to match your exported `${LATENCY_PREDICTOR_TAG}`.
+   Commit the change (if modified):
+
+    ```shell
+    # Update LATENCY_PREDICTOR_TAG ?= vX.Y.Z in Makefile
+    git commit -a -s -m "release: set LATENCY_PREDICTOR_TAG to ${LATENCY_PREDICTOR_TAG}"
+    ```
 
 1. Push your release branch to the llm-d-router remote.
 
     ```shell
-    git push ${REMOTE} release-${MAJOR}.${MINOR}
+    git push ${REMOTE} release-${BRANCH_VERSION}
     ```
 
 ### Tag commit and trigger image build
 
-1. Tag the head of your release branch with the sem-ver release version.
+1. Tag the head of your release branch with the version:
 
-   For a release candidate:
+     ```shell
+     git tag -s -a ${VERSION} -m "llm-d-router ${VERSION} Release"
+     ```
 
-    ```shell
-    git tag -s -a v${MAJOR}.${MINOR}.${PATCH}-rc.${RC} -m "llm-d-router v${MAJOR}.${MINOR}.${PATCH}-rc.${RC} Release Candidate"
-    ```
+1. Push the tag to the llm-d-router repo:
 
-   For a major, minor or patch release:
-
-    ```shell
-    git tag -s -a v${MAJOR}.${MINOR}.${PATCH} -m "llm-d-router v${MAJOR}.${MINOR}.${PATCH} Release"
-    ```
-
-1. Push the tag to the llm-d-router repo.
-
-   For a release candidate:
-
-    ```shell
-    git push ${REMOTE} v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}
-    ```
-
-   For a major, minor or patch release:
-
-    ```shell
-    git push ${REMOTE} v${MAJOR}.${MINOR}.${PATCH}
-    ```
+     ```shell
+     git push ${REMOTE} ${VERSION}
+     ```
 
 1. Pushing the tag triggers CI action to build and publish the EPP image (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) and sidecar image (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) to the [ghcr registry].
 1. Verify the [CI release workflow] completed successfully before proceeding.
@@ -111,8 +110,17 @@ This document defines the process for releasing llm-d-router.
 1. Create a [new release]:
     1. Choose the tag that you created for the release.
     1. Use the tag as the release title, e.g. `v0.1.0`.
-    1. Click "Generate release notes" and preview the release body.
-    1. Ensure the release body includes: highlights, breaking changes (if any), known issues, and upgrade steps.
+    1. Click "Generate release notes" to auto-populate the list of PRs and contributors.
+    1. Summarize the release notes using an LLM of your choice (e.g., Gemini, Copilot, ChatGPT). Provide the newly compiled release notes block from `RELEASE-NOTES.md` (or the unreleased fragments in `release-notes.d/unreleased/`) with the following prompt:
+
+       ```text
+       Please summarize these release notes into three clear sections:
+       1. Highlights (key features, performance wins, bug fixes)
+       2. Upgrade Steps & Deprecations (configuration changes, deprecated flags/metrics)
+       3. Known Issues (if any, otherwise omit)
+       ```
+
+       Review the generated content, edit it if necessary to ensure accuracy, and then copy and prepend this summary at the very top of the release description box on GitHub.
     1. If this is a release candidate, select the "This is a pre-release" checkbox.
 1. If you find any bugs in this process, create an [issue].
 
@@ -120,11 +128,30 @@ This document defines the process for releasing llm-d-router.
 
 Use the following steps to announce the release.
 
-1. Send an announcement email to `llm-d-contributors@googlegroups.com` with the subject:
+1. Generate the announcement email content by running the following block in your terminal (make sure `${VERSION}` is set in your current shell):
 
    ```shell
-   [ANNOUNCE] llm-d-router v${MAJOR}.${MINOR}.${PATCH} is released
+   cat <<EOF
+   Subject: [ANNOUNCE] llm-d-router ${VERSION} is released
+
+   Hi all,
+
+   We are pleased to announce the release of llm-d-router ${VERSION}!
+
+   ### Container Images
+   * Endpoint Picker: ghcr.io/llm-d/llm-d-router-endpoint-picker:${VERSION}
+   * Disaggregated Sidecar: ghcr.io/llm-d/llm-d-router-disagg-sidecar:${VERSION}
+
+   ### Helm Charts (OCI)
+   * Standalone Chart: oci://ghcr.io/llm-d/charts/llm-d-router-standalone (version ${VERSION})
+   * Gateway Chart: oci://ghcr.io/llm-d/charts/llm-d-router-gateway (version ${VERSION})
+
+   ### Release Notes
+   For more details, please see the GitHub release notes: https://github.com/llm-d/llm-d-router/releases/tag/${VERSION}
+   EOF
    ```
+
+1. Copy the generated subject and body, and send an email to `llm-d-contributors@googlegroups.com`.
 
 1. Add a link to the final release in this issue.
 
@@ -135,3 +162,4 @@ Use the following steps to announce the release.
 [new release]: https://github.com/llm-d/llm-d-router/releases/new
 [issue]: https://github.com/llm-d/llm-d-router/issues/new/choose
 [CI release workflow]: https://github.com/llm-d/llm-d-router/actions/workflows/ci-release.yaml
+[latency predictor releases]: https://github.com/orgs/llm-d/packages?repo_name=llm-d-latency-predictor

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -73,7 +73,7 @@ This document defines the process for releasing llm-d-router.
      git checkout release-${BRANCH_VERSION} ${REMOTE}/release-${BRANCH_VERSION}
      ```
 
-1. By default, `LATENCY_PREDICTOR_TAG` in the `Makefile` automatically resolves to the router release version (`${BUILD_REF}`). If the latency predictor tag does **not** align with the router version, update the default value of `LATENCY_PREDICTOR_TAG` in the `Makefile` to match your exported `${LATENCY_PREDICTOR_TAG}`.
+1. By default, `LATENCY_PREDICTOR_TAG` in the `Makefile` resolves from the router release tag (via `BUILD_REF`). If the latency predictor tag does **not** align with the router version, update the default value of `LATENCY_PREDICTOR_TAG` in the `Makefile` to match your exported `${LATENCY_PREDICTOR_TAG}`.
    Commit the change (if modified):
 
     ```shell

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ GIT_COMMIT_SHA ?= $(shell git rev-parse HEAD 2>/dev/null)
 # Match only root-level release tags (v[0-9]*) so submodule tags don't leak into image versions.
 ROOT_RELEASE_TAG_MATCH ?= v[0-9]*
 BUILD_REF ?= $(shell git describe --tags --match '$(ROOT_RELEASE_TAG_MATCH)' --abbrev=0 2>/dev/null)
+LATENCY_PREDICTOR_TAG ?= $(or $(BUILD_REF),latest)
 
 # Host directories for Go module and build caches, bind-mounted into the builder container.
 GO_MOD_CACHE_VOL ?= $(HOME)/.cache/llm-d-gomodcache
@@ -348,7 +349,7 @@ verify-helm-charts: helm-install kubectl-validate ## Render and validate Helm ch
 .PHONY: helm-push
 helm-push: yq helm-install ## Package and push a specified Helm chart. Usage: make helm-push CHART=<chart_name>
 	@if [ -z "$(CHART)" ]; then echo "Error: CHART variable is required (e.g. CHART=llm-d-router-standalone)"; exit 1; fi
-	CHART=$(CHART) EXTRA_TAG="$(EXTRA_TAG)" CHART_SUFFIX="$(CHART_SUFFIX)" EPP_RELEASE_IMAGE_REPOSITORY="$(EPP_RELEASE_IMAGE_REPOSITORY)" YQ="$(YQ)" HELM="$(HELM)" ./hack/push-chart.sh
+	CHART=$(CHART) EXTRA_TAG="$(EXTRA_TAG)" CHART_SUFFIX="$(CHART_SUFFIX)" EPP_RELEASE_IMAGE_REPOSITORY="$(EPP_RELEASE_IMAGE_REPOSITORY)" LATENCY_PREDICTOR_TAG="$(LATENCY_PREDICTOR_TAG)" YQ="$(YQ)" HELM="$(HELM)" ./hack/push-chart.sh
 
 .PHONY: helm-push-gateway
 helm-push-gateway: ## Package and push the llm-d-router-gateway Helm chart.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ GIT_COMMIT_SHA ?= $(shell git rev-parse HEAD 2>/dev/null)
 # Match only root-level release tags (v[0-9]*) so submodule tags don't leak into image versions.
 ROOT_RELEASE_TAG_MATCH ?= v[0-9]*
 BUILD_REF ?= $(shell git describe --tags --match '$(ROOT_RELEASE_TAG_MATCH)' --abbrev=0 2>/dev/null)
-LATENCY_PREDICTOR_TAG ?= $(or $(BUILD_REF),latest)
+LATENCY_PREDICTOR_TAG ?= $(or $(EXTRA_TAG),$(BUILD_REF),latest)
 
 # Host directories for Go module and build caches, bind-mounted into the builder container.
 GO_MOD_CACHE_VOL ?= $(HOME)/.cache/llm-d-gomodcache


### PR DESCRIPTION
This PR configures and passes the  via the Makefile, updating the release template to consolidated version variables and prompting for LLM-based release notes summarization.