### PR TITLE
datalayer: TLS options (CA verify + mTLS client cert) for metrics scrape

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -19,11 +19,13 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"runtime/debug"
 	"slices"
@@ -60,8 +62,23 @@ type HTTPDataSource[T any] struct {
 	exts []fwkdl.PollingExtractor[T]
 }
 
-// NewHTTPDataSource constructs a typed polling dispatcher.
-func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
+// TLSOptions configures the https transport. The zero value verifies the target
+// against the system CA pool with no client certificate.
+type TLSOptions struct {
+	// SkipVerify disables verification of the target's server certificate.
+	SkipVerify bool
+	// CACertPath is a PEM CA bundle used to verify the target instead of the
+	// system pool. Ignored when SkipVerify is set.
+	CACertPath string
+	// ClientCertPath and ClientKeyPath present a client certificate for mTLS.
+	// Both must be set together.
+	ClientCertPath string
+	ClientKeyPath  string
+}
+
+// NewHTTPDataSource constructs a typed polling dispatcher. For https, tlsOpts configures
+// server verification (CACertPath) and optional mTLS (ClientCertPath/ClientKeyPath).
+func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 	pluginType, pluginName string, parser func(io.Reader) (T, error)) (*HTTPDataSource[T], error) {
 	if scheme != "http" && scheme != "https" {
 		return nil, fmt.Errorf("unsupported scheme: %s", scheme)
@@ -73,8 +90,12 @@ func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
 		},
 	}
 	if scheme == "https" {
+		tlsCfg, err := tlsClientConfig(tlsOpts)
+		if err != nil {
+			return nil, err
+		}
 		httpsTransport := baseTransport.Clone()
-		httpsTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipCertVerification}
+		httpsTransport.TLSClientConfig = tlsCfg
 		cl.Transport = httpsTransport
 	}
 	return &HTTPDataSource[T]{
@@ -84,6 +105,46 @@ func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
 		client:    cl,
 		parser:    parser,
 	}, nil
