### PR TITLE
test: cover the not-ready branch in TestPodReconciler

### DIFF
--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -175,8 +175,7 @@ func TestPodReconciler(t *testing.T) {
 				},
 			},
 			incomingPod: testutil.FromBase(basePod1).
-				Labels(map[string]string{"some-wrong-key": "some-val"}).
-				ReadyCondition().ObjRef(),
+				Labels(map[string]string{"some-key": "some-val"}).ObjRef(),
 			wantPods: []*corev1.Pod{basePod2},
 		},
 	}


### PR DESCRIPTION

**What type of PR is this?**

/kind test
/kind cleanup

**What this PR does / why we need it**:

`TestPodReconciler` has a case named "Remove pod that is not ready", but it did
not exercise the not-ready path. Its incoming pod was built with a non-matching
label and a Ready condition:

```go
incomingPod: testutil.FromBase(basePod1).
    Labels(map[string]string{"some-wrong-key": "some-val"}).
    ReadyCondition().ObjRef(),
```

That is byte-for-byte identical to the preceding "Remove pod that does not match
selector" case, so both cases removed the pod through the label-mismatch operand
of the removal condition in `pod_reconciler.go`:

```go
if !podutil.IsPodReady(pod) || !c.Datastore.PoolLabelsMatch(pod.Labels) {
```

The readiness operand (`!IsPodReady`) was never covered on its own.

This gives the case a matching selector label and drops the Ready condition, so
the pod matches the pool but is not ready and is therefore removed because of its
readiness alone. The expected result is unchanged (`wantPods: {basePod2}`). This
mirrors the existing "New pod, not ready, valid selector" case in the same file
(matching labels, no `ReadyCondition()`).

No production code changes.

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

---

## The diff (1 file, +1/-2)

```diff
diff --git a/pkg/epp/controller/pod_reconciler_test.go b/pkg/epp/controller/pod_reconciler_test.go
index dbdfe5a7..7808fdd0 100644
--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -175,8 +175,7 @@ func TestPodReconciler(t *testing.T) {
 				},
 			},
 			incomingPod: testutil.FromBase(basePod1).
-				Labels(map[string]string{"some-wrong-key": "some-val"}).
-				ReadyCondition().ObjRef(),
+				Labels(map[string]string{"some-key": "some-val"}).ObjRef(),
 			wantPods: []*corev1.Pod{basePod2},
 		},
 	}
```
