### PR TITLE
Add DCGM data source and extractor for GPU utilization

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -60,13 +60,16 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrgpu "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/gpu"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/models"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	attrsession "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/session"
 	discoveryfile "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/discovery/file"
+	extdcgm "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/dcgm"
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
+	srcdcgm "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/dcgm"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 	srcmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/models"
 	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
@@ -563,6 +566,10 @@ func (r *Runner) registerInTreePlugins() {
 	// data layer models source/extractor
 	fwkplugin.Register(srcmodels.ModelsDataSourceType, srcmodels.ModelDataSourceFactory)
 	fwkplugin.Register(attrmodels.ModelsExtractorType, extmodels.ModelServerExtractorFactory)
+
+	// data layer DCGM source/extractor
+	fwkplugin.Register(srcdcgm.DCGMDataSourceType, srcdcgm.DCGMDataSourceFactory)
+	fwkplugin.Register(attrgpu.DCGMExtractorType, extdcgm.DCGMExtractorFactory)
 
 	fwkplugin.Register(prefix.PrefixCacheScorerPluginType, prefix.PrefixCachePluginFactory)
 	fwkplugin.Register(maxscore.MaxScorePickerType, maxscore.MaxScorePickerFactory)

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -315,6 +315,7 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 				NamespacedName: createEndpointNamespacedName(pod, idx),
 				PodName:        pod.Name,
 				Address:        pod.Status.PodIP,
+				NodeAddress:    pod.Status.HostIP,
 				Port:           strconv.Itoa(port),
 				MetricsHost:    net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(port)),
 				Labels:         labels,

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -305,6 +305,10 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pod1",
 		},
+		Status: corev1.PodStatus{
+			PodIP:  "10.0.0.1",
+			HostIP: "192.168.1.10",
+		},
 	}
 	pod1Metrics = &fwkdl.Metrics{
 		WaitingQueueSize:    0,
@@ -319,6 +323,10 @@ var (
 	pod2 = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pod2",
+		},
+		Status: corev1.PodStatus{
+			PodIP:  "10.0.0.2",
+			HostIP: "192.168.1.10",
 		},
 	}
 	pod2Metrics = &fwkdl.Metrics{
@@ -506,7 +514,10 @@ func TestPods(t *testing.T) {
 				for idx, pm := range podList {
 					gotPods[idx] = &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().PodName, Namespace: pm.GetMetadata().NamespacedName.Namespace},
-						Status:     corev1.PodStatus{PodIP: pm.GetMetadata().GetIPAddress()},
+						Status: corev1.PodStatus{
+							PodIP:  pm.GetMetadata().GetIPAddress(),
+							HostIP: pm.GetMetadata().GetNodeAddress(),
+						},
 					}
 				}
 				if !cmp.Equal(gotPods, test.wantPods, cmpopts.SortSlices(func(a, b *corev1.Pod) bool { return a.Name < b.Name })) {
@@ -649,6 +660,7 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod1.Name,
 					Address:     pod1.Status.PodIP,
+					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolTargetPort,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolTargetPort),
 					Labels:      map[string]string{},
@@ -671,6 +683,7 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod1.Name,
 					Address:     pod1.Status.PodIP,
+					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort0),
 					Labels:      map[string]string{},
@@ -683,6 +696,7 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod1.Name,
 					Address:     pod1.Status.PodIP,
+					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},
@@ -706,6 +720,7 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod1.Name,
 					Address:     pod1.Status.PodIP,
+					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort0),
 					Labels:      map[string]string{},
@@ -718,6 +733,7 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod1.Name,
 					Address:     pod1.Status.PodIP,
+					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},
@@ -731,8 +747,9 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod2.Name,
 					Address:     pod2.Status.PodIP,
+					NodeAddress: pod2.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
-					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort0),
+					MetricsHost: net.JoinHostPort(pod2.Status.PodIP, inferencePoolMultiTargetPort0),
 					Labels:      map[string]string{},
 				},
 				{
@@ -743,8 +760,9 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod2.Name,
 					Address:     pod2.Status.PodIP,
+					NodeAddress: pod2.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,
-					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
+					MetricsHost: net.JoinHostPort(pod2.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},
 					RankIndex:   1,
 				},
@@ -766,6 +784,7 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod1.Name,
 					Address:     pod1.Status.PodIP,
+					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort0),
 					Labels:      map[string]string{},
