### PR TITLE
feat(epp): match whole prompt when both prefix caps are zero

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
@@ -12,8 +12,10 @@ For each request, the plugin consumes `request.Body.TokenizedPrompt` (token IDs)
 
 - `autoTune` (bool, optional, default: `true`): Infer `blockSizeTokens` and `lruCapacityPerServer` from endpoint metrics when available.
 - `blockSizeTokens` (int, optional, default: `16`): Prefix block size in tokens. Used when `autoTune` is false or endpoint metrics are unavailable; ignored when auto-tuned from metrics. Values below the minimum of `64` are clamped up at request time (see #1158), so the `16` default is effectively `64` absent a larger metric/configured value.
-- `maxPrefixBlocksToMatch` (int, optional, default: `2048`): Maximum number of prefix blocks hashed and matched per request. Not auto-tuned. `0` disables matching (zero blocks hashed).
+- `maxPrefixBlocksToMatch` (int, optional, default: `2048`): Maximum number of prefix blocks hashed and matched per request. Not auto-tuned. Applies only when `maxPrefixTokensToMatch` is `0`.
 - `maxPrefixTokensToMatch` (int, optional, default: `131072`): Cap expressed in tokens instead of blocks (`maxBlocks = maxPrefixTokensToMatch / blockSizeTokens`). Not auto-tuned. Takes precedence over `maxPrefixBlocksToMatch` when set (> 0); set to `0` to fall back to the block-based cap. The `131072` default (128K, the context window of large production models such as gpt-oss 120b) is a reasonable upper bound that covers the long-prompt use cases seen in production.
+
+Setting both caps to `0` matches the whole prompt. Prompt length is bounded by the model server's context window, so this caps matching at one context window without needing to name a token count. It raises EPP CPU on long prompts (see [operations](../../../../../../../docs/operations.md)); to turn prefix matching off, remove this producer from the configuration rather than zeroing the caps.
 - `lruCapacityPerServer` (int, optional, default: `31250`): Per-pod LRU index capacity. Used when `autoTune` is false or endpoint metrics are unavailable; ignored when auto-tuned from metrics.
 - `blockSize` (int, optional): Deprecated — character-based block size. Use `blockSizeTokens` instead.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -227,11 +227,7 @@ func (p *dataProducer) PluginState() *plugin.PluginState {
 // Produce is called by the director before scheduling requests.
 func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
 	blockSize := p.GetBlockSize(pods)
-	maxBlocks := p.config.MaxPrefixBlocksToMatch
-	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
-		maxBlocks = p.config.MaxPrefixTokensToMatch / blockSize
-	}
-	perPromptHashes := prefixhash.GetBlockHashes(ctx, request, blockSize, maxBlocks)
+	perPromptHashes := prefixhash.GetBlockHashes(ctx, request, blockSize, p.resolveMaxBlocks(blockSize))
 
 	prefixCacheServers := make(map[ServerID]int)
 	totalBlocks := 0
@@ -357,6 +353,24 @@ func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 		return minBlockSizeTokens
 	}
 	return blockSize
+}
+
+// resolveMaxBlocks returns the per-request cap on hashed prefix blocks.
+//
+// MaxPrefixTokensToMatch wins when set, converting tokens to blocks at the
+// effective block size. Zeroing both caps means unlimited: prompt length is
+// already bounded by the model server's context window, so the whole prompt is
+// at most one context window of tokens. A token cap smaller than the block size
+// still resolves to 0 and hashes nothing; that is a misconfiguration, not a
+// request for unlimited matching.
+func (p *dataProducer) resolveMaxBlocks(blockSize int) int {
+	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
+		return p.config.MaxPrefixTokensToMatch / blockSize
+	}
+	if p.config.MaxPrefixBlocksToMatch == 0 {
+		return unlimitedPrefixBlocks
+	}
+	return p.config.MaxPrefixBlocksToMatch
 }
 
 // ApproxPrefixCacheFactory is the factory function for the prefix cache data producer plugin.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -443,6 +443,40 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	assert.Equal(t, 3, len(state2.PerPromptHashes[0]), "should fall back to MaxPrefixBlocksToMatch when MaxPrefixTokensToMatch is 0")
 }
 
