### PR TITLE
fix: prevent gRPC payload length overflow panic

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc.go
@@ -42,8 +42,11 @@ func ParseGrpcPayload(data []byte) ([]byte, error) {
 	}
 	msgLen := binary.BigEndian.Uint32(data[1:5])
 
-	if uint32(len(data)) < gRPCPayloadHeaderLen+msgLen {
-		return nil, fmt.Errorf("incomplete gRPC payload: header indicates %d bytes, but only %d bytes are available", msgLen, uint32(len(data))-gRPCPayloadHeaderLen)
+	// Compare in uint64 so gRPCPayloadHeaderLen+msgLen cannot overflow when
+	// msgLen is near math.MaxUint32, which would wrap the check and let the
+	// slice below panic with an out-of-range low>high index.
+	if uint64(len(data)) < uint64(gRPCPayloadHeaderLen)+uint64(msgLen) {
+		return nil, fmt.Errorf("incomplete gRPC payload: header indicates %d bytes, but only %d bytes are available", msgLen, len(data)-gRPCPayloadHeaderLen)
 	}
 	return data[gRPCPayloadHeaderLen : gRPCPayloadHeaderLen+msgLen], nil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc_test.go
@@ -66,6 +66,12 @@ func TestParseGrpcPayload(t *testing.T) {
 			want:    []byte("hello"),
 			wantErr: "",
 		},
+		{
+			name:    "length header overflows uint32",
+			data:    []byte{0, 0xFF, 0xFF, 0xFF, 0xFF, 0xAA, 0xBB, 0xCC, 0xDD},
+			want:    nil,
+			wantErr: "incomplete gRPC payload: header indicates 4294967295 bytes, but only 4 bytes are available",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ParseGrpcPayload` reads a 4-byte big-endian message length from the request
frame and then bounds-checks it against the buffer size before slicing out the
payload. The check computed `gRPCPayloadHeaderLen + msgLen` in `uint32`. Because
`gRPCPayloadHeaderLen` is the untyped constant `5`, when `msgLen` is near
`math.MaxUint32` (`0xFFFFFFFB..0xFFFFFFFF`) the addition wraps to a tiny value,
so `uint32(len(data)) < gRPCPayloadHeaderLen+msgLen` is false and the "incomplete
gRPC payload" guard is skipped. Control then reaches
`data[gRPCPayloadHeaderLen : gRPCPayloadHeaderLen+msgLen]`, where the high index
also wraps below the low index, producing a `low > high` slice that panics with
`runtime error: slice bounds out of range`.

`msgLen` comes directly from the request bytes
(`binary.BigEndian.Uint32(data[1:5])`), so the length is attacker-controlled. A
malformed ~9-byte gRPC body reaching this parser (via the vLLM-gRPC or Vertex AI
request paths) turns what should be a clean `BadRequest` into a panic in the
request handler.

The fix compares the sum in `uint64`, where `5 + 0xFFFFFFFF` cannot overflow, so
the guard now correctly rejects the frame and returns the existing "incomplete
gRPC payload" error. The error-message argument is changed from
`uint32(len(data)) - gRPCPayloadHeaderLen` to `len(data) - gRPCPayloadHeaderLen`;
this is safe as a plain `int` because the function already returns early when
`len(data) < gRPCPayloadHeaderLen`, and it yields the identical value for every
input that reaches this line without overflow.

A regression test case (`length header overflows uint32`) is added: it panics
against the pre-fix code and passes with the fix.

**Which issue(s) this PR fixes**:
