### PR TITLE
Add generic endpoint attribute filter

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -101,6 +101,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
+	endpointattributefilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/endpointattribute"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity"
 	sessionaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier"
@@ -543,6 +544,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(bylabel.EncodeRoleType, bylabel.EncodeRoleFactory)
 	fwkplugin.Register(bylabel.DecodeRoleType, bylabel.DecodeRoleFactory)
 	fwkplugin.Register(bylabel.PrefillRoleType, bylabel.PrefillRoleFactory)
+	fwkplugin.Register(endpointattributefilter.EndpointAttributeFilterType, endpointattributefilter.EndpointAttributeFilterFactory)
 	fwkplugin.Register(sessionaffinityfilter.SessionAffinityType, sessionaffinityfilter.Factory)
 
 	// dataparallel profile handler

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/README.md
@@ -1,0 +1,65 @@
+# Endpoint Attribute Filter Plugin
+
+**Type:** `endpoint-attribute-filter`
+
+This plugin filters candidate endpoints by a single configured numeric endpoint attribute.
+
+## What it does
+
+For each scheduling cycle, the plugin reads the configured attribute (`attribute`) from each candidate endpoint and keeps only the endpoints whose value satisfies the configured algorithm. This PR supports the `threshold` algorithm; `percentile`, `topK` and `range` are planned follow-ups.
+
+With `threshold`, an endpoint is kept when
+
+\[
+\text{value(endpoint)} \ \langle op \rangle\ \text{threshold.value}
+\]
+
+is true for the configured `threshold.operator`.
+
+Policies for the awkward cases:
+
+- **`onMissing`** — what happens to an endpoint that does not have the attribute: `Pass` keeps it (the default), `Fail` drops it.
+- **`fallbackOnEmpty`** — when every endpoint is filtered out and this is `true`, the original candidate list is returned unchanged, so the request can still be routed somewhere. Default `false`.
+
+The attribute is expected to be a numeric custom metric produced by the core metrics extractor (see the [metrics extractor](../../../datalayer/extractor/metrics/README.md)), stored as a `ScalarMetricValue` endpoint attribute.
+
+## Inputs consumed
+
+The plugin consumes:
+
+- the configured `attribute` (`ScalarMetricValue`)
+
+## Configuration
+
+| Parameter                       | Required | Description                                                                              |
+|---------------------------------|----------|------------------------------------------------------------------------------------------|
+| `attribute`                     | yes      | Endpoint attribute to read, e.g. `num_requests_running`.                                  |
+| `onMissing`                     | no       | `Pass` (default) or `Fail` — keep or drop endpoints missing the attribute.                |
+| `fallbackOnEmpty`               | no       | When `true`, return the unfiltered candidates if every endpoint was dropped. Default `false`. |
+| `algorithm.type`                | yes      | Only `threshold` is currently supported.                                                  |
+| `algorithm.threshold.operator`  | yes      | `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `Equal` or `NotEqual`. |
+| `algorithm.threshold.value`     | yes      | The value compared against the endpoint's attribute.                                      |
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: endpoint-attribute-filter
+    name: drop-loaded-endpoints
+    parameters:
+      attribute: "num_requests_running"
+      onMissing: "Pass"
+      fallbackOnEmpty: true
+      algorithm:
+        type: "threshold"
+        threshold:
+          operator: "LessThan"
+          value: 10
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: drop-loaded-endpoints
+```
+
+## See also
+
+The `endpoint-attribute-scorer` plugin ([llm-d/llm-d-router#1620](https://github.com/llm-d/llm-d-router/pull/1620)) is the scoring counterpart of this filter: instead of dropping endpoints, it ranks them by the same kind of configured attribute.

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package endpointattribute provides a generic filter plugin that filters
+// candidate endpoints by a single configured numeric endpoint attribute.
+package endpointattribute

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointattribute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+const (
+	// EndpointAttributeFilterType is the type of the EndpointAttributeFilter.
+	EndpointAttributeFilterType = "endpoint-attribute-filter"
+
+	onMissingPass = "Pass"
+	onMissingFail = "Fail"
+
+	algorithmThreshold = "threshold"
+
+	operatorLessThan           = "LessThan"
+	operatorLessThanOrEqual    = "LessThanOrEqual"
+	operatorGreaterThan        = "GreaterThan"
+	operatorGreaterThanOrEqual = "GreaterThanOrEqual"
+	operatorEqual              = "Equal"
+	operatorNotEqual           = "NotEqual"
+)
+
+// thresholdParameters keeps endpoints whose attribute value compares true
+// against the configured value.
+type thresholdParameters struct {
+	Operator string  `json:"operator"`
+	Value    float64 `json:"value"`
+}
+
+// algorithmParameters selects the filtering algorithm. threshold is the only
+// algorithm currently supported; percentile, topK and range are planned as
+// follow-ups.
+type algorithmParameters struct {
+	Type      string               `json:"type"`
+	Threshold *thresholdParameters `json:"threshold,omitempty"`
+}
+
+type parameters struct {
+	Attribute string `json:"attribute"`
+	// OnMissing decides what happens to endpoints that do not have the
+	// attribute: "Pass" keeps them (the default), "Fail" drops them.
+	OnMissing string `json:"onMissing"`
+	// FallbackOnEmpty returns the unfiltered candidates when every endpoint
+	// was filtered out, so the request can still be routed somewhere.
+	FallbackOnEmpty bool                `json:"fallbackOnEmpty"`
+	Algorithm       algorithmParameters `json:"algorithm"`
+}
+
+// compile-time type assertion
+var _ scheduling.Filter = &EndpointAttributeFilter{}
+
+// EndpointAttributeFilterFactory defines the factory function for EndpointAttributeFilter.
+func EndpointAttributeFilterFactory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	var params parameters
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", EndpointAttributeFilterType, err)
+		}
+	}
+
+	return NewEndpointAttributeFilter(name, params)
+}
+
+// NewEndpointAttributeFilter validates the given parameters and returns a new
+// EndpointAttributeFilter with the given name.
+func NewEndpointAttributeFilter(name string, params parameters) (*EndpointAttributeFilter, error) {
+	if name == "" {
+		name = EndpointAttributeFilterType
+	}
+	if params.Attribute == "" {
+		return nil, errors.New("endpoint attribute filter requires a non-empty attribute")
+	}
+	switch params.OnMissing {
+	case "":
+		params.OnMissing = onMissingPass
+	case onMissingPass, onMissingFail:
+	default:
+		return nil, fmt.Errorf("endpoint attribute filter onMissing must be %q or %q, got %q",
+			onMissingPass, onMissingFail, params.OnMissing)
+	}
+	if params.Algorithm.Type != algorithmThreshold {
+		return nil, fmt.Errorf("endpoint attribute filter algorithm.type must be %q, got %q",
+			algorithmThreshold, params.Algorithm.Type)
+	}
+	threshold := params.Algorithm.Threshold
+	if threshold == nil {
+		return nil, fmt.Errorf("endpoint attribute filter requires algorithm.threshold when algorithm.type is %q",
+			algorithmThreshold)
+	}
+	switch threshold.Operator {
+	case operatorLessThan, operatorLessThanOrEqual, operatorGreaterThan,
+		operatorGreaterThanOrEqual, operatorEqual, operatorNotEqual:
+	default:
+		return nil, fmt.Errorf("endpoint attribute filter threshold.operator must be one of %q, %q, %q, %q, %q, %q, got %q",
+			operatorLessThan, operatorLessThanOrEqual, operatorGreaterThan,
+			operatorGreaterThanOrEqual, operatorEqual, operatorNotEqual, threshold.Operator)
+	}
+
+	return &EndpointAttributeFilter{
+		typedName:       plugin.TypedName{Type: EndpointAttributeFilterType, Name: name},
+		attribute:       params.Attribute,
+		passOnMissing:   params.OnMissing == onMissingPass,
+		fallbackOnEmpty: params.FallbackOnEmpty,
+		threshold:       *threshold,
+	}, nil
+}
+
+// EndpointAttributeFilter filters candidate endpoints by a single configured
+// numeric endpoint attribute (produced by the custom metrics extraction
+// layer). Endpoints whose attribute value compares true against the
+// configured threshold are kept.
+type EndpointAttributeFilter struct {
+	typedName plugin.TypedName
+	attribute string
+	// passOnMissing keeps endpoints that do not have the attribute instead of
+	// dropping them.
+	passOnMissing bool
+	// fallbackOnEmpty returns the unfiltered candidates when every endpoint
+	// was filtered out.
+	fallbackOnEmpty bool
+	threshold       thresholdParameters
+}
+
+// TypedName returns the typed name of the plugin.
+func (f *EndpointAttributeFilter) TypedName() plugin.TypedName {
+	return f.typedName
+}
+
+// Consumes returns the list of data that is consumed by the plugin.
+func (f *EndpointAttributeFilter) Consumes() map[string]any {
+	return map[string]any{
+		f.attribute: attrmetrics.ScalarMetricValue(0),
+	}
+}
+
+// Filter keeps the endpoints whose attribute value satisfies the configured
+// threshold. Endpoints missing the attribute are kept or dropped according to
+// the onMissing policy. When all endpoints are filtered out and
+// fallbackOnEmpty is set, the original candidates are returned.
+func (f *EndpointAttributeFilter) Filter(_ context.Context, _ *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
+	filtered := make([]scheduling.Endpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		value, ok := attrmetrics.ReadScalarMetricValue(endpoint, f.attribute)
+		if !ok {
+			if f.passOnMissing {
+				filtered = append(filtered, endpoint)
+			}
+			continue
+		}
+		if f.matches(float64(value)) {
+			filtered = append(filtered, endpoint)
+		}
+	}
+
+	if len(filtered) == 0 && f.fallbackOnEmpty {
+		return endpoints
+	}
+	return filtered
+}
+
+// matches reports whether the value satisfies the configured threshold.
+func (f *EndpointAttributeFilter) matches(value float64) bool {
+	switch f.threshold.Operator {
+	case operatorLessThan:
+		return value < f.threshold.Value
+	case operatorLessThanOrEqual:
+		return value <= f.threshold.Value
+	case operatorGreaterThan:
+		return value > f.threshold.Value
+	case operatorGreaterThanOrEqual:
+		return value >= f.threshold.Value
+	case operatorEqual:
+		return value == f.threshold.Value
+	case operatorNotEqual:
+		return value != f.threshold.Value
+	default:
+		// Unreachable: the operator is validated at construction time.
+		return false
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointattribute
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+const testAttribute = "num_requests_running"
+
+func TestEndpointAttributeFilterFactory(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters string
+		wantErr    string
+	}{
+		{
+			name: "valid threshold with defaulted onMissing",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "LessThan", "value": 10}}}`,
+		},
+		{
+			name: "valid threshold with explicit policies",
+			parameters: `{"attribute": "num_requests_running",
+				"onMissing": "Fail", "fallbackOnEmpty": true,
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "GreaterThanOrEqual", "value": 0.5}}}`,
+		},
+		{
+			name: "missing attribute",
+			parameters: `{"algorithm": {"type": "threshold",
+				"threshold": {"operator": "LessThan", "value": 10}}}`,
+			wantErr: "attribute",
+		},
+		{
+			name: "invalid onMissing",
+			parameters: `{"attribute": "num_requests_running", "onMissing": "Maybe",
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "LessThan", "value": 10}}}`,
+			wantErr: "onMissing",
+		},
+		{
+			name:       "missing algorithm type",
+			parameters: `{"attribute": "num_requests_running"}`,
+			wantErr:    "algorithm.type",
+		},
+		{
+			name: "unsupported algorithm type",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "percentile"}}`,
+			wantErr: "algorithm.type",
+		},
+		{
+			name: "missing threshold block",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "threshold"}}`,
+			wantErr: "algorithm.threshold",
+		},
+		{
+			name: "invalid threshold operator",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "Around", "value": 10}}}`,
+			wantErr: "threshold.operator",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decoder := json.NewDecoder(strings.NewReader(test.parameters))
+			plugin, err := EndpointAttributeFilterFactory("test-filter", decoder, nil)
+			if test.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, EndpointAttributeFilterType, plugin.TypedName().Type)
+			assert.Equal(t, "test-filter", plugin.TypedName().Name)
+		})
+	}
+}
+
+func newEndpointWithValue(value float64) scheduling.Endpoint {
+	attrs := fwkdl.NewAttributes()
+	attrs.Put(testAttribute, attrmetrics.ScalarMetricValue(value))
+	return scheduling.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{}, attrs)
+}
+
+func newEndpointWithoutValue() scheduling.Endpoint {
+	return scheduling.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{}, nil)
+}
+
+func TestEndpointAttributeFilterFilter(t *testing.T) {
+	tests := []struct {
+		name            string
+		operator        string
+		value           float64
+		onMissing       string
+		fallbackOnEmpty bool
+		endpoints       []scheduling.Endpoint
+		wantKept        []int // indexes into endpoints expected to survive
+	}{
+		{
+			name:     "LessThan keeps values below the threshold",
+			operator: operatorLessThan,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{0},
+		},
+		{
+			name:     "LessThanOrEqual keeps the boundary value",
+			operator: operatorLessThanOrEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{0, 1},
+		},
+		{
+			name:     "GreaterThan keeps values above the threshold",
+			operator: operatorGreaterThan,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{2},
+		},
+		{
+			name:     "GreaterThanOrEqual keeps the boundary value",
+			operator: operatorGreaterThanOrEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{1, 2},
+		},
+		{
+			name:     "Equal keeps only the matching value",
+			operator: operatorEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+			},
+			wantKept: []int{1},
+		},
+		{
+			name:     "NotEqual drops the matching value",
+			operator: operatorNotEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+			},
+			wantKept: []int{0},
+		},
+		{
+			name:      "missing attribute passes by default",
+			operator:  operatorLessThan,
+			value:     10,
+			onMissing: onMissingPass,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(15),
+				newEndpointWithoutValue(),
+			},
+			wantKept: []int{1},
+		},
+		{
+			name:      "missing attribute fails when onMissing is Fail",
+			operator:  operatorLessThan,
+			value:     10,
+			onMissing: onMissingFail,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithoutValue(),
+			},
+			wantKept: []int{0},
+		},
+		{
+			name:     "empty result stays empty without fallback",
+			operator: operatorLessThan,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(15),
+				newEndpointWithValue(20),
+			},
+			wantKept: []int{},
+		},
+		{
+			name:            "empty result returns all candidates with fallbackOnEmpty",
+			operator:        operatorLessThan,
+			value:           10,
+			fallbackOnEmpty: true,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(15),
+				newEndpointWithValue(20),
+			},
+			wantKept: []int{0, 1},
+		},
+		{
+			name:            "fallbackOnEmpty does not trigger when some endpoints survive",
+			operator:        operatorLessThan,
+			value:           10,
+			fallbackOnEmpty: true,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(20),
+			},
+			wantKept: []int{0},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter, err := NewEndpointAttributeFilter("test-filter", parameters{
+				Attribute:       testAttribute,
+				OnMissing:       test.onMissing,
+				FallbackOnEmpty: test.fallbackOnEmpty,
+				Algorithm: algorithmParameters{
+					Type: algorithmThreshold,
+					Threshold: &thresholdParameters{
+						Operator: test.operator,
+						Value:    test.value,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			got := filter.Filter(context.Background(), &scheduling.InferenceRequest{}, test.endpoints)
+
+			want := make([]scheduling.Endpoint, 0, len(test.wantKept))
+			for _, i := range test.wantKept {
+				want = append(want, test.endpoints[i])
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}


### PR DESCRIPTION
Adds an endpoint-attribute-filter scheduling plugin that filters candidate endpoints on one configured endpoint attribute, following the config from #1922. This covers the threshold algorithm plus the onMissing / fallbackOnEmpty policies. percentile, topK and range can come as follow-ups like discussed on the issue.

A few decisions I made along the way, open to changing any of them:

- onMissing defaults to Pass and fallbackOnEmpty to false, same defaults as the issue
- only "threshold" is accepted for algorithm.type for now, anything else fails validation. felt safer that a config meant for percentile/topK/range fails loudly instead of quietly passing every endpoint through
- the threshold block itself is required, and the operator has to be one of the six values from the issue
- fallbackOnEmpty only kicks in when the filter dropped every endpoint. if even one survives, no fallback
- endpoints missing the attribute never reach the comparison, Pass keeps them and Fail drops them
- Consumes() has the same shape as the endpoint-attribute-scorer (#1620) so the two stay consistent. happy to move both to the newer DataDependencies form in a follow-up once the metrics extractor declares its produced keys

Added table tests for the factory validation, all six operators, and the policy/fallback cases. fmt/vet/tests clean, config loader and runner suites pass too.

Fixes #1922