### PR TITLE
fix(epp/metrics): bound model-name label cardinality from user input

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -38,6 +38,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 	podutil "github.com/llm-d/llm-d-router/pkg/epp/util/pod"
 )
 
@@ -243,6 +244,9 @@ func (ds *datastore) ObjectiveGetAll() []*v1alpha2.InferenceObjective {
 }
 
 func (ds *datastore) ModelRewriteSet(infModelRewrite *v1alpha2.InferenceModelRewrite) {
+	// Configured model names always emit their real metric label; only
+	// unconfigured request-supplied names are subject to the cardinality cap.
+	metrics.PreAdmitModelLabels(configuredModelNames(infModelRewrite)...)
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 	ds.modelRewrites.set(infModelRewrite)

--- a/pkg/epp/datastore/modelrewritestore.go
+++ b/pkg/epp/datastore/modelrewritestore.go
@@ -145,6 +145,25 @@ func (ms *modelRewriteStore) getAll() []*v1alpha2.InferenceModelRewrite {
 	return rewrites
 }
 
+// configuredModelNames returns every model name an InferenceModelRewrite
+// enumerates: exact-match sources and rewrite targets. These form the closed
+// set of operator-configured names that metric labels must never fold into the
+// cardinality overflow bucket.
+func configuredModelNames(infModelRewrite *v1alpha2.InferenceModelRewrite) []string {
+	names := sets.New[string]()
+	for _, rule := range infModelRewrite.Spec.Rules {
+		for _, match := range rule.Matches {
+			if match.Model != nil {
+				names.Insert(match.Model.Value)
+			}
+		}
+		for _, target := range rule.Targets {
+			names.Insert(target.ModelRewrite)
+		}
+	}
+	return names.UnsortedList()
+}
+
 // rewriteRuleWithMetadata decorates a rule with metadata from its parent object
 // to be used in precedence sorting.
 type rewriteRuleWithMetadata struct {

--- a/pkg/epp/datastore/modelrewritestore_test.go
+++ b/pkg/epp/datastore/modelrewritestore_test.go
@@ -197,3 +197,30 @@ func TestModelRewriteStore(t *testing.T) {
 		})
 	}
 }
