### PR TITLE
fix(datalayer): set maxIdleTime to Transport.IdleConnTimeout

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/source/http/client.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/client.go
@@ -59,6 +59,7 @@ var (
 	baseTransport = &http.Transport{
 		MaxIdleConns:        maxIdleConnections,
 		MaxIdleConnsPerHost: maxIdleConnsPerHost,
+		IdleConnTimeout:     maxIdleTime,
 		// TODO: set additional timeouts, transport options, etc.
 	}
 )


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind bug
**What this PR does / why we need it**:
The `maxIdleTime` constant in
  `pkg/epp/framework/plugins/datalayer/source/http/client.go` has been defined
  since #1237 with a comment stating its purpose ("once a endpoint goes down,
  allow closing"), but was never wired to `http.Transport.IdleConnTimeout`.
  
  https://github.com/llm-d/llm-d-router/blob/d632664436e0f9d1de8609eb64d94c9d37353bea/pkg/epp/framework/plugins/datalayer/source/http/client.go#L50

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
