### PR TITLE
epp: source prefix-cache hashes from request metadata

### DIFF
--- a/deploy/config/epp-metadata-prefix-cache-config.yaml
+++ b/deploy/config/epp-metadata-prefix-cache-config.yaml
@@ -1,0 +1,26 @@
+# EPP config exercising prefix-cache affinity sourced from request metadata.
+#
+# The approx-prefix-cache-producer is configured with prefixHashSource: metadata, so it reads a precomputed
+# block-hash chain an upstream ext_proc (the IPP) placed in the llm-d.routing dynamic-metadata namespace
+# instead of tokenizing the body. It runs the same per-endpoint prefix match and the standard
+# prefix-cache-scorer scores it. For anything to arrive, the EPP ext_proc filter needs
+# forwarding_namespaces: [llm-d.routing] and an IPP that writes hashes with the same block-hash scheme.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: approx-prefix-cache-producer
+  parameters:
+    prefixHashSource: metadata
+    maxPrefixBlocksToMatch: 256
+    lruCapacityPerServer: 31250
+- type: prefix-cache-scorer
+- type: decode-filter
+- type: max-score-picker
+- type: single-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 1

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -57,6 +57,8 @@ type InferenceRequest struct {
 	FairnessID string
 	// RequestSizeBytes is the size of the raw request body in bytes when available.
 	RequestSizeBytes int
+	// Metadata is the inbound Envoy dynamic metadata keyed by namespace.
+	Metadata map[string]any
 	// SchedulingResult captures the scheduling decisions made during the cycle.
 	SchedulingResult *SchedulingResult
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
@@ -15,6 +15,7 @@ For each request, the plugin consumes `request.Body.TokenizedPrompt` (token IDs)
 - `maxPrefixBlocksToMatch` (int, optional, default: `2048`): Maximum number of prefix blocks hashed and matched per request. Not auto-tuned. `0` disables matching (zero blocks hashed).
 - `maxPrefixTokensToMatch` (int, optional, default: `131072`): Cap expressed in tokens instead of blocks (`maxBlocks = maxPrefixTokensToMatch / blockSizeTokens`). Not auto-tuned. Takes precedence over `maxPrefixBlocksToMatch` when set (> 0); set to `0` to fall back to the block-based cap. The `131072` default (128K, the context window of large production models such as gpt-oss 120b) is a reasonable upper bound that covers the long-prompt use cases seen in production.
 - `lruCapacityPerServer` (int, optional, default: `31250`): Per-pod LRU index capacity. Used when `autoTune` is false or endpoint metrics are unavailable; ignored when auto-tuned from metrics.
+- `prefixHashSource` (string, optional, default: `body`): Where block hashes come from. `body` tokenizes and hashes the request body via the `token-producer` (the default path above). `metadata` instead reads a precomputed block-hash chain that an upstream ext_proc (for example the IPP) placed in the request's `llm-d.routing` Envoy dynamic metadata, and skips the `token-producer` dependency; the body is never re-parsed. The upstream stage must hash with the same block-hash scheme, otherwise the hashes will not match any indexed prefix.
 - `blockSize` (int, optional): Deprecated — character-based block size. Use `blockSizeTokens` instead.
 
 **Configuration Examples:**
@@ -47,6 +48,15 @@ plugins:
     type: prefix-cache-scorer
     parameters:
       prefixMatchInfoProducerName: cpuPrefixProducer
+```
+
+Sourcing prefix hashes from request metadata (an upstream ext_proc supplies the chain, no tokenizer needed):
+```yaml
+plugins:
+  - type: approx-prefix-cache-producer
+    parameters:
+      prefixHashSource: metadata
+  - type: prefix-cache-scorer
 ```
 
 ---

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -130,6 +130,10 @@ func (p *dataProducer) Produces() map[plugin.DataKey]any {
 // the token-producer before this producer runs and auto-creates one when none
 // is configured.
 func (p *dataProducer) Consumes() plugin.DataDependencies {
+	if p.config.PrefixHashSource == prefixHashSourceMetadata {
+		// Hashes come from request dynamic metadata; no token-producer dependency.
+		return plugin.DataDependencies{}
+	}
 	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedPrompt{}},
 	}
@@ -148,6 +152,11 @@ func newDataProducer(ctx context.Context, name string, config config, handle plu
 	}
 	if config.MaxPrefixTokensToMatch < 0 {
 		return nil, fmt.Errorf("invalid configuration: MaxPrefixTokensToMatch must be >= 0 (current value: %d)", config.MaxPrefixTokensToMatch)
+	}
+	switch config.PrefixHashSource {
+	case "", prefixHashSourceBody, prefixHashSourceMetadata:
+	default:
+		return nil, fmt.Errorf("invalid configuration: prefixHashSource must be %q or %q (current value: %q)", prefixHashSourceBody, prefixHashSourceMetadata, config.PrefixHashSource)
 	}
 	if handle == nil {
 		return nil, errors.New("plugin handle is required")
@@ -231,7 +240,12 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
 		maxBlocks = p.config.MaxPrefixTokensToMatch / blockSize
 	}
-	perPromptHashes := prefixhash.GetBlockHashes(ctx, request, blockSize, maxBlocks)
+	var perPromptHashes [][]prefixhash.BlockHash
+	if p.config.PrefixHashSource == prefixHashSourceMetadata {
+		perPromptHashes = prefixhash.BlockHashesFromMetadata(request, maxBlocks)
+	} else {
+		perPromptHashes = prefixhash.GetBlockHashes(ctx, request, blockSize, maxBlocks)
+	}
 
 	prefixCacheServers := make(map[ServerID]int)
 	totalBlocks := 0

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -143,7 +143,15 @@ type config struct {
 	MaxPrefixTokensToMatch int `json:"maxPrefixTokensToMatch"`
 	// Max capacity size of the LRU indexer in number of entries per server (pod).
 	LRUCapacityPerServer int `json:"lruCapacityPerServer"`
+	// PrefixHashSource selects the block-hash source: "body" (default) hashes the tokenized request body;
+	// "metadata" reads a precomputed chain from Envoy dynamic metadata, skipping the token-producer.
+	PrefixHashSource string `json:"prefixHashSource"`
 }
+
+const (
+	prefixHashSourceBody     = "body"
+	prefixHashSourceMetadata = "metadata"
+)
 
 // defaultConfig provides sensible defaults for the prefix cache plugins.
 var defaultConfig = config{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/metadata.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/metadata.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefixhash
+
+import (
+	"strconv"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	// RoutingMetadataNamespace is the Envoy dynamic-metadata namespace an upstream ext_proc (for example the
+	// IPP) writes routing-relevant data to.
+	RoutingMetadataNamespace = "llm-d.routing"
+	// prefixHashesMetadataField is the field within that namespace holding the ordered block-hash chain, as
+	// decimal-string uint64s (JSON cannot carry uint64 precisely as a number).
+	prefixHashesMetadataField = "prefix_hashes"
+)
+
+// BlockHashesFromMetadata reads a precomputed prefix block-hash chain an upstream ext_proc placed in the
+// request's Envoy dynamic metadata (namespace RoutingMetadataNamespace, field "prefix_hashes"), instead of
+// hashing the tokenized body. The upstream stage MUST use the same block-hash scheme as GetBlockHashes for
+// the hashes to match the per-endpoint index. Returns nil when the namespace or field is absent, so the
+// caller treats a missing chain as "no prefix". maxPrefixBlocks (> 0) caps the chain length.
+func BlockHashesFromMetadata(request *scheduling.InferenceRequest, maxPrefixBlocks int) [][]BlockHash {
+	if request == nil || request.Metadata == nil {
+		return nil
+	}
+	ns, ok := request.Metadata[RoutingMetadataNamespace].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := ns[prefixHashesMetadataField].([]any)
+	if !ok {
+		return nil
+	}
+	hashes := make([]BlockHash, 0, len(raw))
+	for _, v := range raw {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		h, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			continue
+		}
+		hashes = append(hashes, BlockHash(h))
+		if maxPrefixBlocks > 0 && len(hashes) >= maxPrefixBlocks {
+			break
+		}
+	}
+	if len(hashes) == 0 {
+		return nil
+	}
+	return [][]BlockHash{hashes}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/metadata_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/metadata_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefixhash
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+func TestBlockHashesFromMetadata(t *testing.T) {
+	// routing wraps a prefix_hashes field value in the llm-d.routing namespace.
+	routing := func(field any) *scheduling.InferenceRequest {
+		return &scheduling.InferenceRequest{
+			Metadata: map[string]any{RoutingMetadataNamespace: map[string]any{prefixHashesMetadataField: field}},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		request         *scheduling.InferenceRequest
+		maxPrefixBlocks int
+		want            [][]BlockHash
+	}{
+		{
+			name:    "valid chain",
+			request: routing([]any{"1", "2", "3"}),
+			want:    [][]BlockHash{{1, 2, 3}},
+		},
+		{
+			name:            "caps at maxPrefixBlocks",
+			request:         routing([]any{"1", "2", "3", "4"}),
+			maxPrefixBlocks: 2,
+			want:            [][]BlockHash{{1, 2}},
+		},
+		{
+			name:            "cap counts kept hashes, not raw entries",
+			request:         routing([]any{"1", "nope", "2", "3"}),
+			maxPrefixBlocks: 2,
+			want:            [][]BlockHash{{1, 2}},
+		},
+		{
+			name:    "skips non-string and unparsable entries",
+			request: routing([]any{"1", 2.0, "nope", "3"}),
+			want:    [][]BlockHash{{1, 3}},
+		},
+		{
+			name:    "empty list",
+			request: routing([]any{}),
+			want:    nil,
+		},
+		{
+			name:    "all entries unparsable",
+			request: routing([]any{"nope", "nan"}),
+			want:    nil,
+		},
+		{
+			name:    "nil request",
+			request: nil,
+			want:    nil,
+		},
+		{
+			name:    "nil metadata",
+			request: &scheduling.InferenceRequest{},
+			want:    nil,
+		},
+		{
+			name:    "namespace absent",
+			request: &scheduling.InferenceRequest{Metadata: map[string]any{"other.ns": map[string]any{}}},
+			want:    nil,
+		},
+		{
+			name:    "namespace not a map",
+			request: &scheduling.InferenceRequest{Metadata: map[string]any{RoutingMetadataNamespace: "not-a-map"}},
+			want:    nil,
+		},
+		{
+			name:    "field absent",
+			request: &scheduling.InferenceRequest{Metadata: map[string]any{RoutingMetadataNamespace: map[string]any{}}},
+			want:    nil,
+		},
+		{
+			name:    "field not a list",
+			request: routing("not-a-list"),
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, BlockHashesFromMetadata(tt.request, tt.maxPrefixBlocks))
+		})
+	}
+}

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -270,6 +270,9 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 		FairnessID:       fairnessID,
 		Objectives:       requestObjectives,
 		RequestSizeBytes: reqCtx.RequestSize,
+		// Expose inbound Envoy dynamic metadata so request-scoped DataProducers can lift attributes an
+		// upstream ext_proc wrote.
+		Metadata: reqCtx.Request.Metadata,
 	}
 
 	logger = logger.WithValues("objectiveKey", reqCtx.ObjectiveKey, "incomingModelName", reqCtx.IncomingModelName, "targetModelName", reqCtx.TargetModelName, "priority", infObjective.Spec.Priority)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Add an optional metadata source to the approximate prefix-cache producer so an upstream ext_proc (for example the IPP) that already opened the request body can pass the block-hash chain as Envoy dynamic metadata, letting the EPP score prefix affinity without re-tokenizing the body.

- scheduling: expose inbound Envoy dynamic metadata on InferenceRequest.Metadata, populated by the director from the request context before the DataProducer stage.
- prefixhash: add BlockHashesFromMetadata, the metadata-sourced sibling of GetBlockHashes, reading the chain from the llm-d.routing namespace.
- approximateprefix: add prefixHashSource: metadata. In this mode it reads the chain from metadata and skips the token-producer dependency, then runs the same per-endpoint match and publishes the same PrefixCacheMatchInfo the stock prefix-cache-scorer consumes.


Precise prefix cache is a follow-up. This targets the approx-prefix-cache-producer, whose scheme (prefixhash) is self-contained.

**Which issue(s) this PR fixes**:

Ref #1971

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The approximate prefix-cache producer can source block hashes from request metadata via `prefixHashSource: metadata`, letting an upstream ext_proc supply the prefix so the EPP does not re-tokenize the body.
```
