### PR TITLE
test: Parallelize the End to End tests - Part one infrastructure

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -63,6 +63,11 @@ ENV ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION}
 # /usr/local/bin.
 RUN GOBIN=/usr/local/bin go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
+# Install the ginkgo CLI. Build-time install ensures runtime invocations under
+# --userns=keep-id / -u <uid> can use the binary without writing to root-owned
+# /usr/local/bin.
+RUN GOBIN=/usr/local/bin go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.3
+
 # Go caches are mounted as volumes at runtime for persistence across image rebuilds.
 # Directories are created with open permissions so non-root users (docker -u) can write.
 ENV GOMODCACHE=/go/pkg/mod

--- a/deploy/environments/dev/e2e-infra/services.yaml
+++ b/deploy/environments/dev/e2e-infra/services.yaml
@@ -21,22 +21,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: e2e-epp-health
-spec:
-  selector:
-    app: e2e-epp
-  ports:
-  - name: health
-    protocol: TCP
-    port: 9003
-    targetPort: 9003
-    nodePort: 30081
-    appProtocol: http2
-  type: NodePort
----
-apiVersion: v1
-kind: Service
-metadata:
   name: e2e-epp-metrics
 spec:
   selector:

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -110,14 +110,14 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		if keepClusterOnFailure && ginkgo.CurrentSpecReport().Failed() {
 			return
 		}
-		testutils.DeleteObjects(testConfig, coordinator)
-		testutils.DeleteObjects(testConfig, modelServers)
-		testutils.DeleteObjects(testConfig, decodeEPP)
-		testutils.DeleteObjects(testConfig, prefillEPP)
-		testutils.DeleteObjects(testConfig, encodeEPP)
-		testutils.DeleteObjects(testConfig, decodePool)
-		testutils.DeleteObjects(testConfig, prefillPool)
-		testutils.DeleteObjects(testConfig, encodePool)
+		testutils.DeleteObjects(testConfig, coordinator, nsName)
+		testutils.DeleteObjects(testConfig, modelServers, nsName)
+		testutils.DeleteObjects(testConfig, decodeEPP, nsName)
+		testutils.DeleteObjects(testConfig, prefillEPP, nsName)
+		testutils.DeleteObjects(testConfig, encodeEPP, nsName)
+		testutils.DeleteObjects(testConfig, decodePool, nsName)
+		testutils.DeleteObjects(testConfig, prefillPool, nsName)
+		testutils.DeleteObjects(testConfig, encodePool, nsName)
 	})
 
 	// Dump coordinator logs on failure, or always when E2E_PRINT_COORDINATOR_LOGS is

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -114,7 +114,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	if k8sContext == "" {
 		setupK8sCluster()
 	}
-	testConfig = testutils.NewTestConfig(nsName, k8sContext)
+	testConfig = testutils.NewTestConfig(k8sContext)
 	setupK8sClient()
 	setupNameSpace()
 
