### PR TITLE
ci: add /rebase bot for maintainer-triggered PR rebases

### DIFF
--- a/.github/workflows/pr-rebase.yaml
+++ b/.github/workflows/pr-rebase.yaml
@@ -5,8 +5,9 @@ on:
     types: [created]
 
 permissions:
-  contents: read
-  pull-requests: read
+  contents: write
+  pull-requests: write
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number }}
@@ -17,7 +18,7 @@ jobs:
     name: Rebase PR on main
     if: >-
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/rebase')
+      github.event.comment.body == '/rebase'
     runs-on: ubuntu-latest
     steps:
       - name: Check commenter has write access
@@ -39,24 +40,6 @@ jobs:
           gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content='rocket' --silent
 
-      - name: Generate App token
-        if: steps.check-access.outputs.skip != 'true'
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.RELEASE_NOTES_APP_ID }}
-          private-key: ${{ secrets.RELEASE_NOTES_APP_PRIVATE_KEY }}
-
-      - name: Get App user info
-        if: steps.check-access.outputs.skip != 'true'
-        id: app-user
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        run: |
-          echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-          echo "app-slug=${APP_SLUG}" >> "$GITHUB_OUTPUT"
-
       - name: Get PR details
         if: steps.check-access.outputs.skip != 'true'
         id: pr
@@ -64,15 +47,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}")
-          echo "head-repo=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')" >> "$GITHUB_OUTPUT"
+          HEAD_REPO=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')
+          echo "head-repo=$HEAD_REPO" >> "$GITHUB_OUTPUT"
           echo "head-ref=$(echo "$PR_JSON" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
           echo "base-ref=$(echo "$PR_JSON" | jq -r '.base.ref')" >> "$GITHUB_OUTPUT"
+          echo "is-fork=$( [ "$HEAD_REPO" != "${{ github.repository }}" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
           echo "maintainer-can-modify=$(echo "$PR_JSON" | jq -r '.maintainer_can_modify')" >> "$GITHUB_OUTPUT"
 
       - name: Check fork allows maintainer push
         if: >-
           steps.check-access.outputs.skip != 'true' &&
-          steps.pr.outputs.head-repo != github.repository &&
+          steps.pr.outputs.is-fork == 'true' &&
           steps.pr.outputs.maintainer-can-modify != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,29 +68,26 @@ jobs:
           Cannot rebase: the PR author has not enabled **Allow edits from maintainers**. Please ask them to enable it in the PR sidebar.' --silent
           exit 1
 
-      - name: Checkout PR head
+      - name: Checkout base repo
         if: steps.check-access.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.pr.outputs.head-repo }}
-          ref: ${{ steps.pr.outputs.head-ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ steps.pr.outputs.base-ref }}
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure git and rebase
+      - name: Fetch PR head and rebase
         if: steps.check-access.outputs.skip != 'true'
         id: rebase
-        env:
-          APP_SLUG: ${{ steps.app-user.outputs.app-slug }}
-          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
         run: |
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git remote add base "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
-          git fetch base "${{ steps.pr.outputs.base-ref }}"
+          # Fetch the PR head ref directly from GitHub
+          git fetch origin "pull/${{ github.event.issue.number }}/head:pr-head"
+          git checkout pr-head
 
-          if git rebase "base/${{ steps.pr.outputs.base-ref }}"; then
+          if git rebase "origin/${{ steps.pr.outputs.base-ref }}"; then
             echo "result=success" >> "$GITHUB_OUTPUT"
           else
             git rebase --abort
@@ -116,13 +98,20 @@ jobs:
         if: >-
           steps.check-access.outputs.skip != 'true' &&
           steps.rebase.outputs.result == 'success'
+        id: push
         run: |
-          git push --force-with-lease origin "${{ steps.pr.outputs.head-ref }}"
+          PUSH_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ steps.pr.outputs.head-repo }}.git"
+          if git push "$PUSH_URL" "HEAD:${{ steps.pr.outputs.head-ref }}" --force-with-lease 2>&1; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failed" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Comment on success
         if: >-
           steps.check-access.outputs.skip != 'true' &&
