### PR TITLE
feat: implement DumpState for predicted-latency-producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -75,6 +77,128 @@ type PredictedLatency struct {
 	prefillTokensInFlight        sync.Map // Key: endpoint NamespacedName.String(), Value: *atomic.Int64
 	prefixMatchDataKey           plugin.DataKey
 	latencyPredictionInfoDataKey plugin.DataKey
+}
+
+const maxDebugDumpEndpoints = 100
+
+var _ plugin.StateDumper = &PredictedLatency{}
+
+type predictedLatencyState struct {
+	Endpoints       []endpointPredictedLatencyState `json:"endpoints"`
+	TotalEndpoints  int                             `json:"totalEndpoints"`
+	MaxEndpoints    int                             `json:"maxEndpoints"`
+	Truncated       bool                            `json:"truncated"`
+	TrackedRequests int                             `json:"trackedRequests"`
+}
+
+type endpointPredictedLatencyState struct {
+	Endpoint              string  `json:"endpoint"`
+	RunningRequests       int     `json:"runningRequests"`
+	MinTPOTSLO            float64 `json:"minTpotSlo"`
+	PrefillTokensInFlight int64   `json:"prefillTokensInFlight"`
+}
+
+// DumpState implements [plugin.StateDumper] and exposes per-endpoint running-request
+// counts, the tightest TPOT SLO among them, and prefill tokens in flight for the
+// /debug/plugins/state endpoint.
+//
+// The running-request queues, the prefill-tokens-in-flight counters, and the context
+// store are read under their own separate synchronization, so per-endpoint values are
+// not guaranteed to be from a single instant. This is acceptable for a debug endpoint,
+// where best-effort visibility is preferred over a global lock contending the hot path.
+//
+// Per-request contexts hold request payloads and are high-cardinality, so only their
+// count is reported. The endpoint list is capped to the busiest endpoints.
+func (pl *PredictedLatency) DumpState() (json.RawMessage, error) {
+	return json.Marshal(pl.snapshotState())
+}
+
+func (pl *PredictedLatency) snapshotState() predictedLatencyState {
+	type agg struct {
+		running int
+		minTPOT float64
+		prefill int64
+	}
+	endpoints := map[string]*agg{}
+	get := func(id string) *agg {
+		a, ok := endpoints[id]
+		if !ok {
+			a = &agg{}
+			endpoints[id] = a
+		}
+		return a
+	}
+
+	pl.runningRequestLists.Range(func(key, value any) bool {
+		name, ok := key.(types.NamespacedName)
+		if !ok {
+			return true
+		}
+		q, ok := value.(*requestPriorityQueue)
+		if !ok || q == nil {
+			return true
+		}
+		a := get(name.String())
+		a.running = q.GetSize()
+		if minReq := q.Peek(); minReq != nil {
+			// Client headers can yield NaN/+Inf TPOT (strconv.ParseFloat accepts
+			// them and Add only rejects negatives). json.Marshal errors on
+			// non-finite floats, which would fail the whole debug response, so
+			// coerce them to 0.
+			if tpot := minReq.tpot; !math.IsNaN(tpot) && !math.IsInf(tpot, 0) {
+				a.minTPOT = tpot
+			}
+		}
+		return true
+	})
+
+	pl.prefillTokensInFlight.Range(func(key, value any) bool {
+		id, ok := key.(string)
+		if !ok {
+			return true
+		}
+		c, ok := value.(*atomic.Int64)
+		if !ok || c == nil {
+			return true
+		}
+		get(id).prefill = c.Load()
+		return true
+	})
+
+	trackedRequests := 0
+	if pl.sloContextStore != nil {
+		trackedRequests = pl.sloContextStore.Len()
+	}
+
+	state := predictedLatencyState{
+		Endpoints:       make([]endpointPredictedLatencyState, 0, len(endpoints)),
+		TotalEndpoints:  len(endpoints),
+		MaxEndpoints:    maxDebugDumpEndpoints,
+		TrackedRequests: trackedRequests,
+	}
+	for id, a := range endpoints {
+		state.Endpoints = append(state.Endpoints, endpointPredictedLatencyState{
+			Endpoint:              id,
+			RunningRequests:       a.running,
+			MinTPOTSLO:            a.minTPOT,
+			PrefillTokensInFlight: a.prefill,
+		})
+	}
+
+	sort.SliceStable(state.Endpoints, func(i, j int) bool {
+		iLoad := int64(state.Endpoints[i].RunningRequests) + state.Endpoints[i].PrefillTokensInFlight
+		jLoad := int64(state.Endpoints[j].RunningRequests) + state.Endpoints[j].PrefillTokensInFlight
+		if iLoad != jLoad {
+			return iLoad > jLoad
+		}
+		return state.Endpoints[i].Endpoint < state.Endpoints[j].Endpoint
+	})
+	if len(state.Endpoints) > maxDebugDumpEndpoints {
+		state.Endpoints = state.Endpoints[:maxDebugDumpEndpoints]
+		state.Truncated = true
+	}
+
+	return state
 }
 
 // endpointCounter returns the atomic counter for the given endpoint key, creating it if necessary.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -20,11 +20,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	latencypredictor "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