@@ -138,7 +138,7 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 		return
 	}
 	if len(rendererObjects) > 0 {
-		testutils.DeleteObjects(testConfig, rendererObjects)
+		testutils.DeleteObjects(testConfig, rendererObjects, nsName)
 	}
 	for _, session := range portForwardSessions {
 		session.Terminate()

--- a/test/coordinator/e2e/coordinator/pools_check_test.go
+++ b/test/coordinator/e2e/coordinator/pools_check_test.go
@@ -39,12 +39,12 @@ func expectedPools() []string {
 func expectAllPoolsExist() {
 	for _, name := range expectedPools() {
 		pool := &inferenceapi.InferencePool{}
-		key := types.NamespacedName{Namespace: testConfig.NsName, Name: name}
+		key := types.NamespacedName{Namespace: nsName, Name: name}
 		gomega.Eventually(func() error {
 			return testConfig.K8sClient.Get(testConfig.Context, key, pool)
 		}, readyTimeout, defaultInterval).Should(
 			gomega.Succeed(),
-			"InferencePool %q not found in namespace %q", name, testConfig.NsName,
+			"InferencePool %q not found in namespace %q", name, nsName,
 		)
 	}
 }

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -65,7 +65,7 @@ func setupInfra() {
 	createCRDs()
 
 	ginkgo.By("Applying shared Role/epp-reader from " + baseRbacManifest)
-	_ = testutils.CreateObjsFromYaml(testConfig, testutils.ReadYaml(baseRbacManifest))
+	_ = testutils.CreateObjsFromYaml(testConfig, testutils.ReadYaml(baseRbacManifest), nsName)
 
 	ginkgo.By("Applying Envoy from " + envoyManifest)
 	applyManifest(envoyManifest, map[string]string{
@@ -79,11 +79,11 @@ func createCRDs() {
 	ginkgo.By("Installing Gateway API CRDs from " + crdGatewayAPIPath)
 	crds := e2eutil.RunKustomize(crdGatewayAPIPath)
 	crds = e2eutil.FilterKinds(crds, "ValidatingAdmissionPolicy", "ValidatingAdmissionPolicyBinding")
-	_ = testutils.CreateObjsFromYaml(testConfig, crds)
+	_ = testutils.CreateObjsFromYaml(testConfig, crds, "")
 
 	ginkgo.By("Installing GIE CRDs from " + crdGIEPath)
 	gieCRDs := e2eutil.RunKustomize(crdGIEPath)
-	_ = testutils.CreateObjsFromYaml(testConfig, gieCRDs)
+	_ = testutils.CreateObjsFromYaml(testConfig, gieCRDs, "")
 }
 
 // createEndPointPicker creates the scheduling ConfigMap and EPP Deployment (plus
@@ -122,7 +122,7 @@ func createInferencePool(phase string, toDelete bool) []string {
 
 	docs := testutils.ReadYaml(manifest)
 	docs = e2eutil.SubstituteMany(docs, eppSubstitutions())
-	return testutils.CreateObjsFromYaml(testConfig, docs)
+	return testutils.CreateObjsFromYaml(testConfig, docs, nsName)
 }
 
 // deletePoolIfExists removes the named InferencePool when present so a rerun
@@ -131,12 +131,12 @@ func createInferencePool(phase string, toDelete bool) []string {
 func deletePoolIfExists(name string) {
 	pool := &inferenceapi.InferencePool{}
 	err := testConfig.K8sClient.Get(testConfig.Context,
-		types.NamespacedName{Namespace: testConfig.NsName, Name: name}, pool)
+		types.NamespacedName{Namespace: nsName, Name: name}, pool)
 	if apierrors.IsNotFound(err) {
 		return
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "checking InferencePool %s", name)
-	testutils.DeleteObjects(testConfig, []string{"InferencePool/" + name})
+	testutils.DeleteObjects(testConfig, []string{"InferencePool/" + name}, nsName)
 }
 
 // createModelServers deploys the vLLM encode/prefill/decode workers from the
@@ -152,7 +152,7 @@ func createModelServers(encodeReplicas, prefillReplicas, decodeReplicas int) []s
 	docs = e2eutil.SubstituteMany(docs, subs)
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	docs = e2eutil.RemoveEmptyLabels(docs)
-	objects := testutils.CreateObjsFromYaml(testConfig, docs)
+	objects := testutils.CreateObjsFromYaml(testConfig, docs, nsName)
 	podsInDeploymentsReady(objects)
 	return objects
 }
@@ -180,7 +180,7 @@ func createCoordinator(config string) []string {
 	docs = e2eutil.FilterKinds(docs, "ConfigMap")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs)...)
+	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, nsName)...)
 
 	podsInDeploymentsReady(objects)
 	if k8sContext != "" {
@@ -239,7 +239,7 @@ func applyManifest(path string, subs map[string]string) []string {
 	docs := testutils.ReadYaml(path)
 	docs = e2eutil.SubstituteMany(docs, subs)
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	return testutils.CreateObjsFromYaml(testConfig, docs)
+	return testutils.CreateObjsFromYaml(testConfig, docs, nsName)
 }
 
 func eppSubstitutions() map[string]string {
@@ -301,7 +301,7 @@ func createRenderer() []string {
 	docs := e2eutil.RunKustomize(rendererComponentDir)
 	docs = e2eutil.SubstituteMany(docs, rendererSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	objects := testutils.CreateObjsFromYaml(testConfig, docs)
+	objects := testutils.CreateObjsFromYaml(testConfig, docs, nsName)
 	podsInDeploymentsReady(objects)
 	return objects
 }

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -107,6 +107,8 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			epp := createEndPointPicker(simpleConfig)
 			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
 
+			nsName := getNamespace()
+
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(2))
@@ -210,6 +212,8 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			epp := createEndPointPicker(simpleConfig)
 			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
 
+			nsName := getNamespace()
+
 			_, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
 
@@ -218,7 +222,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 
 			ginkgo.By("Scaling deployment to zero")
-			scaleDeployment(modelServers, -1)
+			scaleDeployment(nsName, modelServers, -1)
 
 			ginkgo.By("Waiting for all pods to be removed")
 			gomega.Eventually(func() int {
@@ -236,7 +240,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			}, trafficProbeTimeout, 500*time.Millisecond).Should(gomega.Equal(http.StatusServiceUnavailable))
 
 			ginkgo.By("Scaling deployment back up")
-			scaleDeployment(modelServers, 1)
+			scaleDeployment(nsName, modelServers, 1)
 
 			ginkgo.By("Verifying requests succeed after recovery")
 			gomega.Eventually(func() string {
@@ -258,7 +262,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 
 			ginkgo.By("Verifying requests succeed before EPP disruption")
 			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
-			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
+			gomega.Expect(nsHdr).Should(gomega.Equal(getNamespace()))
 
 			ginkgo.By("Finding EPP pod")
 			eppPods := getPods(map[string]string{"app": "e2e-epp"})
@@ -298,6 +302,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 	ginkgo.When("Traffic is flowing during scale-to-zero and back", func() {
 		ginkgo.It("should return 503s when empty and recover when scaled back", func() {
 			infPoolObjects = createInferencePool(1, true)
+			nsName := getNamespace()
 
 			modelServers := createModelServersDecode(1)
 			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers)
@@ -307,7 +312,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 
 			ginkgo.By("Verifying requests succeed before disruption")
 			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
-			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
+			gomega.Expect(nsHdr).Should(gomega.Equal(getNamespace()))
 
 			ginkgo.By("Starting background traffic")
 			ctx, cancel := context.WithCancel(context.Background())
@@ -319,7 +324,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			}()
 
 			ginkgo.By("Scaling to zero")
-			scaleDeployment(modelServers, -1)
+			scaleDeployment(nsName, modelServers, -1)
 
 			ginkgo.By("Waiting for all pods to be removed")
 			gomega.Eventually(func() int {
@@ -331,7 +336,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			gomega.Eventually(tc.failures, trafficProbeTimeout, 500*time.Millisecond).Should(gomega.BeNumerically(">", 0))
 
 			ginkgo.By("Scaling back to 1")
-			scaleDeployment(modelServers, 1)
+			scaleDeployment(nsName, modelServers, 1)
 
 			ginkgo.By("Waiting for traffic to observe recovery")
 			successBaseline := tc.successes()
@@ -418,7 +423,7 @@ func deletePodByName(podName string, gracePeriodSeconds int64) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
-			Namespace: nsName,
+			Namespace: getNamespace(),
 		},
 	}
 	opts := &client.DeleteOptions{

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -85,7 +85,7 @@ func eppPodReady(oldPodName string) func() bool {
 
 // completionRoutedToNamespace sends one completion and reports an error on any
 // failure or namespace-header mismatch, for use inside Eventually blocks.
-func completionRoutedToNamespace() error {
+func completionRoutedToNamespace(nsName string) error {
 	nsHdr, _, err := tryCompletion(simplePrompt, simModelName)
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			}, readyTimeout, 2*time.Second).Should(gomega.Equal(2))
 
 			ginkgo.By("Verifying requests succeed consistently after recovery")
-			gomega.Eventually(completionRoutedToNamespace, eppRecoveryTimeout, 1*time.Second).
+			gomega.Eventually(completionRoutedToNamespace, eppRecoveryTimeout, 1*time.Second).WithArguments(nsName).
 				MustPassRepeatedly(3).Should(gomega.Succeed())
 		})
 	})
@@ -199,7 +199,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			}, readyTimeout, 2*time.Second).Should(gomega.Equal(2))
 
 			ginkgo.By("Verifying requests succeed consistently after recovery")
-			gomega.Eventually(completionRoutedToNamespace, eppRecoveryTimeout, 1*time.Second).
+			gomega.Eventually(completionRoutedToNamespace, eppRecoveryTimeout, 1*time.Second).WithArguments(nsName).
 				MustPassRepeatedly(3).Should(gomega.Succeed())
 		})
 	})

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -101,13 +101,13 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 		ginkgo.It("should recover and route to surviving pods", func() {
 			infPoolObjects = createInferencePool(1, true)
 
+			nsName := getNamespace()
+
 			modelServers := createModelServersDecode(2)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers, nsName)
 
 			epp := createEndPointPicker(simpleConfig)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
-
-			nsName := getNamespace()
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp, nsName)
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -156,11 +156,13 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 		ginkgo.It("should not hang and should recover routing", func() {
 			infPoolObjects = createInferencePool(1, true)
 
+			nsName := getNamespace()
+
 			modelServers := createModelServersDecode(2)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers, nsName)
 
 			epp := createEndPointPicker(simpleConfig)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp, nsName)
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -206,13 +208,13 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 		ginkgo.It("should return 503 to the client", func() {
 			infPoolObjects = createInferencePool(1, true)
 
+			nsName := getNamespace()
+
 			modelServers := createModelServersDecode(1)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers, nsName)
 
 			epp := createEndPointPicker(simpleConfig)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
-
-			nsName := getNamespace()
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp, nsName)
 
 			_, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(decodePods).Should(gomega.HaveLen(1))
@@ -254,11 +256,13 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 		ginkgo.It("should recover and resume routing after restart", func() {
 			infPoolObjects = createInferencePool(1, true)
 
+			nsName := getNamespace()
+
 			modelServers := createModelServersDecode(1)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers, nsName)
 
 			epp := createEndPointPicker(simpleConfig)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp, nsName)
 
 			ginkgo.By("Verifying requests succeed before EPP disruption")
 			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
@@ -305,10 +309,10 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 			nsName := getNamespace()
 
 			modelServers := createModelServersDecode(1)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, modelServers, nsName)
 
 			epp := createEndPointPicker(simpleConfig)
-			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp)
+			ginkgo.DeferCleanup(testutils.DeleteObjects, testConfig, epp, nsName)
 
 			ginkgo.By("Verifying requests succeed before disruption")
 			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -34,7 +34,7 @@ var disruptionClient = &http.Client{Timeout: 10 * time.Second}
 // sendRawCompletion sends a completion request and returns the HTTP status code.
 func sendRawCompletion() (int, error) {
 	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":10}`, simModelName, simplePrompt)
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/completions", port), strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%d/v1/completions", getPort()), strings.NewReader(body))
 	if err != nil {
 		return 0, err
 	}
