### PR TITLE
test: deduplicate GetFreePort helpers

### DIFF
--- a/pkg/sidecar/proxy/data_parallel_test.go
+++ b/pkg/sidecar/proxy/data_parallel_test.go
@@ -32,9 +32,7 @@ var _ = Describe("Data Parallel support", func() {
 			// tell the proxy that it is listening on that port minus one.
 			freePort, err := testutils.GetFreePort()
 			Expect(err).ToNot(HaveOccurred())
-			tmpPort, err := strconv.Atoi(freePort)
-			fakeProxyPort := tmpPort - 1
-			Expect(err).ToNot(HaveOccurred())
+			fakeProxyPort := freePort - 1
 
 			// The data parallel support, assumes that the decoders are
 			// listening on a set of contiguous ports. Get a free port
@@ -43,7 +41,7 @@ var _ = Describe("Data Parallel support", func() {
 			rank1Server := httptest.NewServer(&rank1Handler)
 			tempURL, err := url.Parse(rank1Server.URL)
 			Expect(err).ToNot(HaveOccurred())
-			tmpPort, err = strconv.Atoi(tempURL.Port())
+			tmpPort, err := strconv.Atoi(tempURL.Port())
 			Expect(err).ToNot(HaveOccurred())
 			fakeDecodePort := tmpPort - 1
 

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -56,6 +56,7 @@ import (
 	eppServer "github.com/llm-d/llm-d-router/pkg/epp/server"
 	testutil "github.com/llm-d/llm-d-router/pkg/epp/util/testing"
 	integration "github.com/llm-d/llm-d-router/test/integration"
+	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
 // Global State (Initialized in TestMain)
@@ -299,15 +300,15 @@ func defaultEppServerOptions(t *testing.T, namespace, configText string) *eppSer
 	eppOptions.PoolNamespace = namespace
 	eppOptions.ConfigText = configText
 
-	metricsPort, err := integration.GetFreePort()
+	metricsPort, err := testutils.GetFreePort()
 	require.NoError(t, err)
 	eppOptions.MetricsPort = metricsPort
 
-	grpcPort, err := integration.GetFreePort()
+	grpcPort, err := testutils.GetFreePort()
 	require.NoError(t, err)
 	eppOptions.GRPCPort = grpcPort
 
-	healthPort, err := integration.GetFreePort()
+	healthPort, err := testutils.GetFreePort()
 	require.NoError(t, err)
 	eppOptions.GRPCHealthPort = healthPort
 	eppOptions.EndpointTargetPorts = []int{8000}

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -617,29 +616,6 @@ func ExtProcServerClient(
 	require.NoError(t, err, "failed to initialize ext_proc stream client")
 
 	return extProcClient, conn
-}
-
-// GetFreePort finds an available IPv4 TCP port on localhost.
-// It works by asking the OS to allocate a port by listening on port 0, capturing the assigned address, and then
-// immediately closing the listener.
-//
-// Note: There is a theoretical race condition where another process grabs the port between the Close() call and the
-// subsequent usage, but this is generally acceptable in hermetic test environments.
-func GetFreePort() (int, error) {
-	// Force IPv4 to prevent flakes on dual-stack CI environments
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, fmt.Errorf("failed to listen on a free port: %w", err)
-	}
-
-	// Critical: Close the listener immediately so the caller can bind to it.
-	defer listener.Close()
-
-	addr, ok := listener.Addr().(*net.TCPAddr)
-	if !ok {
-		return 0, errors.New("failed to cast listener address to TCPAddr")
-	}
-	return addr.Port, nil
 }
 
 // --- Internal Helpers ---

--- a/test/utils/network.go
+++ b/test/utils/network.go
@@ -6,20 +6,30 @@ package utils
 //revive:enable:var-naming
 
 import (
+	"errors"
+	"fmt"
 	"net"
 )
 
-// GetFreePort finds a free port to listen on
-func GetFreePort() (string, error) {
-	var listener net.Listener
-	var err error
-	if listener, err = net.Listen("tcp", ":0"); err == nil {
-		var port string
-		_, port, err = net.SplitHostPort(listener.Addr().String())
-		defer func() {
-			_ = listener.Close()
-		}()
-		return port, err
+// GetFreePort finds an available IPv4 TCP port on localhost.
+// It works by asking the OS to allocate a port by listening on port 0, capturing the assigned address, and then
+// immediately closing the listener.
+//
+// Note: There is a theoretical race condition where another process grabs the port between the Close() call and the
+// subsequent usage, but this is generally acceptable in hermetic test environments.
+func GetFreePort() (int, error) {
+	// Force IPv4 to prevent flakes on dual-stack CI environments
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("failed to listen on a free port: %w", err)
 	}
-	return "", err
+
+	// Critical: Close the listener immediately so the caller can bind to it.
+	defer listener.Close()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, errors.New("failed to cast listener address to TCPAddr")
+	}
+	return addr.Port, nil
 }

--- a/test/utils/network_test.go
+++ b/test/utils/network_test.go
@@ -23,28 +23,40 @@ import (
 )
 
 func TestGetFreePort(t *testing.T) {
-	tests := []struct {
-		name string
-	}{
-		{name: "returns a bindable port"},
-		{name: "returns a distinct bindable port on repeat call"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			port, err := GetFreePort()
-			if err != nil {
-				t.Fatalf("GetFreePort() returned error: %v", err)
-			}
-			if port <= 0 || port > 65535 {
-				t.Fatalf("GetFreePort() returned out-of-range port %d", port)
-			}
+	// Allocating several ports while holding each listener open proves three
+	// properties at once: every port is in range, every port is bindable, and no
+	// two allocations collide. Distinctness holds only while the prior port stays
+	// bound - GetFreePort closes its own listener, so two bare calls may repeat a
+	// port; keeping the listener open is what forces the OS to hand out a new one.
+	const numPorts = 8
 
-			// The returned port must be actually bindable on IPv4 localhost.
-			ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-			if err != nil {
-				t.Fatalf("port %d returned by GetFreePort() is not bindable: %v", port, err)
-			}
+	seen := make(map[int]bool, numPorts)
+	held := make([]net.Listener, 0, numPorts)
+	t.Cleanup(func() {
+		for _, ln := range held {
 			_ = ln.Close()
-		})
+		}
+	})
+
+	for i := 0; i < numPorts; i++ {
+		port, err := GetFreePort()
+		if err != nil {
+			t.Fatalf("call %d: GetFreePort() returned error: %v", i, err)
+		}
+		if port <= 0 || port > 65535 {
+			t.Fatalf("call %d: GetFreePort() returned out-of-range port %d", i, port)
+		}
+		if seen[port] {
+			t.Fatalf("call %d: GetFreePort() returned duplicate port %d while it was still bound", i, port)
+		}
+		seen[port] = true
+
+		// The returned port must be bindable on IPv4 localhost; hold it open so the
+		// next iteration cannot be handed the same port back.
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			t.Fatalf("call %d: port %d returned by GetFreePort() is not bindable: %v", i, port, err)
+		}
+		held = append(held, ln)
 	}
 }

--- a/test/utils/network_test.go
+++ b/test/utils/network_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestGetFreePort(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "returns a bindable port"},
+		{name: "returns a distinct bindable port on repeat call"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			port, err := GetFreePort()
+			if err != nil {
+				t.Fatalf("GetFreePort() returned error: %v", err)
+			}
+			if port <= 0 || port > 65535 {
+				t.Fatalf("GetFreePort() returned out-of-range port %d", port)
+			}
+
+			// The returned port must be actually bindable on IPv4 localhost.
+			ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			if err != nil {
+				t.Fatalf("port %d returned by GetFreePort() is not bindable: %v", port, err)
+			}
+			_ = ln.Close()
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind test

**What this PR does / why we need it**:

This is a focused first step toward #1188 (the `test/framework` consolidation
epic): it removes the `GetFreePort` duplication called out as bottleneck #3. It is
intentionally scoped to that one item so it can land and be reviewed on its own; the
remaining tasks (the `test/framework/{net,context,k8s,epp}` tree, builder/harness/
context moves, `wrappers.go` removal, EPP test-import migration) are left for
follow-up PRs.

Two copies of a free-TCP-port helper existed with divergent signatures:

- `test/integration/util.go` - `GetFreePort() (int, error)`, IPv4 `127.0.0.1:0`
- `test/utils/network.go` - `GetFreePort() (string, error)`, dual-stack `:0`

They are collapsed into a single canonical `GetFreePort() (int, error)` (IPv4, to
avoid dual-stack CI flakes). The location is `test/utils` rather than the epic's
proposed `test/framework/net` because import direction forces it: the sidecar test
that needs the helper must not pull in the heavy `test/integration` EPP/k8s tree.

```mermaid
flowchart TD
    A[pkg/sidecar/proxy tests] --> U[test/utils.GetFreePort]
    B[test/integration/epp harness] --> U
    A -. must NOT import .-> I[test/integration<br/>EPP + k8s + envtest]
    U -. lightweight, no domain deps .- U
```

- `test/utils/network.go`: canonical `GetFreePort() (int, error)`.
- `test/integration/util.go`: delete the duplicate.
- `test/integration/epp/harness.go`: migrate the 3 call sites to `testutils.GetFreePort()`.
- `pkg/sidecar/proxy/data_parallel_test.go`: the `int` return drops a `strconv.Atoi`.
- `test/utils/network_test.go`: allocate N ports while holding each listener open,
  asserting in-range, bindable, and distinct together.

The epic also suggests a `GetFreePortString()` for legacy Ginkgo; the sole Ginkgo
caller is converted to the `int` directly, so no string helper is added (it would be
dead code). Pure test-infra refactor, no product code. If maintainers prefer the
`test/framework/net` location up front, I can move it there once that package exists.

**Which issue(s) this PR fixes**:

Part of #1188

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
