### PR TITLE
update helm chart to use preferred backends for gke

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -492,6 +492,12 @@ Configures routing policies, target Gateway interfaces, and priority objectives 
 | `provider.name` | Name of Gateway implementation. Options: `[none, gke, istio]`. | `none` |
 | `provider.istio.destinationRule.host` | Custom host value for Istio DestinationRule. | `""` |
 | `provider.istio.destinationRule.trafficPolicy.connectionPool` | Connection pool settings for Istio DestinationRule. | `{}` |
+| `provider.gke.preferredBackends.enabled` | Enable Preferred Backends high availability routing for GKE. | `false` |
+| `provider.gke.preferredBackends.preferredReplicas` | Replica count for primary active pod ordinals pinned to PREFERRED tier. | `1` |
+| `provider.gke.preferredBackends.defaultReplicas` | Replica count for standby backup pod ordinals pinned to DEFAULT tier. | `1` |
+| `provider.gke.preferredBackends.balancingMode` | Load balancing calculation mode (`RATE`, `UTILIZATION`, `CONNECTION`). | `RATE` |
+| `provider.gke.preferredBackends.maxRatePerEndpoint` | Maximum requests per second per pod instance before spilling over. | `100` |
+| `provider.gke.preferredBackends.capacityScalerPercent` | Effective capacity ceiling percentage (`0` to `100`). | `100` |
 | `httpRoute.create` | Deploy an `HTTPRoute` resource as part of the gateway chart. | `false` |
 | `httpRoute.inferenceGatewayName` | Target Gateway name for the `HTTPRoute`. | `inference-gateway` |
 | `httpRoute.inferenceGatewayNamespace` | Target Gateway namespace for the `HTTPRoute`. | `""` |
