### PR TITLE
feat(helm): support configuring Envoy IPv6 listening via Helm value

### DIFF
--- a/config/charts/llm-d-router-standalone/templates/_validations.tpl
+++ b/config/charts/llm-d-router-standalone/templates/_validations.tpl
@@ -29,6 +29,10 @@ standalone validations
 {{- if and (not (kindIs "invalid" $failOpen)) (not (kindIs "bool" $failOpen)) -}}
   {{- fail (printf ".Values.router.proxy.failOpen must be a boolean, got %q" (toString $failOpen)) -}}
 {{- end -}}
+{{- $ipv6 := index $proxy "ipv6" -}}
+{{- if and (not (kindIs "invalid" $ipv6)) (not (kindIs "bool" $ipv6)) -}}
+  {{- fail (printf ".Values.router.proxy.ipv6 must be a boolean, got %q" (toString $ipv6)) -}}
+{{- end -}}
 {{- if eq $proxyMode "service" -}}
   {{- if not $proxy.enabled -}}
     {{- fail ".Values.router.proxy.enabled must be true when .Values.router.proxy.mode=service" -}}

--- a/config/charts/llm-d-router-standalone/values.yaml
+++ b/config/charts/llm-d-router-standalone/values.yaml
@@ -26,6 +26,9 @@ router:
     # unreachable, for active/passive resiliency.
     failOpen: true
 
+    # (Envoy only) Whether the proxy listens on IPv6 wildcard (::) in addition to IPv4.
+    ipv6: false
+
     resources:
       requests:
         cpu: "4"
@@ -60,11 +63,13 @@ router:
                       socket_address:
                         address: 0.0.0.0
                         port_value: 19001
+                    {{- if .Values.router.proxy.ipv6 }}
                     additional_addresses:
                     - address:
                         socket_address:
                           address: "::"
                           port_value: 19001
+                    {{- end }}
                     filter_chains:
                       - filters:
                           - name: envoy.filters.network.http_connection_manager
@@ -98,11 +103,13 @@ router:
                       socket_address:
                         address: 0.0.0.0
                         port_value: 8081
+                    {{- if .Values.router.proxy.ipv6 }}
                     additional_addresses:
                     - address:
                         socket_address:
                           address: "::"
                           port_value: 8081
+                    {{- end }}
                     per_connection_buffer_limit_bytes: 32768
                     access_log:
                       - name: envoy.access_loggers.file


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

For IPv6 support, we should handle it more elegantly by introducing a Helm toggle to let users manually enable or disable it.

  IPv6 is not a mandatory requirement. In IPv4-only environments where the Linux kernel has  `net.ipv6.conf.all.disable_ipv6=1` , forcing Envoy to listen on IPv6 causes startup bind  failures, leading to process exit. Currently, users must manually edit the chart source code to disable this behavior.

 Adding a Helm value option allows users to toggle this feature based on their environment, or enables upstream chart integrations to control it programmatically.

This better conforms to some conventions for network‑related components.

I recommend disabling this toggle by default. Enabling it directly may impose additional requirements on deployment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
feat(helm): support configuring Envoy IPv6 listening via Helm value
```
