### PR TITLE
docs: remove dead Tokenization Architecture TOC entry

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,6 @@ Documentation for developing the llm-d Router.
     - [Filtered Tests](#filtered-tests)
     - [End-to-End Tests](#end-to-end-tests)
     - [Coverage](#coverage)
-  - [Tokenization Architecture](#tokenization-architecture)
   - [Kubernetes Development Environment](#kubernetes-development-environment)
     - [Infrastructure Setup](#infrastructure-setup)
     - [RBAC and Permissions](#rbac-and-permissions)


### PR DESCRIPTION

**What type of PR is this?**

/kind documentation
/kind cleanup

**What this PR does / why we need it**:

The `DEVELOPMENT.md` table of contents links to a `Tokenization Architecture`
section (`#tokenization-architecture`) that no longer exists in the document. The
section was removed when the UDS tokenizer was replaced by the vLLM render
sidecar, but its TOC entry was left behind, so the anchor resolves to nothing and
the link is dead for anyone reading the doc on GitHub. This drops the single
orphaned line so the table of contents matches the document again.

Scope: one line removed from `DEVELOPMENT.md`. No section is re-added (the removed
section described the now-retired UDS tokenizer architecture, so restoring it
would reintroduce obsolete documentation). No code, workflow, or non-doc file is
touched.

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

---

## The diff (for review; single deletion)
```diff
diff --git a/DEVELOPMENT.md b/DEVELOPMENT.md
index 64fb7306..e39c10ef 100644
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,6 @@ Documentation for developing the llm-d Router.
     - [Filtered Tests](#filtered-tests)
     - [End-to-End Tests](#end-to-end-tests)
     - [Coverage](#coverage)
-  - [Tokenization Architecture](#tokenization-architecture)
   - [Kubernetes Development Environment](#kubernetes-development-environment)
     - [Infrastructure Setup](#infrastructure-setup)
     - [RBAC and Permissions](#rbac-and-permissions)
```
