### PR TITLE
fix(tokenizer): support render tokenizer for Anthropic /v1/messages

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -169,15 +169,11 @@ func chatPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 	return pm
 }
 
-// messagesPayload returns the payload for an Anthropic Messages request.
-// HTTP requests carry a raw map payload and return early;
-// gRPC requests fall back to constructing an OpenAI-shaped PayloadMap from the typed struct.
+// messagesPayload returns the payload for an Anthropic Messages request. The raw
+// body uses the Anthropic Messages schema (top-level system, source-based image
+// blocks), which vLLM /render does not accept, so the payload is always rebuilt
+// from the typed struct into the /render chat schema regardless of body.Payload.
 func messagesPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
-	if body.Payload != nil {
-		if _, ok := body.Payload.AsMap(); ok {
-			return body.Payload
-		}
-	}
 	data, _ := json.Marshal(buildChatRenderRequest("", MessagesToRenderChatRequest(body.Messages)))
 	var pm fwkrh.PayloadMap
 	_ = json.Unmarshal(data, &pm)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -117,6 +117,15 @@ func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequest
 			return nil, fmt.Errorf("tokenization failed: %w", err)
 		}
 		return &fwkrh.TokenizedPrompt{PerPromptTokens: [][]uint32{tokenIDs}, MultiModalFeatures: convertMMFeaturesToUpstream(mmFeatures)}, nil
+	case body.Messages != nil:
+		tokenIDs, mmFeatures, err := b.tk.RenderChat(ctx, messagesPayload(body))
+		if err != nil {
+			return nil, fmt.Errorf("tokenization failed: %w", err)
+		}
+		return &fwkrh.TokenizedPrompt{
+			PerPromptTokens:    [][]uint32{tokenIDs},
+			MultiModalFeatures: convertMMFeaturesToUpstream(mmFeatures),
+		}, nil
 	case body.Generate != nil:
 		return &fwkrh.TokenizedPrompt{
 			PerPromptTokens:    [][]uint32{body.Generate.TokenIDs},
@@ -155,6 +164,21 @@ func chatPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 	}
 	rcr := ChatCompletionsToRenderChatRequest(body.ChatCompletions)
 	data, _ := json.Marshal(buildChatRenderRequest("", rcr))
+	var pm fwkrh.PayloadMap
+	_ = json.Unmarshal(data, &pm)
+	return pm
+}
+
+// messagesPayload returns the payload for an Anthropic Messages request.
+// HTTP requests carry a raw map payload and return early;
+// gRPC requests fall back to constructing an OpenAI-shaped PayloadMap from the typed struct.
+func messagesPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
+	if body.Payload != nil {
+		if _, ok := body.Payload.AsMap(); ok {
+			return body.Payload
+		}
+	}
+	data, _ := json.Marshal(buildChatRenderRequest("", MessagesToRenderChatRequest(body.Messages)))
 	var pm fwkrh.PayloadMap
 	_ = json.Unmarshal(data, &pm)
 	return pm

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -341,11 +341,12 @@ func convertAnthropicContent(ac fwkrh.AnthropicContent) tokenizerTypes.Content {
 				Text: b.Text,
 			})
 		case "image":
-			blocks = append(blocks, tokenizerTypes.ContentBlock{
-				Type:     "image_url",
-				ImageURL: tokenizerTypes.ImageBlock{URL: anthropicImageToURL(b.Source)},
-			})
-		}
+			if url := anthropicImageToURL(b.Source); url != "" {
+				blocks = append(blocks, tokenizerTypes.ContentBlock{
+					Type:     "image_url",
+					ImageURL: tokenizerTypes.ImageBlock{URL: url},
+				})
+			}
 	}
 	return tokenizerTypes.Content{Structured: blocks}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -301,6 +301,70 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 	}
 }
 
