### PR TITLE
docs: document flow_control_requests_total metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -113,6 +113,29 @@ Exposed when the `flowControl` feature gate is enabled. All carry the `llm_d_epp
 *   **Description:** Current saturation level of the inference pool (0.0 = empty, 1.0 = fully saturated).
 *   **Usage:** When saturation reaches the usage limit threshold, the dispatch cycle skips dispatching and requests remain queued. Sustained 1.0 indicates all backends are at capacity.
 
+### `flow_control_requests_total`
+
+*   **Type:** Counter
+*   **Labels:**
+    *   `outcome`: string — the terminal outcome of the request. One of:
+        *   `Dispatched` — request was forwarded to a backend
+        *   `RejectedCapacity` — request was rejected because the queue was at capacity
+        *   `RejectedNoEndpoints` — request was rejected at the capacity boundary while the candidate pool had no endpoints (surfaces as HTTP 503 rather than 429)
+        *   `RejectedOther` — request was rejected for another reason (e.g., controller shutdown)
+        *   `EvictedTTL` — request exceeded its time-to-live while waiting in the queue
+        *   `EvictedContextCancelled` — client disconnected before the request was dispatched
+        *   `EvictedOther` — request was evicted for another reason
+    *   `priority`: string (the priority band, e.g., `"0"`, `"10"`)
+    *   `inference_pool`: string
+*   **Release Stage:** ALPHA
+*   **Description:** Total number of requests processed by the Flow Control layer, incremented once per request after its terminal outcome is determined.
+*   **Usage:** Provides a direct signal for rejection and eviction rates without log parsing. Unlike `flow_control_request_queue_duration_seconds_count`, this counter also captures controller-level early rejections where no queue item is created (e.g., rejection during controller shutdown), covering cases the histogram misses.
+*   **Actionability:**
+    *   A rising rate of `outcome="RejectedCapacity"` indicates the queue capacity limits are too tight or backends are persistently saturated — consider tuning `maxBytes`/`maxRequests` or scaling backends.
+    *   A rising rate of `outcome="RejectedNoEndpoints"` indicates the inference pool has scaled to zero or all endpoints are unregistered — investigate pool health and scaling configuration.
+    *   A rising rate of `outcome="EvictedTTL"` indicates requests are waiting longer than their TTL allows — investigate backend throughput or tighten admission.
+    *   `outcome="Dispatched"` is the healthy baseline; compare it against total request rate to derive the acceptance ratio.
+
 
 ## Opt-in ext_proc Stream Metrics
 


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it

Documents the `flow_control_requests_total` counter metric added in #1636 in `docs/metrics.md`.

This documentation includes:
- The metric type (`Counter`).
- All supported label values with descriptions.
- Actionability guidance for each outcome.
- An explanation of how this metric complements `flow_control_request_queue_duration_seconds_count` by covering controller-level early rejections where no queue item is created.

## Which issue(s) this PR fixes

Fixes #1854

## Release note

```release-note
Document flow_control_requests_total flow control metric in docs/metrics.md.
```