-          steps.rebase.outputs.result == 'success'
+          steps.rebase.outputs.result == 'success' &&
+          steps.push.outputs.result == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -138,8 +127,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BODY=$(cat <<'COMMENT'
-          > /rebase
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body='> /rebase
 
           Rebase failed due to merge conflicts. Please rebase manually:
           ```
@@ -147,8 +136,17 @@ jobs:
           git rebase origin/${{ steps.pr.outputs.base-ref }}
           # resolve conflicts
           git push --force-with-lease
-          ```
-          COMMENT
-          )
+          ```' --silent
+
+      - name: Comment on push failure
+        if: >-
+          steps.check-access.outputs.skip != 'true' &&
+          steps.rebase.outputs.result == 'success' &&
+          steps.push.outputs.result == 'failed'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
-            -f body="$BODY" --silent
+            -f body='> /rebase
+
+          Rebase succeeded but push failed. This usually means the PR is from a fork and the author has not enabled **Allow edits from maintainers**, or the fork repo restricts pushes. Please rebase manually.' --silent

--- a/.github/workflows/pr-rebase.yaml
+++ b/.github/workflows/pr-rebase.yaml
@@ -44,8 +44,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.REBASE_APP_ID }}
-          private-key: ${{ secrets.REBASE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_NOTES_APP_ID }}
+          private-key: ${{ secrets.RELEASE_NOTES_APP_PRIVATE_KEY }}
 
       - name: Get App user info
         if: steps.check-access.outputs.skip != 'true'

--- a/.github/workflows/pr-rebase.yaml
+++ b/.github/workflows/pr-rebase.yaml
@@ -79,15 +79,20 @@ jobs:
       - name: Fetch PR head and rebase
         if: steps.check-access.outputs.skip != 'true'
         id: rebase
+        env:
+          HEAD_REPO: ${{ steps.pr.outputs.head-repo }}
+          HEAD_REF: ${{ steps.pr.outputs.head-ref }}
+          BASE_REF: ${{ steps.pr.outputs.base-ref }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Fetch the PR head ref directly from GitHub
-          git fetch origin "pull/${{ github.event.issue.number }}/head:pr-head"
-          git checkout pr-head
+          HEAD_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${HEAD_REPO}.git"
+          git remote add head-repo "$HEAD_URL"
+          git fetch head-repo "$HEAD_REF"
+          git checkout -b pr-head "head-repo/$HEAD_REF"
 
-          if git rebase "origin/${{ steps.pr.outputs.base-ref }}"; then
+          if git rebase "origin/$BASE_REF"; then
             echo "result=success" >> "$GITHUB_OUTPUT"
           else
             git rebase --abort
@@ -100,8 +105,7 @@ jobs:
           steps.rebase.outputs.result == 'success'
         id: push
         run: |
-          PUSH_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ steps.pr.outputs.head-repo }}.git"
-          if git push "$PUSH_URL" "HEAD:${{ steps.pr.outputs.head-ref }}" --force-with-lease 2>&1; then
+          if git push --force-with-lease head-repo "HEAD:${{ steps.pr.outputs.head-ref }}" 2>&1; then
             echo "result=success" >> "$GITHUB_OUTPUT"
           else
             echo "result=failed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-rebase.yaml
+++ b/.github/workflows/pr-rebase.yaml
@@ -1,0 +1,154 @@
+name: Rebase PR
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  rebase:
+    name: Rebase PR on main
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commenter has write access
+        id: check-access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" && "$PERMISSION" != "maintain" ]]; then
+            echo "User ${{ github.event.comment.user.login }} does not have write access (got: $PERMISSION). Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: React to comment
+        if: steps.check-access.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='rocket' --silent
+
+      - name: Generate App token
+        if: steps.check-access.outputs.skip != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.REBASE_APP_ID }}
+          private-key: ${{ secrets.REBASE_APP_PRIVATE_KEY }}
+
+      - name: Get App user info
+        if: steps.check-access.outputs.skip != 'true'
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+          echo "app-slug=${APP_SLUG}" >> "$GITHUB_OUTPUT"
+
+      - name: Get PR details
+        if: steps.check-access.outputs.skip != 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}")
+          echo "head-repo=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')" >> "$GITHUB_OUTPUT"
+          echo "head-ref=$(echo "$PR_JSON" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
+          echo "base-ref=$(echo "$PR_JSON" | jq -r '.base.ref')" >> "$GITHUB_OUTPUT"
+          echo "maintainer-can-modify=$(echo "$PR_JSON" | jq -r '.maintainer_can_modify')" >> "$GITHUB_OUTPUT"
+
+      - name: Check fork allows maintainer push
+        if: >-
+          steps.check-access.outputs.skip != 'true' &&
+          steps.pr.outputs.head-repo != github.repository &&
+          steps.pr.outputs.maintainer-can-modify != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body='> /rebase
+
+          Cannot rebase: the PR author has not enabled **Allow edits from maintainers**. Please ask them to enable it in the PR sidebar.' --silent
+          exit 1
+
+      - name: Checkout PR head
+        if: steps.check-access.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pr.outputs.head-repo }}
+          ref: ${{ steps.pr.outputs.head-ref }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure git and rebase
+        if: steps.check-access.outputs.skip != 'true'
+        id: rebase
+        env:
+          APP_SLUG: ${{ steps.app-user.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
+        run: |
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          git remote add base "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
+          git fetch base "${{ steps.pr.outputs.base-ref }}"
+
+          if git rebase "base/${{ steps.pr.outputs.base-ref }}"; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            git rebase --abort
+            echo "result=conflict" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push rebased branch
+        if: >-
+          steps.check-access.outputs.skip != 'true' &&
+          steps.rebase.outputs.result == 'success'
+        run: |
+          git push --force-with-lease origin "${{ steps.pr.outputs.head-ref }}"
+
+      - name: Comment on success
+        if: >-
+          steps.check-access.outputs.skip != 'true' &&
+          steps.rebase.outputs.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body='> /rebase
+
+          Done — rebased `${{ steps.pr.outputs.head-ref }}` on `${{ steps.pr.outputs.base-ref }}`.' --silent
+
+      - name: Comment on conflict
+        if: >-
+          steps.check-access.outputs.skip != 'true' &&
+          steps.rebase.outputs.result == 'conflict'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat <<'COMMENT'
+          > /rebase
+
+          Rebase failed due to merge conflicts. Please rebase manually:
+          ```
+          gh pr checkout ${{ github.event.issue.number }}
+          git rebase origin/${{ steps.pr.outputs.base-ref }}
+          # resolve conflicts
+          git push --force-with-lease
+          ```
+          COMMENT
+          )
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body="$BODY" --silent


### PR DESCRIPTION
## Summary

Adds a `/rebase` slash command for PRs, triggered by issue comments (matching the existing prow-style commands in `prow-github.yml`).

When a maintainer comments `/rebase` on a PR, the bot:
- Verifies the commenter has write/maintain/admin access
- Reacts with 🚀 to acknowledge
- Handles fork PRs (checks `maintainer_can_modify`, graceful failure on push)
- Rebases the PR branch on top of the base branch
- Force-pushes with `--force-with-lease`
- Comments back with success, conflict resolution instructions, or push failure details

### Intended workflow

1. Maintainer comments `/rebase` on a PR
2. Bot rebases the branch and pushes (attributed to `github-actions[bot]`)
3. `Check signed commits in PR` fails (expected — rebased commits are unsigned)
4. Maintainer (on the bypass list) merges using **"Merge without waiting for requirements to be met"**

## Test results

Tested E2E on https://github.com/liu-cong/llm-d-router/pull/1:

- Created a test branch 4 commits behind `main` with one test commit
- Commented `/rebase` on the PR
- Workflow run: https://github.com/liu-cong/llm-d-router/actions/runs/29108315334
- **Result:** Branch rebased successfully (0 behind, 1 ahead after rebase)
- Bot posted success comment and added 🚀 reaction