### PR TITLE
test(e2e): wait for EPP pod discovery instead of sleeping

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -147,6 +147,7 @@ var _ = ginkgo.AfterSuite(func() {
 		}
 		if eppPortForwardSession != nil {
 			eppPortForwardSession.Terminate()
+			eppPortForwardSession = nil
 		}
 	}
 })
@@ -378,7 +379,14 @@ func createInferencePool(numTargetPorts int, toDelete bool) []string {
 	return testutils.CreateObjsFromYaml(testConfig, infPoolYaml, nsName)
 }
 
+// startEPPMetricsPortForward is a no-op outside an existing-cluster run (k8sContext
+// unset) and safe to call repeatedly; it starts at most one port-forward session,
+// reused until AfterSuite terminates it.
 func startEPPMetricsPortForward() {
+	if k8sContext == "" || eppPortForwardSession != nil {
+		return
+	}
+
 	pods, err := testConfig.KubeCli.CoreV1().Pods(getNamespace()).List(testConfig.Context, metav1.ListOptions{
 		LabelSelector: "app=e2e-epp",
 	})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -790,11 +789,9 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 		ginkgo.It("should run successfully", func() {
 			infPoolObjects = createInferencePool(1, true)
 
+			modelServers := createModelServersDecodeKV(1)
 			epp := createEndPointPicker(kvConfig)
 			nsName := getNamespace()
-
-			modelServers := createModelServersDecodeKV(1)
-			time.Sleep(5 * time.Second) // wait for model server(s) to become ready
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
@@ -815,11 +812,9 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 		ginkgo.It("should run successfully", func() {
 			infPoolObjects = createInferencePool(1, true)
 
+			modelServers := createModelServersDecodeKV(1)
 			epp := createEndPointPicker(kvExternalTokenizerConfig)
 			nsName := getNamespace()
-
-			modelServers := createModelServersDecodeKV(1)
-			time.Sleep(5 * time.Second) // wait for model server(s) to become ready
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -165,10 +165,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 
-			if k8sContext != "" {
-				// Use port-forward to access the EPP pod's metrics endpoint.
-				startEPPMetricsPortForward()
-			}
+			startEPPMetricsPortForward()
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))
@@ -476,10 +473,7 @@ var _ = ginkgo.Describe("Run end to end tests", ginkgo.Ordered, func() {
 
 			metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 
-			if k8sContext != "" {
-				// Use port-forward to access the EPP pod's metrics endpoint.
-				startEPPMetricsPortForward()
-			}
+			startEPPMetricsPortForward()
 
 			prefillPods, decodePods := getModelServerPods(podSelector, prefillSelector, decodeSelector)
 			gomega.Expect(prefillPods).Should(gomega.HaveLen(prefillReplicas))

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -304,10 +304,7 @@ func verifyMetrics(infPoolName string, numTargetPorts int) {
 
 	metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
 
-	if k8sContext != "" {
-		// Use port-forward to access the EPP pod's metrics endpoint.
-		startEPPMetricsPortForward()
-	}
+	startEPPMetricsPortForward()
 
 	theMetrics := getMetrics(metricsURL)
 	gomega.Expect(theMetrics).ShouldNot(gomega.BeEmpty())

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -148,6 +148,8 @@ func createEndPointPicker(eppConfig string) []string {
 		return resp.StatusCode == http.StatusOK || len(body) > 0
 	}, readyTimeout, 2*time.Second).Should(gomega.BeTrue(), "gateway should be ready within the ready timeout")
 
+	waitForEPPToDiscoverPods(simModelName)
+
 	return objects
 }
 

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -148,7 +148,7 @@ func createEndPointPicker(eppConfig string) []string {
 		return resp.StatusCode == http.StatusOK || len(body) > 0
 	}, readyTimeout, 2*time.Second).Should(gomega.BeTrue(), "gateway should be ready within the ready timeout")
 
-	waitForEPPToDiscoverPods(simModelName)
+	waitForEPPToDiscoverPods(poolName)
 
 	return objects
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -118,6 +118,26 @@ func getPodNames(labels map[string]string) []string {
 	return names
 }
 
+// waitForEPPToDiscoverPods blocks until the EPP's inference_pool_ready_pods
+// gauge for poolName reports at least one pod, indicating the InferencePool
+// controller has finished its initial pod discovery. The EPP reports gRPC
+// health as SERVING as soon as the pool is set, even if pod discovery found
+// zero endpoints, so readiness alone does not guarantee the datastore is
+// populated. Polling the gauge avoids routing a real request through the
+// EPP, which would otherwise be recorded as a routing decision and skew
+// tests that assert exact decision-type counts.
+func waitForEPPToDiscoverPods(poolName string) {
+	ginkgo.By("Waiting for EPP to discover pool members")
+	metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
+	if k8sContext != "" {
+		startEPPMetricsPortForward()
+	}
+	labelMatch := fmt.Sprintf(`name="%s"`, poolName)
+	gomega.Eventually(func() int {
+		return getCounterMetric(metricsURL, "inference_pool_ready_pods", labelMatch)
+	}, readyTimeout, time.Second).Should(gomega.BeNumerically(">", 0), "EPP should discover pool members within the ready timeout")
+}
+
 func podsInDeploymentsReady(nsName string, objects []string) {
 	isDeploymentReady := func(deploymentName string) bool {
 		var deployment appsv1.Deployment

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -129,9 +129,7 @@ func getPodNames(labels map[string]string) []string {
 func waitForEPPToDiscoverPods(poolName string) {
 	ginkgo.By("Waiting for EPP to discover pool members")
 	metricsURL := fmt.Sprintf("http://localhost:%d/metrics", getMetricsPort())
-	if k8sContext != "" {
-		startEPPMetricsPortForward()
-	}
+	startEPPMetricsPortForward()
 	labelMatch := fmt.Sprintf(`name="%s"`, poolName)
 	gomega.Eventually(func() int {
 		return getCounterMetric(metricsURL, "inference_pool_ready_pods", labelMatch)


### PR DESCRIPTION
/kind test
/kind flake

**What this PR does / why we need it**:

The EPP reports gRPC health as SERVING as soon as the InferencePool object is set, even before the pod-discovery controller has finished its initial list. Several e2e tests raced against that discovery by using a fixed sleep, or by issuing requests immediately after EPP readiness with no wait at all.

This PR adds `waitForEPPToDiscoverPods`, which polls the EPP metrics for readiness and number of discovered endpoints > 0, and calls it synchronously from `createEndPointPicker`, the chokepoint nearly all e2e tests already funnel through. Reorders the two KV tests to create model servers before the EPP so the wait has pods to find, and drops the now-redundant sleeps.

Also fixes `startEPPMetricsPortForward`, which was called from six sites and unconditionally started a new `kubectl port-forward` each time, leaking orphaned processes. It now guards on an existing session, and `AfterSuite` resets the session variable to nil after terminating it. The existing-cluster (`k8sContext`) check moved into the function itself instead of being duplicated at every call site.

**Which issue(s) this PR fixes**:
Fixes #764

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```