### PR TITLE
docs: fix EPP config flag names in architecture guide

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,9 +170,9 @@ schedulingProfiles:
     weight: 50
 ```
 
-If the configuration is in a file, the EPP command line argument `--configFile` should be used
+If the configuration is in a file, the EPP command line argument `--config-file` should be used
  to specify the full path of the file in question. If the configuration is passed as in-line
- text the EPP command line argument `--configText` should be used.
+ text the EPP command line argument `--config-text` should be used.
 
 ### Default plugins
 


### PR DESCRIPTION

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The architecture guide's configuration section tells users to pass the EPP
configuration with `--configFile` and `--configText`, but the EPP registers
those flags as `--config-file` and `--config-text` (`pkg/epp/server/options.go`).
pflag rejects unknown flags, so copying the documented commands fails with an
`unknown flag` error.

This updates the two flag names in `docs/architecture.md` to the registered
kebab-case forms, matching the rest of the docs and the deployment manifests
(for example `docs/discovery.md` and
`deploy/components/inference-gateway/deployment.yaml`).

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
docs: correct the EPP configuration flag names in the architecture guide to the registered `--config-file` and `--config-text` (previously `--configFile` and `--configText`, which pflag rejects as unknown flags).
```
