### PR TITLE
chore(codeowners): add owners for kvcache and kvevents

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,6 +44,10 @@
 # Tokenization
 /pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/          @vMaroon @liu-cong @sagearc @llm-d/router-maintainers
 
+# KV-cache subsystem — indexer, KV-block index, KV-events
+/pkg/kvcache/                                                              @vMaroon @liu-cong @hyeongyun0916 @yankay @sagearc @llm-d/router-maintainers
+/pkg/kvevents/                                                             @vMaroon @liu-cong @hyeongyun0916 @yankay @sagearc @llm-d/router-maintainers
+
 # Request handling
 /pkg/epp/framework/interface/requesthandling/                             @zetxqx @llm-d/router-maintainers
 /pkg/epp/framework/plugins/requesthandling/                               @zetxqx @llm-d/router-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kvcache` and `kvevents` libraries were internalized from llm-d-kv-cache in #1886. This assigns CODEOWNERS for the new `pkg/kvcache` and `pkg/kvevents` trees (the kv-cache subsystem owners + the router maintainers team).

**Which issue(s) this PR fixes**:

Follow-up to #1886.

**Release note**:
```release-note
NONE
```