@@ -356,7 +356,7 @@ var _ = ginkgo.Describe("Disruption tests", ginkgo.Ordered, ginkgo.Label(disrupt
 func sendStreamingCompletion(connected chan<- string) error {
 	longPrompt := strings.Repeat("This is a longer prompt to keep the stream open. ", 20)
 	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":100,"stream":true}`, simModelName, longPrompt)
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s/v1/completions", port), strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%d/v1/completions", getPort()), strings.NewReader(body))
 	if err != nil {
 		connected <- ""
 		return err

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -79,8 +79,9 @@ var (
 	sideCarImage     = env.GetEnvString("SIDECAR_IMAGE", "ghcr.io/llm-d/llm-d-router-disagg-sidecar:dev", ginkgo.GinkgoLogr)
 	vllmRenderImage  = env.GetEnvString("VLLM_RENDER_IMAGE", "vllm/vllm-openai-cpu:v0.21.0", ginkgo.GinkgoLogr)
 	loadRenderImage  = env.GetEnvBool("LOAD_VLLM_RENDER_IMAGE", true, ginkgo.GinkgoLogr)
-	// nsName is the namespace in which the K8S objects will be created
-	nsName = env.GetEnvString("NAMESPACE", "default", ginkgo.GinkgoLogr)
+	numProcesses     = env.GetEnvInt("E2E_NUM_PROCS", 1, ginkgo.GinkgoLogr)
+	// baseNsName is the base of the namespace in which the K8S objects will be created
+	baseNsName = env.GetEnvString("NAMESPACE", getDefaultNsName(), ginkgo.GinkgoLogr)
 
 	// k8sContext is the Kubernetes context to work with
 	k8sContext = env.GetEnvString("K8S_CONTEXT", "", ginkgo.GinkgoLogr)
@@ -115,15 +116,16 @@ var _ = ginkgo.BeforeSuite(func() {
 	setupK8sClient()
 	setupNameSpace()
 	createCRDs()
-	createEnvoy()
+	nsName := getNamespace()
+	createEnvoy(nsName)
 	infraSubs := map[string]string{
 		"${EPP_NAME}": "e2e-epp",
 	}
 	rbacYamls := substituteMany(testutils.ReadYaml(rbacManifest), infraSubs)
-	rbacObjects = testutils.CreateObjsFromYaml(testConfig, rbacYamls)
+	rbacObjects = testutils.CreateObjsFromYaml(testConfig, rbacYamls, nsName)
 	saYamls := substituteMany(testutils.ReadYaml(serviceAccountManifest), infraSubs)
-	serviceAccountObjects = testutils.CreateObjsFromYaml(testConfig, saYamls)
-	serviceObjects = testutils.ApplyYAMLFile(testConfig, servicesManifest)
+	serviceAccountObjects = testutils.CreateObjsFromYaml(testConfig, saYamls, nsName)
+	serviceObjects = testutils.ApplyYAMLFile(testConfig, servicesManifest, nsName)
 
 	// Prevent failure in tests due to InferencePool not existing before the test
 	infPoolObjects = createInferencePool(1, false)
@@ -148,7 +150,9 @@ var _ = ginkgo.AfterSuite(func() {
 // ReportAfterEach only fires for individual specs and would miss setup/teardown failures.
 var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 	if !report.SuiteSucceeded {
-		dumpPodsAndLogs()
+		for idx := range numProcesses {
+			dumpPodsAndLogs(fmt.Sprintf("%s-%d", baseNsName, idx+1))
+		}
 	}
 
 	shouldKeep := keepClusterOnFailure && !report.SuiteSucceeded
@@ -171,17 +175,18 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 		if shouldKeep {
 			ginkgo.By("Keeping created Kubernetes objects due to suite failure (E2E_KEEP_CLUSTER_ON_FAILURE=true)")
 		} else {
+			nsName := getNamespace()
 			ginkgo.By("Deleting created Kubernetes objects")
-			testutils.DeleteObjects(testConfig, infPoolObjects)
-			testutils.DeleteObjects(testConfig, serviceObjects)
-			testutils.DeleteObjects(testConfig, serviceAccountObjects)
-			testutils.DeleteObjects(testConfig, rbacObjects)
-			testutils.DeleteObjects(testConfig, envoyObjects)
-			testutils.DeleteObjects(testConfig, crdObjects)
+			testutils.DeleteObjects(testConfig, infPoolObjects, nsName)
+			testutils.DeleteObjects(testConfig, serviceObjects, nsName)
+			testutils.DeleteObjects(testConfig, serviceAccountObjects, nsName)
+			testutils.DeleteObjects(testConfig, rbacObjects, nsName)
+			testutils.DeleteObjects(testConfig, envoyObjects, nsName)
+			testutils.DeleteObjects(testConfig, crdObjects, "")
 
 			if createdNameSpace {
-				ginkgo.By("Deleting namespace " + nsName)
-				err := testConfig.KubeCli.CoreV1().Namespaces().Delete(testConfig.Context, nsName, metav1.DeleteOptions{})
+				ginkgo.By("Deleting namespace " + getNamespace())
+				err := testConfig.KubeCli.CoreV1().Namespaces().Delete(testConfig.Context, getNamespace(), metav1.DeleteOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			}
 		}
@@ -266,43 +271,40 @@ func setupK8sClient() {
 
 // setupNameSpace sets up the specified namespace if it doesn't exist
 func setupNameSpace() {
-	if nsName == "default" {
-		return
-	}
-	_, err := testConfig.KubeCli.CoreV1().Namespaces().Get(testConfig.Context, nsName, metav1.GetOptions{})
+	_, err := testConfig.KubeCli.CoreV1().Namespaces().Get(testConfig.Context, getNamespace(), metav1.GetOptions{})
 	if err == nil {
 		return
 	}
 	gomega.Expect(errors.IsNotFound(err)).To(gomega.BeTrue())
 
-	ginkgo.By("Creating namespace " + nsName)
+	ginkgo.By("Creating namespace " + getNamespace())
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: nsName,
+			Name: getNamespace(),
 		},
 	}
 	_, err = testConfig.KubeCli.CoreV1().Namespaces().Create(testConfig.Context, namespace, metav1.CreateOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	createdNameSpace = true
 
-	ginkgo.By("Ensuring namespace exists: " + nsName)
+	ginkgo.By("Ensuring namespace exists: " + getNamespace())
 	testutils.EventuallyExists(testConfig, func() error {
 		return testConfig.K8sClient.Get(testConfig.Context,
-			types.NamespacedName{Name: nsName}, &corev1.Namespace{})
+			types.NamespacedName{Name: getNamespace()}, &corev1.Namespace{})
 	})
 }
 
 // createCRDs creates the Inference Extension CRDs used for testing.
 func createCRDs() {
 	crds := runKustomize(crdKustomizePath)
-	crdObjects = testutils.CreateObjsFromYaml(testConfig, crds)
+	crdObjects = testutils.CreateObjsFromYaml(testConfig, crds, "")
 }
 
-func createEnvoy() {
+func createEnvoy(nsName string) {
 	manifests := testutils.ReadYaml(envoyManifest)
 	manifests = substituteMany(manifests, map[string]string{"${NAMESPACE}": nsName})
 	ginkgo.By("Creating envoy proxy resources from manifest: " + envoyManifest)
-	envoyObjects = testutils.CreateObjsFromYaml(testConfig, manifests)
+	envoyObjects = testutils.CreateObjsFromYaml(testConfig, manifests, nsName)
 
 	if k8sContext != "" {
 		envoyName := ""
@@ -324,10 +326,11 @@ func createEnvoy() {
 
 func createInferencePool(numTargetPorts int, toDelete bool) []string {
 	poolName := simModelName + "-inference-pool"
+	nsName := getNamespace()
 
 	if toDelete {
 		objName := []string{"inferencepool/" + poolName}
-		testutils.DeleteObjects(testConfig, objName)
+		testutils.DeleteObjects(testConfig, objName, nsName)
 	}
 
 	infPoolYaml := testutils.ReadYaml(inferExtManifest)
@@ -346,11 +349,11 @@ func createInferencePool(numTargetPorts int, toDelete bool) []string {
 			"${TARGET_PORTS}": targetPorts,
 		})
 
-	return testutils.CreateObjsFromYaml(testConfig, infPoolYaml)
+	return testutils.CreateObjsFromYaml(testConfig, infPoolYaml, nsName)
 }
 
 func startEPPMetricsPortForward() {
-	pods, err := testConfig.KubeCli.CoreV1().Pods(nsName).List(testConfig.Context, metav1.ListOptions{
+	pods, err := testConfig.KubeCli.CoreV1().Pods(getNamespace()).List(testConfig.Context, metav1.ListOptions{
 		LabelSelector: "app=e2e-epp",
 	})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -363,6 +366,20 @@ func startEPPMetricsPortForward() {
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	// Give it a moment to establish
 	time.Sleep(3 * time.Second)
+}
+
+func getNamespace() string {
+	if numProcesses == 1 {
+		return baseNsName
+	}
+	return fmt.Sprintf("%s-%d", baseNsName, ginkgo.GinkgoParallelProcess())
+}
+
+func getDefaultNsName() string {
+	if numProcesses == 1 {
+		return "default"
+	}
+	return "e2e"
 }
 
 const kindClusterConfig = `

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -111,7 +111,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	if k8sContext == "" {
 		setupK8sCluster()
 	}
-	testConfig = testutils.NewTestConfig(nsName, k8sContext)
+	testConfig = testutils.NewTestConfig(k8sContext)
 	setupK8sClient()
 	setupNameSpace()
 	createCRDs()

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -195,6 +195,21 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 
 // Create the Kubernetes cluster for the E2E tests and load the local images
 func setupK8sCluster() {
+	// extraPortMappings is substituted into `extraPortMappings: ${EXTRA_PORT_MAPPINGS}` in the Kind
+	// cluster configuration. Each item must use 2-space indentation to match that field's level in the
+	// YAML. If the field is ever reindented in inference-pools.yaml, update the format string here too.
+	var extraPortMappingsBuilder strings.Builder
+	for idx := range numProcesses {
+		inc := idx * 100
+		fmt.Fprintf(&extraPortMappingsBuilder, "\n  - containerPort: %d", 30080+inc)
+		fmt.Fprintf(&extraPortMappingsBuilder, "\n    hostPort: %d", basePort+inc)
+		fmt.Fprintf(&extraPortMappingsBuilder, "\n    protocol: TCP")
+		fmt.Fprintf(&extraPortMappingsBuilder, "\n  - containerPort: %d", 32090+inc)
+		fmt.Fprintf(&extraPortMappingsBuilder, "\n    hostPort: %d", baseMetricsPort+inc)
+		fmt.Fprintf(&extraPortMappingsBuilder, "\n    protocol: TCP")
+	}
+	extraPortMappings := extraPortMappingsBuilder.String()
+
 	command := exec.Command("kind", "create", "cluster", "--name", kindClusterName, "--config", "-")
 	stdin, err := command.StdinPipe()
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -203,8 +218,7 @@ func setupK8sCluster() {
 			err := stdin.Close()
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}()
-		clusterConfig := strings.ReplaceAll(kindClusterConfig, "${PORT}", port)
-		clusterConfig = strings.ReplaceAll(clusterConfig, "${METRICS_PORT}", metricsPort)
+		clusterConfig := strings.ReplaceAll(kindClusterConfig, "${EXTRA_PORT_MAPPINGS}", extraPortMappings)
 		_, err := io.WriteString(stdin, clusterConfig)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	}()
@@ -387,14 +401,5 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - image: kindest/node:v1.31.12
-  extraPortMappings:
-  - containerPort: 30080
-    hostPort: ${PORT}
-    protocol: TCP
-  - containerPort: 30081
-    hostPort: 30081
-    protocol: TCP
-  - containerPort: 32090
-    hostPort: ${METRICS_PORT}
-    protocol: TCP
+  extraPortMappings:${EXTRA_PORT_MAPPINGS}
 `

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -64,8 +65,8 @@ const (
 )
 
 var (
-	port        string = env.GetEnvString("E2E_PORT", "30080", ginkgo.GinkgoLogr)
-	metricsPort string = env.GetEnvString("E2E_METRICS_PORT", "32090", ginkgo.GinkgoLogr)
+	basePort        = env.GetEnvInt("E2E_PORT", 30080, ginkgo.GinkgoLogr)
+	baseMetricsPort = env.GetEnvInt("E2E_METRICS_PORT", 32090, ginkgo.GinkgoLogr)
 
 	testConfig *testutils.TestConfig
 
@@ -330,8 +331,8 @@ func createEnvoy(nsName string) {
 		}
 		gomega.Expect(envoyName).ToNot(gomega.BeEmpty())
 
-		command := exec.Command("kubectl", "port-forward", "deployment/"+envoyName, port+":8081",
-			"--context="+k8sContext, "--namespace="+nsName)
+		command := exec.Command("kubectl", "port-forward", "deployment/"+envoyName, strconv.Itoa(getPort())+":8081",
+			"--context="+k8sContext, "--namespace="+getNamespace())
 		var err error
 		portForwardSession, err = gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -374,12 +375,20 @@ func startEPPMetricsPortForward() {
 	gomega.Expect(pods.Items).NotTo(gomega.BeEmpty())
 
 	eppPodName := pods.Items[0].Name
-	command := exec.Command("kubectl", "port-forward", "pod/"+eppPodName, metricsPort+":9090",
-		"--context="+k8sContext, "--namespace="+nsName)
+	command := exec.Command("kubectl", "port-forward", "pod/"+eppPodName, strconv.Itoa(getMetricsPort())+":9090",
+		"--context="+k8sContext, "--namespace="+getNamespace())
 	eppPortForwardSession, err = gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	// Give it a moment to establish
 	time.Sleep(3 * time.Second)
+}
+
+func getPort() int {
+	return basePort + 100*(ginkgo.GinkgoParallelProcess()-1)
+}
+
+func getMetricsPort() int {
+	return baseMetricsPort + 100*(ginkgo.GinkgoParallelProcess()-1)
 }
 
 func getNamespace() string {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -110,6 +110,12 @@ func TestEndToEnd(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
+	suiteConfig, _ := ginkgo.GinkgoConfiguration()
+	if numProcesses != suiteConfig.ParallelTotal {
+		ginkgo.Fail(fmt.Sprintf("The value of the environment variable `E2E_NUM_PROCS` (%d) is not equal to the number of ginkgo processes being run (%d)",
+			numProcesses, suiteConfig.ParallelTotal))
+	}
+
 	if k8sContext == "" {
 		setupK8sCluster()
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -208,7 +208,8 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 func setupK8sCluster() {
 	// extraPortMappings is substituted into `extraPortMappings: ${EXTRA_PORT_MAPPINGS}` in the Kind
 	// cluster configuration. Each item must use 2-space indentation to match that field's level in the
-	// YAML. If the field is ever reindented in inference-pools.yaml, update the format string here too.
+	// YAML. If the field is ever reindented in Kind cluster configuration (kindClusterConfig), update
+	// the format string here too.
 	var extraPortMappingsBuilder strings.Builder
 	for idx := range numProcesses {
 		inc := idx * 100

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -394,14 +394,33 @@ func startEPPMetricsPortForward() {
 	time.Sleep(3 * time.Second)
 }
 
+// getPort is used by the E2E tests to get the port of the envoy service for their setup.
+// When the tests are running in parallel, there will be up to N processes running. Each process
+// will have it's own envoy instance with its own nodePort. The nodePorts will be of the form
+// 30080, 30180, 30280, etc. In a more general sense they are of the form:
+// (the base port) + 100 * (the process number minus one). The goal is that the port for process
+// one, is the base port specified by the user.
 func getPort() int {
 	return basePort + 100*(ginkgo.GinkgoParallelProcess()-1)
 }
 
+// getMetricsPort is used by the E2E tests to get the EPP's metrics port for their setup.
+// When the tests are running in parallel, there will be up to N processes running. Each process
+// will have it's own EPP instance with its own metrics nodePort. The nodePorts will be of the form
+// 32090, 32190, 32290, etc. In a more general sense they are of the form:
+// (the base metrics port) + 100 * (the process number minus one). The goal is that the metrics port
+// for process one, is the base metrics port specified by the user.
 func getMetricsPort() int {
 	return baseMetricsPort + 100*(ginkgo.GinkgoParallelProcess()-1)
 }
 
+// getNamespace returns the namespace being used by each and every test. When the tests run in
+// parallel, each test is assigned its own namespace to provide isolation between the tests.
+// If the tests are not being run in parallel, then the namespace used is simply the base namespace
+// setup by the NAMESPACE environment variable, defaulting to "default".
+// If the tests are running in parallel, the namespace names will be of the form baseName-N, where
+// baseName is the base namespace setup by the NAMESPACE environment variable, defaulting to "e2e"
+// and N is the process number.
 func getNamespace() string {
 	if numProcesses == 1 {
 		return baseNsName
@@ -409,6 +428,7 @@ func getNamespace() string {
 	return fmt.Sprintf("%s-%d", baseNsName, ginkgo.GinkgoParallelProcess())
 }
 
+// getDefaultNsName is used in setting the default base namespace.
 func getDefaultNsName() string {
 	if numProcesses == 1 {
 		return "default"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -157,8 +157,12 @@ var _ = ginkgo.AfterSuite(func() {
 // ReportAfterEach only fires for individual specs and would miss setup/teardown failures.
 var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 	if !report.SuiteSucceeded {
-		for idx := range numProcesses {
-			dumpPodsAndLogs(fmt.Sprintf("%s-%d", baseNsName, idx+1))
+		if numProcesses > 1 {
+			for idx := range numProcesses {
+				dumpPodsAndLogs(fmt.Sprintf("%s-%d", baseNsName, idx+1))
+			}
+		} else {
+			dumpPodsAndLogs(baseNsName)
 		}
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -65,11 +65,12 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersDecode(1)
 
 			epp := createEndPointPicker(simpleConfig)
+			nsName := getNamespace()
 
 			generateAndCheckLoad(5)
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 
 		ginkgo.It("should report metrics", func() {
@@ -81,11 +82,12 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersDecode(1)
 
 			epp := createEndPointPicker(simpleConfig)
+			nsName := getNamespace()
 
 			verifyMetrics(infPoolName, numTargetPorts)
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -99,12 +101,13 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersDecode(1)
 
 			epp := createEndPointPickerHelper(simpleConfig, numOfPods, true, false)
+			nsName := getNamespace()
 
 			ginkgo.By("Verifying that exactly one EPP pod is ready")
-			waitForReadyLeader(numOfPods)
+			waitForReadyLeader(numOfPods, nsName)
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 
 		ginkgo.It("Should successfully failover and serve traffic after the leader pod is deleted", func() {
@@ -118,9 +121,10 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersDecode(1)
 
 			epp := createEndPointPickerHelper(simpleConfig, numOfPods, true, false)
+			nsName := getNamespace()
 
 			ginkgo.By("STEP 1: Verifying initial leader is working correctly before failover")
-			leaderPod := waitForReadyLeader(numOfPods)
+			leaderPod := waitForReadyLeader(numOfPods, nsName)
 			generateAndCheckLoad(5)
 			verifyMetrics(infPoolName, numTargetPorts)
 
@@ -134,7 +138,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			// to be back to 3, and for one of the other pods to become the new leader.
 			var newLeaderPod *corev1.Pod
 			gomega.Eventually(func(g gomega.Gomega) {
-				newLeaderPod = waitForReadyLeader(numOfPods)
+				newLeaderPod = waitForReadyLeader(numOfPods, nsName)
 				g.Expect(newLeaderPod.Name).NotTo(gomega.Equal(leaderPod.Name), "The new leader should not be the same as the old deleted leader")
 			}, testConfig.ReadyTimeout, testConfig.Interval).Should(gomega.Succeed())
 			ginkgo.By("Found new leader pod: " + newLeaderPod.Name)
@@ -143,8 +147,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			generateAndCheckLoad(5)
 			verifyMetrics(infPoolName, numTargetPorts)
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 
 		})
 	})
@@ -158,6 +162,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersPDNixlV2(prefillReplicas, decodeReplicas)
 
 			epp := createEndPointPicker(deprecatedPdConfig)
+			nsName := getNamespace()
 
 			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
 
@@ -214,8 +219,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodeOnlyCount).Should(gomega.Equal(2))
 			gomega.Expect(decodeOnlyCountllmDEpp).Should(gomega.Equal(2))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -238,6 +243,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				modelServers := createModelServersPDSharedStorage(decodeReplicas)
 
 				epp := createEndPointPicker(config)
+				nsName := getNamespace()
 
 				prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 				gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
@@ -264,8 +270,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 				gomega.Expect(podHdr).Should(gomega.Equal(podHdrCompletion))
 
-				testutils.DeleteObjects(testConfig, epp)
-				testutils.DeleteObjects(testConfig, modelServers)
+				testutils.DeleteObjects(testConfig, epp, nsName)
+				testutils.DeleteObjects(testConfig, modelServers, nsName)
 			})
 
 			ginkgo.It("should run streaming requests successfully", func() {
@@ -276,6 +282,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				modelServers := createModelServersPDSharedStorage(decodeReplicas)
 
 				epp := createEndPointPicker(config)
+				nsName := getNamespace()
 
 				prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 				gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
@@ -296,8 +303,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 				gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
-				testutils.DeleteObjects(testConfig, epp)
-				testutils.DeleteObjects(testConfig, modelServers)
+				testutils.DeleteObjects(testConfig, epp, nsName)
+				testutils.DeleteObjects(testConfig, modelServers, nsName)
 			})
 
 			ginkgo.It("should handle decode-first success scenario with cache_hit_threshold", func() {
@@ -312,13 +319,14 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				modelServers := createModelServersPDSharedStorage(decodeReplicas)
 
 				epp := createEndPointPicker(config)
+				nsName := getNamespace()
 
 				prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 				gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
 				gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
 				// Get prefill request count BEFORE the test
-				prefillCountBefore := getPodRequestCount(prefillPods[0])
+				prefillCountBefore := getPodRequestCount(nsName, prefillPods[0])
 				ginkgo.By(fmt.Sprintf("Prefill request count before decode-first test: %d", prefillCountBefore))
 
 				// Test decode-first success: cache_hit_threshold is set, but simulator returns "stop"
@@ -335,7 +343,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(finishReason).ShouldNot(gomega.Equal("cache_threshold"))
 
 				// Get prefill request count AFTER the test
-				prefillCountAfter := getPodRequestCount(prefillPods[0])
+				prefillCountAfter := getPodRequestCount(nsName, prefillPods[0])
 				ginkgo.By(fmt.Sprintf("Prefill request count after decode-first test: %d", prefillCountAfter))
 
 				// VERIFY: Prefill pod should NOT have processed any new requests
@@ -343,8 +351,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(prefillCountAfter).Should(gomega.Equal(prefillCountBefore),
 					"Prefill pod should NOT process requests when cache threshold is met (decode-first success)")
 
-				testutils.DeleteObjects(testConfig, epp)
-				testutils.DeleteObjects(testConfig, modelServers)
+				testutils.DeleteObjects(testConfig, epp, nsName)
+				testutils.DeleteObjects(testConfig, modelServers, nsName)
 			})
 
 			ginkgo.It("should handle decode-first fallback to P/D when cache threshold not met", func() {
@@ -359,13 +367,14 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				modelServers := createModelServersPDSharedStorage(decodeReplicas)
 
 				epp := createEndPointPicker(config)
+				nsName := getNamespace()
 
 				prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 				gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
 				gomega.Expect(decodePods).Should(gomega.HaveLen(decodeReplicas))
 
 				// Get prefill request count BEFORE the test
-				prefillCountBefore := getPodRequestCount(prefillPods[0])
+				prefillCountBefore := getPodRequestCount(nsName, prefillPods[0])
 				ginkgo.By(fmt.Sprintf("Prefill request count before P/D fallback test: %d", prefillCountBefore))
 
 				// Test decode-first fallback: cache_hit_threshold is set AND X-Cache-Threshold header
@@ -384,7 +393,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(finishReason).Should(gomega.Equal("cache_threshold"))
 
 				// Get prefill request count AFTER the test
-				prefillCountAfter := getPodRequestCount(prefillPods[0])
+				prefillCountAfter := getPodRequestCount(nsName, prefillPods[0])
 				ginkgo.By(fmt.Sprintf("Prefill request count after P/D fallback test: %d", prefillCountAfter))
 
 				// VERIFY: Prefill pod SHOULD have processed 2 new requests (1 regular + 1 streaming)
@@ -394,8 +403,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(prefillCountAfter-prefillCountBefore).Should(gomega.Equal(2),
 					"Prefill pod should have processed exactly 2 requests (1 regular + 1 streaming)")
 
-				testutils.DeleteObjects(testConfig, epp)
-				testutils.DeleteObjects(testConfig, modelServers)
+				testutils.DeleteObjects(testConfig, epp, nsName)
+				testutils.DeleteObjects(testConfig, modelServers, nsName)
 			})
 		})
 	}
@@ -409,6 +418,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersPDMooncake(decodeReplicas)
 
 			epp := createEndPointPicker(pdConfig)
+			nsName := getNamespace()
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
@@ -422,8 +432,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 
 		ginkgo.It("should run streaming requests successfully", func() {
@@ -434,6 +444,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersPDMooncake(decodeReplicas)
 
 			epp := createEndPointPicker(pdConfig)
+			nsName := getNamespace()
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
@@ -447,8 +458,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.BeElementOf(decodePods))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -462,6 +473,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersPDSharedStorage(decodeReplicas)
 
 			epp := createEndPointPicker(pdConfig)
+			nsName := getNamespace()
 
 			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
 
@@ -518,8 +530,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(decodeOnlyCount).Should(gomega.Equal(2))
 			gomega.Expect(decodeOnlyCountllmDEpp).Should(gomega.Equal(2))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -530,6 +542,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersDecode(1)
 
 			epp := createEndPointPicker(decodeOnlyConfig)
+			nsName := getNamespace()
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -543,8 +556,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -557,6 +570,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersEpDDisagg(encodeReplicas, decodeReplicas)
 
 			epp := createEndPointPicker(epdEncodeDecodeConfig)
+			nsName := getNamespace()
 
 			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
 			if k8sContext != "" {
@@ -616,8 +630,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(encodeDecodeCount).Should(gomega.Equal(5))
 			gomega.Expect(encodeDecodeCountllmDEpp).Should(gomega.Equal(5))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -631,6 +645,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersEPDDisagg(encodeReplicas, prefillReplicas, decodeReplicas)
 
 			epp := createEndPointPicker(epdConfig)
+			nsName := getNamespace()
 
 			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
 			if k8sContext != "" {
@@ -699,8 +714,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			// gomega.Expect(epdCount + edCount).Should(gomega.Equal(4))
 			// gomega.Expect(epdCountllmDEpp + edCountllmDEpp).Should(gomega.Equal(4))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -716,6 +731,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			// Using epdConfig instead of decodeOnlyConfig to validate the EPD logic path within
 			// a single pod; multimodal stages will resolve to this same deployment.
 			epp := createEndPointPicker(epdConfig)
+			nsName := getNamespace()
 
 			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
 			if k8sContext != "" {
@@ -765,8 +781,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
 			gomega.Expect(podHdr).Should(gomega.Equal(epdPods[0]))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -775,6 +791,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			infPoolObjects = createInferencePool(1, true)
 
 			epp := createEndPointPicker(kvConfig)
+			nsName := getNamespace()
 
 			modelServers := createModelServersDecodeKV(1)
 			time.Sleep(5 * time.Second) // wait for model server(s) to become ready
@@ -789,8 +806,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -799,6 +816,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			infPoolObjects = createInferencePool(1, true)
 
 			epp := createEndPointPicker(kvExternalTokenizerConfig)
+			nsName := getNamespace()
 
 			modelServers := createModelServersDecodeKV(1)
 			time.Sleep(5 * time.Second) // wait for model server(s) to become ready
@@ -824,8 +842,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -848,7 +866,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(podHdr).Should(gomega.Equal(decodePods[0]))
 			}
 
-			scaleDeployment(modelServers, 1)
+			scaleDeployment(nsName, modelServers, 1)
 
 			scaledUpPrefillPods, scaledUpDecodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(scaledUpPrefillPods).Should(gomega.BeEmpty())
@@ -866,7 +884,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			}
 			gomega.Expect(scaledPodHdr).ShouldNot(gomega.Equal(podHdr))
 
-			scaleDeployment(modelServers, -1)
+			scaleDeployment(nsName, modelServers, -1)
 
 			scaledDownPrefillPods, scaledDownDecodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(scaledDownPrefillPods).Should(gomega.BeEmpty())
@@ -880,8 +898,8 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 				gomega.Expect(podHdr).Should(gomega.Equal(scaledDownDecodePods[0]))
 			}
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 
@@ -892,6 +910,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersDecodeDP(1)
 
 			epp := createEndPointPicker(dataParallelConfig)
+			nsName := getNamespace()
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -929,17 +948,17 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			}
 			gomega.Expect(parallelPortHdr).ShouldNot(gomega.Equal(portHdr))
 
-			testutils.DeleteObjects(testConfig, epp)
-			testutils.DeleteObjects(testConfig, modelServers)
+			testutils.DeleteObjects(testConfig, epp, nsName)
+			testutils.DeleteObjects(testConfig, modelServers, nsName)
 		})
 	})
 })
 
-func waitForReadyLeader(numOfPods int) *corev1.Pod {
+func waitForReadyLeader(numOfPods int, nsName string) *corev1.Pod {
 	var leaderPod *corev1.Pod
 	gomega.Eventually(func(g gomega.Gomega) {
 		podList := &corev1.PodList{}
-		err := testConfig.K8sClient.List(testConfig.Context, podList, client.InNamespace(testConfig.NsName), client.MatchingLabels{"app": eppName})
+		err := testConfig.K8sClient.List(testConfig.Context, podList, client.InNamespace(nsName), client.MatchingLabels{"app": eppName})
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// The deployment should have 3 replicas for leader election.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -164,7 +164,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			epp := createEndPointPicker(deprecatedPdConfig)
 			nsName := getNamespace()
 
-			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
+			metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 
 			if k8sContext != "" {
 				// Use port-forward to access the EPP pod's metrics endpoint.
@@ -475,7 +475,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			epp := createEndPointPicker(pdConfig)
 			nsName := getNamespace()
 
-			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
+			metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 
 			if k8sContext != "" {
 				// Use port-forward to access the EPP pod's metrics endpoint.
@@ -572,7 +572,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			epp := createEndPointPicker(epdEncodeDecodeConfig)
 			nsName := getNamespace()
 
-			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
+			metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 			if k8sContext != "" {
 				startEPPMetricsPortForward()
 			}
@@ -647,7 +647,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			epp := createEndPointPicker(epdConfig)
 			nsName := getNamespace()
 
-			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
+			metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 			if k8sContext != "" {
 				startEPPMetricsPortForward()
 			}
@@ -733,7 +733,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			epp := createEndPointPicker(epdConfig)
 			nsName := getNamespace()
 
-			metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
+			metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 			if k8sContext != "" {
 				startEPPMetricsPortForward()
 			}
@@ -854,6 +854,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 			modelServers := createModelServersDecode(1)
 
 			epp := createEndPointPicker(scaleConfig)
+			nsName := getNamespace()
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newOpenAIClient() *openai.Client {
-	c := openai.NewClient(option.WithBaseURL(fmt.Sprintf("http://localhost:%s/v1", port)))
+	c := openai.NewClient(option.WithBaseURL(fmt.Sprintf("http://localhost:%d/v1", getPort())))
 	return &c
 }
 
@@ -26,6 +26,7 @@ func extractInferenceHeaders(httpResp *http.Response) (string, string, string) {
 }
 
 func generateAndCheckLoad(count int) {
+	nsName := getNamespace()
 	for range count {
 		prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 		gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -52,7 +53,7 @@ func generateAndCheckLoad(count int) {
 // doPost sends a POST request with a JSON body to the given path, asserts HTTP 200,
 // and returns the x-inference-namespace, x-inference-pod headers and the response body.
 func doPost(path, body string, extraHeaders map[string]string) (string, string, []byte) {
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s%s", port, path), strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%d%s", getPort(), path), strings.NewReader(body))
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	req.Header.Set("Content-Type", "application/json")
 	for k, v := range extraHeaders {
@@ -74,7 +75,7 @@ func doPost(path, body string, extraHeaders map[string]string) (string, string, 
 // doPostWithError sends a POST request with a JSON body to the given path
 // and returns the status code and the response body.
 func doPostWithError(path, body string, extraHeaders map[string]string) (int, []byte) {
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s%s", port, path), strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%d%s", getPort(), path), strings.NewReader(body))
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	req.Header.Set("Content-Type", "application/json")
 	for k, v := range extraHeaders {
@@ -102,7 +103,7 @@ func runCompletion(prompt string, theModel openai.CompletionNewParamsModel) (str
 		Model: theModel,
 	}
 
-	ginkgo.By(fmt.Sprintf("Sending Completion Request: (port %s) %#v", port, completionParams))
+	ginkgo.By(fmt.Sprintf("Sending Completion Request: (port %d) %#v", getPort(), completionParams))
 
 	resp, err := newOpenAIClient().Completions.New(testConfig.Context, completionParams, option.WithResponseInto(&httpResp), option.WithRequestTimeout(readyTimeout))
 
@@ -245,7 +246,7 @@ func runChatCompletionWithAudio() (string, string) {
 }
 
 func runStreamingCompletion(prompt string, theModel openai.CompletionNewParamsModel) (string, string) {
-	ginkgo.By(fmt.Sprintf("Sending Streaming Completion Request: (port %s) model=%s", port, theModel))
+	ginkgo.By(fmt.Sprintf("Sending Streaming Completion Request: (port %d) model=%s", getPort(), theModel))
 	body := fmt.Sprintf(`{"model":"%s","prompt":"%s","max_tokens":50,"stream":true}`, theModel, prompt)
 	ns, pod, respBody := doPost("/v1/completions", body, nil)
 	ginkgo.By(fmt.Sprintf("Streaming Completion received response length: %d bytes", len(respBody)))
@@ -253,7 +254,7 @@ func runStreamingCompletion(prompt string, theModel openai.CompletionNewParamsMo
 }
 
 func runStreamingChatCompletion(prompt string) (string, string) {
-	ginkgo.By(fmt.Sprintf("Sending Streaming Chat Completion Request: (port %s)", port))
+	ginkgo.By(fmt.Sprintf("Sending Streaming Chat Completion Request: (port %d)", getPort()))
 	body := fmt.Sprintf(`{"model":"%s","messages":[{"role":"user","content":"%s"}],"stream":true}`, simModelName, prompt)
 	ns, pod, respBody := doPost("/v1/chat/completions", body, nil)
 	ginkgo.By(fmt.Sprintf("Streaming Chat Completion received response length: %d bytes", len(respBody)))
@@ -301,7 +302,7 @@ func verifyMetrics(infPoolName string, numTargetPorts int) {
 		doPostWithError("/v1/chat/completions", "an invalid body", nil)
 	}
 
-	metricsURL := fmt.Sprintf("http://localhost:%s/metrics", metricsPort)
+	metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 
 	if k8sContext != "" {
 		// Use port-forward to access the EPP pod's metrics endpoint.

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -139,7 +139,7 @@ func createEndPointPicker(eppConfig string) []string {
 	// response (200 or 500-with-body) means EPP is reachable from Envoy.
 	ginkgo.By("Waiting for gateway to be ready")
 	gomega.Eventually(func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/v1/models", port))
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/v1/models", getPort()))
 		if err != nil {
 			return false
 		}

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func createModelServersFromKustomize(kustomizeDir string, extra map[string]string) []string {
+	nsName := getNamespace()
 	subs := map[string]string{
 		"${MODEL_NAME}":              simModelName,
 		"${POOL_NAME}":               poolName,
@@ -51,8 +52,8 @@ func createModelServersFromKustomize(kustomizeDir string, extra map[string]strin
 	if !isModelReal(subs["${MODEL_NAME}"]) {
 		manifests = removeRenderSidecar(manifests)
 	}
-	objects := testutils.CreateObjsFromYaml(testConfig, manifests)
-	podsInDeploymentsReady(objects)
+	objects := testutils.CreateObjsFromYaml(testConfig, manifests, nsName)
+	podsInDeploymentsReady(nsName, objects)
 	return objects
 }
 
@@ -131,7 +132,7 @@ func createModelServersEPDUnified(replicas int) []string {
 
 func createEndPointPicker(eppConfig string) []string {
 	objects := createEndPointPickerHelper(eppConfig, 1, false, true)
-	podsInDeploymentsReady(objects)
+	podsInDeploymentsReady(getNamespace(), objects)
 
 	// Envoy registers the EPP as a healthy ext_proc upstream asynchronously.
 	// "no healthy upstream" returns HTTP 500 with empty body; any non-empty
@@ -151,6 +152,7 @@ func createEndPointPicker(eppConfig string) []string {
 }
 
 func createEndPointPickerHelper(eppConfig string, replicas int, isLeaderElectionEnabled bool, waitForReady bool) []string {
+	nsName := getNamespace()
 	configMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -158,7 +160,7 @@ func createEndPointPickerHelper(eppConfig string, replicas int, isLeaderElection
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "epp-config",
-			Namespace: nsName,
+			Namespace: getNamespace(),
 		},
 		Data: map[string]string{"epp-config.yaml": eppConfig},
 	}
@@ -189,10 +191,10 @@ func createEndPointPickerHelper(eppConfig string, replicas int, isLeaderElection
 	eppYamls = appendEppArgs(eppYamls, eppExtraArgs)
 
 	if waitForReady {
-		return append(objects, testutils.CreateObjsFromYaml(testConfig, eppYamls)...)
+		return append(objects, testutils.CreateObjsFromYaml(testConfig, eppYamls, nsName)...)
 	}
 	objs := testutils.CreateUnstructuredObjs(testConfig, eppYamls)
-	return append(objects, testutils.CreateObjsWithVerifier(testConfig, objs, func(kind string, clientObj client.Object) {})...)
+	return append(objects, testutils.CreateObjsWithVerifier(testConfig, objs, nsName, func(kind string, clientObj client.Object) {})...)
 }
 
 func usesTokenProducer(eppConfig string) bool {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -30,7 +30,7 @@ const (
 	kubernetesDeploymentKind = "Deployment"
 )
 
-func scaleDeployment(objects []string, increment int) {
+func scaleDeployment(nsName string, objects []string, increment int) {
 	direction := "up"
 	absIncrement := increment
 	if increment < 0 {
@@ -50,7 +50,7 @@ func scaleDeployment(objects []string, increment int) {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 	}
-	podsInDeploymentsReady(objects)
+	podsInDeploymentsReady(nsName, objects)
 }
 
 // getModelServerPods Returns the list of Prefill and Decode vLLM pods separately
@@ -118,7 +118,7 @@ func getPodNames(labels map[string]string) []string {
 	return names
 }
 
-func podsInDeploymentsReady(objects []string) {
+func podsInDeploymentsReady(nsName string, objects []string) {
 	isDeploymentReady := func(deploymentName string) bool {
 		var deployment appsv1.Deployment
 		err := testConfig.K8sClient.Get(testConfig.Context, types.NamespacedName{Namespace: nsName, Name: deploymentName}, &deployment)
@@ -424,7 +424,7 @@ func extractFinishReasonFromStreaming(sseData string) string {
 }
 
 // getPodRequestCount gets the total vLLM request count from a pod's metrics endpoint.
-func getPodRequestCount(podName string) int {
+func getPodRequestCount(nsName string, podName string) int {
 	ginkgo.By("Getting request count from pod: " + podName)
 
 	// Use Kubernetes API proxy to access the metrics endpoint
@@ -466,7 +466,7 @@ func parseRequestCountFromMetrics(metricsOutput string) int {
 
 // dumpPodsAndLogs dumps all pod statuses and their logs to the Ginkgo writer.
 // Call this before cleanup to insure the information is available when CI tests fail.
-func dumpPodsAndLogs() {
+func dumpPodsAndLogs(nsName string) {
 	if testConfig == nil || testConfig.KubeCli == nil {
 		ginkgo.GinkgoWriter.Println("Skipping pod dump: cluster not initialized")
 		return
@@ -540,15 +540,15 @@ func dumpPodsAndLogs() {
 
 		for _, c := range pod.Spec.InitContainers {
 			if restarted[c.Name] {
-				dumpContainerLogs(ctx, pod.Name, c.Name, true)
+				dumpContainerLogs(ctx, pod.Namespace, pod.Name, c.Name, true)
 			}
-			dumpContainerLogs(ctx, pod.Name, c.Name, false)
+			dumpContainerLogs(ctx, pod.Namespace, pod.Name, c.Name, false)
 		}
 		for _, c := range pod.Spec.Containers {
 			if restarted[c.Name] {
-				dumpContainerLogs(ctx, pod.Name, c.Name, true)
+				dumpContainerLogs(ctx, pod.Namespace, pod.Name, c.Name, true)
 			}
-			dumpContainerLogs(ctx, pod.Name, c.Name, false)
+			dumpContainerLogs(ctx, pod.Namespace, pod.Name, c.Name, false)
 		}
 	}
 	ginkgo.GinkgoWriter.Println("=== End of pod dump ===")
@@ -565,7 +565,7 @@ func printContainerStatus(kind string, cs corev1.ContainerStatus) {
 	ginkgo.GinkgoWriter.Println(status)
 }
 
-func dumpContainerLogs(ctx context.Context, podName, containerName string, previous bool) {
+func dumpContainerLogs(ctx context.Context, nsName, podName, containerName string, previous bool) {
 	tailLines := int64(100)
 	req := testConfig.KubeCli.CoreV1().Pods(nsName).GetLogs(podName, &corev1.PodLogOptions{
 		Container: containerName,

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -424,7 +424,7 @@ func extractFinishReasonFromStreaming(sseData string) string {
 }
 
 // getPodRequestCount gets the total vLLM request count from a pod's metrics endpoint.
-func getPodRequestCount(nsName string, podName string) int {
+func getPodRequestCount(nsName, podName string) int {
 	ginkgo.By("Getting request count from pod: " + podName)
 
 	// Use Kubernetes API proxy to access the metrics endpoint

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -62,7 +62,6 @@ type TestConfig struct {
 	KubeCli           *kubernetes.Clientset
 	K8sClient         client.Client
 	RestConfig        *rest.Config
-	NsName            string
 	Scheme            *runtime.Scheme
 	ExistsTimeout     time.Duration
 	ReadyTimeout      time.Duration
@@ -71,7 +70,7 @@ type TestConfig struct {
 }
 
 // NewTestConfig creates a new TestConfig instance
-func NewTestConfig(nsName string, k8sContext string) *TestConfig {
+func NewTestConfig(k8sContext string) *TestConfig {
 	cfg, err := config.GetConfigWithContext(k8sContext)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.Expect(cfg).NotTo(gomega.BeNil())
@@ -106,7 +105,6 @@ func NewTestConfig(nsName string, k8sContext string) *TestConfig {
 	return &TestConfig{
 		Context:           context.Background(),
 		KubeCli:           kubeCli,
-		NsName:            nsName,
 		RestConfig:        cfg,
 		Scheme:            runtime.NewScheme(),
 		ExistsTimeout:     env.GetEnvDuration("EXISTS_TIMEOUT", defaultExistsTimeout, ginkgo.GinkgoLogr),

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -239,8 +239,8 @@ func EventuallyExists(testConfig *TestConfig, getResource func() error) {
 	}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
 }
 
-func CreateAndVerifyObjs(testConfig *TestConfig, objs []*unstructured.Unstructured) []string {
-	objNames := CreateObjsWithVerifier(testConfig, objs,
+func CreateAndVerifyObjs(testConfig *TestConfig, objs []*unstructured.Unstructured, nsName string) []string {
+	objNames := CreateObjsWithVerifier(testConfig, objs, nsName,
 		func(kind string, clientObj client.Object) {
 			switch kind {
 			case "CustomResourceDefinition":
@@ -255,11 +255,11 @@ func CreateAndVerifyObjs(testConfig *TestConfig, objs []*unstructured.Unstructur
 	return objNames
 }
 
-func CreateObjsWithVerifier(testConfig *TestConfig, objs []*unstructured.Unstructured, verifier func(kind string, clientObj client.Object)) []string {
+func CreateObjsWithVerifier(testConfig *TestConfig, objs []*unstructured.Unstructured, nsName string, verifier func(kind string, clientObj client.Object)) []string {
 	objNames := make([]string, len(objs))
 	for idx, unstrObj := range objs {
 		ginkgo.By(fmt.Sprintf("Processing GVK: %s", unstrObj.GroupVersionKind()))
-		unstrObj.SetNamespace(testConfig.NsName)
+		unstrObj.SetNamespace(nsName)
 
 		kind := unstrObj.GetKind()
 		name := unstrObj.GetName()
@@ -276,7 +276,7 @@ func CreateObjsWithVerifier(testConfig *TestConfig, objs []*unstructured.Unstruc
 		clientObj := getClientObject(kind)
 		EventuallyExists(testConfig, func() error {
 			return testConfig.K8sClient.Get(testConfig.Context,
-				types.NamespacedName{Namespace: testConfig.NsName, Name: name}, clientObj)
+				types.NamespacedName{Namespace: nsName, Name: name}, clientObj)
 		})
 
 		verifier(kind, clientObj)
@@ -285,9 +285,9 @@ func CreateObjsWithVerifier(testConfig *TestConfig, objs []*unstructured.Unstruc
 }
 
 // CreateObjsFromYaml creates K8S objects from yaml and waits for them to be instantiated
-func CreateObjsFromYaml(testConfig *TestConfig, docs []string) []string {
+func CreateObjsFromYaml(testConfig *TestConfig, docs []string, nsName string) []string {
 	objs := CreateUnstructuredObjs(testConfig, docs)
-	return CreateAndVerifyObjs(testConfig, objs)
+	return CreateAndVerifyObjs(testConfig, objs, nsName)
 }
 
 // CreateUnstructuredObjs creates K8S UnstructuredObject structs from an array of YAMLs
@@ -321,19 +321,19 @@ func CreateUnstructuredObjs(testConfig *TestConfig, docs []string) []*unstructur
 }
 
 // DeleteObjects deletes a set of Kubernetes objects in the form of kind/name.
-func DeleteObjects(testConfig *TestConfig, kindAndNames []string) {
+func DeleteObjects(testConfig *TestConfig, kindAndNames []string, nsName string) {
 	for _, kindAndName := range kindAndNames {
 		split := strings.Split(kindAndName, "/")
 		clientObj := getClientObject(split[0])
 		err := testConfig.K8sClient.Get(testConfig.Context,
-			types.NamespacedName{Namespace: testConfig.NsName, Name: split[1]}, clientObj)
+			types.NamespacedName{Namespace: nsName, Name: split[1]}, clientObj)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = testConfig.K8sClient.Delete(testConfig.Context, clientObj)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Eventually(func() bool {
 			clientObj := getClientObject(split[0])
 			err := testConfig.K8sClient.Get(testConfig.Context,
-				types.NamespacedName{Namespace: testConfig.NsName, Name: split[1]}, clientObj)
+				types.NamespacedName{Namespace: nsName, Name: split[1]}, clientObj)
 			return apierrors.IsNotFound(err)
 		}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.BeTrue())
 	}
@@ -341,9 +341,9 @@ func DeleteObjects(testConfig *TestConfig, kindAndNames []string) {
 
 // ApplyYAMLFile reads a file containing YAML (possibly multiple docs)
 // and applies each object to the cluster.
-func ApplyYAMLFile(testConfig *TestConfig, filePath string) []string {
+func ApplyYAMLFile(testConfig *TestConfig, filePath string, nsName string) []string {
 	// Create the resources from the manifest file
-	return CreateObjsFromYaml(testConfig, ReadYaml(filePath))
+	return CreateObjsFromYaml(testConfig, ReadYaml(filePath), nsName)
 }
 
 // ReadYaml is a helper function to read in K8S YAML files and split by the --- separator


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Currently the llm-d-router End to End tests run for quite a long time (about sixteen minutes on my Mac M4 Max).

This long time has affected the CI pipeline in the past. A work around was done to run the tests in parts in parallel in separate Kind clusters. This splitting up of the tests needs to be managed manually and has overhead as prepetory steps are done over and over again for each test "slice'

A better solution is to run tests in parallel on the same Kind cluster using K8S Namespaces for separation as needed.

This PR modifies the End to End test infrastructure to enable the running of different tests in different namespaces. A follow on PR will exploit this ability and Gonkgo's ability to run tests in parallel.

**Which issue(s) this PR fixes**:
Refs #1931

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
