### PR TITLE
feat(epp): expose per-tier cached-block counts in prefix match info

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/README.md
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/README.md
@@ -11,6 +11,8 @@ Contains information about how much of a request's prefix matched the cache on a
   - `MatchBlocks`: Number of blocks that matched the cache.
   - `TotalBlocks`: Total number of blocks in the request prefix.
   - `BlockSizeTokens`: Number of tokens per block. This is fixed across endpoints.
+  - `CachedBlockCount`: Unweighted count of contiguous cached prefix blocks, regardless of device tier. Defaults to `MatchBlocks` when the producer does not set it.
+  - `CachedBlocksByTier`: Per device tier, the count of contiguous cached prefix blocks the endpoint holds in that tier. Nil when the producer supplies no tier data.
 
 This information is used by affinity-based scheduling scorers to prefer endpoints with high cache hits.
 

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
@@ -44,9 +44,8 @@ type PrefixCacheMatchInfo struct {
 	// per device tier, the unweighted count of contiguous cached prefix blocks
 	// the endpoint holds in that tier, from the first block until the first
 	// block missing from that tier. A block held in several tiers counts once
-	// per tier. Entries without a confirmed device tier (e.g. speculative
-	// index entries) count under the empty string. Nil when the producer
-	// supplies no tier data.
+	// per tier. Speculative index entries count under the synthetic
+	// "speculative" tier. Nil when the producer supplies no tier data.
 	cachedBlocksByTier map[string]int
 }
 
@@ -85,7 +84,8 @@ func (p *PrefixCacheMatchInfo) CachedBlockCount() int {
 }
 
 // WithCachedBlocksByTier sets the per-device-tier contiguous cached-block
