### PR TITLE
refactor(flowcontrol): scrub shard vocabulary and rewrite docs to single-processor model

### DIFF
--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controller contains the implementation of the FlowController engine.
-//
-// The FlowController is the central processing engine of the Flow Control layer. It is a high-throughput
-// component responsible for managing the lifecycle of all incoming requests. It achieves this by acting as a stateless
-// supervisor that orchestrates a stateful worker (Processor).
 package controller
 
 import (
@@ -46,7 +41,7 @@ type registryClient interface {
 	contracts.FlowRegistryDataPlane
 }
 
-// processor is the minimal internal interface that the FlowController requires from its workers.
+// processor is the minimal internal interface that the FlowController requires from its worker.
 type processor interface {
 	Run(ctx context.Context)
 	Submit(item *internal.FlowItem) error
@@ -70,8 +65,8 @@ type processorFactory func(
 var _ processor = &internal.Processor{}
 
 // FlowController is the central, high-throughput engine of the Flow Control layer.
-// It is designed as a stateless distributor that orchestrates a stateful worker (Processor), following a
-// supervisor-worker pattern.
+// It is the request-facing front end that hands each request to a single stateful worker (the Processor) and blocks
+// until the request reaches a terminal outcome.
 //
 // Request Lifecycle Management:
 //
@@ -334,7 +329,7 @@ func (fc *FlowController) withConnectionWithFallback(
 	})
 }
 
-// tryDistribution handles a single attempt to select a shard and submit a request.
+// tryDistribution handles a single attempt to submit a request to the processor.
 // It uses the provided `conn` to access the registry data plane.
 // If this function returns an error, it guarantees that the provided `item` has been finalized.
 func (fc *FlowController) tryDistribution(
@@ -426,21 +421,19 @@ func (fc *FlowController) createRequestContext(
 	return reqCtx, cancel, enqueueTime
 }
 
-// distributeRequest implements a flow-aware, two-phase "Join-Shortest-Queue-by-Bytes" (JSQ-Bytes) distribution strategy
-// with graceful backpressure. It attempts to submit an item to the best-ranked candidate from the provided list.
+// distributeRequest submits an item to the processor with graceful backpressure.
 //
-// The algorithm operates as follows:
-//  1. Phase 1 (Non-blocking Fast Failover): It iterates through the ranked candidates and attempts a non-blocking
-//     submission. The first successful submission wins.
-//  2. Phase 2 (Blocking Fallback): If all non-blocking attempts fail, it performs a single blocking submission to the
-//     least-loaded candidate, providing backpressure.
+// It operates in two phases:
+//  1. Non-blocking submit: a fast Submit that succeeds immediately if the processor's enqueue channel has capacity.
+//  2. Blocking fallback: if the processor is busy, a single blocking SubmitOrBlock that applies backpressure until the
+//     item is accepted, the context expires, or the processor shuts down.
 //
 // The provided context (ctx) is used for the blocking submission phase (SubmitOrBlock).
 //
 // Ownership Contract:
-//   - Returns nil: Success. Ownership transferred to Processor.
-//   - Returns error: Failure (Context expiry, shutdown,, etc.).
-//     Ownership retained by Controller. The Controller MUST finalize the item.
+//   - Returns nil: Success. Ownership transferred to the Processor.
+//   - Returns error: Failure (context expiry, shutdown, etc.).
+//     Ownership retained by the Controller, which MUST finalize the item.
 func (fc *FlowController) distributeRequest(
 	ctx context.Context,
 	item *internal.FlowItem,

--- a/pkg/epp/flowcontrol/controller/doc.go
+++ b/pkg/epp/flowcontrol/controller/doc.go
@@ -18,30 +18,29 @@ limitations under the License.
 //
 // # Overview
 //
-// The FlowController is the central processing engine of the Flow Control layer. It acts as a stateless supervisor that
-// orchestrates a pool of stateful workers (internal.ShardProcessor), managing the lifecycle of all incoming requests
-// from initial submission to a terminal outcome (dispatch, rejection, or eviction).
+// The FlowController is the central processing engine of the Flow Control layer. It manages the lifecycle of all
+// incoming requests from initial submission to a terminal outcome (dispatch, rejection, or eviction).
 //
-// # Architecture: Supervisor-Worker Pattern
+// # Architecture
 //
-// This package implements a supervisor-worker pattern to achieve high throughput and dynamic scalability.
+// The engine is split into two cooperating roles:
 //
-//   - The FlowController (Supervisor): The public-facing API of the system. Its primary responsibilities are to execute
-//     a distribution algorithm to select the optimal worker for a new request and to manage the lifecycle of the worker
-//     pool, ensuring it stays synchronized with the underlying shard topology defined by the contracts.FlowRegistry.
-//   - The internal.ShardProcessor (Worker): A stateful, single-goroutine actor responsible for the entire lifecycle of
-//     requests on a single shard. The supervisor manages a pool of these workers, one for each contracts.RegistryShard.
+//   - The FlowController: The public-facing API of the system. Each call to EnqueueAndWait runs on its own (caller's)
+//     goroutine: it acquires a flow lease from the contracts.FlowRegistry, hands the request to the Processor, and
+//     blocks until the request is finalized. It owns asynchronous finalization driven by the request Context
+//     (TTL/cancellation) and queue occupancy metrics.
+//   - The internal.Processor (Worker): A single, stateful, single-goroutine actor that owns the request data plane. It
+//     runs the dispatch loop, performs capacity checks, sweeps externally finalized items, and finalizes requests
+//     synchronously (dispatch, capacity rejection, shutdown).
 //
 // # Concurrency Model
 //
-// The FlowController is designed to be highly concurrent and thread-safe. It acts primarily as a stateless distributor.
+// The FlowController is designed to be highly concurrent and thread-safe. This rests on two properties:
 //
-//   - EnqueueAndWait: Can be called concurrently by many goroutines.
-//   - Worker Management: Uses a sync.Map (workers) for concurrent access and lazy initialization of workers.
-//   - Supervision: A single background goroutine (run) manages the worker pool lifecycle (garbage collection).
-//
-// It achieves high throughput by minimizing shared state and relying on the internal ShardProcessors to handle state
-// mutations serially (using an actor model).
+//   - EnqueueAndWait: Can be called concurrently by many goroutines, each handing its item to the single Processor over
+//     a buffered channel.
+//   - Single-Writer Actor: Routing all state mutations through the Processor's single Run goroutine makes complex
+//     transactions (such as capacity checks) inherently atomic without coarse-grained locks.
 //
 // # Request Lifecycle and Ownership
 //

--- a/pkg/epp/flowcontrol/controller/internal/doc.go
+++ b/pkg/epp/flowcontrol/controller/internal/doc.go
@@ -22,15 +22,15 @@ limitations under the License.
 // # Design Philosophy: The Single-Writer Actor Model
 //
 // The concurrency model for this package is built around a single-writer, channel-based actor pattern, as implemented
-// in the ShardProcessor. All state-mutating operations for a given shard (primarily enqueuing new requests) are
-// funneled through a single Run goroutine.
+// in the Processor. All state-mutating operations (primarily enqueuing new requests) are funneled through a single Run
+// goroutine.
 //
-// This design makes complex, multi-step transactions (like a hierarchical capacity check against both a shard's total
+// This design makes complex, multi-step transactions (like a hierarchical capacity check against both the global total
 // limit and a priority band's limit) inherently atomic without locks. This avoids the performance bottleneck of a
-// coarse, shard-wide lock and allows the top-level Controller to remain decoupled and highly concurrent.
+// coarse, global lock and allows the top-level Controller to remain decoupled and highly concurrent.
 //
 // # Key Components
 //
-//   - ShardProcessor: The implementation of the worker actor. Manages the lifecycle of requests for a single shard.
+//   - Processor: The implementation of the worker actor. Manages the lifecycle of all queued requests.
 //   - FlowItem: The internal representation of a request, managing its state and synchronization across goroutines.
 package internal

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -35,18 +35,18 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
 
-// maxCleanupWorkers caps the number of concurrent workers for background cleanup tasks. This prevents a single shard
+// maxCleanupWorkers caps the number of concurrent workers for background cleanup tasks. This prevents the processor
 // from overwhelming the Go scheduler with too many goroutines.
 const maxCleanupWorkers = 4
 
-// ErrProcessorBusy is a sentinel error returned by the processor's Submit method indicating that the processor's.
+// ErrProcessorBusy is a sentinel error returned by the processor's Submit method indicating that the processor's
 // internal buffer is momentarily full and cannot accept new work.
-var ErrProcessorBusy = errors.New("shard processor is busy")
+var ErrProcessorBusy = errors.New("processor is busy")
 
 // Processor is the core worker of the FlowController.
 //
-// It is paired one-to-one with a RegistryShard instance and is responsible for all request lifecycle operations on that
-// shard, from the point an item is successfully submitted to it.
+// A single Processor owns the entire request data plane and is responsible for all request lifecycle operations from
+// the point an item is successfully submitted to it.
 //
 // # Request Lifecycle Management & Ownership
 //
@@ -126,21 +126,21 @@ func NewProcessor(
 //
 // Ownership Contract:
 //   - Returns nil: The item was successfully handed off.
-//     The ShardProcessor takes responsibility for calling Finalize on the item.
+//     The Processor takes responsibility for calling Finalize on the item.
 //   - Returns error: The item was not handed off.
 //     Ownership of the FlowItem remains with the caller, who is responsible for calling Finalize.
 //
 // Possible errors:
 //   - ErrProcessorBusy: The processor's input channel is full.
 //   - types.ErrFlowControllerNotRunning: The processor is shutting down.
-func (sp *Processor) Submit(item *FlowItem) error {
-	if sp.isShuttingDown.Load() {
+func (p *Processor) Submit(item *FlowItem) error {
+	if p.isShuttingDown.Load() {
 		return types.ErrFlowControllerNotRunning
 	}
 	select { // The default case makes this select non-blocking.
-	case sp.enqueueChan <- item:
+	case p.enqueueChan <- item:
 		return nil // Ownership transferred.
-	case <-sp.lifecycleCtx.Done():
+	case <-p.lifecycleCtx.Done():
 		return types.ErrFlowControllerNotRunning
 	default:
 		return ErrProcessorBusy
@@ -152,49 +152,49 @@ func (sp *Processor) Submit(item *FlowItem) error {
 //
 // Ownership Contract:
 //   - Returns nil: The item was successfully handed off.
-//     The ShardProcessor takes responsibility for calling Finalize on the item.
+//     The Processor takes responsibility for calling Finalize on the item.
 //   - Returns error: The item was not handed off.
 //     Ownership of the FlowItem remains with the caller, who is responsible for calling Finalize.
 //
 // Possible errors:
 //   - ctx.Err(): The provided context was cancelled or its deadline exceeded.
 //   - types.ErrFlowControllerNotRunning: The processor is shutting down.
-func (sp *Processor) SubmitOrBlock(ctx context.Context, item *FlowItem) error {
-	if sp.isShuttingDown.Load() {
+func (p *Processor) SubmitOrBlock(ctx context.Context, item *FlowItem) error {
+	if p.isShuttingDown.Load() {
 		return types.ErrFlowControllerNotRunning
 	}
 
 	select { // The absence of a default case makes this call blocking.
-	case sp.enqueueChan <- item:
+	case p.enqueueChan <- item:
 		return nil // Ownership transferred.
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-sp.lifecycleCtx.Done():
+	case <-p.lifecycleCtx.Done():
 		return types.ErrFlowControllerNotRunning
 	}
 }
 
-// Run is the main operational loop for the shard processor. It must be run as a goroutine.
+// Run is the main operational loop for the processor. It must be run as a goroutine.
 // It uses a `select` statement to interleave accepting new requests with dispatching existing ones, balancing
 // responsiveness with throughput.
-func (sp *Processor) Run(ctx context.Context) {
-	sp.logger.V(logutil.DEFAULT).Info("Shard processor run loop starting.")
-	defer sp.logger.V(logutil.DEFAULT).Info("Shard processor run loop stopped.")
+func (p *Processor) Run(ctx context.Context) {
+	p.logger.V(logutil.DEFAULT).Info("Processor run loop starting.")
+	defer p.logger.V(logutil.DEFAULT).Info("Processor run loop stopped.")
 
-	sp.wg.Add(1)
-	go sp.runCleanupSweep(ctx)
+	p.wg.Add(1)
+	go p.runCleanupSweep(ctx)
 
 	// Create a ticker for periodic dispatch attempts to avoid tight loops
-	dispatchTicker := sp.clock.NewTicker(time.Millisecond)
+	dispatchTicker := p.clock.NewTicker(time.Millisecond)
 	defer dispatchTicker.Stop()
 
 	var gcCh <-chan time.Time
 	var priorityBandUpdateCh <-chan map[int]struct{}
-	if sp.registryBackground != nil {
-		gcTicker := sp.clock.NewTicker(sp.registryBackground.FlowGCTimeout())
+	if p.registryBackground != nil {
+		gcTicker := p.clock.NewTicker(p.registryBackground.FlowGCTimeout())
 		defer gcTicker.Stop()
 		gcCh = gcTicker.C()
-		priorityBandUpdateCh = sp.registryBackground.PriorityBandUpdateChannel()
+		priorityBandUpdateCh = p.registryBackground.PriorityBandUpdateChannel()
 	}
 
 	// This is the main worker loop. It continuously processes incoming requests and dispatches queued requests until the
@@ -211,35 +211,35 @@ func (sp *Processor) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			sp.shutdown()
-			sp.wg.Wait()
+			p.shutdown()
+			p.wg.Wait()
 			return
-		case item, ok := <-sp.enqueueChan:
+		case item, ok := <-p.enqueueChan:
 			if !ok { // Should not happen in practice, but is a clean shutdown signal.
-				sp.shutdown()
-				sp.wg.Wait()
+				p.shutdown()
+				p.wg.Wait()
 				return
 			}
 			// This is a safeguard against logic errors in the distributor.
 			if item == nil {
-				sp.logger.Error(nil, "Logic error: nil item received on shard processor enqueue channel, ignoring.")
+				p.logger.Error(nil, "Logic error: nil item received on processor enqueue channel, ignoring.")
 				continue
 			}
-			sp.enqueue(item)
-			sp.dispatchCycle(ctx) // Process immediately when an item arrives
+			p.enqueue(item)
+			p.dispatchCycle(ctx) // Process immediately when an item arrives
 		case <-dispatchTicker.C():
-			sp.dispatchCycle(ctx) // Periodically attempt to dispatch from queues
+			p.dispatchCycle(ctx) // Periodically attempt to dispatch from queues
 		case desired := <-priorityBandUpdateCh:
-			sp.registryBackground.ApplyDesiredPriorities(desired)
+			p.registryBackground.ApplyDesiredPriorities(desired)
 		case <-gcCh:
-			sp.registryBackground.ExecuteGCCycle()
+			p.registryBackground.ExecuteGCCycle()
 		}
 	}
 }
 
 // enqueue processes an item received from the enqueueChan.
 // It handles capacity checks, checks for external finalization, and either admits the item to a queue or rejects it.
-func (sp *Processor) enqueue(item *FlowItem) {
+func (p *Processor) enqueue(item *FlowItem) {
 
 	req := item.OriginalRequest()
 	key := req.FlowKey()
@@ -261,41 +261,41 @@ func (sp *Processor) enqueue(item *FlowItem) {
 	// This is an optimistic check to avoid unnecessary processing on items already considered dead.
 	// The ultimate guarantee of cleanup for any races is the runCleanupSweep mechanism.
 	if finalState := outcome; finalState != nil {
-		sp.logger.V(logutil.TRACE).Info("Item finalized externally before processing, discarding.",
+		p.logger.V(logutil.TRACE).Info("Item finalized externally before processing, discarding.",
 			"outcome", finalState.Outcome, "err", finalState.Err, "flowKey", key, "requestID", req.ID())
 		return
 	}
 
 	// --- Configuration Validation ---
-	managedQ, err := sp.registry.ManagedQueue(key)
+	managedQ, err := p.registry.ManagedQueue(key)
 	if err != nil {
 		finalErr := fmt.Errorf("configuration error: failed to get queue for flow key %s: %w", key, err)
-		sp.logger.Error(finalErr, "Rejecting request, queue lookup failed", "flowKey", key, "requestID", req.ID())
+		p.logger.Error(finalErr, "Rejecting request, queue lookup failed", "flowKey", key, "requestID", req.ID())
 		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
 		return
 	}
 
-	_, err = sp.registry.PriorityBandAccessor(key.Priority)
+	_, err = p.registry.PriorityBandAccessor(key.Priority)
 	if err != nil {
 		finalErr := fmt.Errorf("configuration error: failed to get priority band for priority %d: %w", key.Priority, err)
-		sp.logger.Error(finalErr, "Rejecting request, priority band lookup failed", "flowKey", key, "requestID", req.ID())
+		p.logger.Error(finalErr, "Rejecting request, priority band lookup failed", "flowKey", key, "requestID", req.ID())
 		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
 		return
 	}
 
 	// --- Capacity Check ---
 	// This check is safe because it is performed by the single-writer Run goroutine.
-	if ok, stats := sp.hasCapacity(key.Priority, req.ByteSize()); !ok {
+	if ok, stats := p.hasCapacity(key.Priority, req.ByteSize()); !ok {
 		// When the pool has no endpoints, the queue is acting as a scale-from-zero waiting room. A capacity rejection in
 		// that state reflects genuine unavailability (surfaced as 503), not backpressure against a contended pool (429).
-		if sp.poolEmpty {
-			sp.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity with no endpoints",
-				"flowKey", key, "reqID", req.ID(), "reqByteSize", req.ByteSize())
+		if p.poolEmpty {
+			p.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity with no endpoints",
+				"flowKey", key, "requestID", req.ID(), "reqByteSize", req.ByteSize())
 			item.FinalizeWithOutcome(types.QueueOutcomeRejectedNoEndpoints, fmt.Errorf("%w: %w",
 				types.ErrRejected, types.ErrNoEndpoints))
 			return
 		}
-		sp.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity",
+		p.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity",
 			"flowKey", key, "requestID", req.ID(), "reqByteSize", req.ByteSize(),
 			"totalLen", stats.TotalLen, "totalCapacityRequests", stats.TotalCapacityRequests,
 			"totalByteSize", stats.TotalByteSize, "totalCapacityBytes", stats.TotalCapacityBytes)
@@ -308,20 +308,20 @@ func (sp *Processor) enqueue(item *FlowItem) {
 	// The item is admitted. The ManagedQueue.Add implementation is responsible for calling item.SetHandle() atomically.
 	if err := managedQ.Add(item); err != nil {
 		finalErr := fmt.Errorf("failed to add item to queue for flow key %s: %w", key, err)
-		sp.logger.Error(finalErr, "Rejecting request, queue add failed",
+		p.logger.Error(finalErr, "Rejecting request, queue add failed",
 			"flowKey", key, "requestID", req.ID())
 		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
 		return
 	}
-	sp.logger.V(logutil.TRACE).Info("Item enqueued.",
+	p.logger.V(logutil.TRACE).Info("Item enqueued.",
 		"flowKey", key, "requestID", req.ID())
 }
 
-// hasCapacity checks if the shard and the specific priority band have enough capacity.
+// hasCapacity checks if the global limits and the specific priority band have enough capacity.
 // This check reflects actual resource utilization, including "zombie" items (finalized but unswept), to prevent
 // physical resource overcommitment.
-func (sp *Processor) hasCapacity(priority int, itemByteSize uint64) (bool, contracts.AggregateStats) {
-	stats := sp.registry.Stats()
+func (p *Processor) hasCapacity(priority int, itemByteSize uint64) (bool, contracts.AggregateStats) {
+	stats := p.registry.Stats()
 	if stats.TotalCapacityBytes > 0 && stats.TotalByteSize+itemByteSize > stats.TotalCapacityBytes {
 		return false, stats
 	}
@@ -354,43 +354,43 @@ func (sp *Processor) hasCapacity(priority int, itemByteSize uint64) (bool, contr
 // However, if a selected item is saturated (cannot be scheduled), the cycle stops immediately. This enforces HoL
 // blocking to respect the policy's decision and prevent priority inversion, where dispatching lower-priority work might
 // exacerbate the saturation affecting the high-priority item.
-func (sp *Processor) dispatchCycle(ctx context.Context) bool {
+func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	dispatchCycleStart := time.Now()
 	defer func() {
 		metrics.RecordFlowControlDispatchCycleDuration(time.Since(dispatchCycleStart))
 	}()
 
-	pool := sp.endpointCandidates.Locate(ctx, nil)
-	sp.poolEmpty = len(pool) == 0
-	saturation := sp.saturationDetector.Saturation(ctx, pool)
+	pool := p.endpointCandidates.Locate(ctx, nil)
+	p.poolEmpty = len(pool) == 0
+	saturation := p.saturationDetector.Saturation(ctx, pool)
 
 	// Record pool saturation metric
-	metrics.RecordFlowControlPoolSaturation(sp.poolName, saturation)
+	metrics.RecordFlowControlPoolSaturation(p.poolName, saturation)
 
-	priorities := sp.registry.AllOrderedPriorityLevels()
-	ceilings := sp.usageLimitPolicy.ComputeLimit(ctx, saturation, priorities)
+	priorities := p.registry.AllOrderedPriorityLevels()
+	ceilings := p.usageLimitPolicy.ComputeLimit(ctx, saturation, priorities)
 
 	for i, priority := range priorities {
 		// --- Viability Check (Saturation/HoL Blocking) ---
 		// Check before selecting an item: if we are already saturated for this priority, stop immediately.
 		usageLimit := ceilings[i]
 		if saturation >= usageLimit {
-			sp.logger.V(logutil.DEBUG).Info("Priority band is saturated; enforcing HoL blocking.",
+			p.logger.V(logutil.DEBUG).Info("Priority band is saturated; enforcing HoL blocking.",
 				"priority", priority, "saturation", saturation, "usageLimit", usageLimit)
 			// Stop the dispatch cycle entirely to respect strict policy decision and prevent priority inversion where
 			// lower-priority work might exacerbate the saturation affecting high-priority work.
 			return false
 		}
 
-		originalBand, err := sp.registry.PriorityBandAccessor(priority)
+		originalBand, err := p.registry.PriorityBandAccessor(priority)
 		if err != nil {
-			sp.logger.Error(err, "Failed to get PriorityBandAccessor, skipping band", "priority", priority)
+			p.logger.Error(err, "Failed to get PriorityBandAccessor, skipping band", "priority", priority)
 			continue
 		}
 
-		item, err := sp.selectItem(ctx, originalBand)
+		item, err := p.selectItem(ctx, originalBand)
 		if err != nil {
-			sp.logger.Error(err, "Failed to select item, skipping priority band for this cycle",
+			p.logger.Error(err, "Failed to select item, skipping priority band for this cycle",
 				"priority", priority)
 			continue // Continue to the next band to maximize work conservation.
 		}
@@ -400,8 +400,8 @@ func (sp *Processor) dispatchCycle(ctx context.Context) bool {
 
 		// --- Dispatch ---
 		req := item.OriginalRequest()
-		if err := sp.dispatchItem(item); err != nil {
-			sp.logger.Error(err, "Failed to dispatch item, skipping priority band for this cycle",
+		if err := p.dispatchItem(item); err != nil {
+			p.logger.Error(err, "Failed to dispatch item, skipping priority band for this cycle",
 				"flowKey", req.FlowKey(), "requestID", req.ID())
 			continue // Continue to the next band to maximize work conservation.
 		}
@@ -411,11 +411,11 @@ func (sp *Processor) dispatchCycle(ctx context.Context) bool {
 }
 
 // selectItem applies the configured fairness and ordering policies to select a single item.
-func (sp *Processor) selectItem(
+func (p *Processor) selectItem(
 	ctx context.Context,
 	flowGroup flowcontrol.PriorityBandAccessor,
 ) (flowcontrol.QueueItemAccessor, error) {
-	fairnessP, err := sp.registry.FairnessPolicy(flowGroup.Priority())
+	fairnessP, err := p.registry.FairnessPolicy(flowGroup.Priority())
 	if err != nil {
 		return nil, fmt.Errorf("could not get FairnessPolicy: %w", err)
 	}
@@ -433,10 +433,10 @@ func (sp *Processor) selectItem(
 }
 
 // dispatchItem handles the final steps of dispatching an item: removing it from the queue and finalizing its outcome.
-func (sp *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
+func (p *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
 	req := itemAcc.OriginalRequest()
 	key := req.FlowKey()
-	managedQ, err := sp.registry.ManagedQueue(key)
+	managedQ, err := p.registry.ManagedQueue(key)
 	if err != nil {
 		return fmt.Errorf("failed to get ManagedQueue for flow %s: %w", key, err)
 	}
@@ -445,26 +445,26 @@ func (sp *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
 	if err != nil {
 		// This happens benignly if the item was already removed by the cleanup sweep loop.
 		// We log it at a low level for visibility but return nil so the dispatch cycle proceeds.
-		sp.logger.V(logutil.DEBUG).Info("Failed to remove item during dispatch (likely already finalized and swept).",
+		p.logger.V(logutil.DEBUG).Info("Failed to remove item during dispatch (likely already finalized and swept).",
 			"flowKey", key, "requestID", req.ID(), "error", err)
 		return nil
 	}
 
 	removedItem := removedItemAcc.(*FlowItem)
-	sp.logger.V(logutil.TRACE).Info("Item dispatched.", "flowKey", req.FlowKey(), "requestID", req.ID())
+	p.logger.V(logutil.TRACE).Info("Item dispatched.", "flowKey", req.FlowKey(), "requestID", req.ID())
 	removedItem.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
 	return nil
 }
 
 // runCleanupSweep starts a background goroutine that periodically scans all queues for externally finalized items
 // ("zombie" items) and removes them in batches.
-func (sp *Processor) runCleanupSweep(ctx context.Context) {
-	defer sp.wg.Done()
-	logger := sp.logger.WithName("runCleanupSweep")
-	logger.V(logutil.DEFAULT).Info("Shard cleanup sweep goroutine starting.")
-	defer logger.V(logutil.DEFAULT).Info("Shard cleanup sweep goroutine stopped.")
+func (p *Processor) runCleanupSweep(ctx context.Context) {
+	defer p.wg.Done()
+	logger := p.logger.WithName("runCleanupSweep")
+	logger.V(logutil.DEFAULT).Info("Cleanup sweep goroutine starting.")
+	defer logger.V(logutil.DEFAULT).Info("Cleanup sweep goroutine stopped.")
 
-	ticker := sp.clock.NewTicker(sp.cleanupSweepInterval)
+	ticker := p.clock.NewTicker(p.cleanupSweepInterval)
 	defer ticker.Stop()
 
 	for {
@@ -472,14 +472,14 @@ func (sp *Processor) runCleanupSweep(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C():
-			sp.sweepFinalizedItems()
+			p.sweepFinalizedItems()
 		}
 	}
 }
 
 // sweepFinalizedItems performs a single scan of all queues, removing finalized items in batch and releasing their
 // memory.
-func (sp *Processor) sweepFinalizedItems() {
+func (p *Processor) sweepFinalizedItems() {
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		predicate := func(itemAcc flowcontrol.QueueItemAccessor) bool {
 			return itemAcc.(*FlowItem).FinalState() != nil
@@ -490,20 +490,20 @@ func (sp *Processor) sweepFinalizedItems() {
 				"count", len(removedItems))
 		}
 	}
-	sp.processAllQueuesConcurrently("sweepFinalizedItems", processFn)
+	p.processAllQueuesConcurrently("sweepFinalizedItems", processFn)
 }
 
 // shutdown handles the graceful termination of the processor, ensuring all pending items (in channel and queues) are
 // Finalized.
-func (sp *Processor) shutdown() {
-	sp.shutdownOnce.Do(func() {
-		sp.isShuttingDown.Store(true)
-		sp.logger.V(logutil.DEFAULT).Info("Shard processor shutting down.")
+func (p *Processor) shutdown() {
+	p.shutdownOnce.Do(func() {
+		p.isShuttingDown.Store(true)
+		p.logger.V(logutil.DEFAULT).Info("Processor shutting down.")
 
 	DrainLoop: // Drain the enqueueChan to finalize buffered items.
 		for {
 			select {
-			case item := <-sp.enqueueChan:
+			case item := <-p.enqueueChan:
 				if item == nil {
 					continue
 				}
@@ -516,12 +516,12 @@ func (sp *Processor) shutdown() {
 		}
 		// We do not close enqueueChan because external goroutines (Controller) send on it.
 		// The channel will be garbage collected when the processor terminates.
-		sp.evictAll()
+		p.evictAll()
 	})
 }
 
-// evictAll drains all queues on the shard, finalizes every item, and releases their memory.
-func (sp *Processor) evictAll() {
+// evictAll drains all queues, finalizes every item, and releases their memory.
+func (p *Processor) evictAll() {
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		key := managedQ.FlowQueueAccessor().FlowKey()
 		removedItems := managedQ.Drain()
@@ -541,16 +541,16 @@ func (sp *Processor) evictAll() {
 			item.FinalizeWithOutcome(outcome, errShutdown)
 		}
 	}
-	sp.processAllQueuesConcurrently("evictAll", processFn)
+	p.processAllQueuesConcurrently("evictAll", processFn)
 }
 
-// processAllQueuesConcurrently iterates over all queues in all priority bands on the shard and executes the given
+// processAllQueuesConcurrently iterates over all queues in all priority bands and executes the given
 // `processFn` for each queue using a dynamically sized worker pool.
-func (sp *Processor) processAllQueuesConcurrently(
+func (p *Processor) processAllQueuesConcurrently(
 	ctxName string,
 	processFn func(mq contracts.ManagedQueue, logger logr.Logger),
 ) {
-	logger := sp.logger.WithName(ctxName)
+	logger := p.logger.WithName(ctxName)
 
 	type resolvedQueue struct {
 		mq     contracts.ManagedQueue
@@ -558,17 +558,17 @@ func (sp *Processor) processAllQueuesConcurrently(
 	}
 
 	// Phase 1: Collect all queues and resolve ManagedQueue handles in one pass.
-	// This avoids holding locks on the shard while processing, and allows us to determine the optimal number of workers.
+	// This avoids holding registry locks while processing, and allows us to determine the optimal number of workers.
 	var resolvedQueues []resolvedQueue
-	for _, priority := range sp.registry.AllOrderedPriorityLevels() {
-		band, err := sp.registry.PriorityBandAccessor(priority)
+	for _, priority := range p.registry.AllOrderedPriorityLevels() {
+		band, err := p.registry.PriorityBandAccessor(priority)
 		if err != nil {
 			logger.Error(err, "Failed to get PriorityBandAccessor", "priority", priority)
 			continue
 		}
 		band.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) bool {
 			key := queue.FlowKey()
-			mq, err := sp.registry.ManagedQueue(key)
+			mq, err := p.registry.ManagedQueue(key)
 			if err != nil {
 				logger.V(logutil.DEBUG).Info("Skipping queue; ManagedQueue no longer resolvable",
 					"flowKey", key, "err", err)

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -70,7 +70,7 @@ func (m *mockSaturationDetector) Saturation(ctx context.Context, candidatePods [
 	return 0.0
 }
 
-// testHarness provides a unified, mock-based testing environment for the ShardProcessor. It centralizes all mock state
+// testHarness provides a unified, mock-based testing environment for the Processor. It centralizes all mock state
 // and provides helper methods for setting up tests and managing the processor's lifecycle.
 type testHarness struct {
 	t *testing.T
@@ -115,7 +115,7 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 	}
 	h.ctx, h.cancel = context.WithCancel(context.Background())
 
-	// Wire up the harness to provide the mock implementations for the shard's dependencies.
+	// Wire up the harness to provide the mock implementations for the processor's dependencies.
 	h.ManagedQueueFunc = h.managedQueue
 	h.AllOrderedPriorityLevelsFunc = h.allOrderedPriorityLevels
 	h.PriorityBandAccessorFunc = h.priorityBandAccessor
@@ -143,7 +143,7 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 		expiryCleanupInterval,
 		100,
 		h.logger)
-	require.NotNil(t, h.processor, "NewShardProcessor should not return nil")
+	require.NotNil(t, h.processor, "NewProcessor should not return nil")
 
 	t.Cleanup(func() { h.Stop() })
 
@@ -209,7 +209,7 @@ func (h *testHarness) addQueue(key flowcontrol.FlowKey) *mocks.MockManagedQueue 
 
 // --- Mock Interface Implementations ---
 
-// managedQueue provides the mock implementation for the `RegistryShard` interface.
+// managedQueue provides the mock implementation for the `registry data-plane` interface.
 func (h *testHarness) managedQueue(key flowcontrol.FlowKey) (contracts.ManagedQueue, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -219,7 +219,7 @@ func (h *testHarness) managedQueue(key flowcontrol.FlowKey) (contracts.ManagedQu
 	return nil, fmt.Errorf("test setup error: no queue for %q", key)
 }
 
-// allOrderedPriorityLevels provides the mock implementation for the `RegistryShard` interface.
+// allOrderedPriorityLevels provides the mock implementation for the `registry data-plane` interface.
 func (h *testHarness) allOrderedPriorityLevels() []int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -234,7 +234,7 @@ func (h *testHarness) allOrderedPriorityLevels() []int {
 	return prios
 }
 
-// priorityBandAccessor provides the mock implementation for the `RegistryShard` interface. It acts as a factory for a
+// priorityBandAccessor provides the mock implementation for the `registry data-plane` interface. It acts as a factory for a
 // fully-configured, stateless mock that is safe for concurrent use.
 func (h *testHarness) priorityBandAccessor(p int) (flowcontrol.PriorityBandAccessor, error) {
 	band := &fwkfcmocks.MockPriorityBandAccessor{PriorityV: p}
@@ -261,7 +261,7 @@ func (h *testHarness) priorityBandAccessor(p int) (flowcontrol.PriorityBandAcces
 	return band, nil
 }
 
-// fairnessPolicy provides the mock implementation for the RegistryShard interface.
+// fairnessPolicy provides the mock implementation for the registry data-plane interface.
 func (h *testHarness) fairnessPolicy(p int) (flowcontrol.FairnessPolicy, error) {
 	policy := &fwkfcmocks.MockFairnessPolicy{}
 	// If the test provided a custom implementation, use it.
@@ -288,8 +288,8 @@ func (h *testHarness) fairnessPolicy(p int) (flowcontrol.FairnessPolicy, error) 
 	return policy, nil
 }
 
-// TestShardProcessor contains all tests for the `ShardProcessor`.
-func TestShardProcessor(t *testing.T) {
+// TestProcessor contains all tests for the `Processor`.
+func TestProcessor(t *testing.T) {
 	t.Parallel()
 
 	// Integration tests use the processor's main `Run` loop to verify the complete end-to-end lifecycle of a request, from
@@ -708,13 +708,13 @@ func TestShardProcessor(t *testing.T) {
 				expectHasCap bool
 			}{
 				{
-					name:         "should deny item if shard byte capacity exceeded",
+					name:         "should deny item if global byte capacity exceeded",
 					itemByteSize: 1,
 					stats:        contracts.AggregateStats{TotalByteSize: 100, TotalCapacityBytes: 100},
 					expectHasCap: false,
 				},
 				{
-					name:         "should deny item if shard request capacity exceeded",
+					name:         "should deny item if global request capacity exceeded",
 					itemByteSize: 0,
 					stats: contracts.AggregateStats{
 						TotalCapacityRequests: 10, TotalLen: 10,
@@ -755,7 +755,7 @@ func TestShardProcessor(t *testing.T) {
 					expectHasCap: false,
 				},
 				{
-					name:         "should allow item if both shard and band have byte capacity",
+					name:         "should allow item if both global and band have byte capacity",
 					itemByteSize: 10,
 					stats: contracts.AggregateStats{
 						TotalCapacityBytes: 200, TotalByteSize: 100,
@@ -766,7 +766,7 @@ func TestShardProcessor(t *testing.T) {
 					expectHasCap: true,
 				},
 				{
-					name:         "should allow item if both shard and band have request capacity",
+					name:         "should allow item if both global and band have request capacity",
 					itemByteSize: 0,
 					stats: contracts.AggregateStats{
 						TotalCapacityRequests: 10, TotalLen: 5,
@@ -790,7 +790,7 @@ func TestShardProcessor(t *testing.T) {
 				},
 				// --- Mixed dimension tests ---
 				{
-					name:         "should deny if shard bytes ok but band requests exceeded",
+					name:         "should deny if global bytes ok but band requests exceeded",
 					itemByteSize: 10,
 					stats: contracts.AggregateStats{
 						TotalCapacityBytes: 200, TotalByteSize: 50,
@@ -802,7 +802,7 @@ func TestShardProcessor(t *testing.T) {
 					expectHasCap: false,
 				},
 				{
-					name:         "should deny if shard requests ok but band bytes exceeded",
+					name:         "should deny if global requests ok but band bytes exceeded",
 					itemByteSize: 10,
 					stats: contracts.AggregateStats{
 						TotalCapacityBytes: 200, TotalByteSize: 50,
@@ -827,7 +827,7 @@ func TestShardProcessor(t *testing.T) {
 				},
 				// --- Boundary value tests ---
 				{
-					name:         "should allow when shard bytes exactly at capacity after add",
+					name:         "should allow when global bytes exactly at capacity after add",
 					itemByteSize: 10,
 					stats: contracts.AggregateStats{
 						TotalCapacityBytes: 110, TotalByteSize: 100,
@@ -838,7 +838,7 @@ func TestShardProcessor(t *testing.T) {
 					expectHasCap: true,
 				},
 				{
-					name:         "should deny when shard bytes one over capacity after add",
+					name:         "should deny when global bytes one over capacity after add",
 					itemByteSize: 11,
 					stats: contracts.AggregateStats{
 						TotalCapacityBytes: 110, TotalByteSize: 100,
@@ -849,7 +849,7 @@ func TestShardProcessor(t *testing.T) {
 					expectHasCap: false,
 				},
 				{
-					name:         "should allow when shard requests exactly at capacity after add",
+					name:         "should allow when global requests exactly at capacity after add",
 					itemByteSize: 0,
 					stats: contracts.AggregateStats{
 						TotalCapacityRequests: 10, TotalLen: 9,
@@ -860,7 +860,7 @@ func TestShardProcessor(t *testing.T) {
 					expectHasCap: true,
 				},
 				{
-					name:         "should deny when shard requests one over capacity after add",
+					name:         "should deny when global requests one over capacity after add",
 					itemByteSize: 0,
 					stats: contracts.AggregateStats{
 						TotalCapacityRequests: 10, TotalLen: 10,

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -66,13 +66,13 @@ type PriorityBandPolicyDefaults struct {
 // Config holds the master configuration for the entire FlowRegistry.
 // It serves as the top-level blueprint, defining global settings and the templates for its priority bands.
 type Config struct {
-	// MaxBytes defines an optional, global maximum total byte size limit aggregated across all priority bands and shards.
+	// MaxBytes defines an optional, global maximum total byte size limit aggregated across all priority bands.
 	// The `controller.FlowController` enforces this limit in addition to per-band capacity limits.
 	// A value of 0 signifies that this global limit is ignored, and only per-band limits apply.
 	// Optional: Defaults to 0.
 	MaxBytes uint64
 
-	// MaxRequests defines an optional, global maximum total request count aggregated across all priority bands and shards.
+	// MaxRequests defines an optional, global maximum total request count aggregated across all priority bands.
 	// The `controller.FlowController` enforces this limit in addition to per-band capacity limits.
 	// A value of 0 signifies that this global limit is ignored, and only per-band limits apply.
 	// Optional: Defaults to 0.
@@ -99,7 +99,7 @@ type Config struct {
 	FlowGCTimeout time.Duration
 
 	// PriorityBandGCTimeout defines the duration of inactivity after which a dynamically provisioned priority band
-	// is garbage collected. A band is considered idle when it has no flows and no buffered requests across all shards.
+	// is garbage collected. A band is considered idle when it has no flows and no buffered requests.
 	// Must be >= FlowGCTimeout to ensure flows are collected before bands.
 	// Optional: Defaults to `defaultPriorityBandGCTimeout` (10 minutes).
 	PriorityBandGCTimeout time.Duration
@@ -142,11 +142,11 @@ type PriorityBandConfig struct {
 	// Optional: Defaults to defaultQueue ("PriorityQueue").
 	Queue queue.RegisteredQueueName
 
-	// MaxBytes defines the maximum total byte size for this priority band, aggregated across all shards.
+	// MaxBytes defines the maximum total byte size for this priority band.
 	// Optional: Defaults to defaultPriorityBandMaxBytes (1 GB).
 	MaxBytes uint64
 
-	// MaxRequests defines the maximum total request count for this priority band, aggregated across all shards.
+	// MaxRequests defines the maximum total request count for this priority band.
 	// A value of 0 signifies no request-count limit is enforced.
 	// Optional: Defaults to defaultPriorityBandMaxRequests (5000).
 	MaxRequests uint64

--- a/pkg/epp/flowcontrol/registry/doc.go
+++ b/pkg/epp/flowcontrol/registry/doc.go
@@ -16,13 +16,13 @@ limitations under the License.
 
 // Package registry provides the concrete implementation of the `contracts.FlowRegistry` interface.
 //
-// This package implements the flow control state machine using a sharded architecture to enable scalable, parallel
-// request processing. It separates the orchestration control plane from the request-processing data plane.
+// This package implements the flow control state machine. It separates the orchestration control plane from the
+// request-processing data plane, and is composed of three core types:
 //
-//   - `FlowRegistry`: The top-level orchestrator (Control Plane). It manages the lifecycle of all flows and shards,
-//     handling registration, garbage collection, and scaling operations.
-//   - `registryShard`: A slice of the data plane. It holds a partition of the total state and provides a
-//     read-optimized, concurrent-safe view for a single `controller.FlowController` worker.
+//   - `FlowRegistry`: The top-level orchestrator and single source of truth. It manages the lifecycle of all flows and
+//     priority bands, handling registration, garbage collection, and dynamic priority-band provisioning. It also
+//     exposes a read-optimized, concurrent-safe data-plane view for the `controller` Processor.
+//   - `priorityBand`: The runtime state for a single priority level, holding its managed queues and configuration.
 //   - `managedQueue`: A stateful decorator around a SafeQueue. It is the fundamental unit of state,
 //     responsible for atomically tracking statistics (e.g., length and byte size) and ensuring data consistency.
 package registry

--- a/pkg/epp/flowcontrol/registry/managedqueue.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue.go
@@ -45,7 +45,7 @@ import (
 //     This ensures the update to the underlying queue and the update to the internal counters occur as a single, atomic
 //     transaction.
 //  2. Synchronous Propagation: Statistics deltas are propagated synchronously within this critical section,
-//     guaranteeing a non-negativity invariant across the entire system (Shard/Registry aggregates).
+//     guaranteeing a non-negativity invariant across the entire system (registry aggregates).
 //  3. Lock-Free Reads (Atomics): The counters use `atomic.Int64`, allowing high-frequency accessors (`Len()`,
 //     `ByteSize()`) to read statistics without acquiring the mutex.
 //
@@ -60,7 +60,7 @@ type managedQueue struct {
 	policy flowcontrol.OrderingPolicy
 	logger logr.Logger
 
-	// onStatsDelta is the callback used to propagate statistics changes up to the parent shard.
+	// onStatsDelta is the callback used to propagate statistics changes up to the registry.
 	onStatsDelta propagateStatsDeltaFunc
 
 	// --- State Protected by `mu` ---
@@ -113,8 +113,7 @@ func (mq *managedQueue) FlowQueueAccessor() flowcontrol.FlowQueueAccessor {
 	return mq.flowQueueAccessor
 }
 
-// Add performs an atomic check on the parent shard's lifecycle state before adding the item to the underlying queue.
-// This is the critical enforcement point that prevents new requests from entering a draining shard.
+// Add enqueues an item into the underlying queue and atomically updates the queue's statistics under the lock.
 func (mq *managedQueue) Add(item flowcontrol.QueueItemAccessor) error {
 	mq.mu.Lock()
 	defer mq.mu.Unlock()
@@ -178,11 +177,11 @@ func (mq *managedQueue) ByteSize() uint64 {
 	return uint64(mq.byteSize.Load())
 }
 
-// propagateStatsDeltaLocked updates the queue's statistics and propagates the delta to the parent shard.
+// propagateStatsDeltaLocked updates the queue's statistics and propagates the delta to the registry.
 // It must be called while holding the `managedQueue.mu` lock.
 //
 // Invariant Check: This function panics if a statistic becomes negative. This enforces the non-negative invariant
-// locally, which mathematically guarantees that the aggregated statistics (Shard/Registry level) also remain
+// locally, which mathematically guarantees that the aggregated statistics (registry level) also remain
 // non-negative.
 func (mq *managedQueue) propagateStatsDeltaLocked(lenDelta, byteSizeDelta int64) {
 	newLen := mq.len.Add(lenDelta)
@@ -191,7 +190,7 @@ func (mq *managedQueue) propagateStatsDeltaLocked(lenDelta, byteSizeDelta int64)
 	}
 	mq.byteSize.Add(byteSizeDelta)
 
-	// Propagate the delta up to the parent shard. This propagation is lock-free and eventually consistent.
+	// Propagate the delta up to the registry. This propagation is lock-free and eventually consistent.
 	mq.onStatsDelta(mq.key.Priority, lenDelta, byteSizeDelta)
 }
 

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -34,11 +34,11 @@ import (
 )
 
 // propagateStatsDeltaFunc defines the callback function used to propagate statistics changes (deltas) up the hierarchy
-// (Queue -> Shard -> Registry).
+// (Queue -> Registry).
 // Implementations MUST be non-blocking (relying on atomics).
 type propagateStatsDeltaFunc func(priority int, lenDelta, byteSizeDelta int64)
 
-// bandStats holds the aggregated atomic statistics for a single priority band across all shards.
+// bandStats holds the aggregated atomic statistics for a single priority band.
 type bandStats struct {
 	byteSize atomic.Int64
 	len      atomic.Int64
@@ -49,7 +49,7 @@ type flowState struct {
 	leasedState
 	key flowcontrol.FlowKey
 
-	// initialized ensures that the heavy-weight infrastructure provisioning (creating queues on shards) happens exactly
+	// initialized ensures that the heavy-weight infrastructure provisioning (creating queues) happens exactly
 	// once per flowState instance.
 	// This prevents race conditions where multiple concurrent requests might attempt to provision the same flow
 	// simultaneously.
@@ -67,8 +67,8 @@ type priorityBandState struct {
 
 // FlowRegistry is the concrete implementation of the contracts.FlowRegistry interface.
 //
-// The FlowRegistry manages the mapping between abstract FlowKeys and the concrete managed queues distributed across
-// internal shards. It serves as the single source of truth for flow control configuration and lifecycle management.
+// The FlowRegistry manages the mapping between abstract FlowKeys and their concrete managed queues. It serves as the
+// single source of truth for flow control configuration and lifecycle management.
 //
 // # Concurrency Model
 //
@@ -339,22 +339,21 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 	return fn(&connection{registry: fr, key: key})
 }
 
-// ensureFlowInfrastructure guarantees that the Priority Band exists and that the flow's queues are synchronized across
-// all active shards.
+// ensureFlowInfrastructure guarantees that the Priority Band exists and that the flow's queue is synchronized.
 //
 // NOTE: The caller (WithConnection) must already hold a lease on the priority band to prevent GC during this operation.
 func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error {
 	// buildFlowComponents validates that the priority band exists (returning ErrPriorityBandNotFound if not)
 	// under the same read lock it uses to read the topology, so a single acquisition covers both.
 	fr.mu.RLock()
-	components, err := fr.buildFlowComponents(key)
+	policy, q, err := fr.buildFlowComponents(key)
 	fr.mu.RUnlock()
 
 	if err != nil {
 		return err
 	}
 
-	fr.synchronizeFlow(key, components.policy, components.queue)
+	fr.synchronizeFlow(key, policy, q)
 
 	fr.logger.V(logging.DEBUG).Info("Provisioned flow infrastructure", "flowKey", key)
 	return nil
@@ -476,7 +475,7 @@ func (fr *FlowRegistry) gcFlows() {
 	}
 }
 
-// cleanupFlowResources removes queue resources from the shards for the specified flows.
+// cleanupFlowResources removes queue resources for the specified flows.
 func (fr *FlowRegistry) cleanupFlowResources(keys []flowcontrol.FlowKey) {
 	fr.mu.Lock() // Exclusive lock to prevent race with ensureFlowInfrastructure.
 	defer fr.mu.Unlock()
@@ -508,7 +507,7 @@ func (fr *FlowRegistry) gcPriorityBands() {
 	}
 }
 
-// cleanupPriorityBandResources removes priority band configuration and resources from the registry and all shards.
+// cleanupPriorityBandResources removes priority band configuration and resources from the registry.
 func (fr *FlowRegistry) cleanupPriorityBandResources(priorities []int) {
 	fr.mu.Lock()
 	defer fr.mu.Unlock()
@@ -543,28 +542,22 @@ func (fr *FlowRegistry) cleanupPriorityBandResourcesLocked(priority int) {
 
 // --- Internal Helpers ---
 
-// flowComponents holds the plugin instances created for a single flow on a single shard.
-type flowComponents struct {
-	policy flowcontrol.OrderingPolicy
-	queue  contracts.SafeQueue
-}
-
-// buildFlowComponents instantiates the necessary plugin components for a new flow instance.
-// It creates a distinct instance of each component to ensure state isolation.
-func (fr *FlowRegistry) buildFlowComponents(key flowcontrol.FlowKey) (*flowComponents, error) {
+// buildFlowComponents instantiates the plugin components (ordering policy and queue) for a new flow instance.
+// It creates a distinct queue instance to ensure state isolation.
+func (fr *FlowRegistry) buildFlowComponents(
+	key flowcontrol.FlowKey,
+) (flowcontrol.OrderingPolicy, contracts.SafeQueue, error) {
 	bandConfig, ok := fr.config.PriorityBands[key.Priority]
 	if !ok {
-		return nil, fmt.Errorf("priority band %d not found: %w", key.Priority, contracts.ErrPriorityBandNotFound)
+		return nil, nil, fmt.Errorf("priority band %d not found: %w", key.Priority, contracts.ErrPriorityBandNotFound)
 	}
 
 	q, err := queue.NewQueueFromName(bandConfig.Queue, bandConfig.OrderingPolicy)
 	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate queue %q for flow %s: %w",
+		return nil, nil, fmt.Errorf("failed to instantiate queue %q for flow %s: %w",
 			bandConfig.Queue, key, err)
 	}
-	components := &flowComponents{policy: bandConfig.OrderingPolicy, queue: q}
-
-	return components, nil
+	return bandConfig.OrderingPolicy, q, nil
 }
 
 // propagateStatsDelta is the top-level, lock-free aggregator for all statistics.

--- a/pkg/epp/flowcontrol/registry/registry_helpers.go
+++ b/pkg/epp/flowcontrol/registry/registry_helpers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 )
 
-// priorityBand holds all managedQueues and configuration for a single priority level within a shard.
+// priorityBand holds all managedQueues and configuration for a single priority level.
 type priorityBand struct {
 	// --- Immutable (set at construction) ---
 
@@ -38,10 +38,10 @@ type priorityBand struct {
 	// It is initialized once at creation via fairnessPolicy.NewState() and exposed via GetPolicyState().
 	policyState any
 
-	// --- State Protected by the parent shard's mu ---
+	// --- State Protected by the registry's mu ---
 
 	// config is the local copy of the band's definition.
-	// It is updated during dynamic scaling events (updateConfig), protected by the parent shard's mutex.
+	// It is updated during dynamic scaling events (updateConfig), protected by the registry's mutex.
 	config PriorityBandConfig
 
 	// queues holds all managedQueue instances within this band, keyed by their logical ID string.
@@ -52,8 +52,8 @@ type priorityBand struct {
 	priorityBandAccessor *priorityBandAccessor
 }
 
-// initPriorityBand constructs the runtime state for a single priority level and registers it within the shard.
-// This is used by both newShard (initialization) and addPriorityBand (dynamic provisioning).
+// initPriorityBand constructs the runtime state for a single priority level and registers it within the registry.
+// This is used during registry initialization and by addPriorityBand (dynamic provisioning).
 // The caller MUST hold fr.mu (Write Lock) as this method modifies the orderedPriorityLevels slice.
 func (fr *FlowRegistry) initPriorityBand(bandConfig *PriorityBandConfig) {
 	policyState := bandConfig.FairnessPolicy.NewState(context.Background())
@@ -192,7 +192,7 @@ func (fr *FlowRegistry) deleteFlow(key flowcontrol.FlowKey) {
 // --- `priorityBandAccessor` ---
 
 // priorityBandAccessor implements PriorityBandAccessor.
-// It provides a read-only, concurrent-safe view of a single priority band within a shard.
+// It provides a read-only, concurrent-safe view of a single priority band.
 type priorityBandAccessor struct {
 	registry *FlowRegistry
 	band     *priorityBand
@@ -249,7 +249,7 @@ func (a *priorityBandAccessor) Queue(id string) flowcontrol.FlowQueueAccessor {
 //
 // To minimize lock contention, this implementation snapshots the queue accessors under a read lock and then executes
 // the callback on the snapshot, outside of the lock. This ensures that a potentially slow policy (the callback) does
-// not block other operations on the shard.
+// not block other operations on the registry.
 func (a *priorityBandAccessor) IterateQueues(callback func(queue flowcontrol.FlowQueueAccessor) bool) {
 	a.registry.mu.RLock()
 	accessors := make([]flowcontrol.FlowQueueAccessor, 0, len(a.band.queues))

--- a/pkg/epp/flowcontrol/registry/registry_helpers_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_helpers_test.go
@@ -94,7 +94,7 @@ func (h *testHarness) synchronizeFlow(key flowcontrol.FlowKey) {
 	h.registry.synchronizeFlow(key, policy, q)
 }
 
-// addItem adds an item to a specific flow's queue on the shard.
+// addItem adds an item to a specific flow's queue.
 func (h *testHarness) addItem(key flowcontrol.FlowKey, size uint64) flowcontrol.QueueItemAccessor {
 	h.t.Helper()
 	mq, err := h.registry.ManagedQueue(key)
@@ -115,7 +115,7 @@ func (h *testHarness) removeItem(key flowcontrol.FlowKey, item flowcontrol.Queue
 
 // --- Basic Tests ---
 
-func TestShard_New(t *testing.T) {
+func TestRegistry_New(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ShouldInitializeCorrectly_WithDefaultConfig", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestShard_New(t *testing.T) {
 	})
 }
 
-func TestShard_Stats(t *testing.T) {
+func TestRegistry_Stats(t *testing.T) {
 	t.Parallel()
 	h := newTestHarness(t)
 	h.addItem(h.highPriorityKey1, 100)
@@ -152,7 +152,7 @@ func TestShard_Stats(t *testing.T) {
 		"Priority band byte size must reflect the items queued at that level")
 }
 
-func TestShard_Accessors(t *testing.T) {
+func TestRegistry_Accessors(t *testing.T) {
 	t.Parallel()
 
 	t.Run("SuccessPaths", func(t *testing.T) {
@@ -223,7 +223,7 @@ func TestShard_Accessors(t *testing.T) {
 	})
 }
 
-func TestShard_PriorityBandAccessor(t *testing.T) {
+func TestRegistry_PriorityBandAccessor(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ShouldFail_WhenPriorityDoesNotExist", func(t *testing.T) {
@@ -352,7 +352,7 @@ func TestShard_PriorityBandAccessor(t *testing.T) {
 
 // --- Lifecycle and State Management Tests ---
 
-func TestShard_SynchronizeFlow(t *testing.T) {
+func TestRegistry_SynchronizeFlow(t *testing.T) {
 	t.Parallel()
 	h := newTestHarness(t)
 	flowKey := flowcontrol.FlowKey{ID: "flow1", Priority: highPriority}
@@ -367,7 +367,7 @@ func TestShard_SynchronizeFlow(t *testing.T) {
 	assert.Same(t, mq1, mq2, "Idempotent synchronization must not replace the existing queue instance")
 }
 
-func TestShard_DeleteFlow(t *testing.T) {
+func TestRegistry_DeleteFlow(t *testing.T) {
 	t.Parallel()
 	h := newTestHarness(t)
 	_, err := h.registry.ManagedQueue(h.highPriorityKey1)
@@ -383,7 +383,7 @@ func TestShard_DeleteFlow(t *testing.T) {
 		"Accessing a deleted flow must return ErrFlowInstanceNotFound")
 }
 
-func TestShard_DynamicProvisioning(t *testing.T) {
+func TestRegistry_DynamicProvisioning(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ShouldAddBandDynamically", func(t *testing.T) {
@@ -437,7 +437,7 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 		t.Parallel()
 		h := newTestHarness(t)
 
-		// Try to add a band that is not in h.shard.config.
+		// Try to add a band that is not in the registry config.
 		assert.Panics(t, func() { h.registry.addPriorityBand(nonExistentPriority) },
 			"Should fail if the definition layer hasn't been updated first")
 	})
@@ -445,11 +445,11 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 
 // --- Concurrency Test ---
 
-// TestShard_Concurrency_MixedWorkload is a general stability test that simulates a realistic workload by having
-// concurrent readers (e.g., dispatchers) and writers operating on the same shard.
+// TestRegistry_Concurrency_MixedWorkload is a general stability test that simulates a realistic workload by having
+// concurrent readers (e.g., dispatchers) and writers operating on the same registry.
 // It provides high confidence that the fine-grained locking strategy is free of deadlocks and data races under
 // sustained, mixed contention.
-func TestShard_Concurrency_MixedWorkload(t *testing.T) {
+func TestRegistry_Concurrency_MixedWorkload(t *testing.T) {
 	t.Parallel()
 	const (
 		numReaders   = 5
@@ -512,10 +512,10 @@ func TestShard_Concurrency_MixedWorkload(t *testing.T) {
 	assert.Zero(t, finalStats.TotalByteSize, "After all paired add/remove operations, the total byte size should be zero")
 }
 
-// TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety verifies that AllOrderedPriorityLevels() is safe to call
+// TestRegistry_Concurrency_AllOrderedPriorityLevels_RaceSafety verifies that AllOrderedPriorityLevels() is safe to call
 // concurrently with addPriorityBand() and deletePriorityBand(). This test is designed to trigger the Go race detector
 // if the implementation returns the internal slice without proper synchronization.
-func TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety(t *testing.T) {
+func TestRegistry_Concurrency_AllOrderedPriorityLevels_RaceSafety(t *testing.T) {
 	t.Parallel()
 	const (
 		numReaders = 5

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -94,7 +94,7 @@ func newRegistryTestHarness(t *testing.T, opts harnessOptions) *registryTestHarn
 	}
 }
 
-// assertFlowExists synchronously checks if a flow's queue exists on the first shard.
+// assertFlowExists synchronously checks if a flow's queue exists.
 func (h *registryTestHarness) assertFlowExists(key flowcontrol.FlowKey, msgAndArgs ...any) {
 	h.t.Helper()
 	_, err := h.fr.ManagedQueue(key)
@@ -191,7 +191,7 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 		assert.ErrorContains(t, err, "no SafeQueue registered", "The returned error must propagate the reason")
 	})
 
-	t.Run("Handle_Shards_ShouldReturnAllActiveShardsAndBeACopy", func(t *testing.T) {
+	t.Run("Handle_GetDataPlane_ShouldReturnNonNil", func(t *testing.T) {
 		t.Parallel()
 		// Create a registry
 		h := newRegistryTestHarness(t, harnessOptions{})
@@ -996,12 +996,12 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		assert.False(t, exists3, "Band 3 should be collected")
 	})
 
-	t.Run("ShouldCollectBand_AcrossMultipleShards", func(t *testing.T) {
+	t.Run("ShouldCollectBand_AfterFlowIdle", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{})
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: dynamicPrio}
 
-		// Create flow on all shards
+		// Create flow
 		h.openConnectionOnFlow(key)
 		// Verify band exists
 		_, ok := h.fr.priorityBands.Load(dynamicPrio)

--- a/pkg/epp/framework/interface/flowcontrol/plugins.go
+++ b/pkg/epp/framework/interface/flowcontrol/plugins.go
@@ -135,8 +135,8 @@ type SaturationDetector interface {
 // as described in [/pkg/epp/flowcontrol/contracts.SaturationDetector]
 //
 // Architecture (Stateless Singleton):
-// UsageLimitPolicy plugins are Singletons. A single instance handles limit computation for all priority bands
-// across all shards. The plugin MUST be stateless: it is a pure function that maps the current saturation and
+// UsageLimitPolicy plugins are Singletons. A single instance handles limit computation for all priority bands.
+// The plugin MUST be stateless: it is a pure function that maps the current saturation and
 // active priority domain to a set of ceilings. Any signal conditioning (trend detection, smoothing) belongs in
 // the SaturationDetector layer, not here.
 //

--- a/pkg/epp/framework/interface/flowcontrol/request.go
+++ b/pkg/epp/framework/interface/flowcontrol/request.go
@@ -31,7 +31,7 @@ import (
 type FlowControlRequest interface {
 	// FlowKey returns the composite key that uniquely identifies the flow instance this request belongs to.
 	// The `controller.FlowController` uses this key as the primary identifier to look up the correct
-	// `contracts.ManagedQueue` and configured OrderingPolicy from a `contracts.RegistryShard`.
+	// `contracts.ManagedQueue` and configured OrderingPolicy from the `contracts.FlowRegistry`.
 	// The returned key is treated as an immutable value.
 	FlowKey() FlowKey
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

The flow control layer became single-processor in the #889 refactor series, but the docs, comments, log/error strings, and test names still describe the old multi-shard supervisor/worker-pool design and reference removed types (`RegistryShard`, `ShardProcessor`). This PR aligns them with the current implementation. No behavior change.

Changes:
- Rename the leftover "shard" vocabulary: the `sp` (shard processor) receiver becomes `p`, and log/error strings and comments drop "shard".
- Rewrite the package `doc.go` files and stale type docs for the single-processor model, and remove the duplicate package comment in `controller.go` so `doc.go` is the only package doc.
- Fix two inaccurate docstrings: `distributeRequest` (described the removed JSQ-Bytes ranked-candidate algorithm) and `managedQueue.Add` (claimed a draining-shard lifecycle check that no longer exists).
- Remove the single-use `flowComponents` wrapper; `buildFlowComponents` returns the policy and queue directly.

First of series of follow-ups to #889: this cleanup, then a `registry_helpers.go` split, then replacing `Stats()` with an allocation-free capacity check.

**Which issue(s) this PR fixes**:

Refs: #889

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
NONE
```