### PR TITLE
epp: add endpoint-attribute-scorer metadata source

### DIFF
--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -57,6 +57,8 @@ type InferenceRequest struct {
 	FairnessID string
 	// RequestSizeBytes is the size of the raw request body in bytes when available.
 	RequestSizeBytes int
+	// Metadata is the inbound Envoy dynamic metadata keyed by namespace.
+	Metadata map[string]any
 	// SchedulingResult captures the scheduling decisions made during the cycle.
 	SchedulingResult *SchedulingResult
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/README.md
@@ -23,6 +23,15 @@ In both strategies, an endpoint missing the attribute receives score `0.0` (and,
 
 The attribute is expected to be a numeric custom metric produced by the core metrics extractor (see the [metrics extractor](../../../datalayer/extractor/metrics/README.md)), stored as a `ScalarMetricValue` endpoint attribute.
 
+## Value source
+
+`source` selects where the per-endpoint value comes from:
+
+- **`endpoint`** (default): the scraped endpoint attribute named `attributeKey`.
+- **`metadata`**: a per-endpoint map an upstream ext_proc wrote to request dynamic metadata at `request.Metadata[metadataNamespace][metadataField]`, keyed by endpoint identity (`namespace/name`). It carries a signal the EPP cannot derive itself, such as an upstream stage's per-endpoint cost or entitlement (`attributeKey` is unused).
+
+The contract is the same for both sources: an endpoint absent from the source scores `0.0` and does not participate in `adaptiveRange`, so an empty or absent map is a neutral no-op. It is a soft preference, not admission; use a filter for a hard allow/deny.
+
 ## Scheduling intent
 
 The scorer returns category `Distribution`, helping spread requests according to the configured attribute.

--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute.go
@@ -33,6 +33,9 @@ const (
 
 	algorithmLinearLowerIsBetter  = "linear_lower_is_better"
 	algorithmLinearHigherIsBetter = "linear_higher_is_better"
+
+	sourceEndpoint = "endpoint"
+	sourceMetadata = "metadata"
 )
 
 // compile-time type assertion
@@ -62,8 +65,11 @@ type algorithmParameters struct {
 }
 
 type parameters struct {
-	AttributeKey string              `json:"attributeKey"`
-	Algorithm    algorithmParameters `json:"algorithm"`
+	AttributeKey      string              `json:"attributeKey"`
+	Algorithm         algorithmParameters `json:"algorithm"`
+	Source            string              `json:"source"`
+	MetadataNamespace string              `json:"metadataNamespace"`
+	MetadataField     string              `json:"metadataField"`
 }
 
 // EndpointAttributeScorerFactory defines the factory function for EndpointAttributeScorer.
@@ -84,9 +90,24 @@ func NewEndpointAttributeScorer(name string, params parameters) (*EndpointAttrib
 	if name == "" {
 		name = EndpointAttributeScorerType
 	}
-	if params.AttributeKey == "" {
-		return nil, errors.New("endpoint attribute scorer requires a non-empty attributeKey")
+
+	source := params.Source
+	if source == "" {
+		source = sourceEndpoint
 	}
+	switch source {
+	case sourceEndpoint:
+		if params.AttributeKey == "" {
+			return nil, errors.New("endpoint attribute scorer requires a non-empty attributeKey")
+		}
+	case sourceMetadata:
+		if params.MetadataNamespace == "" || params.MetadataField == "" {
+			return nil, errors.New("endpoint attribute scorer with source: metadata requires metadataNamespace and metadataField")
+		}
+	default:
+		return nil, fmt.Errorf("endpoint attribute scorer source must be %q or %q, got %q", sourceEndpoint, sourceMetadata, source)
+	}
+
 	switch params.Algorithm.Type {
 	case algorithmLinearLowerIsBetter, algorithmLinearHigherIsBetter:
 	default:
@@ -104,17 +125,19 @@ func NewEndpointAttributeScorer(name string, params parameters) (*EndpointAttrib
 	}
 
 	return &EndpointAttributeScorer{
-		typedName:     fwkplugin.TypedName{Type: EndpointAttributeScorerType, Name: name},
-		attributeKey:  params.AttributeKey,
-		lowerIsBetter: params.Algorithm.Type == algorithmLinearLowerIsBetter,
-		fixedRange:    normalization.FixedRange,
+		typedName:         fwkplugin.TypedName{Type: EndpointAttributeScorerType, Name: name},
+		attributeKey:      params.AttributeKey,
+		lowerIsBetter:     params.Algorithm.Type == algorithmLinearLowerIsBetter,
+		fixedRange:        normalization.FixedRange,
+		source:            source,
+		metadataNamespace: params.MetadataNamespace,
+		metadataField:     params.MetadataField,
 	}, nil
 }
 
-// EndpointAttributeScorer scores candidate endpoints by a single configured
-// numeric endpoint attribute (produced by the custom metrics extraction layer),
-// linearly normalized against either a fixed [min, max] range or an adaptive
-// range computed across the candidates.
+// EndpointAttributeScorer scores candidate endpoints by a single numeric value, linearly normalized against
+// a fixed [min, max] range or an adaptive range across the candidates. The value is a scraped endpoint
+// attribute (source: endpoint) or a per-endpoint map in request metadata (source: metadata).
 type EndpointAttributeScorer struct {
 	typedName     fwkplugin.TypedName
 	attributeKey  string
@@ -122,6 +145,10 @@ type EndpointAttributeScorer struct {
 	// fixedRange selects fixed-range normalization when set; adaptive-range
 	// normalization is used otherwise.
 	fixedRange *fixedRangeParameters
+
+	source            string
+	metadataNamespace string
+	metadataField     string
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
@@ -134,33 +161,74 @@ func (s *EndpointAttributeScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-// Consumes returns the list of data that is consumed by the plugin.
+// Consumes declares the endpoint attribute this scorer reads.
 func (s *EndpointAttributeScorer) Consumes() map[string]any {
+	if s.source == sourceMetadata {
+		// The value comes from request metadata, so there is no endpoint-attribute dependency.
+		return map[string]any{}
+	}
 	return map[string]any{
 		s.attributeKey: attrmetrics.ScalarMetricValue(0),
 	}
 }
 
-// Score returns the scoring result for the given list of endpoints based on the
-// configured endpoint attribute. Endpoints missing the attribute score 0.
-func (s *EndpointAttributeScorer) Score(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+// Score returns the scoring result for the given list of endpoints. Endpoints missing the value score 0.
+func (s *EndpointAttributeScorer) Score(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	valueOf := s.valueReader(request)
 	if s.fixedRange != nil {
-		return s.scoreFixedRange(endpoints)
+		return s.scoreFixedRange(endpoints, valueOf)
 	}
-	return s.scoreAdaptiveRange(endpoints)
+	return s.scoreAdaptiveRange(endpoints, valueOf)
 }
 
-// scoreFixedRange normalizes each endpoint's attribute value against the
-// configured [min, max] range, clamping values outside the range.
-func (s *EndpointAttributeScorer) scoreFixedRange(endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+// valueReader returns the per-endpoint value accessor for the configured source.
+func (s *EndpointAttributeScorer) valueReader(request *fwksched.InferenceRequest) func(fwksched.Endpoint) (float64, bool) {
+	if s.source == sourceMetadata {
+		scores := endpointScoresFromMetadata(request, s.metadataNamespace, s.metadataField)
+		return func(ep fwksched.Endpoint) (float64, bool) {
+			v, ok := scores[ep.GetMetadata().GetNamespacedName().String()]
+			return v, ok
+		}
+	}
+	return func(ep fwksched.Endpoint) (float64, bool) {
+		v, ok := attrmetrics.ReadScalarMetricValue(ep, s.attributeKey)
+		return float64(v), ok
+	}
+}
+
+// endpointScoresFromMetadata reads request.Metadata[namespace][field] as an endpoint-identity to score map.
+func endpointScoresFromMetadata(request *fwksched.InferenceRequest, namespace, field string) map[string]float64 {
+	scores := map[string]float64{}
+	if request == nil || request.Metadata == nil {
+		return scores
+	}
+	ns, ok := request.Metadata[namespace].(map[string]any)
+	if !ok {
+		return scores
+	}
+	raw, ok := ns[field].(map[string]any)
+	if !ok {
+		return scores
+	}
+	for k, v := range raw {
+		if f, ok := v.(float64); ok {
+			scores[k] = f
+		}
+	}
+	return scores
+}
+
+// scoreFixedRange normalizes each endpoint's value against the configured [min, max] range, clamping
+// values outside the range.
+func (s *EndpointAttributeScorer) scoreFixedRange(endpoints []fwksched.Endpoint, valueOf func(fwksched.Endpoint) (float64, bool)) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
-		value, ok := attrmetrics.ReadScalarMetricValue(endpoint, s.attributeKey)
+		value, ok := valueOf(endpoint)
 		if !ok {
 			scores[endpoint] = 0.0
 			continue
 		}
-		normalized := (float64(value) - s.fixedRange.Min) / (s.fixedRange.Max - s.fixedRange.Min)
+		normalized := (value - s.fixedRange.Min) / (s.fixedRange.Max - s.fixedRange.Min)
 		normalized = math.Max(0.0, math.Min(1.0, normalized))
 		if s.lowerIsBetter {
 			normalized = 1.0 - normalized
@@ -170,27 +238,25 @@ func (s *EndpointAttributeScorer) scoreFixedRange(endpoints []fwksched.Endpoint)
 	return scores
 }
 
-// scoreAdaptiveRange normalizes each endpoint's attribute value against the
-// [min, max] range observed across the candidates. Endpoints missing the
-// attribute do not participate in the range. If all endpoints that have the
-// attribute share the same value, they all receive a neutral score of 1.0.
-func (s *EndpointAttributeScorer) scoreAdaptiveRange(endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+// scoreAdaptiveRange normalizes each endpoint's value against the [min, max] range observed across the
+// candidates. Endpoints missing the value do not participate in the range. If all endpoints that have the
+// value share the same value, they all receive a neutral score of 1.0.
+func (s *EndpointAttributeScorer) scoreAdaptiveRange(endpoints []fwksched.Endpoint, valueOf func(fwksched.Endpoint) (float64, bool)) map[fwksched.Endpoint]float64 {
 	values := make(map[fwksched.Endpoint]float64, len(endpoints))
 	minValue := math.Inf(1)
 	maxValue := math.Inf(-1)
 
 	for _, endpoint := range endpoints {
-		value, ok := attrmetrics.ReadScalarMetricValue(endpoint, s.attributeKey)
+		value, ok := valueOf(endpoint)
 		if !ok {
 			continue
 		}
-		floatValue := float64(value)
-		values[endpoint] = floatValue
-		if floatValue < minValue {
-			minValue = floatValue
+		values[endpoint] = value
+		if value < minValue {
+			minValue = value
 		}
-		if floatValue > maxValue {
-			maxValue = floatValue
+		if value > maxValue {
+			maxValue = value
 		}
 	}
 
@@ -202,7 +268,7 @@ func (s *EndpointAttributeScorer) scoreAdaptiveRange(endpoints []fwksched.Endpoi
 			continue
 		}
 		if maxValue == minValue {
-			// All endpoints with the attribute have the same value, return a neutral score.
+			// All endpoints with the value share the same value, return a neutral score.
 			scores[endpoint] = 1.0
 			continue
 		}

--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
@@ -111,6 +112,79 @@ func newEndpointWithValue(value float64) fwksched.Endpoint {
 
 func newEndpointWithoutValue() fwksched.Endpoint {
 	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{}, nil)
+}
+
+func newEndpointNamed(name string) fwksched.Endpoint {
+	return fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: name},
+		},
+		&fwkdl.Metrics{},
+		nil,
+	)
+}
+
+func metadataReq(scores map[string]float64) *fwksched.InferenceRequest {
+	m := make(map[string]any, len(scores))
+	for k, v := range scores {
+		m[k] = v
+	}
+	return &fwksched.InferenceRequest{Metadata: map[string]any{
+		"llm-d.routing": map[string]any{"endpoint_scores": m},
+	}}
+}
+
+func TestEndpointAttributeScorerMetadataSourceContract(t *testing.T) {
+	epA, epB, epC := newEndpointNamed("ep-a"), newEndpointNamed("ep-b"), newEndpointNamed("ep-c")
+
+	tests := []struct {
+		name     string
+		request  *fwksched.InferenceRequest
+		expected map[fwksched.Endpoint]float64
+	}{
+		{
+			name:     "all endpoints scored",
+			request:  metadataReq(map[string]float64{"ns/ep-a": 0.9, "ns/ep-b": 0.5, "ns/ep-c": 0.1}),
+			expected: map[fwksched.Endpoint]float64{epA: 1.0, epB: 0.5, epC: 0.0},
+		},
+		{
+			name:     "only one listed: it wins, the rest score 0",
+			request:  metadataReq(map[string]float64{"ns/ep-a": 0.9}),
+			expected: map[fwksched.Endpoint]float64{epA: 1.0, epB: 0.0, epC: 0.0},
+		},
+		{
+			name:     "one missing from the map scores 0",
+			request:  metadataReq(map[string]float64{"ns/ep-a": 0.9, "ns/ep-c": 0.1}),
+			expected: map[fwksched.Endpoint]float64{epA: 1.0, epB: 0.0, epC: 0.0},
+		},
+		{
+			name:     "empty map is a neutral no-op",
+			request:  metadataReq(map[string]float64{}),
+			expected: map[fwksched.Endpoint]float64{epA: 0.0, epB: 0.0, epC: 0.0},
+		},
+		{
+			name:     "absent namespace is a neutral no-op",
+			request:  &fwksched.InferenceRequest{},
+			expected: map[fwksched.Endpoint]float64{epA: 0.0, epB: 0.0, epC: 0.0},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scorer, err := NewEndpointAttributeScorer("test", parameters{
+				Source:            sourceMetadata,
+				MetadataNamespace: "llm-d.routing",
+				MetadataField:     "endpoint_scores",
+				Algorithm:         algorithmParameters{Type: algorithmLinearHigherIsBetter},
+			})
+			require.NoError(t, err)
+
+			scores := scorer.Score(context.Background(), test.request, []fwksched.Endpoint{epA, epB, epC})
+			for ep, want := range test.expected {
+				assert.InDelta(t, want, scores[ep], 0.0001)
+			}
+		})
+	}
 }
 
 func TestEndpointAttributeScorerScoreAdaptiveRange(t *testing.T) {

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -270,6 +270,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 		FairnessID:       fairnessID,
 		Objectives:       requestObjectives,
 		RequestSizeBytes: reqCtx.RequestSize,
+		Metadata:         reqCtx.Request.Metadata,
 	}
 
 	logger = logger.WithValues("objectiveKey", reqCtx.ObjectiveKey, "incomingModelName", reqCtx.IncomingModelName, "targetModelName", reqCtx.TargetModelName, "priority", infObjective.Spec.Priority)

--- a/test/integration/epp/endpoint_score_metadata_test.go
+++ b/test/integration/epp/endpoint_score_metadata_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package epp
+
+import (
+	"fmt"
+	"testing"
+
+	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
+	integration "github.com/llm-d/llm-d-router/test/integration"
+)
+
+const endpointScoreMetadataConfig = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: openai-parser
+  - type: endpoint-attribute-scorer
+    parameters:
+      source: metadata
+      metadataNamespace: llm-d.routing
+      metadataField: endpoint_scores
+      algorithm:
+        type: linear_higher_is_better
+        normalization:
+          adaptiveRange: {}
+  - type: max-score-picker
+  - type: mock-metrics-source
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: max-score-picker
+      - pluginRef: endpoint-attribute-scorer
+requestHandler:
+  parsers:
+  - pluginRef: openai-parser
+dataLayer:
+  sources:
+  - pluginRef: mock-metrics-source
+`
+
+func TestEndpointScoreFromMetadata(t *testing.T) {
+	ctx := t.Context()
+	h := NewTestHarness(ctx, t, WithStandardMode(), WithConfigText(endpointScoreMetadataConfig)).WithBaseResources()
+
+	pods := []PodState{
+		P(0, 0, 0.1, modelMyModelTarget),
+		P(1, 0, 0.1, modelMyModelTarget),
+		P(2, 0, 0.1, modelMyModelTarget),
+	}
+	h.WithPods(pods).WaitForSync(len(pods), modelMyModel)
+	h.WaitForReadyPodsMetric(len(pods))
+
+	id := func(idx int) string { return fmt.Sprintf("%s/pod-%d-rank-0", h.Namespace, idx) }
+	ep := func(idx int) string { return fmt.Sprintf("192.168.1.%d:8000", idx+1) }
+
+	cases := []struct {
+		name   string
+		scores map[string]float64
+		want   string
+	}{
+		{"highest upstream-scored endpoint wins", map[string]float64{id(0): 0.9, id(1): 0.1, id(2): 0.1}, ep(0)},
+		{"flipping the scores flips the pick", map[string]float64{id(0): 0.1, id(1): 0.1, id(2): 0.9}, ep(2)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, sendScoreRequest(t, h, tc.scores))
+		})
+	}
+}
+
+// sendScoreRequest drives one request whose llm-d.routing dynamic metadata carries a per-endpoint score
+// map (endpoint_scores), and returns the destination endpoint the EPP picked.
+func sendScoreRequest(t *testing.T, h *TestHarness, scores map[string]float64) string {
+	t.Helper()
+
+	scoreMap := make(map[string]any, len(scores))
+	for k, v := range scores {
+		scoreMap[k] = v
+	}
+	routing, err := structpb.NewStruct(map[string]any{"endpoint_scores": scoreMap})
+	require.NoError(t, err)
+	md := &envoyCorev3.Metadata{FilterMetadata: map[string]*structpb.Struct{"llm-d.routing": routing}}
+
+	headers := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &envoyCorev3.HeaderMap{Headers: []*envoyCorev3.HeaderValue{
+					{Key: metadata.ObjectiveKey, Value: modelMyModel},
+					{Key: metadata.ModelNameRewriteKey, Value: modelMyModelTarget},
+					{Key: reqcommon.RequestIDHeaderKey, Value: "score-req"},
+				}},
+			},
+		},
+		MetadataContext: md,
+	}
+	body := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body:        []byte(`{"model":"` + modelMyModel + `","prompt":"hello","max_tokens":10,"temperature":0}`),
+				EndOfStream: true,
+			},
+		},
+		MetadataContext: md,
+	}
+
+	client, err := extProcPb.NewExternalProcessorClient(h.grpcConn).Process(t.Context())
+	require.NoError(t, err)
+	responses, err := integration.StreamedRequest(t, client, []*extProcPb.ProcessingRequest{headers, body}, 2)
+	require.NoError(t, err)
+
+	for _, r := range responses {
+		if e := headerValue(r.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders(), metadata.DestinationEndpointKey); e != "" {
+			return e
+		}
+		if e := headerValue(r.GetRequestBody().GetResponse().GetHeaderMutation().GetSetHeaders(), metadata.DestinationEndpointKey); e != "" {
+			return e
+		}
+	}
+	t.Fatal("no destination endpoint set in the EPP responses")
+	return ""
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Add the [request-metadata internals](https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata) to the EPP so an upstream ext_proc (for example the IPP) can hand request-scoped data to EPP plugins, and provide the endpoint-attribute-scorer's metadata source as the reference implementation of a consumer. This is useful in multi-cluster scenarios where the HUB IPP can score policy based weights against a list of cluster endpoints. 

Metadata internals (the reusable primitive):
- Add `InferenceRequest.Metadata`, populated by the director from inbound Envoy dynamic metadata, so any
  request-scoped plugin can read what an upstream ext_proc wrote.

Reference implementation (endpoint-attribute-scorer):
- Add `source: metadata`. The scorer reads each candidate's value from a per-endpoint map in
  `request.Metadata` (`metadataNamespace`/`metadataField`, keyed by endpoint identity) instead of a scraped
  attribute, then normalizes and scores exactly as before. This demonstrates a plugin consuming a signal the
  EPP cannot derive itself, a per-endpoint cost, entitlement, or tier only the upstream stage knows.
  Multiple instances (each a distinct field, or a scraped attribute) compose by weight.

**Which issue(s) this PR fixes**:

Part of #1971

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
