### PR TITLE
epp: serve the metrics endpoint over mTLS

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -332,6 +332,7 @@ func (r *Runner) runWithGracefulShutdown(ctx context.Context, mgr ctrl.Manager, 
 //
 // The returned Datastore is **only** meant to be used in the integration test.
 // Optional managerOverrides are applied to the controller manager options before creation.
+
 func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Options, managerOverrides []func(*ctrl.Options)) (ctrl.Manager, datastore.Datastore, error) {
 	rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
 	if err != nil {
@@ -386,6 +387,10 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 			return nil
 		}(),
+	}
+
+	if err := runserver.ConfigureMetricsTLS(opts, &metricsServerOptions); err != nil {
+		return nil, nil, err
 	}
 
 	isLeader := &atomic.Bool{}

--- a/pkg/epp/server/metrics_tls_test.go
+++ b/pkg/epp/server/metrics_tls_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// writeCAFile writes a self-signed CA cert to a temp file and returns its path.
+func writeCAFile(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	return path
+}
+
+func TestConfigureMetricsTLS(t *testing.T) {
+	validCA := writeCAFile(t)
+	badPEM := filepath.Join(t.TempDir(), "bad.crt")
+	require.NoError(t, os.WriteFile(badPEM, []byte("not a pem"), 0o600))
+
+	tests := []struct {
+		name           string
+		certDir        string
+		clientCA       string
+		wantErr        error
+		wantSecure     bool
+		wantClientAuth bool
+	}{
+		{name: "neither"},
+		{name: "cert dir only", certDir: "/etc/tls", wantSecure: true},
+		{name: "mTLS", certDir: "/etc/tls", clientCA: validCA, wantSecure: true, wantClientAuth: true},
+		{name: "missing CA file", clientCA: filepath.Join(t.TempDir(), "nope"), wantErr: errReadMetricsClientCA},
+		{name: "invalid CA PEM", clientCA: badPEM, wantErr: errNoValidMetricsCA},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &Options{MetricsCertDir: tc.certDir, MetricsClientCAFile: tc.clientCA}
+			mo := &metricsserver.Options{}
+			err := ConfigureMetricsTLS(opts, mo)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSecure, mo.SecureServing)
+			if tc.certDir != "" {
+				require.Equal(t, tc.certDir, mo.CertDir)
+			}
+			if !tc.wantSecure {
+				require.Empty(t, mo.TLSOpts)
+				return
+			}
+			require.Len(t, mo.TLSOpts, 1)
+			cfg := &tls.Config{}
+			mo.TLSOpts[0](cfg)
+			require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+			if tc.wantClientAuth {
+				require.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+				require.NotNil(t, cfg.ClientCAs)
+			} else {
+				require.Equal(t, tls.NoClientCert, cfg.ClientAuth)
+				require.Nil(t, cfg.ClientCAs)
+			}
+		})
+	}
+}

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -17,9 +17,13 @@ limitations under the License.
 package server
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -27,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
@@ -102,6 +107,8 @@ type Options struct {
 	EnableCertReload        bool   // Enables certificate reloading of the certificates specified in --cert-path.
 	SecureServing           bool   // Enables secure serving.
 	MetricsEndpointAuth     bool   // Enables authentication and authorization of the metrics endpoint.
+	MetricsClientCAFile     string // PEM CA that requires a verified client cert on the metrics endpoint.
+	MetricsCertDir          string // Directory with the metrics server certificates that enables metrics TLS.
 	EnableGRPCStreamMetrics bool   // Enables ext_proc gRPC stream metrics (in-flight gauge, hold duration, completions counter by code).
 	//
 	// Configuration.
@@ -208,6 +215,10 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing, "Enables secure serving.")
 	fs.BoolVar(&opts.MetricsEndpointAuth, "metrics-endpoint-auth", opts.MetricsEndpointAuth,
 		"Enables authentication and authorization of the metrics endpoint.")
+	fs.StringVar(&opts.MetricsClientCAFile, "metrics-client-ca-file", opts.MetricsClientCAFile,
+		"PEM CA for metrics mTLS: require verified client certs.")
+	fs.StringVar(&opts.MetricsCertDir, "metrics-cert-dir", opts.MetricsCertDir,
+		"Directory with the metrics server certificates. Enables TLS on the metrics endpoint.")
 	fs.StringVar(&opts.ConfigFile, "config-file", opts.ConfigFile, "The path to the configuration file.")
 	fs.StringVar(&opts.ConfigText, "config-text", opts.ConfigText, "The configuration specified as text, in lieu of a file.")
 }
@@ -260,8 +271,60 @@ func (opts *Options) Complete() error {
 		opts.GRPCMaxSendMsgSize = int(val)
 	}
 
