### PR TITLE
feat: replay buffer consumer for KV event index recovery

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -73,17 +73,22 @@ func (p *Producer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMet
 	endpointKey := meta.ID.String()
 	port := p.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
 	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
+	replayEndpoint := ""
+	if replayPort := p.kvEventsConfig.PodDiscoveryConfig.EffectiveReplayPort(); replayPort > 0 {
+		replayEndpoint = fmt.Sprintf("tcp://%s:%d", meta.Address, replayPort+meta.GetRankIndex())
+	}
 	sourceEndpoint := fmt.Sprintf("%s:%s", meta.Address, meta.Port)
 
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
 	// subscriberCtx is plugin-lifetime; caller ctx would tear subscribers
 	// down on request completion.
 	if err := p.subscribersManager.EnsureSubscriber(p.subscriberCtx, endpointKey,
-		sourceEndpoint, zmqEndpoint, p.kvEventsConfig.TopicFilter, true); err != nil {
+		sourceEndpoint, zmqEndpoint, replayEndpoint, p.kvEventsConfig.TopicFilter, true); err != nil {
 		logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",
 			"endpoint", endpointKey, "address", meta.Address)
 		return fmt.Errorf("ensure subscriber for %s: %w", endpointKey, err)
 	}
-	logger.V(logging.DEBUG).Info("Ensured KV-events subscriber", "endpoint", endpointKey, "zmq", zmqEndpoint)
+	logger.V(logging.DEBUG).Info("Ensured KV-events subscriber",
+		"endpoint", endpointKey, "zmq", zmqEndpoint, "replay", replayEndpoint)
 	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -75,7 +75,7 @@ var (
 type subscriberManager interface {
 	EnsureSubscriber(
 		ctx context.Context,
-		podIdentifier, sourceEndpoint, endpoint, topicFilter string,
+		podIdentifier, sourceEndpoint, endpoint, replayEndpoint, topicFilter string,
 		remoteSocket bool,
 	) error
 	RemoveSubscriber(ctx context.Context, podIdentifier string)
@@ -192,7 +192,7 @@ func New(ctx context.Context, name string, config PluginConfig) (*Producer, erro
 	subscribersManager := kvevents.NewSubscriberManager(pool)
 	if config.KVEventsConfig.ZMQEndpoint != "" {
 		if err := subscribersManager.EnsureSubscriber(ctx, "local-subscriber", "",
-			config.KVEventsConfig.ZMQEndpoint, config.KVEventsConfig.TopicFilter, false); err != nil {
+			config.KVEventsConfig.ZMQEndpoint, "", config.KVEventsConfig.TopicFilter, false); err != nil {
 			return nil, fmt.Errorf("failed to create local subscriber for global socket mode: %w", err)
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -764,7 +764,7 @@ type fakeSubscriberManager struct {
 
 func (f *fakeSubscriberManager) EnsureSubscriber(
 	_ context.Context,
-	id, sourceEndpoint, endpoint, _ string,
+	id, sourceEndpoint, endpoint, _, _ string,
 	_ bool,
 ) error {
 	f.ids = append(f.ids, id)

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -65,6 +65,8 @@ type RawMessage struct {
 	Payload []byte
 	// SourceEndpoint is the serving endpoint associated with the subscriber.
 	SourceEndpoint string
+	// reset clears the message's pod before later messages on the same queue.
+	reset bool
 }
 
 // EngineAdapter defines the interface for engine-specific message parsers.

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -78,6 +78,18 @@ type PodDiscoveryConfig struct {
 	// The reconciler will connect to tcp://<PodIP>:<SocketPort>
 	// Default: 5557
 	SocketPort int `json:"socketPort"`
+	// ReplaySocketPort is the port where vLLM pods expose their ZMQ ROUTER
+	// socket for replay requests. Disabled when not set (0 or negative).
+	ReplaySocketPort int `json:"replaySocketPort,omitempty"`
+}
+
+// EffectiveReplayPort returns the replay socket port.
+// Returns -1 (disabled) when not explicitly configured.
+func (c *PodDiscoveryConfig) EffectiveReplayPort() int {
+	if c.ReplaySocketPort <= 0 {
+		return -1
+	}
+	return c.ReplaySocketPort
 }
 
 // DefaultPodReconcilerConfig returns a default configuration for the pod reconciler.
@@ -220,6 +232,11 @@ func (p *Pool) AddTask(task *RawMessage) {
 	p.addQueueDepth(1)
 }
 
+// resetForSource queues a pod reset on the same shard as its event stream.
+func (p *Pool) resetForSource(topic, sourceEndpoint string) {
+	p.AddTask(&RawMessage{Topic: topic, SourceEndpoint: sourceEndpoint, reset: true})
+}
+
 // worker is the main processing loop for a single worker goroutine.
 // It processes messages from its dedicated queue using the workqueue pattern.
 func (p *Pool) worker(ctx context.Context, workerIndex int) {
@@ -252,6 +269,14 @@ func (p *Pool) worker(ctx context.Context, workerIndex int) {
 // processRawMessage decodes the raw message payload using the adapter and processes the resulting event batch.
 func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 	logger := log.FromContext(ctx)
+	if msg.reset {
+		podID := msg.SourceEndpoint
+		if podID == "" {
+			podID = p.adapter.ShardingKey(msg)
+		}
+		p.clearPod(ctx, podID)
+		return
+	}
 
 	podID, modelName, batch, err := p.adapter.ParseMessage(msg)
 	if err != nil {
@@ -263,6 +288,15 @@ func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 	}
 
 	p.processEventBatch(ctx, &batch, podID, modelName)
+}
+
+func (p *Pool) clearPod(ctx context.Context, podIdentifier string) {
+	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
+	if err := p.index.Clear(ctx, podIdentifier); err != nil {
+		debugLogger.Error(err, "Failed to clear pod from index",
+			"podIdentifier", podIdentifier)
+	}
+	p.dedup.clear(podIdentifier)
 }
 
 // realignExtraFeatures converts per-engine-block extra features to per-canonical-block
@@ -555,13 +589,7 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 					"anyway (tier-scoped clear is not supported)",
 					"podIdentifier", podIdentifier, "deviceTier", ev.DeviceTier)
 			}
-			if err := p.index.Clear(ctx, podIdentifier); err != nil {
-				debugLogger.Error(err, "Failed to clear pod from index",
-					"podIdentifier", podIdentifier)
-			}
-			// Reset reference counts for this pod in lockstep with the index's
-			// pod-wide eager clear, so no stale references survive the reset.
-			p.dedup.clear(podIdentifier)
+			p.clearPod(ctx, podIdentifier)
 
 		default:
 			debugLogger.Info("Unknown event", "podIdentifier", podIdentifier, "event", genericEvent)

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -1231,3 +1231,25 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 	require.NoError(t, c.Write(&m))
 	return m.GetCounter().GetValue()
 }
+
+func TestEffectiveReplayPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		socketPort int
+		replayPort int
+		want       int
+	}{
+		{"disabled by default", 5556, 0, -1},
+		{"explicit value", 5556, 6000, 6000},
+		{"negative disabled", 5556, -1, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &PodDiscoveryConfig{
+				SocketPort:       tt.socketPort,
+				ReplaySocketPort: tt.replayPort,
+			}
+			assert.Equal(t, tt.want, cfg.EffectiveReplayPort())
+		})
+	}
+}

--- a/pkg/kvevents/subscriber_manager.go
+++ b/pkg/kvevents/subscriber_manager.go
@@ -38,6 +38,7 @@ type subscriberEntry struct {
 	cancel         context.CancelFunc
 	endpoint       string
 	sourceEndpoint string
+	replayEndpoint string
 	// done is closed once the subscriber's goroutine has returned.
 	done chan struct{}
 }
@@ -51,12 +52,12 @@ func NewSubscriberManager(pool *Pool) *SubscriberManager {
 }
 
 // EnsureSubscriber ensures a subscriber exists for the given pod.
-// If the subscriber already exists with the same transport and source
-// endpoints, it's a no-op. If either endpoint changed, the old subscriber is
+// If the subscriber already exists with the same transport, source, and replay
+// endpoints, it's a no-op. If an endpoint changed, the old subscriber is
 // removed and a new one is created.
 func (sm *SubscriberManager) EnsureSubscriber(
 	ctx context.Context,
-	podIdentifier, sourceEndpoint, endpoint, topicFilter string,
+	podIdentifier, sourceEndpoint, endpoint, replayEndpoint, topicFilter string,
 	remoteSocket bool,
 ) error {
 	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
@@ -66,7 +67,8 @@ func (sm *SubscriberManager) EnsureSubscriber(
 
 	// Check if subscriber already exists
 	if entry, exists := sm.subscribers[podIdentifier]; exists {
-		if entry.endpoint == endpoint && entry.sourceEndpoint == sourceEndpoint {
+		if entry.endpoint == endpoint && entry.sourceEndpoint == sourceEndpoint &&
+			entry.replayEndpoint == replayEndpoint {
 			// Subscriber already exists with the same endpoint, nothing to do
 			debugLogger.V(logging.TRACE).Info("Subscriber already exists", "podIdentifier", podIdentifier, "endpoint", endpoint)
 			return nil
@@ -77,7 +79,9 @@ func (sm *SubscriberManager) EnsureSubscriber(
 			"oldEndpoint", entry.endpoint,
 			"newEndpoint", endpoint,
 			"oldSourceEndpoint", entry.sourceEndpoint,
-			"newSourceEndpoint", sourceEndpoint)
+			"newSourceEndpoint", sourceEndpoint,
+			"oldReplayEndpoint", entry.replayEndpoint,
+			"newReplayEndpoint", replayEndpoint)
 		entry.cancel()
 		delete(sm.subscribers, podIdentifier)
 		// The replacement subscriber below reuses podIdentifier, so its series
@@ -86,7 +90,8 @@ func (sm *SubscriberManager) EnsureSubscriber(
 
 	// Create new subscriber
 	debugLogger.Info("Creating new subscriber", "podIdentifier", podIdentifier, "endpoint", endpoint)
-	subscriber := newZMQSubscriber(sm.pool, podIdentifier, sourceEndpoint, endpoint, topicFilter, remoteSocket)
+	subscriber := newZMQSubscriber(
+		sm.pool, podIdentifier, sourceEndpoint, endpoint, replayEndpoint, topicFilter, remoteSocket)
 
 	// Create a context and start subscriber
 	subCtx, cancel := context.WithCancel(ctx)
@@ -102,6 +107,7 @@ func (sm *SubscriberManager) EnsureSubscriber(
 		cancel:         cancel,
 		endpoint:       endpoint,
 		sourceEndpoint: sourceEndpoint,
+		replayEndpoint: replayEndpoint,
 		done:           done,
 	}
 	metrics.SubscriberActive.Set(float64(len(sm.subscribers)))

--- a/pkg/kvevents/subscriber_manager_test.go
+++ b/pkg/kvevents/subscriber_manager_test.go
@@ -47,7 +47,7 @@ func TestSubscriberManager_EnsureSubscriber(t *testing.T) {
 	endpoint := "tcp://127.0.0.1:5557"
 	topicFilter := "kv@"
 
-	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, topicFilter, true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, "", topicFilter, true)
 	assert.NoError(t, err)
 
 	identifiers, endpoints := sm.GetActiveSubscribers()
@@ -56,7 +56,7 @@ func TestSubscriberManager_EnsureSubscriber(t *testing.T) {
 	assert.Contains(t, endpoints, endpoint)
 
 	// Ensure with same endpoint should be no-op
-	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, topicFilter, true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, "", topicFilter, true)
 	assert.NoError(t, err)
 	identifiers, _ = sm.GetActiveSubscribers()
 	assert.Len(t, identifiers, 1)
@@ -84,7 +84,7 @@ func TestSubscriberManager_RemoveSubscriber(t *testing.T) {
 	endpoint := "tcp://127.0.0.1:5557"
 	topicFilter := "kv@"
 
-	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, topicFilter, true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, "", topicFilter, true)
 	require.NoError(t, err)
 
 	sm.RemoveSubscriber(ctx, podID)
@@ -121,7 +121,7 @@ func TestSubscriberManager_MultipleSubscribers(t *testing.T) {
 	}
 
 	for _, pod := range pods {
-		err := sm.EnsureSubscriber(ctx, pod.id, "", pod.endpoint, "kv@", true)
+		err := sm.EnsureSubscriber(ctx, pod.id, "", pod.endpoint, "", "kv@", true)
 		require.NoError(t, err)
 	}
 
@@ -163,12 +163,12 @@ func TestSubscriberManager_EndpointChange(t *testing.T) {
 	endpoint1 := "tcp://10.0.0.1:5557"
 	endpoint2 := "tcp://10.0.0.2:5557"
 
-	err = sm.EnsureSubscriber(ctx, podID, "", endpoint1, "kv@", true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint1, "", "kv@", true)
 	require.NoError(t, err)
 	identifiers, _ := sm.GetActiveSubscribers()
 	assert.Len(t, identifiers, 1)
 
-	err = sm.EnsureSubscriber(ctx, podID, "", endpoint2, "kv@", true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint2, "", "kv@", true)
 	require.NoError(t, err)
 
 	identifiers, endpoints := sm.GetActiveSubscribers()
@@ -202,7 +202,7 @@ func TestSubscriberManager_ConcurrentOperations(t *testing.T) {
 			defer func() { done <- true }()
 			podID := fmt.Sprintf("default/pod-%d", id)
 			endpoint := fmt.Sprintf("tcp://10.0.0.%d:5557", id)
-			if err := sm.EnsureSubscriber(ctx, podID, "", endpoint, "kv@", true); err != nil {
+			if err := sm.EnsureSubscriber(ctx, podID, "", endpoint, "", "kv@", true); err != nil {
 				t.Errorf("failed to add subscriber %s: %v", podID, err)
 			}
 		}(i)

--- a/pkg/kvevents/zmq_subscriber.go
+++ b/pkg/kvevents/zmq_subscriber.go
@@ -27,8 +27,10 @@ import (
 )
 
 const (
-	// How long to wait before retrying to connect.
-	retryInterval = 5 * time.Second
+	retryInterval       = 5 * time.Second
+	replayTimeout       = 30 * time.Second
+	replaySocketTimeout = 10 * time.Second
+	replayCooldown      = 30 * time.Second
 )
 
 // zmqSubscriber connects to a ZMQ publisher and forwards messages to a pool.
@@ -37,20 +39,43 @@ type zmqSubscriber struct {
 	podIdentifier  string
 	sourceEndpoint string
 	endpoint       string
+	replayEndpoint string
 	remote         bool
 	topicFilter    string
+
+	// Replay state persists across reconnections within subscriber lifetime.
+	lastSeq           uint64
+	hasLastSeq        bool
+	lastLiveSeq       uint64
+	hasLastLiveSeq    bool
+	lastReplayFailure time.Time
 }
 
 // newZMQSubscriber creates a new ZMQ subscriber.
-func newZMQSubscriber(pool *Pool, podIdentifier, sourceEndpoint, endpoint, topicFilter string, remote bool) *zmqSubscriber {
+func newZMQSubscriber(
+	pool *Pool,
+	podIdentifier, sourceEndpoint, endpoint, replayEndpoint, topicFilter string,
+	remote bool,
+) *zmqSubscriber {
 	return &zmqSubscriber{
 		pool:           pool,
 		podIdentifier:  podIdentifier,
 		sourceEndpoint: sourceEndpoint,
 		endpoint:       endpoint,
+		replayEndpoint: replayEndpoint,
 		remote:         remote,
 		topicFilter:    topicFilter,
 	}
+}
+
+// parseEventFrame validates and extracts a live or replayed event frame.
+//
+//nolint:gocritic // unnamedResult conflicts with nonamedreturns
+func parseEventFrame(frames [][]byte) (string, uint64, []byte, bool) {
+	if len(frames) != 3 || len(frames[1]) < 8 {
+		return "", 0, nil, false
+	}
+	return string(frames[0]), binary.BigEndian.Uint64(frames[1]), frames[2], true
 }
 
 // Start connects to a ZMQ PUB socket as a SUB, receives messages,
@@ -116,44 +141,185 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 		return
 	}
 
-	debugLogger := logger.V(logging.DEBUG)
+	// Rebuild the index from buffered events without waiting for live traffic.
+	if z.replayEndpoint != "" && !z.hasLastSeq && z.canAttemptReplay() {
+		logger.Info("Requesting proactive replay on connect",
+			"endpoint", z.endpoint, "replayEndpoint", z.replayEndpoint)
+		z.requestReplay(ctx, 0)
+	}
 
+	debugLogger := logger.V(logging.DEBUG)
 	for {
 		msg, err := sub.Recv()
 		if err != nil {
 			if ctx.Err() != nil {
-				return // context cancelled, clean shutdown
+				return
 			}
 			metrics.ZMQErrors.WithLabelValues(z.podIdentifier, "recv").Inc()
 			debugLogger.Error(err, "Failed to receive message from zmq subscriber", "endpoint", z.endpoint)
-			return // exit to trigger reconnect
+			return
 		}
 		metrics.MessagesReceived.WithLabelValues(z.podIdentifier).Inc()
-		parts := msg.Frames
-		if len(parts) != 3 {
-			debugLogger.Error(nil, "Unexpected frame count", "got", len(parts), "want", 3)
+		topic, seq, payload, ok := parseEventFrame(msg.Frames)
+		if !ok {
+			debugLogger.Error(nil, "Malformed event frame",
+				"frameCount", len(msg.Frames), "endpoint", z.endpoint)
 			continue
 		}
-		topic := string(parts[0])
-		seqBytes := parts[1]
-		payload := parts[2]
 
-		if len(seqBytes) < 8 {
-			debugLogger.Error(nil, "Sequence frame too short", "got", len(seqBytes), "want", 8, "topic", topic, "endpoint", z.endpoint)
+		if z.replayEndpoint == "" {
+			z.addTask(topic, seq, payload)
 			continue
 		}
-		seq := binary.BigEndian.Uint64(seqBytes)
+
+		replayAttempted := false
+		if z.hasLastLiveSeq && seq < z.lastLiveSeq {
+			logger.Info("Detected event sequence reset, rebuilding index",
+				"lastLiveSeq", z.lastLiveSeq, "currentSeq", seq,
+				"endpoint", z.endpoint)
+			z.pool.resetForSource(topic, z.sourceEndpoint)
+			z.lastSeq = 0
+			z.hasLastSeq = false
+			z.lastReplayFailure = time.Time{}
+			replayAttempted = true
+			z.requestReplay(ctx, 0)
+		}
+
+		if z.hasLastLiveSeq && seq == z.lastLiveSeq {
+			continue
+		}
+		z.lastLiveSeq = seq
+		z.hasLastLiveSeq = true
+
+		if z.hasLastSeq && seq <= z.lastSeq {
+			continue
+		}
+
+		if z.hasLastSeq && seq > z.lastSeq+1 {
+			missed := seq - z.lastSeq - 1
+			if !z.canAttemptReplay() {
+				debugLogger.Info("Dropping event while replay is in cooldown",
+					"lastSeq", z.lastSeq, "currentSeq", seq, "missed", missed,
+					"endpoint", z.endpoint)
+				continue
+			}
+			logger.Info("Detected gap in event sequence, requesting replay",
+				"lastSeq", z.lastSeq, "currentSeq", seq, "missed", missed,
+				"endpoint", z.endpoint)
+			replayAttempted = true
+			if !z.requestReplay(ctx, z.lastSeq+1) {
+				continue
+			}
+		}
+
+		if !z.hasLastSeq && seq > 0 {
+			if replayAttempted || !z.canAttemptReplay() {
+				continue
+			}
+			logger.Info("Joining mid-stream, requesting full replay",
+				"currentSeq", seq, "endpoint", z.endpoint)
+			if !z.requestReplay(ctx, 0) {
+				continue
+			}
+		}
+
+		if z.hasLastSeq {
+			if seq <= z.lastSeq || seq > z.lastSeq+1 {
+				continue
+			}
+		}
 
 		debugLogger.V(logging.TRACE).Info("Received message from zmq subscriber",
-			"topic", topic,
-			"seq", seq,
-			"payloadSize", len(payload))
-
-		z.pool.AddTask(&RawMessage{
-			Topic:          topic,
-			Sequence:       seq,
-			Payload:        payload,
-			SourceEndpoint: z.sourceEndpoint,
-		})
+			"topic", topic, "seq", seq, "payloadSize", len(payload))
+		z.addTask(topic, seq, payload)
+		z.lastSeq = seq
+		z.hasLastSeq = true
 	}
+}
+
+func (z *zmqSubscriber) addTask(topic string, seq uint64, payload []byte) {
+	z.pool.AddTask(&RawMessage{
+		Topic:          topic,
+		Sequence:       seq,
+		Payload:        payload,
+		SourceEndpoint: z.sourceEndpoint,
+	})
+}
+
+func (z *zmqSubscriber) canAttemptReplay() bool {
+	return z.lastReplayFailure.IsZero() || time.Since(z.lastReplayFailure) >= replayCooldown
+}
+
+// requestReplay requests buffered events starting from startSeq.
+func (z *zmqSubscriber) requestReplay(ctx context.Context, startSeq uint64) bool {
+	logger := log.FromContext(ctx).WithName("zmq-replay")
+	replayCtx, cancel := context.WithTimeout(ctx, replayTimeout)
+	defer cancel()
+
+	dealer := zmq4.NewDealer(replayCtx, zmq4.WithTimeout(replaySocketTimeout))
+	defer dealer.Close()
+	if err := dealer.Dial(z.replayEndpoint); err != nil {
+		z.lastReplayFailure = time.Now()
+		logger.Error(err, "Failed to connect replay socket",
+			"replayEndpoint", z.replayEndpoint)
+		return false
+	}
+
+	seqBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(seqBytes, startSeq)
+	if err := dealer.SendMulti(zmq4.NewMsgFrom([]byte{}, seqBytes)); err != nil {
+		z.lastReplayFailure = time.Now()
+		logger.Error(err, "Failed to send replay request",
+			"startSeq", startSeq, "replayEndpoint", z.replayEndpoint)
+		return false
+	}
+
+	replayed := 0
+	for {
+		select {
+		case <-replayCtx.Done():
+			z.lastReplayFailure = time.Now()
+			logger.Info("Replay timed out",
+				"replayed", replayed, "replayEndpoint", z.replayEndpoint)
+			return false
+		default:
+		}
+
+		msg, err := dealer.Recv()
+		if err != nil {
+			z.lastReplayFailure = time.Now()
+			logger.Error(err, "Failed to receive replay message",
+				"replayed", replayed, "replayEndpoint", z.replayEndpoint)
+			return false
+		}
+
+		frames := msg.Frames
+		if len(frames) > 0 && len(frames[0]) == 0 {
+			frames = frames[1:]
+		}
+		if len(frames) == 3 && len(frames[2]) == 0 {
+			break
+		}
+
+		topic, seq, payload, ok := parseEventFrame(frames)
+		if !ok {
+			z.lastReplayFailure = time.Now()
+			logger.Error(nil, "Malformed replay frame",
+				"frameCount", len(frames), "replayed", replayed)
+			return false
+		}
+		if z.hasLastSeq && seq <= z.lastSeq {
+			continue
+		}
+
+		z.addTask(topic, seq, payload)
+		z.lastSeq = seq
+		z.hasLastSeq = true
+		replayed++
+	}
+
+	z.lastReplayFailure = time.Time{}
+	logger.Info("Replay complete", "replayed", replayed,
+		"startSeq", startSeq, "replayEndpoint", z.replayEndpoint)
+	return true
 }

--- a/pkg/kvevents/zmq_subscriber_test.go
+++ b/pkg/kvevents/zmq_subscriber_test.go
@@ -19,7 +19,10 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,16 +40,24 @@ import (
 func buildEventBatchPayload(t *testing.T) []byte {
 	t.Helper()
 
-	// AllBlocksCleared event — simplest valid event, processed without side-effects.
-	allCleared := []any{string(kvevents.EventTypeAllBlocksCleared)}
-	rawEvent, err := msgpack.Marshal(allCleared)
-	require.NoError(t, err)
+	return buildEventPayload(t, []any{string(kvevents.EventTypeAllBlocksCleared)})
+}
+
+func buildEventPayload(t *testing.T, events ...[]any) []byte {
+	t.Helper()
+
+	rawEvents := make([]msgpack.RawMessage, 0, len(events))
+	for _, event := range events {
+		rawEvent, err := msgpack.Marshal(event)
+		require.NoError(t, err)
+		rawEvents = append(rawEvents, rawEvent)
+	}
 
 	// EventBatch is array-encoded: [TS, Events, DataParallelRank]
 	batch := []any{
-		1234567890.0,                   // TS
-		[]msgpack.RawMessage{rawEvent}, // Events
-		nil,                            // DataParallelRank
+		1234567890.0, // TS
+		rawEvents,    // Events
+		nil,          // DataParallelRank
 	}
 
 	var buf bytes.Buffer
@@ -54,6 +65,30 @@ func buildEventBatchPayload(t *testing.T) []byte {
 	enc.UseArrayEncodedStructs(true)
 	require.NoError(t, enc.Encode(batch))
 	return buf.Bytes()
+}
+
+func buildDistinctBlockStoredPayload(t *testing.T, blockHash uint64) []byte {
+	t.Helper()
+
+	tokens := make([]uint32, 64)
+	for i := range tokens {
+		tokens[i] = uint32(blockHash) + uint32(i) + 1 // #nosec G115 -- test data is small
+	}
+	return buildEventPayload(t, []any{
+		string(kvevents.EventTypeBlockStored),
+		[]uint64{blockHash},
+		uint64(0),
+		tokens,
+		64,
+	})
+}
+
+func buildBlockRemovedPayload(t *testing.T, blockHash uint64) []byte {
+	t.Helper()
+	return buildEventPayload(t, []any{
+		string(kvevents.EventTypeBlockRemoved),
+		[]uint64{blockHash},
+	})
 }
 
 func buildBlockStoredEventBatchPayload(t *testing.T, blockHashBase uint64, dataParallelRank int) []byte {
@@ -96,6 +131,80 @@ func availableEndpoint(t *testing.T, ctx context.Context) string {
 	endpoint := fmt.Sprintf("tcp://%s", ln.Addr().String())
 	require.NoError(t, ln.Close())
 	return endpoint
+}
+
+func seqFrame(seq uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, seq)
+	return b
+}
+
+type replayMessage struct {
+	seq     uint64
+	payload []byte
+}
+
+type replayBuffer struct {
+	mu       sync.RWMutex
+	messages []replayMessage
+	fail     atomic.Bool
+	requests atomic.Int32
+}
+
+func (b *replayBuffer) set(messages ...replayMessage) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.messages = append([]replayMessage(nil), messages...)
+}
+
+func startReplayBuffer(t *testing.T, ctx context.Context, endpoint string) *replayBuffer {
+	t.Helper()
+	buffer := &replayBuffer{}
+	topic := []byte("kv@10.0.0.1:8000@TestModel")
+
+	router := zmq4.NewRouter(ctx)
+	require.NoError(t, router.Listen(endpoint))
+	t.Cleanup(func() { router.Close() })
+
+	go func() {
+		for {
+			msg, err := router.Recv()
+			if err != nil {
+				return
+			}
+			buffer.requests.Add(1)
+			if len(msg.Frames) != 3 {
+				continue
+			}
+			clientID := msg.Frames[0]
+			if buffer.fail.Load() {
+				_ = router.Send(zmq4.NewMsgFrom(clientID, []byte{}, []byte("malformed")))
+				continue
+			}
+
+			startSeq := binary.BigEndian.Uint64(msg.Frames[2])
+			buffer.mu.RLock()
+			messages := append([]replayMessage(nil), buffer.messages...)
+			buffer.mu.RUnlock()
+			for _, replay := range messages {
+				if replay.seq < startSeq {
+					continue
+				}
+				if err := router.Send(zmq4.NewMsgFrom(
+					clientID, []byte{}, topic, seqFrame(replay.seq), replay.payload,
+				)); err != nil {
+					return
+				}
+			}
+			if err := router.Send(zmq4.NewMsgFrom(
+				clientID, []byte{}, []byte{}, seqFrame(math.MaxUint64), []byte{},
+			)); err != nil {
+				return
+			}
+		}
+	}()
+
+	return buffer
 }
 
 // TestZMQPubSub verifies that the pure-Go ZMQ library correctly implements
@@ -168,7 +277,7 @@ func TestZMQSubscriber_ReceivesMessages(t *testing.T) {
 	// Start subscriber — remote=false means it binds (Listen).
 	endpoint := "tcp://127.0.0.1:15559"
 	subManager := kvevents.NewSubscriberManager(pool)
-	err = subManager.EnsureSubscriber(ctx, "test-pod", "", endpoint, "kv@", false)
+	err = subManager.EnsureSubscriber(ctx, "test-pod", "", endpoint, "", "kv@", false)
 	require.NoError(t, err)
 
 	// Give subscriber time to bind.
@@ -218,6 +327,7 @@ func TestZMQSubscribers_SameTopicUsesServingEndpointIdentity(t *testing.T) {
 			fmt.Sprintf("test-rank-%d", i),
 			sourceEndpoints[i],
 			zmqEndpoints[i],
+			"",
 			"kv@",
 			false,
 		))
@@ -293,7 +403,7 @@ func TestZMQSubscriber_ShortSequenceFrameSkipped(t *testing.T) {
 	endpoint := fmt.Sprintf("tcp://%s", ln.Addr().String())
 	ln.Close()
 	subManager := kvevents.NewSubscriberManager(pool)
-	err = subManager.EnsureSubscriber(ctx, "test-pod", "", endpoint, "kv@", false)
+	err = subManager.EnsureSubscriber(ctx, "test-pod", "", endpoint, "", "kv@", false)
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 
@@ -319,4 +429,155 @@ func TestZMQSubscriber_ShortSequenceFrameSkipped(t *testing.T) {
 
 	// If we reach here without a panic, the short frame was correctly skipped.
 	subManager.Shutdown(ctx)
+}
+
+type replayHarness struct {
+	ctx    context.Context
+	index  kvblock.Index
+	buffer *replayBuffer
+	pub    zmq4.Socket
+	topic  []byte
+}
+
+func newReplayHarness(t *testing.T, messages []replayMessage, fail bool) *replayHarness {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
+	index, err := kvblock.NewIndex(ctx, kvblock.DefaultIndexConfig())
+	require.NoError(t, err)
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
+	require.NoError(t, err)
+	pool := kvevents.NewPool(kvevents.DefaultConfig(), index, tokenProcessor, engineadapter.NewVLLMAdapter())
+	pool.Start(ctx)
+
+	pubEndpoint := availableEndpoint(t, ctx)
+	replayEndpoint := availableEndpoint(t, ctx)
+	buffer := startReplayBuffer(t, ctx, replayEndpoint)
+	buffer.set(messages...)
+	buffer.fail.Store(fail)
+
+	subManager := kvevents.NewSubscriberManager(pool)
+	require.NoError(t, subManager.EnsureSubscriber(
+		ctx, "test-pod", "10.0.0.1:8000", pubEndpoint, replayEndpoint, "kv@", false))
+	require.Eventually(t, func() bool { return buffer.requests.Load() == 1 },
+		5*time.Second, 50*time.Millisecond, "proactive replay expected")
+
+	pub := zmq4.NewPub(ctx)
+	require.NoError(t, pub.Dial(pubEndpoint))
+	time.Sleep(100 * time.Millisecond)
+
+	t.Cleanup(func() {
+		pub.Close()
+		subManager.Shutdown(ctx)
+		pool.Shutdown(ctx)
+		cancel()
+	})
+	return &replayHarness{
+		ctx:    ctx,
+		index:  index,
+		buffer: buffer,
+		pub:    pub,
+		topic:  []byte("kv@10.0.0.1:8000@TestModel"),
+	}
+}
+
+func (h *replayHarness) send(t *testing.T, seq uint64, payload []byte) {
+	t.Helper()
+	require.NoError(t, h.pub.Send(zmq4.NewMsgFrom(h.topic, seqFrame(seq), payload)))
+}
+
+func TestZMQSubscriber_ProactiveReplayRebuildsServingEndpoint(t *testing.T) {
+	h := newReplayHarness(t, []replayMessage{
+		{seq: 0, payload: buildDistinctBlockStoredPayload(t, 300)},
+	}, false)
+
+	require.Eventually(t, func() bool {
+		key, err := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(300))
+		if err != nil {
+			return false
+		}
+		hits, err := h.index.Lookup(h.ctx, []kvblock.BlockHash{key}, nil)
+		return err == nil && len(hits[key]) == 1 &&
+			hits[key][0].PodIdentifier == "10.0.0.1:8000"
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestZMQSubscriber_GapReplayDoesNotDuplicateTriggeringEvent(t *testing.T) {
+	h := newReplayHarness(t, nil, false)
+	h.send(t, 0, buildDistinctBlockStoredPayload(t, 100))
+	require.Eventually(t, func() bool {
+		_, err := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(100))
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond)
+
+	h.buffer.set(
+		replayMessage{seq: 1, payload: buildDistinctBlockStoredPayload(t, 200)},
+		replayMessage{seq: 2, payload: buildDistinctBlockStoredPayload(t, 300)},
+	)
+	h.send(t, 2, buildDistinctBlockStoredPayload(t, 300))
+	require.Eventually(t, func() bool { return h.buffer.requests.Load() == 2 },
+		5*time.Second, 50*time.Millisecond, "gap replay expected")
+	require.Eventually(t, func() bool {
+		_, err := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(300))
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond)
+
+	h.send(t, 3, buildBlockRemovedPayload(t, 300))
+	require.Eventually(t, func() bool {
+		_, err := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(300))
+		return err != nil
+	}, 5*time.Second, 50*time.Millisecond,
+		"one remove must evict a block stored once on the wire")
+}
+
+func TestZMQSubscriber_DropsPostGapEventsDuringReplayCooldown(t *testing.T) {
+	h := newReplayHarness(t, nil, true)
+	h.send(t, 0, buildDistinctBlockStoredPayload(t, 100))
+	require.Eventually(t, func() bool {
+		_, err := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(100))
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond)
+
+	h.send(t, 2, buildDistinctBlockStoredPayload(t, 300))
+	time.Sleep(300 * time.Millisecond)
+	_, err := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(300))
+	require.Error(t, err, "event past an unrecovered gap must not reach the index")
+}
+
+func TestZMQSubscriber_SequenceResetClearsAndRebuildsPod(t *testing.T) {
+	h := newReplayHarness(t, nil, false)
+	h.send(t, 0, buildDistinctBlockStoredPayload(t, 100))
+	h.send(t, 1, buildDistinctBlockStoredPayload(t, 200))
+	require.Eventually(t, func() bool {
+		_, firstErr := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(100))
+		_, secondErr := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(200))
+		return firstErr == nil && secondErr == nil
+	}, 5*time.Second, 50*time.Millisecond)
+	oldRequestKey, err := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(100))
+	require.NoError(t, err)
+
+	h.buffer.set(replayMessage{seq: 0, payload: buildDistinctBlockStoredPayload(t, 300)})
+	h.send(t, 0, buildDistinctBlockStoredPayload(t, 300))
+	require.Eventually(t, func() bool { return h.buffer.requests.Load() == 2 },
+		5*time.Second, 50*time.Millisecond, "full replay after sequence reset expected")
+	require.Eventually(t, func() bool {
+		oldHits, lookupErr := h.index.Lookup(h.ctx, []kvblock.BlockHash{oldRequestKey}, nil)
+		_, newErr := h.index.GetRequestKey(h.ctx, kvblock.BlockHash(300))
+		return lookupErr == nil && len(oldHits[oldRequestKey]) == 0 && newErr == nil
+	}, 5*time.Second, 50*time.Millisecond,
+		"restart must replace stale pod state with the replayed epoch")
+}
+
+func TestZMQSubscriber_ReplayedLiveEventsDoNotTriggerAnotherReplay(t *testing.T) {
+	payload := buildEventBatchPayload(t)
+	h := newReplayHarness(t, []replayMessage{
+		{seq: 0, payload: payload},
+		{seq: 1, payload: payload},
+		{seq: 2, payload: payload},
+	}, false)
+
+	h.send(t, 0, payload)
+	h.send(t, 2, payload)
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, int32(1), h.buffer.requests.Load())
 }


### PR DESCRIPTION
## Summary

Add replay buffer consumer to rebuild the KV block index after EPP
restart or network blips. The subscriber connects to vLLM's ROUTER
socket via a DEALER and replays missed events.

- **Proactive replay on connect** — rebuilds index immediately, no
  wait for live traffic
- **Gap detection** — `seq > lastSeq + 1` triggers replay from
  `lastSeq + 1`
- **Dual watermarks** — `lastSeq` (index) vs `lastLiveSeq` (wire)
  so replay overlap cannot inflate dedup reference counts
- **Strict event gate** — after replay, live events with
  `seq <= lastSeq` are dropped before reaching AddTask
- **Sequence reset detection** — `seq < lastLiveSeq` clears index
  and dedup via pool queue (ordered with pending events)
- **Cooldown on failure only** — successful replay clears failure
  state; failed replay backs off 30s
- **DEALER over REQ** — REQ can only receive one reply per request

`EnsureSubscriber` gains `sourceEndpoint` and `replayEndpoint`
parameters. Replay endpoint computed from
`PodDiscoveryConfig.ReplaySocketPort` in the extractor.

Depends on: vllm-project/vllm#45177 (merged)

## Test plan

- [x] Proactive replay rebuilds serving endpoint identity on connect
- [x] Gap replay does not duplicate the triggering event
- [x] Events dropped during replay cooldown
- [x] Sequence reset clears and rebuilds pod index
- [x] Replayed live events do not trigger another replay

```release-note
Add replay buffer consumer for KV event index recovery after EPP
restart or network blips.
```

Relates to #1737