### PR TITLE
fix(scripts): support single quotes in image check

### DIFF
--- a/scripts/check-latest-tags.sh
+++ b/scripts/check-latest-tags.sh
@@ -35,7 +35,7 @@ set -o pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Images under these llm-d-owned registries may use ':latest'.
-OWNED_IMAGE_RE='image:[[:space:]]*"?(ghcr\.io|quay\.io)/llm-d/'
+OWNED_IMAGE_RE='image:[[:space:]]*['\''"]?(ghcr\.io|quay\.io)/llm-d/'
 
 WARN_ONLY=false
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In YAML, quoting image names with either single quotes or double quotes is a valid format.  (e.g.,  image: 'ghcr.io/llm-d/llm-d-inference-sim:latest' ).

the OWNED_IMAGE_RE  regex handles only optional double quotes (  "? ), skipping single-quoted inputs. 
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
