### PR TITLE
docs: align architecture.md terminology with the data layer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,7 +218,9 @@ To learn more about the available plugins, check the plugins [README.md](../pkg/
 
 The data layer follows a Source -> Extract -> Attribute lifecycle:
 
-- Data sources collect metrics (e.g., memory usage, active adapters) from pods
+- Data sources collect per-endpoint data. Some poll pods periodically, for metrics (e.g., memory
+  usage, active adapters) or served models and LoRA adapters (via `/v1/models`); others react to
+  endpoint or Kubernetes object change notifications
 - Extractors populate per-endpoint attributes in the shared datastore for scorers
 - Scoring can rely on numerical metrics or metadata (model ID, adapter tags)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@
   - [`Plugins` Configuration](#plugins-configuration)
   - [`SchedulingProfiles` Configuration](#schedulingprofiles-configuration)
   - [Available plugins](#available-plugins)
-- [Metric Scraping](#metric-scraping)
+- [Metric Scraping and the Data Layer](#metric-scraping-and-the-data-layer)
 - [Disaggregated Encode/Prefill/Decode (E/P/D)](#disaggregated-encodeprefilldecode-epd)
 - [InferencePool & InferenceModel Design](#inferencepool--inferencemodel-design)
   - [Current Assumptions](#current-assumptions)
@@ -214,7 +214,7 @@ To learn more about the available plugins, check the plugins [README.md](../pkg/
 
 ---
 
-## Metric Scraping
+## Metric Scraping and the Data Layer
 
 The data layer follows a Source -> Extract -> Attribute lifecycle:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 - [Overview](#overview)
 - [Core Goals](#core-goals)
-- [Filters, Scorers, and Scrapers](#filters-scorers-and-scrapers)
+- [Filters, Scorers, and the Data Layer](#filters-scorers-and-the-data-layer)
   - [Core Design Principles](#core-design-principles)
   - [Routing Flow](#routing-flow)
 - [Configuration](#configuration)
@@ -31,7 +31,7 @@ The design enables:
 **model metadata**
 - Disaggregated **Prefill/Decode (P/D)** execution
   - We have introduced experimental **Encode/Prefill/Decode (E/P/D and all its permutations)** execution. For a detailed explanation, see [Disaggregated Inference Serving](./disaggregation.md)
-- Pluggable **filters**, **scorers**, and **scrapers** for extensible scheduling
+- Pluggable **filters** and **scorers**, backed by a pluggable **data layer**, for extensible scheduling
 
 ---
 
@@ -42,12 +42,12 @@ The design enables:
   - KV cache reuse
   - Load balancing
 - Support multi-model deployments on heterogeneous hardware
-- Enable runtime extensibility with pluggable logic (filters, scorers, scrapers)
+- Enable runtime extensibility with pluggable logic (filters, scorers, data layer)
 - Community-aligned implementation using GIE and Envoy + External Processing (EPP)
 
 ---
 
-## Filters, Scorers, and Scrapers
+## Filters, Scorers, and the Data Layer
 
 ### Core Design Principles
 
@@ -58,6 +58,8 @@ The design enables:
 
 ### Routing Flow
 
+See the upstream [Request Scheduler](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/scheduling.md) doc for the canonical scheduling model.
+
 1. **Filtering**
    - Pods in an `InferencePool` go through a sequential chain of filters
    - Pods may be excluded based on criteria like model compatibility, resource usage, or custom logic
@@ -65,7 +67,7 @@ The design enables:
 2. **Scoring**
    - Filtered pods are scored using a weighted set of scorers
    - Scorers currently run sequentially (future: parallel execution)
-   - Scorers access a shared datastore populated by scrapers
+   - Scorers access a shared datastore populated by the data layer
 
 3. **Pod Selection**
    - The highest-scored pod is selected
@@ -76,6 +78,8 @@ The design enables:
 ## Configuration
 
 The llm-d Endpoint Picker relies on a YAML-based configuration—provided either as a file or an in-line parameter—to determine which lifecycle hooks (plugins) are active.
+
+See the upstream [Configuration](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/configuration.md) doc for the canonical schema.
 
 Specifically, this configuration establishes the following components:
 
@@ -212,9 +216,13 @@ To learn more about the available plugins, check the plugins [README.md](../pkg/
 
 ## Metric Scraping
 
-- Scrapers collect metrics (e.g., memory usage, active adapters)
-- Data is injected into the shared datastore for scorers
+The data layer follows a Source -> Extract -> Attribute lifecycle:
+
+- Data sources collect metrics (e.g., memory usage, active adapters) from pods
+- Extractors populate per-endpoint attributes in the shared datastore for scorers
 - Scoring can rely on numerical metrics or metadata (model ID, adapter tags)
+
+See the upstream [Data Layer](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/datalayer.md) doc for the canonical model.
 
 ---
 
@@ -307,3 +315,14 @@ Enable chunked decode via the pd-sidecar flag:
 - [Gateway API Inference Extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension)
 - [Envoy External Processing](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter)
 - [EPP Container Sizing Guide](./operations.md)
+
+### Canonical llm-d architecture (upstream)
+
+- [Router overview](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/README.md)
+- [Proxy](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/proxy.md)
+- [Endpoint Picker (EPP)](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/README.md)
+- [Configuration](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/configuration.md)
+- [Request Scheduler](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/scheduling.md)
+- [Request Handler](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/request-handling.md)
+- [Flow Control](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/flow-control.md)
+- [Data Layer](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/datalayer.md)


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

`docs/architecture.md` described a "Scrapers" component that no longer exists in the
code; the metrics-collection subsystem is now the **Data Layer** (data sources plus
extractors under `pkg/epp/framework/plugins/datalayer/**`). This addresses #1307 by
aligning the doc's terminology and cross-links with the current code and the upstream
llm-d/llm-d architecture docs:

- Rename the stale "Scrapers" references to the Data Layer (Table of Contents and
  section heading, Overview, Core Goals, Routing Flow).
- Describe the data layer's actual lifecycle:

```mermaid
flowchart LR
    S[Data Sources<br/>collect raw signals from pods] --> E[Extractors<br/>transform into typed attributes]
    E --> A[Endpoint attributes<br/>in the shared datastore]
    A --> Sc[Scorers read attributes]
```

- Add a "Canonical llm-d architecture (upstream)" reference list plus inline "see
  upstream canonical" pointers (scheduling, configuration, datalayer).

Scope decision: this PR does the terminology + upstream-links alignment as one
coherent unit. Deeper content reconciliation the issue could also be read to want -
the single-`InferencePool`/single-`EPP` "Current Assumptions", the routing-flow
narrative versus upstream `scheduling.md`, and the config examples - is deliberately
left out. Those are substantive and, in the single-pool case, currently accurate for
this repo's code, so they warrant separate discussion rather than a blind rewrite to
match upstream prose. Divergences that are correct for this repo (default-parser
list, flow-control policy names) were re-verified against local code and left
unchanged.

**Which issue(s) this PR fixes**:

Part of #1307

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