+// TestMaxPrefixBothCapsZeroMatchesEverything verifies that zeroing both caps
+// hashes the whole prompt rather than nothing. The prompt length is already
+// bounded by the model server's context window, so an absent cap is an implicit
+// max_model_len cap.
+func TestMaxPrefixBothCapsZeroMatchesEverything(t *testing.T) {
+	disableMinBlockSizeClamp(t)
+	cfg := config{
+		BlockSizeTokens:        1,
+		MaxPrefixTokensToMatch: 0,
+		MaxPrefixBlocksToMatch: 0,
+		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
+	}
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err)
+
+	endpoint := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
+	)
+
+	req := &fwksched.InferenceRequest{
+		RequestID:   uuid.NewString(),
+		TargetModel: "test-model",
+		Body:        tokenizedBody([]uint32{1, 2, 3, 4}),
+	}
+
+	err = p.Produce(context.Background(), req, []fwksched.Endpoint{endpoint})
+	assert.NoError(t, err)
+
+	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(state.PerPromptHashes[0]), "both caps at 0 should hash every block in the prompt")
+}
+
 // TestGetBlockSize_AutotuneClampsBelowMinimum verifies that when AutoTune is on and
 // the endpoint reports a small CacheBlockSize, GetBlockSize floors the result at
 // minBlockSizeTokens to bound EPP indexer memory. See issue #1158.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package approximateprefix
 
 import (
+	"math"
 	"time"
 
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -99,7 +100,8 @@ const (
 	defaultBlockSizeTokens = 16
 
 	// defaultMaxPrefixBlocks is the fallback block cap, consulted only when
-	// MaxPrefixTokensToMatch is 0; the default token cap otherwise supersedes it.
+	// MaxPrefixTokensToMatch is 0 and MaxPrefixBlocksToMatch is non-zero; the
+	// default token cap otherwise supersedes it.
 	// Two long requests with the same prefix up to this limit will be indistinguishable.
 	// This parameter provides a trade-off between cache size, prefix matching speed and matching
 	// accuracy. Use a small value if most requests are short to reduce cache size and speed up the
@@ -111,6 +113,12 @@ const (
 	// that covers the long-prompt use cases seen in production. It takes precedence
 	// over defaultMaxPrefixBlocks: maxBlocks = defaultMaxPrefixTokens / blockSizeTokens.
 	defaultMaxPrefixTokens = 131072
+
+	// unlimitedPrefixBlocks is the block cap used when both MaxPrefixTokensToMatch
+	// and MaxPrefixBlocksToMatch are 0. Prompt length is already bounded by the
+	// model server's context window, so an absent cap matches at most one context
+	// window of tokens.
+	unlimitedPrefixBlocks = math.MaxInt
 
 	// defaultLRUCapacityPerServer is the default capacity of the LRU indexer per server.
 	// The indexer is an approximation to the actual prefix LRU cache state on the model servers per server (pod).
@@ -135,11 +143,12 @@ type config struct {
 	BlockSize int `json:"blockSize"`
 	// Deprecated: use MaxPrefixTokensToMatch, which caps prefix matching in tokens
 	// independent of BlockSizeTokens. MaxPrefixBlocksToMatch applies only when
-	// MaxPrefixTokensToMatch is 0.
+	// MaxPrefixTokensToMatch is 0. Setting both to 0 matches the whole prompt.
 	MaxPrefixBlocksToMatch int `json:"maxPrefixBlocksToMatch"`
 	// MaxPrefixTokensToMatch is the maximum number of prefix tokens to match.
 	// When set (> 0), it takes precedence over MaxPrefixBlocksToMatch by computing
-	// maxBlocks = MaxPrefixTokensToMatch / blockSizeTokens.
+	// maxBlocks = MaxPrefixTokensToMatch / blockSizeTokens. Setting both caps to 0
+	// matches the whole prompt.
 	MaxPrefixTokensToMatch int `json:"maxPrefixTokensToMatch"`
 	// Max capacity size of the LRU indexer in number of entries per server (pod).
 	LRUCapacityPerServer int `json:"lruCapacityPerServer"`


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Setting both `maxPrefixTokensToMatch` and `maxPrefixBlocksToMatch` to `0` now
matches the whole prompt. Previously it hashed nothing at all, leaving the
producer, its indexer, and its cleanup goroutine running while contributing
nothing to scoring, with nothing in the config surface signalling it.

When this plugin was written, the prefix match existed only to inform prefix
*scoring*. For that purpose a capped match is fine: the cap is uniform across
pods, so it biases every candidate equally and the ranking still holds. Matching
"enough" prefix was sufficient, and the cap bought bounded EPP CPU.

The match info is now also consumed by the inflight-load producer to compute
`uncachedInputTokens` -- the prompt tokens an endpoint must actually compute,
discounting the prefix it already has cached. That consumer needs an absolute
quantity rather than a comparable one, so the cap stops being neutral. Beyond
the cap, `uncachedInputTokens` adds the un-indexed tail back from the estimated
`inputTokens` and charges it as fully uncached, because the index cannot say
otherwise. Where the server actually holds that tail in its prefix cache, the
endpoint's in-flight load is over-counted, and the error scales with how far the
prompt runs past the cap rather than with the pod's real cache state. Two pods
with genuinely different cached tails look identical to the estimate.


The 131072-token default was sized against 128K-context models, where it never
binds. GLM-5.2 serves a 1M-token context on Vertex AI
(`vertex_ai/zai-org/glm-5-maas`); at full context ~87% of the prompt falls past
the cap, so the estimate is dominated by the unindexed tail.


Zeroing both caps removes the cap as a source of that error. Prompt length is
already bounded by the model server's context window, so an absent cap matches
at most one context window of tokens -- operators get context-window-sized
matching without hand-maintaining a token count that tracks `max_model_len`.

This does not make the accounting exact. The routing-side index is an
approximation of server-side cache state, so evictions on the model server still
produce a delta between what the index believes is cached and what the server
actually holds. That residual is expected to be small relative to the cap-induced
error, and unlike the cap it is not systematic in prompt length.

Uncapped matching raises EPP CPU on long prompts (see docs/operations.md), so
this stays opt-in: defaults are unchanged, and the behavior only applies when
both caps are explicitly `0`.

Notes on scope:
- Precedence is unchanged -- `maxPrefixTokensToMatch` still wins when set (> 0).
- A token cap smaller than the block size still resolves to zero blocks and
  hashes nothing. That is a misconfiguration (`burstprefix` rejects it outright),
  not a request for unlimited matching, so it is left as-is.
- To disable prefix matching, remove the producer from the configuration. Zeroing
  the caps is no longer a way to do that; README is updated accordingly.

**Which issue(s) this PR fixes**:

Fixes #

**Release note**:
```release-note
The approximate prefix-cache producer (approx-prefix-cache-producer) now matches the entire prompt when both maxPrefixTokensToMatch and maxPrefixBlocksToMatch are set to 0, which previously disabled prefix matching entirely. This makes in-flight token accounting reflect the full prompt on deployments with context windows larger than the 131072-token default cap. Defaults are unchanged. Uncapped matching increases EPP CPU utilization on long prompts. To disable prefix matching, remove the producer from the configuration rather than zeroing the caps.
