### PR TITLE
feat(inflightloadproducer): allow configuring output ratio

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
@@ -28,7 +28,7 @@ Endpoint departure events (pod removed from the pool) are handled via the `Endpo
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `addEstimatedOutputTokens` | `bool` | No | `false` | If true, adds an estimate of the generated output tokens to the in-flight counter. |
-| `outputRatio` | `float` | No | `1.5` | Estimated output-to-input token ratio applied when `addEstimatedOutputTokens` is true: estimated output = inputTokens * `outputRatio`. Computed against the full prompt, not the uncached portion. Must be non-negative. |
+| `outputRatio` | `float` | No | `1.5` | Estimated output-to-input token ratio applied when `addEstimatedOutputTokens` is true: estimated output = round(inputTokens * `outputRatio`). Computed against the full prompt, not the uncached portion. Must be non-negative. |
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
@@ -28,6 +28,7 @@ Endpoint departure events (pod removed from the pool) are handled via the `Endpo
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `addEstimatedOutputTokens` | `bool` | No | `false` | If true, adds an estimate of the generated output tokens to the in-flight counter. |
+| `outputRatio` | `float` | No | `1.5` | Estimated output-to-input token ratio applied when `addEstimatedOutputTokens` is true: estimated output = inputTokens * `outputRatio`. Computed against the full prompt, not the uncached portion. Must be non-negative. |
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -50,6 +50,10 @@ type Config struct {
 	// AddEstimatedOutputTokens controls whether estimated output tokens are added to
 	// the in-flight token counter. Defaults to false.
 	AddEstimatedOutputTokens bool `json:"addEstimatedOutputTokens"`
+	// OutputRatio is the estimated output-to-input token ratio used when
+	// AddEstimatedOutputTokens is true: estimated output = inputTokens * OutputRatio.
+	// Must be non-negative. Unset defaults to DefaultOutputRatio.
+	OutputRatio *float64 `json:"outputRatio,omitempty"`
 	// PrefixMatchInfoProducerName selects which prefix-cache producer's
 	// PrefixCacheMatchInfo to read for the cached-prefix discount. Empty defaults
 	// to the approximate-prefix producer; set it to a precise-prefix-cache
@@ -77,11 +81,19 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 		}
 	}
 
