### PR TITLE
Bump Go to 1.25.12 to fix crypto/tls vulnerability

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.25.11
+FROM golang:1.25.12
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Go build stage
-FROM --platform=${BUILDPLATFORM} golang:1.25.11 AS go-builder
+FROM --platform=${BUILDPLATFORM} golang:1.25.12 AS go-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -5,8 +5,8 @@
 #   COPY --from=builder /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
-# Build Stage: using Go 1.25.11 image
-FROM --platform=${BUILDPLATFORM} golang:1.25.11 AS builder
+# Build Stage: using Go 1.25.12 image
+FROM --platform=${BUILDPLATFORM} golang:1.25.12 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llm-d/llm-d-router
 
-go 1.25.11
+go 1.25.12
 
 require (
 	cloud.google.com/go/aiplatform v1.124.0

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/Dockerfile
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11 AS builder
+FROM golang:1.25.12 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
`setup-go` reads `go-version-file`: `go.mod` in CI lint, so the go directive bump installs the patched toolchain and clears the crypto/tls finding. Builder images updated to match.

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
CI Lint fails on govulncheck: `crypto/tls@go1.25.11` has a known
vulnerability fixed in `crypto/tls@go1.25.12` (exit code 3, reachable).

The `setup-go` action reads `go-version-file: go.mod`, so bumping the
`go` directive to `1.25.12` installs the patched toolchain and clears
the finding. The `golang:1.25.11` builder images (epp, builder,
sidecar, and the latencypredictor test Dockerfile) are bumped to match
so shipped binaries link against the fixed standard library.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Update the Go toolchain to 1.25.12, resolving a crypto/tls security vulnerability in the released images.
```
