### PR TITLE
feat(datalayer): extend file-discovery to support cluster endpoints

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/discovery/file/README.md
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/README.md
@@ -18,10 +18,10 @@ datastore on each change.
 ## How It Works
 
 - **Initial load.** On `Start`, the file is read once. Each entry is
-  validated (address must be a parseable IP, port must be in `[1, 65535]`)
-  and applied via `notifier.Upsert`. Per-entry validation errors are logged
-  and the entry is skipped; file-level problems (open, parse, size > 1 MiB)
-  abort startup.
+  validated (address must be a valid IPv4 or RFC 1123 hostname, port must be
+  in `[1, 65535]`) and applied via `notifier.Upsert`. Per-entry validation
+  errors are logged and the entry is skipped; file-level problems (open,
+  parse, size > 1 MiB) abort startup.
 - **Reload (optional).** When `watchFile: true`, fsnotify Write / Create /
   Remove events trigger a reload. After an atomic rename or ConfigMap-style
   symlink swap (which destroys the inode being watched), the watcher is
@@ -42,11 +42,26 @@ plugin's `path` parameter.
 endpoints:
   - name: <string>              # required -- unique within the file
     namespace: <string>         # optional -- defaults to "default"
-    address: <IPv4>             # required -- must be a valid IPv4 address
+    address: <string>           # required -- IPv4 address or RFC 1123 hostname
     port: <string>              # required -- integer 1-65535 as a string
+    metricsAddress: <string>    # optional -- metrics scrape hostname (defaults to address)
+    metricsPort: <string>       # optional -- metrics scrape port (defaults to port)
     labels:                     # optional -- arbitrary key/value labels
       <key>: <value>
 ```
+
+Both IPv4 addresses and hostnames are accepted. `Name` is always set to the
+entry name regardless of address type.
+
+### Endpoint Type Label
+
+Each endpoint is tagged with the label `llm-d.ai/endpoint-type` so downstream
+plugins can distinguish pod endpoints from cluster endpoints explicitly. The
+label can be set in the endpoints file; when omitted, the plugin auto-detects
+it from the address format:
+
+- IPv4 address → `llm-d.ai/endpoint-type: pod`
+- Hostname → `llm-d.ai/endpoint-type: cluster`
 
 ## Configuration
 
@@ -75,7 +90,7 @@ dataLayer:
     pluginRef: file-discovery
 ```
 
-A two-endpoint file referenced by the config above:
+A two-endpoint file with pod IPs:
 
 ```yaml
 endpoints:
@@ -87,13 +102,38 @@ endpoints:
     port: "8000"
 ```
 
+A cluster endpoints file with host names instead of IP addresses.
+In multi-cluster deployments, `address` is typically a gateway that routes
+inference traffic, while metrics are scraped directly from the spoke EPP at
+a different host — hence `metricsAddress`:
+
+```yaml
+endpoints:
+  - name: cluster-us-east
+    address: gateway.apps.spoke-us-east.example.com
+    port: "443"
+    metricsAddress: epp.apps.spoke-us-east.example.com
+    metricsPort: "9090"
+    labels:
+      region: us-east
+  - name: cluster-eu-west
+    address: gateway.apps.spoke-eu-west.example.com
+    port: "443"
+    metricsAddress: epp.apps.spoke-eu-west.example.com
+    metricsPort: "9090"
+    labels:
+      region: eu-west
+```
+
 ## Limitations
 
 - The endpoints file is capped at 1 MiB.
