### PR TITLE
epp: let parsers own model-name extraction and rewrite

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -52,6 +52,13 @@ type Parser interface {
 	Claims() Claims
 }
 
+// ModelNameRewriter is implemented by parsers whose forwarded body can carry a model name.
+type ModelNameRewriter interface {
+	// RewriteModelName writes model into the payload and returns it. Taking and
+	// returning a MarshalablePayload guarantees the result is repackageable.
+	RewriteModelName(payload MarshalablePayload, model string) (MarshalablePayload, error)
+}
+
 // Claims defines the matching criteria for a parser.
 type Claims struct {
 	Paths     []string         // path patterns this parser claims (e.g., "chat/completions")

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -50,12 +50,26 @@ type RequestPayload interface {
 	AsMap() (PayloadMap, bool)
 }
 
+// Marshaler is implemented by payloads that serialize themselves back to the bytes
+// forwarded downstream. Payloads that do not are forwarded unchanged.
+type Marshaler interface {
+	Marshal() ([]byte, error)
+}
+
+// MarshalablePayload is a RequestPayload that can serialize itself back to bytes.
+// Only such payloads are worth mutating, since only they are re-marshaled on repackage.
+type MarshalablePayload interface {
+	RequestPayload
+	Marshaler
+}
+
 // PayloadMap represents a JSON request body unmarshaled into a map.
 type PayloadMap map[string]any
 
 func (p PayloadMap) isRequestPayload()         {}
 func (p PayloadMap) IsParsed() bool            { return true }
 func (p PayloadMap) AsMap() (PayloadMap, bool) { return p, p != nil }
+func (p PayloadMap) Marshal() ([]byte, error)  { return json.Marshal(map[string]any(p)) }
 
 // PayloadProto represents a gRPC request body unmarshaled into a proto.Message.
 type PayloadProto struct {
@@ -112,6 +126,10 @@ type InferenceRequestBody struct {
 	// It is nil when the client did not specify a cap. Consumers such as output
 	// token estimators use it as an upper bound. Derived, not round-tripped.
 	MaxOutputTokens *int64 `json:"-"`
+
+	// Model is the incoming client-facing model name extracted by the parser, empty
+	// if absent. Not round-tripped; the forwarded model lives in Payload.
+	Model string `json:"-"`
 }
 
 // MaxOutputTokensFromPayload returns the client-requested output-token cap read

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -43,7 +43,10 @@ const (
 )
 
 // compile-time type validation
-var _ fwkrh.Parser = &AnthropicParser{}
+var (
+	_ fwkrh.Parser            = &AnthropicParser{}
+	_ fwkrh.ModelNameRewriter = &AnthropicParser{}
+)
 
 type AnthropicParser struct {
 	typedName fwkplugin.TypedName
@@ -112,11 +115,24 @@ func (p *AnthropicParser) ParseRequest(_ context.Context, body []byte, headers m
 		Payload:         fwkrh.PayloadMap(bodyMap),
 		MaxOutputTokens: fwkrh.MaxOutputTokensFromPayload(bodyMap, "max_tokens"),
 	}
+	if model, ok := bodyMap["model"].(string); ok {
+		result.Model = model
+	}
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		result.Stream = true
 	}
 
 	return &fwkrh.ParseResult{Body: result, SkipResponseProcessing: false}, nil
+}
+
+// RewriteModelName writes the resolved model into the request payload map.
+func (p *AnthropicParser) RewriteModelName(payload fwkrh.MarshalablePayload, model string) (fwkrh.MarshalablePayload, error) {
+	m, ok := payload.(fwkrh.PayloadMap)
+	if !ok {
+		return payload, nil
+	}
+	m["model"] = model
+	return m, nil
 }
 
 func (p *AnthropicParser) ParseResponse(_ context.Context, body []byte, headers map[string]string, _ bool) (*fwkrh.ParsedResponse, error) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -446,6 +446,9 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				t.Errorf("ParseRequest() got.SkipResponseProcessing = %v, want false", got.SkipResponseProcessing)
 			}
 
+			// Model is extracted from the request body's "model" field.
+			tt.want.Model, _ = tt.body["model"].(string)
+
 			if diff := cmp.Diff(tt.want, got.Body); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -61,7 +61,10 @@ const (
 )
 
 // compile-time type validation
-var _ fwkrh.Parser = &OpenAIParser{}
+var (
+	_ fwkrh.Parser            = &OpenAIParser{}
+	_ fwkrh.ModelNameRewriter = &OpenAIParser{}
+)
 
 // OpenAIParser implements the fwkrh.Parser interface for OpenAI API
 // https://developers.openai.com/api/reference/overview
