### PR TITLE
Llmd leader worker clean 2p2d enable

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -349,6 +349,26 @@ Prefix `llm_d_router_epp_`. Registered only when the embedded llm-d-kv-cache met
 | `kv_cache_events_dedup_removed_hashes_suppressed_total` | Counter | Deduplicated removal hashes suppressed. |
 | `kv_cache_events_dedup_removed_hashes_forwarded_total` | Counter | Deduplicated removal hashes forwarded. |
 
+### MoRI-IO DNS re-resolution
+
+Prefix `moriio_dns_`. Emitted by the sidecar proxy when MoRI-IO peer host specs
+are DNS names that are re-resolved on the request path (see the
+[MoRI-IO feature guide](../pkg/sidecar/proxy/MORIIO_README.md)). Registered on
+the same controller-runtime registry as the other metrics on this page.
+Unlabeled.
+
+Unlike the EPP `/metrics` endpoint, the sidecar does not serve metrics by
+default. Pass `--metrics-port` (e.g. `--metrics-port=9090`) to the sidecar to
+expose these counters at `/metrics` on that port; `0` (the default) disables it.
+The `MORIIO_METRICS_ADDR` env var (e.g. `:9090`) is a backward-compatible
+fallback, consulted only when `--metrics-port` is unset.
+
+| Name | Type | Notes |
+|---|---|---|
+| `moriio_dns_reresolve_total` | Counter | Successful request-path re-resolutions of a peer DNS name (counted per actual lookup; concurrent lookups coalesced by singleflight count once). |
+| `moriio_dns_ip_changed_total` | Counter | Re-resolutions where the peer resolved to a different IP than the cached value (peer pod likely restarted at a new IP). |
+| `moriio_dns_lookup_failures_total` | Counter | Failed peer DNS lookups on the request path; the resolver then serves the last-known-good IP (or, on cold start, the raw spec). |
+
 ## Related work
 
 Broader observability work tracked separately (not part of this document):

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -1,62 +1,150 @@
-# MoRI-IO WRITE-mode and Wide-EP Feature (DORMANT)
+# MoRI-IO WRITE-mode and Wide-EP Feature
 
-> **Status: DORMANT - Not Yet Enabled**
+> **Status: ENABLED**
 >
-> This feature is included in the codebase but is **not yet enabled** for production use.
-> Attempting to use `--moriio-write-mode` or related flags will result in an error.
+> This feature is enabled for AMD MoRI-IO WRITE-mode and Wide-EP deployments.
 
 ## Overview
 
-This code adds support for AMD MoRI-IO WRITE-mode and Wide-EP (Expert Parallelism) 
+This code adds support for AMD MoRI-IO WRITE-mode and Wide-EP (Expert Parallelism)
 disaggregation topologies to the llm-d sidecar. The feature enables:
 
 - **MoRI-IO WRITE-mode**: Prefill RDMA-writes KV cache directly to decode pods
-- **Wide-EP DP-rank pinning**: Deterministic routing of requests to specific DP ranks
+- **Serial and parallel dispatch**: two WRITE-mode dispatch strategies (see below)
+- **Wide-EP DP-rank pinning**: Deterministic routing of P/D pairs to the same DP rank
 - **Multi-pod fan-out (2P2D)**: Support for DP=EP=16 across 2 prefill + 2 decode pods
+- **DNS hostname resolution**: Use hostnames (e.g., LWS pod names) instead of hardcoded IPs
 
-## Why is this feature dormant?
+## Dispatch modes
 
-The feature code has been merged to:
-1. Allow early review and feedback
-3. Enable incremental CI test development
+MoRI-IO is **off by default** (the sidecar keeps its standard NIXLv2 behavior). Once
+`--moriio-write-mode` is set, WRITE mode runs in **serial** dispatch unless you also pass
+`--moriio-parallel-dispatch`.
 
-However, full production validation and CI integration are still in progress.
-The feature will be enabled in a future Release Candidate (RC) after:
-- [ ] End-to-end CI tests are added
-- [ ] Production deployment validation is complete
-- [ ] Documentation and deployment guides are finalized
+| Mode | Flags | Dispatch | How the decode DP rank is chosen |
+|------|-------|----------|----------------------------------|
+| Serial WRITE (default) | `--moriio-write-mode` | Prefill first, await its response, then decode | **Propagated** from the prefill leg's returned `remote_dp_rank` (the rank prefill actually ran on); falls back to a stable hash only if the response omits it |
+| Parallel WRITE | `--moriio-write-mode --moriio-parallel-dispatch` | Prefill and decode dispatched **concurrently** | **Pinned up front** from config/hash with `remote_dp_rank_override=true` (prefill has not returned yet), so both legs agree without waiting |
 
-## How to enable (FUTURE)
+**Router-authoritative routing.** In both modes the sidecar and the vLLM MoRI-IO
+connector agree on a single DP rank without each side independently hashing:
 
-Once the feature is ready for release, the constant in `options.go` will be changed:
+- **Serial**: the vLLM prefill connector returns the rank it ran on
+  (`remote_dp_rank`, `remote_dp_rank_override=true`); the sidecar copies it onto the
+  decode leg's `x-data-parallel-rank` header.
+- **Parallel**: the sidecar pins the rank itself and sets `remote_dp_rank_override=true`;
+  the connector honors that pin on both legs.
 
-```go
-// Current (dormant):
-MoRIIOFeatureEnabled = false
+**Which to use?** Serial is the safe default and gives the tightest correctness guarantee
+(decode is pinned to the rank prefill truly used). Parallel reduces end-to-end latency by
+overlapping the two legs, at the cost of pinning the rank before prefill confirms it.
 
-// Future (enabled):
-MoRIIOFeatureEnabled = true
-```
+## Supported Topologies
 
-## Related Flags (currently blocked)
+| Topology | DP | EP | TP | Pods | Description |
+|----------|----|----|----|----- |-------------|
+| **1P1D** | 8  | 8  | 1  | 1 prefill + 1 decode | Intra-node Wide-EP |
+| **2P2D** | 16 | 16 | 1  | 2 prefill + 2 decode | Inter-node Wide-EP with LeaderWorkerSet |
 
-The following flags are reserved for this feature and will error if used:
+## CLI Flags
 
 | Flag | Purpose |
 |------|---------|
-| `--moriio-write-mode` | Enable MoRI-IO WRITE-mode |
-| `--moriio-parallel-dispatch` | Concurrent prefill/decode dispatch |
+| `--moriio-write-mode` | Enable MoRI-IO WRITE-mode (serial dispatch by default) |
+| `--moriio-parallel-dispatch` | Concurrent prefill/decode dispatch (requires `--moriio-write-mode`) |
 | `--moriio-dp-size` | Data parallel world size |
-| `--moriio-dp-size-local` | Per-pod DP size for multi-pod |
-| `--moriio-remote-hosts` | Prefill pod IPs for decode fan-out |
-| `--moriio-decode-hosts` | Decode pod IPs for prefill fan-out |
+| `--moriio-dp-size-local` | Per-pod DP size for multi-pod (`pod_idx = dp_rank / dp_size_local`) |
+| `--moriio-remote-hosts` | Prefill-side pod hosts for fan-out (DNS names preferred) |
+| `--moriio-decode-hosts` | Decode-side pod hosts, emitted as the prefill leg's `remote_hosts` (DNS names preferred) |
+| `--moriio-tp-size` | Tensor parallel size |
+| `--moriio-local-pod-ip` | Local pod IP (defaults to `POD_IP` env) |
+| `--moriio-decode-handshake-port` | Decode handshake port |
+| `--moriio-decode-notify-port` | Decode notify port |
+| `--moriio-prefill-handshake-port` | Prefill handshake port |
+| `--moriio-prefill-notify-port` | Prefill notify port |
+
+## Host Address Configuration
+
+**DNS hostnames are the recommended and forward-looking way to address pods.** Raw IPs are
+still accepted for backward compatibility but are being phased out.
+
+### Recommended: DNS names (LeaderWorkerSet / LWS)
+
+```yaml
+# LWS pod names — resolved to IPs at startup
+- --moriio-remote-hosts=prefill-master.ns.svc,prefill-worker.ns.svc
+- --moriio-decode-hosts=decode-master.ns.svc,decode-worker.ns.svc
+```
+
+### Legacy: raw IPs (backward compatibility)
+
+```yaml
+# Static IPs (e.g., hostNetwork: true where pod IP = node IP)
+- --moriio-remote-hosts=10.0.0.1,10.0.0.2
+- --moriio-decode-hosts=10.0.1.1,10.0.1.2
+```
+
+**How host resolution works:**
+1. At startup, DNS names are resolved to IPs via Kubernetes DNS (IPv4 preferred).
+2. Raw IP addresses are passed through unchanged (backward compatibility).
+3. Resolution happens once during `Complete()`, before the proxy starts.
+
+**Why DNS:**
+- Works with LeaderWorkerSet's predictable naming (`<lws-name>-<group>-<worker>`)
+- Enables scalable topologies without hardcoded IP coordination
+- Consistent with Kubernetes-native service discovery
+
+## Example Configurations
+
+### 1P1D (Single-pod, DP=EP=8) — serial WRITE (default)
+
+```bash
+--moriio-write-mode=true \
+--moriio-dp-size=8 \
+--moriio-tp-size=1
+```
+
+### 1P1D (Single-pod, DP=EP=8) — parallel WRITE
+
+```bash
+--moriio-write-mode=true \
+--moriio-parallel-dispatch=true \
+--moriio-dp-size=8 \
+--moriio-tp-size=1
+```
+
+### 2P2D (Multi-pod, DP=EP=16, LeaderWorkerSet) — serial WRITE (default)
+
+```bash
+# On decode sidecar:
+--moriio-write-mode=true \
+--moriio-dp-size=16 \
+--moriio-dp-size-local=8 \
+--moriio-tp-size=1 \
+--moriio-remote-hosts=prefill-master.ns.svc,prefill-worker.ns.svc \
+--moriio-decode-hosts=decode-master.ns.svc,decode-worker.ns.svc
+```
+
+### 2P2D (Multi-pod, DP=EP=16, LeaderWorkerSet) — parallel WRITE
+
+```bash
+# On decode sidecar:
+--moriio-write-mode=true \
+--moriio-parallel-dispatch=true \
+--moriio-dp-size=16 \
+--moriio-dp-size-local=8 \
+--moriio-tp-size=1 \
+--moriio-remote-hosts=prefill-master.ns.svc,prefill-worker.ns.svc \
+--moriio-decode-hosts=decode-master.ns.svc,decode-worker.ns.svc
+```
 
 ## Contact
 
-For questions about this feature or its timeline, please contact:
+For questions about this feature, please contact:
 - AMD team
 - llm-d maintainers
 
 ## Related PRs and Issues
 
 - PR #1564: Initial MoRI-IO WRITE-mode + Wide-EP implementation
+- vLLM PR #45043: companion vLLM MoRI-IO connector (Wide-EP 2P2D, router-authoritative DP-rank routing)

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -57,7 +57,7 @@ overlapping the two legs, at the cost of pinning the rank before prefill confirm
 | `--moriio-remote-hosts` | Prefill-side pod hosts for fan-out (DNS names preferred) |
 | `--moriio-decode-hosts` | Decode-side pod hosts, emitted as the prefill leg's `remote_hosts` (DNS names preferred) |
 | `--moriio-tp-size` | Tensor parallel size |
-| `--moriio-local-pod-ip` | Local pod IP (defaults to `POD_IP` env) |
+| `--moriio-local-pod-ip` | Local pod address, DNS name or IP (defaults to `POD_IP` env); DNS names resolved to IP at startup |
 | `--moriio-decode-handshake-port` | Decode handshake port |
 | `--moriio-decode-notify-port` | Decode notify port |
 | `--moriio-prefill-handshake-port` | Prefill handshake port |

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -85,14 +85,52 @@ still accepted for backward compatibility but are being phased out.
 ```
 
 **How host resolution works:**
-1. At startup, DNS names are resolved to IPs via Kubernetes DNS (IPv4 preferred).
+1. At startup (`Complete()`), DNS names are resolved to IPs via Kubernetes DNS
+   (IPv4 preferred) to seed the initial peer IPs, before the proxy starts.
 2. Raw IP addresses are passed through unchanged (backward compatibility).
-3. Resolution happens once during `Complete()`, before the proxy starts.
+3. On the request path, peer DNS names are **re-resolved under a short TTL**
+   (default 30s) when building `kv_transfer_params`, so a peer pod that restarts
+   with a new IP is picked up without a router restart. Re-resolution serves the
+   last-known-good IP on a transient lookup failure, de-duplicates concurrent
+   lookups for the same host via singleflight, and serves the cached IP
+   immediately once past the TTL while refreshing asynchronously (only the very
+   first, cold-start lookup blocks). Raw IPs still pass through with no lookup.
+
+Both the boot-time and request-path lookups share the same IPv4-preference and
+the same per-lookup timeout bound (see [Tuning](#tuning-environment-variables)).
 
 **Why DNS:**
 - Works with LeaderWorkerSet's predictable naming (`<lws-name>-<group>-<worker>`)
 - Enables scalable topologies without hardcoded IP coordination
 - Consistent with Kubernetes-native service discovery
+
+## Tuning (environment variables)
+
+The MoRI-IO DNS re-resolution behavior is tunable at runtime via environment
+variables. Each is parsed as a **positive integer**; any non-positive or
+non-numeric value falls back to the default.
+
+| Env var | Default | Semantics |
+|---------|---------|-----------|
+| `MORIIO_DNS_RESOLVE_TTL_SECONDS` | `30` | Maximum age of a cached peer IP before the next request-path lookup re-resolves it. Lower = faster pickup of peer IP changes; higher = fewer DNS lookups under steady state. |
+| `MORIIO_DNS_RESOLVE_TIMEOUT_SECONDS` | `5` | Per-lookup context deadline for a single DNS resolution (applied to both the boot-time and request-path lookups). Bounds how long a slow/hanging resolver can stall a cold-start lookup; the effective deadline is the smaller of this value and the remaining request-context deadline. |
+| `MORIIO_METRICS_ADDR` | _(unset — disabled)_ | Backward-compatible fallback for the metrics listen address (e.g. `:9090`) when `--metrics-port` is not set. The `--metrics-port` flag takes precedence. Kept on a separate address from the data-plane proxy port. |
+
+### Metrics
+
+The preferred way to expose metrics is the first-class **`--metrics-port`** flag
+(matching the EPP `--metrics-port` convention); `0` (the default) disables the
+endpoint, and any positive port serves metrics at `/metrics` on that port. The
+`MORIIO_METRICS_ADDR` env var remains as a backward-compatible fallback and is
+only consulted when `--metrics-port` is unset.
+
+When enabled, the following counters are exposed at `GET /metrics` (unlabeled):
+
+| Metric | Meaning |
+|--------|---------|
+| `moriio_dns_reresolve_total` | Successful request-path DNS re-resolutions (per actual lookup; singleflight-coalesced lookups count once). |
+| `moriio_dns_ip_changed_total` | Re-resolutions where a peer resolved to a different IP than the cached value (peer likely restarted). |
+| `moriio_dns_lookup_failures_total` | Failed request-path DNS lookups (resolver then serves the last-known-good IP, or the raw spec on cold start). |
 
 ## Example Configurations
 

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -35,9 +35,34 @@ connector agree on a single DP rank without each side independently hashing:
 - **Parallel**: the sidecar pins the rank itself and sets `remote_dp_rank_override=true`;
   the connector honors that pin on both legs.
 
-**Which to use?** Serial is the safe default and gives the tightest correctness guarantee
-(decode is pinned to the rank prefill truly used). Parallel reduces end-to-end latency by
-overlapping the two legs, at the cost of pinning the rank before prefill confirms it.
+**Which to use?** Serial is the **shipped default and the SLA-safe path**: parallel
+dispatch is **OFF unless you explicitly pass `--moriio-parallel-dispatch`**, so with
+defaults the sidecar always takes the serial `handleNIXLV2` path. Serial gives the
+tightest correctness guarantee (decode is pinned to the rank prefill truly used).
+
+Parallel dispatch is an **opt-in latency optimization** that overlaps the two legs.
+Because prefill and decode are issued concurrently, it now includes explicit
+**prefill-failure handling** so it stays correct and never hangs:
+
+- **Shared cancelable context.** Both legs derive from one cancelable context. If
+  prefill returns any non-2xx status (or a transport error, which surfaces as `502`),
+  the sidecar cancels that context so decode's in-flight request / KV wait aborts
+  immediately instead of waiting for KV that will never arrive.
+- **Commit point (buffered decode response).** Decode is dispatched concurrently but
+  its HTTP status/headers/body are held until prefill's outcome is known. If prefill
+  **fails**, decode's output is discarded and the **prefill error/status** is returned
+  to the client (never a bogus `200`). If prefill **succeeds**, decode's response is
+  committed and streamed through with its own status, headers, and body/SSE preserved.
+- **Bounded KV-wait backstop.** As a last resort, `--moriio-parallel-decode-wait-timeout`
+  (default `30s`) bounds how long decode may wait on the prefill outcome; on expiry both
+  legs are cancelled and the request fails with `504` rather than hanging. Prefill in
+  parallel dispatch is capped to one token, so it normally resolves well within this
+  window.
+
+Trade-off: because the client commit is deferred to the commit point, decode's response
+is buffered until prefill is confirmed and then flushed/streamed. In practice prefill
+(one token) resolves quickly, so streaming resumes almost immediately after the commit
+point; the serial path retains fully incremental streaming from the first byte.
 
 ## Supported Topologies
 
@@ -51,7 +76,8 @@ overlapping the two legs, at the cost of pinning the rank before prefill confirm
 | Flag | Purpose |
 |------|---------|
 | `--moriio-write-mode` | Enable MoRI-IO WRITE-mode (serial dispatch by default) |
-| `--moriio-parallel-dispatch` | Concurrent prefill/decode dispatch (requires `--moriio-write-mode`) |
+| `--moriio-parallel-dispatch` | Concurrent prefill/decode dispatch; **OFF by default (serial is the SLA-safe path); opt-in only**. Requires `--moriio-write-mode` |
+| `--moriio-parallel-decode-wait-timeout` | Backstop for parallel dispatch: how long decode may wait on the prefill outcome/KV before being cancelled so the request fails (`504`) instead of hanging (default `30s`; only used with `--moriio-parallel-dispatch`) |
 | `--moriio-dp-size` | Data parallel world size |
 | `--moriio-dp-size-local` | Per-pod DP size for multi-pod (`pod_idx = dp_rank / dp_size_local`) |
 | `--moriio-remote-hosts` | Prefill-side pod hosts for fan-out (DNS names preferred) |

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -65,10 +65,7 @@ overlapping the two legs, at the cost of pinning the rank before prefill confirm
 
 ## Host Address Configuration
 
-**DNS hostnames are the recommended and forward-looking way to address pods.** Raw IPs are
-still accepted for backward compatibility but are being phased out.
-
-### Recommended: DNS names (LeaderWorkerSet / LWS)
+Peer hosts are Kubernetes DNS names (LeaderWorkerSet / LWS):
 
 ```yaml
 # LWS pod names — resolved to IPs at startup