-- `address` must be a literal IPv4 address. Hostnames are not resolved;
-  IPv6 is not supported.
-- Metrics are scraped from `address:port` (same host and port that serves
-  inference); separate metrics endpoints are not supported.
+- `address` must be a valid IPv4 address or an RFC 1123 hostname. IPv6 is
+  not supported. Hostnames are not resolved by the plugin; DNS resolution
+  happens at scrape/connect time.
+- Metrics are scraped from `metricsAddress:metricsPort`. When `metricsAddress`
+  is not set, it defaults to `address`. When `metricsPort` is not set, it
+  defaults to `port`.
 - File-discovery mode runs the EPP without a Kubernetes controller manager,
   so several K8s-only features are inactive: the `InferenceModelRewrite`
   and `InferenceObjective` reconcilers do not run, and any

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -28,10 +28,12 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 
@@ -39,15 +41,24 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
-const PluginType = "file-discovery"
+const (
+	PluginType = "file-discovery"
+
+	// EndpointTypeLabel distinguishes pod from cluster endpoints.
+	EndpointTypeLabel   = "llm-d.ai/endpoint-type"
+	EndpointTypePod     = "pod"
+	EndpointTypeCluster = "cluster"
+)
 
 // EndpointEntry is the YAML/JSON representation of a single endpoint.
 type EndpointEntry struct {
-	Name      string            `json:"name"                yaml:"name"`
-	Namespace string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Address   string            `json:"address"             yaml:"address"`
-	Port      string            `json:"port"                yaml:"port"`
-	Labels    map[string]string `json:"labels,omitempty"    yaml:"labels,omitempty"`
+	Name           string            `json:"name"                      yaml:"name"`
+	Namespace      string            `json:"namespace,omitempty"       yaml:"namespace,omitempty"`
+	Address        string            `json:"address"                   yaml:"address"`
+	Port           string            `json:"port"                      yaml:"port"`
+	MetricsAddress string            `json:"metricsAddress,omitempty"  yaml:"metricsAddress,omitempty"`
+	MetricsPort    string            `json:"metricsPort,omitempty"     yaml:"metricsPort,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"          yaml:"labels,omitempty"`
 }
 
 // EndpointsFile is the top-level structure of the endpoints YAML/JSON file.