+// MessagesToRenderChatRequest converts an Anthropic MessagesRequest to a
+// tokenization RenderChatRequest for vLLM /render endpoint with System, Message and Tools set in RenderChatRequest only.
+func MessagesToRenderChatRequest(msg *fwkrh.MessagesRequest) *tokenizerTypes.RenderChatRequest {
+	conversation := make([]tokenizerTypes.Conversation, 0, 1+len(msg.Messages))
+
+	if msg.System.Raw != "" || len(msg.System.Structured) > 0 {
+		conversation = append(conversation, tokenizerTypes.Conversation{
+			Role:    "system",
+			Content: convertAnthropicContent(msg.System),
+		})
+	}
+
+	for _, m := range msg.Messages {
+		conversation = append(conversation, tokenizerTypes.Conversation{
+			Role:    m.Role, // role: user, assistant, system
+			Content: convertAnthropicContent(m.Content),
+		})
+	}
+
+	return &tokenizerTypes.RenderChatRequest{
+		Conversation: conversation,
+		Tools:        msg.Tools,
+	}
+}
+
+// convertAnthropicContent converts an AnthropicContent to the kv-cache tokenizer Content type
+// mapping Anthropic image blocks to OpenAI-shaped image_url blocks.
+func convertAnthropicContent(ac fwkrh.AnthropicContent) tokenizerTypes.Content {
+	if ac.Raw != "" {
+		return tokenizerTypes.Content{Raw: ac.Raw}
+	}
+	blocks := make([]tokenizerTypes.ContentBlock, 0, len(ac.Structured))
+	for _, b := range ac.Structured {
+		switch b.Type {
+		case "text":
+			blocks = append(blocks, tokenizerTypes.ContentBlock{
+				Type: "text",
+				Text: b.Text,
+			})
+		case "image":
+			blocks = append(blocks, tokenizerTypes.ContentBlock{
+				Type:     "image_url",
+				ImageURL: tokenizerTypes.ImageBlock{URL: anthropicImageToURL(b.Source)},
+			})
+		}
+	}
+	return tokenizerTypes.Content{Structured: blocks}
+}
+
+// anthropicImageToURL converts an Anthropic image source to an OpenAI-shaped URL.
+// Base64 sources become data URIs; URL sources pass through.
+func anthropicImageToURL(src *fwkrh.AnthropicImageSource) string {
+	if src == nil {
+		return ""
+	}
+	if src.URL != "" {
+		return src.URL
+	}
+	if src.Data != "" {
+		return "data:" + src.MediaType + ";base64," + src.Data
+	}
+	return ""
+}
+
 // convertMMFeaturesToUpstream flattens the kv-cache map-shaped multimodal
 // metadata into the upstream flat list, sorted by placeholder offset so
 // consumers see items in prompt order. Returns nil when no content is present.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -347,6 +347,7 @@ func convertAnthropicContent(ac fwkrh.AnthropicContent) tokenizerTypes.Content {
 					ImageURL: tokenizerTypes.ImageBlock{URL: url},
 				})
 			}
+		}
 	}
 	return tokenizerTypes.Content{Structured: blocks}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -767,15 +767,23 @@ func TestMessagesToRenderChatRequest_StructuredMessage(t *testing.T) {
 
 func TestProduce_MessagesRequest(t *testing.T) {
 	wantTokens := []uint32{100, 200, 300}
+	var gotPayload fwkrh.RequestPayload
 	tok := &mockTokenizer{
-		renderChatFunc: func(_ fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+		renderChatFunc: func(payload fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			gotPayload = payload
 			return wantTokens, nil, nil
 		},
 	}
 	p := newTestPlugin(tok)
 
+	// Payload holds the raw request body; RenderChat must receive the converted
+	// /render body, not that raw payload.
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
+			Payload: fwkrh.PayloadMap{
+				"system":   "Be helpful.",
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			},
 			Messages: &fwkrh.MessagesRequest{
 				System:   fwkrh.AnthropicContent{Raw: "Be helpful."},
 				Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hi"}}},
@@ -785,4 +793,13 @@ func TestProduce_MessagesRequest(t *testing.T) {
 	require.NoError(t, p.Produce(context.Background(), req, nil))
 	require.NotNil(t, req.Body.TokenizedPrompt)
 	assert.Equal(t, [][]uint32{wantTokens}, req.Body.TokenizedPrompt.PerPromptTokens)
+
+	pm, ok := gotPayload.AsMap()
+	require.True(t, ok, "RenderChat payload must be a map")
+	assert.NotContains(t, pm, "system", "raw Anthropic top-level system must not reach /render")
+	msgs, ok := pm["messages"].([]any)
+	require.True(t, ok, "payload must carry the /render chat messages array")
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "system", msgs[0].(map[string]any)["role"])
+	assert.Equal(t, "user", msgs[1].(map[string]any)["role"])
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -624,3 +624,165 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 		})
 	}
 }
