### PR TITLE
feat: implement DumpState for mm-embeddings-cache-producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -59,6 +60,7 @@ var (
 	_ requestcontrol.DataProducer = &Producer{}
 	_ requestcontrol.PreRequest   = &Producer{}
 	_ fwkdl.EndpointExtractor     = &Producer{}
+	_ plugin.StateDumper          = &Producer{}
 )
 
 // Parameters configures the multimodal encoder-cache data producer.
@@ -170,6 +172,77 @@ func (p *Producer) cleanupLoop(ctx context.Context) {
 // TypedName returns the plugin type/name.
 func (p *Producer) TypedName() plugin.TypedName {
 	return p.typedName
+}
+
+const maxDebugDumpPods = 100
+
+// encoderCacheState is the snapshot returned by DumpState: the known pods from
+// the datalayer and per-pod cached-item counts. The multimodal content hashes
+// (the cache keys) are not exposed. Both lists are capped at MaxPods (PodList by
+// name, Pods by item count) and a list is partial when its matching total
+// exceeds MaxPods. PodList is sampled just before the per-pod view rather than
+// atomically with it, so the snapshot is best-effort: the two need not be
+// perfectly consistent, and a freshly tracked pod can appear in Pods but not yet
+// in PodList.
+type encoderCacheState struct {
+	PodList        []string       `json:"podList"`
+	TotalKnownPods int            `json:"totalKnownPods"`
+	Pods           []podItemCount `json:"pods"`
+	TotalPods      int            `json:"totalPods"`
+	MaxPods        int            `json:"maxPods"`
+}
+
+type podItemCount struct {
+	Pod   string `json:"pod"`
+	Items int    `json:"items"`
+}
+
+// DumpState reports the known pods from the datalayer and how many encoder-cache
+// items are tracked per pod, ordered by count (most first) and capped to
+// maxDebugDumpPods so the payload stays bounded. Pod identities and counts are
+// exposed; the content hashes (cache keys) are not.
+func (p *Producer) DumpState() (json.RawMessage, error) {
+	// podList() is the datalayer accessor; call it outside the cache lock, as
+	// removeStalePods does.
+	podList := []string{}
+	var totalKnownPods int
+	if p.podList != nil {
+		known := p.podList()
+		totalKnownPods = len(known)
+		podList = make([]string, 0, len(known))
+		for _, nn := range known {
+			podList = append(podList, nn.String())
+		}
+		sort.Strings(podList)
+		if len(podList) > maxDebugDumpPods {
+			podList = podList[:maxDebugDumpPods]
+		}
+	}
+
+	p.mutex.RLock()
+	state := encoderCacheState{
+		PodList:        podList,
+		TotalKnownPods: totalKnownPods,
+		MaxPods:        maxDebugDumpPods,
+		TotalPods:      len(p.caches),
+	}
+	pods := make([]podItemCount, 0, len(p.caches))
+	for pod, cache := range p.caches {
+		pods = append(pods, podItemCount{Pod: pod, Items: cache.Len()})
+	}
+	p.mutex.RUnlock()
+
+	sort.SliceStable(pods, func(a, b int) bool {
+		if pods[a].Items != pods[b].Items {
+			return pods[a].Items > pods[b].Items
+		}
+		return pods[a].Pod < pods[b].Pod
+	})
+	if len(pods) > maxDebugDumpPods {
+		pods = pods[:maxDebugDumpPods]
+	}
+	state.Pods = pods
+	return json.Marshal(state)
 }
 
 // Produces returns the data keys this plugin produces.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -19,7 +19,9 @@ package multimodal
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -288,4 +290,111 @@ func assertMatchInfo(t *testing.T, p *Producer, endpoint scheduling.Endpoint, ma
 	require.True(t, ok)
 	assert.ElementsMatch(t, matchedItems, info.MatchedItems())
 	assert.ElementsMatch(t, requestItems, info.RequestItems())
+}
+
+func TestDumpState(t *testing.T) {
+	podA := k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"}
+	podB := k8stypes.NamespacedName{Namespace: "default", Name: "pod-b"}
+	podC := k8stypes.NamespacedName{Namespace: "default", Name: "pod-c"}
+	// podList is the datalayer's known pods (unsorted, and includes pod-c which
+	// has no cache entries); the per-pod cache view is tracked separately, so it
+	// is usually but not necessarily a subset.
+	podList := func() []k8stypes.NamespacedName {
+		return []k8stypes.NamespacedName{podB, podA, podC}
+	}
+	p, err := New(context.Background(), "test", &Parameters{}, podList)
+	require.NoError(t, err)
+
+	p.putCacheEntry("h1", podA)
+	p.putCacheEntry("h2", podA)
+	p.putCacheEntry("h3", podA)
+	p.putCacheEntry("h1", podB)
+	p.putCacheEntry("h2", podB)
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	// Content hashes (cache keys) must never reach the dump.
+	assert.NotContains(t, string(payload), "h1")
+
+	var state encoderCacheState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, encoderCacheState{
+		PodList:        []string{"default/pod-a", "default/pod-b", "default/pod-c"},
+		TotalKnownPods: 3,
+		Pods: []podItemCount{
+			{Pod: "default/pod-a", Items: 3},
+			{Pod: "default/pod-b", Items: 2},
+		},
+		TotalPods: 2,
+		MaxPods:   maxDebugDumpPods,
+	}, state)
+}
+
+func TestDumpStateCapsPods(t *testing.T) {
+	p, err := New(context.Background(), "test", &Parameters{}, nil)
+	require.NoError(t, err)
+
+	const extra = 5
+	for i := 0; i < maxDebugDumpPods+extra; i++ {
+		pod := k8stypes.NamespacedName{Namespace: "default", Name: fmt.Sprintf("pod-%03d", i)}
+		for j := 0; j <= i; j++ {
+			p.putCacheEntry(fmt.Sprintf("h-%03d-%03d", i, j), pod)
+		}
+	}
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+
+	var state encoderCacheState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	// The dump is partial: TotalPods exceeds the returned count, capped at MaxPods.
+	assert.Equal(t, maxDebugDumpPods+extra, state.TotalPods)
+	assert.Greater(t, state.TotalPods, state.MaxPods)
+	assert.Len(t, state.Pods, maxDebugDumpPods)
+	// The pod holding the most items is listed first.
+	assert.Equal(t, "default/pod-104", state.Pods[0].Pod)
+	assert.Equal(t, maxDebugDumpPods+extra, state.Pods[0].Items)
+}
+
+func TestDumpStateEmpty(t *testing.T) {
+	p, err := New(context.Background(), "test", &Parameters{}, nil)
+	require.NoError(t, err)
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	assert.True(t, json.Valid(payload))
+	// Empty lists serialize as [] not null, matching the documented response shape.
+	assert.Contains(t, string(payload), `"podList":[]`)
+	assert.Contains(t, string(payload), `"pods":[]`)
+
+	var state encoderCacheState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Empty(t, state.Pods)
+	assert.Equal(t, 0, state.TotalPods)
+	assert.Equal(t, 0, state.TotalKnownPods)
+	assert.Equal(t, maxDebugDumpPods, state.MaxPods)
+}
+
+func TestDumpStateConcurrentWithWrites(t *testing.T) {
+	p, err := New(context.Background(), "test", &Parameters{}, nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			pod := k8stypes.NamespacedName{Namespace: "default", Name: fmt.Sprintf("pod-%03d", i)}
+			p.putCacheEntry(fmt.Sprintf("h-%d", i), pod)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			if _, err := p.DumpState(); err != nil {
+				t.Errorf("DumpState returned error: %v", err)
+			}
+		}
+	}()
+	wg.Wait()
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `plugin.StateDumper` to the mm-embeddings-cache-producer so its state can be
inspected through `GET /debug/plugins/state`, the same way the
`inflight-load-producer` already exposes its state.

`DumpState` reports the known pods from the datalayer and the per-pod encoder-cache
occupancy (how many items each pod has cached), ordered by count and capped at 100
so the payload stays bounded; the totals report the full counts so a consumer can
tell when a list is partial. It emits pod identities and counts only; the cached
multimodal content hashes (the cache keys) are deliberately left out.

Example response for this plugin:

```json
{"podList":["default/vllm-a","default/vllm-b"],"totalKnownPods":2,"pods":[{"pod":"default/vllm-a","items":12},{"pod":"default/vllm-b","items":8}],"totalPods":2,"maxPods":100}
```

Part of #1755.

**Which issue(s) this PR fixes**:

Fixes #1789

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Testing**:

New unit tests, all passing:
- [x] Known pods and per-pod item counts are reported (ordered by count), with no content hash in the output
- [x] Both lists are capped while the totals report the full counts, busiest pod first
- [x] An empty cache returns valid JSON with empty lists, not null
