### PR TITLE
[Performance Test] Collect pprof profiles and push results to GCS bucket

### DIFF
--- a/.github/workflows/nightly-router-perf-test-optimized-baseline-10k-1k.yaml
+++ b/.github/workflows/nightly-router-perf-test-optimized-baseline-10k-1k.yaml
@@ -40,9 +40,14 @@ on:
         default: 'test/perf/config/shared_prefix_job1.yaml'
         required: true
         type: string
+      gcs_bucket:
+        description: 'GCS bucket name for storing performance test results'
+        default: 'llm-d-router-perf-results'
+        required: true
+        type: string
 
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 jobs:
@@ -58,6 +63,7 @@ jobs:
       ROUTER_CONFIG: ${{ inputs.router_config || 'test/perf/config/router-configs/optimized-baseline.yaml' }}
       TEST_NAME: ${{ inputs.test_name || 'optimized-baseline-job1' }}
       PERF_JOB: ${{ inputs.perf_job || 'test/perf/config/shared_prefix_job1.yaml' }}
+      GCS_BUCKET: ${{ inputs.gcs_bucket || 'llm-d-router-perf-results' }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - name: Checkout llm-d/llm-d-router
@@ -95,6 +101,10 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install Graphviz
+        run: |
+          sudo apt-get update && sudo apt-get install -y graphviz
+
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -110,21 +120,13 @@ jobs:
             --sim-replicas ${{ env.SIM_REPLICAS }} \
             --results-dir test/perf/results/optimized-baseline \
             --router-machine-family e2 \
-            --gcp-project ${{ env.GCP_PROJECT_ID }}
+            --gcp-project ${{ env.GCP_PROJECT_ID }} \
+            --collect-pprof-profiles \
+            --gcs-bucket ${{ env.GCS_BUCKET }}
 
-      - name: Upload Performance Results
+      - name: Upload Performance Results Artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: epp-perf-results
           path: test/perf/results/optimized-baseline/
-
-      - name: Commit and push updated results
-        if: success() && github.ref == 'refs/heads/main'
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add test/perf/results/optimized-baseline/
-          git commit -m "Auto-update EPP nightly performance results [skip ci]" || exit 0
-          git pull --rebase origin main
-          git push

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ vendor
 # Helm dependency artifacts
 config/charts/*/charts/
 config/charts/*/Chart.lock
+
+# Performance benchmark local results directory
+test/perf/__pycache__/
+test/perf/results/

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -8,8 +8,8 @@ This directory contains the performance testing pipeline for the Endpoint Picker
   - **`router-configs/`**: Router Helm configuration values recipes (e.g. `optimized-baseline.yaml`).
   - `llm-d-sim-deployment.yaml` / `llm-d-sim-service.yaml`: Kubernetes manifests for deploying the vLLM simulator.
   - `shared_prefix_job1.yaml`: Performance test workload specification defining load stages, API target, and request distributions.
-- **`results/`**: Execution results logged as Markdown tables, grouped by test recipe name (e.g., `results/optimized-baseline/`).
-- **`run_nightly_perf.py`**: The Python orchestrator script responsible for test namespace setup, application deployment (EPP & simulator), metrics scraping, and markdown generation. It assumes that `kubectl` is already configured to target an active Kubernetes cluster.
+- **`results/`**: Execution results logged as Markdown tables, grouped by test recipe name (e.g., `results/optimized-baseline/`). If profiling is enabled, the `.pprof` and `.svg` files are saved here as well.
+- **`run_nightly_perf.py`**: The Python orchestrator script responsible for test namespace setup, EPP and simulator deployments, pprof profiling collection, metrics scraping, and markdown generation. It assumes that `kubectl` is already configured to target an active Kubernetes cluster.
 
 ---
 
@@ -21,6 +21,8 @@ To execute the performance suite locally, you must target an active GKE cluster.
 - Python 3.10+
 - `pyyaml`
 - `helm`
+- `go` (required to compile/parse pprof profiles)
+- `graphviz` (required to generate SVG diagrams from profiles)
 - A GKE cluster with Gateway API and Inference Extension CRDs installed.
 
 ### Execution Command
@@ -46,6 +48,8 @@ python3 test/perf/run_nightly_perf.py \
 - `--gcp-project`: GCP Project ID hosting your GKE cluster.
 - `--results-dir`: Output path for appending markdown result metrics.
 - `--router-machine-family`: Optional node affinity mapping (e.g. `e2`, `c3`).
+- `--collect-pprof-profiles`: (Optional) Collect EPP CPU & memory pprof profiles and render them as PNG and SVG visual artifacts.
+- `--gcs-bucket`: (Optional) Target GCS bucket name or URI (e.g. `gs://llm-d-perf-results`) to sync and preserve test results and profiling artifacts without committing them to the Git repository.
 - `--no-cleanup`: (Optional) Skip namespace deletion on test completion (useful for debugging).
 
 ---
@@ -57,6 +61,6 @@ The benchmarking pipeline runs daily via GHA:
 - **Schedule**: Daily at 09:00 UTC.
 - **Actions**:
   1. Authenticates to GCP and configures `kubectl` to point to the GKE development cluster.
-  2. Runs `run_nightly_perf.py` (specifying `--router-machine-family e2` for node affinity).
-  3. Appends the metrics results to `test/perf/results/optimized-baseline/optimized-baseline-job1.md`.
-  4. Automatically commits and pushes the updated results file back to the repository.
+  2. Runs `run_nightly_perf.py` (specifying `--router-machine-family e2` and `--gcs-bucket`).
+  3. Appends the metrics results and uploads profiling artifacts directly to the specified Google Cloud Storage bucket.
+

--- a/test/perf/results/optimized-baseline/optimized-baseline-job1.md
+++ b/test/perf/results/optimized-baseline/optimized-baseline-job1.md
@@ -1,7 +1,0 @@
-# EPP Router Performance Benchmarking Results: optimized-baseline-job1
-
-| Timestamp | Namespace | Router Config | Perf Job | Machine Family | Sim Replicas | EPP Images | Container | Idle CPU (m) | Idle Mem (MiB) | Peak CPU (m) | Peak Mem (MiB) | P50 Latency (ms) | P95 Latency (ms) | Status |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| 2026-07-13 18:17:03 | llm-d-perf-1783966623 | [optimized-baseline](../../config/router-configs/optimized-baseline.yaml) | [shared_prefix_job1.yaml](../../config/shared_prefix_job1.yaml) | e2 | 10 | docker.io/envoyproxy/envoy:distroless-v1.33.2<br>ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main | TOTAL | 126 | 35 | 4295 | 136 | 2.42 | 7.81 | SUCCESS |
-| 2026-07-13 18:17:03 | llm-d-perf-1783966623 | [optimized-baseline](../../config/router-configs/optimized-baseline.yaml) | [shared_prefix_job1.yaml](../../config/shared_prefix_job1.yaml) | e2 | 10 | docker.io/envoyproxy/envoy:distroless-v1.33.2<br>ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main | envoy-proxy | 11 | 13 | 2119 | 30 | 2.42 | 7.81 | SUCCESS |
-| 2026-07-13 18:17:03 | llm-d-perf-1783966623 | [optimized-baseline](../../config/router-configs/optimized-baseline.yaml) | [shared_prefix_job1.yaml](../../config/shared_prefix_job1.yaml) | e2 | 10 | docker.io/envoyproxy/envoy:distroless-v1.33.2<br>ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main | epp | 114 | 21 | 2190 | 109 | 2.42 | 7.81 | SUCCESS |

--- a/test/perf/run_nightly_perf.py
+++ b/test/perf/run_nightly_perf.py
@@ -3,12 +3,14 @@
 import argparse
 import json
 import os
+import random
 import re
 import subprocess
 import socket
 import sys
 import time
 from threading import Thread
+import urllib.request
 import yaml
 
 # Global flag to stop the metric monitoring thread
@@ -461,7 +463,7 @@ def cleanup_namespace(ns):
     print(f"Cleaning up namespace: {ns}")
     run_cmd(f"kubectl delete namespace {ns} --wait=false")
 
-def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, router_config_path, perf_job, machine_family, sim_replicas, images, idle_metrics, peak_metrics, p50, p95, status):
+def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, router_config_path, perf_job, machine_family, sim_replicas, images, idle_metrics, peak_metrics, p50, p95, status, profile_results=None):
     os.makedirs(results_dir, exist_ok=True)
     results_file = os.path.join(results_dir, f"{test_name}.md")
     file_exists = os.path.exists(results_file)
