### PR TITLE
[Perf Tests] Fix commit conflict by rebasing

### DIFF
--- a/.github/workflows/nightly-router-perf-test-optimized-baseline-10k-1k.yaml
+++ b/.github/workflows/nightly-router-perf-test-optimized-baseline-10k-1k.yaml
@@ -126,4 +126,5 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add test/perf/results/optimized-baseline/
           git commit -m "Auto-update EPP nightly performance results [skip ci]" || exit 0
+          git pull --rebase origin main
           git push


### PR DESCRIPTION
Perf automation test should rebase before pushing perf results commit because the repo could have new commits added when the test was running over the past 30 minutes-1 hour.

**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Fixes an issue with the automation added in https://github.com/llm-d/llm-d-router/pull/1740.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1346

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
