### PR TITLE
docs(epp): fix filter tutorial factory to use *json.Decoder

### DIFF
--- a/docs/create_new_filter.md
+++ b/docs/create_new_filter.md
@@ -97,13 +97,13 @@ type Selector struct {
 
 ### Factory function
 
-Plugins are instantiated via factory functions. The factory receives the instance name, raw JSON parameters from the configuration, and a `plugin.Handle`:
+Plugins are instantiated via factory functions. The factory receives the instance name, a `*json.Decoder` over the plugin's raw configuration parameters (or `nil` when the plugin was instantiated without parameters), and a `plugin.Handle`:
 
 ```go
-func SelectorFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+func SelectorFactory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
     parameters := metav1.LabelSelector{}
     if rawParameters != nil {
-        if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+        if err := rawParameters.Decode(&parameters); err != nil {
             return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LabelSelectorFilterType, err)
         }
     }


### PR DESCRIPTION

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The "Create a new filter" walkthrough in `docs/create_new_filter.md` shows a
factory that does not compile against the current framework contract.

The tutorial declares:

```go
func SelectorFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
    ...
    if err := json.Unmarshal(rawParameters, &parameters); err != nil {
```

but the factory contract takes a strict decoder,
`FactoryFunc = func(name string, parameters *json.Decoder, handle Handle) (Plugin, error)`
(`pkg/epp/framework/interface/plugin/registry.go`), and the very function the
tutorial walks through, `bylabel.SelectorFactory`, uses `*json.Decoder` and
`rawParameters.Decode(&parameters)`
(`pkg/epp/framework/plugins/scheduling/filter/bylabel/selector.go`). Every
factory in the tree uses `*json.Decoder`. A factory copied from the tutorial
does not satisfy `FactoryFunc` and cannot be passed to `plugin.Register`, so it
fails to compile.

This updates the example signature and body to match the real code and
describes the parameter as the strict decoder the framework provides (or `nil`
when the plugin was instantiated without parameters). The corrected snippet is
now a verbatim match of `bylabel.SelectorFactory`. `docs/discovery.md` already
uses `*json.Decoder`, so this brings the last stale example in line. No code
change; the diff is three lines in one file.

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

---

## Notes on the template fields

- `/kind documentation` - docs-only correction.
- Release note `NONE`: this is a docs fix with no user-facing behavior change, so
  per the repo's `.github/PULL_REQUEST_TEMPLATE.md` / AGENTS.md, the
  `release-note` block is `NONE` and NO `release-notes.d/unreleased/*` file is
  created (that file is auto-generated only when the block has content).
- No test-plan section included: this is a documentation change with no unit
  test. Validation was a compile check (see Context below); there is no new test
  to list.
- "Fixes #" is intentionally left blank pending the issue question below.
