### PR TITLE
fix(flowcontrol): resolve ManagedQueue eagerly and fix FlowKey.String

### DIFF
--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -536,9 +536,15 @@ func (sp *Processor) processAllQueuesConcurrently(
 ) {
 	logger := sp.logger.WithName(ctxName)
 
-	// Phase 1: Collect all queues to be processed into a single slice.
-	// This avoids holding locks on the shard while processing, and allows us to determine the optimal number of workers.
-	var queuesToProcess []flowcontrol.FlowQueueAccessor
+	type queueTask struct {
+		mq     contracts.ManagedQueue
+		logger logr.Logger
+	}
+
+	// Phase 1: Collect all queues and resolve ManagedQueue handles in one pass.
+	// Resolving here (instead of in the worker) eliminates a race where flow GC
+	// can delete a flow between collection and the worker's ManagedQueue lookup.
+	var work []queueTask
 	for _, priority := range sp.registry.AllOrderedPriorityLevels() {
 		band, err := sp.registry.PriorityBandAccessor(priority)
 		if err != nil {
@@ -546,46 +552,44 @@ func (sp *Processor) processAllQueuesConcurrently(
 			continue
 		}
 		band.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) bool {
-			queuesToProcess = append(queuesToProcess, queue)
-			return true // Continue iterating.
+			key := queue.FlowKey()
+			mq, err := sp.registry.ManagedQueue(key)
+			if err != nil {
+				return true
+			}
+			work = append(work, queueTask{
+				mq: mq,
+				logger: logger.WithValues(
+					"flowKey", key,
+					"flowID", key.ID,
+					"flowPriority", key.Priority),
+			})
+			return true
 		})
 	}
 
