### PR TITLE
Adding standard deviation metrics for monitoring epp pool load variance

### DIFF
--- a/pkg/epp/datalayer/logger/logger.go
+++ b/pkg/epp/datalayer/logger/logger.go
@@ -123,7 +123,6 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 	metrics.RecordInferencePoolAvgKVCache(pool.Name, summary.kvCache.mean)
 	metrics.RecordInferencePoolAvgQueueSize(pool.Name, summary.queueSize.mean)
 	metrics.RecordInferencePoolAvgRunningRequests(pool.Name, summary.runningRequests.mean)
-
 	metrics.RecordInferencePoolStdDevKVCache(pool.Name, summary.kvCache.stdv)
 	metrics.RecordInferencePoolStdDevQueueSize(pool.Name, summary.queueSize.stdv)
 	metrics.RecordInferencePoolStdDevRunningRequests(pool.Name, summary.runningRequests.stdv)
@@ -165,9 +164,11 @@ func calculateSummary(endpoints []fwkdl.Endpoint) summary {
 	size := float64(len(endpoints))
 	totals := calculateTotals(endpoints)
 
-	result.kvCache.mean = totals.kvCache / size
-	result.queueSize.mean = float64(totals.queueSize) / size
-	result.runningRequests.mean = float64(totals.runningRequests) / size
+	if size > 0 {
+		result.kvCache.mean = math.Round((totals.kvCache/size)*100) / 100
+		result.queueSize.mean = math.Round((float64(totals.queueSize)/size)*100) / 100
+		result.runningRequests.mean = math.Round((float64(totals.runningRequests)/size)*100) / 100
+	}
 
 	for _, pod := range endpoints {
 		metrics := pod.GetMetrics()
@@ -180,13 +181,15 @@ func calculateSummary(endpoints []fwkdl.Endpoint) summary {
 	if size > 2 {
 		num = size - 1
 	}
-	result.kvCache.vrce /= num
-	result.queueSize.vrce /= num
-	result.runningRequests.vrce /= num
+	if size > 0 {
+		result.kvCache.vrce = math.Round((result.kvCache.vrce/num)*100) / 100
+		result.queueSize.vrce = math.Round((result.queueSize.vrce/num)*100) / 100
+		result.runningRequests.vrce = math.Round((result.runningRequests.vrce/num)*100) / 100
 
-	result.kvCache.stdv = math.Sqrt(result.kvCache.vrce)
-	result.queueSize.stdv = math.Sqrt(result.queueSize.vrce)
-	result.runningRequests.stdv = math.Sqrt(result.runningRequests.vrce)
+		result.kvCache.stdv = math.Round(math.Sqrt(result.kvCache.vrce)*100) / 100
+		result.queueSize.stdv = math.Round(math.Sqrt(result.queueSize.vrce)*100) / 100
+		result.runningRequests.stdv = math.Round(math.Sqrt(result.runningRequests.vrce)*100) / 100
+	}
 
 	return result
 }

--- a/pkg/epp/datalayer/logger/logger.go
+++ b/pkg/epp/datalayer/logger/logger.go
@@ -150,7 +150,6 @@ func calculateTotals(endpoints []fwkdl.Endpoint) totals {
 type stats struct {
 	mean float64 // average
 	stdv float64 // standard deviation
-	vrce float64 // variance
 }
 
 type summary struct {
@@ -174,32 +173,23 @@ func calculateSummary(endpoints []fwkdl.Endpoint) summary {
 
 	for _, pod := range endpoints {
 		metrics := pod.GetMetrics()
-		result.kvCache.vrce += (metrics.KVCacheUsagePercent - result.kvCache.mean) * (metrics.KVCacheUsagePercent - result.kvCache.mean)
-		result.queueSize.vrce += (float64(metrics.WaitingQueueSize) - result.queueSize.mean) * (float64(metrics.WaitingQueueSize) - result.queueSize.mean)
-		result.runningRequests.vrce += (float64(metrics.RunningRequestsSize) - result.runningRequests.mean) * (float64(metrics.RunningRequestsSize) - result.runningRequests.mean)
+		result.kvCache.stdv += (metrics.KVCacheUsagePercent - result.kvCache.mean) * (metrics.KVCacheUsagePercent - result.kvCache.mean)
+		result.queueSize.stdv += (float64(metrics.WaitingQueueSize) - result.queueSize.mean) * (float64(metrics.WaitingQueueSize) - result.queueSize.mean)
+		result.runningRequests.stdv += (float64(metrics.RunningRequestsSize) - result.runningRequests.mean) * (float64(metrics.RunningRequestsSize) - result.runningRequests.mean)
 	}
-
-	var num = 1.0
-	if size > 2 {
-		num = size - 1
-	}
-
-	result.kvCache.vrce /= num
-	result.queueSize.vrce /= num
-	result.runningRequests.vrce /= num
 
 	// Round stats to two decimal places
-	result.kvCache.mean = math.Round(result.kvCache.mean*100) / 100
-	result.queueSize.mean = math.Round(result.queueSize.mean*100) / 100
-	result.runningRequests.mean = math.Round(result.runningRequests.mean*100) / 100
+	result.kvCache.mean = round2(result.kvCache.mean)
+	result.queueSize.mean = round2(result.queueSize.mean)
+	result.runningRequests.mean = round2(result.runningRequests.mean)
 
-	result.kvCache.vrce = math.Round((result.kvCache.vrce)*100) / 100
-	result.queueSize.vrce = math.Round((result.queueSize.vrce)*100) / 100
-	result.runningRequests.vrce = math.Round((result.runningRequests.vrce)*100) / 100
+	sampleSize := math.Max(1, size-1)
 
-	result.kvCache.stdv = math.Round(math.Sqrt(result.kvCache.vrce)*100) / 100
-	result.queueSize.stdv = math.Round(math.Sqrt(result.queueSize.vrce)*100) / 100
-	result.runningRequests.stdv = math.Round(math.Sqrt(result.runningRequests.vrce)*100) / 100
+	result.kvCache.stdv = round2(math.Sqrt(result.kvCache.stdv / sampleSize))
+	result.queueSize.stdv = round2(math.Sqrt(result.queueSize.stdv / sampleSize))
+	result.runningRequests.stdv = round2(math.Sqrt(result.runningRequests.stdv / sampleSize))
 
 	return result
 }
+
+func round2(x float64) float64 { return math.Round(x*100) / 100 }

--- a/pkg/epp/datalayer/logger/logger.go
+++ b/pkg/epp/datalayer/logger/logger.go
@@ -164,11 +164,13 @@ func calculateSummary(endpoints []fwkdl.Endpoint) summary {
 	size := float64(len(endpoints))
 	totals := calculateTotals(endpoints)
 
-	if size > 0 {
-		result.kvCache.mean = math.Round((totals.kvCache/size)*100) / 100
-		result.queueSize.mean = math.Round((float64(totals.queueSize)/size)*100) / 100
-		result.runningRequests.mean = math.Round((float64(totals.runningRequests)/size)*100) / 100
+	if size < 1 {
+		return result
 	}
+
+	result.kvCache.mean = totals.kvCache / size
+	result.queueSize.mean = float64(totals.queueSize) / size
+	result.runningRequests.mean = float64(totals.runningRequests) / size
 
 	for _, pod := range endpoints {
 		metrics := pod.GetMetrics()
@@ -181,15 +183,23 @@ func calculateSummary(endpoints []fwkdl.Endpoint) summary {
 	if size > 2 {
 		num = size - 1
 	}
-	if size > 0 {
-		result.kvCache.vrce = math.Round((result.kvCache.vrce/num)*100) / 100
-		result.queueSize.vrce = math.Round((result.queueSize.vrce/num)*100) / 100
-		result.runningRequests.vrce = math.Round((result.runningRequests.vrce/num)*100) / 100
 
-		result.kvCache.stdv = math.Round(math.Sqrt(result.kvCache.vrce)*100) / 100
-		result.queueSize.stdv = math.Round(math.Sqrt(result.queueSize.vrce)*100) / 100
-		result.runningRequests.stdv = math.Round(math.Sqrt(result.runningRequests.vrce)*100) / 100
-	}
+	result.kvCache.vrce /= num
+	result.queueSize.vrce /= num
+	result.runningRequests.vrce /= num
+
+	// Round stats to two decimal places
+	result.kvCache.mean = math.Round(result.kvCache.mean*100) / 100
+	result.queueSize.mean = math.Round(result.queueSize.mean*100) / 100
+	result.runningRequests.mean = math.Round(result.runningRequests.mean*100) / 100
+
+	result.kvCache.vrce = math.Round((result.kvCache.vrce)*100) / 100
+	result.queueSize.vrce = math.Round((result.queueSize.vrce)*100) / 100
+	result.runningRequests.vrce = math.Round((result.runningRequests.vrce)*100) / 100
+
+	result.kvCache.stdv = math.Round(math.Sqrt(result.kvCache.vrce)*100) / 100
+	result.queueSize.stdv = math.Round(math.Sqrt(result.queueSize.vrce)*100) / 100
+	result.runningRequests.stdv = math.Round(math.Sqrt(result.runningRequests.vrce)*100) / 100
 
 	return result
 }

--- a/pkg/epp/datalayer/logger/logger.go
+++ b/pkg/epp/datalayer/logger/logger.go
@@ -128,24 +128,6 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 	metrics.RecordInferencePoolStdDevRunningRequests(pool.Name, summary.runningRequests.stdv)
 }
 
-// totals holds aggregated metric values
-type totals struct {
-	kvCache         float64
-	queueSize       int
-	runningRequests int
-}
-
-func calculateTotals(endpoints []fwkdl.Endpoint) totals {
-	var result totals
-	for _, pod := range endpoints {
-		metrics := pod.GetMetrics()
-		result.kvCache += metrics.KVCacheUsagePercent
-		result.queueSize += metrics.WaitingQueueSize
-		result.runningRequests += metrics.RunningRequestsSize
-	}
-	return result
-}
-
 // stats holds aggregated metric values
 type stats struct {
 	mean float64 // average
@@ -158,36 +140,45 @@ type summary struct {
 	runningRequests stats
 }
 
-func calculateSummary(endpoints []fwkdl.Endpoint) summary {
-	var result summary
-	size := float64(len(endpoints))
-	totals := calculateTotals(endpoints)
-
-	if size < 1 {
+func calculateSummary(endpoints []fwkdl.Endpoint) (result summary) {
+	if len(endpoints) == 0 {
 		return result
 	}
 
-	result.kvCache.mean = totals.kvCache / size
-	result.queueSize.mean = float64(totals.queueSize) / size
-	result.runningRequests.mean = float64(totals.runningRequests) / size
+	var kvSum, queueSum, reqSum float64
 
 	for _, pod := range endpoints {
 		metrics := pod.GetMetrics()
-		result.kvCache.stdv += (metrics.KVCacheUsagePercent - result.kvCache.mean) * (metrics.KVCacheUsagePercent - result.kvCache.mean)
-		result.queueSize.stdv += (float64(metrics.WaitingQueueSize) - result.queueSize.mean) * (float64(metrics.WaitingQueueSize) - result.queueSize.mean)
-		result.runningRequests.stdv += (float64(metrics.RunningRequestsSize) - result.runningRequests.mean) * (float64(metrics.RunningRequestsSize) - result.runningRequests.mean)
+		kvSum += float64(metrics.KVCacheUsagePercent)
+		queueSum += float64(metrics.WaitingQueueSize)
+		reqSum += float64(metrics.RunningRequestsSize)
 	}
+
+	size := float64(len(endpoints))
+
+	result.kvCache.mean = kvSum / size
+	result.queueSize.mean = queueSum / size
+	result.runningRequests.mean = reqSum / size
+
+	var kvSS, queueSS, reqSS float64
+
+	for _, pod := range endpoints {
+		metrics := pod.GetMetrics()
+		kvSS += (metrics.KVCacheUsagePercent - result.kvCache.mean) * (metrics.KVCacheUsagePercent - result.kvCache.mean)
+		queueSS += (float64(metrics.WaitingQueueSize) - result.queueSize.mean) * (float64(metrics.WaitingQueueSize) - result.queueSize.mean)
+		reqSS += (float64(metrics.RunningRequestsSize) - result.runningRequests.mean) * (float64(metrics.RunningRequestsSize) - result.runningRequests.mean)
+	}
+
+	sampleSize := math.Max(1.0, size-1)
 
 	// Round stats to two decimal places
 	result.kvCache.mean = round2(result.kvCache.mean)
 	result.queueSize.mean = round2(result.queueSize.mean)
 	result.runningRequests.mean = round2(result.runningRequests.mean)
 
-	sampleSize := math.Max(1, size-1)
-
-	result.kvCache.stdv = round2(math.Sqrt(result.kvCache.stdv / sampleSize))
-	result.queueSize.stdv = round2(math.Sqrt(result.queueSize.stdv / sampleSize))
-	result.runningRequests.stdv = round2(math.Sqrt(result.runningRequests.stdv / sampleSize))
+	result.kvCache.stdv = round2(math.Sqrt(kvSS / sampleSize))
+	result.queueSize.stdv = round2(math.Sqrt(queueSS / sampleSize))
+	result.runningRequests.stdv = round2(math.Sqrt(reqSS / sampleSize))
 
 	return result
 }

--- a/pkg/epp/datalayer/logger/logger.go
+++ b/pkg/epp/datalayer/logger/logger.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -117,11 +118,15 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 		return
 	}
 
-	totals := calculateTotals(podMetrics)
+	summary := calculateSummary(podMetrics)
 
-	metrics.RecordInferencePoolAvgKVCache(pool.Name, totals.kvCache/float64(podCount))
-	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(totals.queueSize)/float64(podCount))
-	metrics.RecordInferencePoolAvgRunningRequests(pool.Name, float64(totals.runningRequests)/float64(podCount))
+	metrics.RecordInferencePoolAvgKVCache(pool.Name, summary.kvCache.mean)
+	metrics.RecordInferencePoolAvgQueueSize(pool.Name, summary.queueSize.mean)
+	metrics.RecordInferencePoolAvgRunningRequests(pool.Name, summary.runningRequests.mean)
+
+	metrics.RecordInferencePoolStdDevKVCache(pool.Name, summary.kvCache.stdv)
+	metrics.RecordInferencePoolStdDevQueueSize(pool.Name, summary.queueSize.stdv)
+	metrics.RecordInferencePoolStdDevRunningRequests(pool.Name, summary.runningRequests.stdv)
 }
 
 // totals holds aggregated metric values
@@ -139,5 +144,49 @@ func calculateTotals(endpoints []fwkdl.Endpoint) totals {
 		result.queueSize += metrics.WaitingQueueSize
 		result.runningRequests += metrics.RunningRequestsSize
 	}
+	return result
+}
+
+// stats holds aggregated metric values
+type stats struct {
+	mean float64 // average
+	stdv float64 // standard deviation
+	vrce float64 // variance
+}
+
+type summary struct {
+	kvCache         stats
+	queueSize       stats
+	runningRequests stats
+}
+
+func calculateSummary(endpoints []fwkdl.Endpoint) summary {
+	var result summary
+	size := float64(len(endpoints))
+	totals := calculateTotals(endpoints)
+
+	result.kvCache.mean = totals.kvCache / size
+	result.queueSize.mean = float64(totals.queueSize) / size
+	result.runningRequests.mean = float64(totals.runningRequests) / size
+
+	for _, pod := range endpoints {
+		metrics := pod.GetMetrics()
+		result.kvCache.vrce += (metrics.KVCacheUsagePercent - result.kvCache.mean) * (metrics.KVCacheUsagePercent - result.kvCache.mean)
+		result.queueSize.vrce += (float64(metrics.WaitingQueueSize) - result.queueSize.mean) * (float64(metrics.WaitingQueueSize) - result.queueSize.mean)
+		result.runningRequests.vrce += (float64(metrics.RunningRequestsSize) - result.runningRequests.mean) * (float64(metrics.RunningRequestsSize) - result.runningRequests.mean)
+	}
+
+	var num = 1.0
+	if size > 2 {
+		num = size - 1
+	}
+	result.kvCache.vrce /= num
+	result.queueSize.vrce /= num
+	result.runningRequests.vrce /= num
+
+	result.kvCache.stdv = math.Sqrt(result.kvCache.vrce)
+	result.queueSize.stdv = math.Sqrt(result.queueSize.vrce)
+	result.runningRequests.stdv = math.Sqrt(result.runningRequests.vrce)
+
 	return result
 }

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -142,6 +142,65 @@ func TestCalculateTotals(t *testing.T) {
 	}
 }
 
+func TestCalculateSummary(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints []fwkdl.Endpoint
+		want      summary
+	}{
+		{
+			name:      "empty list",
+			endpoints: []fwkdl.Endpoint{},
+			want:      summary{},
+		},
+		{
+			name: "single endpoint",
+			endpoints: []fwkdl.Endpoint{
+				fwkdl.NewEndpoint(pod1, &fwkdl.Metrics{
+					KVCacheUsagePercent: 50.0,
+					WaitingQueueSize:    3,
+					RunningRequestsSize: 5,
+					UpdateTime:          time.Now(),
+				}),
+			},
+			want: summary{
+				kvCache:         stats{mean: 50.0, stdv: 0, vrce: 0},
+				queueSize:       stats{mean: 3.0, stdv: 0, vrce: 0},
+				runningRequests: stats{mean: 5.0, stdv: 0, vrce: 0},
+			},
+		},
+		{
+			name: "multiple endpoints aggregated",
+			endpoints: []fwkdl.Endpoint{
+				fwkdl.NewEndpoint(pod1, &fwkdl.Metrics{
+					KVCacheUsagePercent: 30.0,
+					WaitingQueueSize:    2,
+					RunningRequestsSize: 1,
+					UpdateTime:          time.Now(),
+				}),
+				fwkdl.NewEndpoint(pod2, &fwkdl.Metrics{
+					KVCacheUsagePercent: 70.0,
+					WaitingQueueSize:    5,
+					RunningRequestsSize: 3,
+					UpdateTime:          time.Now(),
+				}),
+			},
+			want: summary{
+				kvCache:         stats{mean: 50.0, stdv: 28.28, vrce: 800.0},
+				queueSize:       stats{mean: 3.5, stdv: 2.12, vrce: 4.5},
+				runningRequests: stats{mean: 2.0, stdv: 1.41, vrce: 2.0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateSummary(tt.endpoints)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestRefreshPrometheusMetricsAvgValues(t *testing.T) {
 	metrics.Register()
 	metrics.Reset()

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -164,9 +164,9 @@ func TestCalculateSummary(t *testing.T) {
 				}),
 			},
 			want: summary{
-				kvCache:         stats{mean: 50.0, stdv: 0, vrce: 0},
-				queueSize:       stats{mean: 3.0, stdv: 0, vrce: 0},
-				runningRequests: stats{mean: 5.0, stdv: 0, vrce: 0},
+				kvCache:         stats{mean: 50.0, stdv: 0},
+				queueSize:       stats{mean: 3.0, stdv: 0},
+				runningRequests: stats{mean: 5.0, stdv: 0},
 			},
 		},
 		{
@@ -186,9 +186,9 @@ func TestCalculateSummary(t *testing.T) {
 				}),
 			},
 			want: summary{
-				kvCache:         stats{mean: 50.0, stdv: 28.28, vrce: 800.0},
-				queueSize:       stats{mean: 3.5, stdv: 2.12, vrce: 4.5},
-				runningRequests: stats{mean: 2.0, stdv: 1.41, vrce: 2.0},
+				kvCache:         stats{mean: 50.0, stdv: 28.28},
+				queueSize:       stats{mean: 3.5, stdv: 2.12},
+				runningRequests: stats{mean: 2.0, stdv: 1.41},
 			},
 		},
 	}

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -91,57 +91,6 @@ func TestLogger(t *testing.T) {
 	assert.Contains(t, logOutput, "\"Stale metrics\": \"[]\"")
 }
 
-func TestCalculateTotals(t *testing.T) {
-	tests := []struct {
-		name      string
-		endpoints []fwkdl.Endpoint
-		want      totals
-	}{
-		{
-			name:      "empty list",
-			endpoints: []fwkdl.Endpoint{},
-			want:      totals{},
-		},
-		{
-			name: "single endpoint",
-			endpoints: []fwkdl.Endpoint{
-				fwkdl.NewEndpoint(pod1, &fwkdl.Metrics{
-					KVCacheUsagePercent: 50.0,
-					WaitingQueueSize:    3,
-					RunningRequestsSize: 5,
-					UpdateTime:          time.Now(),
-				}),
-			},
-			want: totals{kvCache: 50.0, queueSize: 3, runningRequests: 5},
-		},
-		{
-			name: "multiple endpoints aggregated",
-			endpoints: []fwkdl.Endpoint{
-				fwkdl.NewEndpoint(pod1, &fwkdl.Metrics{
-					KVCacheUsagePercent: 30.0,
-					WaitingQueueSize:    2,
-					RunningRequestsSize: 1,
-					UpdateTime:          time.Now(),
-				}),
-				fwkdl.NewEndpoint(pod2, &fwkdl.Metrics{
-					KVCacheUsagePercent: 70.0,
-					WaitingQueueSize:    5,
-					RunningRequestsSize: 3,
-					UpdateTime:          time.Now(),
-				}),
-			},
-			want: totals{kvCache: 100.0, queueSize: 7, runningRequests: 4},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := calculateTotals(tt.endpoints)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestCalculateSummary(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -208,6 +208,33 @@ var (
 		poolLabels,
 	)
 
+	llmdInferencePoolStdDevKVCache = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "std_dev_kv_cache_utilization",
+			Help:      metricsutil.HelpMsgWithStability("The standard deviation kv cache utilization for an inference server pool.", compbasemetrics.ALPHA),
+		},
+		poolLabels,
+	)
+
+	llmdInferencePoolStdDevQueueSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "std_dev_queue_size",
+			Help:      metricsutil.HelpMsgWithStability("The standard deviation number of requests pending in the model server queue.", compbasemetrics.ALPHA),
+		},
+		poolLabels,
+	)
+
+	llmdInferencePoolStdDevRunningRequests = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "std_dev_running_requests",
+			Help:      metricsutil.HelpMsgWithStability("The standard deviation number of running requests across model servers in the pool.", compbasemetrics.ALPHA),
+		},
+		poolLabels,
+	)
+
 	llmdInferencePoolReadyEndpoints = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -443,10 +443,13 @@ func Register(customCollectors ...prometheus.Collector) {
 		metrics.Registry.MustRegister(llmdInterTokenLatency)
 		metrics.Registry.MustRegister(inferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgKVCache)
+		metrics.Registry.MustRegister(llmdInferencePoolStdDevKVCache)
 		metrics.Registry.MustRegister(inferencePoolAvgQueueSize)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgQueueSize)
+		metrics.Registry.MustRegister(llmdInferencePoolStdDevQueueSize)
 		metrics.Registry.MustRegister(inferencePoolAvgRunningRequests)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgRunningRequests)