+
+func TestMessagesToRenderChatRequest_RawSystem(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		System:   fwkrh.AnthropicContent{Raw: "You are helpful."},
+		Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hello"}}},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 2)
+	assert.Equal(t, "system", result.Conversation[0].Role)
+	assert.Equal(t, tokenizerTypes.Content{Raw: "You are helpful."}, result.Conversation[0].Content)
+	assert.Equal(t, "user", result.Conversation[1].Role)
+	assert.Equal(t, tokenizerTypes.Content{Raw: "Hello"}, result.Conversation[1].Content)
+}
+
+func TestMessagesToRenderChatRequest_Tools(t *testing.T) {
+	tools := []any{map[string]any{"name": "get_weather"}}
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "What is the weather today?"}}},
+		Tools:    tools,
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	assert.Equal(t, tools, result.Tools)
+}
+
+func TestMessagesToRenderChatRequest_StructuredSystem(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		System: fwkrh.AnthropicContent{
+			Structured: []fwkrh.AnthropicContentBlock{
+				{Type: "text", Text: "System line 1."},
+				{Type: "text", Text: "System line 2."},
+			},
+		},
+		Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hi"}}},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 2)
+	assert.Equal(t, "system", result.Conversation[0].Role)
+	require.Len(t, result.Conversation[0].Content.Structured, 2)
+	assert.Equal(t, "text", result.Conversation[0].Content.Structured[0].Type)
+	assert.Equal(t, "System line 1.", result.Conversation[0].Content.Structured[0].Text)
+	assert.Equal(t, "System line 2.", result.Conversation[0].Content.Structured[1].Text)
+}
+
+func TestMessagesToRenderChatRequest_NoSystem(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hi"}}},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 1)
+	assert.Equal(t, "user", result.Conversation[0].Role)
+}
+
+func TestMessagesToRenderChatRequest_StructuredMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []fwkrh.AnthropicMessage
+		wantConv []tokenizerTypes.Conversation
+	}{
+		{
+			name: "text-only structured content",
+			messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{
+					Structured: []fwkrh.AnthropicContentBlock{
+						{Type: "text", Text: "Hello"},
+						{Type: "text", Text: "World"},
+					},
+				}},
+			},
+			wantConv: []tokenizerTypes.Conversation{
+				{Role: "user", Content: tokenizerTypes.Content{
+					Structured: []tokenizerTypes.ContentBlock{
+						{Type: "text", Text: "Hello"},
+						{Type: "text", Text: "World"},
+					},
+				}},
+			},
+		},
+		{
+			name: "image returns data URI",
+			messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{
+					Structured: []fwkrh.AnthropicContentBlock{
+						{Type: "text", Text: "Describe this"},
+						{Type: "image", Source: &fwkrh.AnthropicImageSource{Type: "base64", MediaType: "image/png", Data: "abc123"}},
+					},
+				}},
+			},
+			wantConv: []tokenizerTypes.Conversation{
+				{Role: "user", Content: tokenizerTypes.Content{
+					Structured: []tokenizerTypes.ContentBlock{
+						{Type: "text", Text: "Describe this"},
+						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "data:image/png;base64,abc123"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "image returns https URL",
+			messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{
+					Structured: []fwkrh.AnthropicContentBlock{
+						{Type: "text", Text: "Describe this"},
+						{Type: "image", Source: &fwkrh.AnthropicImageSource{Type: "url", URL: "https://example.com/img.jpg"}},
+					},
+				}},
+			},
+			wantConv: []tokenizerTypes.Conversation{
+				{Role: "user", Content: tokenizerTypes.Content{
+					Structured: []tokenizerTypes.ContentBlock{
+						{Type: "text", Text: "Describe this"},
+						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "https://example.com/img.jpg"}},
+					},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &fwkrh.MessagesRequest{Messages: tt.messages}
+			result := MessagesToRenderChatRequest(msg)
+			require.Len(t, result.Conversation, len(tt.wantConv))
+			for i, want := range tt.wantConv {
+				got := result.Conversation[i]
+				assert.Equal(t, want.Role, got.Role)
+				assert.Equal(t, want.Content.Raw, got.Content.Raw)
+				assert.Equal(t, want.Content.Structured, got.Content.Structured,
+					"message %d: Structured content mismatch", i)
+			}
+		})
+	}
+}
+
+func TestProduce_MessagesRequest(t *testing.T) {
+	wantTokens := []uint32{100, 200, 300}
+	tok := &mockTokenizer{
+		renderChatFunc: func(_ fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			return wantTokens, nil, nil
+		},
+	}
+	p := newTestPlugin(tok)
+
+	req := &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			Messages: &fwkrh.MessagesRequest{
+				System:   fwkrh.AnthropicContent{Raw: "Be helpful."},
+				Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hi"}}},
+			},
+		},
+	}
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+	require.NotNil(t, req.Body.TokenizedPrompt)
+	assert.Equal(t, [][]uint32{wantTokens}, req.Body.TokenizedPrompt.PerPromptTokens)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
currently,  render backend's produce() only handled Completions, ChatCompletions, Generate. 
Anthropic Messages fell through to the default error case,  preventing precise-prefix-cache-producer->prefix-cache-scorer routing for /v1/messages 
To add a Messages case that converts Anthropic content to OpenAI compatiable path


