### PR TITLE
burst prefix-cache affinity for prompt-sharing requests

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -83,6 +83,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter"
 	reqdataprodprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload"
 	mmproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal"
 	preciseproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache"
@@ -520,6 +521,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(nohitlru.NoHitLRUType, nohitlru.Factory)
 	fwkplugin.Register(activerequest.ActiveRequestType, activerequest.Factory)
 	fwkplugin.Register(preciseprefixcache.PrecisePrefixCachePluginType, preciseprefixcache.PluginFactory)
+	fwkplugin.Register(burstprefix.PluginType, burstprefix.Factory)
 	fwkplugin.Register(mmcacheaffinity.Type, mmcacheaffinity.Factory)
 	fwkplugin.Register(preciseproducer.PluginType, preciseproducer.PluginFactory)
 

--- a/deploy/config/epp-burst-prefix-cache-config.yaml
+++ b/deploy/config/epp-burst-prefix-cache-config.yaml
@@ -18,6 +18,7 @@ plugins:
     parameters:
       windowDurationMs: 100       # batch window T
       maxPerReplica: -1           # k; -1 sends all samples of a group to one replica
+      minColocateBlocks: 0        # >0 co-locates distinct groups sharing >= N leading blocks; 0 = load-balanced
   - type: prefix-cache-scorer
     parameters:
       prefixMatchInfoProducerName: burst-prefix-cache-producer

--- a/deploy/config/epp-burst-prefix-cache-config.yaml
+++ b/deploy/config/epp-burst-prefix-cache-config.yaml
@@ -11,7 +11,7 @@ plugins:
     parameters:
       modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
       vllm:
-        url: http://localhost:8000
+        url: http://<vllm-service>.<namespace>.svc.cluster.local:8000
   - type: single-profile-handler
   - type: decode-filter
   - type: burst-prefix-cache-producer

--- a/deploy/config/epp-burst-prefix-cache-config.yaml
+++ b/deploy/config/epp-burst-prefix-cache-config.yaml
@@ -1,0 +1,34 @@
+# Sample EPP config: burst prefix cache pipeline
+#   token-producer -> burst-prefix-cache-producer -> prefix-cache-scorer
+#
+# Co-locates bursts of prompt-sharing requests (e.g. RL rollout group samples)
+# onto shared replicas so a shared prefix is prefilled once instead of scattered
+# across replicas on a cold cache.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: token-producer
+    parameters:
+      modelName: hf-repo/model-name           # set to the model used in the vLLM deployment
+      vllm:
+        url: http://localhost:8000
+  - type: single-profile-handler
+  - type: decode-filter
+  - type: burst-prefix-cache-producer
+    parameters:
+      windowDurationMs: 100       # batch window T
+      maxPerReplica: -1           # k; -1 sends all samples of a group to one replica
+  - type: prefix-cache-scorer
+    parameters:
+      prefixMatchInfoProducerName: burst-prefix-cache-producer
+  - type: load-aware-scorer
+  - type: max-score-picker
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: decode-filter
+      - pluginRef: prefix-cache-scorer
+        weight: 2.0
+      - pluginRef: load-aware-scorer
+        weight: 1.0
+      - pluginRef: max-score-picker

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/README.md
@@ -17,6 +17,7 @@ Producers may also implement additional lifecycle hooks:
 | `token-producer` | [`tokenizer`](tokenizer/) | `TokenizedPrompt` | Tokenizes the request prompt via vLLM `/render`; required by precise-prefix-cache-producer and context-length-aware scorers. |
 | `approx-prefix-cache-producer` | [`approximateprefix`](approximateprefix/) | `PrefixCacheMatchInfo` | Hashes the prompt into blocks and matches against a per-pod LRU index for approximate prefix-cache affinity. |
 | `precise-prefix-cache-producer` | [`preciseprefixcache`](preciseprefixcache/) | `PrefixCacheMatchInfo` | Maintains a precise KV-block index by subscribing to vLLM KV-events; requires `token-producer` upstream. |
+| `burst-prefix-cache-producer` | [`burstprefix`](burstprefix/) | `PrefixCacheMatchInfo` | Batches requests within a time window and co-locates prompt-sharing samples (e.g. RL rollout groups) onto shared replicas; requires `token-producer` upstream. |
 | `inflight-load-producer` | [`inflightload`](inflightload/) | `InFlightLoad` | Tracks real-time in-flight request and token counts per endpoint across the full request lifecycle. |
 | `predicted-latency-producer` | [`predictedlatency`](predictedlatency/) | `LatencyPredictionInfo` | Trains XGBoost models via a sidecar and generates per-endpoint TTFT/TPOT predictions. |
 | `session-id-producer` | [`sessionid`](sessionid/) | `SessionID` | Extracts a session identifier from a request header or cookie and publishes it for affinity-aware plugins. |
@@ -27,6 +28,7 @@ Producers may also implement additional lifecycle hooks:
 The framework resolves a DAG from each plugin's `Produces` and `Consumes` declarations and runs producers in dependency order. Explicit dependencies to be aware of:
 
 - `precise-prefix-cache-producer` **requires** `token-producer` upstream (it consumes `TokenizedPrompt`).
+- `burst-prefix-cache-producer` **requires** `token-producer` upstream (it consumes `TokenizedPrompt`).
 - `mm-embeddings-cache-producer` **optionally** consumes `TokenizedPrompt`; configure `token-producer` first when multimodal features need tokenizer-derived hashes.
 - `inflight-load-producer` **optionally** consumes `PrefixCacheMatchInfo` from an approx or precise prefix producer; prefix-discounting is applied automatically when the attribute is present.
 - `predicted-latency-producer` **optionally** consumes `PrefixCacheMatchInfo`; set `prefixMatchInfoProducerName` in its config to the name of the prefix producer instance.
@@ -35,6 +37,7 @@ The framework resolves a DAG from each plugin's `Produces` and `Consumes` declar
 
 - [Approximate Prefix Cache Producer](approximateprefix/README.md)
 - [Precise Prefix Cache Producer](preciseprefixcache/README.md)
+- [Burst Prefix Cache Producer](burstprefix/README.md)
 - [Token Producer](tokenizer/README.md)
 - [In-Flight Load Producer](inflightload/README.md)
 - [Predicted Latency Producer](predictedlatency/README.md)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -32,6 +32,7 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	approxprefixconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/constants"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
@@ -179,7 +180,7 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
 		maxBlocks = p.config.MaxPrefixTokensToMatch / blockSize
 	}
