### PR TITLE
file-discovery: add per-endpoint metricsAddress/metricsPort

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
@@ -41,13 +42,22 @@ import (
 
 const PluginType = "file-discovery"
 
+var (
+	ErrInvalidMetricsAddress = errors.New("invalid metricsAddress")
+	ErrInvalidMetricsPort    = errors.New("invalid metricsPort")
+)
+
 // EndpointEntry is the YAML/JSON representation of a single endpoint.
 type EndpointEntry struct {
-	Name      string            `json:"name"                yaml:"name"`
-	Namespace string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Address   string            `json:"address"             yaml:"address"`
-	Port      string            `json:"port"                yaml:"port"`
-	Labels    map[string]string `json:"labels,omitempty"    yaml:"labels,omitempty"`
+	Name      string `json:"name"                yaml:"name"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Address   string `json:"address"             yaml:"address"`
+	Port      string `json:"port"                yaml:"port"`
+	// MetricsAddress overrides the scrape host (may be a hostname); defaults to Address.
+	MetricsAddress string `json:"metricsAddress,omitempty" yaml:"metricsAddress,omitempty"`
+	// MetricsPort overrides the scrape port; defaults to Port.
+	MetricsPort string            `json:"metricsPort,omitempty" yaml:"metricsPort,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"      yaml:"labels,omitempty"`
 }
 
 // EndpointsFile is the top-level structure of the endpoints YAML/JSON file.
@@ -210,6 +220,14 @@ func (f *FileDiscovery) Start(ctx context.Context, notifier fwkdl.DiscoveryNotif
 
 const maxEndpointsFileSize = 1 << 20 // 1 MiB
 
+// validatePort reports an error if s is not a valid TCP port (1-65535).
+func validatePort(s string) error {
+	if n, err := strconv.Atoi(s); err != nil || n < 1 || n > 65535 {
+		return fmt.Errorf("invalid port %q", s)
+	}
+	return nil
+}
+
 func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 	fh, err := os.Open(f.path)
 	if err != nil {
@@ -242,9 +260,25 @@ func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 			errs = append(errs, fmt.Errorf("endpoint %q: invalid IPv4 address %q", e.Name, e.Address))
 			continue
 		}
-		if portNum, err := strconv.Atoi(e.Port); err != nil || portNum < 1 || portNum > 65535 {
-			errs = append(errs, fmt.Errorf("endpoint %q: invalid port %q", e.Name, e.Port))
+		if err := validatePort(e.Port); err != nil {
+			errs = append(errs, fmt.Errorf("endpoint %q: %w", e.Name, err))
 			continue
+		}
+		metricsAddr, metricsPort := e.Address, e.Port
+		if e.MetricsAddress != "" {
+			// MetricsAddress lands in the scrape URL host; reject URL metacharacters.
+			if strings.ContainsAny(e.MetricsAddress, "/@#? \t\r\n") {
+				errs = append(errs, fmt.Errorf("endpoint %q: %w %q", e.Name, ErrInvalidMetricsAddress, e.MetricsAddress))
+				continue
+			}
+			metricsAddr = e.MetricsAddress
+		}
+		if e.MetricsPort != "" {
+			if validatePort(e.MetricsPort) != nil {
+				errs = append(errs, fmt.Errorf("endpoint %q: %w %q", e.Name, ErrInvalidMetricsPort, e.MetricsPort))
+				continue
+			}
+			metricsPort = e.MetricsPort
 		}
 		ns := e.Namespace
 		if ns == "" {
@@ -255,7 +289,7 @@ func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 			PodName:        e.Name,
 			Address:        e.Address,
 			Port:           e.Port,
-			MetricsHost:    net.JoinHostPort(e.Address, e.Port),
+			MetricsHost:    net.JoinHostPort(metricsAddr, metricsPort),
 			Labels:         e.Labels,
 		}
 		incoming[meta.NamespacedName] = struct{}{}

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
@@ -182,6 +182,70 @@ endpoints:
 	assert.Equal(t, "10.0.0.1:8000", notifier.upserted[0].MetricsHost)
 }
 
+func TestStart_MetricsAddress(t *testing.T) {
+	tests := []struct {
+		name            string
+		metricsAddress  string
+		metricsPort     string
+		wantMetricsHost string
+		wantErr         error
+	}{
+		{
+			name:            "override host and port",
+			metricsAddress:  "metrics.spoke.example.com",
+			metricsPort:     "9090",
+			wantMetricsHost: "metrics.spoke.example.com:9090",
+		},
+		{
+			name:            "override host defaults port to serving",
+			metricsAddress:  "metrics.spoke.example.com",
+			wantMetricsHost: "metrics.spoke.example.com:8000",
+		},
+		{
+			name:           "reject metricsAddress with URL metacharacter",
+			metricsAddress: "evil.example.com/inject",
+			wantErr:        ErrInvalidMetricsAddress,
+		},
+		{
+			name:           "reject metricsAddress with CRLF",
+			metricsAddress: "evil.example.com\r\nX-Injected: 1",
+			wantErr:        ErrInvalidMetricsAddress,
+		},
+		{
+			name:        "reject out-of-range metricsPort",
+			metricsPort: "99999",
+			wantErr:     ErrInvalidMetricsPort,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := "endpoints:\n  - name: ep1\n    address: \"10.0.0.1\"\n    port: \"8000\"\n"
+			if tt.metricsAddress != "" {
+				ep += fmt.Sprintf("    metricsAddress: %q\n", tt.metricsAddress)
+			}
+			if tt.metricsPort != "" {
+				ep += fmt.Sprintf("    metricsPort: %q\n", tt.metricsPort)
+			}
+			notifier := &recordingNotifier{}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := newFD(writeTemp(t, ep), false).Start(ctx, notifier)
+			switch {
+			case tt.wantErr != nil:
+				assert.ErrorIs(t, err, tt.wantErr)
+			default:
+				require.NoError(t, err)
+				require.Len(t, notifier.upserted, 1)
+				// forward keeps the IP; scrape uses the override
+				assert.Equal(t, "10.0.0.1", notifier.upserted[0].Address)
+				assert.Equal(t, tt.wantMetricsHost, notifier.upserted[0].MetricsHost)
+			}
+		})
+	}
+}
+
 func TestStart_MissingFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Lets a `file-discovery` endpoint declare a metrics scrape target (`metricsAddress` / `metricsPort`) distinct from its serving `address`/`port`. The scrape host may be a hostname, unlike the serving address (validated as IPv4).

This supports cross-cluster routing: traffic forwards to an endpoint IP while aggregate metrics are scraped from a separate host. Both fields default to the serving `address`/`port` when unset; `metricsAddress` rejects URL metacharacters and `metricsPort` is range-checked (`ErrInvalidMetricsPort`).

**Which issue(s) this PR fixes**:

N/A

**Release note**:
```release-note
file-discovery: endpoints can set `metricsAddress`/`metricsPort` to scrape metrics from a host distinct from the serving address.
```
