### PR TITLE
test(e2e): retry post-recovery requests in decode-pod disruption spec

### DIFF
--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -83,6 +83,19 @@ func eppPodReady(oldPodName string) func() bool {
 	}
 }
 
+// completionRoutedToNamespace sends one completion and reports an error on any
+// failure or namespace-header mismatch, for use inside Eventually blocks.
+func completionRoutedToNamespace() error {
+	nsHdr, _, err := tryCompletion(simplePrompt, simModelName)
+	if err != nil {
+		return err
+	}
+	if nsHdr != nsName {
+		return fmt.Errorf("expected namespace %q, got %q", nsName, nsHdr)
+	}
+	return nil
+}
+
 var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disruptiveTestLabel), func() {
 	ginkgo.When("A decode pod is killed mid-request", func() {
 		ginkgo.It("should recover and route to surviving pods", func() {
@@ -132,18 +145,8 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			}, readyTimeout, 2*time.Second).Should(gomega.Equal(2))
 
 			ginkgo.By("Verifying requests succeed consistently after recovery")
-			gomega.Eventually(func() error {
-				for range 3 {
-					nsHdr, _, err := tryCompletion(simplePrompt, simModelName)
-					if err != nil {
-						return err
-					}
-					if nsHdr != nsName {
-						return fmt.Errorf("expected namespace %q, got %q", nsName, nsHdr)
-					}
-				}
-				return nil
-			}, eppRecoveryTimeout, 1*time.Second).Should(gomega.Succeed())
+			gomega.Eventually(completionRoutedToNamespace, eppRecoveryTimeout, 1*time.Second).
+				MustPassRepeatedly(3).Should(gomega.Succeed())
 		})
 	})
 
@@ -191,11 +194,9 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 				return len(currentDecode)
 			}, readyTimeout, 2*time.Second).Should(gomega.Equal(2))
 
-			ginkgo.By("Verifying requests succeed after recovery")
-			for range 3 {
-				nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
-				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
-			}
+			ginkgo.By("Verifying requests succeed consistently after recovery")
+			gomega.Eventually(completionRoutedToNamespace, eppRecoveryTimeout, 1*time.Second).
+				MustPassRepeatedly(3).Should(gomega.Succeed())
 		})
 	})
 

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 
 			ginkgo.By("Verifying new requests eventually route to a pod other than the killed one")
 			gomega.Eventually(func() error {
-				nsHdr, podHdr, _, err := tryCompletion(simplePrompt, simModelName)
+				nsHdr, podHdr, err := tryCompletion(simplePrompt, simModelName)
 				if err != nil {
 					return err
 				}
@@ -131,11 +131,19 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 				return len(currentDecode)
 			}, readyTimeout, 2*time.Second).Should(gomega.Equal(2))
 
-			ginkgo.By("Verifying requests succeed after recovery")
-			for range 3 {
-				nsHdr, _, _ = runCompletion(simplePrompt, simModelName)
-				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
-			}
+			ginkgo.By("Verifying requests succeed consistently after recovery")
+			gomega.Eventually(func() error {
+				for range 3 {
+					nsHdr, _, err := tryCompletion(simplePrompt, simModelName)
+					if err != nil {
+						return err
+					}
+					if nsHdr != nsName {
+						return fmt.Errorf("expected namespace %q, got %q", nsName, nsHdr)
+					}
+				}
+				return nil
+			}, eppRecoveryTimeout, 1*time.Second).Should(gomega.Succeed())
 		})
 	})
 

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -139,6 +139,13 @@ func tryCompletion(prompt string, theModel openai.CompletionNewParamsModel) (str
 	if len(resp.Choices) != 1 {
 		return "", "", fmt.Errorf("expected 1 choice, got %d", len(resp.Choices))
 	}
+	if resp.Choices[0].FinishReason != openai.CompletionChoiceFinishReasonStop {
+		return "", "", fmt.Errorf("expected finish reason %q, got %q",
+			openai.CompletionChoiceFinishReasonStop, resp.Choices[0].FinishReason)
+	}
+	if resp.Choices[0].Text != prompt {
+		return "", "", fmt.Errorf("expected echoed prompt, got %q", resp.Choices[0].Text)
+	}
 	ns, pod, _ := extractInferenceHeaders(httpResp)
 	return ns, pod, nil
 }

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -118,7 +118,7 @@ func runCompletion(prompt string, theModel openai.CompletionNewParamsModel) (str
 
 // tryCompletion is like runCompletion but returns an error instead of asserting,
 // intended for use inside Eventually blocks where transient failures are acceptable.
-func tryCompletion(prompt string, theModel openai.CompletionNewParamsModel) (string, string, string, error) {
+func tryCompletion(prompt string, theModel openai.CompletionNewParamsModel) (string, string, error) {
 	var httpResp *http.Response
 	completionParams := openai.CompletionNewParams{
 		Prompt: openai.CompletionNewParamsPromptUnion{OfString: openai.String(prompt)},
@@ -131,16 +131,16 @@ func tryCompletion(prompt string, theModel openai.CompletionNewParamsModel) (str
 		option.WithRequestTimeout(readyTimeout),
 	)
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
 	if httpResp == nil {
-		return "", "", "", errors.New("missing http response")
+		return "", "", errors.New("missing http response")
 	}
 	if len(resp.Choices) != 1 {
-		return "", "", "", fmt.Errorf("expected 1 choice, got %d", len(resp.Choices))
+		return "", "", fmt.Errorf("expected 1 choice, got %d", len(resp.Choices))
 	}
-	ns, pod, p := extractInferenceHeaders(httpResp)
-	return ns, pod, p, nil
+	ns, pod, _ := extractInferenceHeaders(httpResp)
+	return ns, pod, nil
 }
 
 func runChatCompletion(prompt, modelName string) (string, string, string) {


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

The decode-pod disruption spec's final "requests succeed after recovery" check sends unretried requests seconds after the spec's freshly-created EPP deployment turns Available. Envoy's active gRPC health check of the `ext_proc` cluster (10s interval, healthy_threshold 2) can lag actual EPP readiness in that window, so Envoy locally generates a 500 ("no healthy upstream") and a single transient failure sinks the spec even though recovery already succeeded.

The streaming-disruption spec had the identical unretried post-recovery loop, so both specs now poll a shared `completionRoutedToNamespace` probe with `Eventually(...).MustPassRepeatedly(3)`, preserving the original "consistently succeeds" criterion. `tryCompletion` verifies finish reason and echoed text (as retryable errors), matching `runCompletion`, so the retry tolerance does not weaken what the recovery check asserts; its never-used third return value (the port header) is dropped, which the added callers caused `unparam` to flag.

**Which issue(s) this PR fixes**:

Fixes #1960

**Test plan**:

- [x] Disruption e2e suite passes locally (`E2E_LABEL_FILTER=Disruptive make test-e2e`, 5/5 specs, both rewritten post-recovery checks exercised)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
