### PR TITLE
fix: wrong bundle version in artifacts CRDs

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build Artifacts
         run: |
-          make artifacts
+          make artifacts BUNDLE_VERSION=${{ needs.set-params.outputs.tag }}
 
       - name: Upload Release Assets
         env:

--- a/Makefile
+++ b/Makefile
@@ -362,8 +362,11 @@ helm-push-standalone: ## Package and push the llm-d-router-standalone Helm chart
 
 ##@ Release
 
+BUNDLE_VERSION ?= main-dev
+export BUNDLE_VERSION
+
 .PHONY: artifacts
-artifacts: yq check-kustomize ## Generate release artifacts (CRD manifests)
+artifacts: generate yq check-kustomize ## Generate release artifacts (CRD manifests).
 	if [ -d artifacts ]; then rm -rf artifacts; fi
 	mkdir -p artifacts
 	kubectl kustomize config/crd > artifacts/manifests_all.yaml

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -22,8 +22,9 @@ SCRIPT_ROOT=$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 CODEGEN_PKG=${1:-"${SCRIPT_ROOT}/bin"}
 THIS_PKG="github.com/llm-d/llm-d-router"
 
-echo "Generating CRDs"
-(cd "${SCRIPT_ROOT}" && go run ./pkg/generator)
+BUNDLE_VERSION="${BUNDLE_VERSION:-main-dev}"
+echo "Generating CRDs bundle-version=${BUNDLE_VERSION}"
+(cd "${SCRIPT_ROOT}" && go run -ldflags "-X github.com/llm-d/llm-d-router/version.BundleVersion=${BUNDLE_VERSION}" ./pkg/generator)
 
 source "${CODEGEN_PKG}/kube_codegen.sh"
 

--- a/version/version.go
+++ b/version/version.go
@@ -22,13 +22,14 @@ var (
 
 	// The build ref from the _PULL_BASE_REF from cloud build trigger.
 	BuildRef string
+
+	// BundleVersion is the value used for labeling the CRD bundle version.
+	// Defaults to "main-dev" for development builds. Set via -ldflags at release time via Github workflow.
+	BundleVersion = "main-dev"
 )
 
 const (
 	// BundleVersionAnnotation is the annotation key used in llm-d CRDs to specify
 	// the installed bundle version.
 	BundleVersionAnnotation = "llm-d.ai/bundle-version"
-
-	// BundleVersion is the value used for labeling the CRD bundle version.
-	BundleVersion = "main-dev"
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- 0.9.0 has main-dev set in annoataion llm-d.ai/bundle-version
- set BUNDLE_VERSION which derived from official release tag from github workflow
- ref https://github.com/kserve/kserve/pull/5585/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
