### PR TITLE
feat: implement DumpState for program-aware-fairness

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
@@ -72,6 +72,7 @@ var (
 	_ flowcontrol.FairnessPolicy  = &ProgramAwarePlugin{}
 	_ fwkrc.PreRequest            = &ProgramAwarePlugin{}
 	_ fwkrc.ResponseBodyProcessor = &ProgramAwarePlugin{}
+	_ plugin.StateDumper          = &ProgramAwarePlugin{}
 )
 
 //nolint:revive // factory name matches sibling fairness plugins.
@@ -118,6 +119,45 @@ type ProgramAwarePlugin struct {
 
 func (p *ProgramAwarePlugin) TypedName() plugin.TypedName {
 	return plugin.TypedName{Type: ProgramAwarePluginType, Name: p.name}
+}
+
+// fairnessDumpState is the sanitized snapshot returned by DumpState. Program IDs
+// come from a user-controlled request header, so they are omitted; only these
+// bounded aggregates are reported.
+type fairnessDumpState struct {
+	TotalPrograms int     `json:"totalPrograms"`
+	TotalInFlight int64   `json:"totalInFlight"`
+	FairnessIndex float64 `json:"fairnessIndex"`
+}
+
+// DumpState reports aggregate fairness health: how many programs are tracked,
+// the total in-flight requests across them, and Jain's fairness index. Per-program
+// IDs are deliberately excluded because they are user-controlled and high-cardinality.
+// All three values come from a single pass over the program map.
+func (p *ProgramAwarePlugin) DumpState() (json.RawMessage, error) {
+	var totalPrograms int
+	var totalInFlight int64
+	var sum, sumSq, n float64
+	p.programMetrics.Range(func(_, value any) bool {
+		totalPrograms++
+		m, ok := value.(*ProgramMetrics)
+		if !ok {
+			return true
+		}
+		totalInFlight += m.InFlight()
+		if m.WaitCount() > 0 {
+			x := m.AverageWaitTime()
+			sum += x
+			sumSq += x * x
+			n++
+		}
+		return true
+	})
+	return json.Marshal(fairnessDumpState{
+		TotalPrograms: totalPrograms,
+		TotalInFlight: totalInFlight,
+		FairnessIndex: jainFairnessIndex(sum, sumSq, n),
+	})
 }
 
 // getStrategy falls back to a default LAS strategy for zero-value plugin
@@ -261,6 +301,16 @@ func (p *ProgramAwarePlugin) evictKey(key any) {
 	}
 }
 
+// jainFairnessIndex returns Jain's fairness index for the given sum, sum of
+// squares, and count of per-program wait observations. It is 1.0 (perfectly
+// fair) when fewer than two programs have observations.
+func jainFairnessIndex(sum, sumSq, n float64) float64 {
+	if n <= 1 || sumSq == 0 {
+		return 1.0
+	}
+	return (sum * sum) / (n * sumSq)
+}
+
 // computeFairnessIndex returns Jain's Fairness Index over the average wait
 // time per program. Programs with no wait observations are skipped.
 func (p *ProgramAwarePlugin) computeFairnessIndex() float64 {
@@ -279,8 +329,5 @@ func (p *ProgramAwarePlugin) computeFairnessIndex() float64 {
 		n++
 		return true
 	})
-	if n <= 1 || sumSq == 0 {
-		return 1.0
-	}
-	return (sum * sum) / (n * sumSq)
+	return jainFairnessIndex(sum, sumSq, n)
 }

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
@@ -255,3 +255,44 @@ func TestGetOrCreateMetrics_Idempotent(t *testing.T) {
 	b := p.getOrCreateMetrics("alpha")
 	assert.Same(t, a, b)
 }
+
+func TestDumpState(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+	p.getOrCreateMetrics("prog-a").RecordDispatched(time.Now().Add(-10 * time.Millisecond))
+	p.getOrCreateMetrics("prog-b").RecordDispatched(time.Now().Add(-20 * time.Millisecond))
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+
+	var state fairnessDumpState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, 2, state.TotalPrograms)
+	assert.Equal(t, int64(2), state.TotalInFlight)
+	assert.GreaterOrEqual(t, state.FairnessIndex, 0.0)
+	assert.LessOrEqual(t, state.FairnessIndex, 1.0)
+}
+
+func TestDumpStateOmitsProgramIDs(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+	// Program IDs come from a user-controlled header and must never be dumped.
+	p.getOrCreateMetrics("secret-tenant-xyz").RecordDispatched(time.Now().Add(-5 * time.Millisecond))
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "secret-tenant-xyz")
+}
+
+func TestDumpStateEmpty(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	assert.True(t, json.Valid(payload))
+
+	var state fairnessDumpState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, 0, state.TotalPrograms)
+	assert.Equal(t, int64(0), state.TotalInFlight)
+	// With no programs the policy is trivially fair.
+	assert.Equal(t, 1.0, state.FairnessIndex)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `plugin.StateDumper` to the program-aware-fairness plugin so its health can
be inspected through `GET /debug/plugins/state`, the same way the
`inflight-load-producer` already exposes its state.

Unlike the other plugins, this one keys its state by program ID, which comes from
a user-controlled request header (`x-llm-d-inference-fairness-id`) and is
high-cardinality. Dumping those IDs would expose user-controlled, tenant-identifying
values, which `docs/plugin_debug.md` says to omit. So `DumpState` reports only
bounded aggregates and no IDs: the number of tracked programs, total in-flight
requests, and Jain's fairness index (which the plugin already computes). That is
the right operational signal for a fairness policy without leaking identities.

Example response for this plugin:

```json
{"totalPrograms":12,"totalInFlight":34,"fairnessIndex":0.92}
```

A shared `jainFairnessIndex` helper keeps the index formula in one place so the
dump and the existing metric come from a single snapshot of the program map.

Part of #1755.

**Which issue(s) this PR fixes**:

Fixes #1798

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Testing**:

New unit tests, all passing:
- [x] Aggregates (program count, in-flight, fairness index) are reported
- [x] User-controlled program IDs never appear in the dump
- [x] An empty policy returns valid JSON (trivially fair)
