### PR TITLE
fix(epp): use real flag names in config-file/config-text error

### DIFF
--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -299,7 +299,7 @@ func (opts *Options) Validate() error {
 	}
 
 	if opts.ConfigText != "" && opts.ConfigFile != "" {
-		return fmt.Errorf("both the %q and %q flags can not be set at the same time", "configText", "configFile")
+		return fmt.Errorf("both the %q and %q flags can not be set at the same time", "config-file", "config-text")
 	}
 	if opts.ModelServerMetricsScheme != "http" && opts.ModelServerMetricsScheme != "https" {
 		return fmt.Errorf("unexpected %q value for %q flag, it can only be set to 'http' or 'https'",

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -299,7 +299,7 @@ func (opts *Options) Validate() error {
 	}
 
 	if opts.ConfigText != "" && opts.ConfigFile != "" {
-		return fmt.Errorf("both the %q and %q flags can not be set at the same time", "config-file", "config-text")
+		return fmt.Errorf("both the %q and %q flags cannot be set at the same time", "config-file", "config-text")
 	}
 	if opts.ModelServerMetricsScheme != "http" && opts.ModelServerMetricsScheme != "https" {
 		return fmt.Errorf("unexpected %q value for %q flag, it can only be set to 'http' or 'https'",

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -265,5 +266,22 @@ func TestDrainTimeoutFlag(t *testing.T) {
 	}
 	if opts.DrainTimeout != 30*time.Second {
 		t.Errorf("DrainTimeout = %v, want 30s", opts.DrainTimeout)
+	}
+}
+
+func TestValidateConfigFlagsMutuallyExclusive(t *testing.T) {
+	opts := NewOptions()
+	opts.PoolName = "config-flags-pool" // bypass the pool/selector validation
+	opts.ConfigFile = "fake-config.yaml"
+	opts.ConfigText = "fake: config"
+
+	err := opts.Validate()
+	if err == nil {
+		t.Fatalf("Expected Validate() to fail when both config flags are set, but it succeeded")
+	}
+	for _, want := range []string{"config-file", "config-text"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Validate() error must reference the %q flag, got: %v", want, err)
+		}
 	}
 }


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Options.Validate()` in `pkg/epp/server/options.go` rejects setting both
`--config-file` and `--config-text` at once, but the error names the flags
`"configText"` and `"configFile"`:

```go
return fmt.Errorf("both the %q and %q flags can not be set at the same time", "configText", "configFile")
```

Those identifiers are not registered flags. The flags are registered as
`config-file` and `config-text` (kebab-case) in `AddFlags`, so an operator who
trips this validation is pointed at flag names that do not exist and cannot map
the message back to the flag they set. Every other error in the same
`Validate()` already uses the registered kebab-case name (`endpoint-target-ports`,
`model-server-metrics-scheme`, `grpc-max-receive-msg-size`,
`grpc-max-send-msg-size`); this one line was missed.

This changes the two names in the message to the registered `config-file` and
`config-text` (file first, text second, matching the registration order) and
adds a regression test that sets both flags and asserts the returned error
references both real names.

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP: the error returned when both `--config-file` and `--config-text` are set now names the actual flags (`config-file`, `config-text`) instead of unregistered identifiers, so the message is actionable.
```

### Test plan

- [x] `go test ./pkg/epp/server/ -run TestValidateConfigFlagsMutuallyExclusive` -
  new test: setting both config flags returns an error naming both `config-file`
  and `config-text`. Verified red on the pre-fix message, green after.
- [x] `go test ./pkg/epp/server/` - full package passes.

---

## Verification recap (done locally on this branch, host Go 1.26.4)

Note: the repo runs `make presubmit` inside a builder container (needs Docker,
which is not available on this machine). Ran the underlying tools on the host
with the CI-pinned linter version instead:

- `go build ./...` -> exit 0
- `go vet ./pkg/epp/server/` -> clean
- `go test ./pkg/epp/server/` -> ok (~19s); targeted test PASS
- `gofmt -l` on both files -> clean
- `golangci-lint@v2.8.0 run --config=./.golangci.yml ./pkg/epp/server/` -> 0 issues
  (v2.8.0 is the `GOLANGCI_LINT_VERSION` pinned in `Dockerfile.builder`, i.e. what
  `make lint` uses in CI)
- red->green re-proven post-rebase: reverting the one-line fix makes the new test
  fail on both name assertions; restoring it passes.

Rebased onto the latest `origin/main` (`c4ea166b`); branch is 1 ahead / 0 behind.
The three intervening upstream commits do not touch `options.go`, so the rebase
was clean and the bug still exists on current `main` (confirmed by inspecting
`origin/main:pkg/epp/server/options.go:295`).
