### PR TITLE
flowcontrol/roundrobin: implement DumpState for round-robin-fairness-…

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
@@ -126,3 +126,26 @@ func (p *roundRobin) Pick(
 	c.lastSelected = nil
 	return nil, nil //nolint:nilnil
 }
+// roundRobinState is the JSON payload returned by DumpState.
+type roundRobinState struct {
+	Plugin string `json:"plugin"`
+	Type   string `json:"type"`
+}
+
+// DumpState implements [fwkplugin.StateDumper].
+// The round-robin cursor is stored per priority band on the band's PolicyState,
+// not on the plugin itself, so there is no centralized mutable state to snapshot.
+// This dump returns plugin identity information only.
+func (p *roundRobin) DumpState() (json.RawMessage, error) {
+	return json.Marshal(roundRobinState{
+		Plugin: p.name,
+		Type:   RoundRobinFairnessPolicyType,
+	})
+}
+
+// Ensure roundRobin implements StateDumper.
+var _ fwkplugin.StateDumper = &roundRobin{}
+
+
+
+

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
@@ -18,6 +18,7 @@ package roundrobin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -281,4 +282,45 @@ func TestRoundRobin_Pick_Concurrency(t *testing.T) {
 			t.Logf("Selection distribution: %s", countsStr)
 		})
 	}
+}
+
+func TestRoundRobin_DumpState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default name", func(t *testing.T) {
+		t.Parallel()
+		policy := newRoundRobin("")
+
+		payload, err := policy.DumpState()
+		require.NoError(t, err)
+		require.NotNil(t, payload)
+
+		var state roundRobinState
+		require.NoError(t, json.Unmarshal(payload, &state))
+		require.Equal(t, RoundRobinFairnessPolicyType, state.Plugin)
+		require.Equal(t, RoundRobinFairnessPolicyType, state.Type)
+	})
+
+	t.Run("custom name", func(t *testing.T) {
+		t.Parallel()
+		policy := newRoundRobin("my-rr-policy")
+
+		payload, err := policy.DumpState()
+		require.NoError(t, err)
+		require.NotNil(t, payload)
+
+		var state roundRobinState
+		require.NoError(t, json.Unmarshal(payload, &state))
+		require.Equal(t, "my-rr-policy", state.Plugin)
+		require.Equal(t, RoundRobinFairnessPolicyType, state.Type)
+	})
+
+	t.Run("valid json output", func(t *testing.T) {
+		t.Parallel()
+		policy := newRoundRobin("test")
+
+		payload, err := policy.DumpState()
+		require.NoError(t, err)
+		require.True(t, json.Valid(payload), "DumpState output should be valid JSON")
+	})
 }


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Implements `plugin.StateDumper` on the `round-robin-fairness-policy` plugin as part of the tracking issue #1755.

The round-robin cursor is stored per priority band on the band's `PolicyState`, not on the plugin itself, so there is no centralized mutable state to snapshot. `DumpState` returns plugin identity information (name and type) only.

## Which issue(s) this PR fixes

Fixes #1803

## Testing

Added unit tests covering:
- Default plugin name
- Custom plugin name  
- Valid JSON output

## Release note

```release-note
NONE
```