### PR TITLE
feat(epp/nohitlru): implement DumpState for plugin debug

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/dumpstate.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/dumpstate.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nohitlru
+
+import (
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// maxDebugDumpEndpoints bounds the endpoint sample emitted by DumpState so the
+// debug payload stays small when many endpoints are tracked.
+const maxDebugDumpEndpoints = 100
+
+var _ plugin.StateDumper = &NoHitLRU{}
+
+// noHitLRUState is the sanitized, bounded snapshot returned by DumpState.
+type noHitLRUState struct {
+	TotalEndpoints int  `json:"totalEndpoints"`
+	MaxEndpoints   int  `json:"maxEndpoints"`
+	Truncated      bool `json:"truncated"`
+	// Endpoints in LRU order, least-recently-used first -- the order the scorer
+	// favors for cold requests. Endpoint names only; no request data.
+	Endpoints []string `json:"endpoints"`
+}
+
+// DumpState implements [plugin.StateDumper] for the /debug/plugins/state
+// endpoint, exposing the scorer's LRU of endpoint names. The list is capped to
+// keep the payload bounded; TotalEndpoints reports the true count so operators
+// can tell when the dump is partial.
+func (s *NoHitLRU) DumpState() (json.RawMessage, error) {
+	state := noHitLRUState{MaxEndpoints: maxDebugDumpEndpoints}
+	if s.lruCache != nil {
+		keys := s.lruCache.Keys()
+		state.TotalEndpoints = len(keys)
+		state.Endpoints = keys
+		if len(state.Endpoints) > maxDebugDumpEndpoints {
+			state.Endpoints = state.Endpoints[:maxDebugDumpEndpoints]
+			state.Truncated = true
+		}
+	}
+	return json.Marshal(state)
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/dumpstate_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/dumpstate_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nohitlru
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func lruWith(t *testing.T, size int, keys ...string) *lru.Cache[string, struct{}] {
+	t.Helper()
+	c, err := lru.New[string, struct{}](size)
+	require.NoError(t, err)
+	for _, k := range keys {
+		c.Add(k, struct{}{})
+	}
+	return c
+}
+
+func decodeNoHitDump(t *testing.T, s *NoHitLRU) noHitLRUState {
+	t.Helper()
+	raw, err := s.DumpState()
+	require.NoError(t, err)
+	var state noHitLRUState
+	require.NoError(t, json.Unmarshal(raw, &state))
+	return state
+}
+
+func TestDumpState_NilCacheIsEmpty(t *testing.T) {
+	state := decodeNoHitDump(t, &NoHitLRU{})
+
+	assert.Equal(t, 0, state.TotalEndpoints)
+	assert.Empty(t, state.Endpoints)
+	assert.False(t, state.Truncated)
+	assert.Equal(t, maxDebugDumpEndpoints, state.MaxEndpoints)
+}
+
+func TestDumpState_ReportsEndpointsInLRUOrder(t *testing.T) {
+	// Added oldest-first; Keys() returns least-recently-used first.
+	s := &NoHitLRU{lruCache: lruWith(t, 10, "ns/ep-a", "ns/ep-b", "ns/ep-c")}
+
+	state := decodeNoHitDump(t, s)
+
+	assert.Equal(t, 3, state.TotalEndpoints)
+	assert.False(t, state.Truncated)
+	assert.Equal(t, []string{"ns/ep-a", "ns/ep-b", "ns/ep-c"}, state.Endpoints)
+}
+
+func TestDumpState_CapsAndFlagsTruncation(t *testing.T) {
+	const total = maxDebugDumpEndpoints + 50
+	keys := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		keys = append(keys, fmt.Sprintf("ns/ep-%04d", i))
+	}
+	s := &NoHitLRU{lruCache: lruWith(t, total+10, keys...)}
+
+	state := decodeNoHitDump(t, s)
+
+	assert.Equal(t, total, state.TotalEndpoints, "total reflects the true count, not the capped sample")
+	assert.Len(t, state.Endpoints, maxDebugDumpEndpoints)
+	assert.True(t, state.Truncated)
+}
+
+func TestNoHitLRU_ImplementsStateDumper(t *testing.T) {
+	require.Implements(t, (*interface {
+		DumpState() (json.RawMessage, error)
+	})(nil), &NoHitLRU{})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Implements the optional `plugin.StateDumper` interface for the no-hit-lru-scorer, part of the #1755 effort to add debug-state coverage across in-tree plugins.

`DumpState` returns a sanitized, bounded snapshot of the scorer's dynamic state -- the endpoint LRU -- for the `/debug/plugins/state` endpoint: the endpoint names in least-recently-used order (the order the scorer favors for cold requests), plus `totalEndpoints`, a dump cap, and a `truncated` flag. Endpoint names only; no request data.

**Which issue(s) this PR fixes**:

Fixes #1790

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The no-hit-lru-scorer now exposes its endpoint LRU state through the /debug/plugins/state plugin debug endpoint.
```

**Test plan**:

- [x] LRU-order reporting (endpoints returned least-recently-used first)
- [x] Cap and truncation: endpoint sample bounded, `totalEndpoints` preserves the true count
- [x] Empty/nil cache reports an empty snapshot
- [x] `StateDumper` interface conformance
- [x] `go build`, `go vet`, `gofmt`, and the full package `go test` pass locally
