### PR TITLE
feat: implement DumpState for approx-prefix-cache-producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
@@ -195,3 +195,15 @@ func (i *indexer) Pods() []ServerID {
 	}
 	return pods
 }
+
+// PodBlockCounts returns the number of cached blocks currently tracked per pod.
+func (i *indexer) PodBlockCounts() map[ServerID]int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	counts := make(map[ServerID]int, len(i.podToLRU))
+	for pod, lruCache := range i.podToLRU {
+		counts[pod] = lruCache.Len()
+	}
+	return counts
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -52,6 +53,7 @@ var minBlockSizeTokens = 64
 var (
 	_ requestcontrol.DataProducer = &dataProducer{}
 	_ requestcontrol.PreRequest   = &dataProducer{}
+	_ plugin.StateDumper          = &dataProducer{}
 )
 
 // dataProducer is a plugin that produces data consumed by approx prefix cache aware scheduling.
@@ -67,6 +69,55 @@ type dataProducer struct {
 // TypedName returns the type and name of the plugin.
 func (p *dataProducer) TypedName() plugin.TypedName {
 	return p.typedName
+}
+
+const maxDebugDumpPods = 100
+
+// prefixIndexState is the sanitized snapshot returned by DumpState. It carries
+// per-pod block counts only; the prompt-derived block hashes are never exposed.
+// The dump is partial when TotalPods exceeds MaxPods.
+type prefixIndexState struct {
+	Pods      []podBlockCount `json:"pods"`
+	TotalPods int             `json:"totalPods"`
+	MaxPods   int             `json:"maxPods"`
+}
+
+type podBlockCount struct {
+	Pod    string `json:"pod"`
+	Blocks int    `json:"blocks"`
+}
+
+// DumpState reports how many prefix-cache blocks the indexer currently tracks
+// per pod, ordered by block count and capped to maxDebugDumpPods so the debug
+// payload stays bounded when a pool has many pods.
+func (p *dataProducer) DumpState() (json.RawMessage, error) {
+	return json.Marshal(p.snapshotState())
+}
+
+func (p *dataProducer) snapshotState() prefixIndexState {
+	state := prefixIndexState{MaxPods: maxDebugDumpPods}
+	if p.indexerInst == nil {
+		return state
+	}
+
+	counts := p.indexerInst.PodBlockCounts()
+	state.TotalPods = len(counts)
+	state.Pods = make([]podBlockCount, 0, len(counts))
+	for pod, blocks := range counts {
+		state.Pods = append(state.Pods, podBlockCount{Pod: pod.String(), Blocks: blocks})
+	}
+
+	sort.SliceStable(state.Pods, func(a, b int) bool {
+		if state.Pods[a].Blocks != state.Pods[b].Blocks {
+			return state.Pods[a].Blocks > state.Pods[b].Blocks
+		}
+		return state.Pods[a].Pod < state.Pods[b].Pod
+	})
+
+	if len(state.Pods) > maxDebugDumpPods {
+		state.Pods = state.Pods[:maxDebugDumpPods]
+	}
+	return state
 }
 
 // Produces returns the data produced by the plugin.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -832,3 +832,78 @@ func TestPrefixPluginMatchesSameTokens(t *testing.T) {
 
 	assert.Equal(t, state1.PerPromptHashes, state2.PerPromptHashes, "identical token IDs must produce identical hashes")
 }