**Which issue(s) this PR fixes**:
Fixes #1861

**Test (only done on text not image)**
local build image:  `quay.io/wenzhou/llm-d-router-endpoint-picker:issue-1861` from this PR
1. create GatewayClass + Gateway + install infpool CRD 1.5.0 to ROSA (istio/servicemeshv3), 
2. deply llm-d `precise-prefix-cache-routing` guide (gateway mode) in namespace wenzhou-issue-1861 on a small ROSA cluster(CPU cluster only test text) with render from image `vllm/vllm-openai-cpu:v0.23.0` + model server via `ghcr.io/llm-d/llm-d-cpu:v0.8.0` + `quay.io/wenzhou/llm-d-router-endpoint-picker:issue-1861` via `router.epp.image` override) + pick model `TinyLlama` and tuning to fit for this cluster: 
  - replica to 1 vllm pod 
  -  `--block-size=16`(becuase i am lazy to send long prompt)
  - model-server SA needed privileged SCC (guide uses SYS_NICE/seccomp Unconfined), and the EPP SA needed system:auth-delegator to read its own secured metrics.
 wait till 1 cpu-vllm-decode pod + 1 routing-epp pod + 1 render pod + infpool ready to serve
use  ELB=a469fb92634...elb.amazonaws.com for following tests.

3. test on OpenAI /v1/chat/completions
```
curl -sS http://$ELB/v1/chat/completions \
  -H 'content-type: application/json' \
  -d '{"model":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","messages":[{"role":"user","content":"Say hello in one short sentence."}],"max_tokens":16,"temperature":0}'
```
log:
`{"level":"debug","ts":1783505593.0141592,"caller":"nohitlru/no_hit_lru.go:301","msg":"Cold request detected, scoring endpoints by LRU","x-request-id":"1446159b-511e-406b-bc8d-ad83fcd3aeda","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0}`
4. test on Anthropic /v1/messages
```
curl -sS http://$ELB/v1/messages \
  -H 'content-type: application/json' \
  -d '{"model":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","max_tokens":16,"system":"You are a helpful assistant that answers concisely.","messages":[{"role":"user","content":"Please explain in a few short words what the capital city of France is and why it is historically important to Europe."}]}'
```
log:
```
{"level":"debug","ts":1783505634.652263,"caller":"scheduling/scheduler_profile.go:194","msg":"Calculated score","x-request-id":"62f91c53-ba8a-4058-9608-739cf3b9e47c","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0,"plugin":"prefix-cache-scorer/prefix-cache-scorer","endpoint":{"name":"precise-prefix-cache-routing-cpu-vllm-decode-95b868848-ksnc9-rank-0","namespace":"wenzhou-issue-1861"},"score":0}
```
5. repeat step (4)
```
curl -sS http://$ELB/v1/messages \
  -H 'content-type: application/json' \
  -d '{"model":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","max_tokens":16,"system":"You are a helpful assistant that answers concisely.","messages":[{"role":"user","content":"Please explain in a few short words what the capital city of France is and why it is historically important to Europe."}]}'
```
log:
```
{"level":"info","ts":1783505645.6164691,"caller":"scheduling/scheduler_profile.go:188","msg":"Running scorer plugin","x-request-id":"37794d40-4ac1-44ef-9bbc-4dfe6f043a67","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0,"plugin":"prefix-cache-scorer/prefix-cache-scorer"}
{"level":"debug","ts":1783505645.6164827,"caller":"scheduling/scheduler_profile.go:194","msg":"Calculated score","x-request-id":"37794d40-4ac1-44ef-9bbc-4dfe6f043a67","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0,"plugin":"prefix-cache-scorer/prefix-cache-scorer","endpoint":{"name":"precise-prefix-cache-routing-cpu-vllm-decode-95b868848-ksnc9-rank-0","namespace":"wenzhou-issue-1861"},"score":1}
```

7. verify epp pod log
`oc logs deploy/...epp | grep -c "skipping tokenization"`
none return

9. verify metrics
`oc port-forward -n wenzhou-issue-1861 svc/precise-prefix-cache-routing-epp 19090:9090` as 9090 exposed as clusterip
`curl -H "Authorization: Bearer $(oc whoami -t)" http://localhost:19090/metrics` as MetricsEndpointAuth default to true
```
kvcache_index_lookup_hits_total        3   => increased (the issue reports it never increments for /v1/messages)
kvcache_index_lookup_requests_total    3
plugin_duration_seconds_count{plugin_name="token-producer",extension_point="DataProducer"}  3
```