+	outputRatio := DefaultOutputRatio
+	if cfg.OutputRatio != nil {
+		if *cfg.OutputRatio < 0 {
+			return nil, fmt.Errorf("outputRatio must be non-negative, got %v", *cfg.OutputRatio)
+		}
+		outputRatio = *cfg.OutputRatio
+	}
+
 	return &InFlightLoadProducer{
 		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
 		requestTracker:           newConcurrencyTracker(),
 		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(),
+		tokenEstimator:           NewSimpleTokenEstimatorWithRatio(outputRatio),
 		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
 		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
 		prefixMatchInfoDK:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -51,7 +51,7 @@ type Config struct {
 	// the in-flight token counter. Defaults to false.
 	AddEstimatedOutputTokens bool `json:"addEstimatedOutputTokens"`
 	// OutputRatio is the estimated output-to-input token ratio used when
-	// AddEstimatedOutputTokens is true: estimated output = inputTokens * OutputRatio.
+	// AddEstimatedOutputTokens is true: estimated output = round(inputTokens * OutputRatio).
 	// Must be non-negative. Unset defaults to DefaultOutputRatio.
 	OutputRatio *float64 `json:"outputRatio,omitempty"`
 	// PrefixMatchInfoProducerName selects which prefix-cache producer's

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
@@ -896,5 +897,49 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 		p, err := InFlightLoadProducerFactory("test", nil, nil)
 		require.Error(t, err)
 		require.Nil(t, p)
+	})
+}
+
+func TestInFlightLoadProducerFactory_OutputRatio(t *testing.T) {
+	t.Parallel()
+
+	newProducer := func(t *testing.T, cfg Config) (*InFlightLoadProducer, error) {
+		raw, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		p, err := InFlightLoadProducerFactory("inflight-load-producer",
+			json.NewDecoder(bytes.NewReader(raw)), testutils.NewTestHandle(ctx))
+		if err != nil {
+			return nil, err
+		}
+		return p.(*InFlightLoadProducer), nil
+	}
+
+	t.Run("default when unset", func(t *testing.T) {
+		t.Parallel()
+		p, err := newProducer(t, Config{AddEstimatedOutputTokens: true})
+		require.NoError(t, err)
+		require.Equal(t, int64(15), p.tokenEstimator.EstimateOutput(10)) // 10 * 1.5
+	})
+
+	t.Run("custom ratio applied", func(t *testing.T) {
+		t.Parallel()
+		p, err := newProducer(t, Config{AddEstimatedOutputTokens: true, OutputRatio: ptr.To(2.0)})
+		require.NoError(t, err)
+		require.Equal(t, int64(20), p.tokenEstimator.EstimateOutput(10)) // 10 * 2.0
+	})
+
+	t.Run("zero ratio is valid", func(t *testing.T) {
+		t.Parallel()
+		p, err := newProducer(t, Config{AddEstimatedOutputTokens: true, OutputRatio: ptr.To(0.0)})
+		require.NoError(t, err)
+		require.Equal(t, int64(0), p.tokenEstimator.EstimateOutput(10))
+	})
+
+	t.Run("negative ratio rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := newProducer(t, Config{AddEstimatedOutputTokens: true, OutputRatio: ptr.To(-1.0)})
+		require.Error(t, err)
 	})
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -49,6 +49,7 @@ func NewSimpleTokenEstimator() TokenEstimator {
 
 // NewSimpleTokenEstimatorWithRatio returns a SimpleTokenEstimator that estimates
 // output tokens as round(inputTokens * ratio).
+func NewSimpleTokenEstimatorWithRatio(ratio float64) TokenEstimator {
 	return &SimpleTokenEstimator{
 		OutputRatio: ratio,
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -48,8 +48,7 @@ func NewSimpleTokenEstimator() TokenEstimator {
 }
 
 // NewSimpleTokenEstimatorWithRatio returns a SimpleTokenEstimator that estimates
-// output tokens as inputTokens * ratio.
-func NewSimpleTokenEstimatorWithRatio(ratio float64) TokenEstimator {
+// output tokens as round(inputTokens * ratio).
 	return &SimpleTokenEstimator{
 		OutputRatio: ratio,
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -32,16 +32,26 @@ type TokenEstimator interface {
 	EstimateOutput(inputTokens int64) int64
 }
 
+// DefaultOutputRatio is the estimated output-to-input token ratio used when no
+// ratio is configured.
+const DefaultOutputRatio = 1.5
+
 // SimpleTokenEstimator derives input tokens from the tokenized prompt and
 // estimates output tokens as inputTokens * OutputRatio.
 type SimpleTokenEstimator struct {
 	OutputRatio float64
 }
 
-// NewSimpleTokenEstimator returns a SimpleTokenEstimator with default output ratio.
+// NewSimpleTokenEstimator returns a SimpleTokenEstimator with the default output ratio.
 func NewSimpleTokenEstimator() TokenEstimator {
+	return NewSimpleTokenEstimatorWithRatio(DefaultOutputRatio)
+}
+
+// NewSimpleTokenEstimatorWithRatio returns a SimpleTokenEstimator that estimates
+// output tokens as inputTokens * ratio.
+func NewSimpleTokenEstimatorWithRatio(ratio float64) TokenEstimator {
 	return &SimpleTokenEstimator{
-		OutputRatio: 1.5,
+		OutputRatio: ratio,
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This PR add a new configurable `outputRatio` parameter to inflightloaderproducer defaulting to same 1.5 if unspecified. This allows user to better choose a ratio that represents their traffic pattern for input to output ratio. 1.5x default doesn't work very well for high ISL workload with lot of contexts (200K or above). the estimated output token of 300K is very high in those cases. 

Allowing it to be configured allows user to choose a value that  best matches their workload.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/llm-d/llm-d-router/issues/1730

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add parameter `outputRatio` to inflight load producer for user configurable output token estimation
```
