### PR TITLE
fix(standalone): require modelServers.matchLabels when InferencePool is disabled

### DIFF
--- a/config/charts/llm-d-router-standalone/templates/_validations.tpl
+++ b/config/charts/llm-d-router-standalone/templates/_validations.tpl
@@ -18,6 +18,13 @@ standalone validations
 {{- if not (or (eq $proxyMode "sidecar") (eq $proxyMode "service")) -}}
   {{- fail (printf ".Values.router.proxy.mode must be one of [sidecar, service], got %q" $proxyMode) -}}
 {{- end -}}
+{{- /* Without an InferencePool the EPP --endpoint-selector is rendered from modelServers.matchLabels; an empty selector is rejected by EPP at startup, so require it here. */ -}}
+{{- $useInferencePool := ne .Values.router.inferencePool.create false -}}
+{{- if not $useInferencePool -}}
+  {{- if or (empty .Values.router.modelServers) (not .Values.router.modelServers.matchLabels) -}}
+    {{- fail ".Values.router.modelServers.matchLabels is required when .Values.router.inferencePool.create=false: standalone mode renders the EPP --endpoint-selector from matchLabels and cannot start with an empty selector" -}}
+  {{- end -}}
+{{- end -}}
 {{- $failOpen := index $proxy "failOpen" -}}
 {{- if and (not (kindIs "invalid" $failOpen)) (not (kindIs "bool" $failOpen)) -}}
   {{- fail (printf ".Values.router.proxy.failOpen must be a boolean, got %q" (toString $failOpen)) -}}

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -148,6 +148,13 @@ for key in "${!test_cases_llm_d_router_standalone[@]}"; do
 done
 
 echo "Running llm-d-router-standalone negative validation tests..."
+missing_endpoint_selector_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.inferencePool.create=false --set router.modelServers.type=vllm --set 'router.modelServers.targetPorts[0].number=8000' >/dev/null"
+echo "Executing: ${missing_endpoint_selector_command}"
+if eval "${missing_endpoint_selector_command}"; then
+  echo "Helm template unexpectedly succeeded for inferencePool.create=false without modelServers.matchLabels"
+  exit 1
+fi
+
 invalid_proxy_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.proxyType=bogus >/dev/null"
 echo "Executing: ${invalid_proxy_command}"
 if eval "${invalid_proxy_command}"; then


### PR DESCRIPTION
## Problem

When `router.inferencePool.create=false`, the standalone chart renders the EPP `--endpoint-selector` solely from `router.modelServers.matchLabels`. If `matchLabels` is omitted, the selector renders empty and EPP rejects it at startup, since standalone mode requires either `--pool-name` or a non-empty `--endpoint-selector`.

The existing `matchLabels` validation lives in `_inferencepool.yaml`, which only renders when an InferencePool is created, so the `create=false` path had no guard and produced a broken EPP deployment silently.

## Reproducer (from #1665)

```bash
helm template old-envoy config/charts/llm-d-router-standalone \
  --set router.inferencePool.create=false \
  --set router.modelServers.type=vllm \
  --set 'router.modelServers.targetPorts[0].number=8000'
```

Before: renders `--endpoint-selector ""`. After: fails fast with an actionable message.

## Fix

- Add a guard to the standalone validations requiring `modelServers.matchLabels` when `inferencePool.create=false`.
- Add a negative test case to `hack/verify-helm.sh` covering the reproducer.

Verified: the reproducer now fails, valid configs (with `matchLabels`, and default pool mode) still render, `helm lint` passes, and all existing `verify-helm.sh` cases are unaffected (they already set `matchLabels`).

Fixes #1665
