### PR TITLE
ci: aggregate matrix job results into single status checks

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -1,3 +1,6 @@
+# Matrix jobs (e2e-image-common, e2e-image-router, e2e-router) are each
+# followed by a *-status job that aggregates their result, since GitHub
+# required status checks cannot reference individual matrix legs.
 name: CI - Test
 
 on:
@@ -256,6 +259,19 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  e2e-image-common-status:
+    needs: e2e-image-common
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e-image-common result
+        run: |
+          result="${{ needs.e2e-image-common.result }}"
+          if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+            echo "::error::e2e-image-common failed for at least one matrix image"
+            exit 1
+          fi
+
   e2e-image-router:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.src == 'true' }}
@@ -305,6 +321,19 @@ jobs:
           path: ${{ runner.temp }}/${{ matrix.image.archive }}.tar
           retention-days: 1
           compression-level: 0
+
+  e2e-image-router-status:
+    needs: e2e-image-router
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e-image-router result
+        run: |
+          result="${{ needs.e2e-image-router.result }}"
+          if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+            echo "::error::e2e-image-router failed for at least one matrix image"
+            exit 1
+          fi
 
   e2e-router:
     needs:
@@ -393,3 +422,16 @@ jobs:
           PULL_VLLM_RENDER_IMAGE: "false"
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make test-e2e-run
+
+  e2e-router-status:
+    needs: e2e-router
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e-router result
+        run: |
+          result="${{ needs.e2e-router.result }}"
+          if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+            echo "::error::e2e-router failed for at least one matrix suite"
+            exit 1
+          fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds a status-aggregator job for each matrix job in ci-pr-checks.yaml (e2e-image-common, e2e-image-router, e2e-router). Individual matrix legs can't be required as branch protection checks without listing every suite by name, so a failing leg outside that list doesn't block merge.

After this merges, the main branch ruleset needs the following required checks added, replacing any per-suite entries:
- e2e-image-common-status
- e2e-image-router-status
- e2e-router-status

**Which issue(s) this PR fixes**:
Fixes #2027

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```