### PR TITLE
fix: base release-notes assembly branch on main to exclude unrelated diffs

### DIFF
--- a/.github/workflows/release-notes-assemble.yaml
+++ b/.github/workflows/release-notes-assemble.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   assemble:
+    if: ${{ !contains(github.ref_name, '-rc') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-notes-assemble.yaml
+++ b/.github/workflows/release-notes-assemble.yaml
@@ -45,6 +45,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          # ── Phase 1: read fragments from the tagged commit ──────────
+          # The checkout step landed us on the tagged commit so that
+          # fragments merged into main *after* the tag are excluded.
           shopt -s nullglob
           fragments=( release-notes.d/unreleased/*.md )
           if [[ ${#fragments[@]} -eq 0 ]]; then
@@ -54,15 +57,9 @@ jobs:
 
           tmp=$(mktemp)
           for f in "${fragments[@]}"; do
-            # Extract frontmatter values: strip "key: " prefix, take first match.
-            # Plain field-split breaks on URLs because they contain colons.
             pr=$(sed -n 's/^pr: *//p' "$f" | head -1)
             url=$(sed -n 's/^url: *//p' "$f" | head -1)
             date=$(sed -n 's/^date: *//p' "$f" | head -1)
-            # Print everything after the second `---` line verbatim — once
-            # we're past the closing frontmatter marker, a body line that
-            # happens to be `---` (Markdown horizontal rule) must be kept,
-            # not counted as a third delimiter.
             note=$(awk 'p {print; next} /^---$/ {if (++c == 2) p = 1}' "$f" | sed '/^[[:space:]]*$/d' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
             if [[ -z "$pr" || -z "$url" || -z "$date" || -z "$note" ]]; then
               echo "Malformed fragment: $f" >&2
@@ -81,17 +78,27 @@ jobs:
           done < "$tmp"
           printf '\n' >> "$new_section"
 
-          touch RELEASE-NOTES.md
-          cat "$new_section" RELEASE-NOTES.md > RELEASE-NOTES.md.new
-          mv RELEASE-NOTES.md.new RELEASE-NOTES.md
-
-          git rm -- release-notes.d/unreleased/*.md
-
+          # ── Phase 2: branch from main so the PR contains only
+          #    release-notes changes, not unrelated diffs between
+          #    the tagged commit and main HEAD ─────────────────────
+          git fetch origin main
           BRANCH="release-notes/assemble-${TAG}"
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -b "$BRANCH" origin/main
+
+          # ── Phase 3: apply release-notes changes on top of main ─
+          touch RELEASE-NOTES.md
+          cat "$new_section" RELEASE-NOTES.md > RELEASE-NOTES.md.new
+          mv RELEASE-NOTES.md.new RELEASE-NOTES.md
           git add RELEASE-NOTES.md
+
+          for f in "${fragments[@]}"; do
+            if [[ -f "$f" ]]; then
+              git rm -- "$f"
+            fi
+          done
+
           git commit -s -m "docs: assemble release notes for ${TAG}"
           # Force-push so a re-run (re-tag, manual workflow re-run) overwrites
           # the prior branch rather than failing non-fast-forward.

--- a/.github/workflows/release-notes-assemble.yaml
+++ b/.github/workflows/release-notes-assemble.yaml
@@ -93,6 +93,9 @@ jobs:
           mv RELEASE-NOTES.md.new RELEASE-NOTES.md
           git add RELEASE-NOTES.md
 
+          # Remove only the fragments captured from the tagged commit,
+          # not the current main glob which may include post-tag fragments.
+          # The -f guard skips fragments already absent from main.
           for f in "${fragments[@]}"; do
             if [[ -f "$f" ]]; then
               git rm -- "$f"

--- a/.github/workflows/release-notes-assemble.yaml
+++ b/.github/workflows/release-notes-assemble.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   assemble:
+    # RC tags are pre-release; only assemble notes for final releases.
     if: ${{ !contains(github.ref_name, '-rc') }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Fixes the release-notes assembly workflow including unrelated files in the auto-generated PR (e.g. `hack/push-chart.sh` in #1688).
- Root cause: the tag lives on a release branch that carries release-specific changes (e.g. pinned image versions) that must never be merged back to main. The workflow branched from the tagged commit, so those release-branch-only changes leaked into the PR diff against main.
- Fix: split the script into three phases:
  1. **Read fragments from the tagged commit** — preserves the existing guard against post-tag fragments.
  2. **Branch from `origin/main`** — the PR now only contains release-notes file changes, not release-branch-specific diffs.
  3. **Apply changes on main** — update `RELEASE-NOTES.md` and remove only the fragments that exist on main.
- Additionally, skip the assembly job entirely for RC tags (e.g. `v0.9.0-rc.1`) since release notes should only be assembled for final releases.

## Test plan
Simulated the fixed workflow locally against the v0.9.0 tag (which lives on a release branch that diverges from main):

- [x] Fragments are read from the tagged commit: found 40 fragments on v0.9.0.
- [x] Branch is created from `origin/main`, not the tagged commit.
- [x] Only `RELEASE-NOTES.md` is staged — no unrelated files (e.g. `hack/push-chart.sh`) appear in the diff.
- [x] Fragments already removed from main (by the original #1688 merge) are safely skipped via the `-f` guard.
- [x] No fragments merged after the tag are picked up (glob runs on the tagged commit checkout, not main).
- [x] RC tags are excluded via `if: ${{ !contains(github.ref_name, '-rc') }}` condition on the job.