@@ -238,9 +249,12 @@ func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 	incoming := make(map[types.NamespacedName]struct{}, len(ef.Endpoints))
 	var errs []error
 	for _, e := range ef.Endpoints {
-		if ip := net.ParseIP(e.Address); ip == nil || ip.To4() == nil {
-			errs = append(errs, fmt.Errorf("endpoint %q: invalid IPv4 address %q", e.Name, e.Address))
-			continue
+		ip := net.ParseIP(e.Address)
+		if ip == nil || ip.To4() == nil {
+			if len(validation.IsDNS1123Subdomain(strings.ToLower(e.Address))) > 0 {
+				errs = append(errs, fmt.Errorf("endpoint %q: address %q is not a valid IPv4 or hostname", e.Name, e.Address))
+				continue
+			}
 		}
 		if portNum, err := strconv.Atoi(e.Port); err != nil || portNum < 1 || portNum > 65535 {
 			errs = append(errs, fmt.Errorf("endpoint %q: invalid port %q", e.Name, e.Port))
@@ -250,13 +264,38 @@ func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 		if ns == "" {
 			ns = "default"
 		}
+		mAddr := e.Address
+		if e.MetricsAddress != "" {
+			mAddr = e.MetricsAddress
+		}
+		mPort := e.Port
+		if e.MetricsPort != "" {
+			mPort = e.MetricsPort
+		}
+		labels := e.Labels
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if v := labels[EndpointTypeLabel]; v != EndpointTypePod && v != EndpointTypeCluster {
+			var detected string
+			if ip == nil {
+				detected = EndpointTypeCluster
+			} else {
+				detected = EndpointTypePod
+			}
+			if v != "" {
+				log.Log.Info("auto-correcting invalid endpoint-type label",
+					"endpoint", e.Name, "was", v, "detected", detected)
+			}
+			labels[EndpointTypeLabel] = detected
+		}
 		meta := &fwkdl.EndpointMetadata{
 			ID:          types.NamespacedName{Name: e.Name, Namespace: ns},
 			Name:        e.Name,
 			Address:     e.Address,
 			Port:        e.Port,
-			MetricsHost: net.JoinHostPort(e.Address, e.Port),
-			Labels:      e.Labels,
+			MetricsHost: net.JoinHostPort(mAddr, mPort),
+			Labels:      labels,
 		}
 		incoming[meta.ID] = struct{}{}
 		notifier.Upsert(meta)

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
@@ -189,15 +189,39 @@ func TestStart_MissingFile(t *testing.T) {
 	assert.ErrorContains(t, err, "initial load failed")
 }
 
-func TestStart_InvalidIP(t *testing.T) {
+func TestStart_EmptyAddress(t *testing.T) {
 	path := writeTemp(t, `
 endpoints:
   - name: ep1
-    address: "not-an-ip"
+    address: ""
     port: "8000"
 `)
 	err := newFD(path, false).Start(context.Background(), &recordingNotifier{})
-	assert.ErrorContains(t, err, "invalid IPv4 address")
+	assert.ErrorContains(t, err, "is not a valid IPv4 or hostname")
+}
+
+func TestStart_InvalidAddressFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+	}{
+		{"spaces", "not a valid host"},
+		{"special chars", "!!!garbage!!!"},
+		{"trailing dot label", "host-.example.com"},
+		{"leading hyphen", "-host.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTemp(t, fmt.Sprintf(`
+endpoints:
+  - name: ep1
+    address: %q
+    port: "8000"
+`, tt.address))
+			err := newFD(path, false).Start(context.Background(), &recordingNotifier{})
+			assert.ErrorContains(t, err, "is not a valid IPv4 or hostname")
+		})
+	}
 }
 
 func TestStart_RejectsIPv6(t *testing.T) {
@@ -208,7 +232,217 @@ endpoints:
     port: "8000"
 `)
 	err := newFD(path, false).Start(context.Background(), &recordingNotifier{})
-	assert.ErrorContains(t, err, "invalid IPv4 address")
+	assert.ErrorContains(t, err, "is not a valid IPv4 or hostname")
+}
+
+func TestStart_HostnameAddress(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: cluster-us-east
+    namespace: clusters
+    address: "spoke-us-east.example.com"
+    port: "443"
+    labels:
+      region: us-east
+      model: llama-7b
+  - name: cluster-eu-west
+    namespace: clusters
+    address: "spoke-eu-west.example.com"
+    port: "443"
+    labels:
+      region: eu-west
+      model: llama-7b
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 2)
+
+	for _, m := range notifier.upserted {
+		assert.Equal(t, m.ID.Name, m.Name, "Name should always be set")
+		assert.Equal(t, "cluster", m.Labels[EndpointTypeLabel], "hostname should be auto-labeled as cluster")
+	}
+	assert.Equal(t, "spoke-us-east.example.com:443", notifier.upserted[0].MetricsHost)
+	assert.Equal(t, "spoke-eu-west.example.com:443", notifier.upserted[1].MetricsHost)
+	assert.ElementsMatch(t, []string{"clusters/cluster-us-east", "clusters/cluster-eu-west"}, notifier.upsertedNames())
+}
+
+func TestStart_IPv4NameIsSet(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: vllm-pod-1
+    address: "10.0.0.5"
+    port: "8000"
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 1)
+	assert.Equal(t, "vllm-pod-1", notifier.upserted[0].Name, "IPv4 address should set Name")
+	assert.Equal(t, "10.0.0.5:8000", notifier.upserted[0].MetricsHost)
+	assert.Equal(t, "pod", notifier.upserted[0].Labels[EndpointTypeLabel], "IPv4 should be auto-labeled as pod")
+}
+
+func TestStart_MixedIPv4AndHostname(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: vllm-pod-1
+    address: "10.0.0.5"
+    port: "8000"
+  - name: cluster-us-east
+    address: "spoke-us-east.example.com"
+    port: "443"
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 2)
+
+	var pod, cluster *fwkdl.EndpointMetadata
+	for _, m := range notifier.upserted {
+		if m.ID.Name == "vllm-pod-1" {
+			pod = m
+		} else {
+			cluster = m
+		}
+	}
+	require.NotNil(t, pod)
+	require.NotNil(t, cluster)
+	assert.Equal(t, "vllm-pod-1", pod.Name, "IPv4 endpoint should have Name set")
+	assert.Equal(t, "cluster-us-east", cluster.Name, "hostname endpoint should have Name set")
+	assert.Equal(t, "pod", pod.Labels[EndpointTypeLabel], "IPv4 should be labeled as pod")
+	assert.Equal(t, "cluster", cluster.Labels[EndpointTypeLabel], "hostname should be labeled as cluster")
+}
+
+func TestStart_EndpointTypeLabelAutoDetected(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: ep-ipv4
+    address: "10.0.0.1"
+    port: "8000"
+  - name: ep-hostname
+    address: "spoke.example.com"
+    port: "443"
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 2)
+
+	var ipv4, hostname *fwkdl.EndpointMetadata
+	for _, m := range notifier.upserted {
+		if m.ID.Name == "ep-ipv4" {
+			ipv4 = m
+		} else {
+			hostname = m
+		}
+	}
+	assert.Equal(t, "pod", ipv4.Labels[EndpointTypeLabel], "IPv4 should auto-detect as pod")
+	assert.Equal(t, "cluster", hostname.Labels[EndpointTypeLabel], "hostname should auto-detect as cluster")
+}
+
+func TestStart_EndpointTypeLabelUserProvidedValid(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: ep1
+    address: "spoke.example.com"
+    port: "443"
+    labels:
+      llm-d.ai/endpoint-type: cluster
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 1)
+	assert.Equal(t, "cluster", notifier.upserted[0].Labels[EndpointTypeLabel],
+		"user-provided valid label should be preserved")
+}
+
+func TestStart_EndpointTypeLabelInvalidValueAutoCorrected(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: ep1
+    address: "spoke.example.com"
+    port: "443"
+    labels:
+      llm-d.ai/endpoint-type: clustr
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 1)
+	assert.Equal(t, "cluster", notifier.upserted[0].Labels[EndpointTypeLabel],
+		"invalid label value should be auto-corrected based on address type")
+}
+
+func TestStart_MetricsAddressAndPortOverride(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: spoke-tenant1
+    address: "maas.apps.spoke1.example.com"
+    port: "443"
+    metricsAddress: "inference-gateway.apps.spoke1.example.com"
+    metricsPort: "9090"
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 1)
+
+	m := notifier.upserted[0]
+	assert.Equal(t, "maas.apps.spoke1.example.com", m.Address, "Address should be the routing target")
+	assert.Equal(t, "443", m.Port, "Port should be unchanged")
+	assert.Equal(t, "inference-gateway.apps.spoke1.example.com:9090", m.MetricsHost,
+		"MetricsHost should use metricsAddress with metricsPort")
+}
+
+func TestStart_MetricsAddressOnly(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: spoke-tenant1
+    address: "maas.apps.spoke1.example.com"
+    port: "443"
+    metricsAddress: "inference-gateway.apps.spoke1.example.com"
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 1)
+
+	assert.Equal(t, "inference-gateway.apps.spoke1.example.com:443", notifier.upserted[0].MetricsHost,
+		"MetricsHost should use metricsAddress with default port")
+}
+
+func TestStart_MetricsFieldsNotSetFallsBack(t *testing.T) {
+	path := writeTemp(t, `
+endpoints:
+  - name: ep1
+    address: "10.0.0.1"
+    port: "8000"
+`)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, newFD(path, false).Start(ctx, notifier))
+	require.Len(t, notifier.upserted, 1)
+	assert.Equal(t, "10.0.0.1:8000", notifier.upserted[0].MetricsHost, "MetricsHost should fall back to Address:Port")
 }
 
 func TestStart_InvalidPort(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Extends the `file-discovery` plugin to accept hostname addresses (not just IPv4), enabling multi-cluster hub mode where entire clusters are treated as endpoints.

Changes:
- Relax address validation to accept RFC 1123 hostnames using `validation.IsDNS1123Subdomain` from `k8s.io/apimachinery`
- Set `PodName = ""` for hostname-based entries (cluster endpoints), preserving `PodName = e.Name` for IPv4 entries (pod endpoints)
- Add optional `metricsPort` field to `EndpointEntry` so the metrics scrape port can differ from the traffic port (needed when the spoke EPP metrics endpoint is on a separate port from the spoke gateway)
- IPv6 addresses remain rejected (same as before)
- Fully backward compatible - existing pod YAML files with IPv4 addresses work identically

Hub-mode YAML example:
```yaml
endpoints:
  - name: cluster-us-east
    address: spoke-us-east.example.com
    port: "443"
    metricsPort: "9090"
```

**Which issue(s) this PR fixes**:

Fixes #1903

**Note**:

The `metricsPort` field is optional and backward compatible. When omitted, `MetricsHost` defaults to `Address:Port` (existing behavior). When set, `MetricsHost` uses `Address:metricsPort`, allowing the hub EPP to scrape spoke EPP metrics on a different port than the traffic gateway port. This complements #1858 (mTLS scraper) and #1919 (mTLS metrics server).