### PR TITLE
Ignore deleted IGW files for now

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -2,6 +2,8 @@
 exclude = [
   "^https://www.gnu.org/software/make/?$",
   "^https://www.envoyproxy.io/"
+  "^https://gateway-api-inference-extension.sigs.k8s.io/guides/serving-multiple-inference-pools-latest/"
+  "^https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics-and-observability.md"
 ]
 
 # Per-request timeout in seconds. Sized for slow upstream docs sites


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Unfortunately in some of the files of the llm-d-router repository there are links to files of the IGW repository and the IGW documentation web site. Cleanup work was done in the IGW repository to remove files that are no longer needed. This included deleting a file referenced directly by one of the MarkDown files in the llm-d-router repository as well as a file on the IGW documentation site.

This has caused CI to fail.

This PR adds these two files/paths to the link checking ignore list.

**Which issue(s) this PR fixes**:
Refs: #1863

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
