### PR TITLE
fix: resolve mismatched yq path for nested router subchart values

### DIFF
--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -50,14 +50,14 @@ then
     exit 1
   fi
   ${YQ} -i \
-    '.latencyPredictor.trainingServer.image.registry=strenv(IMAGE_REGISTRY) |
-     .latencyPredictor.trainingServer.image.repository="llm-d-latency-predictor-training-server" |
-     .latencyPredictor.trainingServer.image.tag=strenv(LATENCY_PREDICTOR_TAG) |
-     .latencyPredictor.trainingServer.image.pullPolicy="IfNotPresent" |
-     .latencyPredictor.predictionServers.image.registry=strenv(IMAGE_REGISTRY) |
-     .latencyPredictor.predictionServers.image.repository="llm-d-latency-predictor-prediction-server" |
-     .latencyPredictor.predictionServers.image.tag=strenv(LATENCY_PREDICTOR_TAG) |
-     .latencyPredictor.predictionServers.image.pullPolicy="IfNotPresent"' \
+    '.router.latencyPredictor.trainingServer.image.registry=strenv(IMAGE_REGISTRY) |
+     .router.latencyPredictor.trainingServer.image.repository="llm-d-latency-predictor-training-server" |
+     .router.latencyPredictor.trainingServer.image.tag=strenv(LATENCY_PREDICTOR_TAG) |
+     .router.latencyPredictor.trainingServer.image.pullPolicy="IfNotPresent" |
+     .router.latencyPredictor.predictionServers.image.registry=strenv(IMAGE_REGISTRY) |
+     .router.latencyPredictor.predictionServers.image.repository="llm-d-latency-predictor-prediction-server" |
+     .router.latencyPredictor.predictionServers.image.tag=strenv(LATENCY_PREDICTOR_TAG) |
+     .router.latencyPredictor.predictionServers.image.pullPolicy="IfNotPresent"' \
     config/charts/${CHART}/values.yaml
   if [[ ${CHART} == "llm-d-router-standalone" ]]; then
     ${YQ} -i \


### PR DESCRIPTION
 
**What type of PR is this?**
 
/kind bug
 

**What this PR does / why we need it**:
  
Parent charts [Chart.yaml](https://github.com/weizhoublue/llm-d-router/blob/main/config/charts/llm-d-router-gateway/Chart.yaml) and [Chart.yaml](https://github.com/weizhoublue/llm-d-router/blob/main/config/charts/llm-d-router-standalone/Chart.yaml) import  subchart routerlib under router  alias. 

```
dependencies:
  - name: router
    version: 0.0.0
    repository: "file://../routerlib"
    # This is needed to make use of the common values.yaml in ./config/charts/routerlib/values.yaml
    alias: router
```

So, the issue is that  lines 53-60 in push-chart.sh  incorrectly write  values to root-level  .latencyPredictor

In contrast , Lines 43-46 correctly target  .router.epp.image  to respect  subchart nesting

```
  ${YQ} -i \
    '.router.epp.image.registry=strenv(IMAGE_REGISTRY) |
     .router.epp.image.repository=strenv(EPP_RELEASE_IMAGE_REPOSITORY) |
     .router.epp.image.tag=strenv(EXTRA_TAG) |
     .router.epp.image.pullPolicy="IfNotPresent"' \
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
