### PR TITLE
fix: return gRPC Unavailable on infrastructure errors for Fail-Open

### DIFF
--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -68,6 +68,15 @@ const (
 	ResourceExhausted  = "ResourceExhausted"
 )
 
+// Infrastructure error substrings used to detect EPP readiness/datastore failures
+// where Envoy should fail open (failure_mode_allow: true).
+const (
+	ErrSubstrNoPodsAvailable        = "no pods available in datastore"
+	ErrSubstrFailedToFindCandidates = "failed to find endpoint candidates"
+	ErrSubstrDatastoreNotSynced     = "datastore not synced"
+	ErrSubstrNotServing             = "not serving"
+)
+
 // Error returns a string version of the error.
 func (e Error) Error() string {
 	return fmt.Sprintf("inference error: %s - %s", e.Code, e.Msg)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -233,6 +233,20 @@ func extractFairnessAndPriority(reqCtx *RequestContext) (string, string) {
 	return fairnessID, priority
 }
 
+// isInfrastructureError returns true if the error represents an EPP readiness or infrastructure
+// failure where Envoy should trigger failure_mode_allow: true (Fail-Open) rather than
+// returning an immediate HTTP error response.
+func isInfrastructureError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, errcommon.ErrSubstrNoPodsAvailable) ||
+		strings.Contains(msg, errcommon.ErrSubstrFailedToFindCandidates) ||
+		strings.Contains(msg, errcommon.ErrSubstrDatastoreNotSynced) ||
+		strings.Contains(msg, errcommon.ErrSubstrNotServing)
+}
+
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	ctx := srv.Context()
 
@@ -517,6 +531,9 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				logger.V(logutil.DEBUG).Error(err, "Failed to process request", "request", req)
 			} else {
 				logger.Error(err, "Failed to process request")
+			}
+			if isInfrastructureError(err) {
+				return status.Error(codes.Unavailable, err.Error())
 			}
 			resp, err := errcommon.BuildErrResponse(err)
 			if err != nil {

--- a/pkg/epp/handlers/server_failopen_test.go
+++ b/pkg/epp/handlers/server_failopen_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsInfrastructureError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "no pods available in datastore",
+			err:      errors.New("inference error: Internal - no pods available in datastore"),
+			expected: true,
+		},
+		{
+			name:     "failed to find endpoint candidates",
+			err:      errors.New("inference error: ServiceUnavailable - failed to find endpoint candidates for serving the request"),
+			expected: true,
+		},
+		{
+			name:     "datastore not synced",
+			err:      errors.New("datastore not synced yet"),
+			expected: true,
+		},
+		{
+			name:     "not serving",
+			err:      errors.New("EPP is not serving requests"),
+			expected: true,
+		},
+		{
+			name:     "client bad request payload",
+			err:      errors.New("invalid request body JSON format"),
+			expected: false,
+		},
+		{
+			name:     "model not found policy error",
+			err:      errors.New("model 'llama3' not authorized for user"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isInfrastructureError(tc.err)
+			if got != tc.expected {
+				t.Errorf("isInfrastructureError(%v) = %v, want %v", tc.err, got, tc.expected)
+			}
+		})
+	}
+}

--- a/test/integration/epp/common_tests.go
+++ b/test/integration/epp/common_tests.go
@@ -25,6 +25,7 @@ import (
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"google.golang.org/grpc/codes"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	integration "github.com/llm-d/llm-d-router/test/integration"
@@ -286,6 +287,8 @@ type testCase struct {
 	requiresCRDs bool
 	// wantSpans lists the span names expected to be recorded (hermetic tests only).
 	wantSpans []string
+	// wantErrCode asserts that the gRPC stream terminates with the specified gRPC status code (e.g. codes.Unavailable for Fail-Open).
+	wantErrCode codes.Code
 }
 
 // commonTestCases returns the test cases shared between the standard and data layer test suites.
@@ -321,11 +324,10 @@ func commonTestCases(prio func(int) int) []testCase {
 			},
 		},
 		{
-			name:     "no backend pods available",
-			requests: integration.ReqHeaderOnly(map[string]string{"content-type": "application/json"}),
-			pods:     nil,
-			wantResponses: ExpectReject(envoyTypePb.StatusCode_InternalServerError,
-				"inference error: Internal - no pods available in datastore"),
+			name:        "no backend pods available",
+			requests:    integration.ReqHeaderOnly(map[string]string{"content-type": "application/json"}),
+			pods:        nil,
+			wantErrCode: codes.Unavailable,
 		},
 		{
 			name: "request missing model field",

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -25,6 +25,8 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
@@ -69,6 +71,7 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 		// requiresCRDs indicates that this test case relies on specific Gateway API CRD features (like
 		// InferenceModelRewrite) which are not available in Standalone runMode without CRD.
 		requiresCRDs bool
+		wantErrCode  codes.Code
 	}{
 		// --- Standard Routing Logic ---
 		{
@@ -167,11 +170,10 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 		},
 		{
-			name:     "no backend pods available",
-			requests: integration.ReqHeaderOnly(map[string]string{"content-type": "application/json"}),
-			pods:     nil,
-			wantResponses: ExpectReject(envoyTypePb.StatusCode_InternalServerError,
-				"inference error: Internal - no pods available in datastore"),
+			name:        "no backend pods available",
+			requests:    integration.ReqHeaderOnly(map[string]string{"content-type": "application/json"}),
+			pods:        nil,
+			wantErrCode: codes.Unavailable,
 		},
 
 		// // --- Subsetting & Metadata ---
@@ -469,6 +471,11 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			}
 
 			responses, err := integration.StreamedRequest(t, h.Client, tc.requests, len(tc.wantResponses))
+			if tc.wantErrCode != codes.OK && tc.wantErrCode != 0 {
+				require.Error(t, err)
+				require.Equal(t, tc.wantErrCode, status.Code(err))
+				return
+			}
 			require.NoError(t, err)
 
 			if diff := cmp.Diff(tc.wantResponses, responses,

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -247,11 +249,10 @@ dataLayer:
 					},
 				},
 				{
-					name:     "no backend pods available",
-					requests: integration.ReqHeaderOnly(map[string]string{"content-type": "application/json"}),
-					pods:     nil,
-					wantResponses: ExpectReject(envoyTypePb.StatusCode_InternalServerError,
-						"inference error: Internal - no pods available in datastore"),
+					name:        "no backend pods available",
+					requests:    integration.ReqHeaderOnly(map[string]string{"content-type": "application/json"}),
+					pods:        nil,
+					wantErrCode: codes.Unavailable,
 				},
 				{
 					name: "request missing model field",
@@ -468,6 +469,11 @@ dataLayer:
 					}
 
 					responses, err := integration.StreamedRequest(t, h.Client, tc.requests, len(tc.wantResponses))
+					if tc.wantErrCode != codes.OK && tc.wantErrCode != 0 {
+						require.Error(t, err)
+						assert.Equal(t, tc.wantErrCode, status.Code(err))
+						return
+					}
 					require.NoError(t, err)
 
 					if diff := cmp.Diff(tc.wantResponses, responses,

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -514,9 +514,14 @@ func StreamedRequest(
 	// Buffered channel avoids blocking the goroutine on the last read.
 	recvChan := make(chan recvResult, expectedResponses+1)
 
+	readsCount := expectedResponses
+	if readsCount == 0 {
+		readsCount = 1
+	}
+
 	// Start reading in background.
 	go func() {
-		for range expectedResponses {
+		for range readsCount {
 			res, err := client.Recv()
 			recvChan <- recvResult{res, err}
 			if err != nil {
@@ -531,10 +536,10 @@ func StreamedRequest(
 	defer cancel()
 
 	// Collect results with timeout.
-	for i := range expectedResponses {
+	for i := range readsCount {
 		select {
 		case <-ctx.Done():
-			t.Logf("Timeout waiting for response %d of %d: %v", i+1, expectedResponses, ctx.Err())
+			t.Logf("Timeout waiting for response %d of %d: %v", i+1, readsCount, ctx.Err())
 			return responses, fmt.Errorf("timeout waiting for responses: %w", ctx.Err())
 
 		case result := <-recvChan:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Return status.Error(codes.Unavailable) directly instead of wrapping errors inside an ImmediateResponse protobuf. This enables Envoy's ext_proc filter (when failure_mode_allow: true) to catch the upstream stream error and fail open to the upstream model server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2051

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