+}
+
+var (
+	ErrReadCACert     = errors.New("reading CA cert")
+	ErrNoValidCACerts = errors.New("no valid CA certs")
+	ErrLoadClientCert = errors.New("loading client cert")
+)
+
+// caCertPool loads a PEM CA bundle for TLS verification.
+func caCertPool(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w %s: %w", ErrReadCACert, path, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("%w in %s", ErrNoValidCACerts, path)
+	}
+	return pool, nil
+}
+
+// tlsClientConfig builds a tls.Config: server verification via CACertPath (or the
+// system pool), plus an mTLS client certificate when ClientCertPath is set.
+func tlsClientConfig(opts TLSOptions) (*tls.Config, error) {
+	cfg := &tls.Config{InsecureSkipVerify: opts.SkipVerify}
+	if !opts.SkipVerify && opts.CACertPath != "" {
+		pool, err := caCertPool(opts.CACertPath)
+		if err != nil {
+			return nil, err
+		}
+		cfg.RootCAs = pool
+	}
+	if opts.ClientCertPath != "" || opts.ClientKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(opts.ClientCertPath, opts.ClientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrLoadClientCert, err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	return cfg, nil
 }
 
 func (s *HTTPDataSource[T]) TypedName() fwkplugin.TypedName { return s.typedName }

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeCACert writes a self-signed CA PEM and returns its path.
+func writeCACert(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	return path
+}
+
+func TestCACertPool(t *testing.T) {
+	badPEM := filepath.Join(t.TempDir(), "bad.pem")
+	require.NoError(t, os.WriteFile(badPEM, []byte("not a certificate"), 0o600))
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr error
+	}{
+		{name: "valid CA bundle", path: writeCACert(t)},
+		{name: "missing file", path: filepath.Join(t.TempDir(), "nope.pem"), wantErr: ErrReadCACert},
+		{name: "invalid PEM", path: badPEM, wantErr: ErrNoValidCACerts},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, err := caCertPool(tt.path)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, pool)
+		})
+	}
+}
+
+func TestNewHTTPDataSource_CACertPath(t *testing.T) {
+	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
+
+	tests := []struct {
+		name       string
+		caCertPath string
+		wantErr    error
+		wantRootCA bool
+	}{
+		{name: "valid CA sets RootCAs", caCertPath: writeCACert(t), wantRootCA: true},
+		{name: "empty CA uses system pool", caCertPath: "", wantRootCA: false},
+		{name: "bad CA path errors", caCertPath: "/nonexistent/ca.pem", wantErr: ErrReadCACert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := NewHTTPDataSource[any]("https", "/metrics", TLSOptions{CACertPath: tt.caCertPath}, "test-type", "ds", parser)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			cl, ok := ds.client.(*client)
+			require.True(t, ok)
+			tr, ok := cl.Transport.(*http.Transport)
+			require.True(t, ok)
+			assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
+			if tt.wantRootCA {
+				assert.NotNil(t, tr.TLSClientConfig.RootCAs)
+			} else {
+				assert.Nil(t, tr.TLSClientConfig.RootCAs)
+			}
+		})
+	}
+}
+
+// writeCertKey writes a self-signed cert and its key as separate PEMs; returns their paths.
+func writeCertKey(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+	return certPath, keyPath
+}
+
+func TestNewHTTPDataSource_ClientCert(t *testing.T) {
+	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
+	certPath, keyPath := writeCertKey(t)
+
+	tests := []struct {
+		name           string
+		opts           TLSOptions
+		wantErr        error
+		wantClientCert bool
+	}{
+		{name: "valid client cert sets Certificates", opts: TLSOptions{ClientCertPath: certPath, ClientKeyPath: keyPath}, wantClientCert: true},
+		{name: "no client cert", opts: TLSOptions{}, wantClientCert: false},
+		{name: "bad client cert path errors", opts: TLSOptions{ClientCertPath: "/nonexistent/cert.pem", ClientKeyPath: "/nonexistent/key.pem"}, wantErr: ErrLoadClientCert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := NewHTTPDataSource[any]("https", "/metrics", tt.opts, "test-type", "ds", parser)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			cl, ok := ds.client.(*client)
+			require.True(t, ok)
+			tr, ok := cl.Transport.(*http.Transport)
+			require.True(t, ok)
+			if tt.wantClientCert {
+				assert.Len(t, tr.TLSClientConfig.Certificates, 1)
+			} else {
+				assert.Empty(t, tr.TLSClientConfig.Certificates)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
@@ -28,11 +28,11 @@ func TestHTTPDataSource_ClientIsolation(t *testing.T) {
 	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
 
 	// Create first HTTPS datasource, insecureSkipVerify = false
-	ds1, err := NewHTTPDataSource[any]("https", "/metrics", false, "test-type", "ds1", parser)
+	ds1, err := NewHTTPDataSource[any]("https", "/metrics", TLSOptions{}, "test-type", "ds1", parser)
 	assert.NoError(t, err)
 
 	// Create second HTTPS datasource, insecureSkipVerify = true
-	ds2, err := NewHTTPDataSource[any]("https", "/metrics", true, "test-type", "ds2", parser)
+	ds2, err := NewHTTPDataSource[any]("https", "/metrics", TLSOptions{SkipVerify: true}, "test-type", "ds2", parser)
 	assert.NoError(t, err)
 
 	// Verify ds1 uses isolated transport config

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
@@ -24,6 +24,8 @@ The plugin config supports:
 -   `scheme` (default "http"): The protocol scheme to use for metrics retrieval.
 -   `path` (default "/metrics"): The URL path to use for metrics retrieval.
 -   `insecureSkipVerify` (default true): Whether to skip TLS certificate verification when using the "https" scheme.
+-   `caCertPath`: PEM CA bundle to verify the target's server cert.
+-   `clientCertPath` / `clientKeyPath`: client certificate for mTLS. Set both together.
 
 ### Example Configuration
 

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -45,13 +45,19 @@ type metricsDatasourceParams struct {
 	Path string `json:"path"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+	// CACertPath is an optional PEM CA bundle to verify the scrape target cert.
+	CACertPath string `json:"caCertPath"`
+	// ClientCertPath and ClientKeyPath present a client certificate for mTLS, so the scrape
+	// target authenticates this scraper by certificate instead of a bearer token. Both set together.
+	ClientCertPath string `json:"clientCertPath"`
+	ClientKeyPath  string `json:"clientKeyPath"`
 }
 
 // NewHTTPMetricsDataSource constructs a MetricsDataSource with the given scheme and path.
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource[PrometheusMetricMap], error) {
-	return http.NewHTTPDataSource(scheme, path, defaultMetricsInsecureSkipVerify,
+	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultMetricsInsecureSkipVerify},
 		MetricsDataSourceType, name, parseMetrics)
 }
 
@@ -66,7 +72,13 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		}
 	}
 
-	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify,
+	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
+		http.TLSOptions{
+			SkipVerify:     cfg.InsecureSkipVerify,
+			CACertPath:     cfg.CACertPath,
+			ClientCertPath: cfg.ClientCertPath,
+			ClientKeyPath:  cfg.ClientKeyPath,
+		},
 		MetricsDataSourceType, name, parseMetrics)
 }
 

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package metrics
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,12 +29,36 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 )
 
+func TestMetricsDataSourceFactory_TLS(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  string
+		wantErr error
+	}{
+		{name: "https no certs", params: `{"scheme":"https"}`},
+		{name: "client cert wired to loader", params: `{"scheme":"https","clientCertPath":"/nope/c.pem","clientKeyPath":"/nope/k.pem"}`, wantErr: http.ErrLoadClientCert},
+		{name: "ca path wired to loader", params: `{"scheme":"https","insecureSkipVerify":false,"caCertPath":"/nope/ca.pem"}`, wantErr: http.ErrReadCACert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := MetricsDataSourceFactory("m", json.NewDecoder(bytes.NewBufferString(tt.params)), nil)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, ds)
+		})
+	}
+}
+
 func TestDatasource(t *testing.T) {
-	_, err := http.NewHTTPDataSource("invalid", "/metrics", true, MetricsDataSourceType,
+	_, err := http.NewHTTPDataSource("invalid", "/metrics", http.TLSOptions{SkipVerify: true}, MetricsDataSourceType,
 		"metrics-data-source", parseMetrics)
 	assert.NotNil(t, err, "expected to fail with invalid scheme")
 
-	source, err := http.NewHTTPDataSource("https", "/metrics", true, MetricsDataSourceType,
+	source, err := http.NewHTTPDataSource("https", "/metrics", http.TLSOptions{SkipVerify: true}, MetricsDataSourceType,
 		"metrics-data-source", parseMetrics)
 	assert.Nil(t, err, "failed to create HTTP datasource")
 

--- a/pkg/epp/framework/plugins/datalayer/source/models/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/models/README.md
@@ -20,6 +20,8 @@ The Models Data Source polls inference server pods for model information and pas
 - `scheme` (string, optional, default: `"http"`): Protocol scheme: `"http"` or `"https"`.
 - `path` (string, optional, default: `"/v1/models"`): URL path for the models API endpoint.
 - `insecureSkipVerify` (bool, optional, default: `true`): Skip TLS certificate verification.
+- `caCertPath` (string, optional): PEM CA bundle to verify the target's server cert.
+- `clientCertPath` / `clientKeyPath` (string, optional): client certificate for mTLS. Set both together.
 
 ```yaml
 - type: models-data-source

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
@@ -28,13 +28,19 @@ type modelsDatasourceParams struct {
 	Path string `json:"path"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+	// CACertPath is an optional PEM CA bundle to verify the scrape target cert.
+	CACertPath string `json:"caCertPath"`
+	// ClientCertPath and ClientKeyPath present a client certificate for mTLS, so the scrape
+	// target can require+verify the client.
+	ClientCertPath string `json:"clientCertPath"`
+	ClientKeyPath  string `json:"clientKeyPath"`
 }
 
 // NewHTTPModelsDataSource constructs a ModelsDataSource with the given scheme and path.
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPModelsDataSource(scheme, path, name string) (*http.HTTPDataSource[*extmodels.ModelResponse], error) {
-	return http.NewHTTPDataSource(scheme, path, defaultModelsInsecureSkipVerify,
+	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultModelsInsecureSkipVerify},
 		ModelsDataSourceType, name, parseModels)
 }
 
@@ -51,7 +57,13 @@ func ModelDataSourceFactory(name string, parameters *json.Decoder, _ plugin.Hand
 		return nil, fmt.Errorf("unsupported scheme: %s", cfg.Scheme)
 	}
 
-	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify,
+	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
+		http.TLSOptions{
+			SkipVerify:     cfg.InsecureSkipVerify,
+			CACertPath:     cfg.CACertPath,
+			ClientCertPath: cfg.ClientCertPath,
+			ClientKeyPath:  cfg.ClientKeyPath,
+		},
 		ModelsDataSourceType, name, parseModels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP data source: %w", err)

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -15,7 +15,32 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 )
+
+func TestModelDataSourceFactory_TLS(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  string
+		wantErr error
+	}{
+		{name: "https no certs", params: `{"scheme":"https"}`},
+		{name: "client cert wired to loader", params: `{"scheme":"https","clientCertPath":"/nope/c.pem","clientKeyPath":"/nope/k.pem"}`, wantErr: http.ErrLoadClientCert},
+		{name: "ca path wired to loader", params: `{"scheme":"https","insecureSkipVerify":false,"caCertPath":"/nope/ca.pem"}`, wantErr: http.ErrReadCACert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := ModelDataSourceFactory("m", fwkplugin.StrictDecoder(json.RawMessage(tt.params)), nil)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, ds)
+		})
+	}
+}
 
 func TestDatasource(t *testing.T) {
 	srcPlugin, err := ModelDataSourceFactory("models-data-source",

--- a/test/integration/epp/runtime_polling_test.go
+++ b/test/integration/epp/runtime_polling_test.go
@@ -86,7 +86,7 @@ func TestRuntimePollingDispatch(t *testing.T) {
 			r := datalayer.NewRuntime(pollingInterval)
 			ext := mocks.NewPollingExtractor("test-extractor")
 
-			httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+			httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 				parsePrometheusMetrics)
 			require.NoError(t, err)
 
@@ -138,7 +138,7 @@ func TestRuntimePollingMultipleExtractors(t *testing.T) {
 	ext1 := mocks.NewPollingExtractor("extractor-1")
 	ext2 := mocks.NewPollingExtractor("extractor-2")
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 
@@ -187,7 +187,7 @@ func TestRuntimePollingEndpointLifecycle(t *testing.T) {
 	r := datalayer.NewRuntime(pollingInterval)
 	ext := mocks.NewPollingExtractor("lifecycle-extractor")
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 
@@ -241,7 +241,7 @@ func TestRuntimePollingWithoutExtractors(t *testing.T) {
 
 	r := datalayer.NewRuntime(50 * time.Millisecond)
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 
@@ -280,7 +280,7 @@ func TestRuntimePollingHTTPError(t *testing.T) {
 	r := datalayer.NewRuntime(pollingInterval)
 	ext := mocks.NewPollingExtractor("error-extractor")
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds optional TLS options to the metrics and models data sources (via a `TLSOptions` struct) so an operator can secure the scrape over https:

- `caCertPath` verifies the scrape target's server certificate against a supplied PEM CA bundle, instead of relying on `insecureSkipVerify`.
- `clientCertPath` / `clientKeyPath` present a client certificate for mTLS, so the target authenticates the scraper by certificate rather than a bearer token.

Together these enable a mutually-authenticated scrape (e.g. scraping a target that fronts its metrics with mTLS and a private/service CA) with no shared credential. Empty values preserve existing behavior (system CA pool, honoring `insecureSkipVerify`, no client certificate).

**Usage**

Set the options under the `metrics-data-source` plugin's `parameters` (same fields are available on `models-data-source`):

```yaml
plugins:
  - type: metrics-data-source
    parameters:
      scheme: https
      path: /metrics
      caCertPath: /etc/epp/tls/ca.crt        # verify target server cert (bundle OK)
      clientCertPath: /etc/epp/tls/tls.crt   # present client cert -> mTLS
      clientKeyPath: /etc/epp/tls/tls.key
```

Mount the cert/key/CA (e.g. a cert-manager-issued Secret) into the EPP pod at those paths.

**Note on certificate rotation:** the certificate is loaded once when the data source is constructed, so a rotated cert is not picked up until the EPP restarts. For short-TTL rotation, bounce the EPP on renewal (e.g. a reloader annotation) or use longer-lived certs. Reload-on-change would be a reasonable follow-up.

**Which issue(s) this PR fixes**:

N/A

**Release note**:
```release-note
metrics/models data sources: add optional `caCertPath`, `clientCertPath`, and `clientKeyPath` to verify the scrape target's server certificate against a CA bundle and present a client certificate for mTLS.
```