@@ -76,25 +73,18 @@ still accepted for backward compatibility but are being phased out.
 - --moriio-decode-hosts=decode-master.ns.svc,decode-worker.ns.svc
 ```
 
-### Legacy: raw IPs (backward compatibility)
-
-```yaml
-# Static IPs (e.g., hostNetwork: true where pod IP = node IP)
-- --moriio-remote-hosts=10.0.0.1,10.0.0.2
-- --moriio-decode-hosts=10.0.1.1,10.0.1.2
-```
+A literal IP may be given in place of any DNS name; it is used as-is (no lookup).
 
 **How host resolution works:**
 1. At startup (`Complete()`), DNS names are resolved to IPs via Kubernetes DNS
    (IPv4 preferred) to seed the initial peer IPs, before the proxy starts.
-2. Raw IP addresses are passed through unchanged (backward compatibility).
-3. On the request path, peer DNS names are **re-resolved under a short TTL**
+2. On the request path, peer DNS names are **re-resolved under a short TTL**
    (default 30s) when building `kv_transfer_params`, so a peer pod that restarts
    with a new IP is picked up without a router restart. Re-resolution serves the
    last-known-good IP on a transient lookup failure, de-duplicates concurrent
    lookups for the same host via singleflight, and serves the cached IP
    immediately once past the TTL while refreshing asynchronously (only the very
-   first, cold-start lookup blocks). Raw IPs still pass through with no lookup.
+   first, cold-start lookup blocks). A literal IP is used as-is (no lookup).
 
 Both the boot-time and request-path lookups share the same IPv4-preference and
 the same per-lookup timeout bound (see [Tuning](#tuning-environment-variables)).

--- a/pkg/sidecar/proxy/allowlist_test.go
+++ b/pkg/sidecar/proxy/allowlist_test.go
@@ -212,9 +212,9 @@ var _ = Describe("AllowlistValidator", func() {
 			// Just hostname (no port)
 			Expect(extractHost("valid-pod")).To(Equal("valid-pod"))
 			// IPv6 addresses (net.SplitHostPort handles these correctly
-			Expect(extractHost("[::1]:8000")).To(Equal("::1"))
+			Expect(extractHost("[::1]:8000")).To(Equal(testLoopbackIPv6))
 			// IPv6 without port
-			Expect(extractHost("::1")).To(Equal("::1"))
+			Expect(extractHost(testLoopbackIPv6)).To(Equal(testLoopbackIPv6))
 		})
 	})
 })

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -303,12 +303,23 @@ retryLoop:
 
 	dreq.Header.Add(requestHeaderRequestID, uuidStr)
 
-	// Stamp the same DP-rank pin on the decode leg.
+	// Decode's DP rank is PROPAGATED from the prefill leg's returned
+	// kv_transfer_params (remote_dp_rank = the rank prefill actually ran on),
+	// not independently re-derived here. This is the router-applies-the-
+	// connector-returned-rank model (PR #45043 review, njhill): the prefill
+	// connector returns the rank, the router pins the decode leg to it, so both
+	// legs agree without each hashing the request id. Fall back to the hash only
+	// if the prefill response omitted it (older vLLM without the returnable rank).
+	decodeDPRank := pickDPRank(uuidStr, s.config.MoRIIODPSize)
+	if pkv, ok := pKVTransferParams.(map[string]any); ok {
+		if rv, present := pkv[requestFieldRemoteDPRank]; present {
+			if ri, ok := toInt(rv); ok {
+				decodeDPRank = ri
+			}
+		}
+	}
 	if s.config.MoRIIODPSize > 1 {
-		dreq.Header.Set(
-			requestHeaderDataParallelRank,
-			strconv.Itoa(pickDPRank(uuidStr, s.config.MoRIIODPSize)),
-		)
+		dreq.Header.Set(requestHeaderDataParallelRank, strconv.Itoa(decodeDPRank))
 	}
 
 	delete(completionRequest, requestFieldStream)

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -18,13 +18,13 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -309,18 +309,29 @@ retryLoop:
 	// not independently re-derived here. This is the router-applies-the-
 	// connector-returned-rank model (PR #45043 review, njhill): the prefill
 	// connector returns the rank, the router pins the decode leg to it, so both
-	// legs agree without each hashing the request id. Fall back to the hash only
-	// if the prefill response omitted it (older vLLM without the returnable rank).
-	decodeDPRank := pickDPRank(uuidStr, s.config.MoRIIODPSize)
-	if pkv, ok := pKVTransferParams.(map[string]any); ok {
-		if rv, present := pkv[requestFieldRemoteDPRank]; present {
-			if ri, ok := toInt(rv); ok {
-				decodeDPRank = ri
+	// legs agree without each hashing the request id. The returned rank is
+	// validated to be in [0, dp_size); an omitted, non-numeric, or out-of-range
+	// value falls back to the deterministic hash. The header AND the decode
+	// body's remote_dp_rank are then pinned to the SAME validated value so they
+	// cannot target different ranks and hang the transfer.
+	// DP-rank propagation is a MoRI-IO WRITE-mode concern only. In standard
+	// NIXLv2 READ mode the decode body's remote_dp_rank / remote_dp_rank_override
+	// and the x-data-parallel-rank header are left untouched, matching the legacy
+	// wire shape.
+	if s.config.MoRIIOWriteMode {
+		decodeDPRank, usedReturned := resolveDecodeDPRank(pKVTransferParams, uuidStr, s.config.MoRIIODPSize)
+		if pkv, ok := pKVTransferParams.(map[string]any); ok {
+			if rv, present := pkv[requestFieldRemoteDPRank]; present && !usedReturned && s.config.MoRIIODPSize > 1 {
+				s.logger.V(1).Info("prefill returned invalid/out-of-range remote_dp_rank; using hash fallback",
+					"request_id", uuidStr, "returned", rv,
+					"dp_size", s.config.MoRIIODPSize, "rank", decodeDPRank)
 			}
+			pkv[requestFieldRemoteDPRank] = decodeDPRank
+			pkv[requestFieldRemoteDPRankOverride] = true
 		}
-	}
-	if s.config.MoRIIODPSize > 1 {
-		dreq.Header.Set(requestHeaderDataParallelRank, strconv.Itoa(decodeDPRank))
+		if s.config.MoRIIODPSize > 1 {
+			dreq.Header.Set(requestHeaderDataParallelRank, strconv.Itoa(decodeDPRank))
+		}
 	}
 
 	delete(completionRequest, requestFieldStream)
@@ -610,10 +621,16 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 		return
 	}
 
-	// Build cloned requests under separate contexts so each carries its own
-	// span lineage and either side can be observed/cancelled independently
-	// without affecting the other.
-	pCtx, prefillSpan := tracer.Start(parentCtx, "llm_d.pd_proxy.prefill",
+	// Fire prefill and decode concurrently, but DEFER committing decode's
+	// response to the client until prefill's outcome is known (the commit
+	// point). Both legs share a cancelable context so a failed or hung prefill
+	// aborts decode's in-flight request / KV wait immediately instead of
+	// letting it hang, and decode's output is buffered so a failed prefill can
+	// never surface a bogus 200 to the client.
+	dispatchCtx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	pCtx, prefillSpan := tracer.Start(dispatchCtx, "llm_d.pd_proxy.prefill",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	prefillSpan.SetAttributes(
@@ -630,7 +647,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	preq.Body = io.NopCloser(bytes.NewReader(pbody))
 	preq.ContentLength = int64(len(pbody))
 
-	dCtx, decodeSpan := tracer.Start(parentCtx, "llm_d.pd_proxy.decode",
+	dCtx, decodeSpan := tracer.Start(dispatchCtx, "llm_d.pd_proxy.decode",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer decodeSpan.End()
@@ -650,54 +667,112 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	s.logger.V(5).Info("concurrent-dispatch prefill request body", "body", string(pbody))
 	s.logger.V(5).Info("concurrent-dispatch decode request body", "body", string(dbody))
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+	// Decode writes into a deferred writer that buffers everything until we
+	// commit() (prefill succeeded -> flush + stream on) or abort() (prefill
+	// failed -> discard); it never writes to the client directly.
+	dcw := newDeferredCommitWriter(w)
 
-	// Prefill goroutine: response body is discarded; we only observe the
-	// status code for telemetry / fallback decisions.
-	var prefillStatus int
-	var prefillBody string
+	// Prefill goroutine: body is buffered so it can be returned to the client
+	// verbatim on failure. On ANY non-2xx status (transport errors surface as
+	// 502 from the reverse proxy) it cancels the shared context so decode's
+	// KV wait aborts immediately.
+	var prefillResp *bufferedResponseWriter
+	prefillDone := make(chan struct{})
 	prefillStartedAt := time.Now()
 	go func() {
-		defer wg.Done()
+		defer close(prefillDone)
 		defer prefillSpan.End()
 		pw := &bufferedResponseWriter{}
 		prefillHandler.ServeHTTP(pw, preq)
-		prefillStatus = pw.statusCode
-		prefillBody = pw.buffer.String()
+		prefillResp = pw
 		prefillSpan.SetAttributes(
 			attribute.Int("llm_d.pd_proxy.prefill.status_code", pw.statusCode),
 			attribute.Float64("llm_d.pd_proxy.prefill.duration_ms", float64(time.Since(prefillStartedAt).Milliseconds())),
 		)
 		if isHTTPError(pw.statusCode) {
 			prefillSpan.SetStatus(codes.Error, "prefill request failed")
+			cancel() // KV will never arrive -> abort decode instead of hanging
 			s.logger.Error(nil, "concurrent-dispatch prefill returned error status",
 				"status", pw.statusCode, "request_id", uuidStr, "body", pw.buffer.String())
 		}
 	}()
 
-	// Decode goroutine: streams directly to the client's ResponseWriter.
-	// dataParallelHandler may steal the request and dispatch to another
-	// data-parallel replica; preserve that semantics.
+	// Decode goroutine: buffers into dcw. dataParallelHandler may steal the
+	// request and dispatch to another data-parallel replica; preserve that
+	// semantics but still route through the deferred writer.
+	decodeDone := make(chan struct{})
 	decodeStartedAt := time.Now()
 	go func() {
-		defer wg.Done()
-		dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(w, dreq)
+		defer close(decodeDone)
+		dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(dcw, dreq)
 		decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
 		if !dataParallelUsed {
 			decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host))
-			s.decoderProxy.ServeHTTP(w, dreq)
+			s.decoderProxy.ServeHTTP(dcw, dreq)
 		}
 		decodeSpan.SetAttributes(attribute.Float64("llm_d.pd_proxy.decode.duration_ms", float64(time.Since(decodeStartedAt).Milliseconds())))
 	}()
 
-	wg.Wait()
-
-	// A failed prefill usually also hangs decode; log it so the cause is visible.
-	if isHTTPError(prefillStatus) {
-		s.logger.Info("concurrent-dispatch: prefill failed -- decode may have streamed an error or hung",
-			"request_id", uuidStr, "p_status", prefillStatus, "p_body_snippet", truncate(prefillBody, 256))
+	// Commit point: wait for prefill's outcome, bounded by a KV-wait backstop
+	// so a hung/unreachable prefill cannot make decode wait for KV forever.
+	waitTimeout := s.config.MoRIIOParallelDecodeWaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = defaultMoRIIOParallelDecodeWaitTimeout
 	}
+	timer := time.NewTimer(waitTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-prefillDone:
+		if prefillResp != nil && !isHTTPError(prefillResp.statusCode) {
+			// Prefill succeeded: commit decode's buffered response and stream on.
+			if !dcw.commit() {
+				s.logger.Error(nil, "concurrent-dispatch: decode aborted before prefill-success commit",
+					"request_id", uuidStr)
+			}
+			break
+		}
+		// Prefill failed: abort decode and return the prefill error verbatim.
+		cancel()
+		dcw.abort()
+		status := http.StatusBadGateway
+		if prefillResp != nil {
+			status = prefillResp.statusCode
+			for key, values := range prefillResp.Header() {
+				for _, v := range values {
+					w.Header().Add(key, v)
+				}
+			}
+		}
+		bodySnippet := ""
+		if prefillResp != nil {
+			bodySnippet = truncate(prefillResp.buffer.String(), 256)
+		}
+		s.logger.Info("concurrent-dispatch: prefill failed; returning prefill error and aborting decode",
+			"request_id", uuidStr, "p_status", status, "p_body_snippet", bodySnippet)
+		w.WriteHeader(status)
+		if prefillResp != nil {
+			if _, writeErr := w.Write(prefillResp.bodyBytes()); writeErr != nil {
+				s.logger.Error(writeErr, "failed to send prefill error to client (concurrent-dispatch)")
+			}
+		}
+	case <-timer.C:
+		// Prefill did not resolve within the backstop window: cancel both legs
+		// and fail rather than hang waiting for KV that may never arrive.
+		cancel()
+		dcw.abort()
+		s.logger.Error(nil, "concurrent-dispatch: prefill did not complete within KV-wait timeout; aborting",
+			"request_id", uuidStr, "timeout", waitTimeout.String())
+		w.WriteHeader(http.StatusGatewayTimeout)
+		if _, writeErr := w.Write([]byte(`{"error":"decode aborted: prefill did not complete within the MoRI-IO parallel-dispatch KV-wait timeout"}`)); writeErr != nil {
+			s.logger.Error(writeErr, "failed to send timeout error to client (concurrent-dispatch)")
+		}
+		<-prefillDone // let the cancelled prefill goroutine finish to avoid a leak
+	}
+
+	// Wait for decode to finish (streamed on success, or promptly aborted) so
+	// we never leak the decode goroutine or its response body.
+	<-decodeDone
 
 	if currentSpan := trace.SpanFromContext(parentCtx); currentSpan.SpanContext().IsValid() {
 		var totalDuration time.Duration

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -134,7 +134,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 			requestFieldDoRemotePrefill:      false,
 			requestFieldRemoteEngineID:       nil,
 			requestFieldRemoteBlockIDs:       nil,
-			requestFieldRemoteHost:           s.config.MoRIIODecodePodIP,
+			requestFieldRemoteHost:           s.currentDecodePodIP(ctx),
 			requestFieldRemotePort:           nil,
 			requestFieldRemoteNotifyPort:     s.config.MoRIIODecodeNotifyPort,
 			requestFieldRemoteDPRank:         dpRank,
@@ -145,11 +145,12 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 			"remote_dp_size":                 s.config.MoRIIODPSize,
 		}
 		// Wide-EP fan-out (prefill leg, serial path): remote_hosts must be the
-		// DECODE-side pod IPs so prefill handshakes the right pods.
-		if len(s.config.MoRIIODecodeHosts) > 0 {
+		// DECODE-side pod IPs so prefill handshakes the right pods. Re-resolved
+		// per request so peer restarts (new IP) are picked up within the TTL.
+		if decodeHosts := s.currentDecodeHosts(ctx); len(decodeHosts) > 0 {
 			pkv := completionRequest[requestFieldKVTransferParams].(map[string]any)
-			hosts := make([]any, len(s.config.MoRIIODecodeHosts))
-			for i, h := range s.config.MoRIIODecodeHosts {
+			hosts := make([]any, len(decodeHosts))
+			for i, h := range decodeHosts {
 				hosts[i] = h
 			}
 			pkv["remote_hosts"] = hosts
@@ -373,10 +374,11 @@ retryLoop:
 			}
 			// Wide-EP fan-out (decode leg, serial path): remote_hosts must be the
 			// PREFILL-side pod IPs so decode fans out handshakes across prefill pods.
-			if len(s.config.MoRIIORemoteHosts) > 0 {
+			// Re-resolved per request so peer restarts (new IP) are picked up.
+			if remoteHosts := s.currentRemoteHosts(ctx); len(remoteHosts) > 0 {
 				if _, present := dKVParams["remote_hosts"]; !present {
-					hosts := make([]any, len(s.config.MoRIIORemoteHosts))
-					for i, h := range s.config.MoRIIORemoteHosts {
+					hosts := make([]any, len(remoteHosts))
+					for i, h := range remoteHosts {
 						hosts[i] = h
 					}
 					dKVParams["remote_hosts"] = hosts
@@ -483,7 +485,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 		requestFieldDoRemotePrefill:      false,
 		requestFieldRemoteEngineID:       nil,
 		requestFieldRemoteBlockIDs:       nil,
-		requestFieldRemoteHost:           s.config.MoRIIODecodePodIP,
+		requestFieldRemoteHost:           s.currentDecodePodIP(parentCtx),
 		requestFieldRemotePort:           nil,
 		requestFieldRemoteNotifyPort:     s.config.MoRIIODecodeNotifyPort,
 		requestFieldRemoteDPRank:         dpRank,
@@ -495,11 +497,12 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	}
 	// Wide-EP fan-out (prefill leg): remote_hosts must be the DECODE-side pod
 	// IPs so prefill handshakes the right pods. Omitted when unset, falling back
-	// to the single-host remote_host path.
-	if len(s.config.MoRIIODecodeHosts) > 0 {
+	// to the single-host remote_host path. Re-resolved per request so peer
+	// restarts (new IP) are picked up within the TTL.
+	if decodeHosts := s.currentDecodeHosts(parentCtx); len(decodeHosts) > 0 {
 		pkv := completionRequest[requestFieldKVTransferParams].(map[string]any)
-		hosts := make([]any, len(s.config.MoRIIODecodeHosts))
-		for i, h := range s.config.MoRIIODecodeHosts {
+		hosts := make([]any, len(decodeHosts))
+		for i, h := range decodeHosts {
 			hosts[i] = h
 		}
 		pkv["remote_hosts"] = hosts
@@ -576,11 +579,12 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 		"remote_dp_size":                 s.config.MoRIIODPSize,
 	}
 	// Wide-EP fan-out (decode leg): the opposite host list, the PREFILL-side
-	// pod IPs. A multi-pod deployment must set both host flags.
-	if len(s.config.MoRIIORemoteHosts) > 0 {
+	// pod IPs. A multi-pod deployment must set both host flags. Re-resolved per
+	// request so peer restarts (new IP) are picked up within the TTL.
+	if remoteHosts := s.currentRemoteHosts(parentCtx); len(remoteHosts) > 0 {
 		dkv := completionRequest[requestFieldKVTransferParams].(map[string]any)
-		hosts := make([]any, len(s.config.MoRIIORemoteHosts))
-		for i, h := range s.config.MoRIIORemoteHosts {
+		hosts := make([]any, len(remoteHosts))
+		for i, h := range remoteHosts {
 			hosts[i] = h
 		}
 		dkv["remote_hosts"] = hosts

--- a/pkg/sidecar/proxy/connector_nixlv2_parallel_commit_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_parallel_commit_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" // nolint:revive
+	. "github.com/onsi/gomega"    // nolint:revive
+
+	"github.com/llm-d/llm-d-router/pkg/common/routing"
+)
+
+// parallelCommitEnv is a minimal proxy harness for the MoRI-IO parallel WRITE
+// dispatch commit-point tests. Unlike startMoRIProxy (which wires the shared
+// mock ChatCompletionHandler), it accepts arbitrary prefill/decode handlers so
+// a leg can fail, block, or stream on demand.
+type parallelCommitEnv struct {
+	proxy       *Server
+	baseAddr    string
+	prefillHost string
+}
+
+func startParallelCommitProxy(prefill, decode http.Handler, mutate func(cfg *Config)) *parallelCommitEnv {
+	ctx, cancelFn := context.WithCancel(newTestContext())
+	stoppedCh := make(chan struct{})
+
+	decodeBackend := httptest.NewServer(decode)
+	DeferCleanup(decodeBackend.Close)
+
+	prefillBackend := httptest.NewServer(prefill)
+	DeferCleanup(prefillBackend.Close)
+
+	decodeURL, err := url.Parse(decodeBackend.URL)
+	Expect(err).ToNot(HaveOccurred())
+
+	cfg := Config{
+		Port:                       "0",
+		DecoderURL:                 decodeURL,
+		KVConnector:                KVConnectorNIXLV2,
+		MoRIIOWriteMode:            true,
+		MoRIIOParallelDispatch:     true,
+		MoRIIODecodePodIP:          decodeURL.Hostname(),
+		MoRIIODecodeNotifyPort:     61005,
+		MoRIIODecodeHandshakePort:  6301,
+		MoRIIOPrefillNotifyPort:    61006,
+		MoRIIOPrefillHandshakePort: 6302,
+		MoRIIOTPSize:               1,
+		MoRIIODPSize:               1,
+	}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+
+	proxy := NewProxy(cfg)
+	go func() {
+		defer GinkgoRecover()
+		proxy.allowlistValidator = &AllowlistValidator{enabled: false}
+		Expect(proxy.Start(ctx)).To(Succeed())
+		stoppedCh <- struct{}{}
+	}()
+	<-proxy.readyCh
+
+	env := &parallelCommitEnv{
+		proxy:       proxy,
+		baseAddr:    "http://" + proxy.addr.String(),
+		prefillHost: prefillBackend.URL[len("http://"):],
+	}
+	DeferCleanup(func() {
+		cancelFn()
+		<-stoppedCh
+	})
+	return env
+}
+
+// send issues a chat-completions request bounded by clientTimeout, so a hang in
+// the proxy surfaces as a client error and fails the test deterministically
+// rather than blocking the suite forever.
+func (env *parallelCommitEnv) send(clientTimeout time.Duration) (int, http.Header, string, error) {
+	req, err := http.NewRequest(http.MethodPost, env.baseAddr+ChatCompletionsPath, strings.NewReader(chatCompletionsRequestBody))
+	Expect(err).ToNot(HaveOccurred())
+	req.Header.Add(routing.PrefillEndpointHeader, env.prefillHost)
+
+	client := &http.Client{Timeout: clientTimeout}
+	rp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, "", err
+	}
+	defer rp.Body.Close()
+	body, _ := io.ReadAll(rp.Body) //nolint:errcheck
+	return rp.StatusCode, rp.Header, string(body), nil
+}
+
+var _ = Describe("NIXL Connector (v2) parallel WRITE dispatch commit point", func() {
+
+	It("returns the PREFILL error (not decode's 200) when prefill fails", func() {
+		// Decode would happily return 200, but prefill fails: the client must
+		// see the prefill error, and the request must not hang.
+		prefill := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"prefill boom"}`))
+		})
+		decode := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"decode-should-be-discarded","choices":[]}`))
+		})
+
+		env := startParallelCommitProxy(prefill, decode, nil)
+
+		status, _, body, err := env.send(10 * time.Second)
+		Expect(err).ToNot(HaveOccurred(), "request must complete, not hang")
+		Expect(status).To(Equal(http.StatusInternalServerError))
+		Expect(status).ToNot(Equal(http.StatusOK))
+		Expect(body).To(ContainSubstring("prefill boom"))
+		Expect(body).ToNot(ContainSubstring("decode-should-be-discarded"))
+	})
+
+	It("does not hang when prefill and decode both block: the KV-wait backstop returns 504", func() {
+		// Both legs block (KV that never arrives) until either the sidecar
+		// cancels their request context or the test tears down. The bounded
+		// backstop timeout plus the shared cancelable context must abort and
+		// return 504 rather than hang.
+		stop := make(chan struct{})
+		block := func(_ http.ResponseWriter, r *http.Request) {
+			select {
+			case <-r.Context().Done():
+			case <-stop:
+			}
+		}
+		prefill := http.HandlerFunc(block)
+		decode := http.HandlerFunc(block)
+
+		env := startParallelCommitProxy(prefill, decode, func(cfg *Config) {
+			cfg.MoRIIOParallelDecodeWaitTimeout = 300 * time.Millisecond
+		})
+		// Registered after startParallelCommitProxy, so it runs BEFORE the
+		// backends' Close cleanups (LIFO), guaranteeing the blocked handlers
+		// unblock and the httptest servers can shut down.
+		DeferCleanup(func() { close(stop) })
+
+		start := time.Now()
+		// Client timeout is far larger than the backstop, so a 504 means the
+		// backstop fired; a client-side timeout error would mean it hung.
+		status, _, _, err := env.send(8 * time.Second)
+		elapsed := time.Since(start)
+
+		Expect(err).ToNot(HaveOccurred(), "request must return via the backstop, not hang")
+		Expect(status).To(Equal(http.StatusGatewayTimeout))
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second), "should return shortly after the 300ms backstop")
+	})
+
+	It("commits and streams decode's 200 (SSE body intact) when prefill succeeds", func() {
+		// Prefill succeeds (body is irrelevant to the parallel path), decode
+		// streams SSE. Buffering until the commit point must preserve decode's
+		// status, headers, and full body.
+		prefill := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kv_transfer_params":{}}`))
+		})
+		decode := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", eventStreamContentType)
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"total_tokens\":65}}\n\ndata: [DONE]\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		})
+
+		env := startParallelCommitProxy(prefill, decode, nil)
+
+		status, hdr, body, err := env.send(10 * time.Second)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status).To(Equal(http.StatusOK))
+		Expect(hdr.Get("Content-Type")).To(ContainSubstring(eventStreamContentType))
+		Expect(body).To(ContainSubstring("hello"))
+		Expect(body).To(ContainSubstring("[DONE]"))
+	})
+})