+		metrics.Registry.MustRegister(llmdInferencePoolStdDevRunningRequests)
 		metrics.Registry.MustRegister(inferencePoolReadyPods)
 		metrics.Registry.MustRegister(llmdInferencePoolReadyEndpoints)
 		metrics.Registry.MustRegister(schedulerE2ELatency)
@@ -509,10 +512,13 @@ func Reset() {
 	llmdInterTokenLatency.Reset()
 	inferencePoolAvgKVCache.Reset()
 	llmdInferencePoolAvgKVCache.Reset()
+	llmdInferencePoolStdDevKVCache.Reset()
 	inferencePoolAvgQueueSize.Reset()
 	llmdInferencePoolAvgQueueSize.Reset()
+	llmdInferencePoolStdDevQueueSize.Reset()
 	inferencePoolAvgRunningRequests.Reset()
 	llmdInferencePoolAvgRunningRequests.Reset()
+	llmdInferencePoolStdDevRunningRequests.Reset()
 	inferencePoolReadyPods.Reset()
 	llmdInferencePoolReadyEndpoints.Reset()
 	schedulerE2ELatency.Reset()
@@ -704,6 +710,18 @@ func RecordInferencePoolAvgQueueSize(name string, queueSize float64) {
 func RecordInferencePoolAvgRunningRequests(name string, runningRequests float64) {
 	inferencePoolAvgRunningRequests.WithLabelValues(name).Set(runningRequests)
 	llmdInferencePoolAvgRunningRequests.WithLabelValues(name).Set(runningRequests)
+}
+
+func RecordInferencePoolStdDevKVCache(name string, utilization float64) {
+	llmdInferencePoolStdDevKVCache.WithLabelValues(name).Set(utilization)
+}
+
+func RecordInferencePoolStdDevQueueSize(name string, queueSize float64) {
+	llmdInferencePoolStdDevQueueSize.WithLabelValues(name).Set(queueSize)
+}
+
+func RecordInferencePoolStdDevRunningRequests(name string, runningRequests float64) {
+	llmdInferencePoolStdDevRunningRequests.WithLabelValues(name).Set(runningRequests)
 }
 
 func RecordInferencePoolReadyPods(name string, runningPods float64) {

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -621,18 +621,24 @@ func TestRunningRequestsMetrics(t *testing.T) {
 func TestInferencePoolMetrics(t *testing.T) {
 	Reset()
 	scenarios := []struct {
-		name               string
-		poolName           string
-		kvCacheAvg         float64
-		queueSizeAvg       float64
-		runningRequestsAvg float64
+		name                  string
+		poolName              string
+		kvCacheAvg            float64
+		queueSizeAvg          float64
+		runningRequestsAvg    float64
+		kvCacheStdDev         float64
+		queueSizeStdDev       float64
+		runningRequestsStdDev float64
 	}{
 		{
-			name:               "basic test",
-			poolName:           "p1",
-			kvCacheAvg:         0.3,
-			queueSizeAvg:       0.4,
-			runningRequestsAvg: 0.5,
+			name:                  "basic test",
+			poolName:              "p1",
+			kvCacheAvg:            0.3,
+			queueSizeAvg:          0.4,
+			runningRequestsAvg:    0.5,
+			kvCacheStdDev:         0.1,
+			queueSizeStdDev:       0.2,
+			runningRequestsStdDev: 0.3,
 		},
 	}
 	for _, scenario := range scenarios {
@@ -640,6 +646,9 @@ func TestInferencePoolMetrics(t *testing.T) {
 			RecordInferencePoolAvgKVCache(scenario.poolName, scenario.kvCacheAvg)
 			RecordInferencePoolAvgQueueSize(scenario.poolName, scenario.queueSizeAvg)
 			RecordInferencePoolAvgRunningRequests(scenario.poolName, scenario.runningRequestsAvg)
+			RecordInferencePoolStdDevKVCache(scenario.poolName, scenario.kvCacheStdDev)
+			RecordInferencePoolStdDevQueueSize(scenario.poolName, scenario.queueSizeStdDev)
+			RecordInferencePoolStdDevRunningRequests(scenario.poolName, scenario.runningRequestsStdDev)
 
 			// Verify deprecated metrics
 			wantKVCache, err := os.Open("testdata/kv_cache_avg_metrics")
@@ -694,6 +703,33 @@ func TestInferencePoolMetrics(t *testing.T) {
 			}
 			defer wantRunningRequestsNew.Close()
 			if err := promtestutil.GatherAndCompare(metrics.Registry, wantRunningRequestsNew, "llm_d_epp_average_running_requests"); err != nil {
+				t.Error(err)
+			}
+
+			wantKVCacheStdDev, err := os.Open("testdata/llm_d_kv_cache_std_dev_metrics")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer wantKVCacheStdDev.Close()
+			if err := promtestutil.GatherAndCompare(metrics.Registry, wantKVCacheStdDev, "llm_d_epp_std_dev_kv_cache_utilization"); err != nil {
+				t.Error(err)
+			}
+
+			wantQueueSizeStdDev, err := os.Open("testdata/llm_d_queue_std_dev_size_metrics")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer wantQueueSizeStdDev.Close()
+			if err := promtestutil.GatherAndCompare(metrics.Registry, wantQueueSizeStdDev, "llm_d_epp_std_dev_queue_size"); err != nil {
+				t.Error(err)
+			}
+
+			wantRunningRequestsStdDev, err := os.Open("testdata/llm_d_running_requests_std_dev_metrics")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer wantRunningRequestsStdDev.Close()
+			if err := promtestutil.GatherAndCompare(metrics.Registry, wantRunningRequestsStdDev, "llm_d_epp_std_dev_running_requests"); err != nil {
 				t.Error(err)
 			}
 		})

--- a/pkg/epp/metrics/testdata/llm_d_kv_cache_std_dev_metrics
+++ b/pkg/epp/metrics/testdata/llm_d_kv_cache_std_dev_metrics
@@ -1,0 +1,3 @@
+# HELP llm_d_epp_std_dev_kv_cache_utilization [ALPHA] The standard deviation kv cache utilization for an inference server pool.
+# TYPE llm_d_epp_std_dev_kv_cache_utilization gauge
+llm_d_epp_std_dev_kv_cache_utilization{name="p1} 0.1

--- a/pkg/epp/metrics/testdata/llm_d_kv_cache_std_dev_metrics
+++ b/pkg/epp/metrics/testdata/llm_d_kv_cache_std_dev_metrics
@@ -1,3 +1,3 @@
 # HELP llm_d_epp_std_dev_kv_cache_utilization [ALPHA] The standard deviation kv cache utilization for an inference server pool.
 # TYPE llm_d_epp_std_dev_kv_cache_utilization gauge
-llm_d_epp_std_dev_kv_cache_utilization{name="p1} 0.1
+llm_d_epp_std_dev_kv_cache_utilization{name="p1"} 0.1

--- a/pkg/epp/metrics/testdata/llm_d_queue_std_dev_size_metrics
+++ b/pkg/epp/metrics/testdata/llm_d_queue_std_dev_size_metrics
@@ -1,0 +1,3 @@
+# HELP llm_d_epp_std_dev_queue_size [ALPHA] The standard deviation number of requests pending in the model server queue.
+# TYPE llm_d_epp_std_dev_queue_size gauge
+llm_d_epp_std_dev_queue_size{name="p1"} 0.2

--- a/pkg/epp/metrics/testdata/llm_d_running_requests_std_dev_metrics
+++ b/pkg/epp/metrics/testdata/llm_d_running_requests_std_dev_metrics
@@ -1,0 +1,3 @@
+# HELP llm_d_epp_std_dev_running_requests [ALPHA] The standard deviation number of running requests across model servers in the pool.
+# TYPE llm_d_epp_std_dev_running_requests gauge
+llm_d_epp_std_dev_running_requests{name="p1"} 0.3


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind feature

**What this PR does / why we need it**: 
Currently, the EPP scheduler in LLM-d-router project exposes some [metrics to track the pool health](https://llm-d.ai/docs/architecture/core/router/epp/scheduling#pool-health-metrics). These include average kv cache utilization, average number of pending requests and average number of running requests across replicas within a pool.  Within the EPP, utilizing scheduling profiles, users are able to set weights to various scorer plugins. But the efficiency of intelligent routing and weights applied to different plugins may directly depends on the variance in load between replicas in the same inference pool. Infact, in an extreme case, where there is absolutely no variance, random/round robin routing might be sufficient and a very intelligent scorer weighting may be an overkill. Hence, it is vital to understand the variance in load on replicas within the various InferencePools deployed.

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1870

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Adding standard deviation metrics for monitoring epp pool variance
```
