### PR TITLE
Move coordinator pipeline-building helpers to pipeline/builder subpackage

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -34,8 +33,8 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline/builder"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/server"
-	"github.com/llm-d/llm-d-router/pkg/coordinator/steps"
 )
 
 func main() {
@@ -82,7 +81,7 @@ func main() {
 
 	gwClient := gateway.New(cfg.Gateway)
 
-	steps, err := buildPipeline(cfg, gwClient)
+	steps, err := builder.Build(cfg, gwClient)
 	if err != nil {
 		log.Error(err, "failed to build pipeline")
 		os.Exit(1)
@@ -127,54 +126,4 @@ func serveUntilSignal(srv *server.Server, shutdownTimeout time.Duration) error {
 		}
 	}
 	return nil
-}
-
-// validatePipeline rejects configurations that cannot work before any step runs.
-// The tokens-in format (use_openai_format=false) sends token IDs that only the
-// render step produces, so it requires a render step in the pipeline.
-func validatePipeline(p config.PipelineConfig) error {
-	if p.UseOpenAIFormat {
-		return nil
-	}
-	for _, s := range p.Steps {
-		if s.Type == steps.RenderStepName {
-			return nil
-		}
-	}
-	return fmt.Errorf("pipeline.use_openai_format=false requires a %q step (the tokens-in format sends token IDs that render produces)", steps.RenderStepName)
-}
-
-func mergeConnectorDefaults(params map[string]any, kvConnector, ecConnector string) map[string]any {
-	out := make(map[string]any, len(params))
-	for k, v := range params {
-		out[k] = v
-	}
-	if _, ok := out[steps.ParamKVConnector]; !ok && kvConnector != "" {
-		out[steps.ParamKVConnector] = kvConnector
-	}
-	if _, ok := out[steps.ParamECConnector]; !ok && ecConnector != "" {
-		out[steps.ParamECConnector] = ecConnector
-	}
-	return out
-}
-
-func buildPipeline(cfg *config.Config, gwClient *gateway.Client) ([]pipeline.Step, error) {
-	if err := validatePipeline(cfg.Pipeline); err != nil {
-		return nil, err
-	}
-
-	var steps []pipeline.Step
-	for _, stepCfg := range cfg.Pipeline.Steps {
-		params := mergeConnectorDefaults(stepCfg.Params, cfg.Pipeline.KVConnector, cfg.Pipeline.ECConnector)
-		if _, ok := params["use_openai_format"]; !ok {
-			params["use_openai_format"] = cfg.Pipeline.UseOpenAIFormat
-		}
-		step, err := pipeline.Build(stepCfg.Type, gwClient, params)
-		if err != nil {
-			return nil, err
-		}
-
-		steps = append(steps, step)
-	}
-	return steps, nil
 }

--- a/pkg/coordinator/pipeline/builder/builder.go
+++ b/pkg/coordinator/pipeline/builder/builder.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package builder assembles a coordinator pipeline from configuration. It lives
+// apart from pipeline and steps because it depends on both: steps imports
+// pipeline, so this glue cannot live in pipeline without an import cycle.
+package builder
+
+import (
+	"fmt"
+
+	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/steps"
+)
+
+// validatePipeline rejects configurations that cannot work before any step runs.
+// The tokens-in format (use_openai_format=false) sends token IDs that only the
+// render step produces, so it requires a render step in the pipeline.
+func validatePipeline(p config.PipelineConfig) error {
+	if p.UseOpenAIFormat {
+		return nil
+	}
+	for _, s := range p.Steps {
+		if s.Type == steps.RenderStepName {
+			return nil
+		}
+	}
+	return fmt.Errorf("pipeline.use_openai_format=false requires a %q step (the tokens-in format sends token IDs that render produces)", steps.RenderStepName)
+}
+
+func mergeConnectorDefaults(params map[string]any, kvConnector, ecConnector string) map[string]any {
+	out := make(map[string]any, len(params))
+	for k, v := range params {
+		out[k] = v
+	}
+	if _, ok := out[steps.ParamKVConnector]; !ok && kvConnector != "" {
+		out[steps.ParamKVConnector] = kvConnector
+	}
+	if _, ok := out[steps.ParamECConnector]; !ok && ecConnector != "" {
+		out[steps.ParamECConnector] = ecConnector
+	}
+	return out
+}
+
+// Build validates cfg.Pipeline and constructs its steps in order.
+func Build(cfg *config.Config, gwClient *gateway.Client) ([]pipeline.Step, error) {
+	if err := validatePipeline(cfg.Pipeline); err != nil {
+		return nil, err
+	}
+
+	var steps []pipeline.Step
+	for _, stepCfg := range cfg.Pipeline.Steps {
+		params := mergeConnectorDefaults(stepCfg.Params, cfg.Pipeline.KVConnector, cfg.Pipeline.ECConnector)
+		if _, ok := params["use_openai_format"]; !ok {
+			params["use_openai_format"] = cfg.Pipeline.UseOpenAIFormat
+		}
+		step, err := pipeline.Build(stepCfg.Type, gwClient, params)
+		if err != nil {
+			return nil, err
+		}
+
+		steps = append(steps, step)
+	}
+	return steps, nil
+}

--- a/pkg/coordinator/pipeline/builder/builder.go
+++ b/pkg/coordinator/pipeline/builder/builder.go
@@ -63,7 +63,7 @@ func Build(cfg *config.Config, gwClient *gateway.Client) ([]pipeline.Step, error
 		return nil, err
 	}
 
-	var steps []pipeline.Step
+	var pipelineSteps []pipeline.Step
 	for _, stepCfg := range cfg.Pipeline.Steps {
 		params := mergeConnectorDefaults(stepCfg.Params, cfg.Pipeline.KVConnector, cfg.Pipeline.ECConnector)
 		if _, ok := params["use_openai_format"]; !ok {
@@ -74,7 +74,7 @@ func Build(cfg *config.Config, gwClient *gateway.Client) ([]pipeline.Step, error
 			return nil, err
 		}
 
-		steps = append(steps, step)
+		pipelineSteps = append(pipelineSteps, step)
 	}
-	return steps, nil
+	return pipelineSteps, nil
 }

--- a/pkg/coordinator/pipeline/builder/builder_test.go
+++ b/pkg/coordinator/pipeline/builder/builder_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package builder
 
 import (
 	"testing"


### PR DESCRIPTION
buildPipeline, mergeConnectorDefaults, and validatePipeline lived in cmd/coordinator/main.go only because main was the one package able to depend on both pipeline and steps. They cannot move into pipeline directly: steps imports pipeline, so pipeline importing steps would form a cycle, and pipeline.Build already names the per-step registry builder. A pipeline/builder subpackage depends on both without a cycle, leaving main as pure process wiring.

Pure reorganization; no behavior change. TestValidatePipeline moves with the code.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`buildPipeline`, `mergeConnectorDefaults`, and `validatePipeline` lived in
`cmd/coordinator/main.go` only because `main` was the one package able to
depend on both `pipeline` and `steps`. They cannot move into `pipeline`
directly: `steps` imports `pipeline`, so `pipeline` importing `steps` would
form an import cycle, and `pipeline.Build` already names the per-step
registry builder.

This PR moves them into a new `pkg/coordinator/pipeline/builder` subpackage,
which depends on both `pipeline` and `steps` without a cycle (nothing in
`pipeline` imports it). `buildPipeline` becomes the exported `builder.Build`;
`main` is left as pure process wiring. Pure reorganization, no behavior change.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1879 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
