### PR TITLE
server: add plugin name to default plugin state debug entry

### DIFF
--- a/pkg/epp/server/plugin_state_debug.go
+++ b/pkg/epp/server/plugin_state_debug.go
@@ -40,6 +40,7 @@ type pluginStateDebugResponse struct {
 }
 
 type pluginStateDebugEntry struct {
+	Plugin  string          `json:"plugin"`
 	Type    string          `json:"type"`
 	State   json.RawMessage `json:"state,omitempty"`
 	Message string          `json:"message,omitempty"`
@@ -98,6 +99,7 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		dumper, ok := plugin.(fwkplugin.StateDumper)
 		if !ok {
 			response.Plugins[name] = pluginStateDebugEntry{
+				Plugin : name,
 				Type:    plugin.TypedName().Type,
 				Message: pluginStateUnsupportedText,
 			}
@@ -106,6 +108,7 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		state, err := dumper.DumpState()
 		if err != nil {
 			response.Plugins[name] = pluginStateDebugEntry{
+				Plugin : name,
 				Type:    plugin.TypedName().Type,
 				Message: fmt.Sprintf("failed to dump plugin state: %v", err),
 			}
@@ -116,12 +119,14 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		}
 		if !json.Valid(state) {
 			response.Plugins[name] = pluginStateDebugEntry{
+				Plugin : name,
 				Type:    plugin.TypedName().Type,
 				Message: "plugin returned invalid JSON state",
 			}
 			continue
 		}
 		response.Plugins[name] = pluginStateDebugEntry{
+			Plugin : name,
 			Type:  plugin.TypedName().Type,
 			State: state,
 		}

--- a/pkg/epp/server/plugin_state_debug.go
+++ b/pkg/epp/server/plugin_state_debug.go
@@ -40,7 +40,7 @@ type pluginStateDebugResponse struct {
 }
 
 type pluginStateDebugEntry struct {
-	Plugin  string          `json:"plugin"`
+	Name  string          `json:"name"`
 	Type    string          `json:"type"`
 	State   json.RawMessage `json:"state,omitempty"`
 	Message string          `json:"message,omitempty"`

--- a/pkg/epp/server/plugin_state_debug.go
+++ b/pkg/epp/server/plugin_state_debug.go
@@ -40,7 +40,7 @@ type pluginStateDebugResponse struct {
 }
 
 type pluginStateDebugEntry struct {
-	Name  string          `json:"name"`
+	Name    string          `json:"name"`
 	Type    string          `json:"type"`
 	State   json.RawMessage `json:"state,omitempty"`
 	Message string          `json:"message,omitempty"`
@@ -99,7 +99,8 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		dumper, ok := plugin.(fwkplugin.StateDumper)
 		if !ok {
 			response.Plugins[name] = pluginStateDebugEntry{
-				Name : name,
+
+				Name:    name,
 				Type:    plugin.TypedName().Type,
 				Message: pluginStateUnsupportedText,
 			}
@@ -108,7 +109,7 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		state, err := dumper.DumpState()
 		if err != nil {
 			response.Plugins[name] = pluginStateDebugEntry{
-				Name : name,
+				Name:    name,
 				Type:    plugin.TypedName().Type,
 				Message: fmt.Sprintf("failed to dump plugin state: %v", err),
 			}
@@ -119,14 +120,14 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		}
 		if !json.Valid(state) {
 			response.Plugins[name] = pluginStateDebugEntry{
-				Name : name,
+				Name:    name,
 				Type:    plugin.TypedName().Type,
 				Message: "plugin returned invalid JSON state",
 			}
 			continue
 		}
 		response.Plugins[name] = pluginStateDebugEntry{
-			Name : name,
+			Name:  name,
 			Type:  plugin.TypedName().Type,
 			State: state,
 		}

--- a/pkg/epp/server/plugin_state_debug.go
+++ b/pkg/epp/server/plugin_state_debug.go
@@ -99,7 +99,7 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		dumper, ok := plugin.(fwkplugin.StateDumper)
 		if !ok {
 			response.Plugins[name] = pluginStateDebugEntry{
-				Plugin : name,
+				Name : name,
 				Type:    plugin.TypedName().Type,
 				Message: pluginStateUnsupportedText,
 			}
@@ -108,7 +108,7 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		state, err := dumper.DumpState()
 		if err != nil {
 			response.Plugins[name] = pluginStateDebugEntry{
-				Plugin : name,
+				Name : name,
 				Type:    plugin.TypedName().Type,
 				Message: fmt.Sprintf("failed to dump plugin state: %v", err),
 			}
@@ -126,7 +126,7 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 			continue
 		}
 		response.Plugins[name] = pluginStateDebugEntry{
-			Plugin : name,
+			Name : name,
 			Type:  plugin.TypedName().Type,
 			State: state,
 		}

--- a/pkg/epp/server/plugin_state_debug.go
+++ b/pkg/epp/server/plugin_state_debug.go
@@ -119,7 +119,7 @@ func collectPluginState(plugins fwkplugin.HandlePlugins) pluginStateDebugRespons
 		}
 		if !json.Valid(state) {
 			response.Plugins[name] = pluginStateDebugEntry{
-				Plugin : name,
+				Name : name,
 				Type:    plugin.TypedName().Type,
 				Message: "plugin returned invalid JSON state",
 			}

--- a/pkg/epp/server/plugin_state_debug_test.go
+++ b/pkg/epp/server/plugin_state_debug_test.go
@@ -125,8 +125,8 @@ func TestPluginStateDebugHandlerReportsPluginStateErrors(t *testing.T) {
 	require.JSONEq(t, `{
 		"timestamp": "2025-01-02T03:04:05Z",
 		"plugins": {
-			"bad-dumper": {"plugin":"bad-dumper","type":"test-type","message":"plugin returned invalid JSON state"},
-			"good-dumper": {"plugin":"good-dumper","type":"test-type","state":{"ok":true}}
+			"bad-dumper": {"name":"bad-dumper","type":"test-type","message":"plugin returned invalid JSON state"},
+			"good-dumper": {"name":"good-dumper","type":"test-type","state":{"ok":true}}
 		}
 	}`, recorder.Body.String())
 }

--- a/pkg/epp/server/plugin_state_debug_test.go
+++ b/pkg/epp/server/plugin_state_debug_test.go
@@ -79,9 +79,9 @@ func TestPluginStateDebugHandlerIncludesPlugins(t *testing.T) {
 	require.JSONEq(t, `{
 		"timestamp": "2025-01-02T03:04:05Z",
 		"plugins": {
-			"a-dumper": {"plugin":"a-dumper","type":"test-type","state":{"value":"first"}},
-			"skip": {"plugin":"skip","type":"skip-type","message":"plugin does not support state collection"},
-			"z-dumper": {"plugin":"z-dumper","type":"test-type","state":{"count":2}}
+			"a-dumper": {"name":"a-dumper","type":"test-type","state":{"value":"first"}},
+			"skip": {"name":"skip","type":"skip-type","message":"plugin does not support state collection"},
+			"z-dumper": {"name":"z-dumper","type":"test-type","state":{"count":2}}
 		}
 	}`, recorder.Body.String())
 

--- a/pkg/epp/server/plugin_state_debug_test.go
+++ b/pkg/epp/server/plugin_state_debug_test.go
@@ -79,9 +79,9 @@ func TestPluginStateDebugHandlerIncludesPlugins(t *testing.T) {
 	require.JSONEq(t, `{
 		"timestamp": "2025-01-02T03:04:05Z",
 		"plugins": {
-			"a-dumper": {"type":"test-type","state":{"value":"first"}},
-			"skip": {"type":"skip-type","message":"plugin does not support state collection"},
-			"z-dumper": {"type":"test-type","state":{"count":2}}
+			"a-dumper": {"plugin":"a-dumper","type":"test-type","state":{"value":"first"}},
+			"skip": {"plugin":"skip","type":"skip-type","message":"plugin does not support state collection"},
+			"z-dumper": {"plugin":"z-dumper","type":"test-type","state":{"count":2}}
 		}
 	}`, recorder.Body.String())
 
@@ -125,8 +125,8 @@ func TestPluginStateDebugHandlerReportsPluginStateErrors(t *testing.T) {
 	require.JSONEq(t, `{
 		"timestamp": "2025-01-02T03:04:05Z",
 		"plugins": {
-			"bad-dumper": {"type":"test-type","message":"plugin returned invalid JSON state"},
-			"good-dumper": {"type":"test-type","state":{"ok":true}}
+			"bad-dumper": {"plugin":"bad-dumper","type":"test-type","message":"plugin returned invalid JSON state"},
+			"good-dumper": {"plugin":"good-dumper","type":"test-type","state":{"ok":true}}
 		}
 	}`, recorder.Body.String())
 }


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Adds a `Plugin` field to `pluginStateDebugEntry` so the `/debug/plugins/state` endpoint includes the plugin's instance name explicitly in each entry, not just as the map key.

This repurposes #1803 per maintainer feedback (see discussion in #1833): the `round-robin-fairness-policy` plugin has no centralized state to dump, since its cursor is stored per priority band rather than on the plugin itself. Instead of implementing a plugin-specific `DumpState` for round-robin, the plugin name is now included in the default debug entry for **all** plugins (both `StateDumper`-implementing and non-implementing plugins).

## Which issue(s) this PR fixes

Fixes #1803

## Testing

Updated existing unit tests (`TestPluginStateDebugHandlerIncludesPlugins`, `TestPluginStateDebugHandlerReportsPluginStateErrors`) to assert the new `plugin` field is present in the JSON response.

## Release note

```release-note
NONE
```