### PR TITLE
feat: implement DumpState for no-hit-lru-scorer

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -33,6 +33,7 @@ const (
 var _ scheduling.Scorer = &NoHitLRU{}
 var _ requestcontrol.PreRequest = &NoHitLRU{}
 var _ plugin.ConsumerPlugin = &NoHitLRU{}
+var _ plugin.StateDumper = &NoHitLRU{}
 
 // Parameters defines the parameters for the NoHitLRU scorer.
 type Parameters struct {
@@ -120,6 +121,40 @@ func (s *NoHitLRU) TypedName() plugin.TypedName {
 // Category returns the preference the scorer applies when scoring candidate endpoints.
 func (s *NoHitLRU) Category() scheduling.ScorerCategory {
 	return scheduling.Distribution
+}
+
+const maxDebugDumpEndpoints = 100
+
+// noHitLRUState is the sanitized snapshot returned by DumpState: the endpoint
+// identities tracked in the cold-request LRU, nothing else. The dump is partial
+// when TotalEndpoints exceeds MaxEndpoints.
+type noHitLRUState struct {
+	Endpoints      []string `json:"endpoints"`
+	TotalEndpoints int      `json:"totalEndpoints"`
+	MaxEndpoints   int      `json:"maxEndpoints"`
+}
+
+// DumpState reports the endpoints currently tracked in the cold-request LRU,
+// ordered least-recently-used first (the order the scorer favors for the next
+// cold request) and capped to maxDebugDumpEndpoints so the payload stays bounded.
+// No extra lock is needed: lru.Cache is internally synchronized, so Keys() is
+// safe to call concurrently with PreRequest's Add().
+func (s *NoHitLRU) DumpState() (json.RawMessage, error) {
+	state := noHitLRUState{MaxEndpoints: maxDebugDumpEndpoints}
+	// A constructed scorer always has a cache; this guards zero-value use.
+	if s.lruCache == nil {
+		return json.Marshal(state)
+	}
+
+	// Keys returns a fresh slice, least-recently-used first, safe to truncate.
+	// https://pkg.go.dev/github.com/hashicorp/golang-lru/v2#Cache.Keys
+	keys := s.lruCache.Keys()
+	state.TotalEndpoints = len(keys)
+	if len(keys) > maxDebugDumpEndpoints {
+		keys = keys[:maxDebugDumpEndpoints]
+	}
+	state.Endpoints = keys
+	return json.Marshal(state)
 }
 
 func (s *NoHitLRU) Consumes() plugin.DataDependencies {

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -3,7 +3,9 @@ package nohitlru_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -494,4 +496,135 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 		}
 		scorer.PreRequest(ctx, req, result)
 	})
+}
+
+// dumpedLRUState mirrors the unexported noHitLRUState; keep the JSON tags in sync.
+type dumpedLRUState struct {
+	Endpoints      []string `json:"endpoints"`
+	TotalEndpoints int      `json:"totalEndpoints"`
+	MaxEndpoints   int      `json:"maxEndpoints"`
+}
+
+// seedCold drives one cold request whose target is the given endpoint, which
+// adds the endpoint to the scorer's cold-request LRU. The RequestID must be
+// unique per call when reusing the same scorer.
+func seedCold(ctx context.Context, scorer *nohitlru.NoHitLRU, target scheduling.Endpoint, id string) {
+	req := &scheduling.InferenceRequest{RequestID: id}
+	scorer.Score(ctx, req, []scheduling.Endpoint{target})
+	scorer.PreRequest(ctx, req, &scheduling.SchedulingResult{
+		PrimaryProfileName: "p",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"p": {TargetEndpoints: []scheduling.Endpoint{target}},
+		},
+	})
+}
+
+func dumpLRU(t *testing.T, scorer *nohitlru.NoHitLRU) dumpedLRUState {
+	t.Helper()
+	payload, err := scorer.DumpState()
+	if err != nil {
+		t.Fatalf("DumpState: %v", err)
+	}
+	if !json.Valid(payload) {
+		t.Fatalf("DumpState returned invalid JSON: %s", payload)
+	}
+	var state dumpedLRUState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return state
+}
+
+func TestDumpState(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := nohitlru.NewNoHitLRU(ctx, nohitlru.NoHitLRUType, nil)
+
+	seedCold(ctx, scorer, newColdNS("pod-a"), "cold-a")
+	seedCold(ctx, scorer, newColdNS("pod-b"), "cold-b")
+
+	state := dumpLRU(t, scorer)
+
+	// LRU order is least-recently-used first: pod-a was used before pod-b.
+	if diff := cmp.Diff([]string{"default/pod-a", "default/pod-b"}, state.Endpoints); diff != "" {
+		t.Errorf("endpoints mismatch (-want +got):\n%s", diff)
+	}
+	if state.TotalEndpoints != 2 {
+		t.Errorf("totalEndpoints = %d, want 2", state.TotalEndpoints)
+	}
+	if state.MaxEndpoints != 100 {
+		t.Errorf("maxEndpoints = %d, want 100", state.MaxEndpoints)
+	}
+	if state.TotalEndpoints > state.MaxEndpoints {
+		t.Errorf("dump unexpectedly partial: total %d > max %d", state.TotalEndpoints, state.MaxEndpoints)
+	}
+}
+
+func TestDumpStateCaps(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := nohitlru.NewNoHitLRU(ctx, nohitlru.NoHitLRUType, nil)
+
+	const total = 105 // greater than the 100-endpoint dump cap
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("pod-%03d", i)
+		seedCold(ctx, scorer, newColdNS(name), name)
+	}
+
+	state := dumpLRU(t, scorer)
+
+	// The dump is partial: TotalEndpoints exceeds the returned count, capped at MaxEndpoints.
+	if state.TotalEndpoints <= state.MaxEndpoints {
+		t.Errorf("expected partial dump: total %d should exceed max %d", state.TotalEndpoints, state.MaxEndpoints)
+	}
+	if state.TotalEndpoints != total {
+		t.Errorf("totalEndpoints = %d, want %d", state.TotalEndpoints, total)
+	}
+	if len(state.Endpoints) != state.MaxEndpoints {
+		t.Errorf("len(endpoints) = %d, want %d", len(state.Endpoints), state.MaxEndpoints)
+	}
+	// LRU order keeps the least-recently-used (earliest-seeded) endpoints.
+	if state.Endpoints[0] != "default/pod-000" {
+		t.Errorf("endpoints[0] = %q, want default/pod-000", state.Endpoints[0])
+	}
+	if last := state.Endpoints[len(state.Endpoints)-1]; last != "default/pod-099" {
+		t.Errorf("endpoints[last] = %q, want default/pod-099", last)
+	}
+}
+
+func TestDumpStateEmpty(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	// Fresh scorer: empty LRU.
+	scorer := nohitlru.NewNoHitLRU(ctx, nohitlru.NoHitLRUType, nil)
+	if state := dumpLRU(t, scorer); state.TotalEndpoints != 0 || len(state.Endpoints) != 0 || state.MaxEndpoints != 100 {
+		t.Errorf("fresh scorer dump = %+v, want empty with maxEndpoints 100", state)
+	}
+
+	// Zero-value scorer: a nil LRU must not panic.
+	if state := dumpLRU(t, &nohitlru.NoHitLRU{}); state.TotalEndpoints != 0 || len(state.Endpoints) != 0 {
+		t.Errorf("zero-value scorer dump = %+v, want empty", state)
+	}
+}
+
+func TestDumpStateConcurrentWithPreRequest(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	scorer := nohitlru.NewNoHitLRU(ctx, nohitlru.NoHitLRUType, nil)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			name := fmt.Sprintf("pod-%03d", i)
+			seedCold(ctx, scorer, newColdNS(name), name)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			if _, err := scorer.DumpState(); err != nil {
+				t.Errorf("DumpState returned error: %v", err)
+			}
+		}
+	}()
+	wg.Wait()
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `plugin.StateDumper` to the no-hit-lru-scorer so the endpoints it tracks in
its cold-request LRU can be inspected through `GET /debug/plugins/state`, the
same way the `inflight-load-producer` already exposes its state.

`DumpState` lists the tracked endpoints in LRU order (least-recently-used first,
the order the scorer favors for the next cold request), capped at 100 with a
`truncated` flag so the payload stays bounded. Only endpoint identities are
reported. The cache is already concurrency-safe, so no extra locking is needed.

Example response for this plugin:

```json
{"endpoints":["default/pod-a","default/pod-b"],"totalEndpoints":2,"maxEndpoints":100,"truncated":false}
```

Part of #1755.

**Which issue(s) this PR fixes**:

Fixes #1790

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Testing**:

New unit tests, all passing:
- [x] Tracked endpoints are reported in LRU order
- [x] The list is capped with the truncated flag set, keeping the least-recently-used endpoints
- [x] An empty LRU and a zero-value scorer both return valid JSON without panicking