-	perPromptHashes := getBlockHashes(ctx, request, blockSize, maxBlocks)
+	perPromptHashes := prefixhash.GetBlockHashes(ctx, request, blockSize, maxBlocks)
 
 	prefixCacheServers := make(map[ServerID]int)
 	totalBlocks := 0

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -32,6 +32,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
 )
 
 func testHandle() plugin.Handle {
@@ -138,7 +139,7 @@ func TestPreRequest(t *testing.T) {
 		p.wg.Wait()
 
 		// 4. Verify indexer was updated
-		perPromptHashes := getBlockHashes(context.Background(), req1, config.BlockSizeTokens, defaultMaxPrefixBlocks)
+		perPromptHashes := prefixhash.GetBlockHashes(context.Background(), req1, config.BlockSizeTokens, defaultMaxPrefixBlocks)
 		for _, promptHashes := range perPromptHashes {
 			for _, hash := range promptHashes {
 				pods := p.indexer().Get(hash)
@@ -182,7 +183,7 @@ func TestPreRequest(t *testing.T) {
 			p.PreRequest(context.Background(), req, res)
 			p.wg.Wait()
 
-			perPromptHashes := getBlockHashes(context.Background(), req, config.BlockSizeTokens, defaultMaxPrefixBlocks)
+			perPromptHashes := prefixhash.GetBlockHashes(context.Background(), req, config.BlockSizeTokens, defaultMaxPrefixBlocks)
 			allHashes = append(allHashes, perPromptHashes[0])
 		}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -22,6 +22,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
 )
 
 // indexerInterface maintains an LRU cache of prompt prefix hashes and the server(s) that might have that
@@ -36,8 +37,9 @@ type indexerInterface interface {
 // podSet holds a set of pods that may have a specific prefix hash.
 type podSet map[ServerID]struct{}
 
-// blockHash is a hash of a block of request data.
-type blockHash uint64
+// blockHash is a hash of a block of request data. It aliases prefixhash.BlockHash
+// so this package and other prefix-aware producers share one block-hash type.
+type blockHash = prefixhash.BlockHash
 
 // server contains information about a specific server/pod and its cache capacity.
 type server struct {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
@@ -22,7 +22,13 @@ Requests arriving within a configurable window are assigned jointly:
 2. Requests with an identical prompt prefix are grouped.
 3. Each group with more than one member is steered onto a replica (or a bounded
    set of replicas), filling one replica up to `maxPerReplica` before spilling
-   to the next least-loaded replica. Groups are balanced across replicas.
+   to the next least-loaded replica. When `minColocateBlocks > 0`, a group
+   prefers a replica that already holds a placed group sharing at least that many
+   leading blocks and is still under its fair share of the batch (inter-group
+   prefix co-location bounded by balance, so a long shared prefix is prefilled
+   once without stampeding prefix-sharing groups onto one replica); otherwise
+   groups are balanced across replicas. Longer-prefix groups are placed first so
+   shorter groups match against the richest set of already-placed prefixes.
 4. The producer emits `PrefixCacheMatchInfo` with a full match on the assigned
    replica and zero elsewhere.
 
@@ -48,6 +54,7 @@ This producer emits `PrefixCacheMatchInfo`; it does not score. Reuse the
 | `maxPerReplica` | -1 | max samples of one group per replica (k); -1 = unlimited (whole group to one replica) |
 | `blockSizeTokens` | 64 | token block size for prefix hashing |
 | `maxPrefixTokensToMatch` | 0 | cap on matched prefix tokens; 0 uses the default block cap |
+| `minColocateBlocks` | 0 | min shared leading blocks to co-locate two distinct groups; 0 disables inter-group co-location (placement is purely load-balanced) |
 
 ## Operational notes
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
@@ -55,11 +55,12 @@ This producer emits `PrefixCacheMatchInfo`; it does not score. Reuse the
 
 | field | default | meaning |
 |---|---|---|
-| `windowDurationMs` | 100 | batch window T in milliseconds |
+| `windowDurationMs` | 100 | batch window T in milliseconds; must be in `1..10000`. Every request waits up to this long, so keep it small relative to other request processing times. |
 | `maxPerReplica` | -1 | max samples of one group per replica (k); -1 = unlimited (whole group to one replica) |
 | `blockSizeTokens` | 64 | token block size for prefix hashing |
-| `maxPrefixTokensToMatch` | 0 | cap on matched prefix tokens; 0 uses the default block cap |
+| `maxPrefixTokensToMatch` | 0 | cap on matched prefix tokens; 0 uses the default block cap. A positive value must be >= `blockSizeTokens`, otherwise it yields zero prefix blocks. |
 | `minColocateBlocks` | 0 | min shared leading blocks for inter-unit co-location and for a single request to gain an affinity; 0 disables both (only identical groups are placed, purely load-balanced) |
+| `maxBatchSize` | 1000 | max requests one window may accumulate; Produce returns an error once reached. -1 = unlimited. |
 
 ## Operational notes
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
@@ -1,0 +1,58 @@
+# Burst Prefix Cache Producer
+
+**Type:** `burst-prefix-cache-producer`
+
+A request-level data producer that co-locates bursts of prompt-sharing requests
+so a shared prefix is prefilled once instead of scattered across replicas on a
+cold cache.
+
+## Problem
+
+When many requests that share a prompt arrive at the same instant (for example
+the `n` group samples of an RL rollout step), every replica's prefix cache is
+still cold, so a cache-state scorer scores them all zero and load balancing
+spreads them. The shared prompt is then prefilled redundantly on several
+replicas and the prefix-cache benefit is lost.
+
+## What it does
+
+Requests arriving within a configurable window are assigned jointly:
+
+1. Each request's prompt is hashed into prefix blocks (shared `prefixhash`).
+2. Requests with an identical prompt prefix are grouped.
+3. Each group with more than one member is steered onto a replica (or a bounded
+   set of replicas), filling one replica up to `maxPerReplica` before spilling
+   to the next least-loaded replica. Groups are balanced across replicas.
+4. The producer emits `PrefixCacheMatchInfo` with a full match on the assigned
+   replica and zero elsewhere.
+
+Singletons and prefix-less requests receive no affinity (scored zero
+everywhere), leaving them to other scorers.
+
+## Scoring
+
+This producer emits `PrefixCacheMatchInfo`; it does not score. Reuse the
+`prefix-cache-scorer` and point it at this producer:
+
+```yaml
+- type: prefix-cache-scorer
+  parameters:
+    prefixMatchInfoProducerName: burst-prefix-cache-producer
+```
+
+## Configuration
+
+| field | default | meaning |
+|---|---|---|
+| `windowDurationMs` | 100 | batch window T in milliseconds |
+| `maxPerReplica` | -1 | max samples of one group per replica (k); -1 = unlimited (whole group to one replica) |
+| `blockSizeTokens` | 64 | token block size for prefix hashing |
+| `maxPrefixTokensToMatch` | 0 | cap on matched prefix tokens; 0 uses the default block cap |
+
+## Operational notes
+
+- The producer adds up to `windowDurationMs` of latency per request while a
+  window fills; its producer timeout is extended to cover the window.
+- Grouping is by exact prompt-prefix match. Cross-step warm-cache reuse is left
+  to the persistent (approximate or precise) prefix cache producer, which can
+  run alongside this one.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/README.md
@@ -19,21 +19,26 @@ replicas and the prefix-cache benefit is lost.
 Requests arriving within a configurable window are assigned jointly:
 
 1. Each request's prompt is hashed into prefix blocks (shared `prefixhash`).
-2. Requests with an identical prompt prefix are grouped.
-3. Each group with more than one member is steered onto a replica (or a bounded
-   set of replicas), filling one replica up to `maxPerReplica` before spilling
-   to the next least-loaded replica. When `minColocateBlocks > 0`, a group
-   prefers a replica that already holds a placed group sharing at least that many
-   leading blocks and is still under its fair share of the batch (inter-group
-   prefix co-location bounded by balance, so a long shared prefix is prefilled
-   once without stampeding prefix-sharing groups onto one replica); otherwise
-   groups are balanced across replicas. Longer-prefix groups are placed first so
-   shorter groups match against the richest set of already-placed prefixes.
+2. Requests with an identical prompt prefix are grouped. An identical group of
+   more than one member is always a placement unit; a single request becomes a
+   unit only when `minColocateBlocks > 0` and it shares at least that many leading
+   blocks with some other request in the batch.
+3. Units are steered onto a replica (or a bounded set of replicas), filling one
+   replica up to `maxPerReplica` before spilling to the next least-loaded replica.
+   Identical groups are placed first and kept whole, so the proven same-prompt
+   co-location is the firm structure; prefix-sharing units then attach to it. A
+   unit prefers a replica that already holds a unit sharing at least
+   `minColocateBlocks` leading blocks and is still under its fair share of the
+   batch (prefix co-location bounded by balance, so a shared prefix is prefilled
+   once without stampeding prefix-sharing units onto one replica); otherwise units
+   are balanced across replicas. Longer-prefix units are placed first so shorter
+   units match against the richest set of already-placed prefixes.
 4. The producer emits `PrefixCacheMatchInfo` with a full match on the assigned
    replica and zero elsewhere.
 
-Singletons and prefix-less requests receive no affinity (scored zero
-everywhere), leaving them to other scorers.
+A request that overlaps no other in the batch, and any prefix-less request,
+receives no affinity (scored zero everywhere), leaving it to other scorers.
+With `minColocateBlocks == 0` only identical groups are placed.
 
 ## Scoring
 
@@ -54,12 +59,14 @@ This producer emits `PrefixCacheMatchInfo`; it does not score. Reuse the
 | `maxPerReplica` | -1 | max samples of one group per replica (k); -1 = unlimited (whole group to one replica) |
 | `blockSizeTokens` | 64 | token block size for prefix hashing |
 | `maxPrefixTokensToMatch` | 0 | cap on matched prefix tokens; 0 uses the default block cap |
-| `minColocateBlocks` | 0 | min shared leading blocks to co-locate two distinct groups; 0 disables inter-group co-location (placement is purely load-balanced) |
+| `minColocateBlocks` | 0 | min shared leading blocks for inter-unit co-location and for a single request to gain an affinity; 0 disables both (only identical groups are placed, purely load-balanced) |
 
 ## Operational notes
 
 - The producer adds up to `windowDurationMs` of latency per request while a
   window fills; its producer timeout is extended to cover the window.
-- Grouping is by exact prompt-prefix match. Cross-step warm-cache reuse is left
-  to the persistent (approximate or precise) prefix cache producer, which can
-  run alongside this one.
+- Co-location is decided within a single window from the request prompts. Identity
+  (the samples of one prompt) is matched exactly; partial overlap between distinct
+  prompts is matched to `minColocateBlocks` leading blocks. Cross-step warm-cache
+  reuse is left to the persistent (approximate or precise) prefix cache producer,
+  which can run alongside this one.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -17,7 +17,8 @@ limitations under the License.
 package burstprefix
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
@@ -167,14 +168,17 @@ func assign(entries []*entry, k, minColocateBlocks int) {
 
 	shared := sharedPrefixKeys(groups, order, minColocateBlocks)
 	var groupUnits, singleUnits []string
+	counts := map[string]int{} // prefix-block count per placed unit, computed once
 	total := 0
 	for _, key := range order {
 		switch {
 		case len(groups[key]) >= 2:
 			groupUnits = append(groupUnits, key)
+			counts[key] = totalBlocks(groups[key][0].hashes)
 			total += len(groups[key])
 		case shared[key]:
 			singleUnits = append(singleUnits, key)
+			counts[key] = totalBlocks(groups[key][0].hashes)
 			total += len(groups[key])
 		}
 	}
@@ -184,8 +188,8 @@ func assign(entries []*entry, k, minColocateBlocks int) {
 
 	// Longest-prefix first within each tier: a longer prefix seeds more blocks in
 	// the index, so shorter units match against the richest set of placed blocks.
-	sortByPrefixLen(groupUnits, groups)
-	sortByPrefixLen(singleUnits, groups)
+	sortByPrefixLen(groupUnits, counts)
+	sortByPrefixLen(singleUnits, counts)
 
 	maxShare := (total + len(replicas) - 1) / len(replicas) // ceil: equal samples per replica
 
@@ -197,9 +201,9 @@ func assign(entries []*entry, k, minColocateBlocks int) {
 }
 
 // sortByPrefixLen orders keys by descending prefix-block count (stable).
-func sortByPrefixLen(keys []string, groups map[string][]*entry) {
-	sort.SliceStable(keys, func(i, j int) bool {
-		return totalBlocks(groups[keys[i]][0].hashes) > totalBlocks(groups[keys[j]][0].hashes)
+func sortByPrefixLen(keys []string, counts map[string]int) {
+	slices.SortStableFunc(keys, func(a, b string) int {
+		return cmp.Compare(counts[b], counts[a])
 	})
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -18,6 +18,7 @@ package burstprefix
 
 import (
 	"encoding/binary"
+	"sort"
 	"strings"
 
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
@@ -53,14 +54,68 @@ func groupKey(hashes [][]prefixhash.BlockHash) string {
 	return b.String()
 }
 
-// assign steers each batched request to a replica so samples sharing a prompt
-// co-locate. Requests are grouped by identical prefix; only groups with more
-// than one member receive an affinity (singletons have no reuse to exploit and
-// are left for other scorers). Within a group, samples fill one replica up to
-// maxPerReplica (k) before spilling to the next least-loaded replica; k == -1
-// places the whole group on one replica. Group placement is balanced by the
-// batch-wide assignment count so distinct groups spread across replicas.
-func assign(entries []*entry, k int) {
+// batchIndex records which replicas hold each prefix block, for matching later
+// groups against groups already placed in this batch. Because a whole prompt
+// prefix is added at once, holding block i implies holding blocks 0..i, so a
+// greedy walk that stops at the first unheld block yields the longest contiguous
+// shared prefix per replica (the approximateprefix matchLongestPrefix property).
+type batchIndex struct {
+	holders map[prefixhash.BlockHash]map[string]struct{}
+}
+
+func newBatchIndex() *batchIndex {
+	return &batchIndex{holders: map[prefixhash.BlockHash]map[string]struct{}{}}
+}
+
+// add records every block of hashes as held by replica.
+func (b *batchIndex) add(hashes [][]prefixhash.BlockHash, replica string) {
+	for _, ph := range hashes {
+		for _, h := range ph {
+			s := b.holders[h]
+			if s == nil {
+				s = map[string]struct{}{}
+				b.holders[h] = s
+			}
+			s[replica] = struct{}{}
+		}
+	}
+}
+
+// longestPrefix returns, per replica, the number of leading prefix blocks that
+// replica already holds (summed across prompts) - the shared-prefix length.
+func (b *batchIndex) longestPrefix(hashes [][]prefixhash.BlockHash) map[string]int {
+	res := map[string]int{}
+	for _, ph := range hashes {
+		for _, h := range ph {
+			holders := b.holders[h]
+			if len(holders) == 0 {
+				break
+			}
+			for name := range holders {
+				res[name]++
+			}
+		}
+	}
+	return res
+}
+
+// assign steers each batched request to a replica so prompt-sharing samples
+// co-locate. Pass 1 groups requests by identical prefix (samples of one prompt);
+// only groups with more than one member receive an affinity (singletons have no
+// reuse and are left for other scorers).
+//
+// Pass 2 places the groups jointly over the whole batch. Groups are placed
+// longest-prefix first so they seed the batch index for shorter groups to match
+// against. Each group prefers a replica that already holds a group sharing at
+// least minColocateBlocks leading blocks AND is still below its fair share of the
+// batch (total placed samples / replicas); this prefills a long shared prefix
+// once across groups without letting many prefix-sharing groups stampede onto one
+// replica. With no eligible match a group seeds the least-loaded replica. Within
+// a group, samples fill one replica up to maxPerReplica (k) before spilling to
+// the next least-loaded replica; k == -1 places the whole group on one replica.
+// minColocateBlocks == 0 disables inter-group co-location (placement is purely
+// load-balanced).
+func assign(entries []*entry, k, minColocateBlocks int) {
 	groups := map[string][]*entry{}
 	order := []string{}
 	for _, e := range entries {
@@ -74,33 +129,59 @@ func assign(entries []*entry, k int) {
 		groups[key] = append(groups[key], e)
 	}
 
-	// load is the batch-wide count of samples assigned per replica, used to
-	// spread groups across replicas.
-	load := map[string]int{}
+	// Placeable groups (more than one member) and the total samples they
+	// contribute, which sets the per-replica fair-share cap.
+	var placeKeys []string
+	total := 0
+	var replicas []fwksched.Endpoint
 	for _, key := range order {
 		members := groups[key]
 		if len(members) < 2 {
 			continue
 		}
-		assignGroup(members, members[0].pods, k, load)
+		placeKeys = append(placeKeys, key)
+		total += len(members)
+		if replicas == nil {
+			replicas = members[0].pods
+		}
+	}
+	if len(placeKeys) == 0 || len(replicas) == 0 {
+		return
+	}
+
+	// Longest-prefix first: a longer group seeds more blocks in the index, so
+	// shorter groups match against the richest set of already-placed prefixes.
+	sort.SliceStable(placeKeys, func(i, j int) bool {
+		return totalBlocks(groups[placeKeys[i]][0].hashes) > totalBlocks(groups[placeKeys[j]][0].hashes)
+	})
+
+	maxShare := (total + len(replicas) - 1) / len(replicas) // ceil: equal samples per replica
+
+	idx := newBatchIndex()
+	load := map[string]int{} // batch-wide samples assigned per replica
+	for _, key := range placeKeys {
+		placeGroup(groups[key], replicas, k, minColocateBlocks, maxShare, idx, load)
 	}
 }
 
-// assignGroup places the members of one group across replicas honoring the
-// per-replica cap k and updating the batch-wide load counter.
-func assignGroup(members []*entry, replicas []fwksched.Endpoint, k int, load map[string]int) {
+// placeGroup places one identical-prompt group. The first (primary) replica is
+// chosen with the inter-group prefix preference bounded by the fair-share cap;
+// remaining samples (when k caps the group) spill to least-loaded replicas. The
+// group's blocks are then recorded so later groups can match against it.
+func placeGroup(members []*entry, replicas []fwksched.Endpoint, k, minColocateBlocks, maxShare int, idx *batchIndex, load map[string]int) {
 	if len(replicas) == 0 {
 		return
 	}
-	perReplica := map[string]int{} // samples of THIS group already on a replica
+	hashes := members[0].hashes // identical group: any member represents it
+	matches := idx.longestPrefix(hashes)
 
+	perReplica := map[string]int{} // samples of THIS group already on a replica
+	preferMatch := minColocateBlocks > 0
 	i := 0
 	for i < len(members) {
-		target := pickReplica(replicas, perReplica, k, load)
+		target := pickReplica(replicas, perReplica, k, load, matches, minColocateBlocks, maxShare, preferMatch)
 		name := target.GetMetadata().NamespacedName.String()
 
-		// Fill this replica up to its remaining capacity before moving on, so a
-		// group concentrates rather than scatters.
 		run := len(members) - i
 		if k != unlimitedPerReplica {
 			capLeft := k - perReplica[name]
@@ -117,14 +198,54 @@ func assignGroup(members []*entry, replicas []fwksched.Endpoint, k int, load map
 		perReplica[name] += run
 		load[name] += run
 		i += run
+		preferMatch = false // only the primary replica gets the prefix preference
+	}
+
+	for _, m := range members {
+		if m.assigned != nil {
+			idx.add(hashes, m.assigned.GetMetadata().NamespacedName.String())
+		}
 	}
 }
 
-// pickReplica returns the least batch-loaded replica that still has capacity for
-// this group. When every replica is at the cap (more members than k*replicas)
-// it falls back to the least-loaded replica ignoring the cap. Ties break by
-// running requests then by name for deterministic placement.
-func pickReplica(replicas []fwksched.Endpoint, perReplica map[string]int, k int, load map[string]int) fwksched.Endpoint {
+// pickReplica chooses the target replica for the next run of a group. When
+// preferMatch is set it first tries the replica sharing the longest prefix (at
+// least minColocateBlocks blocks) that still has per-group capacity and is below
+// its fair share of the batch; otherwise, or when no such replica exists, it
+// falls back to the least batch-loaded replica. The fair-share bound is what
+// keeps many prefix-sharing groups from stampeding onto a single replica.
+func pickReplica(replicas []fwksched.Endpoint, perReplica map[string]int, k int, load, matches map[string]int, minColocateBlocks, maxShare int, preferMatch bool) fwksched.Endpoint {
+	if preferMatch {
+		var best fwksched.Endpoint
+		var bestName string
+		bestMatch := 0
+		for _, r := range replicas {
+			name := r.GetMetadata().NamespacedName.String()
+			if k != unlimitedPerReplica && perReplica[name] >= k {
+				continue
+			}
+			if load[name] >= maxShare {
+				continue // at fair share: co-locating here would unbalance the batch
+			}
+			m := matches[name]
+			if m < minColocateBlocks {
+				continue
+			}
+			if best == nil || m > bestMatch || (m == bestMatch && less(r, name, load, best, bestName)) {
+				best, bestName, bestMatch = r, name, m
+			}
+		}
+		if best != nil {
+			return best
+		}
+	}
+	return pickLeastLoaded(replicas, perReplica, k, load)
+}
+
+// pickLeastLoaded returns the least batch-loaded replica with capacity for this
+// group, falling back to the overall least-loaded replica when all are at the
+// cap. Ties break by running requests then by name for deterministic placement.
+func pickLeastLoaded(replicas []fwksched.Endpoint, perReplica map[string]int, k int, load map[string]int) fwksched.Endpoint {
 	var best fwksched.Endpoint
 	var bestName string
 	for _, r := range replicas {
@@ -139,7 +260,6 @@ func pickReplica(replicas []fwksched.Endpoint, perReplica map[string]int, k int,
 	if best != nil {
 		return best
 	}
-	// All replicas at cap: ignore the cap and balance by load.
 	for _, r := range replicas {
 		name := r.GetMetadata().NamespacedName.String()
 		if best == nil || less(r, name, load, best, bestName) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -17,7 +17,6 @@ limitations under the License.
 package burstprefix
 
 import (
-	"encoding/binary"
 	"sort"
 	"strings"
 
@@ -46,11 +45,10 @@ func encodePrefix(hashes [][]prefixhash.BlockHash, n int) string {
 			if count >= n {
 				return b.String()
 			}
-			binary.LittleEndian.PutUint64(buf[:], uint64(h))
+			prefixhash.PutBlockHash(buf[:], h)
 			b.Write(buf[:])
 			count++
 		}
-		b.WriteByte('|')
 	}
 	return b.String()
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -34,30 +34,10 @@ func totalBlocks(hashes [][]prefixhash.BlockHash) int {
 	return total
 }
 
-// groupKey identifies requests that share an identical prompt prefix. Because
-// each block hash chains its predecessor, an identical leading hash sequence
-// means an identical prompt prefix. Requests with no prefix return "" and are
-// never grouped.
-func groupKey(hashes [][]prefixhash.BlockHash) string {
-	if totalBlocks(hashes) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	var buf [8]byte
-	for _, ph := range hashes {
-		for _, h := range ph {
-			binary.LittleEndian.PutUint64(buf[:], uint64(h))
-			b.Write(buf[:])
-		}
-		b.WriteByte('|')
-	}
-	return b.String()
-}
-
-// prefixSignature encodes the first n prefix blocks. Two requests with equal
-// signatures share at least n leading blocks (the chained-hash property), so it
-// groups requests that overlap on a prefix without being identical.
-func prefixSignature(hashes [][]prefixhash.BlockHash, n int) string {
+// encodePrefix serializes the first n prefix blocks. Equal results imply an
+// equal n-block leading prefix: each block hash chains its predecessor, so an
+// equal leading hash sequence means an equal prompt prefix.
+func encodePrefix(hashes [][]prefixhash.BlockHash, n int) string {
 	var b strings.Builder
 	var buf [8]byte
 	count := 0
@@ -73,6 +53,16 @@ func prefixSignature(hashes [][]prefixhash.BlockHash, n int) string {
 		b.WriteByte('|')
 	}
 	return b.String()
+}
+
+// groupKey identifies requests that share an identical prompt prefix. Requests
+// with no prefix return "" and are never grouped.
+func groupKey(hashes [][]prefixhash.BlockHash) string {
+	n := totalBlocks(hashes)
+	if n == 0 {
+		return ""
+	}
+	return encodePrefix(hashes, n)
 }
 
 // sharedPrefixKeys returns the group keys whose requests share at least
@@ -92,7 +82,7 @@ func sharedPrefixKeys(groups map[string][]*entry, order []string, minColocateBlo
 		if totalBlocks(hashes) < minColocateBlocks {
 			continue
 		}
-		s := prefixSignature(hashes, minColocateBlocks)
+		s := encodePrefix(hashes, minColocateBlocks)
 		keySig[key] = s
 		count[s] += len(groups[key])
 	}
@@ -151,25 +141,10 @@ func (b *batchIndex) longestPrefix(hashes [][]prefixhash.BlockHash) map[string]i
 }
 
 // assign steers each batched request to a replica so prompt-sharing requests
-// co-locate. Pass 1 groups requests by identical prefix (the samples of one
-// prompt). An identical group of more than one member is always a placeable
-// unit; a single request becomes placeable only when it shares at least
-// minColocateBlocks leading blocks with some other request in the batch (so a
-// lone, distinct request keeps no affinity and is left for other scorers).
-//
-// Pass 2 places the units jointly over the whole batch. Identical groups are
-// placed first - longest-prefix first, kept whole (never split except by an
-// explicit maxPerReplica cap) - so the proven same-prompt co-location is the firm
-// structure; prefix-sharing singletons then attach to the established clusters.
-// Each unit prefers a replica that already holds a unit sharing at least
-// minColocateBlocks leading blocks AND is still below its fair share of the batch
-// (total placed samples / replicas); this prefills a shared prefix once across
-// units without letting many prefix-sharing units stampede onto one replica. With
-// no eligible match a unit seeds the least-loaded replica. Within a group,
-// samples fill one replica up to maxPerReplica (k) before spilling to the next
-// least-loaded replica; k == -1 places the whole group on one replica.
-// minColocateBlocks == 0 disables inter-unit co-location: only identical groups
-// are placed and purely load-balanced.
+// co-locate. It groups requests by shared prefix, then places the groups jointly
+// over the batch (longest-prefix first) so a shared prefix is prefilled once per
+// replica rather than scattered. Identical groups are placed before prefix-sharing
+// singletons so proven same-prompt co-location anchors the layout.
 func assign(entries []*entry, k, minColocateBlocks int) {
 	groups := map[string][]*entry{}
 	order := []string{}
@@ -191,10 +166,6 @@ func assign(entries []*entry, k, minColocateBlocks int) {
 		return
 	}
 
-	// Identical groups are always placed; a singleton is placed only when it
-	// overlaps another request's prefix. Identical groups are placed before
-	// singletons so same-prompt co-location is never displaced by an attaching
-	// singleton.
 	shared := sharedPrefixKeys(groups, order, minColocateBlocks)
 	var groupUnits, singleUnits []string
 	total := 0
@@ -221,10 +192,7 @@ func assign(entries []*entry, k, minColocateBlocks int) {
 
 	idx := newBatchIndex()
 	load := map[string]int{} // batch-wide samples assigned per replica
-	for _, key := range groupUnits {
-		placeGroup(groups[key], replicas, k, minColocateBlocks, maxShare, idx, load)
-	}
-	for _, key := range singleUnits {
+	for _, key := range append(groupUnits, singleUnits...) {
 		placeGroup(groups[key], replicas, k, minColocateBlocks, maxShare, idx, load)
 	}
 }
@@ -246,10 +214,14 @@ func placeGroup(members []*entry, replicas []fwksched.Endpoint, k, minColocateBl
 		return
 	}
 	hashes := members[0].hashes // identical group: any member represents it
-	matches := idx.longestPrefix(hashes)
 
-	perReplica := map[string]int{} // samples of THIS group already on a replica
+	var matches map[string]int
 	preferMatch := minColocateBlocks > 0
+	if preferMatch {
+		matches = idx.longestPrefix(hashes)
+	}
+
+	perReplica := map[string]int{} // samples of this group already on a replica
 	i := 0
 	for i < len(members) {
 		target := pickReplica(replicas, perReplica, k, load, matches, minColocateBlocks, maxShare, preferMatch)
@@ -317,7 +289,7 @@ func pickReplica(replicas []fwksched.Endpoint, perReplica map[string]int, k int,
 
 // pickLeastLoaded returns the least batch-loaded replica with capacity for this
 // group, falling back to the overall least-loaded replica when all are at the
-// cap. Ties break by running requests then by name for deterministic placement.
+// cap.
 func pickLeastLoaded(replicas []fwksched.Endpoint, perReplica map[string]int, k int, load map[string]int) fwksched.Endpoint {
 	var best fwksched.Endpoint
 	var bestName string

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -195,7 +195,12 @@ func assign(entries []*entry, k, minColocateBlocks int) {
 
 	idx := newBatchIndex()
 	load := map[string]int{} // batch-wide samples assigned per replica
-	for _, key := range append(groupUnits, singleUnits...) {
+	// Groups first, then prefix-sharing singletons: same order as before, without
+	// allocating a combined slice.
+	for _, key := range groupUnits {
+		placeGroup(groups[key], replicas, k, minColocateBlocks, maxShare, idx, load)
+	}
+	for _, key := range singleUnits {
 		placeGroup(groups[key], replicas, k, minColocateBlocks, maxShare, idx, load)
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -323,7 +323,11 @@ func pickLeastLoaded(replicas []fwksched.Endpoint, perReplica map[string]int, k 
 }
 
 // less reports whether replica a should be preferred over replica b: fewer
-// assigned samples first, then fewer running requests, then lower name.
+// assigned samples first, then fewer running requests, then lower name. The
+// batch-local assigned-sample count (load) is the primary signal; running
+// requests only break ties within a batch and deliberately differ from the
+// load-aware-scorer's WaitingQueueSize signal, since placement balances work
+// already committed in this window rather than queue depth observed downstream.
 func less(a fwksched.Endpoint, aName string, load map[string]int, b fwksched.Endpoint, bName string) bool {
 	if load[aName] != load[bName] {
 		return load[aName] < load[bName]

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -126,11 +126,12 @@ func (b *batchIndex) add(hashes [][]prefixhash.BlockHash, replica string) {
 // replica already holds (summed across prompts) - the shared-prefix length.
 func (b *batchIndex) longestPrefix(hashes [][]prefixhash.BlockHash) map[string]int {
 	res := map[string]int{}
+outer:
 	for _, ph := range hashes {
 		for _, h := range ph {
 			holders := b.holders[h]
 			if len(holders) == 0 {
-				break
+				break outer
 			}
 			for name := range holders {
 				res[name]++

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -54,6 +54,57 @@ func groupKey(hashes [][]prefixhash.BlockHash) string {
 	return b.String()
 }
 
+// prefixSignature encodes the first n prefix blocks. Two requests with equal
+// signatures share at least n leading blocks (the chained-hash property), so it
+// groups requests that overlap on a prefix without being identical.
+func prefixSignature(hashes [][]prefixhash.BlockHash, n int) string {
+	var b strings.Builder
+	var buf [8]byte
+	count := 0
+	for _, ph := range hashes {
+		for _, h := range ph {
+			if count >= n {
+				return b.String()
+			}
+			binary.LittleEndian.PutUint64(buf[:], uint64(h))
+			b.Write(buf[:])
+			count++
+		}
+		b.WriteByte('|')
+	}
+	return b.String()
+}
+
+// sharedPrefixKeys returns the group keys whose requests share at least
+// minColocateBlocks leading blocks with some other request in the batch. It is
+// the affinity gate for non-identical requests: a lone request that overlaps no
+// other keeps no affinity, while overlapping ones (e.g. one prompt contained in
+// another) become placeable. Keys with fewer than minColocateBlocks blocks can
+// never meet the threshold and are excluded.
+func sharedPrefixKeys(groups map[string][]*entry, order []string, minColocateBlocks int) map[string]bool {
+	if minColocateBlocks <= 0 {
+		return nil
+	}
+	count := map[string]int{}
+	keySig := map[string]string{}
+	for _, key := range order {
+		hashes := groups[key][0].hashes
+		if totalBlocks(hashes) < minColocateBlocks {
+			continue
+		}
+		s := prefixSignature(hashes, minColocateBlocks)
+		keySig[key] = s
+		count[s] += len(groups[key])
+	}
+	shared := map[string]bool{}
+	for key, s := range keySig {
+		if count[s] >= 2 {
+			shared[key] = true
+		}
+	}
+	return shared
+}
+
 // batchIndex records which replicas hold each prefix block, for matching later
 // groups against groups already placed in this batch. Because a whole prompt
 // prefix is added at once, holding block i implies holding blocks 0..i, so a
@@ -99,25 +150,30 @@ func (b *batchIndex) longestPrefix(hashes [][]prefixhash.BlockHash) map[string]i
 	return res
 }
 
-// assign steers each batched request to a replica so prompt-sharing samples
-// co-locate. Pass 1 groups requests by identical prefix (samples of one prompt);
-// only groups with more than one member receive an affinity (singletons have no
-// reuse and are left for other scorers).
+// assign steers each batched request to a replica so prompt-sharing requests
+// co-locate. Pass 1 groups requests by identical prefix (the samples of one
+// prompt). An identical group of more than one member is always a placeable
+// unit; a single request becomes placeable only when it shares at least
+// minColocateBlocks leading blocks with some other request in the batch (so a
+// lone, distinct request keeps no affinity and is left for other scorers).
 //
-// Pass 2 places the groups jointly over the whole batch. Groups are placed
-// longest-prefix first so they seed the batch index for shorter groups to match
-// against. Each group prefers a replica that already holds a group sharing at
-// least minColocateBlocks leading blocks AND is still below its fair share of the
-// batch (total placed samples / replicas); this prefills a long shared prefix
-// once across groups without letting many prefix-sharing groups stampede onto one
-// replica. With no eligible match a group seeds the least-loaded replica. Within
-// a group, samples fill one replica up to maxPerReplica (k) before spilling to
-// the next least-loaded replica; k == -1 places the whole group on one replica.
-// minColocateBlocks == 0 disables inter-group co-location (placement is purely
-// load-balanced).
+// Pass 2 places the units jointly over the whole batch. Identical groups are
+// placed first - longest-prefix first, kept whole (never split except by an
+// explicit maxPerReplica cap) - so the proven same-prompt co-location is the firm
+// structure; prefix-sharing singletons then attach to the established clusters.
+// Each unit prefers a replica that already holds a unit sharing at least
+// minColocateBlocks leading blocks AND is still below its fair share of the batch
+// (total placed samples / replicas); this prefills a shared prefix once across
+// units without letting many prefix-sharing units stampede onto one replica. With
+// no eligible match a unit seeds the least-loaded replica. Within a group,
+// samples fill one replica up to maxPerReplica (k) before spilling to the next
+// least-loaded replica; k == -1 places the whole group on one replica.
+// minColocateBlocks == 0 disables inter-unit co-location: only identical groups
+// are placed and purely load-balanced.
 func assign(entries []*entry, k, minColocateBlocks int) {
 	groups := map[string][]*entry{}
 	order := []string{}
+	var replicas []fwksched.Endpoint
 	for _, e := range entries {
 		key := groupKey(e.hashes)
 		if key == "" {
@@ -127,47 +183,64 @@ func assign(entries []*entry, k, minColocateBlocks int) {
 			order = append(order, key)
 		}
 		groups[key] = append(groups[key], e)
-	}
-
-	// Placeable groups (more than one member) and the total samples they
-	// contribute, which sets the per-replica fair-share cap.
-	var placeKeys []string
-	total := 0
-	var replicas []fwksched.Endpoint
-	for _, key := range order {
-		members := groups[key]
-		if len(members) < 2 {
-			continue
-		}
-		placeKeys = append(placeKeys, key)
-		total += len(members)
 		if replicas == nil {
-			replicas = members[0].pods
+			replicas = e.pods
 		}
 	}
-	if len(placeKeys) == 0 || len(replicas) == 0 {
+	if len(replicas) == 0 {
 		return
 	}
 
-	// Longest-prefix first: a longer group seeds more blocks in the index, so
-	// shorter groups match against the richest set of already-placed prefixes.
-	sort.SliceStable(placeKeys, func(i, j int) bool {
-		return totalBlocks(groups[placeKeys[i]][0].hashes) > totalBlocks(groups[placeKeys[j]][0].hashes)
-	})
+	// Identical groups are always placed; a singleton is placed only when it
+	// overlaps another request's prefix. Identical groups are placed before
+	// singletons so same-prompt co-location is never displaced by an attaching
+	// singleton.
+	shared := sharedPrefixKeys(groups, order, minColocateBlocks)
+	var groupUnits, singleUnits []string
+	total := 0
+	for _, key := range order {
+		switch {
+		case len(groups[key]) >= 2:
+			groupUnits = append(groupUnits, key)
+			total += len(groups[key])
+		case shared[key]:
+			singleUnits = append(singleUnits, key)
+			total += len(groups[key])
+		}
+	}
+	if len(groupUnits) == 0 && len(singleUnits) == 0 {
+		return
+	}
+
+	// Longest-prefix first within each tier: a longer prefix seeds more blocks in
+	// the index, so shorter units match against the richest set of placed blocks.
+	sortByPrefixLen(groupUnits, groups)
+	sortByPrefixLen(singleUnits, groups)
 
 	maxShare := (total + len(replicas) - 1) / len(replicas) // ceil: equal samples per replica
 
 	idx := newBatchIndex()
 	load := map[string]int{} // batch-wide samples assigned per replica
-	for _, key := range placeKeys {
+	for _, key := range groupUnits {
+		placeGroup(groups[key], replicas, k, minColocateBlocks, maxShare, idx, load)
+	}
+	for _, key := range singleUnits {
 		placeGroup(groups[key], replicas, k, minColocateBlocks, maxShare, idx, load)
 	}
 }
 
-// placeGroup places one identical-prompt group. The first (primary) replica is
-// chosen with the inter-group prefix preference bounded by the fair-share cap;
-// remaining samples (when k caps the group) spill to least-loaded replicas. The
-// group's blocks are then recorded so later groups can match against it.
+// sortByPrefixLen orders keys by descending prefix-block count (stable).
+func sortByPrefixLen(keys []string, groups map[string][]*entry) {
+	sort.SliceStable(keys, func(i, j int) bool {
+		return totalBlocks(groups[keys[i]][0].hashes) > totalBlocks(groups[keys[j]][0].hashes)
+	})
+}
+
+// placeGroup places one unit (an identical group, or a single prefix-sharing
+// request). The first (primary) replica is chosen with the inter-unit prefix
+// preference bounded by the fair-share cap; remaining samples (when k caps the
+// group) spill to least-loaded replicas. The unit's blocks are then recorded so
+// later units can match against it.
 func placeGroup(members []*entry, replicas []fwksched.Endpoint, k, minColocateBlocks, maxShare int, idx *batchIndex, load map[string]int) {
 	if len(replicas) == 0 {
 		return

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package burstprefix
+
+import (
+	"encoding/binary"
+	"strings"
+
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
+)
+
+// totalBlocks returns the number of prefix blocks across all prompts.
+func totalBlocks(hashes [][]prefixhash.BlockHash) int {
+	total := 0
+	for _, ph := range hashes {
+		total += len(ph)
+	}
+	return total
+}
+
+// groupKey identifies requests that share an identical prompt prefix. Because
+// each block hash chains its predecessor, an identical leading hash sequence
+// means an identical prompt prefix. Requests with no prefix return "" and are
+// never grouped.
+func groupKey(hashes [][]prefixhash.BlockHash) string {
+	if totalBlocks(hashes) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	var buf [8]byte
+	for _, ph := range hashes {
+		for _, h := range ph {
+			binary.LittleEndian.PutUint64(buf[:], uint64(h))
+			b.Write(buf[:])
+		}
+		b.WriteByte('|')
+	}
+	return b.String()
+}
+
+// assign steers each batched request to a replica so samples sharing a prompt
+// co-locate. Requests are grouped by identical prefix; only groups with more
+// than one member receive an affinity (singletons have no reuse to exploit and
+// are left for other scorers). Within a group, samples fill one replica up to
+// maxPerReplica (k) before spilling to the next least-loaded replica; k == -1
+// places the whole group on one replica. Group placement is balanced by the
+// batch-wide assignment count so distinct groups spread across replicas.
+func assign(entries []*entry, k int) {
+	groups := map[string][]*entry{}
+	order := []string{}
+	for _, e := range entries {
+		key := groupKey(e.hashes)
+		if key == "" {
+			continue
+		}
+		if _, ok := groups[key]; !ok {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], e)
+	}
+
+	// load is the batch-wide count of samples assigned per replica, used to
+	// spread groups across replicas.
+	load := map[string]int{}
+	for _, key := range order {
+		members := groups[key]
+		if len(members) < 2 {
+			continue
+		}
+		assignGroup(members, members[0].pods, k, load)
+	}
+}
+
+// assignGroup places the members of one group across replicas honoring the
+// per-replica cap k and updating the batch-wide load counter.
+func assignGroup(members []*entry, replicas []fwksched.Endpoint, k int, load map[string]int) {
+	if len(replicas) == 0 {
+		return
+	}
+	perReplica := map[string]int{} // samples of THIS group already on a replica
+
+	i := 0
+	for i < len(members) {
+		target := pickReplica(replicas, perReplica, k, load)
+		name := target.GetMetadata().NamespacedName.String()
+
+		// Fill this replica up to its remaining capacity before moving on, so a
+		// group concentrates rather than scatters.
+		run := len(members) - i
+		if k != unlimitedPerReplica {
+			capLeft := k - perReplica[name]
+			if capLeft < 1 {
+				capLeft = 1 // overflow: more members than k*replicas, place one and rebalance
+			}
+			if capLeft < run {
+				run = capLeft
+			}
+		}
+		for j := 0; j < run; j++ {
+			members[i+j].assigned = target
+		}
+		perReplica[name] += run
+		load[name] += run
+		i += run
+	}
+}
+
+// pickReplica returns the least batch-loaded replica that still has capacity for
+// this group. When every replica is at the cap (more members than k*replicas)
+// it falls back to the least-loaded replica ignoring the cap. Ties break by
+// running requests then by name for deterministic placement.
+func pickReplica(replicas []fwksched.Endpoint, perReplica map[string]int, k int, load map[string]int) fwksched.Endpoint {
+	var best fwksched.Endpoint
+	var bestName string
+	for _, r := range replicas {
+		name := r.GetMetadata().NamespacedName.String()
+		if k != unlimitedPerReplica && perReplica[name] >= k {
+			continue
+		}
+		if best == nil || less(r, name, load, best, bestName) {
+			best, bestName = r, name
+		}
+	}
+	if best != nil {
+		return best
+	}
+	// All replicas at cap: ignore the cap and balance by load.
+	for _, r := range replicas {
+		name := r.GetMetadata().NamespacedName.String()
+		if best == nil || less(r, name, load, best, bestName) {
+			best, bestName = r, name
+		}
+	}
+	return best
+}
+
+// less reports whether replica a should be preferred over replica b: fewer
+// assigned samples first, then fewer running requests, then lower name.
+func less(a fwksched.Endpoint, aName string, load map[string]int, b fwksched.Endpoint, bName string) bool {
+	if load[aName] != load[bName] {
+		return load[aName] < load[bName]
+	}
+	ra, rb := runningRequests(a), runningRequests(b)
+	if ra != rb {
+		return ra < rb
+	}
+	return aName < bName
+}
+
+// runningRequests returns the endpoint's running-request count, or 0 when
+// metrics are unavailable.
+func runningRequests(e fwksched.Endpoint) int {
+	if m := e.GetMetrics(); m != nil {
+		return m.RunningRequestsSize
+	}
+	return 0
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
@@ -180,6 +180,57 @@ func TestAssign_FairShareSpreadsPrefixSharingGroups(t *testing.T) {
 		"the fair-share cap must spread prefix-sharing groups, not stampede them onto one replica")
 }
 
+func TestAssign_SingletonAttachesToOverlappingGroup(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	// An identical group plus a single request that overlaps its prefix but is
+	// not identical (shares leading {1,2} / {7,8}).
+	gx := group(2, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	sx := group(1, []prefixhash.BlockHash{1, 2, 8}, replicas)
+	gy := group(2, []prefixhash.BlockHash{7, 8, 5}, replicas)
+	sy := group(1, []prefixhash.BlockHash{7, 8, 9}, replicas)
+	entries := concat(gx, sx, gy, sy)
+
+	assign(entries, unlimitedPerReplica, 2)
+
+	// The identical group stays whole, and the overlapping singleton attaches to
+	// the replica holding the group it shares a prefix with.
+	assert.Equal(t, assignedName(gx[0]), assignedName(gx[1]), "an identical group is never broken")
+	assert.Equal(t, assignedName(gx[0]), assignedName(sx[0]), "a prefix-sharing singleton attaches to the overlapping group")
+	assert.Equal(t, assignedName(gy[0]), assignedName(sy[0]), "a prefix-sharing singleton attaches to the overlapping group")
+	assert.Equal(t, map[string]int{"pod1": 3, "pod2": 3}, counts(entries))
+}
+
+func TestAssign_LoneSingletonGetsNoAffinity(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	g := group(2, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	lone := group(1, []prefixhash.BlockHash{5, 5, 5}, replicas) // overlaps nothing
+	entries := concat(g, lone)
+
+	assign(entries, unlimitedPerReplica, 2)
+
+	assert.Nil(t, lone[0].assigned, "a request overlapping no other must keep no affinity")
+	assert.Equal(t, assignedName(g[0]), assignedName(g[1]), "the identical group still co-locates")
+}
+
+func TestAssign_OverlappingSingletonsColocateWithoutGroups(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	// No identical duplicates at all: four distinct requests sharing leading
+	// blocks {1,2} (the RAG / shared-system-prompt burst).
+	s1 := group(1, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	s2 := group(1, []prefixhash.BlockHash{1, 2, 4}, replicas)
+	s3 := group(1, []prefixhash.BlockHash{1, 2, 5}, replicas)
+	s4 := group(1, []prefixhash.BlockHash{1, 2, 6}, replicas)
+	entries := concat(s1, s2, s3, s4)
+
+	assign(entries, unlimitedPerReplica, 2)
+
+	for _, e := range entries {
+		assert.NotNil(t, e.assigned, "overlapping singletons receive an affinity even without identical groups")
+	}
+	assert.Equal(t, map[string]int{"pod1": 2, "pod2": 2}, counts(entries),
+		"overlapping singletons co-locate but stay balanced under the fair-share cap")
+}
+
 func TestAssign_SharedPrefixBelowThresholdDoesNotColocate(t *testing.T) {
 	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
 	// Both families share only 2 leading blocks, below minColocateBlocks=3.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
@@ -248,3 +248,34 @@ func TestAssign_SharedPrefixBelowThresholdDoesNotColocate(t *testing.T) {
 		"a shared prefix below minColocateBlocks must not co-locate")
 	assert.Equal(t, map[string]int{"pod1": 4, "pod2": 4}, counts(entries))
 }
+
+func TestAssign_SingleReplicaPlacesEverything(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1")}
+	// Distinct groups that would normally spread across replicas; with a single
+	// replica the fair-share and load logic has nowhere else to send them.
+	groupA := group(4, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	groupB := group(4, []prefixhash.BlockHash{9, 9, 9}, replicas)
+	entries := concat(groupA, groupB)
+
+	assign(entries, unlimitedPerReplica, 2)
+
+	for _, e := range entries {
+		assert.Equal(t, "pod1", assignedName(e), "with a single replica every request must land on it")
+	}
+}
+
+func TestAssign_OverflowGuardBalancesBeyondCap(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	// One group of 8 with k=2 over 2 replicas: k*replicas = 4 < 8, so the
+	// per-replica cap cannot hold the whole group. The capLeft overflow guard must
+	// still place every member and keep the batch balanced.
+	entries := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
+
+	assign(entries, 2, 0)
+
+	for _, e := range entries {
+		assert.NotNil(t, e.assigned, "the overflow guard must still assign every member")
+	}
+	assert.Equal(t, map[string]int{"pod1": 4, "pod2": 4}, counts(entries),
+		"members beyond k*replicas must rebalance evenly rather than drop")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
@@ -49,6 +49,19 @@ func group(n int, prefix []prefixhash.BlockHash, replicas []fwksched.Endpoint) [
 	return entries
 }
 
+// concat flattens groups into one entry slice in order.
+func concat(groups ...[]*entry) []*entry {
+	n := 0
+	for _, g := range groups {
+		n += len(g)
+	}
+	all := make([]*entry, 0, n)
+	for _, g := range groups {
+		all = append(all, g...)
+	}
+	return all
+}
+
 func counts(entries []*entry) map[string]int {
 	c := map[string]int{}
 	for _, e := range entries {
@@ -61,7 +74,7 @@ func TestAssign_UnlimitedColocatesWholeGroup(t *testing.T) {
 	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
 	entries := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
 
-	assign(entries, unlimitedPerReplica)
+	assign(entries, unlimitedPerReplica, 0)
 
 	for _, e := range entries {
 		assert.Equal(t, "pod1", assignedName(e), "all samples of one group must co-locate when k=-1")
@@ -72,7 +85,7 @@ func TestAssign_CapSpreadsEvenly(t *testing.T) {
 	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
 	entries := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
 
-	assign(entries, 2)
+	assign(entries, 2, 0)
 
 	assert.Equal(t, map[string]int{"pod1": 2, "pod2": 2, "pod3": 2, "pod4": 2}, counts(entries),
 		"k=2 over 8 samples and 4 replicas must place 2 per replica")
@@ -82,7 +95,7 @@ func TestAssign_CapFillsBeforeSpilling(t *testing.T) {
 	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
 	entries := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
 
-	assign(entries, 4)
+	assign(entries, 4, 0)
 
 	// k=4 fills one replica to 4 before using the next; only two replicas used.
 	assert.Equal(t, map[string]int{"pod1": 4, "pod2": 4}, counts(entries))
@@ -92,7 +105,7 @@ func TestAssign_SingletonGetsNoAffinity(t *testing.T) {
 	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
 	entries := group(1, []prefixhash.BlockHash{1, 2, 3}, replicas)
 
-	assign(entries, unlimitedPerReplica)
+	assign(entries, unlimitedPerReplica, 0)
 
 	assert.Nil(t, entries[0].assigned, "a singleton group has no reuse and must not receive an affinity")
 }
@@ -104,7 +117,7 @@ func TestAssign_EmptyPrefixGetsNoAffinity(t *testing.T) {
 		{hashes: nil, pods: replicas},
 	}
 
-	assign(entries, unlimitedPerReplica)
+	assign(entries, unlimitedPerReplica, 0)
 
 	for _, e := range entries {
 		assert.Nil(t, e.assigned, "requests with no prefix must not be grouped")
@@ -117,7 +130,7 @@ func TestAssign_DistinctGroupsSpreadAcrossReplicas(t *testing.T) {
 	groupB := group(8, []prefixhash.BlockHash{9, 9, 9}, replicas)
 	entries := append(append([]*entry{}, groupA...), groupB...)
 
-	assign(entries, unlimitedPerReplica)
+	assign(entries, unlimitedPerReplica, 0)
 
 	// Each group co-locates, and the second group lands on a different, less
 	// loaded replica than the first.
@@ -129,4 +142,58 @@ func TestAssign_DistinctGroupsSpreadAcrossReplicas(t *testing.T) {
 	for _, e := range groupB {
 		assert.Equal(t, "pod2", assignedName(e))
 	}
+}
+
+func TestAssign_SharedPrefixFamiliesColocateWithinFairShare(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	// Two prefix families of two groups each: famX groups share leading {1, 2},
+	// famY groups share leading {7, 8}.
+	x1 := group(2, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	x2 := group(2, []prefixhash.BlockHash{1, 2, 4}, replicas)
+	y1 := group(2, []prefixhash.BlockHash{7, 8, 5}, replicas)
+	y2 := group(2, []prefixhash.BlockHash{7, 8, 6}, replicas)
+	entries := concat(x1, x2, y1, y2)
+
+	assign(entries, unlimitedPerReplica, 2)
+
+	// Each family co-locates onto one replica, the two families land on
+	// different replicas, and the batch stays balanced (4 samples per replica).
+	assert.Equal(t, assignedName(x1[0]), assignedName(x2[0]), "groups sharing >= minColocateBlocks leading blocks co-locate")
+	assert.Equal(t, assignedName(y1[0]), assignedName(y2[0]), "groups sharing >= minColocateBlocks leading blocks co-locate")
+	assert.NotEqual(t, assignedName(x1[0]), assignedName(y1[0]), "distinct families spread across replicas")
+	assert.Equal(t, map[string]int{"pod1": 4, "pod2": 4}, counts(entries))
+}
+
+func TestAssign_FairShareSpreadsPrefixSharingGroups(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
+	// Four groups all sharing leading {1, 2}. Pure longest-match would pile them
+	// onto one replica; the fair-share cap must spread them instead.
+	g1 := group(2, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	g2 := group(2, []prefixhash.BlockHash{1, 2, 4}, replicas)
+	g3 := group(2, []prefixhash.BlockHash{1, 2, 5}, replicas)
+	g4 := group(2, []prefixhash.BlockHash{1, 2, 6}, replicas)
+	entries := concat(g1, g2, g3, g4)
+
+	assign(entries, unlimitedPerReplica, 2)
+
+	assert.Equal(t, map[string]int{"pod1": 2, "pod2": 2, "pod3": 2, "pod4": 2}, counts(entries),
+		"the fair-share cap must spread prefix-sharing groups, not stampede them onto one replica")
+}
+
+func TestAssign_SharedPrefixBelowThresholdDoesNotColocate(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	// Both families share only 2 leading blocks, below minColocateBlocks=3.
+	x1 := group(2, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	x2 := group(2, []prefixhash.BlockHash{1, 2, 4}, replicas)
+	y1 := group(2, []prefixhash.BlockHash{7, 8, 5}, replicas)
+	y2 := group(2, []prefixhash.BlockHash{7, 8, 6}, replicas)
+	entries := concat(x1, x2, y1, y2)
+
+	assign(entries, unlimitedPerReplica, 3)
+
+	// The shared prefix falls short of the threshold, so groups are placed purely
+	// by load and a family is not kept together.
+	assert.NotEqual(t, assignedName(x1[0]), assignedName(x2[0]),
+		"a shared prefix below minColocateBlocks must not co-locate")
+	assert.Equal(t, map[string]int{"pod1": 4, "pod2": 4}, counts(entries))
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package burstprefix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
+)
+
+func testEndpoint(name string) fwksched.Endpoint {
+	return fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+		fwkdl.NewMetrics(), fwkdl.NewAttributes())
+}
+
+func assignedName(e *entry) string {
+	if e.assigned == nil {
+		return ""
+	}
+	return e.assigned.GetMetadata().NamespacedName.Name
+}
+
+// group builds n entries sharing one prompt prefix over the given replicas.
+func group(n int, prefix []prefixhash.BlockHash, replicas []fwksched.Endpoint) []*entry {
+	entries := make([]*entry, n)
+	for i := range entries {
+		entries[i] = &entry{hashes: [][]prefixhash.BlockHash{prefix}, pods: replicas}
+	}
+	return entries
+}
+
+func counts(entries []*entry) map[string]int {
+	c := map[string]int{}
+	for _, e := range entries {
+		c[assignedName(e)]++
+	}
+	return c
+}
+
+func TestAssign_UnlimitedColocatesWholeGroup(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
+	entries := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
+
+	assign(entries, unlimitedPerReplica)
+
+	for _, e := range entries {
+		assert.Equal(t, "pod1", assignedName(e), "all samples of one group must co-locate when k=-1")
+	}
+}
+
+func TestAssign_CapSpreadsEvenly(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
+	entries := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
+
+	assign(entries, 2)
+
+	assert.Equal(t, map[string]int{"pod1": 2, "pod2": 2, "pod3": 2, "pod4": 2}, counts(entries),
+		"k=2 over 8 samples and 4 replicas must place 2 per replica")
+}
+
+func TestAssign_CapFillsBeforeSpilling(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
+	entries := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
+
+	assign(entries, 4)
+
+	// k=4 fills one replica to 4 before using the next; only two replicas used.
+	assert.Equal(t, map[string]int{"pod1": 4, "pod2": 4}, counts(entries))
+}
+
+func TestAssign_SingletonGetsNoAffinity(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	entries := group(1, []prefixhash.BlockHash{1, 2, 3}, replicas)
+
+	assign(entries, unlimitedPerReplica)
+
+	assert.Nil(t, entries[0].assigned, "a singleton group has no reuse and must not receive an affinity")
+}
+
+func TestAssign_EmptyPrefixGetsNoAffinity(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	entries := []*entry{
+		{hashes: nil, pods: replicas},
+		{hashes: nil, pods: replicas},
+	}
+
+	assign(entries, unlimitedPerReplica)
+
+	for _, e := range entries {
+		assert.Nil(t, e.assigned, "requests with no prefix must not be grouped")
+	}
+}
+
+func TestAssign_DistinctGroupsSpreadAcrossReplicas(t *testing.T) {
+	replicas := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4")}
+	groupA := group(8, []prefixhash.BlockHash{1, 2, 3}, replicas)
+	groupB := group(8, []prefixhash.BlockHash{9, 9, 9}, replicas)
+	entries := append(append([]*entry{}, groupA...), groupB...)
+
+	assign(entries, unlimitedPerReplica)
+
+	// Each group co-locates, and the second group lands on a different, less
+	// loaded replica than the first.
+	assert.Equal(t, "pod1", assignedName(groupA[0]))
+	assert.Equal(t, "pod2", assignedName(groupB[0]))
+	for _, e := range groupA {
+		assert.Equal(t, "pod1", assignedName(e))
+	}
+	for _, e := range groupB {
+		assert.Equal(t, "pod2", assignedName(e))
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package burstprefix provides a request-level data producer that co-locates
+// bursts of prompt-sharing requests. Requests arriving within a configurable
+// window are assigned jointly: samples that share a prompt are steered to the
+// same replica(s) so the shared prefix is prefilled once instead of scattered
+// across replicas on a cold cache. It emits PrefixCacheMatchInfo and reuses the
+// prefix-cache-scorer (point its prefixMatchInfoProducerName at this producer).
+package burstprefix
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
+)
+
+// produceTimeoutMargin is added to the window so the director's per-producer
+// timeout does not cancel a request still waiting for its batch to seal.
+const produceTimeoutMargin = 300 * time.Millisecond
+
+var (
+	_ requestcontrol.DataProducer         = &dataProducer{}
+	_ requestcontrol.TimeoutAwareProducer = &dataProducer{}
+)
+
+// dataProducer batches requests within a window and assigns each to a replica
+// so prompt-sharing samples co-locate.
+type dataProducer struct {
+	typedName plugin.TypedName
+	config    config
+	window    time.Duration
+	maxBlocks int
+	dk        plugin.DataKey
+
+	mu    sync.Mutex
+	batch *batch
+}
+
+// TypedName returns the type and name of the plugin.
+func (p *dataProducer) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// Produces returns the data produced by the plugin.
+func (p *dataProducer) Produces() map[plugin.DataKey]any {
+	return map[plugin.DataKey]any{p.dk: attrprefix.PrefixCacheMatchInfo{}}
+}
+
+// Consumes declares the TokenizedPrompt dependency so the token-producer runs
+// before this producer and one is auto-created when none is configured.
+func (p *dataProducer) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedPrompt{}},
+	}
+}
+
+// ProduceTimeout extends the producer timeout to cover the batch window.
+func (p *dataProducer) ProduceTimeout() time.Duration {
+	return p.window + produceTimeoutMargin
+}
+
+// newDataProducer initializes a new burst prefix cache producer.
+func newDataProducer(_ context.Context, name string, cfg config) (*dataProducer, error) {
+	if cfg.WindowDurationMs <= 0 {
+		return nil, fmt.Errorf("invalid configuration: windowDurationMs must be > 0 (current value: %d)", cfg.WindowDurationMs)
+	}
+	if cfg.MaxPerReplica != unlimitedPerReplica && cfg.MaxPerReplica < 1 {
+		return nil, fmt.Errorf("invalid configuration: maxPerReplica must be -1 (unlimited) or >= 1 (current value: %d)", cfg.MaxPerReplica)
+	}
+	if cfg.BlockSizeTokens <= 0 {
+		return nil, fmt.Errorf("invalid configuration: blockSizeTokens must be > 0 (current value: %d)", cfg.BlockSizeTokens)
+	}
+	if cfg.MaxPrefixTokensToMatch < 0 {
+		return nil, fmt.Errorf("invalid configuration: maxPrefixTokensToMatch must be >= 0 (current value: %d)", cfg.MaxPrefixTokensToMatch)
+	}
+
+	maxBlocks := defaultMaxPrefixBlocks
+	if cfg.MaxPrefixTokensToMatch > 0 {
+		maxBlocks = cfg.MaxPrefixTokensToMatch / cfg.BlockSizeTokens
+	}
+
+	return &dataProducer{
+		typedName: plugin.TypedName{Type: PluginType, Name: name},
+		config:    cfg,
+		window:    time.Duration(cfg.WindowDurationMs) * time.Millisecond,
+		maxBlocks: maxBlocks,
+		dk:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name),
+	}, nil
+}
+
+// Produce collects the request into the current batch window, waits for the
+// window to seal, then attaches PrefixCacheMatchInfo reflecting the joint
+// assignment: a full match on the assigned replica and zero elsewhere.
+func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
+	hashes := prefixhash.GetBlockHashes(ctx, request, p.config.BlockSizeTokens, p.maxBlocks)
+	e := &entry{hashes: hashes, pods: pods}
+
+	p.mu.Lock()
+	if p.batch == nil {
+		p.batch = &batch{sealed: make(chan struct{})}
+		b := p.batch
+		time.AfterFunc(p.window, func() { p.seal(b) })
+	}
+	b := p.batch
+	b.entries = append(b.entries, e)
+	p.mu.Unlock()
+
+	select {
+	case <-b.sealed:
+	case <-ctx.Done():
+		// Timed out or cancelled before the batch sealed; leave no affinity.
+		return ctx.Err()
+	}
+
+	total := totalBlocks(hashes)
+	for _, pod := range pods {
+		matchLen := 0
+		if e.assigned != nil && pod.GetMetadata().NamespacedName == e.assigned.GetMetadata().NamespacedName {
+			matchLen = total
+		}
+		pod.Put(p.dk.String(), attrprefix.NewPrefixCacheMatchInfo(matchLen, total, p.config.BlockSizeTokens))
+	}
+	return nil
+}
+
+// seal finalizes a batch: it detaches the batch so later requests start a fresh
+// one, computes the joint assignment, and releases all waiting requests.
+func (p *dataProducer) seal(b *batch) {
+	p.mu.Lock()
+	if b.closed {
+		p.mu.Unlock()
+		return
+	}
+	b.closed = true
+	if p.batch == b {
+		p.batch = nil
+	}
+	entries := b.entries
+	p.mu.Unlock()
+
+	assign(entries, p.config.MaxPerReplica)
+	close(b.sealed)
+}
+
+// Factory is the factory function for the burst prefix cache producer plugin.
+func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
+	parameters := defaultConfig
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal burst prefix cache parameters: %w", err)
+		}
+	}
+	if handle == nil {
+		return nil, errors.New("plugin handle is required")
+	}
+	log.FromContext(handle.Context()).V(logutil.DEFAULT).Info("Burst prefix DataProducer initialized", "config", parameters)
+	return newDataProducer(handle.Context(), name, parameters)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -100,6 +100,9 @@ func newDataProducer(_ context.Context, name string, cfg config) (*dataProducer,
 	if cfg.MaxPrefixTokensToMatch < 0 {
 		return nil, fmt.Errorf("invalid configuration: maxPrefixTokensToMatch must be >= 0 (current value: %d)", cfg.MaxPrefixTokensToMatch)
 	}
+	if cfg.MinColocateBlocks < 0 {
+		return nil, fmt.Errorf("invalid configuration: minColocateBlocks must be >= 0 (current value: %d)", cfg.MinColocateBlocks)
+	}
 
 	maxBlocks := defaultMaxPrefixBlocks
 	if cfg.MaxPrefixTokensToMatch > 0 {
@@ -165,7 +168,7 @@ func (p *dataProducer) seal(b *batch) {
 	entries := b.entries
 	p.mu.Unlock()
 
-	assign(entries, p.config.MaxPerReplica)
+	assign(entries, p.config.MaxPerReplica, p.config.MinColocateBlocks)
 	close(b.sealed)
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -91,6 +91,9 @@ func newDataProducer(_ context.Context, name string, cfg config) (*dataProducer,
 	if cfg.WindowDurationMs <= 0 {
 		return nil, fmt.Errorf("invalid configuration: windowDurationMs must be > 0 (current value: %d)", cfg.WindowDurationMs)
 	}
+	if cfg.WindowDurationMs > maxWindowDurationMs {
+		return nil, fmt.Errorf("invalid configuration: windowDurationMs must be <= %d (current value: %d)", maxWindowDurationMs, cfg.WindowDurationMs)
+	}
 	if cfg.MaxPerReplica != unlimitedPerReplica && cfg.MaxPerReplica < 1 {
 		return nil, fmt.Errorf("invalid configuration: maxPerReplica must be -1 (unlimited) or >= 1 (current value: %d)", cfg.MaxPerReplica)
 	}
@@ -99,6 +102,9 @@ func newDataProducer(_ context.Context, name string, cfg config) (*dataProducer,
 	}
 	if cfg.MaxPrefixTokensToMatch < 0 {
 		return nil, fmt.Errorf("invalid configuration: maxPrefixTokensToMatch must be >= 0 (current value: %d)", cfg.MaxPrefixTokensToMatch)
+	}
+	if cfg.MaxPrefixTokensToMatch > 0 && cfg.MaxPrefixTokensToMatch < cfg.BlockSizeTokens {
+		return nil, fmt.Errorf("invalid configuration: maxPrefixTokensToMatch (%d) must be 0 or >= blockSizeTokens (%d); a smaller positive value yields zero prefix blocks", cfg.MaxPrefixTokensToMatch, cfg.BlockSizeTokens)
 	}
 	if cfg.MinColocateBlocks < 0 {
 		return nil, fmt.Errorf("invalid configuration: minColocateBlocks must be >= 0 (current value: %d)", cfg.MinColocateBlocks)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -126,7 +126,7 @@ func newDataProducer(_ context.Context, name string, cfg config) (*dataProducer,
 // assignment: a full match on the assigned replica and zero elsewhere.
 func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
 	hashes := prefixhash.GetBlockHashes(ctx, request, p.config.BlockSizeTokens, p.maxBlocks)
-	e := &entry{hashes: hashes, pods: pods}
+	e := &entry{hashes: hashes, pods: pods, enqueued: time.Now()}
 
 	p.mu.Lock()
 	if p.batch == nil {
@@ -148,6 +148,8 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 		// Timed out or cancelled before the batch sealed; leave no affinity.
 		return ctx.Err()
 	}
+
+	log.FromContext(ctx).V(logutil.DEBUG).Info("burst batch sealed", "wait_ms", time.Since(e.enqueued).Milliseconds())
 
 	total := totalBlocks(hashes)
 	matched := false

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -143,12 +143,21 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 	}
 
 	total := totalBlocks(hashes)
+	matched := false
 	for _, pod := range pods {
 		matchLen := 0
 		if e.assigned != nil && pod.GetMetadata().NamespacedName == e.assigned.GetMetadata().NamespacedName {
 			matchLen = total
+			matched = true
 		}
 		pod.Put(p.dk.String(), attrprefix.NewPrefixCacheMatchInfo(matchLen, total, p.config.BlockSizeTokens))
+	}
+	if e.assigned != nil && !matched {
+		// The endpoint set changed between batching and release (rolling update or
+		// scale event): the assigned replica is not among this request's pods, so
+		// no affinity is produced. Surface it rather than degrading silently.
+		log.FromContext(ctx).V(logutil.DEBUG).Info("assigned replica absent from request pods; producing zero affinity",
+			"assigned", e.assigned.GetMetadata().NamespacedName.String())
 	}
 	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -103,6 +103,9 @@ func newDataProducer(_ context.Context, name string, cfg config) (*dataProducer,
 	if cfg.MinColocateBlocks < 0 {
 		return nil, fmt.Errorf("invalid configuration: minColocateBlocks must be >= 0 (current value: %d)", cfg.MinColocateBlocks)
 	}
+	if cfg.MaxBatchSize != unlimitedBatchSize && cfg.MaxBatchSize < 1 {
+		return nil, fmt.Errorf("invalid configuration: maxBatchSize must be -1 (unlimited) or >= 1 (current value: %d)", cfg.MaxBatchSize)
+	}
 
 	maxBlocks := defaultMaxPrefixBlocks
 	if cfg.MaxPrefixTokensToMatch > 0 {
@@ -132,6 +135,10 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 		time.AfterFunc(p.window, func() { p.seal(b) })
 	}
 	b := p.batch
+	if p.config.MaxBatchSize != unlimitedBatchSize && len(b.entries) >= p.config.MaxBatchSize {
+		p.mu.Unlock()
+		return fmt.Errorf("burst prefix batch full: maxBatchSize %d reached", p.config.MaxBatchSize)
+	}
 	b.entries = append(b.entries, e)
 	p.mu.Unlock()
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package burstprefix
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+)
+
+func tokenizedRequest(tokens []uint32) *fwksched.InferenceRequest {
+	return &fwksched.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{PerPromptTokens: [][]uint32{tokens}},
+		},
+	}
+}
+
+// assignedReplica returns the name of the endpoint this producer steered the
+// request to (the one scored with a non-zero match), or "" if none.
+func (p *dataProducer) assignedReplica(t *testing.T, endpoints []fwksched.Endpoint) string {
+	t.Helper()
+	for _, ep := range endpoints {
+		v, ok := ep.Get(p.dk.String())
+		require.True(t, ok, "PrefixCacheMatchInfo must be attached to every endpoint")
+		info, ok := v.(*attrprefix.PrefixCacheMatchInfo)
+		require.True(t, ok)
+		if info.MatchBlocks() > 0 {
+			return ep.GetMetadata().NamespacedName.Name
+		}
+	}
+	return ""
+}
+
+func TestNew_RejectsInvalidConfig(t *testing.T) {
+	_, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 0, MaxPerReplica: -1, BlockSizeTokens: 64})
+	assert.Error(t, err, "windowDurationMs must be > 0")
+
+	_, err = newDataProducer(context.Background(), "burst", config{WindowDurationMs: 100, MaxPerReplica: 0, BlockSizeTokens: 64})
+	assert.Error(t, err, "maxPerReplica 0 is invalid")
+
+	_, err = newDataProducer(context.Background(), "burst", config{WindowDurationMs: 100, MaxPerReplica: -1, BlockSizeTokens: 0})
+	assert.Error(t, err, "blockSizeTokens must be > 0")
+}
+
+func TestProduce_ColocatesIdenticalPromptBurst(t *testing.T) {
+	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 100, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4})
+	require.NoError(t, err)
+
+	const samples = 8
+	names := make([]string, samples)
+	var wg sync.WaitGroup
+	for i := 0; i < samples; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Each request sees its own snapshot of the same four replicas.
+			endpoints := []fwksched.Endpoint{
+				testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3"), testEndpoint("pod4"),
+			}
+			err := p.Produce(context.Background(), tokenizedRequest([]uint32{1, 2, 3, 4, 5, 6, 7, 8}), endpoints)
+			assert.NoError(t, err)
+			names[i] = p.assignedReplica(t, endpoints)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < samples; i++ {
+		assert.NotEmpty(t, names[i], "every sample of a duplicated prompt must be assigned a replica")
+		assert.Equal(t, names[0], names[i], "all samples of one prompt must co-locate on the same replica")
+	}
+}
+
+func TestProduce_SingletonHasNoAffinity(t *testing.T) {
+	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 50, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4})
+	require.NoError(t, err)
+
+	endpoints := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	err = p.Produce(context.Background(), tokenizedRequest([]uint32{1, 2, 3, 4}), endpoints)
+	require.NoError(t, err)
+
+	assert.Empty(t, p.assignedReplica(t, endpoints),
+		"a lone request in a window shares no prompt and must not be steered")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
@@ -65,7 +65,7 @@ func TestNew_RejectsInvalidConfig(t *testing.T) {
 }
 
 func TestProduce_ColocatesIdenticalPromptBurst(t *testing.T) {
-	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 100, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4})
+	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 100, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4, MaxBatchSize: unlimitedBatchSize})
 	require.NoError(t, err)
 
 	const samples = 8
@@ -93,7 +93,7 @@ func TestProduce_ColocatesIdenticalPromptBurst(t *testing.T) {
 }
 
 func TestProduce_SingletonHasNoAffinity(t *testing.T) {
-	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 50, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4})
+	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 50, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4, MaxBatchSize: unlimitedBatchSize})
 	require.NoError(t, err)
 
 	endpoints := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
@@ -103,3 +103,68 @@ func TestProduce_SingletonHasNoAffinity(t *testing.T) {
 	assert.Empty(t, p.assignedReplica(t, endpoints),
 		"a lone request in a window shares no prompt and must not be steered")
 }
+
+func TestProduce_CancelledContextBeforeSeal(t *testing.T) {
+	// A long window guarantees the batch cannot seal on its own before the
+	// already-cancelled context is observed.
+	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: maxWindowDurationMs, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4, MaxBatchSize: unlimitedBatchSize})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	endpoints := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2")}
+	err = p.Produce(ctx, tokenizedRequest([]uint32{1, 2, 3, 4}), endpoints)
+	require.Error(t, err, "a context cancelled before seal must return an error")
+
+	for _, ep := range endpoints {
+		v, ok := ep.Get(p.dk.String())
+		if !ok {
+			continue // no affinity attached is expected when Produce returns early
+		}
+		info, ok := v.(*attrprefix.PrefixCacheMatchInfo)
+		require.True(t, ok)
+		assert.Zero(t, info.MatchBlocks(), "a cancelled request must not produce a non-zero match")
+	}
+}
+
+func TestProduce_SecondWindowAfterSeal(t *testing.T) {
+	p, err := newDataProducer(context.Background(), "burst", config{WindowDurationMs: 30, MaxPerReplica: unlimitedPerReplica, BlockSizeTokens: 4, MaxBatchSize: unlimitedBatchSize})
+	require.NoError(t, err)
+
+	runWindow := func(prompt []uint32) []string {
+		const samples = 4
+		names := make([]string, samples)
+		var wg sync.WaitGroup
+		for i := 0; i < samples; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				endpoints := []fwksched.Endpoint{testEndpoint("pod1"), testEndpoint("pod2"), testEndpoint("pod3")}
+				assert.NoError(t, p.Produce(context.Background(), tokenizedRequest(prompt), endpoints))
+				names[i] = p.assignedReplica(t, endpoints)
+			}(i)
+		}
+		wg.Wait()
+		return names
+	}
+
+	first := runWindow([]uint32{1, 2, 3, 4, 5, 6, 7, 8})
+
+	// seal must detach the batch so the next request opens a fresh window.
+	p.mu.Lock()
+	reset := p.batch == nil
+	p.mu.Unlock()
+	assert.True(t, reset, "seal must reset p.batch to nil after the first window")
+
+	second := runWindow([]uint32{9, 10, 11, 12, 13, 14, 15, 16})
+
+	for i := range first {
+		assert.NotEmpty(t, first[i], "every first-window sample must be assigned")
+		assert.Equal(t, first[0], first[i], "first-window samples must co-locate")
+	}
+	for i := range second {
+		assert.NotEmpty(t, second[i], "every second-window sample must be assigned")
+		assert.Equal(t, second[0], second[i], "second-window samples must co-locate")
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
@@ -29,9 +29,10 @@ const (
 	// per-replica cap, sending every sample of a group to a single replica.
 	unlimitedPerReplica = -1
 
-	defaultWindowDurationMs = 100
-	defaultMaxPerReplica    = unlimitedPerReplica
-	defaultBlockSizeTokens  = 64
+	defaultWindowDurationMs  = 100
+	defaultMaxPerReplica     = unlimitedPerReplica
+	defaultBlockSizeTokens   = 64
+	defaultMinColocateBlocks = 0
 
 	// defaultMaxPrefixBlocks caps how many leading blocks form a group key.
 	// Two prompts identical up to this many blocks are treated as one group.
@@ -53,6 +54,13 @@ type config struct {
 	// maxBlocks = MaxPrefixTokensToMatch / BlockSizeTokens; otherwise
 	// defaultMaxPrefixBlocks applies.
 	MaxPrefixTokensToMatch int `json:"maxPrefixTokensToMatch"`
+	// MinColocateBlocks is the minimum shared leading blocks required to place two
+	// distinct groups on the same replica (inter-group prefix co-location). 0
+	// disables it: placement is purely load-balanced and only identical prompts
+	// co-locate. A larger value avoids co-locating on a trivial shared preamble.
+	// Co-location is always bounded by a per-replica fair-share cap, so raising
+	// this never lets prefix-sharing groups stampede onto one replica.
+	MinColocateBlocks int `json:"minColocateBlocks"`
 }
 
 // defaultConfig provides sensible defaults for the burst prefix cache producer.
@@ -61,6 +69,7 @@ var defaultConfig = config{
 	MaxPerReplica:          defaultMaxPerReplica,
 	BlockSizeTokens:        defaultBlockSizeTokens,
 	MaxPrefixTokensToMatch: 0,
+	MinColocateBlocks:      defaultMinColocateBlocks,
 }
 
 // entry is one request collected into a batch window.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package burstprefix
+
+import (
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
+)
+
+const (
+	// PluginType is the unique identifier for the burst prefix cache producer plugin.
+	PluginType = "burst-prefix-cache-producer"
+
+	// unlimitedPerReplica is the MaxPerReplica sentinel that disables the
+	// per-replica cap, sending every sample of a group to a single replica.
+	unlimitedPerReplica = -1
+
+	defaultWindowDurationMs = 100
+	defaultMaxPerReplica    = unlimitedPerReplica
+	defaultBlockSizeTokens  = 64
+
+	// defaultMaxPrefixBlocks caps how many leading blocks form a group key.
+	// Two prompts identical up to this many blocks are treated as one group.
+	defaultMaxPrefixBlocks = 2048
+)
+
+// config defines the configuration for the burst prefix cache producer.
+type config struct {
+	// WindowDurationMs is the batch window T in milliseconds. Requests arriving
+	// within one window are assigned jointly so samples sharing a prompt
+	// co-locate on the same replica(s).
+	WindowDurationMs int `json:"windowDurationMs"`
+	// MaxPerReplica caps how many samples of one group are assigned to a single
+	// replica (k). -1 disables the cap (all samples of a group to one replica).
+	MaxPerReplica int `json:"maxPerReplica"`
+	// BlockSizeTokens is the token block size used to compute prefix hashes.
+	BlockSizeTokens int `json:"blockSizeTokens"`
+	// MaxPrefixTokensToMatch caps prefix matching in tokens. When > 0 it sets
+	// maxBlocks = MaxPrefixTokensToMatch / BlockSizeTokens; otherwise
+	// defaultMaxPrefixBlocks applies.
+	MaxPrefixTokensToMatch int `json:"maxPrefixTokensToMatch"`
+}
+
+// defaultConfig provides sensible defaults for the burst prefix cache producer.
+var defaultConfig = config{
+	WindowDurationMs:       defaultWindowDurationMs,
+	MaxPerReplica:          defaultMaxPerReplica,
+	BlockSizeTokens:        defaultBlockSizeTokens,
+	MaxPrefixTokensToMatch: 0,
+}
+
+// entry is one request collected into a batch window.
+type entry struct {
+	hashes [][]prefixhash.BlockHash
+	pods   []fwksched.Endpoint
+	// assigned is the replica this request is steered to, filled when the batch
+	// is sealed. nil means no affinity (singleton group or empty prompt): the
+	// request is scored 0 on every endpoint so other scorers decide.
+	assigned fwksched.Endpoint
+}
+
+// batch accumulates requests arriving within one window and releases them
+// together once sealed.
+type batch struct {
+	entries []*entry
+	sealed  chan struct{}
+	closed  bool
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
@@ -29,10 +29,15 @@ const (
 	// per-replica cap, sending every sample of a group to a single replica.
 	unlimitedPerReplica = -1
 
+	// unlimitedBatchSize is the MaxBatchSize sentinel that disables the
+	// per-window cap on accumulated requests.
+	unlimitedBatchSize = -1
+
 	defaultWindowDurationMs  = 100
 	defaultMaxPerReplica     = unlimitedPerReplica
 	defaultBlockSizeTokens   = 64
 	defaultMinColocateBlocks = 0
+	defaultMaxBatchSize      = 1000
 
 	// defaultMaxPrefixBlocks caps how many leading blocks form a group key.
 	// Two prompts identical up to this many blocks are treated as one group.
@@ -62,6 +67,10 @@ type config struct {
 	// bounded by a per-replica fair-share cap, so raising this never lets
 	// prefix-sharing units stampede onto one replica.
 	MinColocateBlocks int `json:"minColocateBlocks"`
+	// MaxBatchSize caps how many requests one window may accumulate. Once the cap
+	// is reached, Produce returns an error instead of letting a sustained burst or
+	// a long window grow the batch unbounded. -1 disables the cap.
+	MaxBatchSize int `json:"maxBatchSize"`
 }
 
 // defaultConfig provides sensible defaults for the burst prefix cache producer.
@@ -71,6 +80,7 @@ var defaultConfig = config{
 	BlockSizeTokens:        defaultBlockSizeTokens,
 	MaxPrefixTokensToMatch: 0,
 	MinColocateBlocks:      defaultMinColocateBlocks,
+	MaxBatchSize:           defaultMaxBatchSize,
 }
 
 // entry is one request collected into a batch window.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
@@ -54,12 +54,13 @@ type config struct {
 	// maxBlocks = MaxPrefixTokensToMatch / BlockSizeTokens; otherwise
 	// defaultMaxPrefixBlocks applies.
 	MaxPrefixTokensToMatch int `json:"maxPrefixTokensToMatch"`
-	// MinColocateBlocks is the minimum shared leading blocks required to place two
-	// distinct groups on the same replica (inter-group prefix co-location). 0
-	// disables it: placement is purely load-balanced and only identical prompts
-	// co-locate. A larger value avoids co-locating on a trivial shared preamble.
-	// Co-location is always bounded by a per-replica fair-share cap, so raising
-	// this never lets prefix-sharing groups stampede onto one replica.
+	// MinColocateBlocks is the minimum shared leading blocks for inter-unit prefix
+	// co-location, and the minimum a single (non-duplicated) request must share
+	// with another request to gain an affinity at all. 0 disables both: only
+	// identical groups are placed and placement is purely load-balanced. A larger
+	// value avoids co-locating on a trivial shared preamble. Co-location is always
+	// bounded by a per-replica fair-share cap, so raising this never lets
+	// prefix-sharing units stampede onto one replica.
 	MinColocateBlocks int `json:"minColocateBlocks"`
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
@@ -44,6 +44,11 @@ const (
 	// defaultMaxPrefixBlocks caps how many leading blocks form a group key.
 	// Two prompts identical up to this many blocks are treated as one group.
 	defaultMaxPrefixBlocks = 2048
+
+	// maxWindowDurationMs bounds the batch window. Every request waits up to this
+	// long, so a misconfigured large value is rejected at construction rather than
+	// stalling every request.
+	maxWindowDurationMs = 10000
 )
 
 // config defines the configuration for the burst prefix cache producer.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package burstprefix
 
 import (
+	"time"
+
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash"
 )
@@ -87,6 +89,8 @@ var defaultConfig = config{
 type entry struct {
 	hashes [][]prefixhash.BlockHash
 	pods   []fwksched.Endpoint
+	// enqueued is when the request joined the batch, used to report the window wait.
+	enqueued time.Time
 	// assigned is the replica this request is steered to, filled when the batch
 	// is sealed. nil means no affinity (singleton group or empty prompt): the
 	// request is scored 0 on every endpoint so other scorers decide.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package approximateprefix
+// Package prefixhash computes stable prefix block hashes for a tokenized
+// prompt. It is shared by the prefix-aware data producers so they derive
+// identical block hashes for the same request.
+package prefixhash
 
 import (
 	"context"
@@ -28,6 +31,9 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
+
+// BlockHash is a hash of a block of request data.
+type BlockHash uint64
 
 // HashBlock wraps a block of token IDs used for calculating prefix hashes.
 type HashBlock struct {
@@ -45,13 +51,13 @@ func (b HashBlock) Hash() uint64 {
 	return 0
 }
 
-// getBlockHashes divides the tokenized prompt into blocks and calculates a
+// GetBlockHashes divides the tokenized prompt into blocks and calculates a
 // prefix cache hash for each block. Each prompt in PerPromptTokens is hashed
 // independently so cross-prompt block adjacency is avoided. The first block
 // hash of every prompt includes the model name and cache salt (if provided).
 // For subsequent blocks, the hash is calculated as: hash(block i content, hash(i-1)).
 // It requires request.Body.TokenizedPrompt to be populated by a token-producer backend.
-func getBlockHashes(ctx context.Context, request *scheduling.InferenceRequest, blockSizeTokens int, maxPrefixBlocks int) [][]blockHash {
+func GetBlockHashes(ctx context.Context, request *scheduling.InferenceRequest, blockSizeTokens int, maxPrefixBlocks int) [][]BlockHash {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	if request == nil || request.Body == nil {
 		loggerDebug.Info("Request or request data is nil, skipping hashing")
@@ -64,7 +70,7 @@ func getBlockHashes(ctx context.Context, request *scheduling.InferenceRequest, b
 		return nil
 	}
 
-	var result [][]blockHash
+	var result [][]BlockHash
 	for _, tokens := range tp.PerPromptTokens {
 		seq := getKVCacheBlocksFromTokens(tokens, blockSizeTokens)
 		hashes := computeBlockHashes(seq, request, maxPrefixBlocks)
@@ -80,8 +86,8 @@ func getBlockHashes(ctx context.Context, request *scheduling.InferenceRequest, b
 }
 
 // computeBlockHashes calculates the hash for content blocks.
-func computeBlockHashes(seq iter.Seq[HashBlock], request *scheduling.InferenceRequest, maxPrefixBlocks int) []blockHash {
-	var blockHashes []blockHash
+func computeBlockHashes(seq iter.Seq[HashBlock], request *scheduling.InferenceRequest, maxPrefixBlocks int) []BlockHash {
+	var blockHashes []BlockHash
 
 	h := xxhash.New()
 	// Different models should have different hashes even with the same body.
@@ -90,7 +96,7 @@ func computeBlockHashes(seq iter.Seq[HashBlock], request *scheduling.InferenceRe
 		_, _ = h.Write([]byte(cacheSalt))
 	}
 
-	prevBlockHash := blockHash(h.Sum64())
+	prevBlockHash := BlockHash(h.Sum64())
 
 	count := 0
 	for block := range seq {
@@ -99,9 +105,9 @@ func computeBlockHashes(seq iter.Seq[HashBlock], request *scheduling.InferenceRe
 		}
 		h.Reset()
 		blockID := block.Hash()
-		_, _ = h.Write(toBytes(blockHash(blockID)))
+		_, _ = h.Write(toBytes(BlockHash(blockID)))
 		_, _ = h.Write(toBytes(prevBlockHash))
-		blockHashes = append(blockHashes, blockHash(h.Sum64()))
+		blockHashes = append(blockHashes, BlockHash(h.Sum64()))
 
 		prevBlockHash = blockHashes[len(blockHashes)-1]
 		count++
@@ -110,7 +116,7 @@ func computeBlockHashes(seq iter.Seq[HashBlock], request *scheduling.InferenceRe
 	return blockHashes
 }
 
-func toBytes(i blockHash) []byte {
+func toBytes(i BlockHash) []byte {
 	bytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(bytes, uint64(i))
 	return bytes

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
@@ -118,8 +118,15 @@ func computeBlockHashes(seq iter.Seq[HashBlock], request *scheduling.InferenceRe
 
 func toBytes(i BlockHash) []byte {
 	bytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(bytes, uint64(i))
+	PutBlockHash(bytes, i)
 	return bytes
+}
+
+// PutBlockHash writes h into the first 8 bytes of buf in little-endian order.
+// buf must have length at least 8. It lets callers serialize block hashes into
+// a reused buffer without allocating per hash.
+func PutBlockHash(buf []byte, h BlockHash) {
+	binary.LittleEndian.PutUint64(buf, uint64(h))
 }
 
 func getKVCacheBlocksFromTokens(ids []uint32, blockSizeTokens int) iter.Seq[HashBlock] {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package approximateprefix
+package prefixhash
 
 import (
 	"context"
@@ -26,6 +26,10 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
+
+// testMaxPrefixBlocks is a cap large enough not to truncate any prompt in
+// these tests.
+const testMaxPrefixBlocks = 2048
 
 func TestGetKVCacheBlocksFromTokens(t *testing.T) {
 	tests := []struct {
@@ -122,7 +126,7 @@ func TestGetBlockHashes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			perPromptHashes := getBlockHashes(context.Background(), tt.request, tt.blockSizeTokens, defaultMaxPrefixBlocks)
+			perPromptHashes := GetBlockHashes(context.Background(), tt.request, tt.blockSizeTokens, testMaxPrefixBlocks)
 			totalBlocks := 0
 			for _, ph := range perPromptHashes {
 				totalBlocks += len(ph)
@@ -142,12 +146,12 @@ func TestGetBlockHashesCacheSalt(t *testing.T) {
 		}
 	}
 
-	noSalt := getBlockHashes(context.Background(), &fwksched.InferenceRequest{
+	noSalt := GetBlockHashes(context.Background(), &fwksched.InferenceRequest{
 		TargetModel: "m", Body: body(""),
-	}, 2, defaultMaxPrefixBlocks)
-	salted := getBlockHashes(context.Background(), &fwksched.InferenceRequest{
+	}, 2, testMaxPrefixBlocks)
+	salted := GetBlockHashes(context.Background(), &fwksched.InferenceRequest{
 		TargetModel: "m", Body: body("salt"),
-	}, 2, defaultMaxPrefixBlocks)
+	}, 2, testMaxPrefixBlocks)
 
 	assert.Equal(t, len(noSalt), len(salted))
 	assert.NotEqual(t, noSalt, salted, "cache salt must change the block hashes")
@@ -194,7 +198,7 @@ func TestGetBlockHashes_MultiPrompt(t *testing.T) {
 					},
 				},
 			}
-			result := getBlockHashes(context.Background(), request, tt.blockSizeTokens, defaultMaxPrefixBlocks)
+			result := GetBlockHashes(context.Background(), request, tt.blockSizeTokens, testMaxPrefixBlocks)
 			assert.Equal(t, tt.expectedPrompts, len(result))
 			for i, expected := range tt.expectedBlocksPerPrompt {
 				assert.Equal(t, expected, len(result[i]), "prompt %d block count", i)
@@ -221,8 +225,8 @@ func TestGetBlockHashes_MultiPromptHashIndependence(t *testing.T) {
 		},
 	}
 
-	multi := getBlockHashes(context.Background(), multiPrompt, 2, defaultMaxPrefixBlocks)
-	single := getBlockHashes(context.Background(), singlePrompt, 2, defaultMaxPrefixBlocks)
+	multi := GetBlockHashes(context.Background(), multiPrompt, 2, testMaxPrefixBlocks)
+	single := GetBlockHashes(context.Background(), singlePrompt, 2, testMaxPrefixBlocks)
 
 	assert.Equal(t, 2, len(multi), "multi-prompt should produce 2 inner slices")
 	assert.Equal(t, 1, len(single), "single-prompt should produce 1 inner slice")
@@ -232,7 +236,7 @@ func TestGetBlockHashes_MultiPromptHashIndependence(t *testing.T) {
 		"first block of first prompt should match single prompt's first block")
 	// Second prompt's first block [3,4] starts a fresh hash chain from the model
 	// seed, while single prompt's second block [3,4] chains from the first block.
-	// These must differ — this is the cross-prompt adjacency bug the per-prompt
+	// These must differ - this is the cross-prompt adjacency bug the per-prompt
 	// split prevents.
 	assert.NotEqual(t, multi[1][0], single[0][1],
 		"second prompt must start its own hash chain, not chain from the first prompt")


### PR DESCRIPTION
### Summary

A burst of prefix-sharing prompts arriving in one window all score zero on the prefix-cache scorer (no cache is warm yet), so load balancing scatters them and the shared prefix is prefilled redundantly. This adds a request-level data producer that, within a batch window, assigns prompt-sharing requests jointly and before routing - co-locating those that share a prefix so it is prefilled once. It covers identical-prompt bursts (e.g. RL rollout samples) and distinct prompts that share a prefix (shared system prompt, RAG context, one prompt contained in another), bounded by a per-replica fair-share cap so co-location never unbalances the cluster.

Fixes: #1726 

### What changed

Two commits:

1. **refactor(prefix): extract block-hashing into shared prefixhash package** - behavior-preserving move of the prompt block-hashing (`GetBlockHashes`, `HashBlock`, chained block hash) out of `approximateprefix` into a new `dataproducer/prefixhash` package, so multiple prefix producers derive identical block hashes. `approximateprefix` keeps a `type blockHash = prefixhash.BlockHash` alias; no behavior change.

2. **feat(prefix): add burst prefix cache producer for grouped requests** - new `dataproducer/burstprefix` package implementing a `DataProducer`:
   - **Batch-wait**: requests arriving within `windowDurationMs` are collected; when the window seals they are assigned jointly. Processing the batch under a lock removes the per-request race that makes near-simultaneous arrivals unschedulable together.
   - **Grouping**: requests are grouped by identical prompt prefix (the chained block-hash sequence) - this decides which requests are samples of one prompt, not where they land. An identical group of more than one member is always a placement unit. A single request becomes a unit only when `minColocateBlocks > 0` and it shares at least that many leading blocks with another request in the batch (so one prompt contained in another, or many prompts sharing a system preamble, co-locate); a request overlapping no other, and any prefix-less request, is scored zero everywhere so other scorers decide.
   - **Assignment**: within a group, samples fill one replica up to `maxPerReplica` (k) before spilling to the next least-loaded replica; `k = -1` places the whole group on one replica. Identical groups are placed first and kept whole - same-prompt co-location is the firm structure and is never broken by an attaching singleton - then prefix-sharing units attach to it. A unit prefers a replica that already holds a unit sharing at least `minColocateBlocks` leading blocks *and* is still under its fair share of the batch (total placed samples / replicas); otherwise placement is load-balanced. Units are placed longest-prefix first so shorter units match against the richest index. The fair-share cap is what makes co-location balance-safe: many units sharing one prefix spread across replicas up to their share rather than stampeding onto the seed replica. `0` keeps placement to identical groups, purely load-balanced.
   - **Scoring**: emits `PrefixCacheMatchInfo` (full match on the assigned replica, zero elsewhere) and reuses the existing `prefix-cache-scorer` unchanged - point its `prefixMatchInfoProducerName` at this producer. This is the same producer/scorer split already used by the precise and approximate prefix paths.

Also: registration in `cmd/epp/runner/runner.go`, a sample config `deploy/config/epp-burst-prefix-cache-config.yaml`, package READMEs, and the producer index table entry.

### How to enable

Wire `token-producer -> burst-prefix-cache-producer -> prefix-cache-scorer` (see the sample config). Key parameters:

| parameter | default | meaning |
|---|---|---|
| `windowDurationMs` | 100 | batch window T in ms |
| `maxPerReplica` | -1 | per-replica cap k; -1 = whole group to one replica |
| `blockSizeTokens` | 64 | token block size for prefix hashing |
| `maxPrefixTokensToMatch` | 0 | cap on matched prefix tokens; 0 uses the default block cap |
| `minColocateBlocks` | 0 | min shared leading blocks for inter-prompt co-location and for a single request to gain an affinity; 0 = identical groups only (load-balanced) |

The scorer reads from the producer by name:

```yaml
- type: prefix-cache-scorer
  parameters:
    prefixMatchInfoProducerName: burst-prefix-cache-producer
```

### Testing

- Unit tests for the assignment core: an unlimited group co-locates whole; `k` spreads evenly and fills before spilling; a lone group of one and empty-prefix requests get no affinity; distinct groups spread across replicas. With `minColocateBlocks` set: prefix-sharing families co-locate within their fair share; many groups sharing one prefix spread across replicas (no stampede); a shared prefix below the threshold does not co-locate; a single request overlapping a group attaches to it while the identical group stays whole; a lone request overlapping nothing gets no affinity; and overlapping singletons co-locate with no identical groups present (the shared-context case).
- Integration test for batch-wait `Produce`: a concurrent burst of identical prompts all co-locate on one replica; a lone request gets no affinity.
- Race detector clean. `make presubmit` passes (format, lint, typos, govulncheck, tags).

### Results (measured)

Measured on a real verl + llm-d integration: llm-d running in no-kube (local) mode, with EPP serving as the vLLM endpoint picker for verl's rollout requests. The only variable between the two arms is the burst producer; same GRPO/GSM8K rollout workload (4 vLLM replicas, TP=1, Qwen3-4B, group sampling G=8, 40 steps).

- **baseline** - EPP with the current prefix-cache scorer.
- **Burst-producer** - same, plus the burst prefix-cache producer (`windowDurationMs=100`, `maxPerReplica=-1`).

| metric | baseline | Burst-producer |
|---|---|---|
| 8-sample groups fully co-located | 13.6% | 100.0% |
| mean distinct replicas per group | 2.83 | 1.00 |
| prefix-cache hit rate | 51.2% | 68.3% |
| mean rollout gen time / step (s) | 21.0 | 16.4 |

Every full group co-locates onto one replica (mean 1.00 distinct replicas, down from 2.83), the prefix-cache hit rate rises 51.2% -> 68.3%, and mean rollout gen time per step drops 21.0 s -> 16.4 s (~22%). Latency does **not** regress - it improves, and most of the gain is in the tail: the per-step series flattens from spikes near 45 s to a steady ~13-24 s band. Co-locating a group does not serialize decode (vLLM continuous-batches the concurrent sequences) and removing redundant prefill frees headroom.

These timing numbers are a floor, not a ceiling. This workload is decode-dominant with very short prompts (~55-88 tokens, about one block), so prefill is a small fraction of end-to-end time and the latency win here mostly reflects freed prefill headroom rather than the prefill saving itself. As prompts grow - reasoning traces, long system prompts, RAG context - prefill becomes a far larger share of the work, so prefilling a shared prefix once instead of on every replica should yield substantially larger timing wins. The co-location and hit-rate gains shown here are the same mechanism; their latency payoff scales with prompt length.

Group co-location - groups go from 13.6% on a single replica (mean 2.83) to 100% (mean 1.00):

<img width="1200" height="504" alt="result_gen_time_per_step" src="https://github.com/user-attachments/assets/1710f4ef-1922-4c8d-be7a-00d2e10842b1" />

Prefix-cache hit rate - rises 51.2% -> 68.3%:

<img width="960" height="540" alt="result_group_colocation" src="https://github.com/user-attachments/assets/21d5eb46-b310-4583-ba28-c28e7f45a798" />

Mean rollout gen time per step - drops 21.0 s -> 16.4 s, tail spikes flattened:

<img width="600" height="540" alt="result_prefix_cache_hitrate" src="https://github.com/user-attachments/assets/c924eafd-deaa-4578-b4d8-75b8ed614a1d" />