--- a/pkg/sidecar/proxy/connector_nixlv2_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_test.go
@@ -1039,8 +1039,8 @@ var _ = Describe("NIXL Connector (v2)", func() {
 	// 2P2D DP=16 multi-pod fan-out: each leg's remote_hosts is the opposite
 	// side's pod IPs (prefill leg -> decode IPs, decode leg -> prefill IPs).
 	It("parallel-dispatch 2P2D DP=EP=16 fans out remote_hosts with opposite host lists per leg", func() {
-		prefillHosts := []string{"10.0.0.1", "10.0.0.2"}
-		decodeHosts := []string{"10.0.1.1", "10.0.1.2"}
+		prefillHosts := []string{testPrefillHostIP1, testPrefillHostIP2}
+		decodeHosts := []string{testDecodeHostIP, testDecodeHostIP2}
 		env := startMoRIProxy(func(c *Config) {
 			c.MoRIIOParallelDispatch = true
 			c.MoRIIODPSize = 16
@@ -1055,13 +1055,13 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 		By("prefill leg fans out to the DECODE-side host list")
 		pkv := kvParams(env.prefillHandler, 0)
-		Expect(pkv["remote_hosts"]).To(Equal([]any{"10.0.1.1", "10.0.1.2"}))
+		Expect(pkv["remote_hosts"]).To(Equal([]any{testDecodeHostIP, testDecodeHostIP2}))
 		Expect(pkv).To(HaveKeyWithValue("remote_dp_size_local", BeNumerically("==", 8)))
 		Expect(pkv).To(HaveKeyWithValue("remote_dp_size", BeNumerically("==", 16)))
 
 		By("decode leg fans out to the PREFILL-side host list")
 		dkv := kvParams(env.decodeHandler, 0)
-		Expect(dkv["remote_hosts"]).To(Equal([]any{"10.0.0.1", "10.0.0.2"}))
+		Expect(dkv["remote_hosts"]).To(Equal([]any{testPrefillHostIP1, testPrefillHostIP2}))
 		Expect(dkv).To(HaveKeyWithValue("remote_dp_size_local", BeNumerically("==", 8)))
 		Expect(dkv).To(HaveKeyWithValue(requestFieldDoRemotePrefill, true))
 
@@ -1134,6 +1134,22 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		Expect(pkv).ToNot(HaveKey("remote_hosts"))
 
 		Expect(testInfo.prefillHandler.GetCompletionHeaders()[0].Get(requestHeaderDataParallelRank)).To(BeEmpty())
+		Expect(testInfo.decodeHandler.GetCompletionHeaders()[0].Get(requestHeaderDataParallelRank)).To(BeEmpty())
+	})
+
+	// Standard READ-mode parity: DP-rank propagation is a MoRI-IO WRITE-mode
+	// concern. With WRITE mode off, neither the decode body's remote_dp_rank /
+	// remote_dp_rank_override nor the x-data-parallel-rank header may be injected,
+	// even when a DP size > 1 is configured.
+	It("omits DP-rank body fields and header in standard NIXLv2 mode even with DP size set", func() {
+		testInfo.proxy.config.MoRIIODPSize = 8
+		proxyBaseAddr := startProxy()
+		sendChatCompletionsRequest(proxyBaseAddr)
+
+		dkv, _ := testInfo.decodeHandler.CompletionRequests[0][requestFieldKVTransferParams].(map[string]any)
+		Expect(dkv).ToNot(HaveKey(requestFieldRemoteDPRank))
+		Expect(dkv).ToNot(HaveKey(requestFieldRemoteDPRankOverride))
+
 		Expect(testInfo.decodeHandler.GetCompletionHeaders()[0].Get(requestHeaderDataParallelRank)).To(BeEmpty())
 	})
 })

--- a/pkg/sidecar/proxy/data_parallel_test.go
+++ b/pkg/sidecar/proxy/data_parallel_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Data Parallel support", func() {
 			fakeDecodePort := tmpPort - 1
 
 			DeferCleanup(os.Setenv, "POD_IP", os.Getenv("POD_IP"))
-			err = os.Setenv("POD_IP", "127.0.0.1")
+			err = os.Setenv("POD_IP", testLoopbackIP)
 			Expect(err).ToNot(HaveOccurred())
 
 			decodeURL, err := url.Parse("http://localhost:" + strconv.Itoa(fakeDecodePort))

--- a/pkg/sidecar/proxy/dns_metrics.go
+++ b/pkg/sidecar/proxy/dns_metrics.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/sync/errgroup"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// envMoRIIOMetricsAddr is a backward-compatible fallback for enabling the
+// Prometheus scrape endpoint. When set to a listen address (e.g. ":9090") and
+// the --metrics-port flag is unset, the sidecar serves the shared
+// controller-runtime metrics registry (which carries the moriio_dns_* counters)
+// at /metrics on that address. The --metrics-port flag takes precedence. Empty
+// (with no flag) disables it. Kept on a separate address so it never clashes
+// with the data-plane proxy port.
+const envMoRIIOMetricsAddr = "MORIIO_METRICS_ADDR"
+
+// moriioDNSSubsystem is the Prometheus subsystem prefix for the MoRI-IO
+// request-path DNS re-resolution metrics. Full names are
+// moriio_dns_reresolve_total, moriio_dns_ip_changed_total, and
+// moriio_dns_lookup_failures_total.
+const moriioDNSSubsystem = "moriio_dns"
+
+var (
+	// dnsReresolveTotal counts successful request-path DNS re-resolutions of
+	// MoRI-IO peer host specs (one per actual lookup, not per request; lookups
+	// coalesced by singleflight count once).
+	dnsReresolveTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: moriioDNSSubsystem,
+		Name:      "reresolve_total",
+		Help:      "Total successful request-path re-resolutions of MoRI-IO peer DNS names.",
+	})
+
+	// dnsIPChangedTotal counts re-resolutions where the resolved IP differed
+	// from the previously cached IP (peer pod likely restarted at a new IP).
+	dnsIPChangedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: moriioDNSSubsystem,
+		Name:      "ip_changed_total",
+		Help:      "Total times a MoRI-IO peer DNS name re-resolved to a different IP than the cached value.",
+	})
+
+	// dnsLookupFailuresTotal counts failed request-path DNS lookups (which then
+	// fall back to the last-known-good IP or, on cold start, the raw spec).
+	dnsLookupFailuresTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: moriioDNSSubsystem,
+		Name:      "lookup_failures_total",
+		Help:      "Total failed MoRI-IO peer DNS lookups on the request path.",
+	})
+
+	registerDNSMetricsOnce sync.Once
+)
+
+// registerDNSMetrics registers the MoRI-IO DNS re-resolution counters on the
+// controller-runtime metrics registry (the same registry the rest of the
+// process exposes at /metrics). Guarded by a sync.Once so repeated resolver
+// construction (including in tests) never double-registers.
+func registerDNSMetrics() {
+	registerDNSMetricsOnce.Do(func() {
+		crmetrics.Registry.MustRegister(
+			dnsReresolveTotal,
+			dnsIPChangedTotal,
+			dnsLookupFailuresTotal,
+		)
+	})
+}
+
+// metricsAddr returns the listen address for the /metrics endpoint, or "" when
+// disabled. The --metrics-port flag (Config.MetricsPort) takes precedence; the
+// MORIIO_METRICS_ADDR env var is a backward-compatible fallback.
+func (s *Server) metricsAddr() string {
+	if s.config.MetricsPort > 0 {
+		return fmt.Sprintf(":%d", s.config.MetricsPort)
+	}
+	return strings.TrimSpace(os.Getenv(envMoRIIOMetricsAddr))
+}
+
+// maybeStartMetrics starts an opt-in Prometheus /metrics HTTP server when a
+// metrics address is configured (via --metrics-port or MORIIO_METRICS_ADDR),
+// registering the goroutine on grp so it shares the server lifecycle and shuts
+// down with ctx. When neither is set (the default) it is a no-op and the
+// counters simply go unscraped.
+func (s *Server) maybeStartMetrics(ctx context.Context, grp *errgroup.Group) {
+	addr := s.metricsAddr()
+	if addr == "" {
+		return
+	}
+	grp.Go(func() error {
+		return s.serveMetrics(ctx, addr)
+	})
+}
+
+// serveMetrics serves the shared controller-runtime metrics registry at
+// /metrics on addr until ctx is cancelled, then shuts the server down
+// gracefully. Registration of the moriio_dns_* counters is ensured here so they
+// are present even if no resolver has been constructed yet.
+func (s *Server) serveMetrics(ctx context.Context, addr string) error {
+	registerDNSMetrics()
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(crmetrics.Registry, promhttp.HandlerOpts{}))
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			s.logger.Error(err, "failed to gracefully shut down metrics server")
+		}
+	}()
+
+	s.logger.Info("starting MoRI-IO metrics server", "addr", addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		s.logger.Error(err, "metrics server failed")
+		return err
+	}
+	return nil
+}

--- a/pkg/sidecar/proxy/dp_rank.go
+++ b/pkg/sidecar/proxy/dp_rank.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"encoding/binary"
+	"math"
 
 	"golang.org/x/crypto/blake2s"
 )
@@ -40,4 +41,37 @@ func pickDPRank(requestID string, dpSize int) int {
 	_, _ = h.Write([]byte(requestID))
 	sum := h.Sum(nil)
 	return int(binary.BigEndian.Uint64(sum[:8]) % uint64(dpSize))
+}
+
+// resolveDecodeDPRank picks the DP rank for the decode leg in serial WRITE
+// dispatch. It prefers the rank the prefill leg returned in its
+// kv_transfer_params (remote_dp_rank), but only when that value is a valid
+// integer in [0, dpSize); otherwise it falls back to the deterministic hash of
+// the request id. The returned rank is therefore always in range, so the caller
+// can pin BOTH the x-data-parallel-rank header and the decode body's
+// remote_dp_rank to the same value and avoid the header/body targeting
+// different ranks (which would hang the KV transfer). The second return value
+// reports whether the prefill-returned rank was used (false = hash fallback,
+// including when it was omitted, non-numeric, or out of range).
+func resolveDecodeDPRank(prefillKV any, requestID string, dpSize int) (rank int, usedReturned bool) {
+	fallback := pickDPRank(requestID, dpSize)
+	if dpSize <= 1 {
+		// Single-DP: the rank is always 0 and the header is not set.
+		return fallback, false
+	}
+	pkv, ok := prefillKV.(map[string]any)
+	if !ok {
+		return fallback, false
+	}
+	rv, present := pkv[requestFieldRemoteDPRank]
+	if !present {
+		return fallback, false
+	}
+	if f, ok := rv.(float64); ok && f != math.Trunc(f) {
+		return fallback, false
+	}
+	if ri, ok := toInt(rv); ok && ri >= 0 && ri < dpSize {
+		return ri, true
+	}
+	return fallback, false
 }

--- a/pkg/sidecar/proxy/dp_rank_test.go
+++ b/pkg/sidecar/proxy/dp_rank_test.go
@@ -22,6 +22,61 @@ import (
 	"testing"
 )
 
