### PR TITLE
ci: publish CRD manifests to release assets

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -51,3 +51,43 @@ jobs:
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: ${{ fromJSON(needs.set-params.outputs.prerelease) }}
       chart-suffix: ""
+
+  upload-artifacts:
+    needs: set-params
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'latest'
+
+      - name: Build Artifacts
+        run: |
+          make artifacts
+
+      - name: Upload Release Assets
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          files=$(find artifacts -type f -size +0c | tr '\n' ' ')
+          if [ -z "$files" ]; then
+            echo "No artifacts to upload."
+            exit 0
+          fi
+          if gh release view "${{ needs.set-params.outputs.tag }}" >/dev/null 2>&1; then
+            gh release upload "${{ needs.set-params.outputs.tag }}" $files --clobber
+          else
+            echo "Release ${{ needs.set-params.outputs.tag }} does not exist. Creating a draft release..."
+            gh release create "${{ needs.set-params.outputs.tag }}" $files --draft --title "${{ needs.set-params.outputs.tag }}" --notes "Release ${{ needs.set-params.outputs.tag }}"
+          fi
+

--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,19 @@ helm-push-standalone: ## Package and push the llm-d-router-standalone Helm chart
 	$(MAKE) helm-push CHART=llm-d-router-standalone
 
 
+##@ Release
+
+.PHONY: artifacts
+artifacts: yq check-kustomize ## Generate release artifacts (CRD manifests)
+	if [ -d artifacts ]; then rm -rf artifacts; fi
+	mkdir -p artifacts
+	kubectl kustomize config/crd > artifacts/manifests_all.yaml
+	$(YQ) -P 'select(.spec.group == "llm-d.ai")' artifacts/manifests_all.yaml > artifacts/manifests.yaml
+	rm -f artifacts/manifests_all.yaml
+	$(YQ) -P 'select(.spec.versions | map(.name == "v1") | any)' artifacts/manifests.yaml > artifacts/v1-manifests.yaml
+	$(YQ) -P 'select(.spec.versions | map(.name != "v1") | all)' artifacts/manifests.yaml > artifacts/experimental-manifests.yaml
+
+
 ##@ Coverage
 
 COVERAGE_DIR       ?= coverage


### PR DESCRIPTION
This PR adds a release artifacts generation rule and configures the release workflow to build and attach `experimental-manifests.yaml` (as well as `v1-manifests.yaml` and `manifests.yaml` if they are not empty) to release assets.

Instead of modifying the kustomization files, this PR introduces a `select(.spec.group == "llm-d.ai")` filter in the Makefile to cleanly select only local CRDs for build/release, keeping the kustomization root untouched and clean.

### E2E Test Results
The release workflow changes have been successfully verified on a personal fork (`liu-cong/llm-d-router`):
- **Workflow Run**: https://github.com/liu-cong/llm-d-router/actions/runs/27986356983
- **Draft Release**: https://github.com/liu-cong/llm-d-router/releases/tag/untagged-11da50a7747b292d3bc2
- **Uploaded Release Assets**:
  - `experimental-manifests.yaml`
  - `manifests.yaml`