### PR TITLE
feat: add EPP podAnnotations passthrough to router Helm chart

### DIFF
--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -25,6 +25,10 @@ spec:
       labels:
         {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
         {{- include "llm-d-router.modeLabels" . | nindent 8 }}
+      {{- with .Values.router.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict }}
       {{- $proxyType := include "llm-d-router.proxyType" . | trim }}

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       labels:
         {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
         {{- include "llm-d-router.modeLabels" . | nindent 8 }}
-      {{- with .Values.router.podAnnotations }}
+      {{- with .Values.router.epp.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -123,12 +123,18 @@ monitoring:
   prometheus:
     enabled: false
     auth:
-      # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
+      # Set to false to allow unauthenticated /metrics access. Required for annotation-based
+      # Prometheus scraping and Istio metrics-merging, which do not send Bearer tokens.
       enabled: true
       # Service account token secret for authentication
       secretName: inference-gateway-sa-metrics-reader-secret
     # additional labels for the ServiceMonitor
     extraLabels: {}
+
+# Annotations added to the EPP pod template. Useful for clusters that rely on
+# annotation-based Prometheus scraping (prometheus.io/{scrape,port,path}) or
+# Istio metrics-merging, rather than a ServiceMonitor or GMP.
+podAnnotations: {}
 
 tracing:
   enabled: false

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -67,6 +67,11 @@ epp:
   affinity: {}
   tolerations: []
 
+  # Annotations added to the EPP pod template. Useful for clusters that rely on
+  # annotation-based Prometheus scraping (prometheus.io/{scrape,port,path}) or
+  # Istio metrics-merging, rather than a ServiceMonitor or GMP.
+  podAnnotations: {}
+
 # By default no proxy is configured
 proxy:
   enabled: false    
@@ -130,11 +135,6 @@ monitoring:
       secretName: inference-gateway-sa-metrics-reader-secret
     # additional labels for the ServiceMonitor
     extraLabels: {}
-
-# Annotations added to the EPP pod template. Useful for clusters that rely on
-# annotation-based Prometheus scraping (prometheus.io/{scrape,port,path}) or
-# Istio metrics-merging, rather than a ServiceMonitor or GMP.
-podAnnotations: {}
 
 tracing:
   enabled: false


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables passing custom pod annotations for EPP, mainly to enable annotation-based Prometheus scraping (`prometheus.io/{scrape,port,path}`) and Istio metrics-merging of EPP metrics on clusters without the Prometheus Operator or GMP. Annotation-based scraping remains widely used and could be still the default in many self-managed/cloud-provider k8s environments. A `podAnnotations` passthrough is a common pattern in production Helm charts, providing a generic workaround for cluster-specific annotations the chart does not explicitly model.

**Which issue(s) this PR fixes**:
(none)

**Release note**:
```release-note
Helm: added `router.podAnnotations` passthrough to the EPP pod template. Enables annotation-based Prometheus scraping and istio metrics-merging on clusters without the Prometheus Operator or GMP. Empty by default. Requires `router.monitoring.prometheus.auth.enabled: false` when used for metrics scraping.
```