### PR TITLE
fix(coordinator): force non-streaming prefill for chat completions

### DIFF
--- a/pkg/coordinator/steps/prefill.go
+++ b/pkg/coordinator/steps/prefill.go
@@ -138,6 +138,7 @@ func (s *PrefillStep) buildPrefillBody(ctx context.Context, reqCtx *pipeline.Req
 	case gateway.FormatChatCompletions:
 		body := maps.Clone(reqCtx.Body)
 		body["stream"] = false
+		delete(body, "stream_options")
 		tokens := map[string]any{
 			"token_ids": reqCtx.TokenIDs,
 		}

--- a/pkg/coordinator/steps/prefill.go
+++ b/pkg/coordinator/steps/prefill.go
@@ -137,6 +137,7 @@ func (s *PrefillStep) buildPrefillBody(ctx context.Context, reqCtx *pipeline.Req
 	switch format {
 	case gateway.FormatChatCompletions:
 		body := maps.Clone(reqCtx.Body)
+		body["stream"] = false
 		tokens := map[string]any{
 			"token_ids": reqCtx.TokenIDs,
 		}

--- a/pkg/coordinator/steps/prefill_test.go
+++ b/pkg/coordinator/steps/prefill_test.go
@@ -396,8 +396,9 @@ func TestPrefillStep_ChatCompletionsFormat_ForcesNonStreaming(t *testing.T) {
 		OriginalPath: gateway.PathChatCompletions,
 		Model:        "test-model",
 		Body: map[string]any{
-			"model":  "test-model",
-			"stream": true,
+			"model":          "test-model",
+			"stream":         true,
+			"stream_options": map[string]any{"include_usage": true},
 			"messages": []any{
 				map[string]any{"role": "user", "content": "hello"},
 			},
@@ -411,6 +412,9 @@ func TestPrefillStep_ChatCompletionsFormat_ForcesNonStreaming(t *testing.T) {
 
 	if prefillBody["stream"] != false {
 		t.Fatalf("expected prefill request to force stream=false, got %v", prefillBody["stream"])
+	}
+	if _, ok := prefillBody["stream_options"]; ok {
+		t.Fatalf("expected stream_options to be stripped from prefill request, got %v", prefillBody["stream_options"])
 	}
 }
 

--- a/pkg/coordinator/steps/prefill_test.go
+++ b/pkg/coordinator/steps/prefill_test.go
@@ -371,6 +371,12 @@ func TestPrefillStep_ChatCompletionsFormat_ForcesNonStreaming(t *testing.T) {
 	var prefillBody map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != gateway.PathChatCompletions {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get(gateway.EPPPhaseHeader) != gateway.PhasePrefill {
+			t.Fatalf("expected EPP-Phase: prefill, got %q", r.Header.Get(gateway.EPPPhaseHeader))
+		}
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &prefillBody)
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/pkg/coordinator/steps/prefill_test.go
+++ b/pkg/coordinator/steps/prefill_test.go
@@ -367,6 +367,47 @@ func TestPrefillStep_ChatCompletionsFormat(t *testing.T) {
 	}
 }
 
+func TestPrefillStep_ChatCompletionsFormat_ForcesNonStreaming(t *testing.T) {
+	var prefillBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &prefillBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kv_transfer_params": map[string]any{"block_id": "block-3"},
+		})
+	}))
+	defer server.Close()
+
+	gwClient := gateway.New(config.GatewayConfig{Address: server.URL})
+	step, err := NewPrefillStep(gwClient, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reqCtx := &pipeline.RequestContext{
+		RequestID:    "req-chat-stream",
+		OriginalPath: gateway.PathChatCompletions,
+		Model:        "test-model",
+		Body: map[string]any{
+			"model":  "test-model",
+			"stream": true,
+			"messages": []any{
+				map[string]any{"role": "user", "content": "hello"},
+			},
+		},
+		KVTransferParams: make(map[string]any),
+	}
+
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if prefillBody["stream"] != false {
+		t.Fatalf("expected prefill request to force stream=false, got %v", prefillBody["stream"])
+	}
+}
+
 // TestSharedStorage_OmitsECTransferParams_InPrefillBody verifies that the
 // ec-shared-storage EC connector never emits an ec_transfer_params field on
 // the prefill body, in every prefill wire format (chat-completions,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
The prefill step cloned the client's chat/completions request body verbatim, including `stream: true`. That was forwarded to the backend's prefill call, which then replied with an SSE stream instead of a single JSON object, and prefill's decode failed with `invalid character 'd' looking for beginning of value`.

Prefill only needs `kv_transfer_params` from a `max_tokens: 1` call, so it must never stream regardless of what the client requested. This forces `stream: false` on the outgoing prefill request in the chat-completions branch; the client's original `stream` value is still honored later by the decode step, which forwards the body unmodified.

**Which issue(s) this PR fixes**:

Fixes #2000 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
