### PR TITLE
Do not build and push the dev image on a fork

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   set-params:
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     outputs:
       epp_name: ${{ steps.version.outputs.epp_name }}
@@ -33,6 +34,7 @@ jobs:
           echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
   build-and-push:
+    if: github.event.repository.fork != true
     needs: set-params
     uses: ./.github/workflows/ci-build-images.yaml
     with:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently whenever someone synchronizes his/her fork with the upstream repository, various CI jobs run. One of those jobs is the job that creates the "development" images on every push to main. This job fails for most people as they don't have the appropriate secrets set in their repo. In addition, it's not clear at all that people need the development images created for their own private fork of the llm-d-router repository.

This PR adds a pair of if statements to the ci-dev.yaml workflow file to prevent the jobs from running if the repo is a fork.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Merges into the main branch of forks of the llm-d-router repository will no longer cause CI to try and create the development images.
```
