### PR TITLE
feat(epp/preciseprefixcache): implement DumpState for plugin debug

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/dumpstate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/dumpstate.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// maxDebugDumpSpeculativeEntries bounds the per-entry sample emitted by
+// DumpState so the debug payload stays small when many speculative entries
+// are pending.
+const maxDebugDumpSpeculativeEntries = 100
+
+var _ plugin.StateDumper = &Producer{}
+
+// speculativeCacheState is the sanitized, bounded snapshot returned by
+// DumpState. Per-entry values are counts only: block-key hashes and request
+// payloads are never included.
+type speculativeCacheState struct {
+	SpeculativeEnabled    bool                    `json:"speculativeEnabled"`
+	SpeculativeTTLSeconds float64                 `json:"speculativeTTLSeconds"`
+	BlockSizeTokens       int                     `json:"blockSizeTokens"`
+	TotalEntries          int                     `json:"totalEntries"`
+	MaxEntries            int                     `json:"maxEntries"`
+	Truncated             bool                    `json:"truncated"`
+	Entries               []speculativeEntryState `json:"entries"`
+}
+
+type speculativeEntryState struct {
+	RequestID  string `json:"requestID"`
+	Prompts    int    `json:"prompts"`
+	BlockKeys  int    `json:"blockKeys"`
+	PodEntries int    `json:"podEntries"`
+}
+
+// DumpState implements [plugin.StateDumper], exposing a sanitized snapshot of
+// the speculative index cache for the /debug/plugins/state endpoint. The entry
+// list is capped to keep the payload bounded; TotalEntries reports the true
+// count so operators can tell when the dump is partial.
+func (p *Producer) DumpState() (json.RawMessage, error) {
+	return json.Marshal(p.snapshotSpeculativeState())
+}
+
+func (p *Producer) snapshotSpeculativeState() speculativeCacheState {
+	state := speculativeCacheState{
+		SpeculativeEnabled:    p.speculativeEnabled,
+		SpeculativeTTLSeconds: p.speculativeTTL.Seconds(),
+		BlockSizeTokens:       p.blockSizeTokens,
+		MaxEntries:            maxDebugDumpSpeculativeEntries,
+	}
+	if p.speculativeCache == nil {
+		return state
+	}
+
+	items := p.speculativeCache.Items()
+	state.TotalEntries = len(items)
+	state.Entries = make([]speculativeEntryState, 0, len(items))
+	for requestID, item := range items {
+		entry := item.Value()
+		if entry == nil {
+			continue
+		}
+		blockKeys := 0
+		for _, keys := range entry.perPromptKeys {
+			blockKeys += len(keys)
+		}
+		state.Entries = append(state.Entries, speculativeEntryState{
+			RequestID:  requestID,
+			Prompts:    len(entry.perPromptKeys),
+			BlockKeys:  blockKeys,
+			PodEntries: len(entry.podEntries),
+		})
+	}
+
+	sort.Slice(state.Entries, func(i, j int) bool {
+		return state.Entries[i].RequestID < state.Entries[j].RequestID
+	})
+	if len(state.Entries) > maxDebugDumpSpeculativeEntries {
+		state.Entries = state.Entries[:maxDebugDumpSpeculativeEntries]
+		state.Truncated = true
+	}
+	return state
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/dumpstate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/dumpstate_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newSpeculativeCache() *ttlcache.Cache[string, *speculativeEntries] {
+	return ttlcache.New[string, *speculativeEntries](
+		ttlcache.WithTTL[string, *speculativeEntries](time.Hour),
+	)
+}
+
+func decodeDump(t *testing.T, p *Producer) speculativeCacheState {
+	t.Helper()
+	raw, err := p.DumpState()
+	require.NoError(t, err)
+	var state speculativeCacheState
+	require.NoError(t, json.Unmarshal(raw, &state))
+	return state
+}
+
+func TestDumpState_NilCacheReportsConfigOnly(t *testing.T) {
+	p := &Producer{speculativeEnabled: false, blockSizeTokens: 16}
+
+	state := decodeDump(t, p)
+
+	assert.False(t, state.SpeculativeEnabled)
+	assert.Equal(t, 16, state.BlockSizeTokens)
+	assert.Equal(t, 0, state.TotalEntries)
+	assert.Empty(t, state.Entries)
+	assert.False(t, state.Truncated)
+	assert.Equal(t, maxDebugDumpSpeculativeEntries, state.MaxEntries)
+}
+
+func TestDumpState_SummarizesEntriesAsCounts(t *testing.T) {
+	cache := newSpeculativeCache()
+	cache.Set("req-a", &speculativeEntries{
+		perPromptKeys: [][]kvblock.BlockHash{{1, 2, 3}, {4}},
+		podEntries:    []kvblock.PodEntry{{}},
+	}, ttlcache.DefaultTTL)
+	cache.Set("req-b", &speculativeEntries{
+		perPromptKeys: [][]kvblock.BlockHash{{5, 6}},
+		podEntries:    []kvblock.PodEntry{{}, {}},
+	}, ttlcache.DefaultTTL)
+
+	p := &Producer{
+		speculativeEnabled: true,
+		speculativeTTL:     30 * time.Second,
+		blockSizeTokens:    32,
+		speculativeCache:   cache,
+	}
+
+	state := decodeDump(t, p)
+
+	assert.True(t, state.SpeculativeEnabled)
+	assert.Equal(t, 30.0, state.SpeculativeTTLSeconds)
+	assert.Equal(t, 32, state.BlockSizeTokens)
+	assert.Equal(t, 2, state.TotalEntries)
+	assert.False(t, state.Truncated)
+
+	// Entries are sorted by request ID, and carry counts only (no block-key hashes).
+	require.Len(t, state.Entries, 2)
+	assert.Equal(t, speculativeEntryState{RequestID: "req-a", Prompts: 2, BlockKeys: 4, PodEntries: 1}, state.Entries[0])
+	assert.Equal(t, speculativeEntryState{RequestID: "req-b", Prompts: 1, BlockKeys: 2, PodEntries: 2}, state.Entries[1])
+}
+
+func TestDumpState_CapsAndFlagsTruncation(t *testing.T) {
+	cache := newSpeculativeCache()
+	const total = maxDebugDumpSpeculativeEntries + 50
+	for i := 0; i < total; i++ {
+		cache.Set(fmt.Sprintf("req-%04d", i), &speculativeEntries{
+			perPromptKeys: [][]kvblock.BlockHash{{kvblock.BlockHash(i)}},
+		}, ttlcache.DefaultTTL)
+	}
+
+	p := &Producer{speculativeEnabled: true, speculativeCache: cache}
+	state := decodeDump(t, p)
+
+	assert.Equal(t, total, state.TotalEntries, "total reflects the true count, not the capped sample")
+	assert.Len(t, state.Entries, maxDebugDumpSpeculativeEntries)
+	assert.True(t, state.Truncated)
+	// Sorted, so the retained sample is the lexicographically-first cap.
+	assert.Equal(t, "req-0000", state.Entries[0].RequestID)
+}
+
+func TestProducer_ImplementsStateDumper(t *testing.T) {
+	require.Implements(t, (*interface {
+		DumpState() (json.RawMessage, error)
+	})(nil), &Producer{})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Implements the optional `plugin.StateDumper` interface for the precise-prefix-cache producer, part of the #1755 effort to add debug-state coverage across in-tree plugins.

`DumpState` returns a sanitized, bounded snapshot of the producer's dynamic runtime state -- the speculative index cache -- for the `/debug/plugins/state` endpoint: config context (`speculativeEnabled`, TTL, block size) plus per-entry counts (prompts, block keys, pod entries), following the `inflightload` reference and `docs/plugin_debug.md`. The entry sample is capped (100) with a `truncated` flag and a true `totalEntries`; block-key hashes and request payloads are never included.

**Which issue(s) this PR fixes**:

Fixes #1794

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The precise-prefix-cache producer now exposes sanitized speculative-cache state through the /debug/plugins/state plugin debug endpoint.
```

**Test plan**:

- [x] Snapshot shape: config-only when the speculative cache is absent; per-entry counts; deterministic ordering
- [x] Cap and truncation: entry sample bounded, `totalEntries` preserves the true count
- [x] `StateDumper` interface conformance
- [x] `go build`, `go vet`, `gofmt`, and the full package `go test` pass locally
