### PR TITLE
Ensure that plugins that depend on other plugins are instantiated after their dependencies

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -498,10 +498,11 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(random.RandomPickerType, random.RandomPickerFactory)
 	fwkplugin.Register(weightedrandom.WeightedRandomPickerType, weightedrandom.WeightedRandomPickerFactory)
 	fwkplugin.Register(single.SingleProfileHandlerType, single.SingleProfileHandlerFactory)
-	fwkplugin.Register(disagg.DisaggHeadersHandlerType, disagg.HeadersHandlerFactory) //nolint:staticcheck // intentional: keep backward compatibility
-	fwkplugin.Register(disagg.PrefillHeaderHandlerType, disagg.HeadersHandlerFactory) //nolint:staticcheck // intentional: keep backward compatibility
-	fwkplugin.Register(disagg.PdProfileHandlerType, disagg.PdProfileHandlerFactory)   //nolint:staticcheck // intentional: keep backward compatibility
-	fwkplugin.Register(disagg.DisaggProfileHandlerType, disagg.HandlerFactory)
+	fwkplugin.Register(disagg.DisaggHeadersHandlerType, disagg.HeadersHandlerFactory)                     //nolint:staticcheck // intentional: keep backward compatibility
+	fwkplugin.Register(disagg.PrefillHeaderHandlerType, disagg.HeadersHandlerFactory)                     //nolint:staticcheck // intentional: keep backward compatibility
+	fwkplugin.RegisterWithPluginDependencies(disagg.PdProfileHandlerType, disagg.PdProfileHandlerFactory, //nolint:staticcheck // intentional: keep backward compatibility
+		disagg.PdProfileHandlerConfigParser)
+	fwkplugin.RegisterWithPluginDependencies(disagg.DisaggProfileHandlerType, disagg.HandlerFactory, disagg.DisaggProfileHandlerConfigParser)
 	fwkplugin.Register(disagg.AlwaysDisaggPDDeciderPluginType, disagg.AlwaysDisaggPDDeciderPluginFactory)
 	fwkplugin.Register(disagg.PrefixBasedPDDeciderPluginType, disagg.PrefixBasedPDDeciderPluginFactory)
 	fwkplugin.Register(disagg.AlwaysDisaggMulimodalPluginType, disagg.AlwaysDisaggMulimodalDeciderPluginFactory)

--- a/deploy/config/pd-epp-config.yaml
+++ b/deploy/config/pd-epp-config.yaml
@@ -1,4 +1,4 @@
-# Sample EPP configuration for tunning with P/D
+# Sample EPP configuration for running with P/D
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -11,13 +11,13 @@ plugins:
 - type: prefill-filter
 - type: decode-filter
 - type: max-score-picker
-- type: prefix-based-pd-decider
-  parameters:
-    nonCachedTokens: 16
 - type: disagg-profile-handler
   parameters:
     deciders:
       prefill: prefix-based-pd-decider
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
 schedulingProfiles:
 - name: prefill
   plugins:

--- a/deploy/config/sim-e-p-d-epp-config.yaml
+++ b/deploy/config/sim-e-p-d-epp-config.yaml
@@ -6,15 +6,15 @@ plugins:
 - type: encode-filter
 - type: prefill-filter
 - type: decode-filter
-- type: always-disagg-multimodal-decider
-- type: prefix-based-pd-decider
-  parameters:
-    nonCachedTokens: 16
 - type: disagg-profile-handler
   parameters:
     deciders:
       encode: always-disagg-multimodal-decider
       prefill: prefix-based-pd-decider
