### PR TITLE
fix: clear KV block index entries on endpoint removal

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -52,6 +52,12 @@ func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error
 		logger.V(logging.DEBUG).Info("Adding subscriber", "endpoint", endpointKey)
 	case fwkdl.EventDelete:
 		p.subscribersManager.RemoveSubscriber(ctx, endpointKey)
+		if meta.Address != "" {
+			if err := p.kvCacheIndexer.KVBlockIndex().Clear(ctx, meta.Address); err != nil {
+				logger.Error(err, "Failed to clear index entries for removed endpoint",
+					"endpoint", endpointKey, "address", meta.Address)
+			}
+		}
 		logger.V(logging.DEBUG).Info("Removed KV-events subscriber", "endpoint", endpointKey)
 	}
 	return nil

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -53,7 +53,8 @@ func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error
 	case fwkdl.EventDelete:
 		p.subscribersManager.RemoveSubscriber(ctx, endpointKey)
 		if meta.Address != "" {
-			if err := p.kvCacheIndexer.KVBlockIndex().Clear(ctx, meta.Address); err != nil {
+			if err := p.kvCacheIndexer.KVBlockIndex().Clear(ctx, fmt.Sprintf("%s:%s", meta.Address, meta.Port)); err != nil {
+
 				logger.Error(err, "Failed to clear index entries for removed endpoint",
 					"endpoint", endpointKey, "address", meta.Address)
 			}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -54,7 +54,6 @@ func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error
 		p.subscribersManager.RemoveSubscriber(ctx, endpointKey)
 		if meta.Address != "" {
 			if err := p.kvCacheIndexer.KVBlockIndex().Clear(ctx, fmt.Sprintf("%s:%s", meta.Address, meta.Port)); err != nil {
-
 				logger.Error(err, "Failed to clear index entries for removed endpoint",
 					"endpoint", endpointKey, "address", meta.Address)
 			}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -55,7 +55,7 @@ func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error
 		if meta.Address != "" {
 			if err := p.kvCacheIndexer.KVBlockIndex().Clear(ctx, fmt.Sprintf("%s:%s", meta.Address, meta.Port)); err != nil {
 				logger.Error(err, "Failed to clear index entries for removed endpoint",
-					"endpoint", endpointKey, "address", meta.Address)
+					"endpoint", endpointKey, "address", meta.Address, "port", meta.Port)
 			}
 		}
 		logger.V(logging.DEBUG).Info("Removed KV-events subscriber", "endpoint", endpointKey)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
@@ -49,6 +49,7 @@ func newExtractorProducer(discoverPods bool) *Producer {
 		typedName:          plugin.TypedName{Type: PluginType, Name: PluginType},
 		subscribersManager: kvevents.NewSubscriberManager(kvevents.NewPool(cfg, nil, nil, nil)),
 		kvEventsConfig:     cfg,
+		kvCacheIndexer:     &fakeKVCacheIndexer{index: &fakeKVBlockIndex{}},
 		subscriberCtx:      context.Background(),
 	}
 }
@@ -214,6 +215,51 @@ func TestProducer_ExtractEndpoint_SingleRankUsesBaseSocketPort(t *testing.T) {
 	_, zmqEndpoints := p.subscribersManager.GetActiveSubscribers()
 	assert.Equal(t, []string{"tcp://10.0.0.1:5557"}, zmqEndpoints,
 		"single-rank pod (RankIndex=0) must dial the base SocketPort")
+}
+
+// EventDelete clears index entries for the removed pod's address.
+func TestProducer_ExtractEndpoint_DeleteClearsIndex(t *testing.T) {
+	ctx := discardCtx(t)
+
+	var clearedPod string
+	fakeIndex := &fakeKVBlockIndex{
+		clearFn: func(_ context.Context, podIdentifier string) error {
+			clearedPod = podIdentifier
+			return nil
+		},
+	}
+	fakeIndexer := &fakeKVCacheIndexer{index: fakeIndex}
+
+	cfg := kvevents.DefaultConfig()
+	cfg.DiscoverPods = true
+	cfg.PodDiscoveryConfig = kvevents.DefaultPodReconcilerConfig()
+	cfg.PodDiscoveryConfig.SocketPort = 5557
+
+	p := &Producer{
+		typedName:          plugin.TypedName{Type: PluginType, Name: PluginType},
+		subscribersManager: kvevents.NewSubscriberManager(kvevents.NewPool(cfg, nil, nil, nil)),
+		kvEventsConfig:     cfg,
+		kvCacheIndexer:     fakeIndexer,
+		subscriberCtx:      context.Background(),
+	}
+	defer p.subscribersManager.Shutdown(ctx)
+
+	ep := newEndpoint("pod-clear", "10.0.0.99")
+
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+
+	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
+		Type:     fwkdl.EventDelete,
+		Endpoint: ep,
+	}))
+
+	assert.Equal(t, "10.0.0.99", clearedPod, "index should be cleared using pod IP address")
+
+	ids, _ := p.subscribersManager.GetActiveSubscribers()
+	assert.Empty(t, ids)
 }
 
 // Delete by NamespacedName must work even when the event has no address.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