+
+func TestDumpState(t *testing.T) {
+	idx := newIndexer(context.Background(), 100, "test-name", "test-type")
+	podA := server{ServerID: ServerID{Namespace: "ns", Name: "pod-a"}}
+	podB := server{ServerID: ServerID{Namespace: "ns", Name: "pod-b"}}
+	idx.Add([]blockHash{1001, 1002, 1003}, podA)
+	idx.Add([]blockHash{2001, 2002}, podB)
+
+	p := &dataProducer{indexerInst: idx}
+	payload, err := p.DumpState()
+	assert.NoError(t, err)
+	// Block hashes are derived from prompt content and must never reach the dump.
+	assert.NotContains(t, string(payload), "1001")
+
+	var got prefixIndexState
+	assert.NoError(t, json.Unmarshal(payload, &got))
+	assert.Equal(t, prefixIndexState{
+		Pods: []podBlockCount{
+			{Pod: "ns/pod-a", Blocks: 3},
+			{Pod: "ns/pod-b", Blocks: 2},
+		},
+		TotalPods: 2,
+		MaxPods:   maxDebugDumpPods,
+	}, got)
+}
+
+func TestDumpStateCapsPods(t *testing.T) {
+	idx := newIndexer(context.Background(), 1000, "test-name", "test-type")
+	const extra = 5
+	for i := 0; i < maxDebugDumpPods+extra; i++ {
+		pod := server{ServerID: ServerID{Namespace: "ns", Name: fmt.Sprintf("pod-%03d", i)}}
+		hashes := make([]blockHash, i+1)
+		for j := range hashes {
+			hashes[j] = blockHash(i*1000 + j)
+		}
+		idx.Add(hashes, pod)
+	}
+
+	p := &dataProducer{indexerInst: idx}
+	payload, err := p.DumpState()
+	assert.NoError(t, err)
+
+	var got prefixIndexState
+	assert.NoError(t, json.Unmarshal(payload, &got))
+	// The dump is partial: TotalPods exceeds the returned count, capped at MaxPods.
+	assert.Equal(t, maxDebugDumpPods+extra, got.TotalPods)
+	assert.Greater(t, got.TotalPods, got.MaxPods)
+	assert.Len(t, got.Pods, maxDebugDumpPods)
+	// The pod holding the most blocks is listed first.
+	assert.Equal(t, "ns/pod-104", got.Pods[0].Pod)
+	assert.Equal(t, maxDebugDumpPods+extra, got.Pods[0].Blocks)
+}
+
+func TestDumpStateEmpty(t *testing.T) {
+	// A nil indexer should still produce valid JSON instead of panicking.
+	p := &dataProducer{}
+	payload, err := p.DumpState()
+	assert.NoError(t, err)
+	assert.True(t, json.Valid(payload))
+
+	var got prefixIndexState
+	assert.NoError(t, json.Unmarshal(payload, &got))
+	assert.Empty(t, got.Pods)
+	assert.Equal(t, maxDebugDumpPods, got.MaxPods)
+
+	// A live indexer with nothing tracked yet reports zero pods.
+	p.indexerInst = newIndexer(context.Background(), 100, "test-name", "test-type")
+	payload, err = p.DumpState()
+	assert.NoError(t, err)
+
+	got = prefixIndexState{}
+	assert.NoError(t, json.Unmarshal(payload, &got))
+	assert.Equal(t, 0, got.TotalPods)
+	assert.Empty(t, got.Pods)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -31,6 +31,7 @@ type indexerInterface interface {
 	Add(hashes []blockHash, server server)
 	RemovePod(server ServerID)
 	Pods() []ServerID
+	PodBlockCounts() map[ServerID]int
 }
 
 // podSet holds a set of pods that may have a specific prefix hash.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `plugin.StateDumper` to the `approx-prefix-cache-producer` so its prefix index
can be inspected through `GET /debug/plugins/state`, the same way the
`inflight-load-producer` already exposes its state.

`DumpState` returns the number of indexed prefix-cache blocks per pod, sorted by
count and capped at 100 pods (with a `truncated` flag) so the response stays small
when a pool has many pods. It includes pod names and counts only; the block hashes
are derived from prompt content, so they are left out on purpose.

Reading the per-pod sizes needs a small `PodBlockCounts()` accessor on the indexer,
which takes the existing read lock.

Example response for this plugin:

```json
{"pods":[{"pod":"default/vllm-a","blocks":1240},{"pod":"default/vllm-b","blocks":980}],"totalPods":2,"maxPods":100,"truncated":false}
```

Part of #1755.

**Which issue(s) this PR fixes**:

Fixes #1801

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Testing**:

New unit tests, all passing:
- [x] Per-pod block counts are reported, ordered by count, with no block hash in the output
- [x] The pod list is capped and the truncated flag is set, busiest pod first
- [x] Nil and empty indexers return valid JSON without panicking