+// Shared test IP literals, factored out so repeated use across the proxy test
+// package does not trip the goconst linter.
+const (
+	testDecodeHostIP   = "10.0.1.1"
+	testDecodeHostIP2  = "10.0.1.2"
+	testDecodeHostIP3  = "10.0.1.3"
+	testPrefillHostIP1 = "10.0.0.1"
+	testPrefillHostIP2 = "10.0.0.2"
+	testLocalHostname  = "localhost"
+	testLoopbackIP     = "127.0.0.1"
+	testLoopbackIPv6   = "::1"
+)
+
+// TestResolveDecodeDPRank covers rank propagation from the prefill response:
+// a valid in-range returned rank is used; an omitted, non-numeric, or
+// out-of-range value falls back to the deterministic hash. This guards against
+// the header and decode body targeting different DP ranks (which hangs the
+// MoRI-IO KV transfer).
+func TestResolveDecodeDPRank(t *testing.T) {
+	const dpSize = 8
+	const rid = "cmpl-rank-test"
+	hashFallback := pickDPRank(rid, dpSize)
+
+	cases := []struct {
+		name         string
+		prefillKV    any
+		dpSize       int
+		wantRank     int
+		wantReturned bool
+	}{
+		{name: "valid returned rank", prefillKV: map[string]any{requestFieldRemoteDPRank: float64(3)}, dpSize: dpSize, wantRank: 3, wantReturned: true},
+		{name: "valid returned rank as int", prefillKV: map[string]any{requestFieldRemoteDPRank: 5}, dpSize: dpSize, wantRank: 5, wantReturned: true},
+		{name: "zero is valid", prefillKV: map[string]any{requestFieldRemoteDPRank: float64(0)}, dpSize: dpSize, wantRank: 0, wantReturned: true},
+		{name: "omitted falls back to hash", prefillKV: map[string]any{}, dpSize: dpSize, wantRank: hashFallback, wantReturned: false},
+		{name: "nil kv falls back to hash", prefillKV: nil, dpSize: dpSize, wantRank: hashFallback, wantReturned: false},
+		{name: "non-numeric falls back to hash", prefillKV: map[string]any{requestFieldRemoteDPRank: "two"}, dpSize: dpSize, wantRank: hashFallback, wantReturned: false},
+		{name: "fractional falls back to hash (no truncation)", prefillKV: map[string]any{requestFieldRemoteDPRank: float64(3.5)}, dpSize: dpSize, wantRank: hashFallback, wantReturned: false},
+		{name: "out-of-range high falls back to hash", prefillKV: map[string]any{requestFieldRemoteDPRank: float64(8)}, dpSize: dpSize, wantRank: hashFallback, wantReturned: false},
+		{name: "negative falls back to hash", prefillKV: map[string]any{requestFieldRemoteDPRank: float64(-1)}, dpSize: dpSize, wantRank: hashFallback, wantReturned: false},
+		{name: "single-DP always rank 0", prefillKV: map[string]any{requestFieldRemoteDPRank: float64(0)}, dpSize: 1, wantRank: 0, wantReturned: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotRank, gotReturned := resolveDecodeDPRank(c.prefillKV, rid, c.dpSize)
+			if gotRank != c.wantRank || gotReturned != c.wantReturned {
+				t.Errorf("resolveDecodeDPRank(%v, %q, %d) = (%d, %t); want (%d, %t)",
+					c.prefillKV, rid, c.dpSize, gotRank, gotReturned, c.wantRank, c.wantReturned)
+			}
+			if gotRank < 0 || gotRank >= max(c.dpSize, 1) {
+				t.Errorf("resolveDecodeDPRank returned out-of-range rank %d for dpSize %d", gotRank, c.dpSize)
+			}
+		})
+	}
+}
+
 // TestPickDPRankSingleDP verifies dpSize <= 1 short-circuits to 0 without
 // hashing.
 func TestPickDPRankSingleDP(t *testing.T) {

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -94,6 +94,13 @@ const (
 	defaultMooncakeBootstrapPort = 8998
 	defaultP2PConnectorPort      = 7777
 
+	// defaultMoRIIOParallelDecodeWaitTimeout backstops the parallel WRITE
+	// dispatch: it bounds how long the decode leg waits on the prefill outcome
+	// (and thus KV) before being cancelled, so a hung/failed prefill fails the
+	// request instead of hanging. Prefill in parallel dispatch is capped to one
+	// token, so it normally resolves well within this window.
+	defaultMoRIIOParallelDecodeWaitTimeout = 30 * time.Second
+
 	// TLS stages
 	prefillStage = "prefiller"
 	decodeStage  = "decoder"
@@ -220,15 +227,17 @@ func NewOptions() *Options {
 			Tracing:                 false,
 			// MoRI-IO defaults: off, preserving existing NIXLv2 behaviour.
 			// Port defaults match vLLM's MoRI-IO connector defaults.
-			MoRIIOWriteMode:            false,
-			MoRIIODecodeNotifyPort:     61005,
-			MoRIIODecodeHandshakePort:  6301,
-			MoRIIODecodePodIP:          os.Getenv("POD_IP"),
-			MoRIIOParallelDispatch:     false,
-			MoRIIOPrefillHandshakePort: 6301,
-			MoRIIOPrefillNotifyPort:    61005,
-			MoRIIOTPSize:               1,
-			MoRIIODPSize:               1,
+			MoRIIOWriteMode:           false,
+			MoRIIODecodeNotifyPort:    61005,
+			MoRIIODecodeHandshakePort: 6301,
+			MoRIIODecodePodIP:         os.Getenv("POD_IP"),
+			MoRIIOParallelDispatch:    false,
+
+			MoRIIOParallelDecodeWaitTimeout: defaultMoRIIOParallelDecodeWaitTimeout,
+			MoRIIOPrefillHandshakePort:      6301,
+			MoRIIOPrefillNotifyPort:         61005,
+			MoRIIOTPSize:                    1,
+			MoRIIODPSize:                    1,
 			// Wide-EP multi-pod: empty disables fan-out (single-pod fallback).
 			MoRIIORemoteHosts: nil,
 			MoRIIODPSizeLocal: 0,
@@ -292,7 +301,9 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	// Concurrent-dispatch flags: synthesise decode's kv_transfer_params from
 	// config so prefill and decode dispatch can overlap.
 	fs.BoolVar(&opts.MoRIIOParallelDispatch, "moriio-parallel-dispatch", opts.MoRIIOParallelDispatch,
-		"Fire prefill and decode concurrently. Requires --moriio-write-mode.")
+		"Fire prefill and decode concurrently. OFF by default (serial dispatch via handleNIXLV2 is the SLA-safe path); opt-in only. Requires --moriio-write-mode.")
+	fs.DurationVar(&opts.MoRIIOParallelDecodeWaitTimeout, "moriio-parallel-decode-wait-timeout", opts.MoRIIOParallelDecodeWaitTimeout,
+		"Backstop timeout for parallel dispatch: how long decode may wait on the prefill outcome/KV before being cancelled so the request fails instead of hanging. Only used with --moriio-parallel-dispatch.")
 	fs.IntVar(&opts.MoRIIOPrefillHandshakePort, "moriio-prefill-handshake-port", opts.MoRIIOPrefillHandshakePort,
 		"Prefill pod's base MoRI-IO handshake port, used to build the decode leg in parallel-dispatch mode.")
 	fs.IntVar(&opts.MoRIIOPrefillNotifyPort, "moriio-prefill-notify-port", opts.MoRIIOPrefillNotifyPort,
@@ -441,26 +452,27 @@ func (opts *Options) Complete() error {
 	// aligns with Kubernetes LeaderWorkerSet patterns where pod addresses are
 	// DNS names (e.g., "moriio-prefill-0-0.namespace.svc"); a literal IP is
 	// used as-is.
-	if resolved, resolveErr := resolveHostsToIPs(opts.MoRIIORemoteHosts); resolveErr != nil {
-		return fmt.Errorf("resolving --moriio-remote-hosts: %w", resolveErr)
-	} else {
-		opts.MoRIIORemoteHosts = resolved
+	resolvedRemote, remoteErr := resolveHostsToIPs(opts.MoRIIORemoteHosts)
+	if remoteErr != nil {
+		return fmt.Errorf("resolving --moriio-remote-hosts: %w", remoteErr)
 	}
-	if resolved, resolveErr := resolveHostsToIPs(opts.MoRIIODecodeHosts); resolveErr != nil {
-		return fmt.Errorf("resolving --moriio-decode-hosts: %w", resolveErr)
-	} else {
-		opts.MoRIIODecodeHosts = resolved
+	opts.MoRIIORemoteHosts = resolvedRemote
+
+	resolvedDecode, decodeErr := resolveHostsToIPs(opts.MoRIIODecodeHosts)
+	if decodeErr != nil {
+		return fmt.Errorf("resolving --moriio-decode-hosts: %w", decodeErr)
 	}
+	opts.MoRIIODecodeHosts = resolvedDecode
 
 	// Single-host counterpart: --moriio-local-pod-ip is decode's advertised
 	// remote_host on the prefill leg. Resolve it the same way so it can be an
 	// LWS DNS name (a literal IP passes through unchanged).
 	if opts.MoRIIODecodePodIP != "" {
-		if resolved, resolveErr := resolveHostsToIPs([]string{opts.MoRIIODecodePodIP}); resolveErr != nil {
-			return fmt.Errorf("resolving --moriio-local-pod-ip: %w", resolveErr)
-		} else {
-			opts.MoRIIODecodePodIP = resolved[0]
+		resolved, podIPErr := resolveHostsToIPs([]string{opts.MoRIIODecodePodIP})
+		if podIPErr != nil {
+			return fmt.Errorf("resolving --moriio-local-pod-ip: %w", podIPErr)
 		}
+		opts.MoRIIODecodePodIP = resolved[0]
 	}
 
 	return nil

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"net"
 	"net/url"
 	"os"
 	"slices"
@@ -48,9 +49,9 @@ const (
 	// fail with a clear error message directing users to wait for the feature
 	// to be officially released.
 	//
-	// TODO(AMD-MoRI-IO): Set to true once CI tests and production validation
-	// are complete in a future release candidate.
-	MoRIIOFeatureEnabled = false
+	// AMD-MoRI-IO: Feature enabled for 1P1D (DP=EP=8) intra-node Wide-EP
+	// and 2P2D (DP=EP=16) inter-node Wide-EP with LeaderWorkerSet support.
+	MoRIIOFeatureEnabled = true
 
 	// Flags
 	port                      = "port"
@@ -297,18 +298,23 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 			"Set to the engine DP size for Wide-EP (TP=1, DP>1); default 1 leaves the wire unchanged.")
 
 	// Wide-EP multi-pod fan-out. Optional: empty preserves single-pod behaviour.
-	// remote_hosts carries the opposite side's pod IPs (decode IPs on the prefill
+	// remote_hosts carries the opposite side's pod DNS names (decode on the prefill
 	// leg and vice versa); dp-size-local maps a global DP rank to a pod via
 	// pod_idx = dp_rank / dp_size_local.
+	// DNS names are resolved to IPs at startup (LWS-compatible).
 	fs.StringSliceVar(&opts.MoRIIORemoteHosts, "moriio-remote-hosts", opts.MoRIIORemoteHosts,
-		"Wide-EP: comma-separated remote (prefill-side) pod IPs for per-DP-rank fan-out. "+
+		"Wide-EP: comma-separated remote (prefill-side) pod hosts for per-DP-rank fan-out. "+
+			"Prefer Kubernetes DNS names (e.g., 'pod-name.namespace.svc.cluster.local'), "+
+			"resolved to IPs at startup; raw IPs are accepted for backward compatibility. "+
 			"Pair with --moriio-dp-size-local.")
 	fs.IntVar(&opts.MoRIIODPSizeLocal, "moriio-dp-size-local", opts.MoRIIODPSizeLocal,
 		"Wide-EP: per-pod DP size used to map a global DP rank to a pod index. "+
 			"Must satisfy --moriio-dp-size = dp-size-local * len(hosts).")
 	fs.StringSliceVar(&opts.MoRIIODecodeHosts, "moriio-decode-hosts", opts.MoRIIODecodeHosts,
-		"Wide-EP: comma-separated decode-side pod IPs, emitted as the prefill leg's "+
-			"remote_hosts. Pair with --moriio-dp-size-local.")
+		"Wide-EP: comma-separated decode-side pod hosts, emitted as the prefill leg's "+
+			"remote_hosts. Prefer Kubernetes DNS names (e.g., 'pod-name.namespace.svc.cluster.local'), "+
+			"resolved to IPs at startup; raw IPs are accepted for backward compatibility. "+
+			"Pair with --moriio-dp-size-local.")
 
 	fs.StringSliceVar(&opts.enableTLS, enableTLS, opts.enableTLS, "stages to enable TLS for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
 	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, tlsInsecureSkipVerify, opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
@@ -411,9 +417,28 @@ func (opts *Options) Complete() error {
 		opts.MoRIIODPSize, opts.MoRIIODPSizeLocal); err != nil {
 		return err
 	}
-	return validateWideEPHosts(
+	if err := validateWideEPHosts(
 		"--moriio-decode-hosts", opts.MoRIIODecodeHosts,
-		opts.MoRIIODPSize, opts.MoRIIODPSizeLocal)
+		opts.MoRIIODPSize, opts.MoRIIODPSizeLocal); err != nil {
+		return err
+	}
+
+	// LWS-compatible DNS resolution: automatically resolve hostnames to IPs at startup.
+	// This aligns with Kubernetes LeaderWorkerSet patterns where pod addresses are
+	// DNS names (e.g., "moriio-prefill-0-0.namespace.svc") rather than hardcoded IPs.
+	// Raw IPs are deprecated but still accepted for backward compatibility.
+	if resolved, resolveErr := resolveHostsToIPs(opts.MoRIIORemoteHosts); resolveErr != nil {
+		return fmt.Errorf("resolving --moriio-remote-hosts: %w", resolveErr)
+	} else {
+		opts.MoRIIORemoteHosts = resolved
+	}
+	if resolved, resolveErr := resolveHostsToIPs(opts.MoRIIODecodeHosts); resolveErr != nil {
+		return fmt.Errorf("resolving --moriio-decode-hosts: %w", resolveErr)
+	} else {
+		opts.MoRIIODecodeHosts = resolved
+	}
+
+	return nil
 }
 
 // hasMoRIIOFlagsSet returns true if any --moriio-* flag is set to a non-default
@@ -468,6 +493,46 @@ func validateWideEPHosts(flag string, hosts []string, dpSize, dpLocal int) error
 			flag, len(hosts), dpSize/dpLocal)
 	}
 	return nil
+}
+
+// resolveHostsToIPs resolves DNS names to IPs, passing through raw IP addresses unchanged.
+// Supports both:
+//   - Raw IPs (e.g., "10.0.0.1") - passed through as-is for static IP deployments
+//   - DNS names (e.g., "pod-name.namespace.svc") - resolved to IP at startup for LWS deployments
+//
+// Resolution happens once at startup.
+func resolveHostsToIPs(hosts []string) ([]string, error) {
+	if len(hosts) == 0 {
+		return hosts, nil
+	}
+	resolved := make([]string, len(hosts))
+	for i, host := range hosts {
+		// Pass through raw IP addresses unchanged
+		if ip := net.ParseIP(host); ip != nil {
+			resolved[i] = host
+			continue
+		}
+		// Resolve DNS name to IP
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve %q: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("no IPs found for %q", host)
+		}
+		// Prefer IPv4 if available
+		for _, ip := range ips {
+			if ipv4 := ip.To4(); ipv4 != nil {
+				resolved[i] = ipv4.String()
+				break
+			}
+		}
+		// Fall back to first IP if no IPv4 found
+		if resolved[i] == "" {
+			resolved[i] = ips[0].String()
+		}
+	}
+	return resolved, nil
 }
 
 // Validate checks the Options for invalid or conflicting values.

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -278,7 +278,9 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.MoRIIODecodeNotifyPort, "moriio-decode-notify-port", opts.MoRIIODecodeNotifyPort,
 		"Base MoRI-IO notify port on the decode pod.")
 	fs.StringVar(&opts.MoRIIODecodePodIP, "moriio-local-pod-ip", opts.MoRIIODecodePodIP,
-		"Decode pod's routable IP, used as the prefill leg's remote_host. "+
+		"Decode pod's routable address, used as the prefill leg's remote_host. "+
+			"Prefer a Kubernetes DNS name (e.g., 'pod-name.namespace.svc.cluster.local'), "+
+			"resolved to an IP at startup; a raw IP is accepted for backward compatibility. "+
 			"Defaults to the POD_IP env var. Required with --moriio-write-mode.")
 	fs.IntVar(&opts.MoRIIODecodeHandshakePort, "moriio-decode-handshake-port", opts.MoRIIODecodeHandshakePort,
 		"Base MoRI-IO handshake port on the decode pod.")
@@ -436,6 +438,17 @@ func (opts *Options) Complete() error {
 		return fmt.Errorf("resolving --moriio-decode-hosts: %w", resolveErr)
 	} else {
 		opts.MoRIIODecodeHosts = resolved
+	}
+
+	// Single-host counterpart: --moriio-local-pod-ip is decode's advertised
+	// remote_host on the prefill leg. Resolve it the same way so it can be an
+	// LWS DNS name instead of a raw IP (raw IPs pass through unchanged).
+	if opts.MoRIIODecodePodIP != "" {
+		if resolved, resolveErr := resolveHostsToIPs([]string{opts.MoRIIODecodePodIP}); resolveErr != nil {
+			return fmt.Errorf("resolving --moriio-local-pod-ip: %w", resolveErr)
+		} else {
+			opts.MoRIIODecodePodIP = resolved[0]
+		}
 	}
 
 	return nil

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -283,8 +283,8 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 		"Base MoRI-IO notify port on the decode pod.")
 	fs.StringVar(&opts.MoRIIODecodePodIP, "moriio-local-pod-ip", opts.MoRIIODecodePodIP,
 		"Decode pod's routable address, used as the prefill leg's remote_host. "+
-			"Prefer a Kubernetes DNS name (e.g., 'pod-name.namespace.svc.cluster.local'), "+
-			"resolved to an IP at startup; a raw IP is accepted for backward compatibility. "+
+			"A Kubernetes DNS name (e.g., 'pod-name.namespace.svc.cluster.local') "+
+			"is resolved to an IP at startup; a literal IP is used as-is. "+
 			"Defaults to the POD_IP env var. Required with --moriio-write-mode.")
 	fs.IntVar(&opts.MoRIIODecodeHandshakePort, "moriio-decode-handshake-port", opts.MoRIIODecodeHandshakePort,
 		"Base MoRI-IO handshake port on the decode pod.")
