### PR TITLE
add ipv6 setting

### DIFF
--- a/config/charts/llm-d-router-standalone/values.yaml
+++ b/config/charts/llm-d-router-standalone/values.yaml
@@ -60,6 +60,11 @@ router:
                       socket_address:
                         address: 0.0.0.0
                         port_value: 19001
+                    additional_addresses:
+                    - address:
+                        socket_address:
+                          address: "::"
+                          port_value: 19001
                     filter_chains:
                       - filters:
                           - name: envoy.filters.network.http_connection_manager
@@ -93,6 +98,11 @@ router:
                       socket_address:
                         address: 0.0.0.0
                         port_value: 8081
+                    additional_addresses:
+                    - address:
+                        socket_address:
+                          address: "::"
+                          port_value: 8081
                     per_connection_buffer_limit_bytes: 32768
                     access_log:
                       - name: envoy.access_loggers.file


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
- This PR adds IPv6 support configuration to the llm-d-router chart. This is required to allow the service to be reachable in an IPv6-only environment/cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
None

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
None