@@ -256,7 +256,7 @@ func TestProducer_ExtractEndpoint_DeleteClearsIndex(t *testing.T) {
 		Endpoint: ep,
 	}))
 
-	assert.Equal(t, "10.0.0.99", clearedPod, "index should be cleared using pod IP address")
+	assert.Equal(t, "10.0.0.99:8080", clearedPod, "index should be cleared using pod IP:Port matching PodIdentifier format")
 
 	ids, _ := p.subscribersManager.GetActiveSubscribers()
 	assert.Empty(t, ids)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -52,8 +52,9 @@ func (f *fakeKVCacheIndexer) ComputeBlockKeysFromTokens(ctx context.Context, tok
 func (f *fakeKVCacheIndexer) KVBlockIndex() kvblock.Index { return f.index }
 
 type fakeKVBlockIndex struct {
-	lookup func(ctx context.Context, keys []kvblock.BlockHash, podSet sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error)
-	addFn  func(ctx context.Context, prevKeys, keys []kvblock.BlockHash, entries []kvblock.PodEntry) error
+	lookup  func(ctx context.Context, keys []kvblock.BlockHash, podSet sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error)
+	addFn   func(ctx context.Context, prevKeys, keys []kvblock.BlockHash, entries []kvblock.PodEntry) error
+	clearFn func(ctx context.Context, podIdentifier string) error
 }
 
 func (f *fakeKVBlockIndex) Lookup(ctx context.Context, keys []kvblock.BlockHash, podSet sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
@@ -78,7 +79,10 @@ func (f *fakeKVBlockIndex) GetRequestKey(_ context.Context, _ kvblock.BlockHash)
 	return kvblock.EmptyBlockHash, nil
 }
 
-func (f *fakeKVBlockIndex) Clear(_ context.Context, _ string) error {
+func (f *fakeKVBlockIndex) Clear(ctx context.Context, podIdentifier string) error {
+	if f.clearFn != nil {
+		return f.clearFn(ctx, podIdentifier)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Call `Index.Clear` on `EventDelete` to remove stale entries for pods that are no longer running
- Uses meta.Address (pod IP) to match the PodIdentifier stored in the index by the ZMQ event pipeline
- Updates test helper to provide a fake indexer instead of nil

## Context
When a vLLM pod restarts or is removed, RemoveSubscriber cancels the ZMQ connection but leaves stale index entries. These cause the router to preferentially route to a pod that no longer has the expected KV cache, degrading routing quality.

## Known limitation
There is a small race window where Pool workers may still be processing events queued before RemoveSubscriber cancelled the subscriber. These in-flight events can re-add a few entries after Index.Clear. 

Fixes #1736