+
+func TestConfiguredModelNames(t *testing.T) {
+	rewrite := &v1alpha2.InferenceModelRewrite{
+		ObjectMeta: metav1.ObjectMeta{Name: "rewrite", Namespace: "default"},
+		Spec: v1alpha2.InferenceModelRewriteSpec{Rules: []v1alpha2.InferenceModelRewriteRule{
+			{
+				Matches: []v1alpha2.Match{{Model: &v1alpha2.ModelMatch{Value: "model1"}}},
+				Targets: []v1alpha2.TargetModel{{ModelRewrite: "model1-v1"}, {ModelRewrite: "model1-v2"}},
+			},
+			{
+				// Generic rule: no exact-match source to enumerate, target only.
+				Targets: []v1alpha2.TargetModel{{ModelRewrite: "generic-fallback"}},
+			},
+			{
+				// Duplicate names collapse.
+				Matches: []v1alpha2.Match{{Model: &v1alpha2.ModelMatch{Value: "model1"}}},
+				Targets: []v1alpha2.TargetModel{{ModelRewrite: "model1-v2"}},
+			},
+		}},
+	}
+
+	got := configuredModelNames(rewrite)
+	want := []string{"generic-fallback", "model1", "model1-v1", "model1-v2"}
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+		t.Errorf("configuredModelNames() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/epp/metrics/cardinality.go
+++ b/pkg/epp/metrics/cardinality.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "sync"
+
+// Model name labels are populated from the request body, which is not validated
+// against a closed set of served models. Prometheus *Vec types never evict label
+// combinations, so an unbounded number of distinct model names would grow the time
+// series set without limit and exhaust memory. boundedLabel caps the number of
+// distinct values a label may take; values beyond the cap collapse to overflowValue.
+//
+// Names configured through InferenceModelRewrite rules (exact-match sources and
+// rewrite targets) are pinned: they always emit their real label and do not count
+// against the cap, so a flood of unconfigured names cannot displace a configured
+// model into the overflow bucket.
+const (
+	maxModelLabelValues = 1000
+	overflowValue       = "other"
+)
+
+type boundedLabel struct {
+	mu     sync.RWMutex
+	seen   map[string]struct{}
+	pinned map[string]struct{}
+	max    int
+}
+
+func newBoundedLabel(max int) *boundedLabel {
+	return &boundedLabel{
+		seen:   make(map[string]struct{}),
+		pinned: make(map[string]struct{}),
+		max:    max,
+	}
+}
+
+// bound returns v if it is pinned, already admitted, or there is room to admit
+// it, otherwise overflowValue. A value, once admitted, always returns itself, so
+// paired calls (e.g. running-request increment and decrement) stay balanced. The
+// one exception is a value that folded to overflowValue and is later pinned by a
+// new rewrite rule: pairs in flight across that instant can leave a small,
+// bounded residue on the overflow series.
+func (b *boundedLabel) bound(v string) string {
+	if v == "" {
+		return v
+	}
+	b.mu.RLock()
+	_, pin := b.pinned[v]
+	_, ok := b.seen[v]
+	full := len(b.seen) >= b.max
+	b.mu.RUnlock()
+	if pin || ok {
+		return v
+	}
+	if full {
+		return overflowValue
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.seen[v]; ok {
+		return v
+	}
+	if len(b.seen) >= b.max {
+		return overflowValue
+	}
+	b.seen[v] = struct{}{}
+	return v
+}
+
+// pin marks v as always admitted without consuming a cap slot. Pins are never
+// removed: a model deconfigured at runtime keeps emitting its real label, which
+// matches Prometheus semantics (its existing series persist regardless) and
+// keeps paired gauge calls balanced.
+func (b *boundedLabel) pin(v string) {
+	if v == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.pinned[v] = struct{}{}
+}
+
+var modelLabelLimiter = newBoundedLabel(maxModelLabelValues)
+
+// PreAdmitModelLabels pins the given model names so they always emit their real
+// label value on model-labeled metrics, regardless of how many unconfigured
+// names have been admitted. The datastore calls this when InferenceModelRewrite
+// rules are loaded or updated.
+func PreAdmitModelLabels(names ...string) {
+	for _, n := range names {
+		modelLabelLimiter.pin(n)
+	}
+}
+
+// boundModel caps a single request-derived model-name label.
+func boundModel(modelName string) string {
+	return modelLabelLimiter.bound(modelName)
+}
+
+// boundModels caps the model-name labels shared by request metrics.
+func boundModels(modelName, targetModelName string) (string, string) {
+	return modelLabelLimiter.bound(modelName), modelLabelLimiter.bound(targetModelName)
+}

--- a/pkg/epp/metrics/cardinality_test.go
+++ b/pkg/epp/metrics/cardinality_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedLabel(t *testing.T) {
+	b := newBoundedLabel(2)
+
+	require.Equal(t, "a", b.bound("a"), "first value admitted")
+	require.Equal(t, "b", b.bound("b"), "second value admitted")
+	require.Equal(t, overflowValue, b.bound("c"), "value beyond cap collapses to overflow")
+	require.Equal(t, "a", b.bound("a"), "already-admitted value still returns itself after cap")
+	require.Equal(t, overflowValue, b.bound("d"), "further unseen values keep collapsing")
+	require.Equal(t, "", b.bound(""), "empty value passes through without consuming a slot")
+}
+
+// Pinned names model operator-configured models (InferenceModelRewrite sources
+// and targets): they must emit their real label even when the cap is exhausted
+// by unconfigured names, and must not consume cap slots themselves.
+func TestBoundedLabelPin(t *testing.T) {
+	b := newBoundedLabel(2)
+
+	b.pin("configured")
+	b.pin("configured") // idempotent
+	require.Equal(t, "a", b.bound("a"), "pin does not consume a cap slot")
+	require.Equal(t, "b", b.bound("b"), "cap still has room for a second unconfigured name")
+	require.Equal(t, overflowValue, b.bound("c"), "cap full for unconfigured names")
+	require.Equal(t, "configured", b.bound("configured"), "pinned name survives a full cap")
+
+	b.pin("late")
+	require.Equal(t, "late", b.bound("late"), "name pinned after the cap fills still emits its real label")
+}
+
+// PreAdmitModelLabels feeds the package-level limiter used by the record
+// functions, so a flood of junk names must not displace a configured model.
+func TestPreAdmitModelLabelsSurvivesFlood(t *testing.T) {
+	const testCap = 5
+	old := modelLabelLimiter
+	modelLabelLimiter = newBoundedLabel(testCap)
+	requestCounter.Reset()
+	t.Cleanup(func() {
+		modelLabelLimiter = old
+		requestCounter.Reset()
+	})
+
+	PreAdmitModelLabels("llama-70b", "llama-70b-canary")
+	for i := 0; i < 1000; i++ {
+		RecordRequestCounter(fmt.Sprintf("junk-%d", i), "target", "fairness", 0)
+	}
+	RecordRequestCounter("llama-70b", "llama-70b-canary", "fairness", 0)
+
+	series := promtestutil.CollectAndCount(requestCounter)
+	require.LessOrEqualf(t, series, testCap+2, "cardinality must stay bounded, got %d series", series)
+	require.Equal(t, "llama-70b", boundModel("llama-70b"),
+		"configured model emits its real label after the flood")
+	require.Equal(t, "llama-70b-canary", boundModel("llama-70b-canary"),
+		"configured target emits its real label after the flood")
+}
+
+// RecordRequestCounter draws its model_name label from the request body, so a
+// flood of distinct names must not grow the time series set without bound.
+func TestRecordRequestCounterBoundsModelCardinality(t *testing.T) {
+	const testCap = 5
+	old := modelLabelLimiter
+	modelLabelLimiter = newBoundedLabel(testCap)
+	requestCounter.Reset()
+	t.Cleanup(func() {
+		modelLabelLimiter = old
+		requestCounter.Reset()
+	})
+
+	for i := 0; i < 1000; i++ {
+		RecordRequestCounter(fmt.Sprintf("model-%d", i), "target", "fairness", 0)
+	}
+
+	count := promtestutil.CollectAndCount(requestCounter)
+	require.LessOrEqualf(t, count, testCap+1,
+		"model_name cardinality must stay bounded by the cap, got %d series", count)
+}

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -545,6 +545,7 @@ func Reset() {
 
 // RecordRequestCounter records the number of requests.
 func RecordRequestCounter(modelName, targetModelName, fairnessID string, priority int) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	prioStr := strconv.Itoa(priority)
 	requestCounter.WithLabelValues(modelName, targetModelName, prioStr).Inc()
 	llmdRequestCounter.WithLabelValues(modelName, targetModelName, fairnessID, prioStr).Inc()
@@ -552,6 +553,7 @@ func RecordRequestCounter(modelName, targetModelName, fairnessID string, priorit
 
 // RecordRequestErrCounter records the number of error requests.
 func RecordRequestErrCounter(modelName, targetModelName, fairnessID, priority string, code string) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if code != "" {
 		requestErrCounter.WithLabelValues(modelName, targetModelName, code).Inc()
 		llmdRequestErrCounter.WithLabelValues(modelName, targetModelName, fairnessID, priority, code).Inc()
@@ -560,12 +562,14 @@ func RecordRequestErrCounter(modelName, targetModelName, fairnessID, priority st
 
 // RecordRequestSizes records the request sizes.
 func RecordRequestSizes(modelName, targetModelName, fairnessID, priority string, reqSize int) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	requestSizes.WithLabelValues(modelName, targetModelName).Observe(float64(reqSize))
 	llmdRequestSizes.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(reqSize))
 }
 
 // RecordRequestLatencies records duration of request.
 func RecordRequestLatencies(ctx context.Context, modelName, targetModelName, fairnessID, priority string, received time.Time, complete time.Time) bool {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if !complete.After(received) {
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "Request latency values are invalid",
 			"modelName", modelName, "targetModelName", targetModelName, "completeTime", complete, "receivedTime", received)
@@ -579,12 +583,14 @@ func RecordRequestLatencies(ctx context.Context, modelName, targetModelName, fai
 
 // RecordResponseSizes records the response sizes.
 func RecordResponseSizes(modelName, targetModelName, fairnessID, priority string, size int) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	responseSizes.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 	llmdResponseSizes.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
 }
 
 // RecordInputTokens records input tokens count.
 func RecordInputTokens(modelName, targetModelName, fairnessID, priority string, size int) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if size > 0 {
 		inputTokens.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 		llmdInputTokens.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
@@ -593,6 +599,7 @@ func RecordInputTokens(modelName, targetModelName, fairnessID, priority string, 
 
 // RecordOutputTokens records output tokens count.
 func RecordOutputTokens(modelName, targetModelName, fairnessID, priority string, size int) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if size > 0 {
 		outputTokens.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 		llmdOutputTokens.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
@@ -601,12 +608,14 @@ func RecordOutputTokens(modelName, targetModelName, fairnessID, priority string,
 
 // RecordPromptCachedTokens records prompt cached tokens count.
 func RecordPromptCachedTokens(modelName, targetModelName, fairnessID, priority string, size int) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	promptCachedTokens.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 	llmdPromptCachedTokens.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
 }
 
 // RecordNormalizedTimePerOutputToken (NTPOT) records the normalized time per output token.
 func RecordNormalizedTimePerOutputToken(ctx context.Context, modelName, targetModelName, fairnessID, priority string, received time.Time, complete time.Time, outputTokenCount int) bool {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if outputTokenCount <= 0 {
 		return false
 	}
@@ -627,6 +636,7 @@ func RecordNormalizedTimePerOutputToken(ctx context.Context, modelName, targetMo
 
 // RecordRequestTTFT records the time to first token.
 func RecordRequestTTFT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, streaming bool, received time.Time, firstToken time.Time) bool {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if firstToken.IsZero() {
 		return false
 	}
@@ -647,6 +657,7 @@ func RecordRequestTTFT(ctx context.Context, modelName, targetModelName, fairness
 
 // RecordRequestTPOT records the average time per output token.
 func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, received time.Time, firstToken time.Time, complete time.Time, outputTokenCount int) bool {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if firstToken.IsZero() || outputTokenCount <= 1 {
 		return false
 	}
@@ -666,6 +677,7 @@ func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairness
 
 // RecordInterTokenLatency records the time between consecutive response body chunks for streaming requests.
 func RecordInterTokenLatency(ctx context.Context, modelName, targetModelName, fairnessID, priority string, itlSeconds float64) bool {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if itlSeconds < 0 {
 		log.FromContext(ctx).Error(nil, "Inter-token latency value must be non-negative",
 			"modelName", modelName, "targetModelName", targetModelName, "itlSeconds", itlSeconds)
@@ -677,6 +689,7 @@ func RecordInterTokenLatency(ctx context.Context, modelName, targetModelName, fa
 
 // IncRunningRequests increases the current running requests.
 func IncRunningRequests(modelName, targetModelName, fairnessID, priority string) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if modelName != "" {
 		runningRequests.WithLabelValues(modelName).Inc()
 		llmdRunningRequests.WithLabelValues(modelName, targetModelName, fairnessID, priority).Inc()
@@ -685,6 +698,7 @@ func IncRunningRequests(modelName, targetModelName, fairnessID, priority string)
 
 // DecRunningRequests decreases the current running requests.
 func DecRunningRequests(modelName, targetModelName, fairnessID, priority string) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	if modelName != "" {
 		runningRequests.WithLabelValues(modelName).Dec()
 		llmdRunningRequests.WithLabelValues(modelName, targetModelName, fairnessID, priority).Dec()
@@ -803,24 +817,28 @@ func RecordFlowControlRequestEnqueueDuration(
 
 // IncFlowControlQueueSize increments the Flow Control queue size gauge.
 func IncFlowControlQueueSize(fairnessID, priority, inferencePool, modelName, targetModelName string) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	flowControlQueueSize.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Inc()
 	llmdFlowControlQueueSize.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Inc()
 }
 
 // DecFlowControlQueueSize decrements the Flow Control queue size gauge.
 func DecFlowControlQueueSize(fairnessID, priority, inferencePool, modelName, targetModelName string) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	flowControlQueueSize.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Dec()
 	llmdFlowControlQueueSize.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Dec()
 }
 
 // AddFlowControlQueueBytes increments the Flow Control queue bytes gauge.
 func AddFlowControlQueueBytes(fairnessID, priority, inferencePool, modelName, targetModelName string, bytes uint64) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	flowControlQueueBytes.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Add(float64(bytes))
 	llmdFlowControlQueueBytes.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Add(float64(bytes))
 }
 
 // SubFlowControlQueueBytes decrements the Flow Control queue bytes gauge.
 func SubFlowControlQueueBytes(fairnessID, priority, inferencePool, modelName, targetModelName string, bytes uint64) {
+	modelName, targetModelName = boundModels(modelName, targetModelName)
 	flowControlQueueBytes.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Sub(float64(bytes))
 	llmdFlowControlQueueBytes.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Sub(float64(bytes))
 }
@@ -832,7 +850,10 @@ func RecordFlowControlPoolSaturation(inferencePool string, saturation float64) {
 }
 
 // RecordInferenceModelRewriteDecision records the routing decision for InferenceModelRewrite.
+// The rewrite name and target come from configuration; only the source model name is
+// request-derived and needs bounding (a generic rule matches arbitrary model names).
 func RecordInferenceModelRewriteDecision(modelRewriteName, modelName, targetModel string) {
+	modelName = boundModel(modelName)
 	inferenceModelRewriteDecisionsTotal.WithLabelValues(modelRewriteName, modelName, targetModel).Inc()
 	llmdInferenceModelRewriteDecisionsTotal.WithLabelValues(modelRewriteName, modelName, targetModel).Inc()
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Model-name labels on EPP request metrics come from the request body, which is not validated against a closed set of served models, and `client_golang` `*Vec` types never evict label combinations. A client sending distinct `model` values therefore grows the time series set without bound (metrics cardinality DoS).

Implements the shape converged on in the issue discussion (allowlist the enumerable set, bounded cap as backstop for the by-design passthrough path):

- A shared limiter in `pkg/epp/metrics` bounds every request-derived model label. Unconfigured names are admitted up to a cap of 1000 distinct values; beyond that they fold into a fixed `"other"` label.
- Names enumerated by `InferenceModelRewrite` rules (exact-match sources and rewrite targets) are **pinned** via `datastore.ModelRewriteSet` on reconciliation: they always emit their real label and do not consume cap slots, so a junk-name flood cannot displace a configured model into the overflow bucket.
- Admission is sticky (a value admitted once always returns itself), keeping paired gauge calls (running-requests inc/dec, flow-control queue add/sub) balanced.

Scope notes:
- Covers the model-labeled record functions in `pkg/epp/metrics` (request/latency/token/TTFT/TPOT/ITL/running-requests, flow-control queue gauges, and the rewrite-decision counter's request-derived source label). Vector 2 (`fairness_id`, header-derived) and pod-name churn from the issue are deferred follow-ups per the issue discussion.
- Plugin-local metrics with model labels (`profilehandler/disagg`, `dataproducer/predictedlatency`) have the same exposure but live outside the central metrics package; flagging for a follow-up rather than folding into this PR.
- One documented edge: a name that folded to `"other"` and is later pinned by a new rewrite rule can leave a small, bounded residue on the overflow series for gauge pairs in flight at that instant.

**Which issue(s) this PR fixes**:
Fixes #1625

**Test plan**
- [x] Bounded-label unit tests: flood of 1000 distinct names stays capped; pinned (configured) names survive a full cap without consuming slots; empty names pass through
- [x] `configuredModelNames` extraction from InferenceModelRewrite rules (exact sources + targets, duplicates collapse)
- [x] `go test ./pkg/...`
- [x] `make test-integration-hermetic` (130 tests)
- [x] `make presubmit`

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP model-name metric labels are now bounded: names configured via InferenceModelRewrite always emit their real label, while unconfigured request-supplied names are limited to 1000 distinct values and collapse into an "other" label beyond that, preventing unbounded metric cardinality growth from arbitrary request bodies.
```