### PR TITLE
chore: switch default vllm port from 8001 to 8200 for sidecar

### DIFF
--- a/deploy/components/vllm-decode/deployment.yaml
+++ b/deploy/components/vllm-decode/deployment.yaml
@@ -25,7 +25,6 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - "--port=8000"
-        - "--vllm-port=8200"
         - "--secure-proxy=false"
         - "--data-parallel-size=${VLLM_DATA_PARALLEL_SIZE}"
         ports:

--- a/deploy/environments/dev/e-p-d/patch-decode.yaml
+++ b/deploy/environments/dev/e-p-d/patch-decode.yaml
@@ -12,7 +12,6 @@ spec:
       - name: routing-sidecar
         args:
         - "--port=8000"
-        - "--vllm-port=8200"
         - "--kv-connector=${KV_CONNECTOR_TYPE}"
         - "--ec-connector=${EC_CONNECTOR_TYPE}"
         - "--secure-proxy=false"

--- a/deploy/environments/dev/e-pd/patch-decode.yaml
+++ b/deploy/environments/dev/e-pd/patch-decode.yaml
@@ -12,7 +12,6 @@ spec:
       - name: routing-sidecar
         args:
         - "--port=8000"
-        - "--vllm-port=8200"
         - "--ec-connector=${EC_CONNECTOR_TYPE}"
         - "--secure-proxy=false"
         - "--data-parallel-size=${VLLM_DATA_PARALLEL_SIZE}"

--- a/deploy/environments/dev/p-d/patch-decode.yaml
+++ b/deploy/environments/dev/p-d/patch-decode.yaml
@@ -12,7 +12,6 @@ spec:
       - name: routing-sidecar
         args:
         - "--port=8000"
-        - "--vllm-port=8200"
         - "--kv-connector=${CONNECTOR_TYPE}"
         - "--mooncake-bootstrap-port=8000"
         - "--secure-proxy=false"

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -89,7 +89,7 @@ const (
 
 	// Defaults
 	defaultPort                  = "8000"
-	defaultVLLMPort              = "8001"
+	defaultVLLMPort              = "8200"
 	defaultDataParallelSize      = 1
 	defaultMooncakeBootstrapPort = 8998
 

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -43,7 +43,7 @@ func createConfigWithValidYAML(t *testing.T) string {
 	t.Helper()
 	return writeTempYAML(t, "valid.yaml", fmt.Sprintf(`
 port: 8100
-vllm-port: 8200
+vllm-port: 8001
 data-parallel-size: 5
 kv-connector: %q
 connector: %q
@@ -74,7 +74,7 @@ func createConfigWithUnknownKeys(t *testing.T) string {
 	t.Helper()
 	return writeTempYAML(t, "valid.yaml", `
 port: 8100
-vllm-port: 8200
+vllm-port: 8001
 unknown-key: 1001
 `)
 }
@@ -183,7 +183,7 @@ func TestSidecarConfiguration(t *testing.T) {
 			},
 			expected: func(o *Options) {
 				o.Port = "8100"
-				o.vllmPort = "8200"
+				o.vllmPort = "8001"
 				o.DataParallelSize = 5
 				o.MaxIdleConnsPerHost = 300
 				o.MooncakeBootstrapPort = 9000

--- a/test/sidecar/config/nixl/qwen-decoder-pod.yaml
+++ b/test/sidecar/config/nixl/qwen-decoder-pod.yaml
@@ -25,7 +25,6 @@ spec:
         runAsNonRoot: true
       args:
         - "-port=8000"
-        - "-vllm-port=8200"
         - "-connector=nixlv2"
         - "-v=6"
       ports:


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup


**What this PR does / why we need it**:
- remove explicitly config to use 8200 in deployment and test
- keep local dev test with 8001


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