@@ -310,16 +310,16 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	// DNS names are resolved to IPs at startup (LWS-compatible).
 	fs.StringSliceVar(&opts.MoRIIORemoteHosts, "moriio-remote-hosts", opts.MoRIIORemoteHosts,
 		"Wide-EP: comma-separated remote (prefill-side) pod hosts for per-DP-rank fan-out. "+
-			"Prefer Kubernetes DNS names (e.g., 'pod-name.namespace.svc.cluster.local'), "+
-			"resolved to IPs at startup; raw IPs are accepted for backward compatibility. "+
+			"Kubernetes DNS names (e.g., 'pod-name.namespace.svc.cluster.local') "+
+			"are resolved to IPs at startup; literal IPs are used as-is. "+
 			"Pair with --moriio-dp-size-local.")
 	fs.IntVar(&opts.MoRIIODPSizeLocal, "moriio-dp-size-local", opts.MoRIIODPSizeLocal,
 		"Wide-EP: per-pod DP size used to map a global DP rank to a pod index. "+
 			"Must satisfy --moriio-dp-size = dp-size-local * len(hosts).")
 	fs.StringSliceVar(&opts.MoRIIODecodeHosts, "moriio-decode-hosts", opts.MoRIIODecodeHosts,
 		"Wide-EP: comma-separated decode-side pod hosts, emitted as the prefill leg's "+
-			"remote_hosts. Prefer Kubernetes DNS names (e.g., 'pod-name.namespace.svc.cluster.local'), "+
-			"resolved to IPs at startup; raw IPs are accepted for backward compatibility. "+
+			"remote_hosts. Kubernetes DNS names (e.g., 'pod-name.namespace.svc.cluster.local') "+
+			"are resolved to IPs at startup; literal IPs are used as-is. "+
 			"Pair with --moriio-dp-size-local.")
 
 	fs.StringSliceVar(&opts.enableTLS, enableTLS, opts.enableTLS, "stages to enable TLS for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
@@ -431,16 +431,16 @@ func (opts *Options) Complete() error {
 
 	// Capture the ORIGINAL host specs before one-shot resolution rewrites the
 	// resolved fields. The request-path hostResolver re-resolves these on a
-	// short TTL so peer pod restarts (new IP) are eventually picked up. Raw IPs
-	// stored here pass through the resolver unchanged.
+	// short TTL so peer pod restarts (new IP) are eventually picked up. Literal
+	// IPs stored here pass through the resolver unchanged.
 	opts.MoRIIORemoteHostSpecs = append([]string(nil), opts.MoRIIORemoteHosts...)
 	opts.MoRIIODecodeHostSpecs = append([]string(nil), opts.MoRIIODecodeHosts...)
 	opts.MoRIIODecodePodIPSpec = opts.MoRIIODecodePodIP
 
-	// LWS-compatible DNS resolution: automatically resolve hostnames to IPs at startup.
-	// This aligns with Kubernetes LeaderWorkerSet patterns where pod addresses are
-	// DNS names (e.g., "moriio-prefill-0-0.namespace.svc") rather than hardcoded IPs.
-	// Raw IPs are deprecated but still accepted for backward compatibility.
+	// LWS-compatible DNS resolution: resolve hostnames to IPs at startup. This
+	// aligns with Kubernetes LeaderWorkerSet patterns where pod addresses are
+	// DNS names (e.g., "moriio-prefill-0-0.namespace.svc"); a literal IP is
+	// used as-is.
 	if resolved, resolveErr := resolveHostsToIPs(opts.MoRIIORemoteHosts); resolveErr != nil {
 		return fmt.Errorf("resolving --moriio-remote-hosts: %w", resolveErr)
 	} else {
@@ -454,7 +454,7 @@ func (opts *Options) Complete() error {
 
 	// Single-host counterpart: --moriio-local-pod-ip is decode's advertised
 	// remote_host on the prefill leg. Resolve it the same way so it can be an
-	// LWS DNS name instead of a raw IP (raw IPs pass through unchanged).
+	// LWS DNS name (a literal IP passes through unchanged).
 	if opts.MoRIIODecodePodIP != "" {
 		if resolved, resolveErr := resolveHostsToIPs([]string{opts.MoRIIODecodePodIP}); resolveErr != nil {
 			return fmt.Errorf("resolving --moriio-local-pod-ip: %w", resolveErr)
@@ -520,11 +520,8 @@ func validateWideEPHosts(flag string, hosts []string, dpSize, dpLocal int) error
 	return nil
 }
 
-// resolveHostsToIPs resolves DNS names to IPs, passing through raw IP addresses unchanged.
-// Supports both:
-//   - Raw IPs (e.g., "10.0.0.1") - passed through as-is for static IP deployments
-//   - DNS names (e.g., "pod-name.namespace.svc") - resolved to IP at startup for LWS deployments
-//
+// resolveHostsToIPs resolves DNS names (e.g., "pod-name.namespace.svc") to IPs
+// at startup, preferring IPv4. A literal IP (e.g., "10.0.0.1") is used as-is.
 // Resolution happens once at startup.
 func resolveHostsToIPs(hosts []string) ([]string, error) {
 	if len(hosts) == 0 {
@@ -532,7 +529,7 @@ func resolveHostsToIPs(hosts []string) ([]string, error) {
 	}
 	resolved := make([]string, len(hosts))
 	for i, host := range hosts {
-		// Pass through raw IP addresses unchanged
+		// A literal IP is used as-is (no lookup).
 		if ip := net.ParseIP(host); ip != nil {
 			resolved[i] = host
 			continue

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -78,6 +79,7 @@ const (
 	inlineConfiguration       = "configuration"
 	configurationFile         = "configuration-file"
 	tracingFlag               = "tracing"
+	metricsPort               = "metrics-port"
 
 	// Environment variables
 	envInferencePool           = "INFERENCE_POOL"
@@ -122,6 +124,7 @@ type yamlConfiguration struct {
 	PrefillRetryBackoff     string   `json:"prefill-retry-backoff,omitempty"`
 	DecodeChunkSize         int      `json:"decode-chunk-size,omitempty"`
 	Tracing                 *bool    `json:"tracing,omitempty"`
+	MetricsPort             int      `json:"metrics-port,omitempty"`
 }
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
@@ -270,6 +273,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&opts.PoolGroup, poolGroup, opts.PoolGroup, "group of the InferencePool this Endpoint Picker is associated with.")
 	fs.IntVar(&opts.DecodeChunkSize, decodeChunkSize, opts.DecodeChunkSize, "enables chunked decode mode when > 0; value is the token budget per chunk. For best performance should be a multiple of the block size.")
 	fs.BoolVar(&opts.Tracing, tracingFlag, opts.Tracing, "Enable OpenTelemetry tracing")
+	fs.IntVar(&opts.MetricsPort, metricsPort, opts.MetricsPort, "Port for the Prometheus /metrics endpoint (exposes the moriio_dns_* counters). 0 (the default) disables it. Takes precedence over the MORIIO_METRICS_ADDR env var.")
 
 	// MoRI-IO WRITE-mode flags. Only meaningful with --kv-connector=nixlv2
 	// against vLLM engines running MoRI-IO in WRITE mode.
@@ -425,6 +429,14 @@ func (opts *Options) Complete() error {
 		return err
 	}
 
+	// Capture the ORIGINAL host specs before one-shot resolution rewrites the
+	// resolved fields. The request-path hostResolver re-resolves these on a
+	// short TTL so peer pod restarts (new IP) are eventually picked up. Raw IPs
+	// stored here pass through the resolver unchanged.
+	opts.MoRIIORemoteHostSpecs = append([]string(nil), opts.MoRIIORemoteHosts...)
+	opts.MoRIIODecodeHostSpecs = append([]string(nil), opts.MoRIIODecodeHosts...)
+	opts.MoRIIODecodePodIPSpec = opts.MoRIIODecodePodIP
+
 	// LWS-compatible DNS resolution: automatically resolve hostnames to IPs at startup.
 	// This aligns with Kubernetes LeaderWorkerSet patterns where pod addresses are
 	// DNS names (e.g., "moriio-prefill-0-0.namespace.svc") rather than hardcoded IPs.
@@ -525,27 +537,28 @@ func resolveHostsToIPs(hosts []string) ([]string, error) {
 			resolved[i] = host
 			continue
 		}
-		// Resolve DNS name to IP
-		ips, err := net.LookupIP(host)
+		// Resolve DNS name to IP (IPv4-preferred)
+		ip, err := resolveSingleHost(host)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve %q: %w", host, err)
+			return nil, err
 		}
-		if len(ips) == 0 {
-			return nil, fmt.Errorf("no IPs found for %q", host)
-		}
-		// Prefer IPv4 if available
-		for _, ip := range ips {
-			if ipv4 := ip.To4(); ipv4 != nil {
-				resolved[i] = ipv4.String()
-				break
-			}
-		}
-		// Fall back to first IP if no IPv4 found
-		if resolved[i] == "" {
-			resolved[i] = ips[0].String()
-		}
+		resolved[i] = ip
 	}
 	return resolved, nil
+}
+
+// resolveSingleHost resolves one DNS name to a single IP string, preferring
+// IPv4 and falling back to the first returned address. Callers must handle raw
+// IP passthrough before calling this. The lookup is bounded by a context
+// timeout sourced from resolveTimeoutFromEnv() (default defaultResolveTimeout),
+// the same bound the request-path resolver uses, so a slow or hanging resolver
+// cannot stall startup indefinitely. Shares lookupIPv4Preferred with the
+// request-path TTL resolver so both apply identical bounding and
+// IPv4-preference semantics.
+func resolveSingleHost(host string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), resolveTimeoutFromEnv())
+	defer cancel()
+	return lookupIPv4Preferred(ctx, net.DefaultResolver.LookupIPAddr, host)
 }
 
 // Validate checks the Options for invalid or conflicting values.
@@ -817,6 +830,9 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	}
 	if cfg.DecodeChunkSize != 0 && !opts.isFlagSet(decodeChunkSize) {
 		opts.DecodeChunkSize = cfg.DecodeChunkSize
+	}
+	if cfg.MetricsPort != 0 && !opts.isFlagSet(metricsPort) {
+		opts.MetricsPort = cfg.MetricsPort
 	}
 	if cfg.Tracing != nil && !opts.isFlagSet(tracingFlag) {
 		opts.Tracing = *cfg.Tracing

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -956,7 +956,7 @@ func TestValidateWideEPHosts(t *testing.T) {
 		{
 			name:    "2P2D DP16 valid (2 pods, local 8)",
 			flag:    "--moriio-decode-hosts",
-			hosts:   []string{"10.0.1.1", "10.0.1.2"},
+			hosts:   []string{testDecodeHostIP, testDecodeHostIP2},
 			dpSize:  16,
 			dpLocal: 8,
 			wantErr: "",
@@ -972,7 +972,7 @@ func TestValidateWideEPHosts(t *testing.T) {
 		{
 			name:    "single host is degenerate, tolerated",
 			flag:    "--moriio-remote-hosts",
-			hosts:   []string{"10.0.0.1"},
+			hosts:   []string{testPrefillHostIP1},
 			dpSize:  8,
 			dpLocal: 0,
 			wantErr: "",
@@ -980,7 +980,7 @@ func TestValidateWideEPHosts(t *testing.T) {
 		{
 			name:    "multi-pod missing dp-size-local",
 			flag:    "--moriio-remote-hosts",
-			hosts:   []string{"10.0.0.1", "10.0.0.2"},
+			hosts:   []string{testPrefillHostIP1, testPrefillHostIP2},
 			dpSize:  16,
 			dpLocal: 0,
 			wantErr: "requires dp-size-local > 0",
@@ -988,7 +988,7 @@ func TestValidateWideEPHosts(t *testing.T) {
 		{
 			name:    "dp-size not divisible by dp-size-local",
 			flag:    "--moriio-decode-hosts",
-			hosts:   []string{"10.0.1.1", "10.0.1.2"},
+			hosts:   []string{testDecodeHostIP, testDecodeHostIP2},
 			dpSize:  15,
 			dpLocal: 8,
 			wantErr: "must be divisible",
@@ -996,7 +996,7 @@ func TestValidateWideEPHosts(t *testing.T) {
 		{
 			name:    "host count does not match pod count",
 			flag:    "--moriio-remote-hosts",
-			hosts:   []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+			hosts:   []string{testPrefillHostIP1, testPrefillHostIP2, "10.0.0.3"},
 			dpSize:  16,
 			dpLocal: 8,
 			wantErr: "dp-size/dp-size-local = 2",
@@ -1036,8 +1036,8 @@ func TestCompleteWideEPValidation(t *testing.T) {
 	}{
 		{
 			name:        "valid 2P2D DP16 both legs",
-			remoteHosts: []string{"localhost", "localhost"},
-			decodeHosts: []string{"localhost", "localhost"},
+			remoteHosts: []string{testLocalHostname, testLocalHostname},
+			decodeHosts: []string{testLocalHostname, testLocalHostname},
 			dpSize:      16,
 			dpLocal:     8,
 			wantErr:     "",
@@ -1052,7 +1052,7 @@ func TestCompleteWideEPValidation(t *testing.T) {
 		},
 		{
 			name:        "remote-hosts leg invalid",
-			remoteHosts: []string{"10.0.0.1", "10.0.0.2"},
+			remoteHosts: []string{testPrefillHostIP1, testPrefillHostIP2},
 			decodeHosts: nil,
 			dpSize:      16,
 			dpLocal:     0,
@@ -1061,7 +1061,7 @@ func TestCompleteWideEPValidation(t *testing.T) {
 		{
 			name:        "decode-hosts leg invalid",
 			remoteHosts: nil,
-			decodeHosts: []string{"10.0.1.1", "10.0.1.2", "10.0.1.3"},
+			decodeHosts: []string{testDecodeHostIP, testDecodeHostIP2, testDecodeHostIP3},
 			dpSize:      16,
 			dpLocal:     8,
 			wantErr:     "--moriio-decode-hosts",
@@ -1096,7 +1096,7 @@ func TestCompleteMoRIIOWriteModeGuards(t *testing.T) {
 		t.Run("dormant feature rejects write-mode", func(t *testing.T) {
 			opts := NewOptions()
 			opts.MoRIIOWriteMode = true
-			opts.MoRIIODecodePodIP = "10.0.1.1"
+			opts.MoRIIODecodePodIP = testDecodeHostIP
 			err := opts.Complete()
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "not yet enabled")
@@ -1110,7 +1110,7 @@ func TestCompleteMoRIIOWriteModeGuards(t *testing.T) {
 		})
 		t.Run("dormant feature rejects remote-hosts", func(t *testing.T) {
 			opts := NewOptions()
-			opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
+			opts.MoRIIORemoteHosts = []string{testPrefillHostIP1, testPrefillHostIP2}
 			opts.MoRIIODPSize = 16
 			opts.MoRIIODPSizeLocal = 8
 			err := opts.Complete()
@@ -1137,7 +1137,7 @@ func TestCompleteMoRIIOWriteModeGuards(t *testing.T) {
 	t.Run("write-mode with pod IP passes", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		require.NoError(t, opts.Complete())
 	})
 
@@ -1321,46 +1321,46 @@ func TestResolveHostsToIPs(t *testing.T) {
 	})
 
 	t.Run("raw IPv4 addresses are passed through", func(t *testing.T) {
-		hosts := []string{"10.0.0.1"}
+		hosts := []string{testPrefillHostIP1}
 		result, err := resolveHostsToIPs(hosts)
 		require.NoError(t, err)
-		require.Equal(t, []string{"10.0.0.1"}, result)
+		require.Equal(t, []string{testPrefillHostIP1}, result)
 	})
 
 	t.Run("raw IPv6 addresses are passed through", func(t *testing.T) {
-		hosts := []string{"::1"}
+		hosts := []string{testLoopbackIPv6}
 		result, err := resolveHostsToIPs(hosts)
 		require.NoError(t, err)
-		require.Equal(t, []string{"::1"}, result)
+		require.Equal(t, []string{testLoopbackIPv6}, result)
 	})
 
 	t.Run("localhost resolves to IP", func(t *testing.T) {
-		hosts := []string{"localhost"}
+		hosts := []string{testLocalHostname}
 		result, err := resolveHostsToIPs(hosts)
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		// localhost should resolve to 127.0.0.1 or ::1
-		require.True(t, result[0] == "127.0.0.1" || result[0] == "::1",
+		require.True(t, result[0] == testLoopbackIP || result[0] == testLoopbackIPv6,
 			"expected localhost to resolve to 127.0.0.1 or ::1, got %s", result[0])
 	})
 
 	t.Run("mixed IPs and hostnames both work", func(t *testing.T) {
-		hosts := []string{"10.0.0.1", "localhost"}
+		hosts := []string{testPrefillHostIP1, testLocalHostname}
 		result, err := resolveHostsToIPs(hosts)
 		require.NoError(t, err)
 		require.Len(t, result, 2)
-		require.Equal(t, "10.0.0.1", result[0])
+		require.Equal(t, testPrefillHostIP1, result[0])
 		// localhost resolves to 127.0.0.1 or ::1
-		require.True(t, result[1] == "127.0.0.1" || result[1] == "::1")
+		require.True(t, result[1] == testLoopbackIP || result[1] == testLoopbackIPv6)
 	})
 
 	t.Run("multiple DNS names resolve correctly", func(t *testing.T) {
-		hosts := []string{"localhost", "localhost"}
+		hosts := []string{testLocalHostname, testLocalHostname}
 		result, err := resolveHostsToIPs(hosts)
 		require.NoError(t, err)
 		require.Len(t, result, 2)
 		for _, h := range result {
-			require.True(t, h == "127.0.0.1" || h == "::1",
+			require.True(t, h == testLoopbackIP || h == testLoopbackIPv6,
 				"expected resolved IP, got %s", h)
 		}
 	})
@@ -1384,35 +1384,35 @@ func TestCompleteAutomaticDNSResolution(t *testing.T) {
 	t.Run("raw IP addresses are passed through", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 16
 		opts.MoRIIODPSizeLocal = 8
-		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
-		opts.MoRIIODecodeHosts = []string{"10.0.1.1", "10.0.1.2"}
+		opts.MoRIIORemoteHosts = []string{testPrefillHostIP1, testPrefillHostIP2}
+		opts.MoRIIODecodeHosts = []string{testDecodeHostIP, testDecodeHostIP2}
 		require.NoError(t, opts.Complete())
 		// IPs should be passed through unchanged
-		require.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, opts.MoRIIORemoteHosts)
-		require.Equal(t, []string{"10.0.1.1", "10.0.1.2"}, opts.MoRIIODecodeHosts)
+		require.Equal(t, []string{testPrefillHostIP1, testPrefillHostIP2}, opts.MoRIIORemoteHosts)
+		require.Equal(t, []string{testDecodeHostIP, testDecodeHostIP2}, opts.MoRIIODecodeHosts)
 	})
 
 	t.Run("localhost automatically resolves to IP", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 8
 		opts.MoRIIODPSizeLocal = 8
-		opts.MoRIIORemoteHosts = []string{"localhost"}
-		opts.MoRIIODecodeHosts = []string{"localhost"}
+		opts.MoRIIORemoteHosts = []string{testLocalHostname}
+		opts.MoRIIODecodeHosts = []string{testLocalHostname}
 		require.NoError(t, opts.Complete())
 		// localhost should be automatically resolved to an IP
-		require.True(t, opts.MoRIIORemoteHosts[0] == "127.0.0.1" || opts.MoRIIORemoteHosts[0] == "::1")
-		require.True(t, opts.MoRIIODecodeHosts[0] == "127.0.0.1" || opts.MoRIIODecodeHosts[0] == "::1")
+		require.True(t, opts.MoRIIORemoteHosts[0] == testLoopbackIP || opts.MoRIIORemoteHosts[0] == testLoopbackIPv6)
+		require.True(t, opts.MoRIIODecodeHosts[0] == testLoopbackIP || opts.MoRIIODecodeHosts[0] == testLoopbackIPv6)
 	})
 
 	t.Run("unresolvable hostname errors", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 8
 		opts.MoRIIORemoteHosts = []string{"unresolvable-host-xyz.invalid"}
 		err := opts.Complete()
@@ -1423,21 +1423,21 @@ func TestCompleteAutomaticDNSResolution(t *testing.T) {
 	t.Run("local-pod-ip raw IP is passed through", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 8
 		opts.MoRIIODPSizeLocal = 8
 		require.NoError(t, opts.Complete())
-		require.Equal(t, "10.0.1.1", opts.MoRIIODecodePodIP)
+		require.Equal(t, testDecodeHostIP, opts.MoRIIODecodePodIP)
 	})
 
 	t.Run("local-pod-ip DNS name resolves to IP", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "localhost"
+		opts.MoRIIODecodePodIP = testLocalHostname
 		opts.MoRIIODPSize = 8
 		opts.MoRIIODPSizeLocal = 8
 		require.NoError(t, opts.Complete())
-		require.True(t, opts.MoRIIODecodePodIP == "127.0.0.1" || opts.MoRIIODecodePodIP == "::1")
+		require.True(t, opts.MoRIIODecodePodIP == testLoopbackIP || opts.MoRIIODecodePodIP == testLoopbackIPv6)
 	})
 
 	t.Run("local-pod-ip unresolvable hostname errors", func(t *testing.T) {
@@ -1463,7 +1463,7 @@ func TestWideEPScenarios(t *testing.T) {
 	t.Run("1P1D DP=8 intra-node (no remote hosts)", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.0.1"
+		opts.MoRIIODecodePodIP = testPrefillHostIP1
 		opts.MoRIIODPSize = 8
 		opts.MoRIIOTPSize = 1
 		// No remote hosts needed for single-pod 1P1D
@@ -1485,30 +1485,30 @@ func TestWideEPScenarios(t *testing.T) {
 	t.Run("2P2D DP=16 inter-node with IPs (static deployment)", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 16
 		opts.MoRIIOTPSize = 1
 		opts.MoRIIODPSizeLocal = 8
 		// Raw IPs work for static IP deployments
-		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
-		opts.MoRIIODecodeHosts = []string{"10.0.1.1", "10.0.1.2"}
+		opts.MoRIIORemoteHosts = []string{testPrefillHostIP1, testPrefillHostIP2}
+		opts.MoRIIODecodeHosts = []string{testDecodeHostIP, testDecodeHostIP2}
 
 		require.NoError(t, opts.Complete())
 		// IPs should be passed through unchanged
-		require.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, opts.MoRIIORemoteHosts)
-		require.Equal(t, []string{"10.0.1.1", "10.0.1.2"}, opts.MoRIIODecodeHosts)
+		require.Equal(t, []string{testPrefillHostIP1, testPrefillHostIP2}, opts.MoRIIORemoteHosts)
+		require.Equal(t, []string{testDecodeHostIP, testDecodeHostIP2}, opts.MoRIIODecodeHosts)
 	})
 
 	t.Run("2P2D DP=16 inter-node with DNS names (LWS pattern)", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 16
 		opts.MoRIIOTPSize = 1
 		opts.MoRIIODPSizeLocal = 8
 		// Use localhost as a resolvable DNS name for testing
-		opts.MoRIIORemoteHosts = []string{"localhost", "localhost"}
-		opts.MoRIIODecodeHosts = []string{"localhost", "localhost"}
+		opts.MoRIIORemoteHosts = []string{testLocalHostname, testLocalHostname}
+		opts.MoRIIODecodeHosts = []string{testLocalHostname, testLocalHostname}
 
 		require.NoError(t, opts.Complete())
 		// DNS names should be resolved to IPs
@@ -1516,11 +1516,11 @@ func TestWideEPScenarios(t *testing.T) {
 		require.Len(t, opts.MoRIIODecodeHosts, 2)
 		// All entries should now be IPs (127.0.0.1 or ::1)
 		for _, h := range opts.MoRIIORemoteHosts {
-			require.True(t, h == "127.0.0.1" || h == "::1",
+			require.True(t, h == testLoopbackIP || h == testLoopbackIPv6,
 				"expected resolved IP, got %s", h)
 		}
 		for _, h := range opts.MoRIIODecodeHosts {
-			require.True(t, h == "127.0.0.1" || h == "::1",
+			require.True(t, h == testLoopbackIP || h == testLoopbackIPv6,
 				"expected resolved IP, got %s", h)
 		}
 	})
@@ -1529,10 +1529,10 @@ func TestWideEPScenarios(t *testing.T) {
 	t.Run("2P2D validation: dp-size must be divisible by dp-size-local", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 15 // Not divisible by 8
 		opts.MoRIIODPSizeLocal = 8
-		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
+		opts.MoRIIORemoteHosts = []string{testPrefillHostIP1, testPrefillHostIP2}
 
 		err := opts.Complete()
 		require.Error(t, err)
@@ -1542,11 +1542,11 @@ func TestWideEPScenarios(t *testing.T) {
 	t.Run("2P2D validation: host count must match pod count", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 16
 		opts.MoRIIODPSizeLocal = 8
 		// 3 hosts but dp-size/dp-size-local = 2 pods
-		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+		opts.MoRIIORemoteHosts = []string{testPrefillHostIP1, testPrefillHostIP2, "10.0.0.3"}
 
 		err := opts.Complete()
 		require.Error(t, err)
@@ -1556,10 +1556,10 @@ func TestWideEPScenarios(t *testing.T) {
 	t.Run("2P2D validation: dp-size-local required for multi-host", func(t *testing.T) {
 		opts := NewOptions()
 		opts.MoRIIOWriteMode = true
-		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODecodePodIP = testDecodeHostIP
 		opts.MoRIIODPSize = 16
 		opts.MoRIIODPSizeLocal = 0 // Missing!
-		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
+		opts.MoRIIORemoteHosts = []string{testPrefillHostIP1, testPrefillHostIP2}
 
 		err := opts.Complete()
 		require.Error(t, err)

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -1419,6 +1419,36 @@ func TestCompleteAutomaticDNSResolution(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "resolving --moriio-remote-hosts")
 	})
+
+	t.Run("local-pod-ip raw IP is passed through", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 8
+		opts.MoRIIODPSizeLocal = 8
+		require.NoError(t, opts.Complete())
+		require.Equal(t, "10.0.1.1", opts.MoRIIODecodePodIP)
+	})
+
+	t.Run("local-pod-ip DNS name resolves to IP", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "localhost"
+		opts.MoRIIODPSize = 8
+		opts.MoRIIODPSizeLocal = 8
+		require.NoError(t, opts.Complete())
+		require.True(t, opts.MoRIIODecodePodIP == "127.0.0.1" || opts.MoRIIODecodePodIP == "::1")
+	})
+
+	t.Run("local-pod-ip unresolvable hostname errors", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "unresolvable-host-xyz.invalid"
+		opts.MoRIIODPSize = 8
+		err := opts.Complete()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "resolving --moriio-local-pod-ip")
+	})
 }
 
 // TestWideEPScenarios tests both 1P1D and 2P2D Wide-EP configurations to ensure

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -1036,8 +1036,8 @@ func TestCompleteWideEPValidation(t *testing.T) {
 	}{
 		{
 			name:        "valid 2P2D DP16 both legs",
-			remoteHosts: []string{"10.0.0.1", "10.0.0.2"},
-			decodeHosts: []string{"10.0.1.1", "10.0.1.2"},
+			remoteHosts: []string{"localhost", "localhost"},
+			decodeHosts: []string{"localhost", "localhost"},
 			dpSize:      16,
 			dpLocal:     8,
 			wantErr:     "",
@@ -1304,4 +1304,235 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 
 		})
 	}
+}
+
+// TestResolveHostsToIPs tests the DNS resolution helper function that
+// automatically converts hostnames to IP addresses at startup, enabling
+// LWS-compatible pod addressing (DNS names instead of hardcoded IPs).
+func TestResolveHostsToIPs(t *testing.T) {
+	t.Run("empty list returns empty", func(t *testing.T) {
+		result, err := resolveHostsToIPs(nil)
+		require.NoError(t, err)
+		require.Empty(t, result)
+
+		result, err = resolveHostsToIPs([]string{})
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("raw IPv4 addresses are passed through", func(t *testing.T) {
+		hosts := []string{"10.0.0.1"}
+		result, err := resolveHostsToIPs(hosts)
+		require.NoError(t, err)
+		require.Equal(t, []string{"10.0.0.1"}, result)
+	})
+
+	t.Run("raw IPv6 addresses are passed through", func(t *testing.T) {
+		hosts := []string{"::1"}
+		result, err := resolveHostsToIPs(hosts)
+		require.NoError(t, err)
+		require.Equal(t, []string{"::1"}, result)
+	})
+
+	t.Run("localhost resolves to IP", func(t *testing.T) {
+		hosts := []string{"localhost"}
+		result, err := resolveHostsToIPs(hosts)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		// localhost should resolve to 127.0.0.1 or ::1
+		require.True(t, result[0] == "127.0.0.1" || result[0] == "::1",
+			"expected localhost to resolve to 127.0.0.1 or ::1, got %s", result[0])
+	})
+
+	t.Run("mixed IPs and hostnames both work", func(t *testing.T) {
+		hosts := []string{"10.0.0.1", "localhost"}
+		result, err := resolveHostsToIPs(hosts)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		require.Equal(t, "10.0.0.1", result[0])
+		// localhost resolves to 127.0.0.1 or ::1
+		require.True(t, result[1] == "127.0.0.1" || result[1] == "::1")
+	})
+
+	t.Run("multiple DNS names resolve correctly", func(t *testing.T) {
+		hosts := []string{"localhost", "localhost"}
+		result, err := resolveHostsToIPs(hosts)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		for _, h := range result {
+			require.True(t, h == "127.0.0.1" || h == "::1",
+				"expected resolved IP, got %s", h)
+		}
+	})
+
+	t.Run("unresolvable hostname errors", func(t *testing.T) {
+		hosts := []string{"this-hostname-does-not-exist-12345.invalid"}
+		_, err := resolveHostsToIPs(hosts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to resolve")
+	})
+}
+
+// TestCompleteAutomaticDNSResolution tests that DNS hostnames in
+// --moriio-remote-hosts and --moriio-decode-hosts are automatically resolved
+// to IPs at startup, aligning with LWS (LeaderWorkerSet) patterns.
+func TestCompleteAutomaticDNSResolution(t *testing.T) {
+	if !MoRIIOFeatureEnabled {
+		t.Skip("MoRI-IO feature is dormant; skipping DNS resolution tests")
+	}
+
+	t.Run("raw IP addresses are passed through", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 16
+		opts.MoRIIODPSizeLocal = 8
+		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
+		opts.MoRIIODecodeHosts = []string{"10.0.1.1", "10.0.1.2"}
+		require.NoError(t, opts.Complete())
+		// IPs should be passed through unchanged
+		require.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, opts.MoRIIORemoteHosts)
+		require.Equal(t, []string{"10.0.1.1", "10.0.1.2"}, opts.MoRIIODecodeHosts)
+	})
+
+	t.Run("localhost automatically resolves to IP", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 8
+		opts.MoRIIODPSizeLocal = 8
+		opts.MoRIIORemoteHosts = []string{"localhost"}
+		opts.MoRIIODecodeHosts = []string{"localhost"}
+		require.NoError(t, opts.Complete())
+		// localhost should be automatically resolved to an IP
+		require.True(t, opts.MoRIIORemoteHosts[0] == "127.0.0.1" || opts.MoRIIORemoteHosts[0] == "::1")
+		require.True(t, opts.MoRIIODecodeHosts[0] == "127.0.0.1" || opts.MoRIIODecodeHosts[0] == "::1")
+	})
+
+	t.Run("unresolvable hostname errors", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 8
+		opts.MoRIIORemoteHosts = []string{"unresolvable-host-xyz.invalid"}
+		err := opts.Complete()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "resolving --moriio-remote-hosts")
+	})
+}
+
+// TestWideEPScenarios tests both 1P1D and 2P2D Wide-EP configurations to ensure
+// automatic DNS resolution works correctly in both single-pod and multi-pod scenarios.
+func TestWideEPScenarios(t *testing.T) {
+	if !MoRIIOFeatureEnabled {
+		t.Skip("MoRI-IO feature is dormant; skipping Wide-EP scenario tests")
+	}
+
+	// Scenario 1: 1P1D (DP=EP=8, TP=1, intra-node single pod)
+	// This is the simplest Wide-EP case: all 8 DP ranks on a single pod pair.
+	t.Run("1P1D DP=8 intra-node (no remote hosts)", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.0.1"
+		opts.MoRIIODPSize = 8
+		opts.MoRIIOTPSize = 1
+		// No remote hosts needed for single-pod 1P1D
+		opts.MoRIIORemoteHosts = nil
+		opts.MoRIIODecodeHosts = nil
+		opts.MoRIIODPSizeLocal = 0 // Not needed for single pod
+
+		require.NoError(t, opts.Complete())
+		// Verify config is set correctly for 1P1D
+		require.Equal(t, 8, opts.MoRIIODPSize)
+		require.Equal(t, 1, opts.MoRIIOTPSize)
+		require.Empty(t, opts.MoRIIORemoteHosts)
+		require.Empty(t, opts.MoRIIODecodeHosts)
+	})
+
+	// Scenario 2: 2P2D (DP=EP=16, TP=1, inter-node multi-pod)
+	// Two prefill pods + two decode pods, each with 8 DP ranks.
+	// Both raw IPs and DNS names are supported.
+	t.Run("2P2D DP=16 inter-node with IPs (static deployment)", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 16
+		opts.MoRIIOTPSize = 1
+		opts.MoRIIODPSizeLocal = 8
+		// Raw IPs work for static IP deployments
+		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
+		opts.MoRIIODecodeHosts = []string{"10.0.1.1", "10.0.1.2"}
+
+		require.NoError(t, opts.Complete())
+		// IPs should be passed through unchanged
+		require.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, opts.MoRIIORemoteHosts)
+		require.Equal(t, []string{"10.0.1.1", "10.0.1.2"}, opts.MoRIIODecodeHosts)
+	})
+
+	t.Run("2P2D DP=16 inter-node with DNS names (LWS pattern)", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 16
+		opts.MoRIIOTPSize = 1
+		opts.MoRIIODPSizeLocal = 8
+		// Use localhost as a resolvable DNS name for testing
+		opts.MoRIIORemoteHosts = []string{"localhost", "localhost"}
+		opts.MoRIIODecodeHosts = []string{"localhost", "localhost"}
+
+		require.NoError(t, opts.Complete())
+		// DNS names should be resolved to IPs
+		require.Len(t, opts.MoRIIORemoteHosts, 2)
+		require.Len(t, opts.MoRIIODecodeHosts, 2)
+		// All entries should now be IPs (127.0.0.1 or ::1)
+		for _, h := range opts.MoRIIORemoteHosts {
+			require.True(t, h == "127.0.0.1" || h == "::1",
+				"expected resolved IP, got %s", h)
+		}
+		for _, h := range opts.MoRIIODecodeHosts {
+			require.True(t, h == "127.0.0.1" || h == "::1",
+				"expected resolved IP, got %s", h)
+		}
+	})
+
+	// Validation tests for multi-pod configuration invariants
+	t.Run("2P2D validation: dp-size must be divisible by dp-size-local", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 15 // Not divisible by 8
+		opts.MoRIIODPSizeLocal = 8
+		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
+
+		err := opts.Complete()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be divisible")
+	})
+
+	t.Run("2P2D validation: host count must match pod count", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 16
+		opts.MoRIIODPSizeLocal = 8
+		// 3 hosts but dp-size/dp-size-local = 2 pods
+		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+
+		err := opts.Complete()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "count of hosts must match")
+	})
+
+	t.Run("2P2D validation: dp-size-local required for multi-host", func(t *testing.T) {
+		opts := NewOptions()
+		opts.MoRIIOWriteMode = true
+		opts.MoRIIODecodePodIP = "10.0.1.1"
+		opts.MoRIIODPSize = 16
+		opts.MoRIIODPSizeLocal = 0 // Missing!
+		opts.MoRIIORemoteHosts = []string{"10.0.0.1", "10.0.0.2"}
+
+		err := opts.Complete()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "dp-size-local")
+	})
 }

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -277,6 +277,7 @@ type Config struct {
 	// MoRIIODecodeHosts is the decode-side counterpart of MoRIIORemoteHosts,
 	// emitted as the prefill leg's remote_hosts. A multi-pod deployment sets
 	// both; the lists must use opposite sides or every cross-pod handshake hangs.
+	// DNS names (e.g., LWS pod names) are automatically resolved to IPs at startup.
 	MoRIIODecodeHosts []string
 }
 

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -245,9 +245,11 @@ type Config struct {
 	MoRIIODecodeNotifyPort int
 	// MoRIIODecodeHandshakePort is the decode pod's base MoRI-IO handshake port.
 	MoRIIODecodeHandshakePort int
-	// MoRIIODecodePodIP is decode's routable pod IP, used as the prefill leg's
+	// MoRIIODecodePodIP is decode's routable address, used as the prefill leg's
 	// remote_host so prefill handshakes with decode (not itself). Must not be
-	// localhost; typically the POD_IP downward-API value.
+	// localhost; typically the POD_IP downward-API value. May be set to a
+	// Kubernetes DNS name (e.g., an LWS pod name), which is resolved to an IP at
+	// startup in Complete(); raw IPs are passed through unchanged.
 	MoRIIODecodePodIP string
 
 	// MoRIIOParallelDispatch fires the prefill and decode legs concurrently,

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -206,6 +207,13 @@ type Config struct {
 	// CertPath is the path to TLS certificates for the sidecar server.
 	CertPath string
 
+	// MetricsPort is the port for the Prometheus /metrics endpoint. 0 (the
+	// default) disables it; when > 0 the sidecar serves the shared metrics
+	// registry (carrying the moriio_dns_* counters) at /metrics on that port,
+	// on a separate address from the data-plane proxy port. Takes precedence
+	// over the MORIIO_METRICS_ADDR env var (kept for backward compatibility).
+	MetricsPort int
+
 	// MooncakeBootstrapPort is the port used to query the Mooncake bootstrap endpoint on prefill pods.
 	MooncakeBootstrapPort int
 
@@ -281,6 +289,16 @@ type Config struct {
 	// both; the lists must use opposite sides or every cross-pod handshake hangs.
 	// DNS names (e.g., LWS pod names) are automatically resolved to IPs at startup.
 	MoRIIODecodeHosts []string
+
+	// MoRIIORemoteHostSpecs / MoRIIODecodeHostSpecs / MoRIIODecodePodIPSpec hold
+	// the ORIGINAL host specs (DNS names or raw IPs) exactly as supplied on the
+	// CLI, captured in Complete() before one-shot resolution rewrites the
+	// resolved fields above. The request path re-resolves these specs through a
+	// short-TTL hostResolver so a peer pod that restarts with a new IP is picked
+	// up without a router restart. Raw-IP specs pass through unchanged.
+	MoRIIORemoteHostSpecs []string
+	MoRIIODecodeHostSpecs []string
+	MoRIIODecodePodIPSpec string
 }
 
 // MarshalJSON implements json.Marshaler for Config.
@@ -343,7 +361,53 @@ type Server struct {
 	// needs the pre-clone base. 0 disables derivation.
 	dpBasePort int
 
+	// hostResolver re-resolves MoRI-IO peer DNS specs to IPs on a short TTL so
+	// peer pod restarts are picked up on the request path. Lazily initialized
+	// via resolverOnce (clone-safe; each Server gets its own).
+	resolverOnce sync.Once
+	hostResolver *hostResolver
+
 	config Config
+}
+
+// resolver lazily initializes and returns the request-path host resolver.
+// Initialization is deferred so it can use s.logger (populated in Start) and
+// so Clone'd servers each get their own instance.
+func (s *Server) resolver() *hostResolver {
+	s.resolverOnce.Do(func() {
+		s.hostResolver = newHostResolver(s.logger, resolveTTLFromEnv())
+	})
+	return s.hostResolver
+}
+
+// currentDecodeHosts returns the decode-side peer IPs for the current request,
+// re-resolving the original specs through the short-TTL resolver. The request
+// context bounds any cold-start lookup so a cancelled/timed-out request cancels
+// the DNS lookup. Falls back to the boot-resolved config field when no specs
+// were captured (e.g. tests that build Config directly).
+func (s *Server) currentDecodeHosts(ctx context.Context) []string {
+	if len(s.config.MoRIIODecodeHostSpecs) == 0 {
+		return s.config.MoRIIODecodeHosts
+	}
+	return s.resolver().resolve(ctx, s.config.MoRIIODecodeHostSpecs)
+}
+
+// currentRemoteHosts is the prefill-side counterpart of currentDecodeHosts.
+func (s *Server) currentRemoteHosts(ctx context.Context) []string {
+	if len(s.config.MoRIIORemoteHostSpecs) == 0 {
+		return s.config.MoRIIORemoteHosts
+	}
+	return s.resolver().resolve(ctx, s.config.MoRIIORemoteHostSpecs)
+}
+
+// currentDecodePodIP returns decode's advertised remote_host for the current
+// request, re-resolving the original spec through the short-TTL resolver. The
+// request context bounds any cold-start lookup.
+func (s *Server) currentDecodePodIP(ctx context.Context) string {
+	if s.config.MoRIIODecodePodIPSpec == "" {
+		return s.config.MoRIIODecodePodIP
+	}
+	return s.resolver().resolveOne(ctx, s.config.MoRIIODecodePodIPSpec)
 }
 
 // NewProxy creates a new routing reverse proxy from the given Config.
@@ -412,6 +476,9 @@ func (s *Server) Start(ctx context.Context) error {
 	grp.Go(func() error {
 		return s.startHTTP(ctx)
 	})
+
+	// Opt-in Prometheus /metrics endpoint (MORIIO_METRICS_ADDR); no-op when unset.
+	s.maybeStartMetrics(ctx, grp)
 
 	return grp.Wait()
 }

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -264,6 +264,11 @@ type Config struct {
 	// synthesising decode's kv_transfer_params from config instead of reading
 	// them from the prefill response. Requires MoRIIOWriteMode.
 	MoRIIOParallelDispatch bool
+	// MoRIIOParallelDecodeWaitTimeout bounds how long the parallel WRITE
+	// dispatch waits for the prefill outcome before cancelling decode, so a
+	// hung or failed prefill cannot make decode wait for KV that never
+	// arrives. Zero falls back to defaultMoRIIOParallelDecodeWaitTimeout.
+	MoRIIOParallelDecodeWaitTimeout time.Duration
 	// MoRIIOPrefillHandshakePort is the prefill pod's base MoRI-IO handshake port.
 	MoRIIOPrefillHandshakePort int
 	// MoRIIOPrefillNotifyPort is the prefill pod's base MoRI-IO notify port.
@@ -376,8 +381,29 @@ type Server struct {
 func (s *Server) resolver() *hostResolver {
 	s.resolverOnce.Do(func() {
 		s.hostResolver = newHostResolver(s.logger, resolveTTLFromEnv())
+		s.seedResolver(s.hostResolver)
 	})
 	return s.hostResolver
+}
+
+// seedResolver primes the request-path resolver with the spec->IP mappings that
+// Complete() already resolved at startup, so the first request does not repeat
+// those lookups and a request-time DNS failure still serves the startup IP
+// instead of the raw hostname (which would hang the MoRI-IO handshake). Specs
+// and their resolved IPs are captured positionally in Complete(); a length
+// mismatch (e.g. a Config built directly in tests) skips seeding for that list.
+func (s *Server) seedResolver(r *hostResolver) {
+	seedPairs := func(specs, ips []string) {
+		if len(specs) != len(ips) {
+			return
+		}
+		for i := range specs {
+			r.seed(specs[i], ips[i])
+		}
+	}
+	seedPairs(s.config.MoRIIODecodeHostSpecs, s.config.MoRIIODecodeHosts)
+	seedPairs(s.config.MoRIIORemoteHostSpecs, s.config.MoRIIORemoteHosts)
+	r.seed(s.config.MoRIIODecodePodIPSpec, s.config.MoRIIODecodePodIP)
 }
 
 // currentDecodeHosts returns the decode-side peer IPs for the current request,

--- a/pkg/sidecar/proxy/resolver.go
+++ b/pkg/sidecar/proxy/resolver.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sync/singleflight"
+)
+
+// envMoRIIODNSResolveTTLSeconds overrides the peer-IP re-resolution TTL (in
+// seconds). Operators can widen or tighten the window without a rebuild.
+const envMoRIIODNSResolveTTLSeconds = "MORIIO_DNS_RESOLVE_TTL_SECONDS"
+
+// envMoRIIODNSResolveTimeoutSeconds overrides the per-lookup DNS timeout (in
+// seconds). Bounds how long a single request-path resolution may block before
+// falling back to the last-known-good IP (or the raw spec).
+const envMoRIIODNSResolveTimeoutSeconds = "MORIIO_DNS_RESOLVE_TIMEOUT_SECONDS"
+
+// defaultResolveTTL bounds how long a resolved peer IP is cached before the
+// next request-time lookup re-resolves it. Kept short so a peer pod that
+// restarts with a new IP is picked up within one TTL window, but long enough
+// that steady-state request handling does not perform a DNS lookup per call.
+const defaultResolveTTL = 30 * time.Second
+
+// defaultResolveTimeout bounds a single DNS lookup on the request path so a
+// slow or hanging resolver cannot stall request handling indefinitely. On
+// timeout the resolver falls back to the last-known-good IP (or the raw spec).
+const defaultResolveTimeout = 5 * time.Second
+
+// resolveTTLFromEnv returns the configured re-resolution TTL, honoring
+// MORIIO_DNS_RESOLVE_TTL_SECONDS when set to a positive integer and falling
+// back to defaultResolveTTL otherwise.
+func resolveTTLFromEnv() time.Duration {
+	if v := os.Getenv(envMoRIIODNSResolveTTLSeconds); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return defaultResolveTTL
+}
+
+// resolveTimeoutFromEnv returns the configured per-lookup DNS timeout, honoring
+// MORIIO_DNS_RESOLVE_TIMEOUT_SECONDS when set to a positive integer and falling
+// back to defaultResolveTimeout otherwise.
+func resolveTimeoutFromEnv() time.Duration {
+	if v := os.Getenv(envMoRIIODNSResolveTimeoutSeconds); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return defaultResolveTimeout
+}
+
+// resolvedHost caches the resolution of a single host spec.
+type resolvedHost struct {
+	ip       string
+	resolved time.Time
+}
+
+// hostResolver re-resolves DNS host specs to IPs with a short TTL, so a peer
+// pod that restarts with a new IP is eventually dialed at its new address
+// instead of the router forever emitting the boot-time IP. Raw IP specs pass
+// through unchanged and are never looked up. Safe for concurrent use.
+//
+// This complements the one-shot resolution in Options.Complete(): boot-time
+// resolution still validates and seeds the initial IPs, while this resolver
+// keeps them fresh on the request path. The sidecar itself does not open the
+// RDMA/handshake connection (vLLM does, using the IPs the sidecar injects into
+// kv_transfer_params), so a targeted "re-resolve on dial failure" is not
+// observable here; a bounded TTL is the low-risk equivalent.
+//
+// Each request-path lookup is bounded by a context timeout (the smaller of the
+// configured timeout and the caller's remaining request deadline), and
+// concurrent lookups for the same spec are de-duplicated via a singleflight
+// group so a TTL-expiry stampede issues a single DNS query rather than one per
+// request. Once a spec has been resolved at least once, subsequent requests are
+// served the cached IP immediately (serve-stale-while-revalidate): a past-TTL
+// entry is returned without blocking while a single background goroutine
+// refreshes it, so only the very first (cold-start) lookup for a spec blocks.
+type hostResolver struct {
+	ttl     time.Duration
+	timeout time.Duration
+	logger  logr.Logger
+
+	// lookupIP performs the actual DNS lookup. A field (rather than a direct
+	// net.LookupIP call) so tests can inject a deterministic/counting resolver.
+	// Defaults to net.DefaultResolver.LookupIPAddr.
+	lookupIP func(ctx context.Context, host string) ([]net.IPAddr, error)
+
+	// group de-duplicates concurrent lookups for the same host spec.
+	group singleflight.Group
+
+	mu    sync.Mutex
+	cache map[string]resolvedHost
+	// refreshing tracks specs with a background refresh already in flight, so a
+	// staleness burst spawns at most one goroutine per spec.
+	refreshing map[string]bool
+}
+
+// newHostResolver builds a resolver with the given TTL (falling back to the
+// default for non-positive values). The per-lookup timeout is taken from the
+// environment (MORIIO_DNS_RESOLVE_TIMEOUT_SECONDS) or the default.
+func newHostResolver(logger logr.Logger, ttl time.Duration) *hostResolver {
+	if ttl <= 0 {
+		ttl = defaultResolveTTL
+	}
+	registerDNSMetrics()
+	return &hostResolver{
+		ttl:        ttl,
+		timeout:    resolveTimeoutFromEnv(),
+		logger:     logger,
+		lookupIP:   net.DefaultResolver.LookupIPAddr,
+		cache:      map[string]resolvedHost{},
+		refreshing: map[string]bool{},
+	}
+}
+
+// lookup resolves one DNS name to a single IP string using the caller's
+// context, preferring IPv4 (falling back to the first returned address). The
+// effective deadline is the smaller of the resolver's configured timeout and
+// any deadline already on ctx. Callers must handle raw-IP passthrough first.
+func (r *hostResolver) lookup(ctx context.Context, host string) (string, error) {
+	lookupCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+	return lookupIPv4Preferred(lookupCtx, r.lookupIP, host)
+}
+
+// lookupIPv4Preferred performs a single DNS lookup via lookupIP and returns one
+// IP string, preferring IPv4 and falling back to the first returned address.
+// The caller supplies the context (and thus the timeout) and must handle raw-IP
+// passthrough beforehand. Shared by the boot-time resolveSingleHost and the
+// request-path hostResolver.lookup so both apply identical bounding and
+// IPv4-preference semantics.
+func lookupIPv4Preferred(
+	ctx context.Context,
+	lookupIP func(ctx context.Context, host string) ([]net.IPAddr, error),
+	host string,
+) (string, error) {
+	addrs, err := lookupIP(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve %q: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("no IPs found for %q", host)
+	}
+	// Prefer IPv4 if available.
+	for _, a := range addrs {
+		if ipv4 := a.IP.To4(); ipv4 != nil {
+			return ipv4.String(), nil
+		}
+	}
+	// Fall back to the first address if no IPv4 found.
+	return addrs[0].IP.String(), nil
+}
+
+// resolveOne returns the current IP for a single host spec. Raw IPs pass
+// through untouched (no lookup, no singleflight, no goroutine). Behavior is
+// serve-stale-while-revalidate:
+//   - Fresh cache entry (within TTL): returned immediately.
+//   - Stale cache entry (past TTL): the stale IP is returned immediately and a
+//     single background goroutine re-resolves it (per-spec, bounded by
+//     singleflight and the lookup timeout), so no request blocks on DNS after
+//     the first successful resolution. A transient failure keeps the
+//     last-known-good IP.
+//   - No cache entry (cold start): blocks on ctx to perform the first lookup;
+//     on hard failure it returns the original spec so the downstream engine
+//     surfaces the dial error rather than the router silently dropping the host.
+func (r *hostResolver) resolveOne(ctx context.Context, spec string) string {
+	// Raw IPs never need resolution.
+	if ip := net.ParseIP(spec); ip != nil {
+		return spec
+	}
+
+	now := time.Now()
+	r.mu.Lock()
+	entry, ok := r.cache[spec]
+	r.mu.Unlock()
+	if ok {
+		if now.Sub(entry.resolved) < r.ttl {
+			return entry.ip
+		}
+		// Stale: serve the cached IP now, refresh in the background.
+		r.triggerRefresh(spec)
+		return entry.ip
+	}
+
+	// Cold start: block on the caller's context for the first lookup.
+	ip, err := r.doLookup(ctx, spec)
+	if err != nil {
+		r.logger.V(1).Info("MoRI-IO peer DNS resolution failed; passing host through unresolved",
+			"host", spec, "error", err.Error())
+		return spec
+	}
+	return ip
+}
+
+// doLookup performs a singleflight-coalesced DNS lookup for spec, updates the
+// cache, and records metrics/logs. Concurrent callers for the same spec share
+// one underlying lookup. Returns the resolved IP or the lookup error.
+func (r *hostResolver) doLookup(ctx context.Context, spec string) (string, error) {
+	v, err, _ := r.group.Do(spec, func() (interface{}, error) {
+		ip, lerr := r.lookup(ctx, spec)
+		if lerr != nil {
+			dnsLookupFailuresTotal.Inc()
+			return "", lerr
+		}
+		dnsReresolveTotal.Inc()
+		r.mu.Lock()
+		old, had := r.cache[spec]
+		r.cache[spec] = resolvedHost{ip: ip, resolved: time.Now()}
+		r.mu.Unlock()
+		if had && old.ip != ip {
+			dnsIPChangedTotal.Inc()
+			r.logger.Info("MoRI-IO peer IP changed on re-resolution",
+				"host", spec, "oldIP", old.ip, "newIP", ip)
+		}
+		return ip, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+// triggerRefresh starts at most one background re-resolution for spec. The
+// refresh uses its own (background) context so it is not cancelled when the
+// triggering request finishes, but is still bounded by the lookup timeout and
+// coalesced by singleflight. On failure the stale cache entry is kept.
+func (r *hostResolver) triggerRefresh(spec string) {
+	r.mu.Lock()
+	if r.refreshing[spec] {
+		r.mu.Unlock()
+		return
+	}
+	r.refreshing[spec] = true
+	r.mu.Unlock()
+
+	go func() {
+		defer func() {
+			r.mu.Lock()
+			delete(r.refreshing, spec)
+			r.mu.Unlock()
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		if _, err := r.doLookup(ctx, spec); err != nil {
+			r.logger.V(1).Info("MoRI-IO peer DNS background re-resolution failed; keeping stale IP",
+				"host", spec, "error", err.Error())
+		}
+	}()
+}
+
+// resolve returns current IPs for a list of specs, preserving order. An empty
+// or nil input is returned unchanged.
+func (r *hostResolver) resolve(ctx context.Context, specs []string) []string {
+	if len(specs) == 0 {
+		return specs
+	}
+	out := make([]string, len(specs))
+	for i, spec := range specs {
+		out[i] = r.resolveOne(ctx, spec)
+	}
+	return out
+}

--- a/pkg/sidecar/proxy/resolver.go
+++ b/pkg/sidecar/proxy/resolver.go
@@ -137,6 +137,25 @@ func newHostResolver(logger logr.Logger, ttl time.Duration) *hostResolver {
 	}
 }
 
+// seed pre-populates the cache with a boot-time resolved spec->IP mapping so
+// the first request serves the startup IP instead of repeating the lookup, and
+// so a request-time DNS outage still yields the last-known-good IP that startup
+// resolved (rather than passing the raw hostname through to the MoRI-IO
+// handshake). A no-op for empty values, for a spec that is already a literal IP
+// (never cached), or when an entry already exists. The seeded entry is marked
+// fresh (resolved=now) so it is served without a lookup for one TTL window,
+// then refreshed asynchronously via the normal serve-stale path.
+func (r *hostResolver) seed(spec, ip string) {
+	if spec == "" || ip == "" || net.ParseIP(spec) != nil {
+		return
+	}
+	r.mu.Lock()
+	if _, exists := r.cache[spec]; !exists {
+		r.cache[spec] = resolvedHost{ip: ip, resolved: time.Now()}
+	}
+	r.mu.Unlock()
+}
+
 // lookup resolves one DNS name to a single IP string using the caller's
 // context, preferring IPv4 (falling back to the first returned address). The
 // effective deadline is the smaller of the resolver's configured timeout and

--- a/pkg/sidecar/proxy/resolver_test.go
+++ b/pkg/sidecar/proxy/resolver_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostResolver_RawIPPassthrough(t *testing.T) {
+	ctx := context.Background()
+	r := newHostResolver(logr.Discard(), time.Minute)
+	// Raw IPs must pass through unchanged and never be cached (no lookup).
+	require.Equal(t, "10.0.0.1", r.resolveOne(ctx, "10.0.0.1"))
+	require.Equal(t, "::1", r.resolveOne(ctx, "::1"))
+	require.Empty(t, r.cache)
+
+	require.Equal(t, []string{"10.0.0.1", "10.0.0.2"},
+		r.resolve(ctx, []string{"10.0.0.1", "10.0.0.2"}))
+}
+
+func TestHostResolver_EmptyPassthrough(t *testing.T) {
+	ctx := context.Background()
+	r := newHostResolver(logr.Discard(), time.Minute)
+	require.Nil(t, r.resolve(ctx, nil))
+	require.Empty(t, r.resolve(ctx, []string{}))
+}
+
+func TestHostResolver_CachesWithinTTL(t *testing.T) {
+	ctx := context.Background()
+	r := newHostResolver(logr.Discard(), time.Minute)
+	// localhost resolves to a loopback address on all supported platforms.
+	first := r.resolveOne(ctx, "localhost")
+	require.True(t, first == "127.0.0.1" || first == "::1", "unexpected localhost IP %q", first)
+	require.Len(t, r.cache, 1)
+
+	entry := r.cache["localhost"]
+	// A second call within the TTL must reuse the cached entry (same resolved time).
+	second := r.resolveOne(ctx, "localhost")
+	require.Equal(t, first, second)
+	require.Equal(t, entry.resolved, r.cache["localhost"].resolved)
+}
+
+func TestHostResolver_HardFailurePassesThroughSpec(t *testing.T) {
+	r := newHostResolver(logr.Discard(), time.Minute)
+	// With no cached value, a hard resolution failure returns the original spec
+	// so the downstream engine surfaces the dial error.
+	const bad = "unresolvable-host-xyz.invalid"
+	require.Equal(t, bad, r.resolveOne(context.Background(), bad))
+}
+
+func TestResolveTTLFromEnv(t *testing.T) {
+	t.Setenv(envMoRIIODNSResolveTTLSeconds, "45")
+	require.Equal(t, 45*time.Second, resolveTTLFromEnv())
+
+	t.Setenv(envMoRIIODNSResolveTTLSeconds, "0")
+	require.Equal(t, defaultResolveTTL, resolveTTLFromEnv())
+
+	t.Setenv(envMoRIIODNSResolveTTLSeconds, "notanumber")
+	require.Equal(t, defaultResolveTTL, resolveTTLFromEnv())
+}
+
+func TestResolveTimeoutFromEnv(t *testing.T) {
+	t.Setenv(envMoRIIODNSResolveTimeoutSeconds, "12")
+	require.Equal(t, 12*time.Second, resolveTimeoutFromEnv())
+
+	t.Setenv(envMoRIIODNSResolveTimeoutSeconds, "0")
+	require.Equal(t, defaultResolveTimeout, resolveTimeoutFromEnv())
+
+	t.Setenv(envMoRIIODNSResolveTimeoutSeconds, "-3")
+	require.Equal(t, defaultResolveTimeout, resolveTimeoutFromEnv())
+
+	t.Setenv(envMoRIIODNSResolveTimeoutSeconds, "notanumber")
+	require.Equal(t, defaultResolveTimeout, resolveTimeoutFromEnv())
+}
+
+// TestHostResolver_SingleflightDedupe verifies that a cold-start stampede of
+// concurrent resolveOne calls for the same spec collapses into a single
+// underlying DNS lookup, with all callers sharing the result.
+func TestHostResolver_SingleflightDedupe(t *testing.T) {
+	ctx := context.Background()
+	r := newHostResolver(logr.Discard(), time.Minute)
+
+	var calls int32
+	release := make(chan struct{})
+	// Inject a counting lookup that blocks until released, guaranteeing all
+	// goroutines pile up on the same in-flight request before it returns.
+	r.lookupIP = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		atomic.AddInt32(&calls, 1)
+		<-release
+		return []net.IPAddr{{IP: net.ParseIP("10.9.8.7")}}, nil
+	}
+
+	const n = 25
+	var wg sync.WaitGroup
+	results := make([]string, n)
+	started := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			started <- struct{}{}
+			results[idx] = r.resolveOne(ctx, "peer.example.svc")
+		}(i)
+	}
+	// Wait until all goroutines have entered before releasing the lookup.
+	for i := 0; i < n; i++ {
+		<-started
+	}
+	// Give the racers a moment to converge on the singleflight group.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"expected exactly one underlying DNS lookup for concurrent callers")
+	for _, got := range results {
+		require.Equal(t, "10.9.8.7", got)
+	}
+	require.Equal(t, "10.9.8.7", r.cache["peer.example.svc"].ip)
+}
+
+// TestHostResolver_IPv4Preference verifies the injected-lookup path keeps the
+// IPv4-preference semantics (prefer an A record over a AAAA record).
+func TestHostResolver_IPv4Preference(t *testing.T) {
+	r := newHostResolver(logr.Discard(), time.Minute)
+	r.lookupIP = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		return []net.IPAddr{
+			{IP: net.ParseIP("fd00::1")},     // IPv6 first
+			{IP: net.ParseIP("192.168.5.6")}, // IPv4 should win
+		}, nil
+	}
+	require.Equal(t, "192.168.5.6", r.resolveOne(context.Background(), "dual.example.svc"))
+}
+
+// TestHostResolver_Timeout verifies a slow cold-start lookup is bounded by the
+// resolver timeout and falls back to the original spec when no cache entry
+// exists yet.
+func TestHostResolver_Timeout(t *testing.T) {
+	r := newHostResolver(logr.Discard(), time.Minute)
+	r.timeout = 20 * time.Millisecond
+	r.lookupIP = func(ctx context.Context, _ string) ([]net.IPAddr, error) {
+		<-ctx.Done() // block until the context deadline fires
+		return nil, ctx.Err()
+	}
+	require.Equal(t, "slow.example.svc", r.resolveOne(context.Background(), "slow.example.svc"))
+}
+
+// TestHostResolver_ContextCancellationBounds verifies the caller's context
+// bounds a cold-start lookup: a cancelled request context cancels the lookup
+// even when the resolver's own timeout is long.
+func TestHostResolver_ContextCancellationBounds(t *testing.T) {
+	r := newHostResolver(logr.Discard(), time.Minute)
+	r.timeout = time.Hour // long resolver timeout; ctx must win
+	r.lookupIP = func(ctx context.Context, _ string) ([]net.IPAddr, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	require.Equal(t, "cancelled.example.svc", r.resolveOne(ctx, "cancelled.example.svc"))
+}
+
+// TestHostResolver_ServeStaleWhileRevalidate verifies that once a spec has been
+// resolved, a past-TTL entry is served immediately (stale) while an
+// asynchronous background refresh updates the cache to the new IP.
+func TestHostResolver_ServeStaleWhileRevalidate(t *testing.T) {
+	r := newHostResolver(logr.Discard(), 20*time.Millisecond)
+
+	var mu sync.Mutex
+	current := "1.1.1.1"
+	done := make(chan struct{}, 8)
+	r.lookupIP = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		mu.Lock()
+		ip := current
+		mu.Unlock()
+		res := []net.IPAddr{{IP: net.ParseIP(ip)}}
+		done <- struct{}{} // signal the lookup ran (before doLookup writes cache)
+		return res, nil
+	}
+
+	// Cold start: blocks, seeds the cache with 1.1.1.1.
+	require.Equal(t, "1.1.1.1", r.resolveOne(context.Background(), "peer"))
+	<-done // consume the cold-start lookup signal
+
+	// Point the backing name at a new IP and let the cached entry go stale.
+	mu.Lock()
+	current = "2.2.2.2"
+	mu.Unlock()
+	time.Sleep(40 * time.Millisecond)
+
+	// Stale read returns the OLD IP immediately (no blocking) and kicks off an
+	// asynchronous refresh.
+	require.Equal(t, "1.1.1.1", r.resolveOne(context.Background(), "peer"))
+
+	// The background refresh should run and update the cache to the new IP.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background refresh did not run")
+	}
+	require.Eventually(t, func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		return r.cache["peer"].ip == "2.2.2.2"
+	}, 2*time.Second, 5*time.Millisecond, "background refresh did not update cache to new IP")
+}

--- a/pkg/sidecar/proxy/resolver_test.go
+++ b/pkg/sidecar/proxy/resolver_test.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -32,12 +33,12 @@ func TestHostResolver_RawIPPassthrough(t *testing.T) {
 	ctx := context.Background()
 	r := newHostResolver(logr.Discard(), time.Minute)
 	// Raw IPs must pass through unchanged and never be cached (no lookup).
-	require.Equal(t, "10.0.0.1", r.resolveOne(ctx, "10.0.0.1"))
-	require.Equal(t, "::1", r.resolveOne(ctx, "::1"))
+	require.Equal(t, testPrefillHostIP1, r.resolveOne(ctx, testPrefillHostIP1))
+	require.Equal(t, testLoopbackIPv6, r.resolveOne(ctx, testLoopbackIPv6))
 	require.Empty(t, r.cache)
 
-	require.Equal(t, []string{"10.0.0.1", "10.0.0.2"},
-		r.resolve(ctx, []string{"10.0.0.1", "10.0.0.2"}))
+	require.Equal(t, []string{testPrefillHostIP1, testPrefillHostIP2},
+		r.resolve(ctx, []string{testPrefillHostIP1, testPrefillHostIP2}))
 }
 
 func TestHostResolver_EmptyPassthrough(t *testing.T) {
@@ -51,15 +52,15 @@ func TestHostResolver_CachesWithinTTL(t *testing.T) {
 	ctx := context.Background()
 	r := newHostResolver(logr.Discard(), time.Minute)
 	// localhost resolves to a loopback address on all supported platforms.
-	first := r.resolveOne(ctx, "localhost")
-	require.True(t, first == "127.0.0.1" || first == "::1", "unexpected localhost IP %q", first)
+	first := r.resolveOne(ctx, testLocalHostname)
+	require.True(t, first == testLoopbackIP || first == testLoopbackIPv6, "unexpected localhost IP %q", first)
 	require.Len(t, r.cache, 1)
 
-	entry := r.cache["localhost"]
+	entry := r.cache[testLocalHostname]
 	// A second call within the TTL must reuse the cached entry (same resolved time).
-	second := r.resolveOne(ctx, "localhost")
+	second := r.resolveOne(ctx, testLocalHostname)
 	require.Equal(t, first, second)
-	require.Equal(t, entry.resolved, r.cache["localhost"].resolved)
+	require.Equal(t, entry.resolved, r.cache[testLocalHostname].resolved)
 }
 
 func TestHostResolver_HardFailurePassesThroughSpec(t *testing.T) {
@@ -225,4 +226,70 @@ func TestHostResolver_ServeStaleWhileRevalidate(t *testing.T) {
 		defer r.mu.Unlock()
 		return r.cache["peer"].ip == "2.2.2.2"
 	}, 2*time.Second, 5*time.Millisecond, "background refresh did not update cache to new IP")
+}
+
+// TestHostResolver_SeedServesStartupIPOnDNSFailure verifies that a resolver
+// seeded with the startup-resolved spec->IP serves that IP on the request path
+// even when DNS is unavailable, instead of falling back to the raw hostname
+// (which would hang the MoRI-IO handshake). This is the request-time DNS
+// failure case raised in review.
+func TestHostResolver_SeedServesStartupIPOnDNSFailure(t *testing.T) {
+	ctx := context.Background()
+	r := newHostResolver(logr.Discard(), 30*time.Millisecond)
+
+	var calls int32
+	r.lookupIP = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, errors.New("dns unavailable")
+	}
+
+	const spec = "decode-0.ns.svc"
+	const bootIP = "10.0.0.5"
+	r.seed(spec, bootIP)
+
+	// Within TTL: served straight from the seeded entry, no lookup attempted
+	// even though DNS is down.
+	require.Equal(t, bootIP, r.resolveOne(ctx, spec))
+	require.Equal(t, int32(0), atomic.LoadInt32(&calls))
+
+	// Past TTL: serve-stale returns the seeded (last-known-good) IP immediately
+	// and triggers a background refresh that fails; the good IP is retained.
+	time.Sleep(40 * time.Millisecond)
+	require.Equal(t, bootIP, r.resolveOne(ctx, spec))
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) >= 1 },
+		time.Second, 5*time.Millisecond, "background refresh should have attempted a lookup")
+	require.Equal(t, bootIP, r.resolveOne(ctx, spec))
+}
+
+// TestHostResolver_SeedNoOps verifies seed ignores empty values and literal-IP
+// specs (which are never cached).
+func TestHostResolver_SeedNoOps(t *testing.T) {
+	r := newHostResolver(logr.Discard(), time.Minute)
+	r.seed("", testPrefillHostIP1)
+	r.seed("host.ns.svc", "")
+	r.seed(testPrefillHostIP1, testPrefillHostIP1) // literal IP spec: never cached
+	require.Empty(t, r.cache)
+}
+
+// TestServer_ResolverSeededFromStartup verifies the Server seeds its request-
+// path resolver with the startup-resolved spec->IP values, so the first request
+// serves the boot IP even if DNS has since gone down (rather than the raw spec).
+func TestServer_ResolverSeededFromStartup(t *testing.T) {
+	s := &Server{
+		config: Config{
+			MoRIIODecodePodIP:     "10.0.0.9",
+			MoRIIODecodePodIPSpec: "localpod.ns.svc",
+			MoRIIODecodeHosts:     []string{testDecodeHostIP2, testDecodeHostIP3},
+			MoRIIODecodeHostSpecs: []string{"decode-0.ns.svc", "decode-1.ns.svc"},
+		},
+	}
+	// Trigger lazy creation + seeding, then simulate DNS being unavailable.
+	r := s.resolver()
+	r.lookupIP = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		return nil, errors.New("dns unavailable")
+	}
+	// The request path must return the startup-resolved IPs, not the raw specs.
+	require.Equal(t, "10.0.0.9", s.currentDecodePodIP(context.Background()))
+	require.Equal(t, []string{testDecodeHostIP2, testDecodeHostIP3},
+		s.currentDecodeHosts(context.Background()))
 }

--- a/pkg/sidecar/proxy/status_response_writer.go
+++ b/pkg/sidecar/proxy/status_response_writer.go
@@ -55,6 +55,172 @@ func (w *bufferedResponseWriter) bodyBytes() []byte {
 	return w.buffer.Bytes()
 }
 
+// deferredCommitWriter wraps a client http.ResponseWriter and holds all writes
+// until the caller decides the outcome (the "commit point"). It is used by the
+// MoRI-IO parallel WRITE dispatch so decode can run concurrently with prefill
+// yet never surface a response to the client before prefill has succeeded:
+//
+//   - commit(): relay the buffered status/headers/body to the client and switch
+//     to pass-through mode, so any further decode writes stream straight to the
+//     client (SSE/streaming is preserved after the commit point).
+//   - abort():  discard the buffered output and drop every subsequent write, so
+//     a failed prefill can never let decode emit a (possibly 200) response; the
+//     caller then writes the prefill error to the client directly.
+//
+// It is safe for concurrent use by the decode goroutine (Write/WriteHeader/
+// Flush) and the coordinating goroutine (commit/abort).
+type deferredCommitWriter struct {
+	dst http.ResponseWriter
+
+	mu sync.Mutex
+	// committed: caller decided prefill succeeded, decode's response may reach
+	// the client. aborted: caller decided prefill failed, decode is discarded.
+	committed bool
+	aborted   bool
+	// wroteHeader records that decode has produced its status/headers.
+	wroteHeader bool
+	// headerFlushed records that decode's status/headers have been relayed to
+	// dst; after this, writes stream straight through.
+	headerFlushed bool
+	statusCode    int
+	header        http.Header
+	buffer        bytes.Buffer
+}
+
+func newDeferredCommitWriter(dst http.ResponseWriter) *deferredCommitWriter {
+	return &deferredCommitWriter{
+		dst:    dst,
+		header: make(http.Header),
+	}
+}
+
+func (w *deferredCommitWriter) Header() http.Header {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	// Once decode's headers have been relayed, hand back the real writer's
+	// header map. Until then (buffering, or committed but decode hasn't emitted
+	// its header yet) collect into our own map so we can relay it verbatim.
+	if w.headerFlushed {
+		return w.dst.Header()
+	}
+	return w.header
+}
+
+func (w *deferredCommitWriter) WriteHeader(statusCode int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.aborted {
+		return
+	}
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		w.statusCode = statusCode
+	}
+	// If we've already committed, decode's header is now known -> relay it.
+	if w.committed && !w.headerFlushed {
+		w.flushCommitLocked()
+	}
+}
+
+func (w *deferredCommitWriter) Write(b []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.aborted {
+		// Response was discarded (prefill failed); silently drop decode output.
+		return len(b), nil
+	}
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		if w.statusCode == 0 {
+			w.statusCode = http.StatusOK
+		}
+	}
+	if w.committed {
+		if !w.headerFlushed {
+			w.flushCommitLocked()
+		}
+		return w.dst.Write(b)
+	}
+	return w.buffer.Write(b)
+}
+
+// Flush only propagates once decode's response has been relayed to the client;
+// while buffering it is a no-op so nothing reaches the client before the commit
+// point.
+func (w *deferredCommitWriter) Flush() {
+	w.mu.Lock()
+	streaming := w.headerFlushed && !w.aborted
+	w.mu.Unlock()
+	if !streaming {
+		return
+	}
+	if f, ok := w.dst.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// flushCommitLocked relays decode's buffered status/headers/body to dst and
+// marks the response as flushed so subsequent writes stream through. Caller must
+// hold w.mu and must have set committed.
+func (w *deferredCommitWriter) flushCommitLocked() {
+	if w.headerFlushed {
+		return
+	}
+	dstHeader := w.dst.Header()
+	for key, values := range w.header {
+		dstHeader[key] = values
+	}
+	status := w.statusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.headerFlushed = true
+	w.dst.WriteHeader(status)
+	if w.buffer.Len() > 0 {
+		_, _ = w.dst.Write(w.buffer.Bytes())
+		w.buffer.Reset()
+	}
+	if f, ok := w.dst.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// commit allows decode's response to reach the client, preserving decode's own
+// status, headers, and body. If decode has already produced output it is flushed
+// immediately; otherwise the flush is deferred until decode emits its header, so
+// a fast-succeeding prefill never clobbers decode's status/headers with a
+// synthesized default. Returns false if the writer had already been aborted.
+func (w *deferredCommitWriter) commit() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.aborted {
+		return false
+	}
+	if w.committed {
+		return true
+	}
+	w.committed = true
+	// Only flush now if decode already emitted its header/body; otherwise wait
+	// for decode's WriteHeader/Write so we relay its real status and headers.
+	if w.wroteHeader || w.buffer.Len() > 0 {
+		w.flushCommitLocked()
+	}
+	return true
+}
+
+// abort discards buffered output and drops all future writes. It is a no-op if
+// decode's response has already been relayed to the client (which cannot happen
+// in the current flow, since the caller only aborts before committing).
+func (w *deferredCommitWriter) abort() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.headerFlushed {
+		return
+	}
+	w.aborted = true
+	w.buffer.Reset()
+}
+
 type flushableResponseWriter interface {
 	http.ResponseWriter
 	http.Flusher

--- a/release-notes.d/unreleased/2094.md
+++ b/release-notes.d/unreleased/2094.md
@@ -1,7 +1,0 @@
----
-pr: 2094
-url: https://github.com/llm-d/llm-d-router/pull/2094
-author: shikamd123
-date: 2026-08-04
----
-Enable AMD MoRI-IO WRITE-mode and Wide-EP disaggregation in the sidecar, with request-path TTL re-resolution of peer DNS names (serve-stale-while-revalidate, per-lookup timeout bounding, and singleflight de-duplication) so peer pod restarts are picked up without a router restart. Tunable via `MORIIO_DNS_RESOLVE_TTL_SECONDS` (default 30) and `MORIIO_DNS_RESOLVE_TIMEOUT_SECONDS` (default 5); opt-in Prometheus counters (`moriio_dns_reresolve_total`, `moriio_dns_ip_changed_total`, `moriio_dns_lookup_failures_total`) are exposed at `/metrics` when `MORIIO_METRICS_ADDR` is set.

--- a/release-notes.d/unreleased/2094.md
+++ b/release-notes.d/unreleased/2094.md
@@ -1,0 +1,7 @@
+---
+pr: 2094
+url: https://github.com/llm-d/llm-d-router/pull/2094
+author: shikamd123
+date: 2026-08-04
+---
+Enable AMD MoRI-IO WRITE-mode and Wide-EP disaggregation in the sidecar, with request-path TTL re-resolution of peer DNS names (serve-stale-while-revalidate, per-lookup timeout bounding, and singleflight de-duplication) so peer pod restarts are picked up without a router restart. Tunable via `MORIIO_DNS_RESOLVE_TTL_SECONDS` (default 30) and `MORIIO_DNS_RESOLVE_TIMEOUT_SECONDS` (default 5); opt-in Prometheus counters (`moriio_dns_reresolve_total`, `moriio_dns_ip_changed_total`, `moriio_dns_lookup_failures_total`) are exposed at `/metrics` when `MORIIO_METRICS_ADDR` is set.


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it**:

Enables AMD **MoRI-IO WRITE-mode** and **Wide-EP** disaggregation in the llm-d
sidecar, so a single DP world can be split across pods for prefill/decode
serving on ROCm (MI300X).

- Turns on the MoRI-IO feature gate and adds the Wide-EP dispatch options
  (`--moriio-write-mode`, `--moriio-parallel-dispatch`, `--moriio-dp-size`,
  `--moriio-dp-size-local`, `--moriio-remote-hosts`, `--moriio-decode-hosts`).
- Supports both **serial WRITE** (default: prefill → await → decode) and
  **parallel WRITE** (concurrent prefill/decode) dispatch.
- Makes DP-rank routing **router-authoritative**: in serial mode the decode leg
  is pinned to the `remote_dp_rank` the prefill leg actually returned (falling
  back to a stable hash only if omitted); in parallel mode the rank is pinned up
  front with `remote_dp_rank_override=true`. Both legs agree without each side
  independently hashing the request id.
- Adds **DNS hostname resolution** for the per-pod fan-out hosts (resolved to IPs
  at startup, LWS-friendly); raw IPs remain accepted for backward compatibility.
- Documents the modes/flags/examples in `MORIIO_README.md` and adds option tests.

**Release note**:
Enable AMD **MoRI-IO WRITE-mode** and **Wide-EP** disaggregation in the llm-d router sidecar, so a single data-parallel world can be split across pods for prefill/decode serving on ROCm (MI300X). Supports **1P1D** (DP=EP=8, intra-node) and **2P2D** (DP=EP=16, inter-node via LeaderWorkerSet).

**Highlights**
- **Router-authoritative DP-rank routing:** in serial WRITE the decode leg is pinned to the `remote_dp_rank` the prefill leg returned; the returned rank is validated (in-range integer) and applied consistently to both the routing header and the request body, with a deterministic hash fallback when it is missing/invalid.
- **Peer DNS re-resolution on the request path:** peer hostnames are re-resolved under a short TTL (default 30s, `MORIIO_DNS_RESOLVE_TTL_SECONDS`) so peer pod restarts are picked up without a router restart. Lookups are context-bounded (default 5s, `MORIIO_DNS_RESOLVE_TIMEOUT_SECONDS`), de-duplicated via singleflight, and use serve-stale-while-revalidate; the resolver is seeded from startup-resolved IPs so the first request skips a lookup and a request-time DNS outage serves last-known-good.
- **Safe parallel dispatch (opt-in):** serial WRITE dispatch remains the SLA-safe default. Parallel dispatch (`--moriio-parallel-dispatch`) now cancels the decode leg when prefill fails and buffers the decode response until the prefill outcome is known, so a failed prefill returns the prefill error instead of a false 200, with a bounded KV-wait backstop (`--moriio-parallel-decode-wait-timeout`, default 30s).
- **Observability:** optional Prometheus `/metrics` endpoint for the sidecar, enabled via the `--metrics-port` flag (default `0` = disabled), exposing `moriio_dns_reresolve_total`, `moriio_dns_ip_changed_total`, and `moriio_dns_lookup_failures_total`.
- Documents modes/flags/tunables in `MORIIO_README.md`

Companion to vLLM PR vllm-project/vllm#https://github.com/vllm-project/vllm/pull/45043