### PR TITLE
fix(sidecar): allowlist selector parsing for GA InferencePool API

### DIFF
--- a/pkg/sidecar/proxy/allowlist.go
+++ b/pkg/sidecar/proxy/allowlist.go
@@ -250,27 +250,34 @@ func (av *AllowlistValidator) onInferencePoolDelete(obj interface{}) {
 func (av *AllowlistValidator) updatePodsForPool(poolObj *unstructured.Unstructured) {
 	poolName := poolObj.GetName()
 
-	// Parse the pool spec to get selector
+	selector, err := av.poolSelector(poolObj)
+	if err != nil {
+		av.logger.Error(err, "failed to extract selector from InferencePool", "name", poolName)
+		return
+	}
+
+	av.createPodInformer(poolName, selector)
+}
+
+func (av *AllowlistValidator) poolSelector(poolObj *unstructured.Unstructured) (labels.Selector, error) {
 	spec, found, err := unstructured.NestedMap(poolObj.Object, "spec")
 	if err != nil || !found {
-		av.logger.Error(err, "InferencePool missing or invalid spec field", "name", poolName, "found", found)
-		return
+		return nil, fmt.Errorf("missing or invalid spec field (found=%t): %w", found, err)
 	}
 
-	selectorData, found, err := unstructured.NestedMap(spec, "selector")
+	// GA API (inference.networking.k8s.io) uses spec.selector.matchLabels;
+	// deprecated alpha API (inference.networking.x-k8s.io) uses a flat spec.selector map.
+	selectorPath := []string{"selector", "matchLabels"}
+	if av.gvr.Group != routing.InferencePoolAPIGroup {
+		selectorPath = []string{"selector"}
+	}
+
+	selectorData, found, err := unstructured.NestedStringMap(spec, selectorPath...)
 	if err != nil || !found {
-		av.logger.Error(err, "InferencePool missing or invalid selector field", "name", poolName, "found", found)
-		return
+		return nil, fmt.Errorf("missing or invalid selector field at %v (found=%t): %w", selectorPath, found, err)
 	}
 
-	// Convert to labels.Selector
-	labelSelector := labels.Set{}
-	for k, v := range selectorData {
-		labelSelector[k] = fmt.Sprintf("%v", v)
-	}
-
-	// Create or update pod informer for this selector
-	av.createPodInformer(poolName, labelSelector.AsSelector())
+	return labels.Set(selectorData).AsSelector(), nil
 }
 
 // createPodInformer creates a new pod informer for the given selector

--- a/pkg/sidecar/proxy/allowlist_test.go
+++ b/pkg/sidecar/proxy/allowlist_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/gomega"    // nolint:revive
 
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/set"
 )
 
@@ -38,6 +40,139 @@ var _ = Describe("AllowlistValidator", func() {
 			Expect(validator.IsAllowed("malicious.example.com:8080")).To(BeTrue())
 			Expect(validator.IsAllowed("10.0.0.1:8000")).To(BeTrue())
 			Expect(validator.IsAllowed("http://evil.host/ssrf")).To(BeTrue())
+		})
+	})
+
+	Context("poolSelector", func() {
+		It("should extract selector from GA InferencePool (matchLabels)", func() {
+			av := &AllowlistValidator{
+				gvr: schema.GroupVersionResource{
+					Group:    routing.InferencePoolAPIGroup,
+					Version:  "v1",
+					Resource: "inferencepools",
+				},
+			}
+			pool := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "inference.networking.k8s.io/v1",
+					"kind":       "InferencePool",
+					"metadata":   map[string]interface{}{"name": "test-pool"},
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"app.kubernetes.io/name": "my-model",
+								"component":              "serving",
+							},
+						},
+					},
+				},
+			}
+
+			selector, err := av.poolSelector(pool)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(selector.String()).To(SatisfyAll(
+				ContainSubstring("app.kubernetes.io/name=my-model"),
+				ContainSubstring("component=serving"),
+			))
+		})
+
+		It("should extract selector from deprecated alpha InferencePool (flat map)", func() {
+			av := &AllowlistValidator{
+				gvr: schema.GroupVersionResource{
+					Group:    "inference.networking.x-k8s.io",
+					Version:  "v1alpha2",
+					Resource: "inferencepools",
+				},
+			}
+			pool := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "inference.networking.x-k8s.io/v1alpha2",
+					"kind":       "InferencePool",
+					"metadata":   map[string]interface{}{"name": "test-pool"},
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"app.kubernetes.io/name": "my-model",
+							"component":              "serving",
+						},
+					},
+				},
+			}
+
+			selector, err := av.poolSelector(pool)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(selector.String()).To(SatisfyAll(
+				ContainSubstring("app.kubernetes.io/name=my-model"),
+				ContainSubstring("component=serving"),
+			))
+		})
+
+		It("should fail for GA pool with flat selector (no matchLabels)", func() {
+			av := &AllowlistValidator{
+				gvr: schema.GroupVersionResource{
+					Group:    routing.InferencePoolAPIGroup,
+					Version:  "v1",
+					Resource: "inferencepools",
+				},
+			}
+			pool := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "inference.networking.k8s.io/v1",
+					"kind":       "InferencePool",
+					"metadata":   map[string]interface{}{"name": "test-pool"},
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"app": "my-model",
+						},
+					},
+				},
+			}
+
+			_, err := av.poolSelector(pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("matchLabels"))
+		})
+
+		It("should fail when spec is missing", func() {
+			av := &AllowlistValidator{
+				gvr: schema.GroupVersionResource{
+					Group:    routing.InferencePoolAPIGroup,
+					Version:  "v1",
+					Resource: "inferencepools",
+				},
+			}
+			pool := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "inference.networking.k8s.io/v1",
+					"kind":       "InferencePool",
+					"metadata":   map[string]interface{}{"name": "test-pool"},
+				},
+			}
+
+			_, err := av.poolSelector(pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec"))
+		})
+
+		It("should fail when selector is missing", func() {
+			av := &AllowlistValidator{
+				gvr: schema.GroupVersionResource{
+					Group:    "inference.networking.x-k8s.io",
+					Version:  "v1alpha2",
+					Resource: "inferencepools",
+				},
+			}
+			pool := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "inference.networking.x-k8s.io/v1alpha2",
+					"kind":       "InferencePool",
+					"metadata":   map[string]interface{}{"name": "test-pool"},
+					"spec":       map[string]interface{}{},
+				},
+			}
+
+			_, err := av.poolSelector(pool)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("selector"))
 		})
 	})
 


### PR DESCRIPTION
The GA InferencePool API (inference.networking.k8s.io/v1) nests pod labels under spec.selector.matchLabels, while the deprecated alpha API (inference.networking.x-k8s.io/v1alpha2) uses a flat spec.selector map.

The allowlist validator read spec.selector unconditionally and fmt.Sprintf'd nested map values into label strings, producing invalid selectors like "map[app.kubernetes.io/name:...]" that Kubernetes rejected for exceeding the 63-character label value limit.

Branch the selector path based on the detected API group and use NestedStringMap for type-safe extraction.

