### PR TITLE
docs: update SIG-router Google Meet link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ Contributions are welcome!
 [create an issue]:https://github.com/llm-d/llm-d-router/issues/new
 [discussion]:https://github.com/llm-d/llm-d-router/discussions/new?category=q-a
 [Slack]:https://llm-d.slack.com/
-[Google Meet]:https://meet.google.com/zij-zekm-jvt
+[Google Meet]:https://meet.google.com/ozx-goao-cxh
 [Meeting Notes]:https://docs.google.com/document/d/1Pf3x7ZM8nNpU56nt6CzePAOmFZ24NXDeXyaYb565Wq4
 [#sig-router]:https://llm-d.slack.com/?redir=%2Fmessages%2Fsig-router


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The SIG-router video call moved to a new Google Meet link. Updates the [Google Meet] reference link in the README to https://meet.google.com/ozx-goao-cxh so contributors land in the right call.

**Which issue(s) this PR fixes**:
NONE

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```