@@ -468,4 +472,134 @@ func TestSloContextStoreEviction(t *testing.T) {
 	item = pl.sloContextStore.Get(requestID)
 	assert.Nil(t, item, "Item should have been evicted from cache")
 	assert.False(t, queue.Contains(requestID), "Request should be removed from queue via OnEviction")
+}
+
+func dumpSeedQueue(ids map[string]float64) *requestPriorityQueue {
+	q := newRequestPriorityQueue()
+	for id, tpot := range ids {
+		q.Add(id, tpot)
+	}
+	return q
+}
+
+func dumpNN(name string) types.NamespacedName {
+	return types.NamespacedName{Name: name, Namespace: "default"}
+}
+
+func TestPredictedLatency_DumpState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populated sorted by busyness", func(t *testing.T) {
+		pl := &PredictedLatency{}
+		pl.runningRequestLists.Store(dumpNN("pod-a"), dumpSeedQueue(map[string]float64{"r1": 5, "r2": 5}))
+		pl.runningRequestLists.Store(dumpNN("pod-b"), dumpSeedQueue(map[string]float64{"r3": 9}))
+		c := new(atomic.Int64)
+		c.Store(30)
+		pl.prefillTokensInFlight.Store(dumpNN("pod-b").String(), c)
+
+		payload, err := pl.DumpState()
+		require.NoError(t, err)
+		require.True(t, json.Valid(payload))
+
+		var state predictedLatencyState
+		require.NoError(t, json.Unmarshal(payload, &state))
+		require.Equal(t, predictedLatencyState{
+			Endpoints: []endpointPredictedLatencyState{
+				{Endpoint: dumpNN("pod-b").String(), RunningRequests: 1, MinTPOTSLO: 9, PrefillTokensInFlight: 30},
+				{Endpoint: dumpNN("pod-a").String(), RunningRequests: 2, MinTPOTSLO: 5, PrefillTokensInFlight: 0},
+			},
+			TotalEndpoints: 2,
+			MaxEndpoints:   maxDebugDumpEndpoints,
+		}, state)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		pl := &PredictedLatency{}
+		payload, err := pl.DumpState()
+		require.NoError(t, err)
+		var state predictedLatencyState
+		require.NoError(t, json.Unmarshal(payload, &state))
+		require.Empty(t, state.Endpoints)
+		require.Equal(t, 0, state.TotalEndpoints)
+		require.Equal(t, maxDebugDumpEndpoints, state.MaxEndpoints)
+		require.False(t, state.Truncated)
+		require.Equal(t, 0, state.TrackedRequests)
+	})
+
+	t.Run("merge across maps", func(t *testing.T) {
+		pl := &PredictedLatency{}
+		pl.runningRequestLists.Store(dumpNN("pod-a"), dumpSeedQueue(map[string]float64{"r1": 3}))
+		c := new(atomic.Int64)
+		c.Store(40)
+		pl.prefillTokensInFlight.Store(dumpNN("pod-b").String(), c)
+
+		var state predictedLatencyState
+		payload, err := pl.DumpState()
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(payload, &state))
+		require.Equal(t, 2, state.TotalEndpoints)
+		// pod-b busier (40) sorts first; pod-a has prefill 0, pod-b has running 0.
+		require.Equal(t, dumpNN("pod-b").String(), state.Endpoints[0].Endpoint)
+		require.Equal(t, int64(40), state.Endpoints[0].PrefillTokensInFlight)
+		require.Equal(t, 0, state.Endpoints[0].RunningRequests)
+		require.Equal(t, dumpNN("pod-a").String(), state.Endpoints[1].Endpoint)
+		require.Equal(t, 1, state.Endpoints[1].RunningRequests)
+		require.Equal(t, int64(0), state.Endpoints[1].PrefillTokensInFlight)
+	})
+
+	t.Run("caps endpoints", func(t *testing.T) {
+		pl := &PredictedLatency{}
+		for i := range maxDebugDumpEndpoints + 5 {
+			c := new(atomic.Int64)
+			c.Store(int64(i))
+			pl.prefillTokensInFlight.Store(dumpNN(fmt.Sprintf("pod-%03d", i)).String(), c)
+		}
+		var state predictedLatencyState
+		payload, err := pl.DumpState()
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(payload, &state))
+		require.True(t, state.Truncated)
+		require.Equal(t, maxDebugDumpEndpoints+5, state.TotalEndpoints)
+		require.Len(t, state.Endpoints, maxDebugDumpEndpoints)
+		require.Equal(t, int64(maxDebugDumpEndpoints+4), state.Endpoints[0].PrefillTokensInFlight)
+	})
+
+	t.Run("tracked requests count", func(t *testing.T) {
+		pl := &PredictedLatency{}
+		pl.sloContextStore = ttlcache.New(ttlcache.WithTTL[string, *predictedLatencyCtx](time.Minute))
+		pl.sloContextStore.Set("req-1", &predictedLatencyCtx{}, ttlcache.DefaultTTL)
+		pl.sloContextStore.Set("req-2", &predictedLatencyCtx{}, ttlcache.DefaultTTL)
+
+		var state predictedLatencyState
+		payload, err := pl.DumpState()
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(payload, &state))
+		require.Equal(t, 2, state.TrackedRequests)
+		require.Empty(t, state.Endpoints)
+	})
+
+	// Non-finite head TPOT (NaN / +Inf) must not break json.Marshal; it is coerced to 0.
+	t.Run("non-finite min tpot sanitized", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			tpot float64
+		}{
+			{"nan", math.NaN()},
+			{"posinf", math.Inf(1)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				pl := &PredictedLatency{}
+				pl.runningRequestLists.Store(dumpNN("pod-a"), dumpSeedQueue(map[string]float64{"r1": tc.tpot}))
+
+				payload, err := pl.DumpState()
+				require.NoError(t, err)
+				require.True(t, json.Valid(payload))
+				var state predictedLatencyState
+				require.NoError(t, json.Unmarshal(payload, &state))
+				require.Len(t, state.Endpoints, 1)
+				require.Equal(t, float64(0), state.Endpoints[0].MinTPOTSLO)
+				require.Equal(t, 1, state.Endpoints[0].RunningRequests)
+			})
+		}
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `plugin.StateDumper` to the predicted-latency data producer so the runtime
state it maintains can be inspected through `GET /debug/plugins/state`, the same
way the `inflight-load-producer` already exposes its state.