-// counts and returns the receiver for chaining.
+// counts and returns the receiver for chaining. Takes ownership of the map;
+// the caller must not mutate it after the call.
 func (p *PrefixCacheMatchInfo) WithCachedBlocksByTier(cachedBlocksByTier map[string]int) *PrefixCacheMatchInfo {
 	p.cachedBlocksByTier = cachedBlocksByTier
 	return p

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package prefix
 
 import (
+	"maps"
+
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	approxprefixconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/constants"
@@ -39,6 +41,13 @@ type PrefixCacheMatchInfo struct {
 	// the prefix-based PD decider) get an accurate cached-token figure rather
 	// than a tier-attenuated one. Defaults to matchBlocks when not set.
 	cachedBlockCount int
+	// per device tier, the unweighted count of contiguous cached prefix blocks
+	// the endpoint holds in that tier, from the first block until the first
+	// block missing from that tier. A block held in several tiers counts once
+	// per tier. Entries without a confirmed device tier (e.g. speculative
+	// index entries) count under the empty string. Nil when the producer
+	// supplies no tier data.
+	cachedBlocksByTier map[string]int
 }
 
 func NewPrefixCacheMatchInfo(matchBlocks int, totalBlocks int, blockSizeTokens int) *PrefixCacheMatchInfo {
@@ -75,11 +84,26 @@ func (p *PrefixCacheMatchInfo) CachedBlockCount() int {
 	return p.cachedBlockCount
 }
 
+// WithCachedBlocksByTier sets the per-device-tier contiguous cached-block
+// counts and returns the receiver for chaining.
+func (p *PrefixCacheMatchInfo) WithCachedBlocksByTier(cachedBlocksByTier map[string]int) *PrefixCacheMatchInfo {
+	p.cachedBlocksByTier = cachedBlocksByTier
+	return p
+}
+
+// CachedBlocksByTier returns, per device tier, the unweighted count of
+// contiguous cached prefix blocks the endpoint holds in that tier. Nil means
+// the producer supplies no tier data. Callers must not mutate the map.
+func (p *PrefixCacheMatchInfo) CachedBlocksByTier() map[string]int {
+	return p.cachedBlocksByTier
+}
+
 func (p *PrefixCacheMatchInfo) Clone() fwkdl.Cloneable {
 	return &PrefixCacheMatchInfo{
-		matchBlocks:      p.matchBlocks,
-		totalBlocks:      p.totalBlocks,
-		blockSizeTokens:  p.blockSizeTokens,
-		cachedBlockCount: p.cachedBlockCount,
+		matchBlocks:        p.matchBlocks,
+		totalBlocks:        p.totalBlocks,
+		blockSizeTokens:    p.blockSizeTokens,
+		cachedBlockCount:   p.cachedBlockCount,
+		cachedBlocksByTier: maps.Clone(p.cachedBlocksByTier),
 	}
 }

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
@@ -26,6 +26,10 @@ import (
 
 var PrefixCacheMatchInfoDataKey = plugin.NewDataKey("PrefixCacheMatchInfoDataKey", approxprefixconstants.ApproxPrefixCachePluginType)
 
+// SpeculativeTierKey is the CachedBlocksByTier key for speculative index
+// entries, which carry no engine-reported device tier.
+const SpeculativeTierKey = "speculative"
+
 type PrefixCacheMatchInfo struct {
 	// matched prefix length in blocks. For the precise prefix cache this is the
 	// device-tier-weighted longest-prefix score (e.g. RAM-tier blocks count as
@@ -44,8 +48,8 @@ type PrefixCacheMatchInfo struct {
 	// per device tier, the unweighted count of contiguous cached prefix blocks
 	// the endpoint holds in that tier, from the first block until the first
 	// block missing from that tier. A block held in several tiers counts once
-	// per tier. Speculative index entries count under the synthetic
-	// "speculative" tier. Nil when the producer supplies no tier data.
+	// per tier. Speculative index entries count under SpeculativeTierKey.
+	// Nil when the producer supplies no tier data.
 	cachedBlocksByTier map[string]int
 }
 

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
@@ -55,3 +55,34 @@ func TestPrefixCacheMatchInfo_CloneCopiesCachedBlockCount(t *testing.T) {
 	assert.Equal(t, 240, orig.CachedBlockCount())
 	assert.Equal(t, 1, clone.CachedBlockCount())
 }
+
+func TestPrefixCacheMatchInfo_CachedBlocksByTierDefaultsToNil(t *testing.T) {
+	info := NewPrefixCacheMatchInfo(5, 10, 16)
+	// Nil distinguishes producers without tier data from a producer that saw
+	// zero cached blocks in every tier.
+	assert.Nil(t, info.CachedBlocksByTier())
+}
+
+func TestPrefixCacheMatchInfo_WithCachedBlocksByTier(t *testing.T) {
+	info := NewPrefixCacheMatchInfo(5, 10, 16).WithCachedBlocksByTier(map[string]int{"gpu": 3, "cpu": 2})
+	assert.Equal(t, map[string]int{"gpu": 3, "cpu": 2}, info.CachedBlocksByTier())
+
+	empty := NewPrefixCacheMatchInfo(0, 10, 16).WithCachedBlocksByTier(map[string]int{})
+	assert.NotNil(t, empty.CachedBlocksByTier())
+	assert.Empty(t, empty.CachedBlocksByTier())
+}
+
+func TestPrefixCacheMatchInfo_CloneDeepCopiesCachedBlocksByTier(t *testing.T) {
+	orig := NewPrefixCacheMatchInfo(5, 10, 16).WithCachedBlocksByTier(map[string]int{"gpu": 3, "cpu": 2})
+	clone, ok := orig.Clone().(*PrefixCacheMatchInfo)
+	require.True(t, ok)
+	assert.Equal(t, orig.CachedBlocksByTier(), clone.CachedBlocksByTier())
+
+	// Mutating the clone's map must not affect the original.
+	clone.CachedBlocksByTier()["gpu"] = 99
+	assert.Equal(t, 3, orig.CachedBlocksByTier()["gpu"])
+
+	nilClone, ok := NewPrefixCacheMatchInfo(5, 10, 16).Clone().(*PrefixCacheMatchInfo)
+	require.True(t, ok)
+	assert.Nil(t, nilClone.CachedBlocksByTier())
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
@@ -19,7 +19,7 @@ to the auto-spawned approx producer.
 Pipeline per request:
 - Consume `TokenizedPrompt` from `token-producer`.
 - Hash tokens → KV-block keys → `kvblock.Index.Lookup`.
-- Write `PrefixCacheMatchInfo(matchBlocks, totalBlocks, blockSizeTokens)` per endpoint.
+- Write `PrefixCacheMatchInfo(matchBlocks, totalBlocks, blockSizeTokens)` per endpoint, including the unweighted cached-block count and its per-device-tier breakdown.
 - (`PreRequest`) Speculative-index the selected endpoint(s) with TTL eviction.
 - (`EndpointExtractor`) Per-pod ZMQ subscriber lifecycle on add/delete.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -297,11 +297,17 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 			maxMatch = matchLen
 		}
 		cachedBlocks := 0
+		cachedBlocksByTier := map[string]int{}
 		for _, lu := range lookups {
 			cachedBlocks += matchedBlockCount(lu.keys, lu.keyToPods, addr)
+			for tier, count := range matchedBlockCountByTier(lu.keys, lu.keyToPods, addr) {
+				cachedBlocksByTier[tier] += count
+			}
 		}
 		ep.Put(p.dk.String(),
-			attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens).WithCachedBlockCount(cachedBlocks))
+			attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens).
+				WithCachedBlockCount(cachedBlocks).
+				WithCachedBlocksByTier(cachedBlocksByTier))
 	}
 
 	if p.speculativeEnabled {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -366,6 +366,79 @@ func TestProduce_MultiPromptSkipsEmptyPromptKeys(t *testing.T) {
 	assert.Equal(t, 1, info.TotalBlocks())
 }
 
+// Per-tier contiguous counts are attached per endpoint and summed across
+// prompts; endpoints without tier data get a non-nil empty map.
+func TestProduce_WritesCachedBlocksByTier(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	endpoints := freshEndpoints()
+
+	promptA := []uint32{1, 2, 3, 4, 5, 6, 7, 8}
+	promptB := []uint32{20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35}
+	keysA := []kvblock.BlockHash{0xA1, 0xA2}
+	keysB := []kvblock.BlockHash{0xB1}
+
+	gpuA := kvblock.PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu"}
+	cpuA := kvblock.PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "cpu"}
+
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, ts []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			if len(ts) == len(promptA) {
+				return keysA, nil
+			}
+			return keysB, nil
+		},
+		index: &fakeKVBlockIndex{
+			lookup: func(_ context.Context, keys []kvblock.BlockHash, _ sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
+				if keys[0] == keysA[0] {
+					// Prompt A: block 0 on gpu+cpu, block 1 on gpu only.
+					return map[kvblock.BlockHash][]kvblock.PodEntry{
+						keysA[0]: {gpuA, cpuA},
+						keysA[1]: {gpuA},
+					}, nil
+				}
+				// Prompt B: single block on gpu+cpu.
+				return map[kvblock.BlockHash][]kvblock.PodEntry{
+					keysB[0]: {gpuA, cpuA},
+				}, nil
+			},
+		},
+	}
+	scorer := &fakeKVBlockScorer{
+		score: func(_ context.Context, _ []kvblock.BlockHash, _ map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error) {
+			return map[string]float64{"10.0.0.1:8080": 1.0}, nil
+		},
+	}
+
+	p := newProducerWithIndexer(ctx, idx, scorer)
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-by-tier",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{
+				PerPromptTokens: [][]uint32{promptA, promptB},
+			},
+		},
+	}
+
+	require.NoError(t, p.Produce(ctx, req, endpoints))
+
+	raw, ok := endpoints[0].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test").String())
+	require.True(t, ok)
+	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
+	require.True(t, ok)
+	assert.Equal(t, 3, info.CachedBlockCount())
+	// gpu: 2 (prompt A) + 1 (prompt B); cpu: 1 (prompt A) + 1 (prompt B).
+	assert.Equal(t, map[string]int{"gpu": 3, "cpu": 2}, info.CachedBlocksByTier())
+
+	raw, ok = endpoints[1].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test").String())
+	require.True(t, ok)
+	info, ok = raw.(*attrprefix.PrefixCacheMatchInfo)
+	require.True(t, ok)
+	assert.Equal(t, 0, info.CachedBlockCount())
+	assert.NotNil(t, info.CachedBlocksByTier())
+	assert.Empty(t, info.CachedBlocksByTier())
+}
+
 // Multimodal features flow through to ComputeBlockKeysFromTokens.
 func TestProduce_PassesMMExtraFeatures(t *testing.T) {
 	ctx := utils.NewTestContext(t)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
@@ -55,12 +55,18 @@ func matchedBlockCount(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash
 	return count
 }
 
+// speculativeTierKey is the CachedBlocksByTier key for speculative index
+// entries: PreRequest inserts them before vLLM has reported placement, so
+// they carry no device tier.
+const speculativeTierKey = "speculative"
+
 // matchedBlockCountByTier returns, per device tier, the number of contiguous
 // cached prefix blocks podID holds in that tier, counting from the first
 // block until the first block the pod does not hold in that tier. A block
 // held in several tiers counts once per tier, so each tier's count is at most
 // matchedBlockCount for the same pod. Tiers are recorded as found in the
-// index. Returns a non-nil (possibly empty) map.
+// index, except speculative entries, which count under speculativeTierKey.
+// Returns a non-nil (possibly empty) map.
 func matchedBlockCountByTier(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash][]kvblock.PodEntry, podID string) map[string]int {
 	counts := map[string]int{}
 	var alive sets.Set[string]
@@ -68,7 +74,11 @@ func matchedBlockCountByTier(keys []kvblock.BlockHash, keyToPods map[kvblock.Blo
 		tiersAtKey := sets.New[string]()
 		for _, e := range keyToPods[key] {
 			if e.PodIdentifier == podID {
-				tiersAtKey.Insert(e.DeviceTier)
+				if e.Speculative {
+					tiersAtKey.Insert(speculativeTierKey)
+				} else {
+					tiersAtKey.Insert(e.DeviceTier)
+				}
 			}
 		}
 		if alive == nil {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 // extractEndpointSet builds the "address:port" identifier set used to filter
@@ -55,17 +56,14 @@ func matchedBlockCount(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash
 	return count
 }
 
-// speculativeTierKey is the CachedBlocksByTier key for speculative index
-// entries: PreRequest inserts them before vLLM has reported placement, so
-// they carry no device tier.
-const speculativeTierKey = "speculative"
-
 // matchedBlockCountByTier returns, per device tier, the number of contiguous
 // cached prefix blocks podID holds in that tier, counting from the first
 // block until the first block the pod does not hold in that tier. A block
 // held in several tiers counts once per tier, so each tier's count is at most
 // matchedBlockCount for the same pod. Tiers are recorded as found in the
-// index, except speculative entries, which count under speculativeTierKey.
+// index, except speculative entries, which count under
+// attrprefix.SpeculativeTierKey: PreRequest inserts them before vLLM has
+// reported placement, so they carry no device tier.
 // Returns a non-nil (possibly empty) map.
 func matchedBlockCountByTier(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash][]kvblock.PodEntry, podID string) map[string]int {
 	counts := map[string]int{}
@@ -75,7 +73,7 @@ func matchedBlockCountByTier(keys []kvblock.BlockHash, keyToPods map[kvblock.Blo
 		for _, e := range keyToPods[key] {
 			if e.PodIdentifier == podID {
 				if e.Speculative {
-					tiersAtKey.Insert(speculativeTierKey)
+					tiersAtKey.Insert(attrprefix.SpeculativeTierKey)
 				} else {
 					tiersAtKey.Insert(e.DeviceTier)
 				}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
@@ -54,3 +54,34 @@ func matchedBlockCount(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash
 	}
 	return count
 }
+
+// matchedBlockCountByTier returns, per device tier, the number of contiguous
+// cached prefix blocks podID holds in that tier, counting from the first
+// block until the first block the pod does not hold in that tier. A block
+// held in several tiers counts once per tier, so each tier's count is at most
+// matchedBlockCount for the same pod. Tiers are recorded as found in the
+// index. Returns a non-nil (possibly empty) map.
+func matchedBlockCountByTier(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash][]kvblock.PodEntry, podID string) map[string]int {
+	counts := map[string]int{}
+	var alive sets.Set[string]
+	for _, key := range keys {
+		tiersAtKey := sets.New[string]()
+		for _, e := range keyToPods[key] {
+			if e.PodIdentifier == podID {
+				tiersAtKey.Insert(e.DeviceTier)
+			}
+		}
+		if alive == nil {
+			alive = tiersAtKey
+		} else {
+			alive = alive.Intersection(tiersAtKey)
+		}
+		if alive.Len() == 0 {
+			break
+		}
+		for tier := range alive {
+			counts[tier]++
+		}
+	}
+	return counts
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/stretchr/testify/assert"
+
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
 func TestMatchedBlockCount(t *testing.T) {
@@ -160,7 +162,7 @@ func TestMatchedBlockCountByTier(t *testing.T) {
 				1: {speculative(podA), gpu(podA)}, 2: {speculative(podA)},
 			},
 			podID: podA,
-			want:  map[string]int{"gpu": 1, speculativeTierKey: 2},
+			want:  map[string]int{"gpu": 1, attrprefix.SpeculativeTierKey: 2},
 		},
 		{
 			name:      "empty index yields empty map",

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
@@ -155,12 +155,12 @@ func TestMatchedBlockCountByTier(t *testing.T) {
 			want:  map[string]int{"gpu": 2},
 		},
 		{
-			name: "speculative entries count under the empty tier",
+			name: "speculative entries count under the speculative key",
 			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
 				1: {speculative(podA), gpu(podA)}, 2: {speculative(podA)},
 			},
 			podID: podA,
-			want:  map[string]int{"gpu": 1, "": 2},
+			want:  map[string]int{"gpu": 1, speculativeTierKey: 2},
 		},
 		{
 			name:      "empty index yields empty map",

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
@@ -94,3 +94,92 @@ func TestMatchedBlockCount(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchedBlockCountByTier(t *testing.T) {
+	const (
+		podA = "10.0.0.1:8000"
+		podB = "10.0.0.2:8000"
+	)
+	keys := []kvblock.BlockHash{1, 2, 3, 4}
+
+	gpu := func(pod string) kvblock.PodEntry { return kvblock.PodEntry{PodIdentifier: pod, DeviceTier: "gpu"} }
+	cpu := func(pod string) kvblock.PodEntry { return kvblock.PodEntry{PodIdentifier: pod, DeviceTier: "cpu"} }
+	speculative := func(pod string) kvblock.PodEntry {
+		return kvblock.PodEntry{PodIdentifier: pod, Speculative: true}
+	}
+
+	tests := []struct {
+		name      string
+		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry
+		podID     string
+		want      map[string]int
+	}{
+		{
+			name: "all blocks on one tier",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {gpu(podA)}, 2: {gpu(podA)}, 3: {gpu(podA)}, 4: {gpu(podA)},
+			},
+			podID: podA,
+			want:  map[string]int{"gpu": 4},
+		},
+		{
+			name: "dual-tier block counts once per tier",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {gpu(podA), cpu(podA)}, 2: {gpu(podA)},
+			},
+			podID: podA,
+			want:  map[string]int{"gpu": 2, "cpu": 1},
+		},
+		{
+			name: "tier-specific gap stops that tier only",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {gpu(podA), cpu(podA)}, 2: {gpu(podA), cpu(podA)}, 3: {gpu(podA)}, 4: {gpu(podA), cpu(podA)},
+			},
+			podID: podA,
+			want:  map[string]int{"gpu": 4, "cpu": 2},
+		},
+		{
+			name: "pod absent from first block yields empty map",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {gpu(podB)}, 2: {gpu(podA)},
+			},
+			podID: podA,
+			want:  map[string]int{},
+		},
+		{
+			name: "counts are per-pod independent",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {gpu(podA), cpu(podB)}, 2: {gpu(podA), cpu(podB)}, 3: {cpu(podB)},
+			},
+			podID: podA,
+			want:  map[string]int{"gpu": 2},
+		},
+		{
+			name: "speculative entries count under the empty tier",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {speculative(podA), gpu(podA)}, 2: {speculative(podA)},
+			},
+			podID: podA,
+			want:  map[string]int{"gpu": 1, "": 2},
+		},
+		{
+			name:      "empty index yields empty map",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{},
+			podID:     podA,
+			want:      map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchedBlockCountByTier(keys, tt.keyToPods, tt.podID)
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.want, got)
+			// Each tier's contiguous count never exceeds the any-tier count.
+			anyTier := matchedBlockCount(keys, tt.keyToPods, tt.podID)
+			for tier, count := range got {
+				assert.LessOrEqual(t, count, anyTier, "tier %q", tier)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The precise prefix-cache producer flattens KV-block lookups into a single cached-block count, so consumers of `PrefixCacheMatchInfo` cannot distinguish GPU-resident blocks from offloaded ones. The kvblock index already tracks the device tier per pod entry and returns it from `Lookup`; this PR carries it through: `PrefixCacheMatchInfo` gains a per-device-tier breakdown of the contiguous cached prefix, populated by the precise producer and recorded as found in the index (entries without a confirmed tier, e.g. speculative, count under the empty string). Producers without tier data (approx, burst) leave it nil.

Purely additive: no existing field, accessor, or consumer behavior changes.

A follow-up PR makes `p2p-source-producer` select sources by p2p-servable tiers using this data, and will close the issue.

**Which issue(s) this PR fixes**:
Part of #1952

**Release note**:
```release-note
PrefixCacheMatchInfo produced by the precise prefix-cache producer now carries per-device-tier cached-block counts, letting consumers distinguish GPU-resident from offloaded prefix blocks.
```