@@ -121,11 +124,24 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 		return nil, err
 	}
 	extractedBody.Payload = fwkrh.PayloadMap(bodyMap)
+	if model, ok := bodyMap["model"].(string); ok {
+		extractedBody.Model = model
+	}
 	extractedBody.MaxOutputTokens = maxOutputTokensForAPI(apiType, bodyMap)
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		extractedBody.Stream = true
 	}
 	return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
+}
+
+// RewriteModelName writes the resolved model into the request payload map.
+func (p *OpenAIParser) RewriteModelName(payload fwkrh.MarshalablePayload, model string) (fwkrh.MarshalablePayload, error) {
+	m, ok := payload.(fwkrh.PayloadMap)
+	if !ok {
+		return payload, nil
+	}
+	m["model"] = model
+	return m, nil
 }
 
 // maxOutputTokensForAPI normalizes the per-API output-token cap field into a

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1055,6 +1055,9 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				t.Errorf("ParseRequest() got.SkipResponseProcessing = %v, want false", got.SkipResponseProcessing)
 			}
 
+			// Model is extracted from the request body's "model" field.
+			tt.want.Model, _ = tt.body["model"].(string)
+
 			if diff := cmp.Diff(tt.want, got.Body); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -43,7 +43,10 @@ const (
 )
 
 // compile-time type validation
-var _ fwkrh.Parser = &VllmHTTPParser{}
+var (
+	_ fwkrh.Parser            = &VllmHTTPParser{}
+	_ fwkrh.ModelNameRewriter = &VllmHTTPParser{}
+)
 
 // VllmHTTPParser implements fwkrh.Parser for vLLM HTTP endpoints. It handles
 // /inference/v1/generate and delegates response parsing to an embedded
@@ -102,6 +105,11 @@ func (p *VllmHTTPParser) ParseResponse(ctx context.Context, body []byte, headers
 	return p.openai.ParseResponse(ctx, body, headers, isStreaming)
 }
 
