### PR TITLE
Only check links in Markdown files, if Markdown files changed

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -18,14 +18,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            src:
+              - '**/*.md'
+
   lychee:
     name: Check Markdown Links
+    needs: check-changes
     # pull_request_target fires even when GITHUB_TOKEN creates the PR (e.g. the
     # release-notes bot). pull_request does not. We register pull_request_target
     # so bot-created PRs get a "skipped" conclusion that satisfies branch
     # protection, but we skip all real work: pull_request already covers human
     # PRs, and running twice would cause the concurrency group to cancel one run.
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name != 'pull_request_target' && ${{ needs.check-changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   
-  check-changes:
+  check-for-markdown-files:
     runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}
@@ -35,7 +35,7 @@ jobs:
 
   lychee:
     name: Check Markdown Links
-    needs: check-changes
+    needs: check-for-markdown-files
     # pull_request_target fires even when GITHUB_TOKEN creates the PR (e.g. the
     # release-notes bot). pull_request does not. We register pull_request_target
     # so bot-created PRs get a "skipped" conclusion that satisfies branch


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
Currently the Markdown file link check is run on all PRs. It should only be run on PRs that modify Markdown files.
Otherwise it is very difficult to correct CI problems.

**Which issue(s) this PR fixes**:
Refs: #1863

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