+	if opts.MetricsClientCAFile != "" {
+		if _, err := os.Stat(opts.MetricsClientCAFile); err != nil {
+			return fmt.Errorf("%w: %s: %v", errMetricsCertUnreadable, opts.MetricsClientCAFile, err)
+		}
+	}
+	if opts.MetricsCertDir != "" {
+		for _, name := range []string{"tls.crt", "tls.key"} {
+			p := filepath.Join(opts.MetricsCertDir, name)
+			if _, err := os.Stat(p); err != nil {
+				return fmt.Errorf("%w: %s: %v", errMetricsCertUnreadable, p, err)
+			}
+		}
+	}
+
 	// Complete logging options.
 	return opts.LoggingOptions.Complete()
+}
+
+var (
+	errMetricsClientCARequiresCertDir = errors.New(`"metrics-client-ca-file" requires "metrics-cert-dir"`)
+	errMetricsTLSWithoutAuth          = errors.New(`"metrics-cert-dir" enables metrics TLS without authentication; set "metrics-client-ca-file" or "metrics-endpoint-auth"`)
+	errMetricsCertUnreadable          = errors.New("metrics TLS cert file unreadable")
+	errReadMetricsClientCA            = errors.New("reading metrics client CA")
+	errNoValidMetricsCA               = errors.New("no valid CA certs in metrics client CA file")
+)
+
+// ConfigureMetricsTLS enables TLS, and optional client mTLS, on the metrics server.
+func ConfigureMetricsTLS(opts *Options, mo *metricsserver.Options) error {
+	if opts.MetricsCertDir == "" && opts.MetricsClientCAFile == "" {
+		return nil
+	}
+	mo.SecureServing = true
+	if opts.MetricsCertDir != "" {
+		mo.CertDir = opts.MetricsCertDir
+	}
+	var clientCAs *x509.CertPool
+	if opts.MetricsClientCAFile != "" {
+		caPEM, err := os.ReadFile(opts.MetricsClientCAFile)
+		if err != nil {
+			return fmt.Errorf("%w %s: %v", errReadMetricsClientCA, opts.MetricsClientCAFile, err)
+		}
+		clientCAs = x509.NewCertPool()
+		if !clientCAs.AppendCertsFromPEM(caPEM) {
+			return fmt.Errorf("%w: %s", errNoValidMetricsCA, opts.MetricsClientCAFile)
+		}
+	}
+	mo.TLSOpts = append(mo.TLSOpts, func(c *tls.Config) {
+		c.MinVersion = tls.VersionTLS12
+		if clientCAs != nil {
+			c.ClientCAs = clientCAs
+			c.ClientAuth = tls.RequireAndVerifyClientCert
+		}
+	})
+	return nil
 }
 
 func (opts *Options) Validate() error {
@@ -281,6 +344,13 @@ func (opts *Options) Validate() error {
 
 	if opts.ConfigText != "" && opts.ConfigFile != "" {
 		return fmt.Errorf("both the %q and %q flags cannot be set at the same time", "config-file", "config-text")
+	}
+
+	if opts.MetricsClientCAFile != "" && opts.MetricsCertDir == "" {
+		return errMetricsClientCARequiresCertDir
+	}
+	if opts.MetricsCertDir != "" && opts.MetricsClientCAFile == "" && !opts.MetricsEndpointAuth {
+		return errMetricsTLSWithoutAuth
 	}
 
 	if opts.GRPCMaxRecvMsgSize < 0 {

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -17,12 +17,20 @@ limitations under the License.
 package server
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPoolName   = "test-pool"
+	testConfigFile = "fake-config.yaml"
 )
 
 // TestEndpointTargetPorts
@@ -90,7 +98,7 @@ func TestEndpointTargetPorts(t *testing.T) {
 			opts.AddFlags(tt.fs)
 
 			argv := make([]string, 0, 4+len(tt.args))
-			argv = append(argv, "--endpoint-selector", "app=vllm", "--config-file", "fake-config.yaml") // avoid an options validation error
+			argv = append(argv, "--endpoint-selector", "app=vllm", "--config-file", testConfigFile) // avoid an options validation error
 			argv = append(argv, tt.args...)
 
 			if err := tt.fs.Parse(argv); err != nil {
@@ -201,7 +209,7 @@ func TestGRPCFlags(t *testing.T) {
 			opts.AddFlags(fs)
 
 			argv := make([]string, 0, 4+len(tt.args))
-			argv = append(argv, "--pool-name", "test-pool", "--config-file", "fake-config.yaml")
+			argv = append(argv, "--pool-name", testPoolName, "--config-file", testConfigFile)
 			argv = append(argv, tt.args...)
 
 			if err := fs.Parse(argv); err != nil {
@@ -235,14 +243,14 @@ func TestGRPCFlags(t *testing.T) {
 
 func TestValidateDirectValues(t *testing.T) {
 	opts := NewOptions()
-	opts.PoolName = "test-pool" // bypass other validations
+	opts.PoolName = testPoolName // bypass other validations
 	opts.GRPCMaxRecvMsgSize = -5
 	if err := opts.Validate(); err == nil {
 		t.Errorf("Expected Validate() to fail for negative GRPCMaxRecvMsgSize, but it succeeded")
 	}
 
 	opts = NewOptions()
-	opts.PoolName = "test-pool"
+	opts.PoolName = testPoolName
 	opts.GRPCMaxSendMsgSize = -5
 	if err := opts.Validate(); err == nil {
 		t.Errorf("Expected Validate() to fail for negative GRPCMaxSendMsgSize, but it succeeded")
@@ -272,7 +280,7 @@ func TestDrainTimeoutFlag(t *testing.T) {
 func TestValidateConfigFlagsMutuallyExclusive(t *testing.T) {
 	opts := NewOptions()
 	opts.PoolName = "config-flags-pool" // bypass the pool/selector validation
-	opts.ConfigFile = "fake-config.yaml"
+	opts.ConfigFile = testConfigFile
 	opts.ConfigText = "fake: config"
 
 	err := opts.Validate()
@@ -284,4 +292,75 @@ func TestValidateConfigFlagsMutuallyExclusive(t *testing.T) {
 			t.Errorf("Validate() error must reference the %q flag, got: %v", want, err)
 		}
 	}
+}
+
+func TestMetricsMTLSFlags(t *testing.T) {
+	fs := pflag.NewFlagSet("metrics-mtls", pflag.ContinueOnError)
+	opts := NewOptions()
+	opts.AddFlags(fs)
+	require.NoError(t, fs.Parse([]string{
+		"--pool-name", testPoolName, "--config-file", testConfigFile,
+		"--metrics-cert-dir", "/etc/epp-tls",
+		"--metrics-client-ca-file", "/etc/epp-ca/ca.crt",
+	}))
+	require.Equal(t, "/etc/epp-tls", opts.MetricsCertDir)
+	require.Equal(t, "/etc/epp-ca/ca.crt", opts.MetricsClientCAFile)
+}
+
+func TestValidateMetricsMTLS(t *testing.T) {
+	tests := []struct {
+		name         string
+		clientCA     string
+		certDir      string
+		endpointAuth bool
+		wantErr      error
+	}{
+		{name: "neither set"},
+		{name: "endpoint auth only", endpointAuth: true},
+		{name: "mTLS (cert dir + client CA)", clientCA: "ca.crt", certDir: "tls"},
+		{name: "cert dir + endpoint auth", certDir: "tls", endpointAuth: true},
+		{name: "cert dir + client CA + auth", clientCA: "ca.crt", certDir: "tls", endpointAuth: true},
+		{name: "cert dir only, no auth (fail-open)", certDir: "tls", wantErr: errMetricsTLSWithoutAuth},
+		{name: "client CA without cert dir", clientCA: "ca.crt", wantErr: errMetricsClientCARequiresCertDir},
+		{name: "client CA without cert dir, auth on", clientCA: "ca.crt", endpointAuth: true, wantErr: errMetricsClientCARequiresCertDir},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.AddFlags(pflag.NewFlagSet(tc.name, pflag.ContinueOnError))
+			opts.PoolName = testPoolName
+			opts.MetricsClientCAFile = tc.clientCA
+			opts.MetricsCertDir = tc.certDir
+			opts.MetricsEndpointAuth = tc.endpointAuth
+			err := opts.Validate()
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestCompleteMetricsCertFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	missing := NewOptions()
+	missing.AddFlags(pflag.NewFlagSet("missing", pflag.ContinueOnError))
+	missing.MetricsCertDir = dir
+	require.ErrorIs(t, missing.Complete(), errMetricsCertUnreadable)
+
+	// tls.crt present but tls.key still missing: partial cert must fail.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.crt"), []byte("x"), 0o600))
+	partial := NewOptions()
+	partial.AddFlags(pflag.NewFlagSet("partial", pflag.ContinueOnError))
+	partial.MetricsCertDir = dir
+	require.ErrorIs(t, partial.Complete(), errMetricsCertUnreadable)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.key"), []byte("x"), 0o600))
+
+	present := NewOptions()
+	present.AddFlags(pflag.NewFlagSet("present", pflag.ContinueOnError))
+	present.MetricsCertDir = dir
+	require.NoError(t, present.Complete())
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Serves the EPP metrics endpoint over mTLS. `--metrics-cert-dir` supplies the server cert (`tls.crt`/`tls.key`) and enables TLS serving; `--metrics-client-ca-file` supplies a CA bundle and makes the endpoint require and verify a client certificate, so it can be scraped with mutual authentication instead of bearer-token auth.

**Which issue(s) this PR fixes**:
Fixes #1918

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP: the metrics endpoint can now be served over mTLS via `--metrics-cert-dir` (server cert) and `--metrics-client-ca-file` (client CA).
```