+// RewriteModelName delegates to the OpenAI parser; the generate body shares the payload map format.
+func (p *VllmHTTPParser) RewriteModelName(payload fwkrh.MarshalablePayload, model string) (fwkrh.MarshalablePayload, error) {
+	return p.openai.RewriteModelName(payload, model)
+}
+
 // parseGenerateRequest decodes a /inference/v1/generate body into an
 // InferenceRequestBody. Token IDs are required; everything else is optional.
 func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResult, error) {
@@ -121,6 +129,9 @@ func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResul
 	body := &fwkrh.InferenceRequestBody{
 		Generate: &generate,
 		Payload:  fwkrh.PayloadMap(bodyMap),
+	}
+	if model, ok := bodyMap["model"].(string); ok {
+		body.Model = model
 	}
 	// max_tokens lives under sampling_params in the generate wire format.
 	if sp, ok := bodyMap["sampling_params"].(map[string]any); ok {

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -20,7 +20,6 @@ package requestcontrol
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -244,6 +243,9 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 
 	logger := log.FromContext(ctx)
 
+	// Record the client-facing model for every request, including forwarded-unchanged ones.
+	reqCtx.IncomingModelName = inferenceRequestBody.Model
+
 	err = d.modelRewriteIfNeeded(ctx, reqCtx, inferenceRequestBody)
 	if err != nil {
 		return reqCtx, err
@@ -356,45 +358,44 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 }
 
 func (d *Director) modelRewriteIfNeeded(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
-	if v, ok := inferenceRequestBody.Payload.(fwkrh.PayloadMap); ok {
-		// Mutate the model name inside the map, this is currently only supported if the payload is a PayloadMap.
-		_, err := d.mutateModel(ctx, reqCtx, v)
-		if err != nil {
-			return err
-		}
+	rewriter, ok := reqCtx.Parser.(fwkrh.ModelNameRewriter)
+	if !ok {
+		return nil
 	}
-	return nil
-}
-
-func (d *Director) mutateModel(ctx context.Context, reqCtx *handlers.RequestContext, bodyMap map[string]any) (*handlers.RequestContext, error) {
-	reqCtx.IncomingModelName, _ = bodyMap["model"].(string)
+	payload, ok := inferenceRequestBody.Payload.(fwkrh.MarshalablePayload)
+	if !ok {
+		return nil
+	}
 	if reqCtx.TargetModelName == "" {
 		reqCtx.TargetModelName = reqCtx.IncomingModelName
 	}
 	d.applyWeightedModelRewrite(ctx, reqCtx)
 	if reqCtx.TargetModelName == "" {
-		return reqCtx, errcommon.Error{Code: errcommon.BadRequest, Msg: "model not found in request body"}
+		return errcommon.Error{Code: errcommon.BadRequest, Msg: "model not found in request body"}
 	}
-	bodyMap["model"] = reqCtx.TargetModelName
-	return reqCtx, nil
+	mutated, err := rewriter.RewriteModelName(payload, reqCtx.TargetModelName)
+	if err != nil {
+		return err
+	}
+	// Store the result back so repackage serializes the mutated payload.
+	inferenceRequestBody.Payload = mutated
+	return nil
 }
 
 func (d *Director) repackage(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
-	logger := log.FromContext(ctx)
-	switch v := inferenceRequestBody.Payload.(type) {
-	case fwkrh.PayloadMap:
-		requestBodyBytes, err := json.Marshal(v)
-		if err != nil {
-			logger.Error(err, "Error marshalling request body")
-			return errcommon.Error{Code: errcommon.Internal, Msg: "Error marshalling request body"}
-		}
-		reqCtx.Request.RawBody = requestBodyBytes
-		reqCtx.RequestSize = len(requestBodyBytes)
-	case fwkrh.PayloadProto, fwkrh.RawPayload:
+	marshaler, ok := inferenceRequestBody.Payload.(fwkrh.Marshaler)
+	if !ok {
+		// Payload forwarded unchanged (raw or proto).
 		reqCtx.RequestSize = len(reqCtx.Request.RawBody)
-	default:
-		return errcommon.Error{Code: errcommon.BadRequest, Msg: "Unsupported llmRequest parsedBody"}
+		return nil
 	}
+	requestBodyBytes, err := marshaler.Marshal()
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error marshalling request body")
+		return errcommon.Error{Code: errcommon.Internal, Msg: "Error marshalling request body"}
+	}
+	reqCtx.Request.RawBody = requestBodyBytes
+	reqCtx.RequestSize = len(requestBodyBytes)
 	return nil
 }
 

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -358,12 +358,15 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 }
 
 func (d *Director) modelRewriteIfNeeded(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
+	logger := log.FromContext(ctx)
 	rewriter, ok := reqCtx.Parser.(fwkrh.ModelNameRewriter)
 	if !ok {
+		logger.Info("Warning: parser does not implement ModelNameRewriter, skipping model rewrite")
 		return nil
 	}
 	payload, ok := inferenceRequestBody.Payload.(fwkrh.MarshalablePayload)
 	if !ok {
+		logger.Info("Warning: payload does not implement MarshalablePayload, skipping model rewrite")
 		return nil
 	}
 	if reqCtx.TargetModelName == "" {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -887,7 +887,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 					reqCtx.Request.Headers[metadata.FlowFairnessIDKey] = test.fairnessIDHeader
 				}
 
-				parseResult, parseErr := openai.NewOpenAIParser().ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
+				reqCtx.Parser = openai.NewOpenAIParser()
+				parseResult, parseErr := reqCtx.Parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 				var returnedReqCtx *handlers.RequestContext
 				if parseErr != nil {
 					err = errcommon.Error{Code: errcommon.BadRequest, Msg: parseErr.Error()}
@@ -1898,7 +1899,8 @@ func TestDirector_HandleRequest_ConditionalDecode(t *testing.T) {
 			require.NoError(t, err)
 			reqCtx.Request.RawBody = body
 
-			parseResult, err := openai.NewOpenAIParser().ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
+			reqCtx.Parser = openai.NewOpenAIParser()
+			parseResult, err := reqCtx.Parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 			require.NoError(t, err)
 
 			_, err = dir.HandleRequest(ctx, reqCtx, parseResult.Body)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The director only read the model name from `PayloadMap` request bodies, so a request whose parser returns a `RawPayload` or `PayloadProto` (for example a multipart HTTP body that must be forwarded unchanged) had an empty `IncomingModelName` — leaving its prometheus metric labels blank.

This moves model-name extraction into the parser:

- Add `InferenceRequestBody.Model`, populated by each parser during `ParseRequest`. The director reads it into `reqCtx.IncomingModelName` for **every** request, including those forwarded unchanged, so metric labels are populated regardless of payload type.
- Add the `ModelNameRewriter` parser interface for writing the resolved target model back into the payload. It takes and returns a `MarshalablePayload`, so only serializable (repackageable) payloads are mutated and the result is guaranteed to be re-forwarded.
- `repackage` now serializes any `Marshaler` payload instead of switching on the concrete payload type.

**Which issue(s) this PR fixes**:

Fixes #1900

**Release note**:
```release-note
NONE
```
