### PR TITLE
chore: remove deprecated sidecar flags

### DIFF
--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -76,14 +76,6 @@ const (
 	configurationFile         = "configuration-file"
 	tracingFlag               = "tracing"
 
-	// Deprecated flags
-	connector                      = "connector"
-	prefillerUseTLS                = "prefiller-use-tls"
-	decoderUseTLS                  = "decoder-use-tls"
-	encoderUseTLS                  = "UseTLSForEncoder"
-	prefillerTLSInsecureSkipVerify = "prefiller-tls-insecure-skip-verify"
-	decoderTLSInsecureSkipVerify   = "decoder-tls-insecure-skip-verify"
-
 	// Environment variables
 	envInferencePool           = "INFERENCE_POOL"
 	envEnablePrefillerSampling = "ENABLE_PREFILLER_SAMPLING"
@@ -105,32 +97,27 @@ const (
 
 // yamlConfiguration represents structure of YAML configuration for sidecar proxy
 type yamlConfiguration struct {
-	Port                           int      `json:"port,omitempty"`
-	VLLMPort                       int      `json:"vllm-port,omitempty"`
-	MooncakeBootstrapPort          int      `json:"mooncake-bootstrap-port,omitempty"`
-	P2PConnectorPort               int      `json:"p2p-connector-port,omitempty"`
-	DataParallelSize               int      `json:"data-parallel-size,omitempty"`
-	KVConnector                    string   `json:"kv-connector,omitempty"`
-	Connector                      string   `json:"connector,omitempty"`
-	ECConnector                    string   `json:"ec-connector,omitempty"`
-	EnableSSRFProtection           *bool    `json:"enable-ssrf-protection,omitempty"`
-	EnablePrefillerSampling        *bool    `json:"enable-prefiller-sampling,omitempty"`
-	EnableP2PPull                  *bool    `json:"enable-p2p-pull,omitempty"`
-	SecureServing                  *bool    `json:"secure-proxy,omitempty"`
-	CertPath                       string   `json:"cert-path,omitempty"`
-	EnableTLS                      []string `json:"enable-tls,omitempty"`
-	TLSInsecureSkipVerify          []string `json:"tls-insecure-skip-verify,omitempty"`
-	PrefillerUseTLS                *bool    `json:"prefiller-use-tls,omitempty"`
-	DecoderUseTLS                  *bool    `json:"decoder-use-tls,omitempty"`
-	PrefillerTLSInsecureSkipVerify *bool    `json:"prefiller-tls-insecure-skip-verify,omitempty"`
-	DecoderTLSInsecureSkipVerify   *bool    `json:"decoder-tls-insecure-skip-verify,omitempty"`
-	InferencePool                  string   `json:"inference-pool,omitempty"`
-	PoolGroup                      string   `json:"pool-group,omitempty"`
-	MaxIdleConnsPerHost            int      `json:"max-idle-conns-per-host,omitempty"`
-	PrefillMaxRetries              *int     `json:"prefill-max-retries,omitempty"`
-	PrefillRetryBackoff            string   `json:"prefill-retry-backoff,omitempty"`
-	DecodeChunkSize                int      `json:"decode-chunk-size,omitempty"`
-	Tracing                        *bool    `json:"tracing,omitempty"`
+	Port                    int      `json:"port,omitempty"`
+	VLLMPort                int      `json:"vllm-port,omitempty"`
+	MooncakeBootstrapPort   int      `json:"mooncake-bootstrap-port,omitempty"`
+	P2PConnectorPort        int      `json:"p2p-connector-port,omitempty"`
+	DataParallelSize        int      `json:"data-parallel-size,omitempty"`
+	KVConnector             string   `json:"kv-connector,omitempty"`
+	ECConnector             string   `json:"ec-connector,omitempty"`
+	EnableSSRFProtection    *bool    `json:"enable-ssrf-protection,omitempty"`
+	EnablePrefillerSampling *bool    `json:"enable-prefiller-sampling,omitempty"`
+	EnableP2PPull           *bool    `json:"enable-p2p-pull,omitempty"`
+	SecureServing           *bool    `json:"secure-proxy,omitempty"`
+	CertPath                string   `json:"cert-path,omitempty"`
+	EnableTLS               []string `json:"enable-tls,omitempty"`
+	TLSInsecureSkipVerify   []string `json:"tls-insecure-skip-verify,omitempty"`
+	InferencePool           string   `json:"inference-pool,omitempty"`
+	PoolGroup               string   `json:"pool-group,omitempty"`
+	MaxIdleConnsPerHost     int      `json:"max-idle-conns-per-host,omitempty"`
+	PrefillMaxRetries       *int     `json:"prefill-max-retries,omitempty"`
+	PrefillRetryBackoff     string   `json:"prefill-retry-backoff,omitempty"`
+	DecodeChunkSize         int      `json:"decode-chunk-size,omitempty"`
+	Tracing                 *bool    `json:"tracing,omitempty"`
 }
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
@@ -150,13 +137,6 @@ type Options struct {
 	tlsInsecureSkipVerify []string
 	// inferencePool in namespace/name or name format; used to compute Config.InferencePoolNamespace/Name in Complete().
 	inferencePool string
-
-	// Deprecated flag fields - kept for backward compatibility; migrated in Complete()
-	connector                   string // Deprecated: use --kv-connector instead
-	prefillerUseTLS             bool   // Deprecated: use --enable-tls=prefiller instead
-	decoderUseTLS               bool   // Deprecated: use --enable-tls=decoder instead
-	prefillerInsecureSkipVerify bool   // Deprecated: use --tls-insecure-skip-verify=prefiller instead
-	decoderInsecureSkipVerify   bool   // Deprecated: use --tls-insecure-skip-verify=decoder instead
 
 	loggingOptions      zap.Options // loggingOptions holds the zap logging configuration
 	pflagSet            *pflag.FlagSet
@@ -217,6 +197,7 @@ func NewOptions() *Options {
 	return &Options{
 		Config: Config{
 			Port:                    defaultPort,
+			KVConnector:             KVConnectorNIXLV2,
 			DataParallelSize:        defaultDataParallelSize,
 			SecureServing:           true,
 			EnablePrefillerSampling: enablePrefillerSampling,
@@ -246,7 +227,6 @@ func NewOptions() *Options {
 		},
 		vllmPort:      defaultVLLMPort,
 		inferencePool: os.Getenv(envInferencePool),
-		connector:     KVConnectorNIXLV2,
 	}
 }
 
@@ -326,19 +306,6 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, tlsInsecureSkipVerify, opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
 	fs.StringVar(&opts.inferencePool, inferencePool, opts.inferencePool, "InferencePool in namespace/name or name format (e.g., default/my-pool or my-pool). A single name implies the 'default' namespace. Can also use INFERENCE_POOL env var.")
 
-	// Deprecated flags - kept for backward compatibility
-	fs.StringVar(&opts.connector, connector, opts.connector, "Deprecated: use --kv-connector instead. The P/D connector being used. Supported: "+supportedKVConnectorNamesStr)
-	_ = fs.MarkDeprecated(connector, "use --kv-connector instead")
-
-	fs.BoolVar(&opts.prefillerUseTLS, prefillerUseTLS, opts.prefillerUseTLS, "Deprecated: use --enable-tls=prefiller instead. Whether to use TLS when sending requests to prefillers.")
-	_ = fs.MarkDeprecated(prefillerUseTLS, "use --enable-tls=prefiller instead")
-	fs.BoolVar(&opts.decoderUseTLS, "decoder-use-tls", opts.decoderUseTLS, "Deprecated: use --enable-tls=decoder instead. Whether to use TLS when sending requests to the decoder.")
-	_ = fs.MarkDeprecated(decoderUseTLS, "use --enable-tls=decoder instead")
-	fs.BoolVar(&opts.prefillerInsecureSkipVerify, prefillerTLSInsecureSkipVerify, opts.prefillerInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=prefiller instead. Skip TLS verification for requests to prefiller.")
-	_ = fs.MarkDeprecated(prefillerTLSInsecureSkipVerify, "use --tls-insecure-skip-verify=prefiller instead")
-	fs.BoolVar(&opts.decoderInsecureSkipVerify, decoderTLSInsecureSkipVerify, opts.decoderInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=decoder instead. Skip TLS verification for requests to decoder.")
-	_ = fs.MarkDeprecated(decoderTLSInsecureSkipVerify, "use --tls-insecure-skip-verify=decoder instead")
-
 	fs.IntVar(&opts.MaxIdleConnsPerHost, "max-idle-conns-per-host", opts.MaxIdleConnsPerHost, "max idle keep-alive connections per host for reverse proxy transports; set to at least the expected concurrency")
 	fs.IntVar(&opts.PrefillMaxRetries, prefillMaxRetries, opts.PrefillMaxRetries, "max retry attempts when a prefill request fails with a 5xx error; 0 means no retries (default)")
 	fs.DurationVar(&opts.PrefillRetryBackoff, prefillRetryBackoff, opts.PrefillRetryBackoff, "delay between prefill retry attempts")
@@ -365,11 +332,6 @@ func (opts *Options) Complete() error {
 		return err
 	}
 
-	// Migrate deprecated connector flag to KVConnector
-	if opts.connector != "" && opts.KVConnector == "" {
-		opts.KVConnector = opts.connector
-	}
-
 	// Parse inferencePool field (namespace/name or just name) into Config.
 	if opts.inferencePool != "" {
 		parts := strings.SplitN(opts.inferencePool, "/", 2)
@@ -380,20 +342,6 @@ func (opts *Options) Complete() error {
 			opts.InferencePoolNamespace = "default"
 			opts.InferencePoolName = parts[0]
 		}
-	}
-
-	// Migrate deprecated boolean TLS flags into enableTLS/tlsInsecureSkipVerify slices
-	if opts.prefillerUseTLS && !slices.Contains(opts.enableTLS, prefillStage) {
-		opts.enableTLS = append(opts.enableTLS, prefillStage)
-	}
-	if opts.decoderUseTLS && !slices.Contains(opts.enableTLS, decodeStage) {
-		opts.enableTLS = append(opts.enableTLS, decodeStage)
-	}
-	if opts.prefillerInsecureSkipVerify && !slices.Contains(opts.tlsInsecureSkipVerify, prefillStage) {
-		opts.tlsInsecureSkipVerify = append(opts.tlsInsecureSkipVerify, prefillStage)
-	}
-	if opts.decoderInsecureSkipVerify && !slices.Contains(opts.tlsInsecureSkipVerify, decodeStage) {
-		opts.tlsInsecureSkipVerify = append(opts.tlsInsecureSkipVerify, decodeStage)
 	}
 
 	// Compute Config TLS fields from stage slices
@@ -519,13 +467,6 @@ func (opts *Options) Validate() error {
 	if opts.ECConnector != "" {
 		if _, ok := supportedECConnectors[opts.ECConnector]; !ok {
 			return fmt.Errorf("--ec-connector must be one of: %s", supportedECConnectorNamesStr)
-		}
-	}
-
-	// Validate deprecated connector flag
-	if opts.connector != "" && opts.connector != opts.KVConnector {
-		if _, ok := supportedKVConnectors[opts.connector]; !ok {
-			return fmt.Errorf("--connector must be one of: %s", supportedKVConnectorNamesStr)
 		}
 	}
 
@@ -687,9 +628,6 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	if cfg.KVConnector != "" && !opts.isFlagSet(kvConnector) {
 		opts.KVConnector = cfg.KVConnector
 	}
-	if cfg.Connector != "" && !opts.isFlagSet(connector) {
-		opts.connector = cfg.Connector
-	}
 	if cfg.ECConnector != "" && !opts.isFlagSet(ecConnector) {
 		opts.ECConnector = cfg.ECConnector
 	}
@@ -716,26 +654,6 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	}
 	if len(cfg.TLSInsecureSkipVerify) > 0 && !opts.isFlagSet(tlsInsecureSkipVerify) {
 		opts.tlsInsecureSkipVerify = cfg.TLSInsecureSkipVerify
-	}
-
-	// update prefiller/decoder TLS settings from deprecated YAML fields if corresponding new fields are not set by user via flags
-	// (i.e., prefillerUseTLS only applies if --enable-tls and --prefiller-use-tls are not set,
-	// and decoderUseTLS only applies if --enable-tls and --decoder-use-tls are not set)
-	if cfg.PrefillerUseTLS != nil && !opts.isFlagSet(enableTLS) && !opts.isFlagSet(prefillerUseTLS) {
-		opts.prefillerUseTLS = *cfg.PrefillerUseTLS
-	}
-	if cfg.DecoderUseTLS != nil && !opts.isFlagSet(enableTLS) && !opts.isFlagSet(decoderUseTLS) {
-		opts.decoderUseTLS = *cfg.DecoderUseTLS
-	}
-
-	// update prefiller/decoder TLS insecure skip verify settings from deprecated YAML fields if corresponding new fields are not set by user via flags
-	// (i.e., prefillerTLSInsecureSkipVerify only applies if --tls-insecure-skip-verify and --prefiller-tls-insecure-skip-verify are not set,
-	// and decoderTLSInsecureSkipVerify only applies if --tls-insecure-skip-verify and --decoder-tls-insecure-skip-verify are not set)
-	if cfg.PrefillerTLSInsecureSkipVerify != nil && !opts.isFlagSet(prefillerTLSInsecureSkipVerify) && !opts.isFlagSet(tlsInsecureSkipVerify) {
-		opts.prefillerInsecureSkipVerify = *cfg.PrefillerTLSInsecureSkipVerify
-	}
-	if cfg.DecoderTLSInsecureSkipVerify != nil && !opts.isFlagSet(decoderTLSInsecureSkipVerify) && !opts.isFlagSet(tlsInsecureSkipVerify) {
-		opts.decoderInsecureSkipVerify = *cfg.DecoderTLSInsecureSkipVerify
 	}
 
 	if cfg.InferencePool != "" && !opts.isFlagSet(inferencePool) {

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -46,7 +46,6 @@ port: 8100
 vllm-port: 8001
 data-parallel-size: 5
 kv-connector: %q
-connector: %q
 ec-connector: %q
 enable-ssrf-protection: true
 enable-prefiller-sampling: true
@@ -54,10 +53,8 @@ enable-p2p-pull: true
 enable-tls:
 - prefiller
 - decoder
-prefiller-use-tls: false
 tls-insecure-skip-verify:
 - prefiller
-decoder-tls-insecure-skip-verify: true
 secure-proxy: false
 cert-path: "/etc/certificates-file"
 inference-pool: "file-ns/inference-pool-file"
@@ -68,7 +65,7 @@ prefill-retry-backoff: "500ms"
 decode-chunk-size: 128
 mooncake-bootstrap-port: 9000
 tracing: true
-`, KVConnectorNIXLV2, KVConnectorSGLang, ECExampleConnector))
+`, KVConnectorNIXLV2, ECExampleConnector))
 }
 
 func createConfigWithUnknownKeys(t *testing.T) string {
@@ -95,16 +92,12 @@ func TestSidecarConfiguration(t *testing.T) {
 		vllm-port: 8021,
 		data-parallel-size: 3,
 		kv-connector: %s,
-		connector: %s,
 		ec-connector: %s,
 		enable-ssrf-protection: true,
 		enable-prefiller-sampling: true,
 		enable-p2p-pull: true,
 		enable-tls: ['prefiller', 'decoder'],
-		prefiller-use-tls: false,
-		decoder-use-tls: true,
 		tls-insecure-skip-verify: ['decoder'],
-		prefiller-tls-insecure-skip-verify: true,
 		secure-proxy: false,
 		cert-path: '/etc/certificates-inline',
 		inference-pool: inline-ns/inference-pool-inline,
@@ -115,7 +108,7 @@ func TestSidecarConfiguration(t *testing.T) {
 		decode-chunk-size: 256,
 		mooncake-bootstrap-port: 9001,
 		tracing: true
-	}`, KVConnectorNIXLV2, KVConnectorSGLang, ECExampleConnector)
+	}`, KVConnectorNIXLV2, ECExampleConnector)
 	invalidInlineYAML := "{port: 8200, invalid-yaml}"
 
 	// -- file YAML for testing ---
@@ -143,7 +136,6 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.MooncakeBootstrapPort = 9001
 
 				o.KVConnector = KVConnectorNIXLV2
-				o.connector = KVConnectorSGLang
 				o.ECConnector = ECExampleConnector
 
 				o.EnableSSRFProtection = true
@@ -155,8 +147,8 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.UseTLSForDecoder = true
 				o.UseTLSForEncoder = false
 
-				o.tlsInsecureSkipVerify = []string{prefillStage, decodeStage}
-				o.InsecureSkipVerifyForPrefiller = true
+				o.tlsInsecureSkipVerify = []string{decodeStage}
+				o.InsecureSkipVerifyForPrefiller = false
 				o.InsecureSkipVerifyForDecoder = true
 				o.InsecureSkipVerifyForEncoder = false
 
@@ -203,9 +195,9 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.UseTLSForDecoder = true
 				o.UseTLSForEncoder = false
 
-				o.tlsInsecureSkipVerify = []string{prefillStage, decodeStage}
+				o.tlsInsecureSkipVerify = []string{prefillStage}
 				o.InsecureSkipVerifyForPrefiller = true
-				o.InsecureSkipVerifyForDecoder = true
+				o.InsecureSkipVerifyForDecoder = false
 				o.InsecureSkipVerifyForEncoder = false
 
 				o.SecureServing = false
@@ -295,7 +287,6 @@ func TestSidecarConfiguration(t *testing.T) {
 				ecConnector: ECConnectorNIXL,
 			},
 			expected: func(o *Options) {
-				// Complete() migrates the default connector (KVConnectorNIXLV2) into KVConnector.
 				o.KVConnector = KVConnectorNIXLV2
 				o.ECConnector = ECConnectorNIXL
 			},
@@ -386,6 +377,13 @@ func TestSidecarConfiguration(t *testing.T) {
 			expectedError: errors.New("failed to unmarshal sidecar configuration"),
 		},
 		{
+			name: "removed connector key in YAML is rejected",
+			inputFlags: map[string]any{
+				inlineConfiguration: "{port: 8011, connector: nixlv2}",
+			},
+			expectedError: errors.New("failed to unmarshal sidecar configuration"),
+		},
+		{
 			name: "both inline and file YAML",
 			inputFlags: map[string]any{
 				inlineConfiguration: inlineYAML,
@@ -466,12 +464,12 @@ func compareOptions(t *testing.T, expected, actual *Options) {
 	assertEqual(enablePrefillerSampling, expected.EnablePrefillerSampling, actual.EnablePrefillerSampling)
 	assertEqual(enableP2PPull, expected.EnableP2PPull, actual.EnableP2PPull)
 
-	assertEqual(prefillerUseTLS, expected.UseTLSForPrefiller, actual.UseTLSForPrefiller)
-	assertEqual(decoderUseTLS, expected.UseTLSForDecoder, actual.UseTLSForDecoder)
-	assertEqual(encoderUseTLS, expected.UseTLSForEncoder, actual.UseTLSForEncoder)
+	assertEqual("UseTLSForPrefiller", expected.UseTLSForPrefiller, actual.UseTLSForPrefiller)
+	assertEqual("UseTLSForDecoder", expected.UseTLSForDecoder, actual.UseTLSForDecoder)
+	assertEqual("UseTLSForEncoder", expected.UseTLSForEncoder, actual.UseTLSForEncoder)
 
-	assertEqual(prefillerTLSInsecureSkipVerify, expected.InsecureSkipVerifyForPrefiller, actual.InsecureSkipVerifyForPrefiller)
-	assertEqual(decoderTLSInsecureSkipVerify, expected.InsecureSkipVerifyForDecoder, actual.InsecureSkipVerifyForDecoder)
+	assertEqual("InsecureSkipVerifyForPrefiller", expected.InsecureSkipVerifyForPrefiller, actual.InsecureSkipVerifyForPrefiller)
+	assertEqual("InsecureSkipVerifyForDecoder", expected.InsecureSkipVerifyForDecoder, actual.InsecureSkipVerifyForDecoder)
 	assertEqual("InsecureSkipVerifyForEncoder", expected.InsecureSkipVerifyForEncoder, actual.InsecureSkipVerifyForEncoder)
 
 	assertSlice(enableTLS, expected.enableTLS, actual.enableTLS)
@@ -688,7 +686,7 @@ func TestValidateConnector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := NewOptions()
-			opts.connector = tt.connector
+			opts.KVConnector = tt.connector
 			_ = opts.Complete() // Complete must be called before Validate
 			err := opts.Validate()
 			if (err != nil) != tt.wantErr {
@@ -1024,10 +1022,6 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 		name                         string
 		enableTLS                    []string
 		tlsInsecureSkipVerify        []string
-		deprecatedPrefillerUseTLS    bool
-		deprecatedDecoderUseTLS      bool
-		deprecatedPrefillerInsecure  bool
-		deprecatedDecoderInsecure    bool
 		vllmPort                     string
 		expectedDecoderURL           string
 		expectedUseTLSForPrefiller   bool
@@ -1090,34 +1084,6 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			expectedInsecureForPrefiller: true,
 			expectedInsecureForDecoder:   true,
 		},
-		{
-			name:                         "deprecated flags migration",
-			enableTLS:                    []string{},
-			tlsInsecureSkipVerify:        []string{},
-			deprecatedPrefillerUseTLS:    true,
-			deprecatedDecoderUseTLS:      true,
-			deprecatedPrefillerInsecure:  true,
-			deprecatedDecoderInsecure:    true,
-			vllmPort:                     "8001",
-			expectedDecoderURL:           "https://localhost:8001",
-			expectedUseTLSForPrefiller:   true,
-			expectedUseTLSForDecoder:     true,
-			expectedInsecureForPrefiller: true,
-			expectedInsecureForDecoder:   true,
-		},
-		{
-			name:                         "mixed deprecated and new flags",
-			enableTLS:                    []string{"prefiller"},
-			tlsInsecureSkipVerify:        []string{},
-			deprecatedDecoderUseTLS:      true,
-			deprecatedDecoderInsecure:    true,
-			vllmPort:                     "8001",
-			expectedDecoderURL:           "https://localhost:8001",
-			expectedUseTLSForPrefiller:   true,
-			expectedUseTLSForDecoder:     true,
-			expectedInsecureForPrefiller: false,
-			expectedInsecureForDecoder:   true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -1125,10 +1091,6 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			opts := NewOptions()
 			opts.enableTLS = tt.enableTLS
 			opts.tlsInsecureSkipVerify = tt.tlsInsecureSkipVerify
-			opts.prefillerUseTLS = tt.deprecatedPrefillerUseTLS
-			opts.decoderUseTLS = tt.deprecatedDecoderUseTLS
-			opts.prefillerInsecureSkipVerify = tt.deprecatedPrefillerInsecure
-			opts.decoderInsecureSkipVerify = tt.deprecatedDecoderInsecure
 			opts.vllmPort = tt.vllmPort
 
 			err := opts.Complete()


### PR DESCRIPTION


**What type of PR is this?**
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
flag deprecation was added in 0.7.0 (2026.02)
- `connector` is replaced by `kv-connector`
- `prefiller-use-tls` and  `decoder-use-tls` are both replaced by `enable-tls`
- `prefiller-tls-insecure-skip-verify` and `decoder-tls-insecure-skip-verify` are both replaced by `tls-insecure-skip-verify`
- yamlconfig is parsed strictly, a removed key or CLI flag now aborts sidecar startup with  error


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Ref #2039

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The following pd-sidecar flags, deprecated since v0.7.0, have been removed in 0.10
Use their replacements instead:
- `--connector` -> `--kv-connector`
- `--prefiller-use-tls` -> `--enable-tls=prefiller`
- `--decoder-use-tls` -> `--enable-tls=decoder`
- `--prefiller-tls-insecure-skip-verify` -> `--tls-insecure-skip-verify=prefiller`
- `--decoder-tls-insecure-skip-verify` -> `--tls-insecure-skip-verify=decoder`
The same names apply to the sidecar YAML configuration keys.
```
