### PR TITLE
Fix Trivy SARIF scans failing on unfiltered severities

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -26,6 +26,11 @@ runs:
         output: 'trivy-results.sarif'
         severity: ${{ inputs.severity }}
         exit-code: '1'
+        # trivy-action drops the severity filter for SARIF output unless told
+        # otherwise, which fails the scan on findings outside `severity` (e.g.
+        # UNKNOWN-severity Go vulndb notes).
+        limit-severities-for-sarif: 'true'
+        version: 'v0.72.0'
 
     - name: Upload Trivy SARIF to Security tab
       uses: github/codeql-action/upload-sarif@v4.35.4 # v4.35.4 68bde559dea0fdcac2102bfdf6230c5f70eb485e


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`aquasecurity/trivy-action` unconditionally unsets `TRIVY_SEVERITY` when `format: sarif` is set in the action, unless `limit-severities-for-sarif: true` is also passed.
Our `.github/actions/trivy-scan` action set `severity: HIGH,CRITICAL` but never
set the flags so the sevirity filter was silently discarded and Trivy scanned/failed the build on **every severity**, including `UNKNOWN` severity. Specifically, Go vulndb "notes" (e.g. `GO-2026-5932` for `golang.org/x/crypto/openpgp`, an unused transitive dependency).

Example failing runs:
- https://github.com/llm-d/llm-d-router/actions/runs/29247655416/job/86808363974
- https://github.com/llm-d/llm-d-router/actions/runs/29245121855/job/86800075243

This PR
- adds `limit-severities-for-sarif: 'true'` so the configured severity filter is actually honored for SARIF output
- pin trivy to `v0.72.0`.

**Which issue(s) this PR fixes**:
NA

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```