### PR TITLE
feat(sidecar): add P2P connector for OffloadingConnector disaggregation

### DIFF
--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -529,11 +529,11 @@ Specifies which KV transfer protocol the sidecar uses to coordinate prefill/deco
 | `shared-storage` | `SharedStorageConnector` | KV transfer via shared filesystem |
 | `sglang` | — | SGLang disaggregation protocol |
 | `mooncake` | `MooncakeConnector` | [Mooncake](https://github.com/kvcache-ai/Mooncake) KV transfer using RDMA |
-| `p2p` | `OffloadingConnector` | P2P KV transfer over the vLLM CPU offloading tier. The decoder pulls KV from the prefiller via the `p2p` secondary tier. |
+| `offloading` | `OffloadingConnector` | KV transfer over the vLLM CPU offloading tier. The decoder pulls KV from the prefiller via the `p2p` secondary tier. |
 
-With `p2p`, the sidecar dispatches prefill and decode concurrently. It injects role-keyed `kv_transfer_params`: the prefiller receives `{"decode": {"kv_request_id": <id>}}` (no peer address), and the decoder receives `{"prefill": {"kv_request_id": <id>, "remote_host": <prefiller host>, "remote_port": <p2p-connector-port>}}` so it can pull KV from the prefiller. The prefiller host comes from the `x-prefiller-host-port` header; the port is `--p2p-connector-port`.
+With `offloading`, the sidecar dispatches prefill and decode concurrently. It injects role-keyed `kv_transfer_params`: the prefiller receives `{"decode": {"kv_request_id": <id>}}` (no peer address), and the decoder receives `{"prefill": {"kv_request_id": <id>, "remote_host": <prefiller host>, "remote_port": <p2p-connector-port>}}` so it can pull KV from the prefiller. The prefiller host comes from the `x-prefiller-host-port` header; the port is `--p2p-connector-port`.
 
-The vLLM-side connector for `p2p` is `OffloadingConnector` (not `P2PConnector`). Both prefill and decode pods require the following `--kv-transfer-config`:
+Both prefill and decode pods require the following `--kv-transfer-config`:
 
 ```json
 {

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -529,6 +529,25 @@ Specifies which KV transfer protocol the sidecar uses to coordinate prefill/deco
 | `shared-storage` | `SharedStorageConnector` | KV transfer via shared filesystem |
 | `sglang` | — | SGLang disaggregation protocol |
 | `mooncake` | `MooncakeConnector` | [Mooncake](https://github.com/kvcache-ai/Mooncake) KV transfer using RDMA |
+| `p2p` | `OffloadingConnector` | P2P KV transfer over the vLLM CPU offloading tier. The decoder pulls KV from the prefiller via the `p2p` secondary tier. |
+
+With `p2p`, the sidecar dispatches prefill and decode concurrently. It injects role-keyed `kv_transfer_params`: the prefiller receives `{"decode": {"kv_request_id": <id>}}` (no peer address), and the decoder receives `{"prefill": {"kv_request_id": <id>, "remote_host": <prefiller host>, "remote_port": <p2p-connector-port>}}` so it can pull KV from the prefiller. The prefiller host comes from the `x-prefiller-host-port` header; the port is `--p2p-connector-port`.
+
+The vLLM-side connector for `p2p` is `OffloadingConnector` (not `P2PConnector`). Both prefill and decode pods require the following `--kv-transfer-config`:
+
+```json
+{
+  "kv_connector": "OffloadingConnector",
+  "kv_role": "kv_both",
+  "kv_connector_extra_config": {
+    "spec_name": "TieringOffloadingSpec",
+    "cpu_bytes_to_use": <bytes>,
+    "secondary_tiers": [{"type": "p2p", "host": "<POD_IP>", "port": <p2p-connector-port>}]
+  }
+}
+```
+
+`host` must be the pod's own IP at runtime (use the Kubernetes downward API env var `status.podIP`). `port` must match `--p2p-connector-port` (default `7777`). `cpu_bytes_to_use` controls the CPU KV offload buffer size; size it to hold the KV for the expected concurrent in-flight transfers. `OffloadingConnector` is available in vLLM nightly builds from 2026-06-30 onward (commit `bec232a`, [PR #42285](https://github.com/vllm-project/vllm/pull/42285)).
 
 ### General Sidecar Flags
 
@@ -545,6 +564,7 @@ Specifies which KV transfer protocol the sidecar uses to coordinate prefill/deco
 |---|---|---|---|---|
 | `mooncake` | `--mooncake-bootstrap-port` | `MOONCAKE_BOOTSTRAP_PORT` | `8998` | Port used to query the Mooncake bootstrap endpoint on prefill pods. Corresponds to vLLM's `VLLM_MOONCAKE_BOOTSTRAP_PORT`. |
 | `sglang` | — | `SGLANG_BOOTSTRAP_PORT` | `8998` | Port used for the SGLang bootstrap endpoint on prefill pods. |
+| `p2p` | `--p2p-connector-port` | `P2P_CONNECTOR_PORT` | `7777` | Prefiller's P2PConnector listening port, injected as `remote_port` on the decode leg so the decoder can pull KV. |
 
 ---
 
@@ -555,3 +575,4 @@ Specifies which KV transfer protocol the sidecar uses to coordinate prefill/deco
 - vLLM: [[RFC]: Prototype Separating Vision Encoder to Its Own Worker](https://github.com/vllm-project/vllm/issues/20799)
 - vLLM: [Encoder Disaggregation for Scalable Multimodal Model Serving](https://vllm.ai/blog/vllm-epd)
 - Mooncake: [MooncakeConnector Usage Guide](https://github.com/vllm-project/vllm/blob/main/docs/features/mooncake_connector_usage.md)
+- vLLM: [OffloadingConnector / P2P secondary tier (PR #42285)](https://github.com/vllm-project/vllm/pull/42285)

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -549,6 +549,8 @@ Both prefill and decode pods require the following `--kv-transfer-config`:
 
 `host` must be the pod's own IP at runtime (use the Kubernetes downward API env var `status.podIP`). `port` must match `--p2p-connector-port` (default `7777`). `cpu_bytes_to_use` controls the CPU KV offload buffer size; size it to hold the KV for the expected concurrent in-flight transfers. `OffloadingConnector` is available in vLLM nightly builds from 2026-06-30 onward (commit `bec232a`, [PR #42285](https://github.com/vllm-project/vllm/pull/42285)).
 
+**Restriction:** `--kv-connector=offloading` requires `--data-parallel-size=1`. Wide-EP pods (DP > 1) are rejected at startup: every DP rank would bind the same `POD_IP:<p2p-connector-port>`. DP-aware support is not yet implemented.
+
 ### General Sidecar Flags
 
 | Flag | Env var | Values | Default | Description |
@@ -564,7 +566,7 @@ Both prefill and decode pods require the following `--kv-transfer-config`:
 |---|---|---|---|---|
 | `mooncake` | `--mooncake-bootstrap-port` | `MOONCAKE_BOOTSTRAP_PORT` | `8998` | Port used to query the Mooncake bootstrap endpoint on prefill pods. Corresponds to vLLM's `VLLM_MOONCAKE_BOOTSTRAP_PORT`. |
 | `sglang` | — | `SGLANG_BOOTSTRAP_PORT` | `8998` | Port used for the SGLang bootstrap endpoint on prefill pods. |
-| `p2p` | `--p2p-connector-port` | `P2P_CONNECTOR_PORT` | `7777` | Prefiller's P2PConnector listening port, injected as `remote_port` on the decode leg so the decoder can pull KV. |
+| `offloading` | `--p2p-connector-port` | `P2P_CONNECTOR_PORT` | `7777` | Prefiller's P2PConnector listening port, injected as `remote_port` on the decode leg so the decoder can pull KV. |
 
 ---
 

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -566,7 +566,7 @@ Both prefill and decode pods require the following `--kv-transfer-config`:
 |---|---|---|---|---|
 | `mooncake` | `--mooncake-bootstrap-port` | `MOONCAKE_BOOTSTRAP_PORT` | `8998` | Port used to query the Mooncake bootstrap endpoint on prefill pods. Corresponds to vLLM's `VLLM_MOONCAKE_BOOTSTRAP_PORT`. |
 | `sglang` | — | `SGLANG_BOOTSTRAP_PORT` | `8998` | Port used for the SGLang bootstrap endpoint on prefill pods. |
-| `offloading` | `--p2p-connector-port` | `P2P_CONNECTOR_PORT` | `7777` | Prefiller's P2PConnector listening port, injected as `remote_port` on the decode leg so the decoder can pull KV. |
+| `offloading` | `--p2p-connector-port` | `P2P_CONNECTOR_PORT` | `7777` | Prefiller's OffloadingConnector P2P tier listening port, injected as `remote_port` on the decode leg so the decoder can pull KV. |
 
 ---
 

--- a/pkg/sidecar/constants/constants.go
+++ b/pkg/sidecar/constants/constants.go
@@ -29,6 +29,9 @@ const (
 	// KVConnectorMooncake enables mooncake the P/D KV disaggregation protocol
 	KVConnectorMooncake = "mooncake"
 
+	// KVConnectorP2P enables the P2PConnector P/D KV disaggregation protocol
+	KVConnectorP2P = "p2p"
+
 	// ECExampleConnector enables the Encoder disaggregation protocol (E/PD, E/P/D)
 	ECExampleConnector = "ec-example"
 

--- a/pkg/sidecar/constants/constants.go
+++ b/pkg/sidecar/constants/constants.go
@@ -29,8 +29,8 @@ const (
 	// KVConnectorMooncake enables mooncake the P/D KV disaggregation protocol
 	KVConnectorMooncake = "mooncake"
 
-	// KVConnectorP2P enables the P2PConnector P/D KV disaggregation protocol
-	KVConnectorP2P = "p2p"
+	// KVConnectorOffloading enables the OffloadingConnector P/D KV disaggregation protocol
+	KVConnectorOffloading = "offloading"
 
 	// ECExampleConnector enables the Encoder disaggregation protocol (E/PD, E/P/D)
 	ECExampleConnector = "ec-example"

--- a/pkg/sidecar/proxy/connector_mooncake_test.go
+++ b/pkg/sidecar/proxy/connector_mooncake_test.go
@@ -63,14 +63,7 @@ var _ = Describe("Mooncake Connector", func() {
 	It("should send concurrent requests with correct mooncake kv_transfer_params", func() {
 		proxyBaseAddr := testInfo.startProxy()
 
-		body := `{
-				"model": "Qwen/Qwen2-0.5B",
-				"messages": [
-				  {"role": "user", "content": "Hello"}
-				],
-				"max_tokens": 50,
-				"max_completion_tokens": 100
-			}`
+		body := chatCompletionsRequestBodyWithMaxCompletionTokens
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -132,7 +132,7 @@ func (s *Server) handleP2PConcurrentRequests(w http.ResponseWriter, r *http.Requ
 	)
 	prefillSpan.SetAttributes(
 		attribute.String("llm_d.pd_proxy.prefill_target", prefillHost),
-		attribute.String("llm_d.pd_proxy.connector", KVConnectorP2P),
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorOffloading),
 		attribute.Bool("llm_d.pd_proxy.prefill.async", true),
 	)
 	prefillStart := time.Now()
@@ -174,7 +174,7 @@ func (s *Server) handleP2PConcurrentRequests(w http.ResponseWriter, r *http.Requ
 	defer decodeSpan.End()
 
 	decodeSpan.SetAttributes(
-		attribute.String("llm_d.pd_proxy.connector", KVConnectorP2P),
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorOffloading),
 		attribute.Bool("llm_d.pd_proxy.decode.concurrent_with_prefill", true),
 	)
 	decodeStart := time.Now()

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -32,9 +32,9 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 )
 
-// handleP2P implements the vLLM P2PConnector orchestration contract. The
+// handleP2P implements the vLLM OffloadingConnector P2P orchestration contract. The
 // prefiller stores KV under a kv_request_id with no peer address; the decoder
-// pulls it using the prefiller's P2PConnector host/port. Both legs are
+// pulls it using the prefiller's OffloadingConnector P2P tier host/port. Both legs are
 // dispatched concurrently: the connector parks any KV blocks stored before the
 // decoder's fetch binds the session, so ordering between the legs is safe.
 func (s *Server) handleP2P(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -89,7 +89,7 @@ func (s *Server) handleP2P(w http.ResponseWriter, r *http.Request, prefillPodHos
 		v.Info("prefill request body", "body", string(prefillBody))
 	}
 
-	// Decode leg: pull KV from the prefiller's P2PConnector. Original body
+	// Decode leg: pull KV from the prefiller's OffloadingConnector P2P tier. Original body
 	// (streaming, token limits) is preserved.
 	decodeData := make(map[string]any, len(requestData)+1)
 	for k, v := range requestData {

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	logging "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
+)
+
+// handleP2P implements the vLLM P2PConnector orchestration contract. The
+// prefiller stores KV under a kv_request_id with no peer address; the decoder
+// pulls it using the prefiller's P2PConnector host/port. Both legs are
+// dispatched concurrently: the connector parks any KV blocks stored before the
+// decoder's fetch binds the session, so ordering between the legs is safe.
+func (s *Server) handleP2P(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if err := errorJSONInvalid(fmt.Errorf("failed to read request body: %w", err), w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	var requestData map[string]any
+	if err := json.Unmarshal(body, &requestData); err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	kvRequestID := newUUID()
+	s.logger.Info("running P2P protocol",
+		"prefill_host", extractHost(prefillPodHostPort),
+		"kv_request_id", kvRequestID,
+		"p2p_connector_port", s.config.P2PConnectorPort)
+
+	// Prefill leg: store KV under kv_request_id, no peer address. Capped to a
+	// single output token so the prefiller returns as soon as KV is stored.
+	prefillData := make(map[string]any, len(requestData)+1)
+	for k, v := range requestData {
+		prefillData[k] = v
+	}
+	prefillData[requestFieldKVTransferParams] = map[string]any{
+		requestFieldP2PDecodeParams: map[string]any{
+			requestFieldKVRequestID: kvRequestID,
+		},
+	}
+	prefillData[requestFieldStream] = false
+	delete(prefillData, requestFieldStreamOptions)
+	prefillData[requestFieldMaxTokens] = 1
+	if _, ok := prefillData[requestFieldMaxCompletionTokens]; ok {
+		prefillData[requestFieldMaxCompletionTokens] = 1
+	}
+
+	prefillBody, err := json.Marshal(prefillData)
+	if err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+	if v := s.logger.V(logging.TRACE); v.Enabled() {
+		v.Info("prefill request body", "body", string(prefillBody))
+	}
+
+	// Decode leg: pull KV from the prefiller's P2PConnector. Original body
+	// (streaming, token limits) is preserved.
+	decodeData := make(map[string]any, len(requestData)+1)
+	for k, v := range requestData {
+		decodeData[k] = v
+	}
+	decodeData[requestFieldKVTransferParams] = map[string]any{
+		requestFieldP2PPrefillParams: map[string]any{
+			requestFieldKVRequestID: kvRequestID,
+			requestFieldRemoteHost:  extractHost(prefillPodHostPort),
+			requestFieldRemotePort:  s.config.P2PConnectorPort,
+		},
+	}
+
+	decodeBody, err := json.Marshal(decodeData)
+	if err != nil {
+		if err := errorJSONInvalid(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+	if v := s.logger.V(logging.TRACE); v.Enabled() {
+		v.Info("decode request body", "body", string(decodeBody))
+	}
+
+	s.handleP2PConcurrentRequests(w, r, prefillBody, decodeBody, prefillPodHostPort)
+}
+
+func (s *Server) handleP2PConcurrentRequests(w http.ResponseWriter, r *http.Request, prefillBody, decodeBody []byte, prefillHost string) {
+	tracer := tracing.Tracer(tracerScope)
+	ctx := r.Context()
+
+	// WithoutCancel for prefill so it isn't aborted when the decode response finishes first.
+	prefillReq := cloneRequestWithBody(context.WithoutCancel(ctx), r, prefillBody)
+	decodeReq := cloneRequestWithBody(ctx, r, decodeBody)
+
+	// Prefill runs in a goroutine: only stores KV, response is discarded.
+	// Decode runs on the main thread: writes the actual response back via w.
+	ctx, prefillSpan := tracer.Start(ctx, "llm_d.pd_proxy.prefill",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	prefillSpan.SetAttributes(
+		attribute.String("llm_d.pd_proxy.prefill_target", prefillHost),
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorP2P),
+		attribute.Bool("llm_d.pd_proxy.prefill.async", true),
+	)
+	prefillStart := time.Now()
+
+	prefillHandler, err := s.prefillerProxyHandler(prefillHost)
+	if err != nil {
+		prefillSpan.SetStatus(codes.Error, "failed to create prefill handler")
+		prefillSpan.End()
+		if err := errorBadGateway(err, w); err != nil {
+			s.logger.Error(err, "failed to send error response to client")
+		}
+		return
+	}
+
+	go func() {
+		defer prefillSpan.End()
+		defer func() {
+			if rec := recover(); rec != nil && rec != http.ErrAbortHandler {
+				s.logger.Error(fmt.Errorf("panic: %v", rec), "panic in prefill request")
+			}
+		}()
+		pw := &bufferedResponseWriter{}
+		prefillHandler.ServeHTTP(pw, prefillReq)
+		prefillDuration := time.Since(prefillStart)
+		prefillSpan.SetAttributes(
+			attribute.Int("llm_d.pd_proxy.prefill.status_code", pw.statusCode),
+			attribute.Float64("llm_d.pd_proxy.prefill.duration_ms", float64(prefillDuration.Milliseconds())),
+		)
+		if isHTTPError(pw.statusCode) {
+			prefillSpan.SetStatus(codes.Error, "prefill request failed")
+		}
+		s.logger.V(logging.DEBUG).Info("p2p prefill request completed", "status", pw.statusCode)
+	}()
+
+	// Decode Stage
+	ctx, decodeSpan := tracer.Start(ctx, "llm_d.pd_proxy.decode",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer decodeSpan.End()
+
+	decodeSpan.SetAttributes(
+		attribute.String("llm_d.pd_proxy.connector", KVConnectorP2P),
+		attribute.Bool("llm_d.pd_proxy.decode.concurrent_with_prefill", true),
+	)
+	decodeStart := time.Now()
+
+	decodeReq = decodeReq.WithContext(ctx)
+	s.decoderProxy.ServeHTTP(w, decodeReq)
+
+	decodeDuration := time.Since(decodeStart)
+	decodeSpan.SetAttributes(
+		attribute.Float64("llm_d.pd_proxy.decode.duration_ms", float64(decodeDuration.Milliseconds())),
+		attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host),
+	)
+
+	// End-to-end P/D timing. True TTFT captures time from gateway request start
+	// to decode start; prefill duration is tracked in the async prefill span.
+	if currentSpan := trace.SpanFromContext(ctx); currentSpan.SpanContext().IsValid() {
+		var totalDuration time.Duration
+		var trueTTFT time.Duration
+		if requestStartValue := ctx.Value(requestStartTimeKey); requestStartValue != nil {
+			if requestStart, ok := requestStartValue.(time.Time); ok {
+				totalDuration = time.Since(requestStart)
+				trueTTFT = decodeStart.Sub(requestStart)
+			}
+		}
+
+		currentSpan.SetAttributes(
+			attribute.Float64("llm_d.pd_proxy.total_duration_ms", float64(totalDuration.Milliseconds())),
+			attribute.Float64("llm_d.pd_proxy.true_ttft_ms", float64(trueTTFT.Milliseconds())),
+			attribute.Float64("llm_d.pd_proxy.decode_duration_ms", float64(decodeDuration.Milliseconds())),
+			attribute.Bool("llm_d.pd_proxy.concurrent_pd", true),
+		)
+	}
+}

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -34,7 +34,7 @@ var _ = Describe("P2P Connector", func() {
 	const p2pConnectorPort = 7777
 
 	BeforeEach(func() {
-		testInfo = sidecarConnectionTestSetup(KVConnectorP2P)
+		testInfo = sidecarConnectionTestSetup(KVConnectorOffloading)
 		testInfo.proxy.config.P2PConnectorPort = p2pConnectorPort
 	})
 

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -41,14 +41,7 @@ var _ = Describe("P2P Connector", func() {
 	It("should send concurrent requests with correct p2p kv_transfer_params", func() {
 		proxyBaseAddr := testInfo.startProxy()
 
-		body := `{
-				"model": "Qwen/Qwen2-0.5B",
-				"messages": [
-				  {"role": "user", "content": "Hello"}
-				],
-				"max_tokens": 50,
-				"max_completion_tokens": 100
-			}`
+		body := chatCompletionsRequestBodyWithMaxCompletionTokens
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -83,7 +83,7 @@ var _ = Describe("P2P Connector", func() {
 		Expect(preq[requestFieldStream]).To(BeFalse())
 
 		// Decode leg: kv_transfer_params.prefill carries the prefiller's
-		// P2PConnector address plus the matching kv_request_id.
+		// OffloadingConnector P2P tier address plus the matching kv_request_id.
 		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
 		decodeReqs := testInfo.decodeHandler.GetCompletionRequests()
 		Expect(decodeReqs).To(HaveLen(1))

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2" // nolint:revive
+	. "github.com/onsi/gomega"    // nolint:revive
+
+	"github.com/llm-d/llm-d-router/pkg/common/routing"
+)
+
+var _ = Describe("P2P Connector", func() {
+
+	var testInfo *sidecarTestInfo
+
+	const p2pConnectorPort = 7777
+
+	BeforeEach(func() {
+		testInfo = sidecarConnectionTestSetup(KVConnectorP2P)
+		testInfo.proxy.config.P2PConnectorPort = p2pConnectorPort
+	})
+
+	It("should send concurrent requests with correct p2p kv_transfer_params", func() {
+		proxyBaseAddr := testInfo.startProxy()
+
+		body := `{
+				"model": "Qwen/Qwen2-0.5B",
+				"messages": [
+				  {"role": "user", "content": "Hello"}
+				],
+				"max_tokens": 50,
+				"max_completion_tokens": 100
+			}`
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
+		Expect(err).ToNot(HaveOccurred())
+
+		prefillHostPort := testInfo.prefillBackend.URL[len("http://"):]
+		req.Header.Add(routing.PrefillEndpointHeader, prefillHostPort)
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		if resp.StatusCode != 200 {
+			bp, _ := io.ReadAll(resp.Body) //nolint:errcheck
+			Fail(string(bp))
+		}
+
+		// Wait for the async prefill request to be recorded.
+		Eventually(func() int {
+			return len(testInfo.prefillHandler.GetCompletionRequests())
+		}).Should(Equal(1))
+
+		// Prefill leg: kv_transfer_params.decode carries only kv_request_id,
+		// with no peer address.
+		prefillReqs := testInfo.prefillHandler.GetCompletionRequests()
+		Expect(prefillReqs).To(HaveLen(1))
+		preq := prefillReqs[0]
+
+		Expect(preq).To(HaveKey(requestFieldKVTransferParams))
+		prefillKVParams, ok := preq[requestFieldKVTransferParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(prefillKVParams).ToNot(HaveKey(requestFieldP2PPrefillParams))
+		prefillDecode, ok := prefillKVParams[requestFieldP2PDecodeParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+		prefillKVRequestID := prefillDecode[requestFieldKVRequestID]
+		Expect(prefillKVRequestID).ToNot(BeEmpty())
+		Expect(prefillDecode).ToNot(HaveKey(requestFieldRemoteHost))
+		Expect(prefillDecode).ToNot(HaveKey(requestFieldRemotePort))
+
+		// Prefill is capped to a single output token and non-streaming.
+		Expect(preq[requestFieldMaxTokens]).To(BeNumerically("==", 1))
+		Expect(preq).To(HaveKeyWithValue(requestFieldMaxCompletionTokens, BeNumerically("==", 1)))
+		Expect(preq[requestFieldStream]).To(BeFalse())
+
+		// Decode leg: kv_transfer_params.prefill carries the prefiller's
+		// P2PConnector address plus the matching kv_request_id.
+		Expect(testInfo.decodeHandler.RequestCount.Load()).To(BeNumerically("==", 1))
+		decodeReqs := testInfo.decodeHandler.GetCompletionRequests()
+		Expect(decodeReqs).To(HaveLen(1))
+		dreq := decodeReqs[0]
+
+		Expect(dreq).To(HaveKey(requestFieldKVTransferParams))
+		decodeKVParams, ok := dreq[requestFieldKVTransferParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(decodeKVParams).ToNot(HaveKey(requestFieldP2PDecodeParams))
+		decodePrefill, ok := decodeKVParams[requestFieldP2PPrefillParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(decodePrefill[requestFieldKVRequestID]).To(Equal(prefillKVRequestID))
+		Expect(decodePrefill[requestFieldRemoteHost]).To(Equal(extractHost(prefillHostPort)))
+		Expect(decodePrefill[requestFieldRemotePort]).To(BeNumerically("==", p2pConnectorPort))
+
+		// Decode preserves the caller's original token limits.
+		Expect(dreq[requestFieldMaxTokens]).To(BeNumerically("==", 50))
+		Expect(dreq).To(HaveKeyWithValue(requestFieldMaxCompletionTokens, BeNumerically("==", 100)))
+
+		testInfo.cancelFn()
+		<-testInfo.stoppedCh
+	})
+})

--- a/pkg/sidecar/proxy/connector_test.go
+++ b/pkg/sidecar/proxy/connector_test.go
@@ -40,6 +40,15 @@ const chatCompletionsRequestBody = `{
 				"max_tokens": 50
 			}`
 
+const chatCompletionsRequestBodyWithMaxCompletionTokens = `{
+				"model": "Qwen/Qwen2-0.5B",
+				"messages": [
+				  {"role": "user", "content": "Hello"}
+				],
+				"max_tokens": 50,
+				"max_completion_tokens": 100
+			}`
+
 type sidecarTestInfo struct {
 	ctx            context.Context
 	cancelFn       context.CancelFunc
@@ -96,15 +105,7 @@ var _ = Describe("Common Connector tests", func() {
 				proxyBaseAddr := "http://" + testInfo.proxy.addr.String()
 
 				By("sending a /v1/chat/completions request with max_completion_tokens set")
-				//nolint:goconst
-				body := `{
-				"model": "Qwen/Qwen2-0.5B",
-				"messages": [
-				  {"role": "user", "content": "Hello"}
-				],
-				"max_tokens": 50,
-				"max_completion_tokens": 100
-			}`
+				body := chatCompletionsRequestBodyWithMaxCompletionTokens
 
 				req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -169,7 +169,7 @@ var (
 		KVConnectorSharedStorage: {},
 		KVConnectorSGLang:        {},
 		KVConnectorMooncake:      {},
-		KVConnectorP2P:           {},
+		KVConnectorOffloading:    {},
 	}
 
 	// supportedECConnectors defines all valid E/P EC connector types
@@ -185,7 +185,7 @@ var (
 		encodeStage:  {},
 	}
 
-	supportedKVConnectorNamesStr = strings.Join([]string{KVConnectorNIXLV2, KVConnectorSharedStorage, KVConnectorSGLang, KVConnectorMooncake, KVConnectorP2P}, ", ")
+	supportedKVConnectorNamesStr = strings.Join([]string{KVConnectorNIXLV2, KVConnectorSharedStorage, KVConnectorSGLang, KVConnectorMooncake, KVConnectorOffloading}, ", ")
 	supportedECConnectorNamesStr = strings.Join([]string{ECExampleConnector, ECConnectorNIXL}, ", ")
 
 	supportedTLSStageNamesStr = strings.Join([]string{prefillStage, decodeStage, encodeStage}, ", ")

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -566,6 +566,12 @@ func (opts *Options) Validate() error {
 		return fmt.Errorf("--p2p-connector-port must be between 1 and 65535, got %d", opts.P2PConnectorPort)
 	}
 
+	// offloading does not support wide-EP: every DP rank would bind the same
+	// POD_IP:<p2p-connector-port>. DP-aware support is not yet implemented.
+	if opts.KVConnector == KVConnectorOffloading && opts.DataParallelSize > 1 {
+		return fmt.Errorf("--kv-connector=offloading does not support --data-parallel-size > 1 (got %d)", opts.DataParallelSize)
+	}
+
 	// Validate SSRF protection requirements
 	if opts.EnableSSRFProtection {
 		if opts.InferencePoolNamespace == "" || opts.InferencePoolName == "" {

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -269,7 +269,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.MooncakeBootstrapPort, mooncakeBootstrapPortFlag, opts.MooncakeBootstrapPort,
 		"the port used to query the Mooncake bootstrap endpoint on prefill pods (only used with --kv-connector=mooncake)")
 	fs.IntVar(&opts.P2PConnectorPort, p2pConnectorPortFlag, opts.P2PConnectorPort,
-		"the prefiller's P2PConnector listening port, injected as remote_port on the decode leg (only used with --kv-connector=p2p)")
+		"the prefiller's OffloadingConnector P2P tier listening port, injected as remote_port on the decode leg (only used with --kv-connector=offloading)")
 	fs.BoolVar(&opts.SecureServing, secureServing, opts.SecureServing, "Enables secure proxy. Defaults to true.")
 	fs.StringVar(&opts.CertPath, certPath, opts.CertPath, "The path to the certificate for secure proxy. The certificate and private key files are assumed to be named tls.crt and tls.key, respectively. If not set, and secureProxy is enabled, then a self-signed certificate is used (for testing).")
 	fs.BoolVar(&opts.EnableSSRFProtection, enableSSRFProtection, opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -58,6 +58,7 @@ const (
 	kvConnector               = "kv-connector"
 	ecConnector               = "ec-connector"
 	mooncakeBootstrapPortFlag = "mooncake-bootstrap-port"
+	p2pConnectorPortFlag      = "p2p-connector-port"
 	enableSSRFProtection      = "enable-ssrf-protection"
 	enablePrefillerSampling   = "enable-prefiller-sampling"
 	enableTLS                 = "enable-tls"
@@ -86,12 +87,14 @@ const (
 	envInferencePool           = "INFERENCE_POOL"
 	envEnablePrefillerSampling = "ENABLE_PREFILLER_SAMPLING"
 	envMooncakeBootstrapPort   = "MOONCAKE_BOOTSTRAP_PORT"
+	envP2PConnectorPort        = "P2P_CONNECTOR_PORT"
 
 	// Defaults
 	defaultPort                  = "8000"
 	defaultVLLMPort              = "8200"
 	defaultDataParallelSize      = 1
 	defaultMooncakeBootstrapPort = 8998
+	defaultP2PConnectorPort      = 7777
 
 	// TLS stages
 	prefillStage = "prefiller"
@@ -104,6 +107,7 @@ type yamlConfiguration struct {
 	Port                           int      `json:"port,omitempty"`
 	VLLMPort                       int      `json:"vllm-port,omitempty"`
 	MooncakeBootstrapPort          int      `json:"mooncake-bootstrap-port,omitempty"`
+	P2PConnectorPort               int      `json:"p2p-connector-port,omitempty"`
 	DataParallelSize               int      `json:"data-parallel-size,omitempty"`
 	KVConnector                    string   `json:"kv-connector,omitempty"`
 	Connector                      string   `json:"connector,omitempty"`
@@ -165,6 +169,7 @@ var (
 		KVConnectorSharedStorage: {},
 		KVConnectorSGLang:        {},
 		KVConnectorMooncake:      {},
+		KVConnectorP2P:           {},
 	}
 
 	// supportedECConnectors defines all valid E/P EC connector types
@@ -180,7 +185,7 @@ var (
 		encodeStage:  {},
 	}
 
-	supportedKVConnectorNamesStr = strings.Join([]string{KVConnectorNIXLV2, KVConnectorSharedStorage, KVConnectorSGLang, KVConnectorMooncake}, ", ")
+	supportedKVConnectorNamesStr = strings.Join([]string{KVConnectorNIXLV2, KVConnectorSharedStorage, KVConnectorSGLang, KVConnectorMooncake, KVConnectorP2P}, ", ")
 	supportedECConnectorNamesStr = strings.Join([]string{ECExampleConnector, ECConnectorNIXL}, ", ")
 
 	supportedTLSStageNamesStr = strings.Join([]string{prefillStage, decodeStage, encodeStage}, ", ")
@@ -200,6 +205,13 @@ func NewOptions() *Options {
 		}
 	}
 
+	p2pConnectorPort := defaultP2PConnectorPort
+	if portStr := os.Getenv(envP2PConnectorPort); portStr != "" {
+		if port, err := strconv.Atoi(portStr); err == nil {
+			p2pConnectorPort = port
+		}
+	}
+
 	return &Options{
 		Config: Config{
 			Port:                    defaultPort,
@@ -210,6 +222,7 @@ func NewOptions() *Options {
 			PrefillMaxRetries:       0,
 			PrefillRetryBackoff:     200 * time.Millisecond,
 			MooncakeBootstrapPort:   mooncakeBootstrapPort,
+			P2PConnectorPort:        p2pConnectorPort,
 			PoolGroup:               routing.InferencePoolAPIGroup,
 			DecodeChunkSize:         0,
 			Tracing:                 false,
@@ -255,6 +268,8 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 		"the EC protocol between encoder and prefiller (for EPD mode). Supported: "+supportedECConnectorNamesStr+". Leave empty to skip encoder stage.")
 	fs.IntVar(&opts.MooncakeBootstrapPort, mooncakeBootstrapPortFlag, opts.MooncakeBootstrapPort,
 		"the port used to query the Mooncake bootstrap endpoint on prefill pods (only used with --kv-connector=mooncake)")
+	fs.IntVar(&opts.P2PConnectorPort, p2pConnectorPortFlag, opts.P2PConnectorPort,
+		"the prefiller's P2PConnector listening port, injected as remote_port on the decode leg (only used with --kv-connector=p2p)")
 	fs.BoolVar(&opts.SecureServing, secureServing, opts.SecureServing, "Enables secure proxy. Defaults to true.")
 	fs.StringVar(&opts.CertPath, certPath, opts.CertPath, "The path to the certificate for secure proxy. The certificate and private key files are assumed to be named tls.crt and tls.key, respectively. If not set, and secureProxy is enabled, then a self-signed certificate is used (for testing).")
 	fs.BoolVar(&opts.EnableSSRFProtection, enableSSRFProtection, opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")
@@ -546,6 +561,11 @@ func (opts *Options) Validate() error {
 		return fmt.Errorf("--mooncake-bootstrap-port must be between 1 and 65535, got %d", opts.MooncakeBootstrapPort)
 	}
 
+	// Validate P2P connector port
+	if opts.P2PConnectorPort < 1 || opts.P2PConnectorPort > 65535 {
+		return fmt.Errorf("--p2p-connector-port must be between 1 and 65535, got %d", opts.P2PConnectorPort)
+	}
+
 	// Validate SSRF protection requirements
 	if opts.EnableSSRFProtection {
 		if opts.InferencePoolNamespace == "" || opts.InferencePoolName == "" {
@@ -636,6 +656,9 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	}
 	if cfg.MooncakeBootstrapPort != 0 && !opts.isFlagSet(mooncakeBootstrapPortFlag) {
 		opts.MooncakeBootstrapPort = cfg.MooncakeBootstrapPort
+	}
+	if cfg.P2PConnectorPort != 0 && !opts.isFlagSet(p2pConnectorPortFlag) {
+		opts.P2PConnectorPort = cfg.P2PConnectorPort
 	}
 	if cfg.DataParallelSize != 0 && !opts.isFlagSet(dataParallelSize) {
 		opts.DataParallelSize = cfg.DataParallelSize

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -619,6 +619,24 @@ func TestP2PConnectorPort(t *testing.T) {
 	})
 }
 
+func TestValidateOffloadingDP(t *testing.T) {
+	t.Run("rejects offloading with data-parallel-size > 1", func(t *testing.T) {
+		opts := NewOptions()
+		opts.KVConnector = KVConnectorOffloading
+		opts.DataParallelSize = 2
+		require.NoError(t, opts.Complete())
+		require.ErrorContains(t, opts.Validate(), "--kv-connector=offloading does not support --data-parallel-size > 1")
+	})
+
+	t.Run("allows offloading with data-parallel-size 1", func(t *testing.T) {
+		opts := NewOptions()
+		opts.KVConnector = KVConnectorOffloading
+		opts.DataParallelSize = 1
+		require.NoError(t, opts.Complete())
+		require.NoError(t, opts.Validate())
+	})
+}
+
 func TestValidateConnector(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -595,6 +595,30 @@ func TestNewOptionsWithEnvVars(t *testing.T) {
 	}
 }
 
+func TestP2PConnectorPort(t *testing.T) {
+	t.Run("defaults to 7777", func(t *testing.T) {
+		opts := NewOptions()
+		require.NoError(t, opts.Complete())
+		require.NoError(t, opts.Validate())
+		require.Equal(t, defaultP2PConnectorPort, opts.P2PConnectorPort)
+	})
+
+	t.Run("env var overrides default", func(t *testing.T) {
+		t.Setenv(envP2PConnectorPort, "9500")
+		opts := NewOptions()
+		require.NoError(t, opts.Complete())
+		require.NoError(t, opts.Validate())
+		require.Equal(t, 9500, opts.P2PConnectorPort)
+	})
+
+	t.Run("rejects out-of-range port", func(t *testing.T) {
+		opts := NewOptions()
+		opts.P2PConnectorPort = 70000
+		require.NoError(t, opts.Complete())
+		require.ErrorContains(t, opts.Validate(), "--p2p-connector-port must be between 1 and 65535")
+	})
+}
+
 func TestValidateConnector(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -605,6 +629,7 @@ func TestValidateConnector(t *testing.T) {
 		{"valid shared-storage", KVConnectorSharedStorage, false},
 		{"valid sglang", KVConnectorSGLang, false},
 		{"valid mooncake", KVConnectorMooncake, false},
+		{"valid p2p", KVConnectorP2P, false},
 		{"invalid connector", "invalid", true},
 	}
 

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -629,7 +629,7 @@ func TestValidateConnector(t *testing.T) {
 		{"valid shared-storage", KVConnectorSharedStorage, false},
 		{"valid sglang", KVConnectorSGLang, false},
 		{"valid mooncake", KVConnectorMooncake, false},
-		{"valid p2p", KVConnectorP2P, false},
+		{"valid offloading", KVConnectorOffloading, false},
 		{"invalid connector", "invalid", true},
 	}
 

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -90,10 +90,17 @@ const (
 	// Mooncake transfer fields
 	requestFieldRemoteBootstrapAddr = "remote_bootstrap_addr"
 
+	// P2PConnector kv_transfer_params fields. The role is encoded by the
+	// nesting key: "decode" on the prefiller leg, "prefill" on the decoder leg.
+	requestFieldP2PDecodeParams  = "decode"
+	requestFieldP2PPrefillParams = "prefill"
+	requestFieldKVRequestID      = "kv_request_id"
+
 	KVConnectorNIXLV2        = constants.KVConnectorNIXLV2
 	KVConnectorSharedStorage = constants.KVConnectorSharedStorage
 	KVConnectorSGLang        = constants.KVConnectorSGLang
 	KVConnectorMooncake      = constants.KVConnectorMooncake
+	KVConnectorP2P           = constants.KVConnectorP2P
 	ECExampleConnector       = constants.ECExampleConnector
 	ECConnectorNIXL          = constants.ECConnectorNIXL
 )
@@ -196,6 +203,11 @@ type Config struct {
 
 	// MooncakeBootstrapPort is the port used to query the Mooncake bootstrap endpoint on prefill pods.
 	MooncakeBootstrapPort int
+
+	// P2PConnectorPort is the prefiller's P2PConnector listening port, injected
+	// as remote_port on the decode leg so the decoder can pull KV from it.
+	// Only meaningful with --kv-connector=p2p.
+	P2PConnectorPort int
 
 	// EnableSSRFProtection enables SSRF protection using InferencePool allowlisting.
 	EnableSSRFProtection bool
@@ -447,6 +459,10 @@ func (s *Server) setKVConnector() {
 	case KVConnectorMooncake:
 		s.handlePDConnector = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
 			s.handleMooncake(w, r, host)
+		}
+	case KVConnectorP2P:
+		s.handlePDConnector = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
+			s.handleP2P(w, r, host)
 		}
 	case KVConnectorNIXLV2:
 		fallthrough

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -100,7 +100,7 @@ const (
 	KVConnectorSharedStorage = constants.KVConnectorSharedStorage
 	KVConnectorSGLang        = constants.KVConnectorSGLang
 	KVConnectorMooncake      = constants.KVConnectorMooncake
-	KVConnectorP2P           = constants.KVConnectorP2P
+	KVConnectorOffloading    = constants.KVConnectorOffloading
 	ECExampleConnector       = constants.ECExampleConnector
 	ECConnectorNIXL          = constants.ECConnectorNIXL
 )
@@ -460,7 +460,7 @@ func (s *Server) setKVConnector() {
 		s.handlePDConnector = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
 			s.handleMooncake(w, r, host)
 		}
-	case KVConnectorP2P:
+	case KVConnectorOffloading:
 		s.handlePDConnector = func(w http.ResponseWriter, r *http.Request, host string, _ APIType) {
 			s.handleP2P(w, r, host)
 		}

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -90,7 +90,7 @@ const (
 	// Mooncake transfer fields
 	requestFieldRemoteBootstrapAddr = "remote_bootstrap_addr"
 
-	// P2PConnector kv_transfer_params fields. The role is encoded by the
+	// OffloadingConnector kv_transfer_params fields. The role is encoded by the
 	// nesting key: "decode" on the prefiller leg, "prefill" on the decoder leg.
 	requestFieldP2PDecodeParams  = "decode"
 	requestFieldP2PPrefillParams = "prefill"
@@ -204,9 +204,9 @@ type Config struct {
 	// MooncakeBootstrapPort is the port used to query the Mooncake bootstrap endpoint on prefill pods.
 	MooncakeBootstrapPort int
 
-	// P2PConnectorPort is the prefiller's P2PConnector listening port, injected
-	// as remote_port on the decode leg so the decoder can pull KV from it.
-	// Only meaningful with --kv-connector=p2p.
+	// P2PConnectorPort is the prefiller's OffloadingConnector P2P tier listening port,
+	// injected as remote_port on the decode leg so the decoder can pull KV from it.
+	// Only meaningful with --kv-connector=offloading.
 	P2PConnectorPort int
 
 	// EnableSSRFProtection enables SSRF protection using InferencePool allowlisting.


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Adds the `offloading` KV connector to the disaggregation sidecar. When `--kv-connector=offloading` is set, the sidecar orchestrates the two-leg P2P protocol: the prefill leg stores KV cache under a `kv_request_id` (decode params only, capped to 1 output token); the decode leg pulls KV from the prefiller's OffloadingConnector endpoint (prefill params with `remote_host` and `remote_port`). Both legs are dispatched concurrently via the existing `handleP2PConcurrentRequests` path.

A new `--p2p-connector-port` flag (env `P2P_CONNECTOR_PORT`, default `7777`) carries the vLLM OffloadingConnector P2P tier port; this is expected to become a well-known value in a future release, at which point the flag and the `remote_port` decode param can be dropped.

The vLLM-side connector is `OffloadingConnector` with `kv_role=kv_both` and a `p2p` secondary tier. Available in vLLM nightly builds from 2026-06-30 onward (commit `bec232a`, PR vllm-project/vllm#42285).

**Which issue(s) this PR fixes**:
Fixes #1197

**Known limitations**:
`--kv-connector=offloading` is rejected at startup when `--data-parallel-size > 1`. Wide-EP support requires per-rank port binding on the vLLM side and rank-aware port injection in the sidecar. Tracked in #1889.

**Test plan**:
- [x] Unit tests: `connector_p2p_test.go` covers prefill/decode body construction and `kv_transfer_params` shape; `options_test.go` covers flag default, env override, out-of-range rejection, and DP > 1 rejection
- [x] `make presubmit` passes
- [x] End-to-end on cluster (`pokprod001.ete14.res.ibm.com`, namespace `llm-d-p2p-test`): model `facebook/opt-125m`, 1 prefill + 1 decode pod, vLLM nightly `nightly-09663abde0f50944a8d5ea30120666024b503faa`

Sidecar startup confirms connector and port:
```
{"msg":"Proxy configuration","config":"{\"KVConnector\":\"offloading\",\"P2PConnectorPort\":7777,...}"}
```

Sidecar INFO log per request confirms P2P protocol is running:
```
{"msg":"running P2P protocol","prefill_host":"10.130.3.169","kv_request_id":"5000d5f6-1230-4a6b-a1c8-d4c4cdc3f5e1","p2p_connector_port":7777}
{"msg":"running P2P protocol","prefill_host":"10.130.3.169","kv_request_id":"340bb3a4-7dc3-40ef-a12f-b25f1d14e1bb","p2p_connector_port":7777}
```

vLLM EngineCore on the decode pod confirms the outbound P2P connection to the prefill pod:
```
ZmqTransport 10.131.9.17:7777: opening OUTBOUND connection to 10.130.3.169:7777
ZmqTransport 10.131.9.17:7777: outbound connection established to 10.130.3.169:7777 (active connections: 1)
```

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add `offloading` KV connector to the disaggregation sidecar (`--kv-connector=offloading`), implementing the two-leg OffloadingConnector protocol for prefill/decode KV transfer without RDMA. A new `--p2p-connector-port` flag (env `P2P_CONNECTOR_PORT`, default `7777`) sets the P2P tier port. Requires `--data-parallel-size=1`; wide-EP support tracked in #1889.
```