@@ -778,6 +797,7 @@ func TestEndpointMetadata(t *testing.T) {
 
 					PodName:     pod1.Name,
 					Address:     pod1.Status.PodIP,
+					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,
 					MetricsHost: net.JoinHostPort(pod1.Status.PodIP, inferencePoolMultiTargetPort1),
 					Labels:      map[string]string{},

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -28,9 +28,12 @@ type EndpointMetadata struct {
 	NamespacedName types.NamespacedName
 	PodName        string
 	Address        string
-	Port           string
-	MetricsHost    string
-	Labels         map[string]string
+	// NodeAddress is the node IP hosting this pod (pod.Status.HostIP).
+	// Empty for non-Kubernetes discovery sources (e.g. file discovery).
+	NodeAddress string
+	Port        string
+	MetricsHost string
+	Labels      map[string]string
 	// RankIndex is this endpoint's position in the pool's TargetPorts,
 	// identifying the pod-local rank in multi-port deployments.
 	RankIndex int
@@ -59,6 +62,7 @@ func (epm *EndpointMetadata) Clone() *EndpointMetadata {
 		},
 		PodName:     epm.PodName,
 		Address:     epm.Address,
+		NodeAddress: epm.NodeAddress,
 		Port:        epm.Port,
 		MetricsHost: epm.MetricsHost,
 		Labels:      clonedLabels,
@@ -75,6 +79,7 @@ func (epm *EndpointMetadata) Equal(other *EndpointMetadata) bool {
 	return epm.NamespacedName == other.NamespacedName &&
 		epm.PodName == other.PodName &&
 		epm.Address == other.Address &&
+		epm.NodeAddress == other.NodeAddress &&
 		epm.Port == other.Port &&
 		epm.MetricsHost == other.MetricsHost &&
 		epm.RankIndex == other.RankIndex &&
@@ -98,6 +103,14 @@ func (epm *EndpointMetadata) GetNamespacedName() types.NamespacedName {
 // GetIPAddress returns the Endpoint's IP address.
 func (epm *EndpointMetadata) GetIPAddress() string {
 	return epm.Address
+}
+
+// GetNodeAddress returns the IP of the node hosting this endpoint.
+func (epm *EndpointMetadata) GetNodeAddress() string {
+	if epm == nil {
+		return ""
+	}
+	return epm.NodeAddress
 }
 
 // GetPort returns the Endpoint's inference port.

--- a/pkg/epp/framework/plugins/datalayer/attribute/gpu/README.md
+++ b/pkg/epp/framework/plugins/datalayer/attribute/gpu/README.md
@@ -1,0 +1,15 @@
+# GPU Attributes
+
+This package defines the data structures for GPU hardware metrics collected from NVIDIA DCGM Exporter.
+
+## `GPUUtilization`
+
+A normalized GPU compute utilization value in [0.0, 1.0], derived from `DCGM_FI_DEV_GPU_UTIL` (which reports 0-100). For multi-GPU pods the extractor aggregates across visible devices using `max`.
+
+- **Key**: `GPUUtilizationDataKey` (`GPUUtilization/dcgm-extractor`)
+
+## Producers
+
+The following plugins produce this attribute:
+
+- **`dcgm-extractor`** (Data Layer): Extracts GPU utilization from the DCGM Exporter Prometheus endpoint.

--- a/pkg/epp/framework/plugins/datalayer/attribute/gpu/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/gpu/data_types.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpu
+
+import (
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+const (
+	// DCGMExtractorType is the plugin type for the DCGM metrics extractor.
+	DCGMExtractorType = "dcgm-extractor"
+)
+
+// GPUUtilizationDataKey identifies per-endpoint GPU utilization published
+// by the DCGM extractor and consumed by GPU-aware filters and scorers.
+var GPUUtilizationDataKey = plugin.NewDataKey("GPUUtilization", DCGMExtractorType)
+
+// GPUUtilization is a normalized GPU compute utilization value in [0.0, 1.0],
+// derived from DCGM_FI_DEV_GPU_UTIL (which reports 0-100).
+// For multi-GPU pods the extractor aggregates across visible devices.
+type GPUUtilization float64
+
+func (v GPUUtilization) Clone() fwkdl.Cloneable {
+	return v
+}
+
+// ReadGPUUtilization retrieves GPU utilization from an endpoint's AttributeMap.
+func ReadGPUUtilization(attrs fwkdl.AttributeMap, key string) (GPUUtilization, bool) {
+	return fwkdl.ReadAttribute[GPUUtilization](attrs, key)
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/README.md
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/README.md
@@ -2,19 +2,26 @@
 
 **Type:** `dcgm-extractor`
 
-The DCGM Extractor converts the Prometheus metrics response from a `dcgm-data-source` into a per-endpoint GPU utilization attribute consumed by GPU-aware filters and scorers.
+The DCGM Extractor converts the Prometheus metrics response from a
+`dcgm-data-source` into a per-endpoint GPU utilization attribute consumed by
+GPU-aware filters and scorers.
 
 ## What it does
 
 1. Receives the parsed Prometheus metric families forwarded by `dcgm-data-source`.
 2. Looks up the `DCGM_FI_DEV_GPU_UTIL` metric family.
-3. Aggregates across all GPU samples using `max` (the highest-utilized GPU determines the pod's score).
-4. Normalizes the value from 0-100 to [0.0, 1.0].
-5. Stores the result as a `GPUUtilization` attribute on the corresponding endpoint.
+3. Keeps samples that belong to this endpoint:
+   - If a sample has a `pod` label and the endpoint has a `PodName`, only
+     matching samples are kept (DaemonSet multi-pod payloads).
+   - If the sample has no `pod` label, it is kept (sidecar / unlabeled payloads).
+4. Aggregates matching samples using `max` (highest-utilized GPU for the pod).
+5. Normalizes the value from 0-100 to [0.0, 1.0].
+6. Stores the result as a `GPUUtilization` attribute on the corresponding endpoint.
 
 ## Attributes produced
 
-- `GPUUtilization` stored at attribute key `GPUUtilizationDataKey` (`GPUUtilization/dcgm-extractor`) on each endpoint.
+- `GPUUtilization` stored at attribute key `GPUUtilizationDataKey`
+  (`GPUUtilization/dcgm-extractor`) on each endpoint.
 
 ```go
 key := attrgpu.GPUUtilizationDataKey.String()

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/README.md
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/README.md
@@ -1,0 +1,26 @@
+# DCGM Extractor
+
+**Type:** `dcgm-extractor`
+
+The DCGM Extractor converts the Prometheus metrics response from a `dcgm-data-source` into a per-endpoint GPU utilization attribute consumed by GPU-aware filters and scorers.
+
+## What it does
+
+1. Receives the parsed Prometheus metric families forwarded by `dcgm-data-source`.
+2. Looks up the `DCGM_FI_DEV_GPU_UTIL` metric family.
+3. Aggregates across all GPU samples using `max` (the highest-utilized GPU determines the pod's score).
+4. Normalizes the value from 0-100 to [0.0, 1.0].
+5. Stores the result as a `GPUUtilization` attribute on the corresponding endpoint.
+
+## Attributes produced
+
+- `GPUUtilization` stored at attribute key `GPUUtilizationDataKey` (`GPUUtilization/dcgm-extractor`) on each endpoint.
+
+```go
+key := attrgpu.GPUUtilizationDataKey.String()
+util, ok := attrgpu.ReadGPUUtilization(endpoint.GetAttributes(), key)
+```
+
+## Configuration
+
+No configuration parameters.

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
@@ -29,7 +29,10 @@ import (
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
-const gpuUtilMetricName = "DCGM_FI_DEV_GPU_UTIL"
+const (
+	gpuUtilMetricName = "DCGM_FI_DEV_GPU_UTIL"
+	podLabelName      = "pod"
+)
 
 var _ fwkplugin.ProducerPlugin = &Extractor{}
 
@@ -65,17 +68,26 @@ func DCGMExtractorFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwk
 }
 
 // Extract parses DCGM_FI_DEV_GPU_UTIL from the Prometheus families,
-// aggregates across GPUs (max), normalizes to [0.0, 1.0], and stores
-// the result in the endpoint's AttributeMap.
+// keeps samples for this endpoint's pod (when the pod label is present),
+// aggregates across matching GPUs (max), normalizes to [0.0, 1.0], and
+// stores the result in the endpoint's AttributeMap.
 func (e *Extractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]) error {
 	family, ok := in.Payload[gpuUtilMetricName]
 	if !ok {
 		return fmt.Errorf("metric %q not found in DCGM response", gpuUtilMetricName)
 	}
 
+	podName := ""
+	if meta := in.Endpoint.GetMetadata(); meta != nil {
+		podName = meta.PodName
+	}
+
 	maxUtil := 0.0
 	found := false
 	for _, m := range family.GetMetric() {
+		if !sampleBelongsToPod(m, podName) {
+			continue
+		}
 		val := gaugeValue(m)
 		if val > maxUtil {
 			maxUtil = val
@@ -83,7 +95,7 @@ func (e *Extractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.
 		found = true
 	}
 	if !found {
-		return fmt.Errorf("metric %q present but has no samples", gpuUtilMetricName)
+		return fmt.Errorf("metric %q present but has no samples for pod %q", gpuUtilMetricName, podName)
 	}
 
 	normalized := attrgpu.GPUUtilization(maxUtil / 100.0)
@@ -94,6 +106,30 @@ func (e *Extractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.
 // Produces declares the data key this extractor publishes.
 func (e *Extractor) Produces() map[fwkplugin.DataKey]any {
 	return map[fwkplugin.DataKey]any{e.dk: attrgpu.GPUUtilization(0)}
+}
+
+// sampleBelongsToPod reports whether m should contribute to this endpoint's
+// utilization. When podName is empty, or the sample has no pod label, the
+// sample is kept (sidecar / single-tenant payloads). When both are set, only
+// matching samples are kept (DaemonSet multi-pod payloads).
+func sampleBelongsToPod(m *dto.Metric, podName string) bool {
+	if podName == "" {
+		return true
+	}
+	samplePod, ok := labelValue(m, podLabelName)
+	if !ok {
+		return true
+	}
+	return samplePod == podName
+}
+
+func labelValue(m *dto.Metric, name string) (string, bool) {
+	for _, l := range m.GetLabel() {
+		if l.GetName() == name {
+			return l.GetValue(), true
+		}
+	}
+	return "", false
 }
 
 func gaugeValue(m *dto.Metric) float64 {

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
@@ -88,7 +88,10 @@ func (e *Extractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.
 		if !sampleBelongsToPod(m, podName) {
 			continue
 		}
-		val := gaugeValue(m)
+		val, err := gaugeValue(m)
+		if err != nil {
+			return err
+		}
 		if val > maxUtil {
 			maxUtil = val
 		}
@@ -132,9 +135,9 @@ func labelValue(m *dto.Metric, name string) (string, bool) {
 	return "", false
 }
 
-func gaugeValue(m *dto.Metric) float64 {
+func gaugeValue(m *dto.Metric) (float64, error) {
 	if g := m.GetGauge(); g != nil {
-		return g.GetValue()
+		return g.GetValue(), nil
 	}
-	return 0
+	return 0, fmt.Errorf("expected gauge metric for %s", gpuUtilMetricName)
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dcgm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	attrgpu "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/gpu"
+	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+)
+
+const gpuUtilMetricName = "DCGM_FI_DEV_GPU_UTIL"
+
+var _ fwkplugin.ProducerPlugin = &Extractor{}
+
+var _ fwkdl.PollingExtractor[sourcemetrics.PrometheusMetricMap] = &Extractor{}
+
+// Extractor reads DCGM Exporter metrics and stores aggregated GPU
+// utilization in the endpoint's AttributeMap.
+type Extractor struct {
+	typedName fwkplugin.TypedName
+	dk        fwkplugin.DataKey
+}
+
+// NewDCGMExtractor returns a new DCGM metrics extractor.
+func NewDCGMExtractor() *Extractor {
+	return &Extractor{
+		typedName: fwkplugin.TypedName{
+			Type: attrgpu.DCGMExtractorType,
+			Name: attrgpu.DCGMExtractorType,
+		},
+		dk: attrgpu.GPUUtilizationDataKey,
+	}
+}
+
+func (e *Extractor) TypedName() fwkplugin.TypedName {
+	return e.typedName
+}
+
+// DCGMExtractorFactory instantiates a dcgm-extractor plugin from configuration.
+func DCGMExtractorFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	ext := NewDCGMExtractor()
+	ext.typedName.Name = name
+	return ext, nil
+}
+
+// Extract parses DCGM_FI_DEV_GPU_UTIL from the Prometheus families,
+// aggregates across GPUs (max), normalizes to [0.0, 1.0], and stores
+// the result in the endpoint's AttributeMap.
+func (e *Extractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]) error {
+	family, ok := in.Payload[gpuUtilMetricName]
+	if !ok {
+		return fmt.Errorf("metric %q not found in DCGM response", gpuUtilMetricName)
+	}
+
+	maxUtil := 0.0
+	found := false
+	for _, m := range family.GetMetric() {
+		val := gaugeValue(m)
+		if val > maxUtil {
+			maxUtil = val
+		}
+		found = true
+	}
+	if !found {
+		return fmt.Errorf("metric %q present but has no samples", gpuUtilMetricName)
+	}
+
+	normalized := attrgpu.GPUUtilization(maxUtil / 100.0)
+	in.Endpoint.GetAttributes().Put(e.dk.String(), normalized)
+	return nil
+}
+
+// Produces declares the data key this extractor publishes.
+func (e *Extractor) Produces() map[fwkplugin.DataKey]any {
+	return map[fwkplugin.DataKey]any{e.dk: attrgpu.GPUUtilization(0)}
+}
+
+func gaugeValue(m *dto.Metric) float64 {
+	if g := m.GetGauge(); g != nil {
+		return g.GetValue()
+	}
+	return 0
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dcgm
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	attrgpu "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/gpu"
+	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+)
+
+func makeGauge(values ...float64) *dto.MetricFamily {
+	gaugeType := dto.MetricType_GAUGE
+	fam := &dto.MetricFamily{
+		Name: proto.String(gpuUtilMetricName),
+		Type: &gaugeType,
+	}
+	for _, v := range values {
+		fam.Metric = append(fam.Metric, &dto.Metric{
+			Gauge: &dto.Gauge{Value: &v},
+		})
+	}
+	return fam
+}
+
+func TestExtractorExtract(t *testing.T) {
+	ctx := context.Background()
+
+	extPlugin, err := DCGMExtractorFactory("test-extractor", nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create extractor: %v", err)
+	}
+	extractor := extPlugin.(*Extractor)
+
+	if exType := extPlugin.TypedName().Type; exType == "" {
+		t.Error("empty extractor type")
+	}
+	if exName := extPlugin.TypedName().Name; exName == "" {
+		t.Error("empty extractor name")
+	}
+
+	key := attrgpu.GPUUtilizationDataKey.WithNonEmptyProducerName(attrgpu.DCGMExtractorType).String()
+	gaugeType := dto.MetricType_GAUGE
+
+	tests := []struct {
+		name        string
+		data        sourcemetrics.PrometheusMetricMap
+		wantErr     bool
+		errContains string
+		updated     bool
+		wantUtil    float64
+	}{
+		{
+			name:        "missing metric",
+			data:        sourcemetrics.PrometheusMetricMap{},
+			wantErr:     true,
+			errContains: gpuUtilMetricName,
+		},
+		{
+			name: "empty samples",
+			data: sourcemetrics.PrometheusMetricMap{
+				gpuUtilMetricName: &dto.MetricFamily{
+					Name:   proto.String(gpuUtilMetricName),
+					Type:   &gaugeType,
+					Metric: []*dto.Metric{},
+				},
+			},
+			wantErr:     true,
+			errContains: "no samples",
+		},
+		{
+			name: "single GPU",
+			data: sourcemetrics.PrometheusMetricMap{
+				gpuUtilMetricName: makeGauge(73),
+			},
+			updated:  true,
+			wantUtil: 0.73,
+		},
+		{
+			name: "multi-GPU takes max",
+			data: sourcemetrics.PrometheusMetricMap{
+				gpuUtilMetricName: makeGauge(73, 81, 65),
+			},
+			updated:  true,
+			wantUtil: 0.81,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Extract panicked: %v", r)
+				}
+			}()
+
+			ep := fwkdl.NewEndpoint(nil, nil)
+			attr := ep.GetAttributes()
+			before, _ := attr.Get(key)
+
+			err := extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{
+				Payload: tt.data, Endpoint: ep,
+			})
+			after, _ := attr.Get(key)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+			}
+
+			if tt.updated {
+				if diff := cmp.Diff(before, after); diff == "" {
+					t.Error("expected attribute to be updated, but no change detected")
+				}
+				val, ok := attrgpu.ReadGPUUtilization(attr, key)
+				if !ok {
+					t.Fatal("GPU utilization not found in attributes after extract")
+				}
+				if math.Abs(float64(val)-tt.wantUtil) > 0.001 {
+					t.Errorf("expected utilization %.3f, got %.3f", tt.wantUtil, float64(val))
+				}
+			} else {
+				if diff := cmp.Diff(before, after); diff != "" {
+					t.Errorf("expected no attribute update, but got changes:\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestFactory_SetsName(t *testing.T) {
+	p, err := DCGMExtractorFactory("my-dcgm", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := p.TypedName().Type; got != attrgpu.DCGMExtractorType {
+		t.Errorf("Type = %q, want %q", got, attrgpu.DCGMExtractorType)
+	}
+	if got := p.TypedName().Name; got != "my-dcgm" {
+		t.Errorf("Name = %q, want %q", got, "my-dcgm")
+	}
+}
+
+func TestProduces_DeclaresGPUUtilization(t *testing.T) {
+	ext := NewDCGMExtractor()
+	produced := ext.Produces()
+	if _, ok := produced[attrgpu.GPUUtilizationDataKey]; !ok {
+		t.Error("Produces must declare GPUUtilizationDataKey")
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor_test.go
@@ -45,6 +45,32 @@ func makeGauge(values ...float64) *dto.MetricFamily {
 	return fam
 }
 
+type labeledSample struct {
+	pod   string
+	value float64
+}
+
+func makeLabeledGauge(samples ...labeledSample) *dto.MetricFamily {
+	gaugeType := dto.MetricType_GAUGE
+	fam := &dto.MetricFamily{
+		Name: proto.String(gpuUtilMetricName),
+		Type: &gaugeType,
+	}
+	for _, s := range samples {
+		m := &dto.Metric{
+			Gauge: &dto.Gauge{Value: &s.value},
+		}
+		if s.pod != "" {
+			m.Label = []*dto.LabelPair{{
+				Name:  proto.String(podLabelName),
+				Value: proto.String(s.pod),
+			}}
+		}
+		fam.Metric = append(fam.Metric, m)
+	}
+	return fam
+}
+
 func TestExtractorExtract(t *testing.T) {
 	ctx := context.Background()
 
@@ -66,6 +92,7 @@ func TestExtractorExtract(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		podName     string
 		data        sourcemetrics.PrometheusMetricMap
 		wantErr     bool
 		errContains string
@@ -106,6 +133,52 @@ func TestExtractorExtract(t *testing.T) {
 			updated:  true,
 			wantUtil: 0.81,
 		},
+		{
+			name:    "DaemonSet payload filters by pod label",
+			podName: "vllm-pod-2",
+			data: sourcemetrics.PrometheusMetricMap{
+				gpuUtilMetricName: makeLabeledGauge(
+					labeledSample{"vllm-pod-1", 25},
+					labeledSample{"vllm-pod-2", 80},
+					labeledSample{"vllm-pod-3", 10},
+				),
+			},
+			updated:  true,
+			wantUtil: 0.80,
+		},
+		{
+			name:    "DaemonSet multi-GPU for same pod takes max",
+			podName: "vllm-pod-1",
+			data: sourcemetrics.PrometheusMetricMap{
+				gpuUtilMetricName: makeLabeledGauge(
+					labeledSample{"vllm-pod-1", 40},
+					labeledSample{"vllm-pod-1", 70},
+					labeledSample{"vllm-pod-2", 99},
+				),
+			},
+			updated:  true,
+			wantUtil: 0.70,
+		},
+		{
+			name:    "no matching pod label returns error",
+			podName: "missing-pod",
+			data: sourcemetrics.PrometheusMetricMap{
+				gpuUtilMetricName: makeLabeledGauge(
+					labeledSample{"vllm-pod-1", 50},
+				),
+			},
+			wantErr:     true,
+			errContains: "missing-pod",
+		},
+		{
+			name:    "unlabeled samples kept when podName set (sidecar compat)",
+			podName: "vllm-pod-1",
+			data: sourcemetrics.PrometheusMetricMap{
+				gpuUtilMetricName: makeGauge(55),
+			},
+			updated:  true,
+			wantUtil: 0.55,
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,7 +189,8 @@ func TestExtractorExtract(t *testing.T) {
 				}
 			}()
 
-			ep := fwkdl.NewEndpoint(nil, nil)
+			meta := &fwkdl.EndpointMetadata{PodName: tt.podName}
+			ep := fwkdl.NewEndpoint(meta, nil)
 			attr := ep.GetAttributes()
 			before, _ := attr.Get(key)
 

--- a/pkg/epp/framework/plugins/datalayer/source/dcgm/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/dcgm/README.md
@@ -2,33 +2,51 @@
 
 **Type:** `dcgm-data-source`
 
-The DCGM Data Source polls NVIDIA DCGM Exporter sidecar containers for GPU hardware metrics and passes the response to a paired `dcgm-extractor` extractor.
+The DCGM Data Source polls NVIDIA DCGM Exporter for GPU hardware metrics and
+passes the response to a paired `dcgm-extractor`.
 
 ## What it does
 
 1. Iterates over every ready endpoint associated with the `InferencePool`.
-2. Issues a `GET <scheme>://<pod-ip>:<port>/<path>` request to each endpoint's DCGM Exporter sidecar.
+2. Issues a `GET <scheme>://<host>:<port>/<path>` request to the DCGM Exporter.
 3. Parses the Prometheus text response.
-4. Returns the parsed metric families to the datalayer runtime, which forwards them to any extractors wired to this source via `data: sources:`.
+4. Returns the parsed metric families to the datalayer runtime, which forwards
+   them to any extractors wired to this source via `dataLayer: sources:`.
 
-The source uses `portOverride` on the underlying `HTTPDataSource` to reach the DCGM Exporter on a different port than the inference server.
+The scrape host is either the pod IP (sidecar) or the node IP (DaemonSet),
+controlled by `useNodeAddress`. In both cases `port` overrides the inference
+server port via `HTTPDataSource` options.
 
 ## Inputs consumed
 
 - Pod list from the `InferencePool` (polled individually on each scheduling cycle).
+- When `useNodeAddress` is true, each endpoint's `NodeAddress` (`pod.Status.HostIP`).
 
 ## Configuration
 
 - `scheme` (string, optional, default: `"http"`): Protocol scheme: `"http"` or `"https"`.
 - `path` (string, optional, default: `"/metrics"`): URL path for the DCGM Exporter metrics endpoint.
-- `port` (int, optional, default: `9400`): Port where the DCGM Exporter sidecar listens.
+- `port` (int, optional, default: `9400`): Port where the DCGM Exporter listens.
 - `insecureSkipVerify` (bool, optional, default: `true`): Skip TLS certificate verification.
+- `useNodeAddress` (bool, optional, default: `false`): When true, scrape
+  `NodeAddress:port` (DaemonSet). When false, scrape `PodIP:port` (sidecar).
+
+DaemonSet deployments require `DCGM_EXPORTER_KUBERNETES=true` on the exporter
+so metrics include a `pod` label (GPU Operator sets this by default).
 
 ```yaml
+# Sidecar (default)
 - type: dcgm-data-source
   name: my-dcgm-source
   parameters:
     port: 9400
+
+# DaemonSet
+- type: dcgm-data-source
+  name: my-dcgm-source
+  parameters:
+    port: 9400
+    useNodeAddress: true
 ```
 
 ## Complete Configuration Example
@@ -41,10 +59,11 @@ plugins:
   name: dcgm-source
   parameters:
     port: 9400
+    useNodeAddress: true
 - type: dcgm-extractor
   name: dcgm-extractor
 # ... other plugins (filters, scorers, profile handler, picker) ...
-data:
+dataLayer:
   sources:
   - pluginRef: dcgm-source
     extractors:

--- a/pkg/epp/framework/plugins/datalayer/source/dcgm/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/dcgm/README.md
@@ -1,0 +1,52 @@
+# DCGM Data Source
+
+**Type:** `dcgm-data-source`
+
+The DCGM Data Source polls NVIDIA DCGM Exporter sidecar containers for GPU hardware metrics and passes the response to a paired `dcgm-extractor` extractor.
+
+## What it does
+
+1. Iterates over every ready endpoint associated with the `InferencePool`.
+2. Issues a `GET <scheme>://<pod-ip>:<port>/<path>` request to each endpoint's DCGM Exporter sidecar.
+3. Parses the Prometheus text response.
+4. Returns the parsed metric families to the datalayer runtime, which forwards them to any extractors wired to this source via `data: sources:`.
+
+The source uses `portOverride` on the underlying `HTTPDataSource` to reach the DCGM Exporter on a different port than the inference server.
+
+## Inputs consumed
+
+- Pod list from the `InferencePool` (polled individually on each scheduling cycle).
+
+## Configuration
+
+- `scheme` (string, optional, default: `"http"`): Protocol scheme: `"http"` or `"https"`.
+- `path` (string, optional, default: `"/metrics"`): URL path for the DCGM Exporter metrics endpoint.
+- `port` (int, optional, default: `9400`): Port where the DCGM Exporter sidecar listens.
+- `insecureSkipVerify` (bool, optional, default: `true`): Skip TLS certificate verification.
+
+```yaml
+- type: dcgm-data-source
+  name: my-dcgm-source
+  parameters:
+    port: 9400
+```
+
+## Complete Configuration Example
+
+```yaml
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: dcgm-data-source
+  name: dcgm-source
+  parameters:
+    port: 9400
+- type: dcgm-extractor
+  name: dcgm-extractor
+# ... other plugins (filters, scorers, profile handler, picker) ...
+data:
+  sources:
+  - pluginRef: dcgm-source
+    extractors:
+    - pluginRef: dcgm-extractor
+```

--- a/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource.go
@@ -43,14 +43,16 @@ type dcgmDatasourceParams struct {
 	Path               string `json:"path"`
 	Port               int    `json:"port"`
 	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+	// UseNodeAddress scrapes the node IP (DaemonSet) instead of the pod IP (sidecar).
+	UseNodeAddress bool `json:"useNodeAddress"`
 }
 
 // NewHTTPDCGMDataSource constructs a DCGMDataSource with the given parameters.
 // Use this function directly in tests to bypass JSON parameter marshaling.
-func NewHTTPDCGMDataSource(scheme, path string, port int, name string) (*http.HTTPDataSource[metrics.PrometheusMetricMap], error) {
+func NewHTTPDCGMDataSource(scheme, path string, port int, name string, opts ...http.Option) (*http.HTTPDataSource[metrics.PrometheusMetricMap], error) {
+	opts = append([]http.Option{http.WithPortOverride(port)}, opts...)
 	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultDCGMInsecureSkipVerify},
-		DCGMDataSourceType, name, parsePrometheus,
-		http.WithPortOverride(port))
+		DCGMDataSourceType, name, parsePrometheus, opts...)
 }
 
 // DCGMDataSourceFactory instantiates a dcgm-data-source plugin from configuration.
@@ -65,9 +67,13 @@ func DCGMDataSourceFactory(name string, parameters *json.Decoder, _ plugin.Handl
 		return nil, fmt.Errorf("unsupported scheme: %s", cfg.Scheme)
 	}
 
+	opts := []http.Option{http.WithPortOverride(cfg.Port)}
+	if cfg.UseNodeAddress {
+		opts = append(opts, http.WithUseNodeAddress())
+	}
+
 	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, http.TLSOptions{SkipVerify: cfg.InsecureSkipVerify},
-		DCGMDataSourceType, name, parsePrometheus,
-		http.WithPortOverride(cfg.Port))
+		DCGMDataSourceType, name, parsePrometheus, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DCGM data source: %w", err)
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dcgm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+)
+
+const DCGMDataSourceType = "dcgm-data-source"
+
+const (
+	defaultDCGMScheme             = "http"
+	defaultDCGMPath               = "/metrics"
+	defaultDCGMPort               = 9400
+	defaultDCGMInsecureSkipVerify = true
+)
+
+type dcgmDatasourceParams struct {
+	Scheme             string `json:"scheme"`
+	Path               string `json:"path"`
+	Port               int    `json:"port"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+}
+
+// NewHTTPDCGMDataSource constructs a DCGMDataSource with the given parameters.
+// Use this function directly in tests to bypass JSON parameter marshaling.
+func NewHTTPDCGMDataSource(scheme, path string, port int, name string) (*http.HTTPDataSource[metrics.PrometheusMetricMap], error) {
+	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultDCGMInsecureSkipVerify},
+		DCGMDataSourceType, name, parsePrometheus,
+		http.WithPortOverride(port))
+}
+
+// DCGMDataSourceFactory instantiates a dcgm-data-source plugin from configuration.
+func DCGMDataSourceFactory(name string, parameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	cfg := defaultDCGMConfigParams()
+	if parameters != nil {
+		if err := parameters.Decode(cfg); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Scheme != "http" && cfg.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme: %s", cfg.Scheme)
+	}
+
+	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, http.TLSOptions{SkipVerify: cfg.InsecureSkipVerify},
+		DCGMDataSourceType, name, parsePrometheus,
+		http.WithPortOverride(cfg.Port))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DCGM data source: %w", err)
+	}
+	return ds, nil
+}
+
+func defaultDCGMConfigParams() *dcgmDatasourceParams {
+	return &dcgmDatasourceParams{
+		Scheme:             defaultDCGMScheme,
+		Path:               defaultDCGMPath,
+		Port:               defaultDCGMPort,
+		InsecureSkipVerify: defaultDCGMInsecureSkipVerify,
+	}
+}
+
+func parsePrometheus(data io.Reader) (metrics.PrometheusMetricMap, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	return parser.TextToMetricFamilies(data)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dcgm
+
+import (
+	"testing"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+func TestDCGMDataSourceFactory_Defaults(t *testing.T) {
+	p, err := DCGMDataSourceFactory("test", fwkplugin.StrictDecoder(nil), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil plugin")
+	}
+	if got := p.TypedName().Type; got != DCGMDataSourceType {
+		t.Errorf("Type = %q, want %q", got, DCGMDataSourceType)
+	}
+	if got := p.TypedName().Name; got != "test" {
+		t.Errorf("Name = %q, want %q", got, "test")
+	}
+}
+
+func TestDCGMDataSourceFactory_CustomParams(t *testing.T) {
+	raw := []byte(`{"scheme":"https","path":"/gpu","port":9500,"insecureSkipVerify":false,"useNodeAddress":true}`)
+	p, err := DCGMDataSourceFactory("custom", fwkplugin.StrictDecoder(raw), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil plugin")
+	}
+	if got := p.TypedName().Name; got != "custom" {
+		t.Errorf("Name = %q, want %q", got, "custom")
+	}
+}
+
+func TestDCGMDataSourceFactory_InvalidScheme(t *testing.T) {
+	raw := []byte(`{"scheme":"grpc"}`)
+	_, err := DCGMDataSourceFactory("test", fwkplugin.StrictDecoder(raw), nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+}
+
+func TestDCGMDataSourceFactory_InvalidJSON(t *testing.T) {
+	raw := []byte(`{invalid`)
+	_, err := DCGMDataSourceFactory("test", fwkplugin.StrictDecoder(raw), nil)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestDCGMDataSourceFactory_UnknownField(t *testing.T) {
+	raw := []byte(`{"scheme":"http","bogus":"value"}`)
+	_, err := DCGMDataSourceFactory("test", fwkplugin.StrictDecoder(raw), nil)
+	if err == nil {
+		t.Fatal("expected error for unknown field (strict decoding)")
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/dcgm/datasource_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 )
 
 func TestDCGMDataSourceFactory_Defaults(t *testing.T) {
@@ -73,5 +74,28 @@ func TestDCGMDataSourceFactory_UnknownField(t *testing.T) {
 	_, err := DCGMDataSourceFactory("test", fwkplugin.StrictDecoder(raw), nil)
 	if err == nil {
 		t.Fatal("expected error for unknown field (strict decoding)")
+	}
+}
+
+func TestNewHTTPDCGMDataSource(t *testing.T) {
+	ds, err := NewHTTPDCGMDataSource("http", "/metrics", 9400, "direct")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := ds.TypedName().Type; got != DCGMDataSourceType {
+		t.Errorf("Type = %q, want %q", got, DCGMDataSourceType)
+	}
+	if got := ds.TypedName().Name; got != "direct" {
+		t.Errorf("Name = %q, want %q", got, "direct")
+	}
+}
+
+func TestNewHTTPDCGMDataSource_WithUseNodeAddress(t *testing.T) {
+	ds, err := NewHTTPDCGMDataSource("http", "/metrics", 9400, "node", http.WithUseNodeAddress())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ds == nil {
+		t.Fatal("expected non-nil data source")
 	}
 }

--- a/pkg/epp/framework/plugins/datalayer/source/http/client.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/client.go
@@ -35,6 +35,7 @@ type Client interface {
 // Addressable supports getting an IP address and a namespaced name.
 type Addressable interface {
 	GetIPAddress() string
+	GetNodeAddress() string
 	GetPort() string
 	GetMetricsHost() string
 	GetNamespacedName() types.NamespacedName

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -59,6 +59,9 @@ type HTTPDataSource[T any] struct {
 	// different port on the same pod (e.g. DCGM Exporter on :9400)
 	// without changing the endpoint metadata set by the discovery layer.
 	portOverride int
+	// useNodeAddress, when true, scrapes NodeAddress:portOverride instead
+	// of the pod IP. Used for node-level exporters (e.g. DCGM DaemonSet).
+	useNodeAddress bool
 
 	client Client
 	// parser converts the response body to T. MUST NOT return (zero, nil) for nilable T;
@@ -87,7 +90,8 @@ type TLSOptions struct {
 type Option func(*options)
 
 type options struct {
-	portOverride int
+	portOverride   int
+	useNodeAddress bool
 }
 
 // WithPortOverride makes the source scrape podIP:port instead of the
@@ -95,6 +99,13 @@ type options struct {
 // listens on a different port than the inference server.
 func WithPortOverride(port int) Option {
 	return func(o *options) { o.portOverride = port }
+}
+
+// WithUseNodeAddress makes the source scrape nodeIP:portOverride instead
+// of podIP:portOverride. Requires a non-zero portOverride and a non-empty
+// NodeAddress on the endpoint metadata.
+func WithUseNodeAddress() Option {
+	return func(o *options) { o.useNodeAddress = true }
 }
 
 // NewHTTPDataSource constructs a typed polling dispatcher. For https, tlsOpts configures
@@ -127,12 +138,13 @@ func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 		cl.Transport = httpsTransport
 	}
 	return &HTTPDataSource[T]{
-		typedName:    fwkplugin.TypedName{Type: pluginType, Name: pluginName},
-		scheme:       scheme,
-		path:         path,
-		portOverride: cfg.portOverride,
-		client:       cl,
-		parser:       parser,
+		typedName:      fwkplugin.TypedName{Type: pluginType, Name: pluginName},
+		scheme:         scheme,
+		path:           path,
+		portOverride:   cfg.portOverride,
+		useNodeAddress: cfg.useNodeAddress,
+		client:         cl,
+		parser:         parser,
 	}, nil
 }
 
@@ -262,7 +274,13 @@ func (s *HTTPDataSource[T]) AppendExtractor(ext fwkplugin.Plugin) error {
 func (s *HTTPDataSource[T]) getEndpoint(ep Addressable) *url.URL {
 	host := ep.GetMetricsHost()
 	if s.portOverride > 0 {
-		host = net.JoinHostPort(ep.GetIPAddress(), strconv.Itoa(s.portOverride))
+		ip := ep.GetIPAddress()
+		if s.useNodeAddress {
+			if nodeIP := ep.GetNodeAddress(); nodeIP != "" {
+				ip = nodeIP
+			}
+		}
+		host = net.JoinHostPort(ip, strconv.Itoa(s.portOverride))
 	}
 	return &url.URL{Scheme: s.scheme, Host: host, Path: s.path}
 }

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -122,7 +122,7 @@ func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 		o(&cfg)
 	}
 	if cfg.useNodeAddress && cfg.portOverride == 0 {
-		return nil, fmt.Errorf("WithUseNodeAddress requires a non-zero WithPortOverride")
+		return nil, errors.New("WithUseNodeAddress requires a non-zero WithPortOverride")
 	}
 
 	cl := &client{

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -23,12 +23,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"reflect"
 	"runtime/debug"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
@@ -52,6 +54,11 @@ type HTTPDataSource[T any] struct {
 	typedName fwkplugin.TypedName
 	scheme    string
 	path      string
+	// portOverride, when non-zero, replaces the port in the endpoint's
+	// MetricsHost with this value. This allows a source to target a
+	// different port on the same pod (e.g. DCGM Exporter on :9400)
+	// without changing the endpoint metadata set by the discovery layer.
+	portOverride int
 
 	client Client
 	// parser converts the response body to T. MUST NOT return (zero, nil) for nilable T;
@@ -76,13 +83,34 @@ type TLSOptions struct {
 	ClientKeyPath  string
 }
 
+// Option configures optional behaviour on an HTTPDataSource.
+type Option func(*options)
+
+type options struct {
+	portOverride int
+}
+
+// WithPortOverride makes the source scrape podIP:port instead of the
+// endpoint's MetricsHost. Use this when a sidecar (e.g. DCGM Exporter)
+// listens on a different port than the inference server.
+func WithPortOverride(port int) Option {
+	return func(o *options) { o.portOverride = port }
+}
+
 // NewHTTPDataSource constructs a typed polling dispatcher. For https, tlsOpts configures
 // server verification (CACertPath) and optional mTLS (ClientCertPath/ClientKeyPath).
 func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
-	pluginType, pluginName string, parser func(io.Reader) (T, error)) (*HTTPDataSource[T], error) {
+	pluginType, pluginName string, parser func(io.Reader) (T, error),
+	opts ...Option) (*HTTPDataSource[T], error) {
 	if scheme != "http" && scheme != "https" {
 		return nil, fmt.Errorf("unsupported scheme: %s", scheme)
 	}
+
+	var cfg options
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	cl := &client{
 		Client: http.Client{
 			Timeout:   timeout,
@@ -99,11 +127,12 @@ func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 		cl.Transport = httpsTransport
 	}
 	return &HTTPDataSource[T]{
-		typedName: fwkplugin.TypedName{Type: pluginType, Name: pluginName},
-		scheme:    scheme,
-		path:      path,
-		client:    cl,
-		parser:    parser,
+		typedName:    fwkplugin.TypedName{Type: pluginType, Name: pluginName},
+		scheme:       scheme,
+		path:         path,
+		portOverride: cfg.portOverride,
+		client:       cl,
+		parser:       parser,
 	}, nil
 }
 
@@ -231,5 +260,9 @@ func (s *HTTPDataSource[T]) AppendExtractor(ext fwkplugin.Plugin) error {
 }
 
 func (s *HTTPDataSource[T]) getEndpoint(ep Addressable) *url.URL {
-	return &url.URL{Scheme: s.scheme, Host: ep.GetMetricsHost(), Path: s.path}
+	host := ep.GetMetricsHost()
+	if s.portOverride > 0 {
+		host = net.JoinHostPort(ep.GetIPAddress(), strconv.Itoa(s.portOverride))
+	}
+	return &url.URL{Scheme: s.scheme, Host: host, Path: s.path}
 }

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -121,6 +121,9 @@ func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 	for _, o := range opts {
 		o(&cfg)
 	}
+	if cfg.useNodeAddress && cfg.portOverride == 0 {
+		return nil, fmt.Errorf("WithUseNodeAddress requires a non-zero WithPortOverride")
+	}
 
 	cl := &client{
 		Client: http.Client{

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
@@ -241,11 +241,6 @@ func TestGetEndpoint_PortOverride(t *testing.T) {
 			opts:     []Option{WithPortOverride(9400), WithUseNodeAddress()},
 			wantHost: "192.168.1.10:9400",
 		},
-		{
-			name:     "WithUseNodeAddress without portOverride is a no-op",
-			opts:     []Option{WithUseNodeAddress()},
-			wantHost: "10.0.0.1:8000",
-		},
 	}
 
 	for _, tc := range cases {
@@ -258,6 +253,14 @@ func TestGetEndpoint_PortOverride(t *testing.T) {
 			assert.Equal(t, "/metrics", got.Path)
 		})
 	}
+}
+
+func TestNewHTTPDataSource_UseNodeAddressWithoutPortOverride(t *testing.T) {
+	parser := func(r io.Reader) (int, error) { return 0, nil }
+	_, err := NewHTTPDataSource("http", "/metrics", TLSOptions{SkipVerify: true}, "test", "test", parser,
+		WithUseNodeAddress())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithUseNodeAddress requires a non-zero WithPortOverride")
 }
 
 func TestGetEndpoint_UseNodeAddress_FallsBackToPodIP(t *testing.T) {

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
@@ -213,6 +213,42 @@ func (c *cancelOnExtract) Extract(ctx context.Context, in fwkdl.PollInput[int]) 
 	return err
 }
 
+func TestGetEndpoint_PortOverride(t *testing.T) {
+	parser := func(r io.Reader) (int, error) { return 0, nil }
+	ep := &fwkdl.EndpointMetadata{
+		Address:     "10.0.0.1",
+		MetricsHost: "10.0.0.1:8000",
+	}
+
+	cases := []struct {
+		name     string
+		opts     []Option
+		wantHost string
+	}{
+		{
+			name:     "no option uses MetricsHost as-is",
+			opts:     nil,
+			wantHost: "10.0.0.1:8000",
+		},
+		{
+			name:     "WithPortOverride overrides port with pod IP",
+			opts:     []Option{WithPortOverride(9400)},
+			wantHost: "10.0.0.1:9400",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := NewHTTPDataSource("http", "/metrics", TLSOptions{SkipVerify: true}, "test", "test", parser, tc.opts...)
+			assert.NoError(t, err)
+			got := s.getEndpoint(ep)
+			assert.Equal(t, tc.wantHost, got.Host)
+			assert.Equal(t, "http", got.Scheme)
+			assert.Equal(t, "/metrics", got.Path)
+		})
+	}
+}
+
 func TestAppendExtractor(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
@@ -217,6 +217,7 @@ func TestGetEndpoint_PortOverride(t *testing.T) {
 	parser := func(r io.Reader) (int, error) { return 0, nil }
 	ep := &fwkdl.EndpointMetadata{
 		Address:     "10.0.0.1",
+		NodeAddress: "192.168.1.10",
 		MetricsHost: "10.0.0.1:8000",
 	}
 
@@ -235,6 +236,16 @@ func TestGetEndpoint_PortOverride(t *testing.T) {
 			opts:     []Option{WithPortOverride(9400)},
 			wantHost: "10.0.0.1:9400",
 		},
+		{
+			name:     "WithUseNodeAddress scrapes node IP with port override",
+			opts:     []Option{WithPortOverride(9400), WithUseNodeAddress()},
+			wantHost: "192.168.1.10:9400",
+		},
+		{
+			name:     "WithUseNodeAddress without portOverride is a no-op",
+			opts:     []Option{WithUseNodeAddress()},
+			wantHost: "10.0.0.1:8000",
+		},
 	}
 
 	for _, tc := range cases {
@@ -247,6 +258,21 @@ func TestGetEndpoint_PortOverride(t *testing.T) {
 			assert.Equal(t, "/metrics", got.Path)
 		})
 	}
+}
+
+func TestGetEndpoint_UseNodeAddress_FallsBackToPodIP(t *testing.T) {
+	parser := func(r io.Reader) (int, error) { return 0, nil }
+	ep := &fwkdl.EndpointMetadata{
+		Address:     "10.0.0.1",
+		NodeAddress: "",
+		MetricsHost: "10.0.0.1:8000",
+	}
+	s, err := NewHTTPDataSource("http", "/metrics", TLSOptions{SkipVerify: true}, "test", "test", parser,
+		WithPortOverride(9400), WithUseNodeAddress())
+	require.NoError(t, err)
+	got := s.getEndpoint(ep)
+	assert.Equal(t, "10.0.0.1:9400", got.Host,
+		"empty NodeAddress must fall back to pod IP")
 }
 
 func TestAppendExtractor(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

The EPP routes requests using application-level metrics (KV cache, queue
depth) but has no GPU hardware utilization signal. This adds the
data-layer infrastructure to collect GPU metrics from a DCGM Exporter endpoints:

- `HTTPDataSource` port override to scrape a different port on the same
  pod IP (backward-compatible, default 0 preserves existing behavior)
- `dcgm-data-source` plugin that polls and parses Prometheus metrics
- `dcgm-extractor` plugin that reads `DCGM_FI_DEV_GPU_UTIL`, aggregates
  across GPUs (max), and stores normalized utilization in the endpoint's
  `AttributeMap`
- `GPUUtilization` attribute type with `Produces`/`Consumes` data key

A follow-up PR adds a filter and scorer that consume this attribute.

**Which issue(s) this PR fixes**:
Part of #1706

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```