@@ -470,8 +472,8 @@ def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, route
         if not file_exists:
             # Write header
             f.write(f"# EPP Router Performance Benchmarking Results: {test_name}\n\n")
-            f.write("| Timestamp | Namespace | Router Config | Perf Job | Machine Family | Sim Replicas | EPP Images | Container | Idle CPU (m) | Idle Mem (MiB) | Peak CPU (m) | Peak Mem (MiB) | P50 Latency (ms) | P95 Latency (ms) | Status |\n")
-            f.write("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n")
+            f.write("| Timestamp | Namespace | Router Config | Perf Job | Machine Family | Sim Replicas | EPP Images | Container | Idle CPU (m) | Idle Mem (MiB) | Peak CPU (m) | Peak Mem (MiB) | P50 Latency (ms) | P95 Latency (ms) | CPU Profile | Memory Profile | Status |\n")
+            f.write("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n")
             
         epp_images = "<br>".join(images)
         mf_str = machine_family if machine_family else "-"
@@ -484,6 +486,34 @@ def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, route
         job_basename = os.path.basename(perf_job)
         job_link = f"[{job_basename}]({rel_perf_job})"
         
+        cpu_link = "-"
+        mem_link = "-"
+        if profile_results:
+            cpu_svg = profile_results.get('cpu_svg')
+            cpu_png = profile_results.get('cpu_png')
+            cpu_pprof = profile_results.get('cpu_pprof')
+            mem_svg = profile_results.get('mem_svg')
+            mem_png = profile_results.get('mem_png')
+            mem_pprof = profile_results.get('mem_pprof')
+            
+            if cpu_svg and cpu_pprof:
+                rel_cpu_svg = os.path.relpath(cpu_svg, results_dir)
+                rel_cpu_pprof = os.path.relpath(cpu_pprof, results_dir)
+                if cpu_png:
+                    rel_cpu_png = os.path.relpath(cpu_png, results_dir)
+                    cpu_link = f"[PNG]({rel_cpu_png}) ([SVG]({rel_cpu_svg}) / [pprof]({rel_cpu_pprof}))"
+                else:
+                    cpu_link = f"[SVG]({rel_cpu_svg}) ([pprof]({rel_cpu_pprof}))"
+                
+            if mem_svg and mem_pprof:
+                rel_mem_svg = os.path.relpath(mem_svg, results_dir)
+                rel_mem_pprof = os.path.relpath(mem_pprof, results_dir)
+                if mem_png:
+                    rel_mem_png = os.path.relpath(mem_png, results_dir)
+                    mem_link = f"[PNG]({rel_mem_png}) ([SVG]({rel_mem_svg}) / [pprof]({rel_mem_pprof}))"
+                else:
+                    mem_link = f"[SVG]({rel_mem_svg}) ([pprof]({rel_mem_pprof}))"
+
         # Write rows for each container
         for container in sorted(peak_metrics.keys()):
             idle_cpu = idle_metrics.get(container, {}).get('cpu', '-')
