### PR TITLE
feat(epp/multimodal): implement DumpState for plugin debug

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/dumpstate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/dumpstate.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multimodal
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// maxDebugDumpPods bounds the per-pod sample emitted by DumpState so the debug
+// payload stays small when many pods are tracked.
+const maxDebugDumpPods = 100
+
+var _ plugin.StateDumper = &Producer{}
+
+// encoderCacheState is the sanitized, bounded snapshot returned by DumpState.
+// It reports counts only: item hashes and request data are never included.
+type encoderCacheState struct {
+	CacheSizePerPod int             `json:"cacheSizePerPod"`
+	TotalPods       int             `json:"totalPods"`
+	TotalEntries    int             `json:"totalEntries"`
+	MaxPods         int             `json:"maxPods"`
+	Truncated       bool            `json:"truncated"`
+	Pods            []podCacheState `json:"pods"`
+}
+
+type podCacheState struct {
+	Pod     string `json:"pod"`
+	Entries int    `json:"entries"`
+}
+
+// DumpState implements [plugin.StateDumper] for the /debug/plugins/state
+// endpoint, exposing the per-pod encoder-cache entry counts. The pod list is
+// sorted by entry count and capped; TotalPods reports the true count so
+// operators can tell when the dump is partial.
+func (p *Producer) DumpState() (json.RawMessage, error) {
+	p.mutex.RLock()
+	state := encoderCacheState{
+		CacheSizePerPod: p.cacheSize,
+		TotalPods:       len(p.caches),
+		MaxPods:         maxDebugDumpPods,
+		Pods:            make([]podCacheState, 0, len(p.caches)),
+	}
+	for pod, cache := range p.caches {
+		size := cache.Len()
+		state.TotalEntries += size
+		state.Pods = append(state.Pods, podCacheState{Pod: pod, Entries: size})
+	}
+	p.mutex.RUnlock()
+
+	sort.Slice(state.Pods, func(a, b int) bool {
+		if state.Pods[a].Entries != state.Pods[b].Entries {
+			return state.Pods[a].Entries > state.Pods[b].Entries
+		}
+		return state.Pods[a].Pod < state.Pods[b].Pod
+	})
+	if len(state.Pods) > maxDebugDumpPods {
+		state.Pods = state.Pods[:maxDebugDumpPods]
+		state.Truncated = true
+	}
+	return json.Marshal(state)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/dumpstate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/dumpstate_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multimodal
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func podCache(t *testing.T, size int, hashes ...string) *lru.Cache[string, struct{}] {
+	t.Helper()
+	c, err := lru.New[string, struct{}](size)
+	require.NoError(t, err)
+	for _, h := range hashes {
+		c.Add(h, struct{}{})
+	}
+	return c
+}
+
+func decodeMMDump(t *testing.T, p *Producer) encoderCacheState {
+	t.Helper()
+	raw, err := p.DumpState()
+	require.NoError(t, err)
+	var state encoderCacheState
+	require.NoError(t, json.Unmarshal(raw, &state))
+	return state
+}
+
+func TestDumpState_EmptyReportsConfigOnly(t *testing.T) {
+	p := &Producer{cacheSize: 256, caches: map[string]*lru.Cache[string, struct{}]{}}
+
+	state := decodeMMDump(t, p)
+
+	assert.Equal(t, 256, state.CacheSizePerPod)
+	assert.Equal(t, 0, state.TotalPods)
+	assert.Equal(t, 0, state.TotalEntries)
+	assert.Empty(t, state.Pods)
+	assert.False(t, state.Truncated)
+	assert.Equal(t, maxDebugDumpPods, state.MaxPods)
+}
+
+func TestDumpState_SummarizesPerPodCounts(t *testing.T) {
+	p := &Producer{
+		cacheSize: 256,
+		caches: map[string]*lru.Cache[string, struct{}]{
+			"ns/pod-a": podCache(t, 256, "h1", "h2", "h3"),
+			"ns/pod-b": podCache(t, 256, "h1", "h2"),
+		},
+	}
+
+	state := decodeMMDump(t, p)
+
+	assert.Equal(t, 2, state.TotalPods)
+	assert.Equal(t, 5, state.TotalEntries)
+	assert.False(t, state.Truncated)
+
+	// Sorted busiest-first; counts only, no item hashes.
+	require.Len(t, state.Pods, 2)
+	assert.Equal(t, podCacheState{Pod: "ns/pod-a", Entries: 3}, state.Pods[0])
+	assert.Equal(t, podCacheState{Pod: "ns/pod-b", Entries: 2}, state.Pods[1])
+}
+
+func TestDumpState_CapsAndFlagsTruncation(t *testing.T) {
+	const total = maxDebugDumpPods + 50
+	caches := make(map[string]*lru.Cache[string, struct{}], total)
+	for i := 0; i < total; i++ {
+		caches[fmt.Sprintf("ns/pod-%04d", i)] = podCache(t, 8, "h1")
+	}
+	p := &Producer{cacheSize: 8, caches: caches}
+
+	state := decodeMMDump(t, p)
+
+	assert.Equal(t, total, state.TotalPods, "total reflects the true count, not the capped sample")
+	assert.Len(t, state.Pods, maxDebugDumpPods)
+	assert.True(t, state.Truncated)
+	assert.Equal(t, "ns/pod-0000", state.Pods[0].Pod)
+}
+
+func TestProducer_ImplementsStateDumper(t *testing.T) {
+	require.Implements(t, (*interface {
+		DumpState() (json.RawMessage, error)
+	})(nil), &Producer{})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Implements the optional `plugin.StateDumper` interface for the multimodal encoder-cache producer, part of the #1755 effort to add debug-state coverage across in-tree plugins.

`DumpState` returns a sanitized, bounded snapshot of the producer's dynamic state -- the per-pod encoder caches -- for the `/debug/plugins/state` endpoint: `cacheSizePerPod`, `totalPods`, `totalEntries`, and a capped per-pod sample (pod + entry count, busiest first, with a `truncated` flag). Counts only; item hashes and request data are never included.

**Which issue(s) this PR fixes**:

Fixes #1789

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The multimodal encoder-cache producer now exposes sanitized per-pod cache state through the /debug/plugins/state plugin debug endpoint.
```

**Test plan**:

- [x] Per-pod count summarization (busiest-first ordering)
- [x] Cap and truncation: pod sample bounded, `totalPods` preserves the true count
- [x] Empty cache reports config only
- [x] `StateDumper` interface conformance
- [x] `go build`, `go vet`, `gofmt`, and the full package `go test` pass locally