`DumpState` reports, per endpoint, the number of running requests, the tightest
(minimum) TPOT SLO among them, and prefill tokens in flight. Endpoints are sorted
by busyness (running requests plus prefill tokens in flight) and capped at 100
with a `truncated` flag so the payload stays bounded. Per-request SLO contexts
hold request payloads and are high-cardinality, so only their count
(`trackedRequests`) is reported, never their contents.

The running-request queues, the prefill-tokens-in-flight counters, and the
context store are read under their own separate synchronization, so per-endpoint
values are best-effort rather than a single global instant. This is acceptable
for a debug endpoint, and avoids a global lock on the request hot path. Non-finite
TPOT values that a client could inject via headers are coerced to 0 so a single
bad request cannot fail the whole debug response.

Example response for this plugin:

```json
{"endpoints":[{"endpoint":"default/pod-a","runningRequests":3,"minTpotSlo":0.03,"prefillTokensInFlight":128},{"endpoint":"default/pod-b","runningRequests":1,"minTpotSlo":0.05,"prefillTokensInFlight":0}],"totalEndpoints":2,"maxEndpoints":100,"truncated":false,"trackedRequests":4}
```

Part of #1755.

**Which issue(s) this PR fixes**:

Fixes #1782

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Testing**:

New unit tests, all passing:
- [x] Populated state is reported per endpoint and sorted by busyness
- [x] Running-request counts, min TPOT SLO, and prefill tokens are merged across the separate maps
- [x] The endpoint list is capped with the truncated flag set, keeping the busiest endpoints
- [x] Tracked-request count reflects the SLO context store
- [x] Non-finite (NaN/+Inf) min TPOT values are sanitized to 0 so JSON marshaling never fails
- [x] A zero-value producer with no tracked state returns valid JSON without panicking