+- type: always-disagg-multimodal-decider
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
 schedulingProfiles:
 - name: encode
   plugins:

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -229,7 +229,7 @@ func decodeRawConfig(configBytes []byte) (*configapi.EndpointPickerConfig, error
 func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle fwkplugin.Handle) error {
 	orderedPlugins, err := buildPluginDAG(configuredPlugins, handle)
 	if err != nil {
-		return fmt.Errorf("cycle in dependencies between plugins: %w", err)
+		return fmt.Errorf("failed to build plugin dependency graph: %w", err)
 	}
 
 	for _, spec := range orderedPlugins {
@@ -252,8 +252,8 @@ func buildPluginDAG(configuredPlugins []configapi.PluginSpec, handle fwkplugin.H
 
 	for _, spec := range configuredPlugins {
 		if parserFunc, ok := fwkplugin.PluginsWithPluginDependencies[spec.Type]; !ok {
-			// All plugins that don't have dependencies should be instantiated first
-			orderedPlugins = append(orderedPlugins, spec)
+			// Add plugins that don't have dependencies to the graph
+			graph[spec.Name] = []string{}
 		} else {
 			// Ignore extra fields.
 			configStruct, err := parserFunc(fwkplugin.StrictDecoder(spec.Parameters), handle)
@@ -271,7 +271,11 @@ func buildPluginDAG(configuredPlugins []configapi.PluginSpec, handle fwkplugin.H
 	}
 
 	for _, pluginName := range sortedGraph {
-		orderedPlugins = append(orderedPlugins, pluginMap[pluginName])
+		if spec, ok := pluginMap[pluginName]; ok {
+			orderedPlugins = append(orderedPlugins, spec)
+		} else {
+			return nil, fmt.Errorf("a plugin has a dependency on the unregistered plugin %s", pluginName)
+		}
 	}
 
 	return orderedPlugins, nil

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -19,6 +19,7 @@ package loader
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
 	"github.com/llm-d/llm-d-router/pkg/epp/config"
@@ -43,6 +43,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-router/pkg/epp/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/util"
 )
 
 var (
@@ -149,6 +150,9 @@ func InstantiateAndConfigure(
 	handle fwkplugin.Handle,
 	logger logr.Logger,
 ) (*config.Config, error) {
+	if err := validatePlugins(rawConfig.Plugins); err != nil {
+		return nil, fmt.Errorf("configuration validation failed: %w", err)
+	}
 
 	if err := instantiatePlugins(rawConfig.Plugins, handle); err != nil {
 		return nil, fmt.Errorf("plugin instantiation failed: %w", err)
@@ -223,20 +227,13 @@ func decodeRawConfig(configBytes []byte) (*configapi.EndpointPickerConfig, error
 }
 
 func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle fwkplugin.Handle) error {
-	pluginNames := sets.New[string]()
-	for _, spec := range configuredPlugins {
-		if spec.Type == "" {
-			return fmt.Errorf("plugin '%s' is missing a type", spec.Name)
-		}
-		if pluginNames.Has(spec.Name) {
-			return fmt.Errorf("duplicate plugin name '%s'", spec.Name)
-		}
-		pluginNames.Insert(spec.Name)
+	orderedPlugins, err := buildPluginDAG(configuredPlugins, handle)
+	if err != nil {
+		return fmt.Errorf("cycle in dependencies between plugins: %w", err)
+	}
 
-		factory, ok := fwkplugin.Registry[spec.Type]
-		if !ok {
-			return fmt.Errorf("plugin type '%s' is not registered", spec.Type)
-		}
+	for _, spec := range orderedPlugins {
+		factory := fwkplugin.Registry[spec.Type]
 		plugin, err := factory(spec.Name, fwkplugin.StrictDecoder(spec.Parameters), handle)
 		if err != nil {
 			return fmt.Errorf("failed to create plugin '%s' (type: %s): %w", spec.Name, spec.Type, err)
@@ -246,6 +243,77 @@ func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle fwkplug
 	}
 
 	return nil
+}
+
+func buildPluginDAG(configuredPlugins []configapi.PluginSpec, handle fwkplugin.Handle) ([]configapi.PluginSpec, error) {
+	graph := map[string][]string{}
+	pluginMap := map[string]configapi.PluginSpec{}
+	orderedPlugins := []configapi.PluginSpec{}
+
+	for _, spec := range configuredPlugins {
+		if parserFunc, ok := fwkplugin.PluginsWithPluginDependencies[spec.Type]; !ok {
+			// All plugins that don't have dependencies should be instantiated first
+			orderedPlugins = append(orderedPlugins, spec)
+		} else {
+			// Ignore extra fields.
+			configStruct, err := parserFunc(fwkplugin.StrictDecoder(spec.Parameters), handle)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse plugin parameters for %s (type: %s): %w", spec.Name, spec.Type, err)
+			}
+			graph[spec.Name] = findPluginDependencies(configStruct)
+		}
+		pluginMap[spec.Name] = spec
+	}
+
+	sortedGraph, err := util.TopologicalSort(graph)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pluginName := range sortedGraph {
+		orderedPlugins = append(orderedPlugins, pluginMap[pluginName])
+	}
+
+	return orderedPlugins, nil
+}
+
+func findPluginDependencies(params any) []string {
+	dependencies := []string{}
+
+	theType := reflect.TypeOf(params)
+	theValue := reflect.ValueOf(params)
+	if theType.Kind() == reflect.Pointer {
+		theType = theType.Elem()
+		theValue = theValue.Elem()
+	}
+	if theType.Kind() == reflect.Struct {
+		for idx := range theValue.NumField() {
+			field := theType.Field(idx)
+			value := theValue.Field(idx)
+			if (value.Kind() == reflect.Pointer && value.IsNil()) || !field.IsExported() {
+				continue
+			}
+			if value.Kind() == reflect.Pointer || value.Kind() == reflect.Struct {
+				dependencies = append(dependencies, findPluginDependencies(value.Interface())...)
+			} else {
+				_, ok := field.Tag.Lookup("pluginRef")
+				if ok {
+					if (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && field.Type.Elem().Kind() == reflect.String {
+						for idx := range value.Len() {
+							if dependency := value.Index(idx).String(); len(dependency) != 0 {
+								dependencies = append(dependencies, dependency)
+							}
+						}
+					} else if value.Kind() == reflect.String {
+						if dependency := value.String(); len(dependency) != 0 {
+							dependencies = append(dependencies, dependency)
+						}
+					}
+				}
+			}
+		}
+	}
+	return dependencies
 }
 
 func buildSchedulerConfig(

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -302,17 +302,18 @@ func findPluginDependencies(params any) []string {
 			} else {
 				_, ok := field.Tag.Lookup("pluginRef")
 				if ok {
-					if (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && field.Type.Elem().Kind() == reflect.String {
+					switch {
+					case (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) && field.Type.Elem().Kind() == reflect.String:
 						for idx := range value.Len() {
 							if dependency := value.Index(idx).String(); len(dependency) != 0 {
 								dependencies = append(dependencies, dependency)
 							}
 						}
-					} else if value.Kind() == reflect.String {
+					case value.Kind() == reflect.String:
 						if dependency := value.String(); len(dependency) != 0 {
 							dependencies = append(dependencies, dependency)
 						}
-					} else if value.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.String {
+					case value.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.String:
 						if dependency := value.Elem().String(); len(dependency) != 0 {
 							dependencies = append(dependencies, dependency)
 						}

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -297,7 +297,7 @@ func findPluginDependencies(params any) []string {
 			if (value.Kind() == reflect.Pointer && value.IsNil()) || !field.IsExported() {
 				continue
 			}
-			if value.Kind() == reflect.Pointer || value.Kind() == reflect.Struct {
+			if (value.Kind() == reflect.Pointer && field.Type.Elem().Kind() != reflect.String) || value.Kind() == reflect.Struct {
 				dependencies = append(dependencies, findPluginDependencies(value.Interface())...)
 			} else {
 				_, ok := field.Tag.Lookup("pluginRef")
@@ -310,6 +310,10 @@ func findPluginDependencies(params any) []string {
 						}
 					} else if value.Kind() == reflect.String {
 						if dependency := value.String(); len(dependency) != 0 {
+							dependencies = append(dependencies, dependency)
+						}
+					} else if value.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.String {
+						if dependency := value.Elem().String(); len(dependency) != 0 {
 							dependencies = append(dependencies, dependency)
 						}
 					}

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -60,12 +61,14 @@ import (
 // Define constants for test plugins.
 // Constants must match those used in testdata_test.go.
 const (
-	testPluginType     = "test-plugin"
-	testPickerType     = "test-picker"
-	testScorerType     = "test-scorer"
-	testProfileHandler = "test-profile-handler"
-	testSourceType     = "test-source"
-	testExtractorType  = "test-extractor"
+	testPluginType             = "test-plugin"
+	testPickerType             = "test-picker"
+	testScorerType             = "test-scorer"
+	testProfileHandler         = "test-profile-handler"
+	testSourceType             = "test-source"
+	testExtractorType          = "test-extractor"
+	testWithDependencies       = "test-with-dependencies"
+	testWithNestedDependencies = "test-with-nested-dependencies"
 
 	testFeatureGate = "test-feature-gate"
 )
@@ -377,6 +380,64 @@ func TestLoadRawConfiguration(t *testing.T) {
 }
 
 // --- Test: Phase 2 (Instantiation, System Defaulting, Deep Validation) ---
+
+func TestPluginsWithDependencies(t *testing.T) {
+	// Not parallel because it modifies global plugin registry.
+	registerTestPlugins(t)
+
+	tests := []struct {
+		name       string
+		configText string
+		wantErr    bool
+	}{
+		{
+			name:       "pluginsInOrder",
+			configText: pluginsInOrderText,
+		},
+		{
+			name:       "pluginsOutOfOrder",
+			configText: pluginsOutOfOrderText,
+		},
+		{
+			name:       "pluginsRefedByPointer",
+			configText: pluginsRefedByPointerText,
+		},
+		{
+			name:       "pluginsRefedInNesteding",
+			configText: pluginsRefedInNestedingText,
+		},
+		{
+			name:       "errorPluginsRefedInLoop",
+			configText: errorPluginsRefedInLoopText,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logging.NewTestLogger()
+
+			// 1. Load Raw (Assuming valid yaml/structure for Phase 2 tests)
+			rawConfig, _, err := LoadRawConfig([]byte(tc.configText), logger)
+			if err != nil {
+				// If we expected failure (and it failed early in Phase 1), success.
+				if tc.wantErr {
+					return
+				}
+				require.NoError(t, err, "Setup: LoadRawConfig failed")
+			}
+
+			// 2. Instantiate
+			handle := testutils.NewTestHandle(context.Background())
+			err = instantiatePlugins(rawConfig.Plugins, handle)
+			if tc.wantErr {
+				require.Error(t, err, "Expected instantiatePlugins to fail")
+				return
+			}
+			require.NoError(t, err, "Expected instantiatePlugins to succeed")
+		})
+	}
+}
 
 func TestInstantiateAndConfigure(t *testing.T) {
 	// Not parallel because it modifies global plugin registry.
@@ -887,6 +948,61 @@ func (m *mockExtractor) Extract(_ context.Context, _ fwkdl.NotificationEvent) er
 	return nil
 }
 
+// mockWithDependencies is a ProfileHandler that "uses" other plugins
+type mockWithDependencies struct{ mockPlugin }
+type mockWithDependenciesConfig struct {
+	Dependency string  `json:"dependency" pluginRef:""`
+	PointedTo  *string `json:"pointedTo" pluginRef:""`
+}
+
+// compile-time type assertion
+var _ fwksched.ProfileHandler = &mockWithDependencies{}
+
+func (m *mockWithDependencies) Pick(context.Context, *fwksched.InferenceRequest, map[string]fwksched.SchedulerProfile,
+	map[string]*fwksched.ProfileRunResult) map[string]fwksched.SchedulerProfile {
+	return nil
+}
+func (m *mockWithDependencies) ProcessResults(context.Context, *fwksched.InferenceRequest,
+	map[string]*fwksched.ProfileRunResult) (*fwksched.SchedulingResult, error) {
+	return nil, errors.New("sentinel error for mock handler")
+}
+
+func mockWithDependenciesConfigParser(decoder *json.Decoder, _ fwkplugin.Handle) (any, error) {
+	cfg := &mockWithDependenciesConfig{}
+	err := decoder.Decode(cfg)
+	return cfg, err
+}
+
+// mockWithNestedDependencies is a ProfileHandler that "uses" other plugins
+type mockWithNestedDependencies struct{ mockPlugin }
+type mockWithNestedDependenciesConfig struct {
+	Nested    MockNestedDependenciesStruct  `json:"nested"`
+	NestedPtr *MockNestedDependenciesStruct `json:"nestedPtr"`
+	Extras    []string                      `json:"extras" pluginRef:""`
+	PointedTo *string                       `json:"pointedTo" pluginRef:""`
+}
+type MockNestedDependenciesStruct struct {
+	Dependency string `json:"dependency" pluginRef:""`
+}
+
+// compile-time type assertion
+var _ fwksched.ProfileHandler = &mockWithDependencies{}
+
+func (m *mockWithNestedDependencies) Pick(context.Context, *fwksched.InferenceRequest, map[string]fwksched.SchedulerProfile,
+	map[string]*fwksched.ProfileRunResult) map[string]fwksched.SchedulerProfile {
+	return nil
+}
+func (m *mockWithNestedDependencies) ProcessResults(context.Context, *fwksched.InferenceRequest,
+	map[string]*fwksched.ProfileRunResult) (*fwksched.SchedulingResult, error) {
+	return nil, errors.New("sentinel error for mock handler")
+}
+
+func mockWithNestedDependenciesConfigParser(decoder *json.Decoder, _ fwkplugin.Handle) (any, error) {
+	cfg := &mockWithNestedDependenciesConfig{}
+	err := decoder.Decode(cfg)
+	return cfg, err
+}
+
 func registerTestPlugins(t *testing.T) {
 	t.Helper()
 
@@ -928,6 +1044,54 @@ func registerTestPlugins(t *testing.T) {
 	fwkplugin.Register(testProfileHandler, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockHandler{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testProfileHandler}}}, nil
 	})
+
+	fwkplugin.RegisterWithPluginDependencies(testWithDependencies,
+		func(name string, decoder *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+			rawCfg, err := mockWithDependenciesConfigParser(decoder, handle)
+			if err != nil {
+				return nil, err
+			}
+			cfg := rawCfg.(*mockWithDependenciesConfig)
+			if dependency := handle.Plugin(cfg.Dependency); dependency == nil {
+				return nil, fmt.Errorf("failed to find dependency %s", cfg.Dependency)
+			}
+			if cfg.PointedTo != nil {
+				if dependency := handle.Plugin(*cfg.PointedTo); dependency == nil {
+					return nil, fmt.Errorf("failed to find dependency %s", *cfg.PointedTo)
+				}
+			}
+			return &mockWithDependencies{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testWithDependencies}}}, nil
+		}, mockWithDependenciesConfigParser,
+	)
+
+	fwkplugin.RegisterWithPluginDependencies(testWithNestedDependencies,
+		func(name string, decoder *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+			rawCfg, err := mockWithNestedDependenciesConfigParser(decoder, handle)
+			if err != nil {
+				return nil, err
+			}
+			cfg := rawCfg.(*mockWithNestedDependenciesConfig)
+			if dependency := handle.Plugin(cfg.Nested.Dependency); dependency == nil {
+				return nil, fmt.Errorf("failed to find dependency %s", cfg.Nested.Dependency)
+			}
+			for _, pluginName := range cfg.Extras {
+				if dependency := handle.Plugin(pluginName); dependency == nil {
+					return nil, fmt.Errorf("failed to find dependency %s", pluginName)
+				}
+			}
+			if cfg.NestedPtr != nil {
+				if dependency := handle.Plugin(cfg.NestedPtr.Dependency); dependency == nil {
+					return nil, fmt.Errorf("failed to find dependency %s", cfg.NestedPtr.Dependency)
+				}
+			}
+			if cfg.PointedTo != nil {
+				if dependency := handle.Plugin(*cfg.PointedTo); dependency == nil {
+					return nil, fmt.Errorf("failed to find dependency %s", *cfg.PointedTo)
+				}
+			}
+			return &mockWithNestedDependencies{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testWithNestedDependencies}}}, nil
+		}, mockWithNestedDependenciesConfigParser,
+	)
 
 	fwkplugin.Register(testSourceType, func(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 		return &mockSource{mockPlugin{t: fwkplugin.TypedName{Name: name, Type: testSourceType}}}, nil

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -671,9 +671,7 @@ schedulingProfiles:
   - pluginRef: maxScore
 `
 
-// pluginsRefedByPointerText represents a valid config with a plugin that is dependent
-// on another plugin. In this case the dependent plugin is before the dependency and is
-// referenced via a pointer
+// errorPluginsRefedInLoopText has a cycle in the plugin dependencies and should fail due to cycle detection
 const errorPluginsRefedInLoopText = `
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -83,6 +83,76 @@ flowControl:
     pluginRef: utilization-detector
 `
 
+// pluginsInOrderText represents a valid config with a plugin that is dependent
+// on another plugin. In this case the dependency is before the dependent plugin
+const pluginsInOrderText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: test1
+  type: test-plugin
+- type: test-with-dependencies
+  parameters:
+    dependency: test1
+`
+
+// pluginsOutOfOrderText represents a valid config with a plugin that is dependent
+// on another plugin. In this case the dependent plugin is before the dependency
+const pluginsOutOfOrderText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: test-with-dependencies
+  parameters:
+    dependency: test1
+- name: test1
+  type: test-plugin
+`
+
+// pluginsRefedByPointerText represents a valid config with a plugin that is dependent
+// on another plugin. In this case the dependent plugin is before the dependency and is
+// referenced via a pointer
+const pluginsRefedByPointerText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: test-with-dependencies
+  parameters:
+    dependency: test1
+    pointedTo:  test2
+- name: test1
+  type: test-plugin
+- name: test2
+  type: test-scorer
+`
+
+// pluginsRefedByPointerText represents a valid config with a plugin that is dependent
+// on another plugin. In this case the dependent plugin is before the dependency and is
+// referenced via a pointer
+const pluginsRefedInNestedingText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: test-with-nested-dependencies
+  parameters:
+    nested:
+      dependency: test1
+    pointedTo:  test2
+    nestedPtr:
+      dependency: test2
+    extras:
+    - test4
+    - test3
+- name: test1
+  type: test-plugin
+- name: test2
+  type: test-scorer
+- name: test3
+  type: test-source
+- name: test4
+  type: test-extractor
+`
+
 // successNoProfilesText represents a valid config with plugins but no profiles.
 // The loader should apply the system default profile automatically.
 const successNoProfilesText = `
@@ -299,6 +369,74 @@ requestHandler:
   parsers:
   - pluginRef: openai-parser
   - pluginRef: secondParser
+`
+
+// successDataLayerAutoDefaultText has the datalayer enabled without data config.
+// The loader should auto-populate default datalayer plugins.
+// successDataLayerAutoDefaultText has NO featureGates — datalayer is enabled by default.
+const successDataLayerAutoDefaultText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+`
+
+// successDataLayerNoSourcesText has an explicit empty dataLayer section with no sources.
+// The loader should additively inject the default metrics source because InjectDefaults is unset (default: true).
+const successDataLayerNoSourcesText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+dataLayer: {}
+`
+
+// successDataLayerOptOutText has dataLayer with injectDefaults: false, disabling automatic injection.
+const successDataLayerOptOutText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+dataLayer:
+  injectDefaults: false
+`
+
+// successDataLayerExplicitConfigText has the datalayer enabled with an explicit non-metrics source.
+// The loader should inject the default metrics source in addition to the user's source (additive).
+const successDataLayerExplicitConfigText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+- name: testSource
+  type: test-source
+- name: testExtractor
+  type: test-extractor
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+dataLayer:
+  sources:
+  - pluginRef: testSource
+    extractors:
+    - pluginRef: testExtractor
 `
 
 // --- Invalid Configurations (Syntax/Structure) ---
@@ -533,74 +671,23 @@ schedulingProfiles:
   - pluginRef: maxScore
 `
 
-// successDataLayerAutoDefaultText has the datalayer enabled without data config.
-// The loader should auto-populate default datalayer plugins.
-// successDataLayerAutoDefaultText has NO featureGates — datalayer is enabled by default.
-const successDataLayerAutoDefaultText = `
+// pluginsRefedByPointerText represents a valid config with a plugin that is dependent
+// on another plugin. In this case the dependent plugin is before the dependency and is
+// referenced via a pointer
+const errorPluginsRefedInLoopText = `
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- name: maxScore
-  type: max-score-picker
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: maxScore
-`
-
-// successDataLayerNoSourcesText has an explicit empty dataLayer section with no sources.
-// The loader should additively inject the default metrics source because InjectDefaults is unset (default: true).
-const successDataLayerNoSourcesText = `
-apiVersion: llm-d.ai/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-- name: maxScore
-  type: max-score-picker
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: maxScore
-dataLayer: {}
-`
-
-// successDataLayerOptOutText has dataLayer with injectDefaults: false, disabling automatic injection.
-const successDataLayerOptOutText = `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-- name: maxScore
-  type: max-score-picker
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: maxScore
-dataLayer:
-  injectDefaults: false
-`
-
-// successDataLayerExplicitConfigText has the datalayer enabled with an explicit non-metrics source.
-// The loader should inject the default metrics source in addition to the user's source (additive).
-const successDataLayerExplicitConfigText = `
-apiVersion: llm-d.ai/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-- name: maxScore
-  type: max-score-picker
-- name: testSource
-  type: test-source
-- name: testExtractor
-  type: test-extractor
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: maxScore
-dataLayer:
-  sources:
-  - pluginRef: testSource
-    extractors:
-    - pluginRef: testExtractor
-featureGates:
-- test-feature-gate
+- type: test-with-dependencies
+  parameters:
+    dependency: test1
+    pointedTo:  test2
+- name: test1
+  type: test-with-dependencies
+  parameters:
+    dependency: test1
+- name: test2
+  type: test-scorer
 `
 
 // errorBadSourceReferenceText has a bad DataSource plugin reference

--- a/pkg/epp/config/loader/validation.go
+++ b/pkg/epp/config/loader/validation.go
@@ -25,7 +25,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	configapi "github.com/llm-d/llm-d-router/apix/config/v1alpha1"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
+
+// validatePlugins validates the plugins section of the configuration file.
+func validatePlugins(configuredPlugins []configapi.PluginSpec) error {
+	pluginNames := sets.New[string]()
+	for _, spec := range configuredPlugins {
+		if spec.Type == "" {
+			return fmt.Errorf("plugin '%s' is missing a type", spec.Name)
+		}
+		if pluginNames.Has(spec.Name) {
+			return fmt.Errorf("duplicate plugin name '%s'", spec.Name)
+		}
+		pluginNames.Insert(spec.Name)
+
+		_, ok := fwkplugin.Registry[spec.Type]
+		if !ok {
+			return fmt.Errorf("plugin type '%s' is not registered", spec.Type)
+		}
+	}
+	return nil
+}
 
 // validateConfig performs a deep validation of the configuration integrity.
 // It checks relationships between profiles, plugins, and feature gates.

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"slices"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/util"
 )
 
 // ValidateAndOrderDataDependencies validates that the data dependencies among the given plugins are acyclic
@@ -54,7 +54,7 @@ func ValidateAndOrderDataDependencies(plugins []plugin.Plugin) ([]string, error)
 		return nil, err
 	}
 	// Topologically sort the DAG to determine the order of plugin execution.
-	pluginNames, err := topologicalSort(dag)
+	pluginNames, err := util.TopologicalSort(dag)
 	if err != nil {
 		return nil, err
 	}
@@ -241,60 +241,4 @@ func buildDAG(producers map[string]plugin.ProducerPlugin, consumers map[string]p
 		}
 	}
 	return dag, nil
-}
-
-// TopologicalSort performs Kahn's Algorithm on a DAG.
-// It returns the sorted order or an error if a cycle is detected.
-func topologicalSort(graph map[string][]string) ([]string, error) {
-	// 1. Initialize in-degree map
-	inDegree := make(map[string]int)
-
-	// Ensure all nodes are present in the inDegree map, even those with no dependencies
-	for u, neighbors := range graph {
-		if _, ok := inDegree[u]; !ok {
-			inDegree[u] = 0
-		}
-		for _, v := range neighbors {
-			inDegree[v]++ // Increment in-degree for the destination node
-		}
-	}
-
-	// 2. Initialize the queue with nodes having 0 in-degree
-	var queue []string
-	for node, degree := range inDegree {
-		if degree == 0 {
-			queue = append(queue, node)
-		}
-	}
-
-	var result []string
-
-	// 3. Process the queue
-	for len(queue) > 0 {
-		// Dequeue
-		u := queue[0]
-		queue = queue[1:]
-
-		result = append(result, u)
-
-		// Decrease in-degree of neighbors
-		if neighbors, ok := graph[u]; ok {
-			for _, v := range neighbors {
-				inDegree[v]--
-				if inDegree[v] == 0 {
-					queue = append(queue, v)
-				}
-			}
-		}
-	}
-
-	// 4. Check for cycles
-	// If the result size != total nodes, there is a cycle
-	if len(result) != len(inDegree) {
-		return nil, errors.New("cycle detected: graph is not a DAG")
-	}
-
-	// Reverse to get the correct order since edges point from consumer to producer
-	slices.Reverse(result)
-	return result, nil
 }

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -32,6 +32,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/util"
 )
 
 const mockProducedDataKey = "mockProducedData"
@@ -264,7 +265,7 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 				}
 				assert.NoError(t, err)
 			}
-			orderedPlugins, err := topologicalSort(dag)
+			orderedPlugins, err := util.TopologicalSort(dag)
 
 			if tc.expectedErr != "" {
 				assert.Error(t, err)

--- a/pkg/epp/framework/interface/plugin/registry.go
+++ b/pkg/epp/framework/interface/plugin/registry.go
@@ -21,12 +21,16 @@ import (
 	"encoding/json"
 )
 
-// Factory is the definition of the factory functions that are used to instantiate plugins
+// FactoryFunc is the definition of the factory functions that are used to instantiate plugins
 // specified in a configuration. The framework provides a strict decoder
 // (DisallowUnknownFields) over the plugin's raw parameters, or nil when the plugin was
 // instantiated without parameters (e.g., as a default producer). Factories that ignore
 // parameters can take the decoder as `_ *json.Decoder`.
 type FactoryFunc func(name string, parameters *json.Decoder, handle Handle) (Plugin, error)
+
+// ConfigParserFunc is the definition of the factory functions that are used to parse the
+// parameters of plugins that have been registered as having dependencies on other plugins
+type ConfigParserFunc func(parameters *json.Decoder, handle Handle) (any, error)
 
 // StrictDecoder returns a *json.Decoder configured with DisallowUnknownFields over the
 // given raw plugin parameters, or nil when raw is empty. The framework uses this when
@@ -55,9 +59,19 @@ func RegisterAsDefaultProducer(pluginType string, factory FactoryFunc, key DataK
 	DefaultProducerRegistry[key.String()] = pluginType
 }
 
+// RegisterWithPluginDependencies registers a factory for the given plugin type and records it as dependent on
+// other plugins referenced in the provided instance of the configuration struct used by the plugin.
+func RegisterWithPluginDependencies(pluginType string, factory FactoryFunc, parser ConfigParserFunc) {
+	Register(pluginType, factory)
+	PluginsWithPluginDependencies[pluginType] = parser
+}
+
 // Registry is a mapping from plugin type to Factory function.
 var Registry = map[string]FactoryFunc{}
 
 // DefaultProducerRegistry maps a data key to the default producer plugin name (same as type).
 // Populated via RegisterAsDefaultProducer.
 var DefaultProducerRegistry = map[string]string{}
+
+// PluginsWithPluginDependencies maps plugin types to their configuration parser function, used to determine plugin dependencies
+var PluginsWithPluginDependencies = map[string]ConfigParserFunc{}

--- a/pkg/epp/framework/interface/plugin/registry.go
+++ b/pkg/epp/framework/interface/plugin/registry.go
@@ -60,7 +60,7 @@ func RegisterAsDefaultProducer(pluginType string, factory FactoryFunc, key DataK
 }
 
 // RegisterWithPluginDependencies registers a factory for the given plugin type and records it as dependent on
-// other plugins referenced in the provided instance of the configuration struct used by the plugin.
+// other plugins referenced in the configuration struct returned by the plugin's configuration parser function.
 func RegisterWithPluginDependencies(pluginType string, factory FactoryFunc, parser ConfigParserFunc) {
 	Register(pluginType, factory)
 	PluginsWithPluginDependencies[pluginType] = parser

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -44,12 +44,12 @@ type disaggProfilesParameters struct {
 }
 
 type disaggDecidersParameters struct {
-	Prefill string `json:"prefill,omitempty"`
-	Encode  string `json:"encode,omitempty"`
+	Prefill string `json:"prefill,omitempty" pluginRef:""`
+	Encode  string `json:"encode,omitempty" pluginRef:""`
 }
 
-// disaggProfileHandlerParameters is the current parameter format using nested maps.
-type disaggProfileHandlerParameters struct {
+// DisaggProfileHandlerParameters is the current parameter format using nested maps.
+type DisaggProfileHandlerParameters struct {
 	Profiles disaggProfilesParameters `json:"profiles"`
 	Deciders disaggDecidersParameters `json:"deciders"`
 }
@@ -69,8 +69,8 @@ type legacyDisaggProfileHandlerParameters struct {
 
 // toDisaggParams copies legacy flat fields into the nested format, logging a
 // deprecation warning for each field in use.
-func (l *legacyDisaggProfileHandlerParameters) toDisaggParams(logger logr.Logger) disaggProfileHandlerParameters {
-	p := disaggProfileHandlerParameters{}
+func (l *legacyDisaggProfileHandlerParameters) toDisaggParams(logger logr.Logger) DisaggProfileHandlerParameters {
+	p := DisaggProfileHandlerParameters{}
 	if l.DecodeProfile != "" {
 		logger.Info("Deprecated parameter 'decodeProfile', use 'profiles.decode' instead")
 		p.Profiles.Decode = l.DecodeProfile
@@ -112,7 +112,54 @@ func HandlerFactory(name string, rawParameters *json.Decoder, handle plugin.Hand
 	}
 	logger := log.FromContext(handle.Context())
 
-	parameters := disaggProfileHandlerParameters{}
+	tmpParameters, err := DisaggProfileHandlerConfigParser(rawParameters, handle)
+	if err != nil {
+		return nil, err
+	}
+	parameters := tmpParameters.(DisaggProfileHandlerParameters)
+
+	// Resolve PD decider (optional).
+	var pdDecider deciderPlugin
+	if parameters.Deciders.Prefill != "" {
+		p := handle.Plugin(parameters.Deciders.Prefill)
+		if p == nil {
+			return nil, fmt.Errorf("deciders.prefill plugin not found: %s", parameters.Deciders.Prefill)
+		}
+		var ok bool
+		pdDecider, ok = p.(deciderPlugin)
+		if !ok {
+			return nil, fmt.Errorf("plugin %s does not implement prefillDeciderPlugin", parameters.Deciders.Prefill)
+		}
+	} else {
+		logger.Info("No deciders.prefill configured, P/D disaggregation disabled")
+	}
+	// Resolve encode decider (optional).
+	var encodeDecider deciderPlugin
+	if parameters.Deciders.Encode != "" {
+		ep := handle.Plugin(parameters.Deciders.Encode)
+		if ep == nil {
+			return nil, fmt.Errorf("deciders.encode plugin not found: %s", parameters.Deciders.Encode)
+		}
+		var ok bool
+		encodeDecider, ok = ep.(deciderPlugin)
+		if !ok {
+			return nil, fmt.Errorf("plugin %s does not implement encodeDeciderPlugin", parameters.Deciders.Encode)
+		}
+	} else {
+		logger.Info("No deciders.encode configured, E disaggregation disabled")
+	}
+	// Create handler
+	handler := NewDisaggProfileHandler(
+		parameters.Profiles.Decode, parameters.Profiles.Prefill, parameters.Profiles.Encode,
+		pdDecider, encodeDecider,
+	)
+	return handler.WithName(name), nil
+}
+
+func DisaggProfileHandlerConfigParser(rawParameters *json.Decoder, handle plugin.Handle) (any, error) {
+	logger := log.FromContext(handle.Context())
+
+	parameters := DisaggProfileHandlerParameters{}
 	if rawParameters != nil {
 		// Capture raw bytes once so we can try each schema independently with
 		// strict decoding. The decoder passed in is one-shot, so we re-read
@@ -155,42 +202,7 @@ func HandlerFactory(name string, rawParameters *json.Decoder, handle plugin.Hand
 		parameters.Profiles.Encode = defaultEncodeProfile
 	}
 
-	// Resolve PD decider (optional).
-	var pdDecider deciderPlugin
-	if parameters.Deciders.Prefill != "" {
-		p := handle.Plugin(parameters.Deciders.Prefill)
-		if p == nil {
-			return nil, fmt.Errorf("deciders.prefill plugin not found: %s", parameters.Deciders.Prefill)
-		}
-		var ok bool
-		pdDecider, ok = p.(deciderPlugin)
-		if !ok {
-			return nil, fmt.Errorf("plugin %s does not implement prefillDeciderPlugin", parameters.Deciders.Prefill)
-		}
-	} else {
-		logger.Info("No deciders.prefill configured, P/D disaggregation disabled")
-	}
-	// Resolve encode decider (optional).
-	var encodeDecider deciderPlugin
-	if parameters.Deciders.Encode != "" {
-		ep := handle.Plugin(parameters.Deciders.Encode)
-		if ep == nil {
-			return nil, fmt.Errorf("deciders.encode plugin not found: %s", parameters.Deciders.Encode)
-		}
-		var ok bool
-		encodeDecider, ok = ep.(deciderPlugin)
-		if !ok {
-			return nil, fmt.Errorf("plugin %s does not implement encodeDeciderPlugin", parameters.Deciders.Encode)
-		}
-	} else {
-		logger.Info("No deciders.encode configured, E disaggregation disabled")
-	}
-	// Create handler
-	handler := NewDisaggProfileHandler(
-		parameters.Profiles.Decode, parameters.Profiles.Prefill, parameters.Profiles.Encode,
-		pdDecider, encodeDecider,
-	)
-	return handler.WithName(name), nil
+	return parameters, nil
 }
 
 // NewDisaggProfileHandler creates a Handler directly.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -30,15 +30,15 @@ const (
 
 // pdDeciderPlugin interface for pd decider plugins
 
-type pdProfileHandlerParameters struct {
+type PdProfileHandlerParameters struct {
 	DecodeProfile  string `json:"decodeProfile"`
 	PrefillProfile string `json:"prefillProfile"`
 	// Deprecated: This field was never used.
 	PrefixPluginType string `json:"prefixPluginType"`
 	// Deprecated: This field was never used.
-	PrefixPluginName            string `json:"prefixPluginName"`
+	PrefixPluginName            string `json:"prefixPluginName"  pluginRef:""`
 	PrimaryPort                 int    `json:"primaryPort"`
-	DeciderPluginName           string `json:"deciderPluginName"`
+	DeciderPluginName           string `json:"deciderPluginName" pluginRef:""`
 	PrefixMatchInfoProducerName string `json:"prefixMatchInfoProducerName"`
 }
 
@@ -56,21 +56,12 @@ func PdProfileHandlerFactory(name string, rawParameters *json.Decoder, handle pl
 		return nil, err
 	}
 	log.FromContext(handle.Context()).Info("Deprecated: pd-profile-handler is deprecated, use disagg-profile-handler instead")
-	parameters := pdProfileHandlerParameters{
-		DecodeProfile:     defaultDecodeProfile,
-		PrefillProfile:    defaultPrefillProfile,
-		PrimaryPort:       0,
-		DeciderPluginName: defaultDeciderPluginName,
-	}
-	if rawParameters != nil {
-		if err := rawParameters.Decode(&parameters); err != nil {
-			return nil, fmt.Errorf("failed to parse the parameters of the '%s' profile handler - %w", PdProfileHandlerType, err)
-		}
-	}
 
-	if parameters.PrefixPluginName == "" {
-		parameters.PrefixPluginName = parameters.PrefixPluginType
+	tmpParameters, err := PdProfileHandlerConfigParser(rawParameters, handle)
+	if err != nil {
+		return nil, err
 	}
+	parameters := tmpParameters.(PdProfileHandlerParameters)
 
 	if parameters.PrimaryPort != 0 {
 		log.FromContext(handle.Context()).Info("Deprecated: primaryPort not needed with Istio >= 1.28.1")
@@ -103,10 +94,30 @@ func PdProfileHandlerFactory(name string, rawParameters *json.Decoder, handle pl
 
 }
 
+func PdProfileHandlerConfigParser(rawParameters *json.Decoder, handle plugin.Handle) (any, error) {
+	parameters := PdProfileHandlerParameters{
+		DecodeProfile:     defaultDecodeProfile,
+		PrefillProfile:    defaultPrefillProfile,
+		PrimaryPort:       0,
+		DeciderPluginName: defaultDeciderPluginName,
+	}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' profile handler - %w", PdProfileHandlerType, err)
+		}
+	}
+
+	if parameters.PrefixPluginName == "" {
+		parameters.PrefixPluginName = parameters.PrefixPluginType
+	}
+
+	return parameters, nil
+}
+
 // NewPdProfileHandler initializes a new PdProfileHandler and returns its pointer.
 //
 // Deprecated: Use NewDisaggProfileHandler instead.
-func NewPdProfileHandler(name string, parameters pdProfileHandlerParameters, deciderPlugin deciderPlugin) (*PdProfileHandler, error) {
+func NewPdProfileHandler(name string, parameters PdProfileHandlerParameters, deciderPlugin deciderPlugin) (*PdProfileHandler, error) {
 	result := &PdProfileHandler{
 		typedName:      plugin.TypedName{Name: name, Type: PdProfileHandlerType},
 		decodeProfile:  parameters.DecodeProfile,

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
@@ -323,7 +323,7 @@ func TestPdProfileHandler_Pick(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler, err := NewPdProfileHandler(
 				"test-handler",
-				pdProfileHandlerParameters{
+				PdProfileHandlerParameters{
 					PrefillProfile: defaultPrefillProfile,
 					DecodeProfile:  defaultDecodeProfile,
 				},
@@ -423,7 +423,7 @@ func TestPdProfileHandler_PickSeries(t *testing.T) {
 
 			handler, err := NewPdProfileHandler(
 				"test-handler",
-				pdProfileHandlerParameters{
+				PdProfileHandlerParameters{
 					PrefillProfile: defaultPrefillProfile,
 					DecodeProfile:  defaultDecodeProfile,
 				},
@@ -521,7 +521,7 @@ func TestPdProfileHandler_ProcessResults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler, err := NewPdProfileHandler(
 				"test-handler",
-				pdProfileHandlerParameters{
+				PdProfileHandlerParameters{
 					PrefillProfile: defaultPrefillProfile,
 					DecodeProfile:  defaultDecodeProfile,
 					PrimaryPort:    tt.primaryPort,

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -444,7 +444,7 @@ func TestConsumes(t *testing.T) {
 
 	handler, err := NewPdProfileHandler(
 		"test-handler",
-		pdProfileHandlerParameters{
+		PdProfileHandlerParameters{
 			PrefillProfile:              "prefill",
 			DecodeProfile:               "decode",
 			PrefixMatchInfoProducerName: "test",

--- a/pkg/epp/util/utils.go
+++ b/pkg/epp/util/utils.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"slices"
+)
+
+// TopologicalSort performs Kahn's Algorithm on a DAG.
+// It returns the sorted order or an error if a cycle is detected.
+func TopologicalSort(graph map[string][]string) ([]string, error) {
+	// 1. Initialize in-degree map
+	inDegree := make(map[string]int)
+
+	// Ensure all nodes are present in the inDegree map, even those with no dependencies
+	for u, neighbors := range graph {
+		if _, ok := inDegree[u]; !ok {
+			inDegree[u] = 0
+		}
+		for _, v := range neighbors {
+			inDegree[v]++ // Increment in-degree for the destination node
+		}
+	}
+
+	// 2. Initialize the queue with nodes having 0 in-degree
+	var queue []string
+	for node, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, node)
+		}
+	}
+
+	var result []string
+
+	// 3. Process the queue
+	for len(queue) > 0 {
+		// Dequeue
+		u := queue[0]
+		queue = queue[1:]
+
+		result = append(result, u)
+
+		// Decrease in-degree of neighbors
+		if neighbors, ok := graph[u]; ok {
+			for _, v := range neighbors {
+				inDegree[v]--
+				if inDegree[v] == 0 {
+					queue = append(queue, v)
+				}
+			}
+		}
+	}
+
+	// 4. Check for cycles
+	// If the result size != total nodes, there is a cycle
+	if len(result) != len(inDegree) {
+		return nil, errors.New("cycle detected: graph is not a DAG")
+	}
+
+	// Reverse to get the correct order since edges point from consumer to producer
+	slices.Reverse(result)
+	return result, nil
+}

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -65,11 +65,11 @@ plugins:
 - type: encode-filter
 - type: decode-filter
 - type: max-score-picker
-- type: always-disagg-multimodal-decider
 - type: disagg-profile-handler
   parameters:
     deciders:
       encode: always-disagg-multimodal-decider
+- type: always-disagg-multimodal-decider
 schedulingProfiles:
 - name: encode
   plugins:
@@ -94,15 +94,15 @@ plugins:
     lruCapacityPerServer: 256
 - type: prefix-cache-scorer
 - type: max-score-picker
-- type: always-disagg-multimodal-decider
-- type: prefix-based-pd-decider
-  parameters:
-    nonCachedTokens: 16
 - type: disagg-profile-handler
   parameters:
     deciders:
       encode: always-disagg-multimodal-decider
       prefill: prefix-based-pd-decider
+- type: always-disagg-multimodal-decider
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
 schedulingProfiles:
 - name: encode
   plugins:

--- a/test/integration/epp/wellknown_configs_test.go
+++ b/test/integration/epp/wellknown_configs_test.go
@@ -108,10 +108,11 @@ apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: disagg-headers-handler
-- type: always-disagg-pd-decider
 - type: disagg-profile-handler
   parameters:
-    deciderPluginName: always-disagg-pd-decider
+    deciders:
+      prefill: always-disagg-pd-decider
+- type: always-disagg-pd-decider
 - type: prefill-filter
 - type: decode-filter
 - type: prefix-cache-scorer
@@ -162,10 +163,11 @@ apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: disagg-headers-handler
-- type: always-disagg-pd-decider
 - type: disagg-profile-handler
   parameters:
-    deciderPluginName: always-disagg-pd-decider
+    deciders:
+      prefill: always-disagg-pd-decider
+- type: always-disagg-pd-decider
 - type: prefill-filter
 - type: decode-filter
 - type: prefix-cache-scorer


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Today plugins are instantiated in the order they appear in the textual configuration's plugins section.

In most cases this is perfectly fine, however there are plugins that reference other plugins. The noted example is the DisaggProfileHandler. The deprecated PdProfileHandler is similar in nature. For these plugins to work correctly they must be placed in the configuration after any plugins they reference.

This behavior is error prone.

This PR enables plugins to declare the plugins they are dependent on. These dependencies are by name in the dependent plugin's configuration.

See issue #1421 for more details.

**Which issue(s) this PR fixes**:
Fixes #1421 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The need to place the Disaggregation profile handler after its deciders in the plugins list of the configuration profile has been removed.
```