-	if len(queuesToProcess) == 0 {
+	if len(work) == 0 {
 		return
 	}
 
 	// Phase 2: Determine the optimal number of workers.
-	// We cap the number of workers to a reasonable fixed number to avoid overwhelming the scheduler when many shards are
-	// running. We also don't need more workers than there are queues.
-	numWorkers := min(maxCleanupWorkers, len(queuesToProcess))
+	numWorkers := min(maxCleanupWorkers, len(work))
 
-	// Phase 3: Create a worker pool to process the queues.
-	tasks := make(chan flowcontrol.FlowQueueAccessor)
+	// Phase 3: Create a worker pool to process the resolved queues.
+	tasks := make(chan queueTask)
 
 	var wg sync.WaitGroup
 	for range numWorkers {
 		wg.Go(func() {
-			for q := range tasks {
-				key := q.FlowKey()
-				queueLogger := logger.WithValues(
-					"flowKey", key,
-					"flowID", key.ID,
-					"flowPriority", key.Priority)
-				managedQ, err := sp.registry.ManagedQueue(key)
-				if err != nil {
-					queueLogger.Error(err, "Failed to get ManagedQueue")
-					continue
-				}
-				processFn(managedQ, queueLogger)
+			for t := range tasks {
+				processFn(t.mq, t.logger)
 			}
 		})
 	}
 
-	// Feed the channel with all the queues to be processed.
-	for _, q := range queuesToProcess {
-		tasks <- q
+	for _, t := range work {
+		tasks <- t
 	}
-	close(tasks) // Close the channel to signal workers to exit.
-	wg.Wait()    // Wait for all workers to finish.
+	close(tasks)
+	wg.Wait()
 }

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -536,15 +536,14 @@ func (sp *Processor) processAllQueuesConcurrently(
 ) {
 	logger := sp.logger.WithName(ctxName)
 
-	type queueTask struct {
+	type resolvedQueue struct {
 		mq     contracts.ManagedQueue
 		logger logr.Logger
 	}
 
 	// Phase 1: Collect all queues and resolve ManagedQueue handles in one pass.
-	// Resolving here (instead of in the worker) eliminates a race where flow GC
-	// can delete a flow between collection and the worker's ManagedQueue lookup.
-	var resolvedQueues []queueTask
+	// This avoids holding locks on the shard while processing, and allows us to determine the optimal number of workers.
+	var resolvedQueues []resolvedQueue
 	for _, priority := range sp.registry.AllOrderedPriorityLevels() {
 		band, err := sp.registry.PriorityBandAccessor(priority)
 		if err != nil {
@@ -555,9 +554,10 @@ func (sp *Processor) processAllQueuesConcurrently(
 			key := queue.FlowKey()
 			mq, err := sp.registry.ManagedQueue(key)
 			if err != nil {
+				logger.V(logutil.DEBUG).Info("Skipping GC'd flow during queue collection", "flowKey", key)
 				return true
 			}
-			resolvedQueues = append(resolvedQueues, queueTask{
+			resolvedQueues = append(resolvedQueues, resolvedQueue{
 				mq: mq,
 				logger: logger.WithValues(
 					"flowKey", key,
@@ -576,7 +576,7 @@ func (sp *Processor) processAllQueuesConcurrently(
 	numWorkers := min(maxCleanupWorkers, len(resolvedQueues))
 
 	// Phase 3: Create a worker pool to process the resolved queues.
-	tasks := make(chan queueTask)
+	tasks := make(chan resolvedQueue)
 
 	var wg sync.WaitGroup
 	for range numWorkers {
@@ -587,9 +587,10 @@ func (sp *Processor) processAllQueuesConcurrently(
 		})
 	}
 
+	// Feed the channel with all the queues to be processed.
 	for _, task := range resolvedQueues {
 		tasks <- task
 	}
-	close(tasks)
-	wg.Wait()
+	close(tasks) // Close the channel to signal workers to exit.
+	wg.Wait()    // Wait for all workers to finish.
 }

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -544,7 +544,7 @@ func (sp *Processor) processAllQueuesConcurrently(
 	// Phase 1: Collect all queues and resolve ManagedQueue handles in one pass.
 	// Resolving here (instead of in the worker) eliminates a race where flow GC
 	// can delete a flow between collection and the worker's ManagedQueue lookup.
-	var work []queueTask
+	var resolvedQueues []queueTask
 	for _, priority := range sp.registry.AllOrderedPriorityLevels() {
 		band, err := sp.registry.PriorityBandAccessor(priority)
 		if err != nil {
@@ -557,7 +557,7 @@ func (sp *Processor) processAllQueuesConcurrently(
 			if err != nil {
 				return true
 			}
-			work = append(work, queueTask{
+			resolvedQueues = append(resolvedQueues, queueTask{
 				mq: mq,
 				logger: logger.WithValues(
 					"flowKey", key,
@@ -568,12 +568,12 @@ func (sp *Processor) processAllQueuesConcurrently(
 		})
 	}
 
-	if len(work) == 0 {
+	if len(resolvedQueues) == 0 {
 		return
 	}
 
 	// Phase 2: Determine the optimal number of workers.
-	numWorkers := min(maxCleanupWorkers, len(work))
+	numWorkers := min(maxCleanupWorkers, len(resolvedQueues))
 
 	// Phase 3: Create a worker pool to process the resolved queues.
 	tasks := make(chan queueTask)
@@ -581,14 +581,14 @@ func (sp *Processor) processAllQueuesConcurrently(
 	var wg sync.WaitGroup
 	for range numWorkers {
 		wg.Go(func() {
-			for t := range tasks {
-				processFn(t.mq, t.logger)
+			for task := range tasks {
+				processFn(task.mq, task.logger)
 			}
 		})
 	}
 
-	for _, t := range work {
-		tasks <- t
+	for _, task := range resolvedQueues {
+		tasks <- task
 	}
 	close(tasks)
 	wg.Wait()

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -554,7 +554,8 @@ func (sp *Processor) processAllQueuesConcurrently(
 			key := queue.FlowKey()
 			mq, err := sp.registry.ManagedQueue(key)
 			if err != nil {
-				logger.V(logutil.DEBUG).Info("Skipping GC'd flow during queue collection", "flowKey", key)
+				logger.V(logutil.DEBUG).Info("Skipping queue; ManagedQueue no longer resolvable",
+					"flowKey", key, "err", err)
 				return true
 			}
 			resolvedQueues = append(resolvedQueues, resolvedQueue{

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1230,6 +1230,67 @@ func TestShardProcessor(t *testing.T) {
 				assert.Equal(t, int32(numQueues), processedCount.Load(),
 					"The number of processed queues should match the number created")
 			})
+
+			t.Run("should resolve ManagedQueue eagerly so late GC does not skip work", func(t *testing.T) {
+				t.Parallel()
+				// --- ARRANGE ---
+				// Regression test: ManagedQueue must be resolved during IterateQueues
+				// (Phase 1), not deferred to Phase 3 workers. A deferred lookup
+				// races with flow GC which can delete the flow after collection.
+				//
+				// Strategy: ManagedQueueFunc succeeds while IterateQueues is running
+				// and fails after it returns — simulating GC firing between phases.
+				//
+				// With eager resolution (Phase 1): ManagedQueue resolved inside
+				//   IterateQueues callback -> succeeds -> processFn called.
+				// With deferred resolution (Phase 3, regression): ManagedQueue
+				//   resolved in worker after IterateQueues returns -> fails ->
+				//   processFn NOT called.
+				h := newTestHarness(t, testCleanupTick)
+				h.addQueue(testFlow)
+
+				var iteratingDone atomic.Bool
+				h.PriorityBandAccessorFunc = func(p int) (flowcontrol.PriorityBandAccessor, error) {
+					h.mu.Lock()
+					flowKeys := h.priorityFlows[p]
+					h.mu.Unlock()
+
+					band := &fwkfcmocks.MockPriorityBandAccessor{PriorityV: p}
+					band.IterateQueuesFunc = func(cb func(fqa flowcontrol.FlowQueueAccessor) bool) {
+						for _, key := range flowKeys {
+							q, err := h.managedQueue(key)
+							if err == nil && q != nil {
+								mq := q.(*mocks.MockManagedQueue)
+								if !cb(mq.FlowQueueAccessor()) {
+									break
+								}
+							}
+						}
+						iteratingDone.Store(true)
+					}
+					return band, nil
+				}
+
+				h.ManagedQueueFunc = func(key flowcontrol.FlowKey) (contracts.ManagedQueue, error) {
+					if iteratingDone.Load() {
+						return nil, fmt.Errorf("failed to get managed queue for flow %q: %w",
+							key, contracts.ErrFlowInstanceNotFound)
+					}
+					return h.managedQueue(key)
+				}
+
+				var processedCount atomic.Int32
+				processFn := func(mq contracts.ManagedQueue, logger logr.Logger) {
+					processedCount.Add(1)
+				}
+
+				// --- ACT ---
+				h.processor.processAllQueuesConcurrently("test-eager-resolve", processFn)
+
+				// --- ASSERT ---
+				assert.Equal(t, int32(1), processedCount.Load(),
+					"processFn must be called: ManagedQueue was resolved eagerly in Phase 1")
+			})
 		})
 	})
 

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1238,14 +1238,9 @@ func TestShardProcessor(t *testing.T) {
 				// (Phase 1), not deferred to Phase 3 workers. A deferred lookup
 				// races with flow GC which can delete the flow after collection.
 				//
-				// Strategy: ManagedQueueFunc succeeds while IterateQueues is running
-				// and fails after it returns — simulating GC firing between phases.
-				//
-				// With eager resolution (Phase 1): ManagedQueue resolved inside
-				//   IterateQueues callback -> succeeds -> processFn called.
-				// With deferred resolution (Phase 3, regression): ManagedQueue
-				//   resolved in worker after IterateQueues returns -> fails ->
-				//   processFn NOT called.
+				// ManagedQueueFunc succeeds while IterateQueues is running and fails
+				// after it returns, simulating GC firing between phases. With eager
+				// resolution processFn is called; with deferred resolution it is not.
 				h := newTestHarness(t, testCleanupTick)
 				h.addQueue(testFlow)
 

--- a/pkg/epp/framework/interface/flowcontrol/flow.go
+++ b/pkg/epp/framework/interface/flowcontrol/flow.go
@@ -45,7 +45,7 @@ type FlowKey struct {
 }
 
 func (k FlowKey) String() string {
-	return k.ID + ":" + strconv.FormatUint(uint64(k.Priority), 10)
+	return k.ID + ":" + strconv.Itoa(k.Priority)
 }
 
 // Compare provides a stable comparison function for two FlowKey instances, suitable for use with sorting algorithms.


### PR DESCRIPTION
## Summary

- **Resolve ManagedQueue in Phase 1 of `processAllQueuesConcurrently`** instead of deferring to Phase 3 workers. This eliminates a race where flow GC deletes a flow between collection and the worker's `ManagedQueue(key)` lookup, producing spurious error-level logs with full stack traces every GC cycle.
- **Fix `FlowKey.String()` for negative priorities**: `strconv.FormatUint(uint64(Priority))` rendered `-1` as `18446744073709551615` in logs. Changed to `strconv.Itoa`.

Both bugs were discovered and reproduced on a live cluster with flow control enabled (utilization-detector, `max-num-seqs=2`, multiple InferenceObjectives).

## Test plan

- [x] Regression test: `should resolve ManagedQueue eagerly so late GC does not skip work` — uses a phase-aware mock that succeeds during `IterateQueues` and fails after, so the test passes only with eager resolution
- [x] Verified test FAILs without the fix (detached HEAD at test-only commit)
- [x] Verified test PASSes with the fix
- [x] All 33 existing processor tests pass
- [x] All flow control package tests pass (`go test ./pkg/epp/flowcontrol/... -count=1`)
- [x] `go build ./...` and `go vet` clean