@@ -491,7 +521,133 @@ def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, route
             peak_cpu = peak_metrics.get(container, {}).get('cpu', '-')
             peak_mem = peak_metrics.get(container, {}).get('mem', '-')
             
-            f.write(f"| {run_time} | {ns} | {config_link} | {job_link} | {mf_str} | {sim_replicas} | {epp_images} | {container} | {idle_cpu} | {idle_mem} | {peak_cpu} | {peak_mem} | {p50:.2f} | {p95:.2f} | {status} |\n")
+            f.write(f"| {run_time} | {ns} | {config_link} | {job_link} | {mf_str} | {sim_replicas} | {epp_images} | {container} | {idle_cpu} | {idle_mem} | {peak_cpu} | {peak_mem} | {p50:.2f} | {p95:.2f} | {cpu_link} | {mem_link} | {status} |\n")
+
+
+def collect_profiles(ns, epp_pod_name, results_dir, test_name, run_time_clean, profile_results):
+    os.makedirs(results_dir, exist_ok=True)
+    print("Profile collector: waiting for benchmark job to be created...")
+    job_pod_name = ""
+    for _ in range(120):
+        res = run_cmd(f"kubectl get pods -n {ns} -l app=inference-perf -o jsonpath='{{.items[0].metadata.name}}'", check=False)
+        if res.returncode == 0 and res.stdout.strip():
+            job_pod_name = res.stdout.strip()
+            break
+        time.sleep(5)
+        
+    if not job_pod_name:
+        print("Profile collector: timed out waiting for benchmark job pod. Profiles will not be collected.")
+        return
+
+    print(f"Profile collector: found benchmark pod {job_pod_name}. Waiting for it to start running...")
+    pod_running = False
+    for _ in range(120): # Wait up to 10 minutes
+        phase_res = run_cmd(f"kubectl get pod {job_pod_name} -n {ns} -o jsonpath='{{.status.phase}}'", check=False)
+        if phase_res.returncode == 0 and phase_res.stdout.strip() == "Running":
+            pod_running = True
+            break
+        time.sleep(5)
+        
+    if not pod_running:
+        print(f"Profile collector: pod {job_pod_name} did not enter Running state. Exiting.")
+        return
+
+    print(f"Profile collector: pod {job_pod_name} is running. Monitoring logs for 'Stage 1 - run started'...")
+    
+    log_proc = subprocess.Popen(
+        ["kubectl", "logs", "-n", ns, job_pod_name, "-f"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True
+    )
+    
+    found_started = False
+    start_time = time.time()
+    timeout = 300
+    
+    while True:
+        if time.time() - start_time > timeout:
+            print("Profile collector: timed out waiting for log line 'Stage 1 - run started'")
+            break
+            
+        if log_proc.poll() is not None:
+            break
+            
+        line = log_proc.stdout.readline()
+        if not line:
+            time.sleep(1)
+            continue
+            
+        if "Stage 1 - run started" in line:
+            print("Profile collector: detected 'Stage 1 - run started' in logs!")
+            found_started = True
+            break
+            
+    log_proc.terminate()
+    log_proc.wait()
+    
+    if not found_started:
+        print("Profile collector: failed to detect run start. Exiting.")
+        return
+        
+    print("Profile collector: waiting 60 seconds before initiating profiling...")
+    time.sleep(60)
+    
+    pf_port = random.randint(30000, 40000)
+    print(f"Profile collector: port-forwarding to EPP pod {epp_pod_name} on port {pf_port}...")
+    pf_process = subprocess.Popen(
+        ["kubectl", "port-forward", "-n", ns, f"pod/{epp_pod_name}", f"{pf_port}:9090"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
+    time.sleep(5)
+    
+    try:
+        artifact_dir = os.path.join(results_dir, f"{test_name}-{run_time_clean}")
+        os.makedirs(artifact_dir, exist_ok=True)
+
+        cpu_profile_path = os.path.join(artifact_dir, f"{test_name}-{run_time_clean}-cpu.pprof")
+        cpu_svg_path = os.path.join(artifact_dir, f"{test_name}-{run_time_clean}-cpu.svg")
+        cpu_png_path = os.path.join(artifact_dir, f"{test_name}-{run_time_clean}-cpu.png")
+        print("Profile collector: fetching CPU profile (30s)...")
+        req = urllib.request.Request(f"http://localhost:{pf_port}/debug/pprof/profile?seconds=30")
+        with urllib.request.urlopen(req, timeout=45) as response:
+            cpu_data = response.read()
+        with open(cpu_profile_path, "wb") as f:
+            f.write(cpu_data)
+        print(f"Profile collector: CPU profile saved to {cpu_profile_path}")
+
+        mem_profile_path = os.path.join(artifact_dir, f"{test_name}-{run_time_clean}-memory.pprof")
+        mem_svg_path = os.path.join(artifact_dir, f"{test_name}-{run_time_clean}-memory.svg")
+        mem_png_path = os.path.join(artifact_dir, f"{test_name}-{run_time_clean}-memory.png")
+        print("Profile collector: fetching memory (heap) profile...")
+        req = urllib.request.Request(f"http://localhost:{pf_port}/debug/pprof/heap")
+        with urllib.request.urlopen(req, timeout=15) as response:
+            mem_data = response.read()
+        with open(mem_profile_path, "wb") as f:
+            f.write(mem_data)
+        print(f"Profile collector: Memory profile saved to {mem_profile_path}")
+
+        print("Profile collector: generating visualizations using go tool pprof...")
+        run_cmd(f"go tool pprof -svg -output {cpu_svg_path} {cpu_profile_path}")
+        run_cmd(f"go tool pprof -png -output {cpu_png_path} {cpu_profile_path}")
+        run_cmd(f"go tool pprof -svg -output {mem_svg_path} {mem_profile_path}")
+        run_cmd(f"go tool pprof -png -output {mem_png_path} {mem_profile_path}")
+        print(f"Profile collector: visualizations generated in {artifact_dir}")
+        
+        profile_results['cpu_pprof'] = cpu_profile_path
+        profile_results['cpu_svg'] = cpu_svg_path
+        profile_results['cpu_png'] = cpu_png_path
+        profile_results['mem_pprof'] = mem_profile_path
+        profile_results['mem_svg'] = mem_svg_path
+        profile_results['mem_png'] = mem_png_path
+
+    except Exception as e:
+        print(f"Profile collector failed with error: {e}")
+    finally:
+        pf_process.terminate()
+        pf_process.wait()
+
 
 
 def main():
@@ -525,6 +681,8 @@ def main():
     parser.add_argument("--epp-cpu", default="2", help="EPP CPU request (limit will be 2x this amount)")
     parser.add_argument("--epp-memory", default="4Gi", help="EPP memory request (limit will be 2x this amount)")
     parser.add_argument("--router-machine-family", default=None, help="Add node affinity for specific Google Cloud machine-family (e.g. c3)")
+    parser.add_argument("--collect-pprof-profiles", action="store_true", help="Collect EPP CPU & memory pprof profiles and render them as SVGs")
+    parser.add_argument("--gcs-bucket", default=None, help="Optional GCS bucket name or URI (e.g. gs://my-bucket) to sync performance results to")
     args = parser.parse_args()
 
 
@@ -540,6 +698,14 @@ def main():
     peak_metrics = {}
     p50, p95 = 0.0, 0.0
     images = []
+    profile_results = {
+        'cpu_pprof': None,
+        'cpu_svg': None,
+        'cpu_png': None,
+        'mem_pprof': None,
+        'mem_svg': None,
+        'mem_png': None
+    }
 
     try:
         # Step 1: Create Namespace
@@ -627,11 +793,19 @@ def main():
         monitoring_thread = Thread(target=monitor_resources_loop, args=(ns, pod_name, 5, peak_metrics))
         monitoring_thread.start()
 
+        profile_thread = None
+        if args.collect_pprof_profiles:
+            run_time_clean = run_time.replace(" ", "_").replace(":", "")
+            profile_thread = Thread(target=collect_profiles, args=(ns, pod_name, args.results_dir, args.test_name, run_time_clean, profile_results))
+            profile_thread.start()
+
         try:
             run_benchmark(ns, args.perf_job, args.perf_chart, release_name)
         finally:
             stop_monitoring = True
             monitoring_thread.join()
+            if profile_thread:
+                profile_thread.join()
 
         # Step 8: Scrape Post-Benchmark Metrics & Compute Latency
         metrics_after = scrape_scheduler_metrics(ns, pod_name)
@@ -651,8 +825,16 @@ def main():
         else:
             print(f"Skipping namespace cleanup. Namespace '{ns}' remains active.")
 
-        # Step 10: Log Results to Markdown File
+        # Step 10: Log Results to Markdown File and optional GCS sync
         if idle_metrics or peak_metrics:
+            gcs_dest = None
+            if args.gcs_bucket:
+                bucket = args.gcs_bucket if args.gcs_bucket.startswith("gs://") else f"gs://{args.gcs_bucket}"
+                recipe_folder = os.path.basename(os.path.normpath(args.results_dir))
+                gcs_dest = f"{bucket}/{recipe_folder}"
+                print(f"Syncing existing performance results from GCS bucket {gcs_dest}...")
+                run_cmd(f"gcloud storage cp -r {gcs_dest}/* {args.results_dir}/", check=False)
+
             write_results_to_markdown_folder(
                 args.results_dir, 
                 args.test_name,
@@ -667,9 +849,15 @@ def main():
                 peak_metrics, 
                 p50, 
                 p95, 
-                status
+                status,
+                profile_results=profile_results
             )
             print(f"Performance results successfully written to {args.results_dir}/{args.test_name}.md")
+
+            if gcs_dest:
+                print(f"Uploading performance results to GCS bucket {gcs_dest}...")
+                run_cmd(f"gcloud storage cp -r {args.results_dir}/* {gcs_dest}/")
+                print(f"Successfully uploaded performance results to {gcs_dest}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds pprof memory and CPU profile collection to the epp performance test and uploads the results to GCS bucket. It also saves png and svg files that can be used to visualize the pprof profiles.

I tested this script and workflow via my own llm-d-router fork.

Below are visualized svg files:
CPU: 
<img width="300" height="150" alt="optimized-baseline_optimized-baseline-job1-2026-07-14_233623_optimized-baseline-job1-2026-07-14_233623-cpu" src="https://github.com/user-attachments/assets/3b038a9e-0acb-4608-9f4c-a597d29eb889" />

Memory: 
<img width="300" height="150" alt="optimized-baseline_optimized-baseline-job1-2026-07-14_233623_optimized-baseline-job1-2026-07-14_233623-memory" src="https://github.com/user-attachments/assets/3baa5fe3-3cca-4a19-b82d-01b818a5b4a4" />


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

\kind test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#1906 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