@@ -502,6 +508,14 @@ Configures routing policies, target Gateway interfaces, and priority objectives 
 ```yaml
 provider:
   name: gke # Use GKE gateway implementation
+  gke:
+    preferredBackends:
+      enabled: true
+      preferredReplicas: 1
+      defaultReplicas: 1
+      balancingMode: RATE
+      maxRatePerEndpoint: 100
+      capacityScalerPercent: 100
   
 httpRoute:
   create: true

--- a/config/charts/llm-d-router-gateway/templates/gke.yaml
+++ b/config/charts/llm-d-router-gateway/templates/gke.yaml
@@ -59,7 +59,43 @@ spec:
         portSpecification: "USE_FIXED_PORT"
         port: {{ $eppHealthPort }}
 {{- end }}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+{{- range $i := untilStep 1 (int $totalReplicas) 1 }}
+{{- $serviceName := printf "%s-preferred-%d" (include "llm-d-router.name" $) (int $i) }}
+{{- if ge (int $i) (int $preferredReplicas) }}
+  {{- if eq (int $i) (int $preferredReplicas) }}
+    {{- $serviceName = printf "%s-backup" (include "llm-d-router.name" $) }}
+  {{- else }}
+    {{- $serviceName = printf "%s-backup-%d" (include "llm-d-router.name" $) (sub (int $i) (int $preferredReplicas)) }}
+  {{- end }}
+{{- end }}
 ---
+kind: HealthCheckPolicy
+apiVersion: networking.gke.io/v1
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" $ | nindent 4 }}
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $serviceName }}
+  default:
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        portSpecification: "USE_FIXED_PORT"
+        port: {{ $eppHealthPort }}
+{{- end }}
+{{- end }}
+---
+{{- if not $gkePB.enabled }}
 apiVersion: networking.gke.io/v1
 kind: GCPBackendPolicy
 metadata:
@@ -78,4 +114,51 @@ spec:
       enabled: true    # log all requests by default
 ---
 {{- end }}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+{{- range $i := untilStep 0 (int $totalReplicas) 1 }}
+{{- $serviceName := printf "%s-preferred-%d" (include "llm-d-router.name" $) (int $i) }}
+{{- $policyName := printf "%s-preferred-%d" $.Release.Name (int $i) }}
+{{- $pref := "PREFERRED" }}
+{{- if eq (int $i) 0 }}
+  {{- $serviceName = include "llm-d-router.name" $ }}
+  {{- $policyName = $.Release.Name }}
+{{- else if ge (int $i) (int $preferredReplicas) }}
+  {{- $pref = "DEFAULT" }}
+  {{- if eq (int $i) (int $preferredReplicas) }}
+    {{- $serviceName = printf "%s-backup" (include "llm-d-router.name" $) }}
+    {{- $policyName = printf "%s-backup" $.Release.Name }}
+  {{- else }}
+    {{- $serviceName = printf "%s-backup-%d" (include "llm-d-router.name" $) (sub (int $i) (int $preferredReplicas)) }}
+    {{- $policyName = printf "%s-backup-%d" $.Release.Name (sub (int $i) (int $preferredReplicas)) }}
+  {{- end }}
+{{- end }}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $serviceName }}
+  default:
+    timeoutSec: 300
+    backendPreference: {{ $pref }}
+    {{- if $gkePB.balancingMode }}
+    balancingMode: {{ $gkePB.balancingMode }}
+    {{- end }}
+    {{- if $gkePB.maxRatePerEndpoint }}
+    maxRatePerEndpoint: {{ $gkePB.maxRatePerEndpoint }}
+    {{- end }}
+    {{- if $gkePB.capacityScalerPercent }}
+    capacityScalerPercent: {{ $gkePB.capacityScalerPercent }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}
 {{- include "llm-d-router.gke" . -}}
+{{- end }}

--- a/config/charts/llm-d-router-gateway/values.yaml
+++ b/config/charts/llm-d-router-gateway/values.yaml
@@ -21,6 +21,23 @@ provider:
         #   http:
         #     maxRequestsPerConnection: 256000
 
+  # GKE-specific configuration.
+  # This block is only used if name is "gke".
+  gke:
+    preferredBackends:
+      enabled: false
+      # Number of primary active pod instances pinned to the PREFERRED load balancing tier.
+      # Setting >1 scales concurrent active routing.
+      preferredReplicas: 1
+      # Number of standby pod instances pinned to the DEFAULT load balancing tier.
+      # Setting >1 scales warm standby failover capacity.
+      defaultReplicas: 1
+      # Benchmark capacity and threshold settings for PREFERRED load balancing tier.
+      # When incoming traffic exceeds capacityScalerPercent of maxRatePerEndpoint, excess traffic spills over to DEFAULT standby pods.
+      balancingMode: RATE
+      maxRatePerEndpoint: 100
+      capacityScalerPercent: 100
+
 # httpRoute section is used to deploy an HTTPRoute resource as part of the gateway chart.
 httpRoute:
   create: false # a flag to indicate whether to create the httproute as part of the chart or not.

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -1,35 +1,4 @@
-{{- define "llm-d-epp.deployment" -}}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "llm-d-router.name" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "llm-d-router.labels" . | nindent 4 }}
-    {{- include "llm-d-router.modeLabels" . | nindent 4 }}
-spec:
-  replicas: {{ .Values.router.epp.replicas | default 1 }}
-  strategy:
-    # The current recommended EPP deployment pattern is to have a single active replica. This ensures
-    # optimal performance of the stateful operations such prefix cache aware scorer.
-    # The Recreate strategy the old replica is killed immediately, and allow the new replica(s) to
-    # quickly take over. This is particularly important in the high availability set up with leader
-    # election, as the rolling update strategy would prevent the old leader being killed because
-    # otherwise the maxUnavailable would be 100%.
-    type: Recreate
-  selector:
-    matchLabels:
-      {{- include "llm-d-router.selectorLabels" . | nindent 6 }}
-  template:
-    metadata:
-      labels:
-        {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
-        {{- include "llm-d-router.modeLabels" . | nindent 8 }}
-      {{- with .Values.router.epp.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    spec:
+{{- define "llm-d-epp.deployment-pod-spec" -}}
       {{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict }}
       {{- $proxyType := include "llm-d-router.proxyType" . | trim }}
       {{- $proxyMode := include "llm-d-router.proxyMode" . | trim }}
@@ -132,8 +101,8 @@ spec:
               - --zap-encoder
               - "json"
               - --config-file
-              - "/config/{{ .Values.router.epp.pluginsConfigFile }}"
-          {{- if gt (.Values.router.epp.replicas | int) 1 }}
+          {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
+          {{- if and (gt (.Values.router.epp.replicas | int) 1) (not $gkePB.enabled) }}
               - --ha-enable-leader-election
           {{- end }}
           {{- $grpcHealthPort := .Values.router.epp.grpcHealthPort | default 9003 }}
@@ -309,5 +278,74 @@ spec:
       tolerations:
         {{- toYaml .Values.router.epp.tolerations | nindent 8 }}
       {{- end }}
+{{- end }}
+
+{{- define "llm-d-epp.deployment" -}}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.modeLabels" . | nindent 4 }}
+spec:
+  replicas: {{ $totalReplicas }}
+  serviceName: {{ include "llm-d-router.name" . }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
+        {{- include "llm-d-router.modeLabels" . | nindent 8 }}
+      {{- with .Values.router.epp.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+{{ include "llm-d-epp.deployment-pod-spec" . }}
 ---
+{{- else }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-d-router.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+    {{- include "llm-d-router.modeLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.router.epp.replicas | default 1 }}
+  strategy:
+    # The current recommended EPP deployment pattern is to have a single active replica. This ensures
+    # optimal performance of the stateful operations such prefix cache aware scorer.
+    # The Recreate strategy the old replica is killed immediately, and allow the new replica(s) to
+    # quickly take over. This is particularly important in the high availability set up with leader
+    # election, as the rolling update strategy would prevent the old leader being killed because
+    # otherwise the maxUnavailable would be 100%.
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "llm-d-router.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
+        {{- include "llm-d-router.modeLabels" . | nindent 8 }}
+      {{- with .Values.router.epp.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+{{ include "llm-d-epp.deployment-pod-spec" . }}
+---
+{{- end }}
 {{- end }}

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -443,13 +443,37 @@ EPP resource validations
 {{- end -}}
 
 {{/*
+Helper to retrieve GKE preferredBackends configuration safely across chart contexts.
+*/}}
+{{- define "llm-d-router.gkePreferredBackends" -}}
+{{- $provider := .Values.provider | default dict -}}
+{{- $gke := index $provider "gke" | default dict -}}
+{{- index $gke "preferredBackends" | default dict | toYaml -}}
+{{- end -}}
+
+{{/*
 EPP generic validations
 */}}
+{{- define "llm-d-router.validations.epp.preferredBackends" -}}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- if $gkePB.enabled }}
+  {{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+  {{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+  {{- if lt $preferredReplicas 1 }}
+    {{- fail ".Values.provider.gke.preferredBackends.preferredReplicas must be at least 1 when preferredBackends.enabled is true" }}
+  {{- end }}
+  {{- if lt $defaultReplicas 1 }}
+    {{- fail ".Values.provider.gke.preferredBackends.defaultReplicas must be at least 1 when preferredBackends.enabled is true" }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "llm-d-router.validations.epp" -}}
 {{- include "llm-d-router.validations.deprecations" . }}
 {{- include "llm-d-router.validations.epp.resources" . }}
 {{- include "llm-d-router.validations.epp.inferenceObjectives" . }}
 {{- include "llm-d-router.validations.epp.tokenizer" . }}
+{{- include "llm-d-router.validations.epp.preferredBackends" . }}
 {{- end -}}
 
 {{/*

--- a/config/charts/routerlib/templates/_inferencepool.yaml
+++ b/config/charts/routerlib/templates/_inferencepool.yaml
@@ -26,7 +26,12 @@ spec:
       {{- end }}
       {{- end }}
   endpointPickerRef:
+    {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
+    {{- if $gkePB.enabled }}
+    name: {{ printf "%s-backup" (include "llm-d-router.name" .) }}
+    {{- else }}
     name: {{ include "llm-d-router.name" . }}
+    {{- end }}
     port:
       number: {{ .Values.router.epp.extProcPort | default 9002 }}
     failureMode: {{ .Values.router.inferencePool.failureMode | default "FailOpen" }}

--- a/config/charts/routerlib/templates/_service.yaml
+++ b/config/charts/routerlib/templates/_service.yaml
@@ -1,4 +1,47 @@
 {{- define "llm-d-epp.service" -}}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- if $gkePB.enabled }}
+{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+{{- range $i := untilStep 0 (int $totalReplicas) 1 }}
+{{- $serviceName := printf "%s-preferred-%d" (include "llm-d-router.name" $) (int $i) }}
+{{- if eq (int $i) 0 }}
+  {{- $serviceName = include "llm-d-router.name" $ }}
+{{- else if ge (int $i) (int $preferredReplicas) }}
+  {{- if eq (int $i) (int $preferredReplicas) }}
+    {{- $serviceName = printf "%s-backup" (include "llm-d-router.name" $) }}
+  {{- else }}
+    {{- $serviceName = printf "%s-backup-%d" (include "llm-d-router.name" $) (sub (int $i) (int $preferredReplicas)) }}
+  {{- end }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" $ | nindent 4 }}
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports":{"{{ $.Values.router.epp.extProcPort | default 9002 }}":{}}}'
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: {{ printf "%s-%d" (include "llm-d-router.name" $) (int $i) }}
+  ports:
+    - name: grpc-ext-proc
+      protocol: TCP
+      port: {{ $.Values.router.epp.extProcPort | default 9002 }}
+      appProtocol: kubernetes.io/h2c
+    - name: http-metrics
+      protocol: TCP
+      port: {{ $.Values.router.metricsPort | default 9090 }}
+    {{- with $.Values.router.extraServicePorts }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+  type: ClusterIP
+---
+{{- end }}
+{{- else }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,6 +56,7 @@ spec:
     - name: grpc-ext-proc
       protocol: TCP
       port: {{ .Values.router.epp.extProcPort | default 9002 }}
+      appProtocol: kubernetes.io/h2c
     - name: http-metrics
       protocol: TCP
       port: {{ .Values.router.metricsPort | default 9090 }}
@@ -20,5 +64,5 @@ spec:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   type: ClusterIP
----
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enable helm chart to deploy multiple EPP services and GCPBackendPolicies for gke preferred backends.

[Link to external guide](https://docs.google.com/document/d/10MhQXrj9XOwo-gg14yOG9fevDhcBf3vW2WeITqG7Y04/edit?pli=1&tab=t.0)

The helm chart deploys 2 EPP deployments, where the "standby/default" pods are attached to the inferencepool. The preferred pods (Active) are deployed after where the user will have to run gcloud commands to attach the backend to the inferencepool. This ensures that when active goes down, passive is always ready to ingest traffic. 

Preferred Backends also allows for safe failover by setting traffic capacity to avoid overloading the pod. (Ex. We can set the traffic threshold to be 95% capacity before standby pods get traffic).

## Test Results

### Active-Passive HA (preferredReplicas: 1, defaultReplicas: 1)

Test Scenario | Traffic Profile | Succeeded / Total | Median Latency (p50) | Notes
-- | -- | -- | -- | --
Baseline Routing | 20 sequential requests | 20 / 20 (0 dropped) | 0.092 s | Traffic routes to active Preferred pod ordinal (optimized-baseline-epp-0).
Live Failover / Draining | Continuous stream while draining primary tier (capacityScalerPercent: 0) | 24 / 25 (1 timed out) | 0.092 s | 1 timeout (HTTP 504) during ~3s window while health probers mark primary NEG capacity zero; 100% instant failover to warm standby backup pod (optimized-baseline-epp-1).
Graceful Failback | Continuous stream while restoring primary capacity (capacityScalerPercent: 100) | 25 / 25 (0 dropped) | 0.092 s | 0 dropped connections. Traffic continues hitting standby pod until GCP probers mark recovered primary pod healthy.
Load Spillover | 100 concurrent requests (~40 req/s vs maxRatePerEndpoint: 5) | 99 / 100 (1 dropped) | 0.100 s | Excess burst traffic spills over natively in Envoy memory to standby default tier without dropped connections.

### Active-Active HA (preferredReplicas: 2, defaultReplicas: 2)

Test Scenario | Traffic Profile | Succeeded / Total | Median Latency (p50) | Notes
-- | -- | -- | -- | --
Active-Active Baseline | 50 concurrent requests across 10 threads | 50 / 50 (0 dropped) | 0.104 s | Traffic actively balances across both active leader pod ordinals (optimized-baseline-epp-0 and optimized-baseline-epp-1).
Scenario A: 1 Active Pod Down | Stream during primary pod crash / drain (capacityScalerPercent: 50) | 25 / 25 (0 dropped) | 0.104 s | When 1 active leader pod crashes or drains, the remaining active leader pod handles 100% of Preferred traffic without dropped connections.
Scenario B: Both Actives Down | Stream during full primary drain (capacityScalerPercent: 0) | 25 / 25 (0 dropped) | 0.100 s | Once all active Preferred leader pods terminate or drain, 100% of incoming traffic shifts seamlessly to warm standby backup pods (optimized-baseline-epp-2 and optimized-baseline-epp-3).


### Optimized Baseline Benchmark

Workload Profile | Mean Prompt / Output | Success Rate | Achieved QPS | Total Throughput | Output Throughput | TTFT (Median) | TPOT (Median) | Req Latency (Median / p99)
-- | -- | -- | -- | -- | -- | -- | -- | --
guide_optimized-baseline_1.yaml | 6,000 / 1,000 tokens | 100% (250 / 250) | 36.38 req/s | 18,885 tokens/s | 13,163 tokens/s | 0.156 s | 0.047 s | 47.16 s / 52.40 s


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Enable helm chart to deploy epp with GKE preferred backends
```