### PR TITLE
feat(epp/program-aware-fairness): implement DumpState for plugin debug

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/dumpstate.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/dumpstate.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package programaware
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// maxDebugDumpPrograms bounds the per-program sample emitted by DumpState so the
+// debug payload stays small when many programs are tracked.
+const maxDebugDumpPrograms = 100
+
+var _ plugin.StateDumper = &ProgramAwarePlugin{}
+
+// fairnessState is the sanitized, bounded snapshot returned by DumpState.
+type fairnessState struct {
+	TotalPrograms int            `json:"totalPrograms"`
+	MaxPrograms   int            `json:"maxPrograms"`
+	Truncated     bool           `json:"truncated"`
+	Programs      []programState `json:"programs"`
+}
+
+type programState struct {
+	ProgramID     string  `json:"programID"`
+	Dispatched    int64   `json:"dispatched"`
+	InFlight      int64   `json:"inFlight"`
+	AverageWaitMs float64 `json:"averageWaitMs"`
+}
+
+// DumpState implements [plugin.StateDumper] for the /debug/plugins/state
+// endpoint, exposing per-program fairness counters. The program list is sorted
+// by dispatched count and capped; TotalPrograms reports the true count so
+// operators can tell when the dump is partial.
+func (p *ProgramAwarePlugin) DumpState() (json.RawMessage, error) {
+	state := fairnessState{MaxPrograms: maxDebugDumpPrograms}
+	p.programMetrics.Range(func(key, value any) bool {
+		id, _ := key.(string)
+		m, ok := value.(*ProgramMetrics)
+		if !ok {
+			return true
+		}
+		state.Programs = append(state.Programs, programState{
+			ProgramID:     id,
+			Dispatched:    m.DispatchedCount(),
+			InFlight:      m.InFlight(),
+			AverageWaitMs: m.AverageWaitTime(),
+		})
+		return true
+	})
+	state.TotalPrograms = len(state.Programs)
+
+	sort.Slice(state.Programs, func(a, b int) bool {
+		if state.Programs[a].Dispatched != state.Programs[b].Dispatched {
+			return state.Programs[a].Dispatched > state.Programs[b].Dispatched
+		}
+		return state.Programs[a].ProgramID < state.Programs[b].ProgramID
+	})
+	if len(state.Programs) > maxDebugDumpPrograms {
+		state.Programs = state.Programs[:maxDebugDumpPrograms]
+		state.Truncated = true
+	}
+	return json.Marshal(state)
+}

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/dumpstate_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/dumpstate_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package programaware
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func decodeFairnessDump(t *testing.T, p *ProgramAwarePlugin) fairnessState {
+	t.Helper()
+	raw, err := p.DumpState()
+	require.NoError(t, err)
+	var state fairnessState
+	require.NoError(t, json.Unmarshal(raw, &state))
+	return state
+}
+
+func TestDumpState_EmptyHasNoPrograms(t *testing.T) {
+	state := decodeFairnessDump(t, &ProgramAwarePlugin{})
+
+	assert.Equal(t, 0, state.TotalPrograms)
+	assert.Empty(t, state.Programs)
+	assert.False(t, state.Truncated)
+	assert.Equal(t, maxDebugDumpPrograms, state.MaxPrograms)
+}
+
+func TestDumpState_SummarizesPerProgramCounters(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+	a := p.getOrCreateMetrics("prog-a")
+	a.RecordDispatched(time.Time{})
+	a.RecordDispatched(time.Time{})
+	b := p.getOrCreateMetrics("prog-b")
+	b.RecordDispatched(time.Time{})
+
+	state := decodeFairnessDump(t, p)
+
+	assert.Equal(t, 2, state.TotalPrograms)
+	assert.False(t, state.Truncated)
+
+	// Sorted by dispatched count, busiest first.
+	require.Len(t, state.Programs, 2)
+	assert.Equal(t, programState{ProgramID: "prog-a", Dispatched: 2, InFlight: 2, AverageWaitMs: 0}, state.Programs[0])
+	assert.Equal(t, programState{ProgramID: "prog-b", Dispatched: 1, InFlight: 1, AverageWaitMs: 0}, state.Programs[1])
+}
+
+func TestDumpState_CapsAndFlagsTruncation(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+	const total = maxDebugDumpPrograms + 50
+	for i := 0; i < total; i++ {
+		p.getOrCreateMetrics(fmt.Sprintf("prog-%04d", i)).RecordDispatched(time.Time{})
+	}
+
+	state := decodeFairnessDump(t, p)
+
+	assert.Equal(t, total, state.TotalPrograms, "total reflects the true count, not the capped sample")
+	assert.Len(t, state.Programs, maxDebugDumpPrograms)
+	assert.True(t, state.Truncated)
+	// Equal dispatched counts, so the sort tiebreaks by program ID.
+	assert.Equal(t, "prog-0000", state.Programs[0].ProgramID)
+}
+
+func TestProgramAwarePlugin_ImplementsStateDumper(t *testing.T) {
+	require.Implements(t, (*interface {
+		DumpState() (json.RawMessage, error)
+	})(nil), &ProgramAwarePlugin{})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Implements the optional `plugin.StateDumper` interface for the program-aware-fairness plugin, part of the #1755 effort to add debug-state coverage across in-tree plugins.

`DumpState` returns a sanitized, bounded snapshot of the plugin's dynamic state -- the per-program fairness metrics -- for the `/debug/plugins/state` endpoint: per-program `dispatched`, `inFlight`, and `averageWaitMs`, sorted busiest-first, with `totalPrograms`, a cap, and a `truncated` flag. Program IDs and counters only; no request data.

**Which issue(s) this PR fixes**:

Fixes #1798

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The program-aware-fairness plugin now exposes sanitized per-program fairness counters through the /debug/plugins/state plugin debug endpoint.
```

**Test plan**:

- [x] Per-program counter summarization (busiest-first ordering)
- [x] Cap and truncation: program sample bounded, `totalPrograms` preserves the true count
- [x] Empty plugin reports no programs
- [x] `StateDumper` interface conformance
- [x] `go build`, `go vet`, `gofmt`, and the full package `go test` pass locally
