### PR TITLE
test(flowcontrol): eviction dynamics benchmark

### DIFF
--- a/pkg/epp/flowcontrol/benchmark/evictiondynamics_test.go
+++ b/pkg/epp/flowcontrol/benchmark/evictiondynamics_test.go
@@ -1,0 +1,433 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/types"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+)
+
+func TestMinEvictionsRequired(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name                string
+		preload, hp, cap    int
+		ceiling             float64
+		wantMin, wantAdmits int
+	}{
+		// C=20, h=0.9: maxBelow = 17 (occupancy must be <= 17 to admit).
+		{"FullPool_SingleHP", 20, 1, 20, 0.9, 3, 1},
+		{"FullPool_Batch32", 20, 32, 20, 0.9, 20, 18},
+		{"FullPool_Batch10", 20, 10, 20, 0.9, 12, 10},
+		{"HalfPool_SingleHP", 10, 1, 20, 0.9, 0, 1},
+		{"IntegralCeiling", 18, 1, 18, 1.0, 1, 1}, // maxBelow = 17; need 18-E <= 17 -> E=1.
+		{"FractionalCeiling", 20, 1, 20, 0.95, 2, 1},
+		{"ZeroCeiling", 20, 5, 20, 0.0, 0, 0},
+		{"EmptyPool", 0, 5, 20, 0.9, 0, 5},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotMin, gotAdmits := minEvictionsRequired(tc.preload, tc.hp, tc.cap, tc.ceiling)
+			if gotMin != tc.wantMin || gotAdmits != tc.wantAdmits {
+				t.Fatalf("minEvictionsRequired(%d,%d,%d,%v) = (%d,%d), want (%d,%d)",
+					tc.preload, tc.hp, tc.cap, tc.ceiling, gotMin, gotAdmits, tc.wantMin, tc.wantAdmits)
+			}
+		})
+	}
+}
+
+// scenarioResult holds one scenario run's measurements.
+type scenarioResult struct {
+	ttfr           time.Duration // burst start -> first HP dispatch (0 = none dispatched)
+	p50, p95       time.Duration
+	admitted       int64
+	elapsed        time.Duration
+	evictSignaled  int64
+	evictConfirmed int64
+	evictHPIdle    int64
+	overEvict      int64 // confirmed - analytic minimum (sticky scenarios only; else -1)
+	maxHPWaiting   int64
+	overshoot      int64
+	timedOut       bool
+}
+
+const scenarioTimeout = 8 * time.Second
+
+// runScenario executes one full scenario against a fresh harness and returns its measurements.
+func runScenario(b *testing.B, sc evictionScenario) scenarioResult {
+	b.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fc, pool := setupEvictionBenchHarness(ctx, b, sc)
+
+	var churnFn func(i int) time.Duration
+	if sc.churnMean > 0 {
+		n := sc.preload
+		mean := sc.churnMean
+		// Deterministic exponential quantile ladder so churn is identical across runs.
+		churnFn = func(i int) time.Duration {
+			u := (float64(i) + 0.5) / float64(n)
+			return time.Duration(-float64(mean) * math.Log(1.0-u))
+		}
+	}
+	pool.PreloadSheddable(b, sc.preload, churnFn)
+
+	minEvict, admittable := minEvictionsRequired(sc.preload, sc.burst.hpCount, sc.capacity, sc.hpCeiling)
+	timed := sc.burst.window > 0
+
+	var admitted atomic.Int64
+	var ttfrNanos atomic.Int64
+	var waitsMu sync.Mutex
+	waits := make([]time.Duration, 0, sc.burst.hpCount)
+
+	clientCtx, clientCancel := context.WithCancel(ctx)
+	defer clientCancel()
+	var clientWG sync.WaitGroup
+	burstStart := time.Now()
+
+	launch := func(i int) {
+		clientWG.Add(1)
+		go func() {
+			defer clientWG.Done()
+			req := &hpBenchRequest{id: fmt.Sprintf("hp-%d", i), key: flowcontrol.FlowKey{ID: "hp-flow", Priority: 0}}
+			pool.HPEnqueued()
+			t0 := time.Now()
+			outcome, err := fc.EnqueueAndWait(clientCtx, req)
+			wait := time.Since(t0)
+			pool.HPFinishedWaiting()
+			if err != nil || outcome != types.QueueOutcomeDispatched {
+				return
+			}
+			pool.HPDispatched(sc.burst.serviceTime)
+			ttfrNanos.CompareAndSwap(0, time.Since(burstStart).Nanoseconds())
+			admitted.Add(1)
+			waitsMu.Lock()
+			waits = append(waits, wait)
+			waitsMu.Unlock()
+		}()
+	}
+
+	timedOut := false
+	if timed {
+		gap := sc.burst.window / time.Duration(sc.burst.hpCount)
+		ticker := time.NewTicker(gap)
+		windowEnd := time.NewTimer(sc.burst.window)
+		i := 0
+	genLoop:
+		for {
+			select {
+			case <-ticker.C:
+				if i < sc.burst.hpCount {
+					launch(i)
+					i++
+				}
+			case <-windowEnd.C:
+				break genLoop
+			}
+		}
+		ticker.Stop()
+	} else {
+		for i := range sc.burst.hpCount {
+			launch(i)
+			if sc.burst.arrivalGap > 0 {
+				time.Sleep(sc.burst.arrivalGap)
+			}
+		}
+		// Baselines with no churn admit nothing; observe a fixed window instead of the full timeout.
+		waitBudget := scenarioTimeout
+		target := int64(admittable)
+		if sc.evictionOff && sc.churnMean == 0 {
+			waitBudget = 2 * time.Second
+			target = math.MaxInt64
+		}
+		deadline := time.Now().Add(waitBudget)
+		for admitted.Load() < target {
+			if time.Now().After(deadline) {
+				timedOut = target != math.MaxInt64
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+	elapsed := time.Since(burstStart)
+
+	// Unblock any still-queued HP clients and collect.
+	clientCancel()
+	clientWG.Wait()
+
+	sort.Slice(waits, func(i, j int) bool { return waits[i] < waits[j] })
+	percentile := func(p float64) time.Duration {
+		if len(waits) == 0 {
+			return 0
+		}
+		idx := int(p * float64(len(waits)-1))
+		return waits[idx]
+	}
+
+	res := scenarioResult{
+		ttfr:           time.Duration(ttfrNanos.Load()),
+		p50:            percentile(0.50),
+		p95:            percentile(0.95),
+		admitted:       admitted.Load(),
+		elapsed:        elapsed,
+		evictSignaled:  pool.evictionsSignaled.Load(),
+		evictConfirmed: pool.evictionsConfirmed.Load(),
+		evictHPIdle:    pool.evictionsWhileIdle.Load(),
+		overEvict:      -1,
+		maxHPWaiting:   pool.maxHPWaiting.Load(),
+		// Overshoot beyond the higher of the preload watermark and the ceiling: any rise above it
+		// means dispatch outran the gauge.
+		overshoot: max(0, pool.maxObservedUnits.Load()-
+			max(int64(sc.preload), int64(math.Ceil(sc.hpCeiling*float64(sc.capacity))))),
+		timedOut: timedOut,
+	}
+	if !timed && !sc.evictionOff {
+		res.overEvict = res.evictConfirmed - int64(minEvict)
+	}
+
+	// Teardown: stop the controller, then the pool (leases, HP release timers).
+	cancel()
+	pool.Close(b)
+	time.Sleep(50 * time.Millisecond) // Drain processor goroutines (package precedent).
+	return res
+}
+
+// --- Aggregation over b.N iterations ---
+
+type scenarioAgg struct {
+	n       int
+	sum     scenarioResult
+	anyTO   bool
+	sumTTFR time.Duration
+}
+
+func (a *scenarioAgg) add(r scenarioResult) {
+	a.n++
+	a.sumTTFR += r.ttfr
+	a.sum.p50 += r.p50
+	a.sum.p95 += r.p95
+	a.sum.admitted += r.admitted
+	a.sum.elapsed += r.elapsed
+	a.sum.evictSignaled += r.evictSignaled
+	a.sum.evictConfirmed += r.evictConfirmed
+	a.sum.evictHPIdle += r.evictHPIdle
+	a.sum.overEvict += r.overEvict
+	a.sum.maxHPWaiting += r.maxHPWaiting
+	a.sum.overshoot += r.overshoot
+	a.anyTO = a.anyTO || r.timedOut
+}
+
+// evictionRow is one line of the shareable results table.
+type evictionRow struct {
+	name                                             string
+	ttfrMS, p50MS, p95MS, goodput                    float64
+	evictConfirmed, overEvict, evictHPIdle, maxQueue float64
+	timedOut                                         bool
+}
+
+var (
+	evictionTableMu sync.Mutex
+	evictionTable   []evictionRow
+)
+
+func (a *scenarioAgg) report(b *testing.B, name string) {
+	n := float64(a.n)
+	ms := func(d time.Duration) float64 { return math.Round(float64(d)/float64(time.Millisecond)/n*10) / 10 }
+	row := evictionRow{
+		name:           name,
+		ttfrMS:         ms(a.sumTTFR),
+		p50MS:          ms(a.sum.p50),
+		p95MS:          ms(a.sum.p95),
+		goodput:        math.Round(float64(a.sum.admitted)/a.sum.elapsed.Seconds()*10) / 10,
+		evictConfirmed: float64(a.sum.evictConfirmed) / n,
+		overEvict:      float64(a.sum.overEvict) / n,
+		evictHPIdle:    float64(a.sum.evictHPIdle) / n,
+		maxQueue:       float64(a.sum.maxHPWaiting) / n,
+		timedOut:       a.anyTO,
+	}
+
+	b.ReportMetric(row.ttfrMS, "ttfr-ms")
+	b.ReportMetric(row.p50MS, "p50-ms")
+	b.ReportMetric(row.p95MS, "p95-ms")
+	b.ReportMetric(row.goodput, "goodput-rps")
+	b.ReportMetric(row.evictConfirmed, "evict-confirmed")
+	if row.overEvict >= 0 {
+		b.ReportMetric(row.overEvict, "over-evict")
+	}
+	b.ReportMetric(row.evictHPIdle, "evict-hp-idle")
+	b.ReportMetric(float64(a.sum.overshoot)/n, "overshoot")
+	if a.anyTO {
+		b.ReportMetric(1, "timed-out")
+	}
+
+	evictionTableMu.Lock()
+	evictionTable = append(evictionTable, row)
+	evictionTableMu.Unlock()
+}
+
+// --- The matrix ---
+
+var (
+	burstSingle    = burstShape{name: "single", hpCount: 1}
+	burstBatch32   = burstShape{name: "batch32", hpCount: 32}
+	burstSustained = burstShape{name: "sustained", hpCount: 300, serviceTime: 250 * time.Millisecond, window: 3 * time.Second}
+)
+
+// matchedGrace is the grace a deployment would pair with each sensor profile per the design doc.
+func matchedGrace(p sensorProfile) time.Duration {
+	if p.freeVisibilityLag == 0 {
+		return 50 * time.Millisecond
+	}
+	return 500 * time.Millisecond
+}
+
+func evictionScenarios(full bool) []evictionScenario {
+	base := evictionScenario{capacity: 20, preload: 20, hpCeiling: 0.9, maxRevoc: 2}
+	profiles := []sensorProfile{profileConcurrency, profileUtilization}
+	graces := []time.Duration{5 * time.Millisecond, 50 * time.Millisecond, 200 * time.Millisecond, 500 * time.Millisecond}
+	ks := []int{1, 2, 5}
+	bursts := []burstShape{burstSingle, burstBatch32, burstSustained}
+
+	var out []evictionScenario
+	seen := map[string]bool{}
+	add := func(sc evictionScenario) {
+		if name := sc.name(); !seen[name] {
+			seen[name] = true
+			out = append(out, sc)
+		}
+	}
+
+	for _, p := range profiles {
+		if full {
+			for _, g := range graces {
+				for _, k := range ks {
+					for _, bu := range bursts {
+						sc := base
+						sc.profile, sc.grace, sc.maxRevoc, sc.burst = p, g, k, bu
+						add(sc)
+					}
+				}
+			}
+		} else {
+			// Informative diagonal: grace sweep at k=2/batch32; k sweep at matched grace/batch32;
+			// single + sustained at matched settings.
+			for _, g := range graces {
+				sc := base
+				sc.profile, sc.grace, sc.burst = p, g, burstBatch32
+				add(sc)
+			}
+			for _, k := range ks {
+				sc := base
+				sc.profile, sc.grace, sc.maxRevoc, sc.burst = p, matchedGrace(p), k, burstBatch32
+				add(sc)
+			}
+			for _, bu := range []burstShape{burstSingle, burstSustained} {
+				sc := base
+				sc.profile, sc.grace, sc.burst = p, matchedGrace(p), bu
+				add(sc)
+			}
+			// Over-eviction exposure: low grace on shallow demand. Against the lagged sensor, debits
+			// expire before frees become gauge-visible (expect over-eviction); against the leading
+			// sensor, near-zero grace should stay clean (expect none).
+			lowGrace := 5 * time.Millisecond
+			if p.freeVisibilityLag > 0 {
+				lowGrace = 50 * time.Millisecond
+			}
+			{
+				sc := base
+				sc.profile, sc.grace, sc.burst = p, lowGrace, burstSingle
+				add(sc)
+			}
+		}
+		// Baselines: eviction off, with and without natural churn.
+		for _, churn := range []time.Duration{0, 500 * time.Millisecond} {
+			sc := base
+			sc.profile, sc.grace, sc.burst = p, matchedGrace(p), burstBatch32
+			sc.evictionOff, sc.churnMean = true, churn
+			add(sc)
+		}
+	}
+	return out
+}
+
+// BenchmarkEvictionDynamics measures the reclamation controller's pacing behavior end-to-end.
+//
+// Invocation:
+//
+//	go test ./pkg/epp/flowcontrol/benchmark/ -run '^$' -bench EvictionDynamics -benchtime=1x -count=5
+//
+// Set EVICTION_BENCH_FULL=1 for the full matrix and EVICTION_BENCH_TABLE=1 to print a markdown
+// summary table after the run.
+func BenchmarkEvictionDynamics(b *testing.B) {
+	if testing.Short() {
+		b.Skip("eviction dynamics benchmark skipped in -short mode")
+	}
+
+	// Reset so -count>1 repeats do not accumulate rows from earlier runs.
+	evictionTableMu.Lock()
+	evictionTable = nil
+	evictionTableMu.Unlock()
+
+	for _, sc := range evictionScenarios(os.Getenv("EVICTION_BENCH_FULL") != "") {
+		b.Run(sc.name(), func(b *testing.B) {
+			agg := &scenarioAgg{}
+			for range b.N {
+				agg.add(runScenario(b, sc))
+			}
+			agg.report(b, sc.name())
+		})
+	}
+
+	if os.Getenv("EVICTION_BENCH_TABLE") != "" {
+		printEvictionTable()
+	}
+}
+
+func printEvictionTable() {
+	evictionTableMu.Lock()
+	defer evictionTableMu.Unlock()
+
+	var sb strings.Builder
+	sb.WriteString("\n| scenario | ttfr(ms) | p50(ms) | p95(ms) | goodput(r/s) | evicted | over-evict | evict-hp-idle | maxq |\n")
+	sb.WriteString("|---|---|---|---|---|---|---|---|---|\n")
+	for _, r := range evictionTable {
+		over := "n/a"
+		if r.overEvict >= 0 {
+			over = fmt.Sprintf("%.1f", r.overEvict)
+		}
+		name := r.name
+		if r.timedOut {
+			name += " (TIMEOUT)"
+		}
+		fmt.Fprintf(&sb, "| %s | %.1f | %.1f | %.1f | %.1f | %.1f | %s | %.1f | %.0f |\n",
+			name, r.ttfrMS, r.p50MS, r.p95MS, r.goodput, r.evictConfirmed, over, r.evictHPIdle, r.maxQueue)
+	}
+	fmt.Println(sb.String())
+}

--- a/pkg/epp/flowcontrol/benchmark/evictionsim_test.go
+++ b/pkg/epp/flowcontrol/benchmark/evictionsim_test.go
@@ -1,0 +1,401 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file implements a closed-loop simulator for the eviction/reclamation dynamics benchmark
+// (BenchmarkEvictionDynamics). It models an inference pool as a fixed number of capacity units
+// occupied by sheddable leases, with configurable sensor lag between a lease's termination and
+// the moment the saturation gauge reflects the freed capacity. All flow control components are
+// real (FlowController, registry, RequestEvictor, ReclamationController); only the pool and its
+// sensor are synthetic. See docs/flow-control-eviction.md for the pacing design under test.
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts/mocks"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/controller"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/eviction"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	evictfiltering "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/eviction/filtering"
+	evictordering "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/eviction/ordering"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
+	testutils "github.com/llm-d/llm-d-router/test/utils"
+)
+
+// sensorProfile models where the saturation sensor sits relative to reality when a lease frees.
+type sensorProfile struct {
+	name string
+	// termLatency is the delay between the eviction signal (EvictCh close) and the stream's
+	// termination (the confirmation event).
+	termLatency time.Duration
+	// freeVisibilityLag is the additional delay between termination and the freed capacity
+	// appearing in the gauge (engine GC + metrics scrape + staleness for a utilization-style
+	// sensor; ~0 for a concurrency-style sensor whose counters decrement at termination).
+	freeVisibilityLag time.Duration
+}
+
+var (
+	profileConcurrency = sensorProfile{name: "conc", termLatency: 3 * time.Millisecond, freeVisibilityLag: 0}
+	profileUtilization = sensorProfile{name: "util", termLatency: 3 * time.Millisecond, freeVisibilityLag: 200 * time.Millisecond}
+)
+
+// burstShape describes the high-priority demand applied to the saturated pool.
+type burstShape struct {
+	name       string
+	hpCount    int           // total HP requests issued (rate-shaped when window > 0)
+	arrivalGap time.Duration // spacing between HP arrivals (0 = simultaneous burst)
+	// serviceTime is how long a dispatched HP request occupies its capacity unit before freeing it
+	// through the same lagged path as evictions. 0 = sticky: held until scenario end.
+	serviceTime time.Duration
+	// window, when non-zero, switches the scenario to timed mode: HP arrivals are generated for
+	// the window duration and goodput is measured over it, instead of waiting for an analytic
+	// admission count.
+	window time.Duration
+}
+
+// evictionScenario is one coordinate of the benchmark matrix.
+type evictionScenario struct {
+	profile  sensorProfile
+	grace    time.Duration
+	maxRevoc int
+	burst    burstShape
+	// evictionOff disables reclamation for baseline arms.
+	evictionOff bool
+	// churnMean, when non-zero, gives sheddable leases a natural completion time drawn
+	// deterministically from a truncated exponential-like ladder with this mean.
+	churnMean time.Duration
+	capacity  int     // C, pool capacity in lease units
+	preload   int     // S, sheddable leases occupying the pool at burst start
+	hpCeiling float64 // h, the HP band's dispatch ceiling
+}
+
+func (sc evictionScenario) name() string {
+	mode := fmt.Sprintf("g%d/k%d", sc.grace.Milliseconds(), sc.maxRevoc)
+	if sc.evictionOff {
+		if sc.churnMean > 0 {
+			mode = "off-churn"
+		} else {
+			mode = "off-nochurn"
+		}
+	}
+	return fmt.Sprintf("%s/%s/%s", sc.profile.name, mode, sc.burst.name)
+}
+
+// maxUnitsBelowCeiling returns the largest integer unit count strictly below h*C, i.e. the highest
+// occupancy at which the HP band can still dispatch.
+func maxUnitsBelowCeiling(capacity int, ceiling float64) int {
+	return int(math.Ceil(ceiling*float64(capacity))) - 1
+}
+
+// minEvictionsRequired computes the analytic minimum number of sheddable evictions needed for a
+// sticky HP burst: preloaded S leases in a pool of capacity C, K HP arrivals, HP ceiling h. The
+// k-th admission requires occupancy <= maxUnitsBelowCeiling just before it; admitted HP requests
+// are sticky (never free). Returns (minEvictions, admittableHP).
+func minEvictionsRequired(preload, hpCount, capacity int, ceiling float64) (minEvictions, admittable int) {
+	maxBelow := maxUnitsBelowCeiling(capacity, ceiling)
+	if maxBelow < 0 {
+		return 0, 0 // Ceiling of zero admits nothing.
+	}
+	// With every sheddable lease evicted, the k-th admission needs k-1 <= maxBelow.
+	admittable = min(hpCount, maxBelow+1)
+	if admittable == 0 {
+		return 0, 0
+	}
+	// The last admission needs preload - E + (admittable-1) <= maxBelow.
+	minEvictions = max(0, preload+admittable-1-maxBelow)
+	minEvictions = min(minEvictions, preload)
+	return minEvictions, admittable
+}
+
+// syntheticPool is the synthetic pool + sensor. visibleUnits is the gauge numerator: sheddable
+// leases whose free is not yet sensor-visible, plus dispatched HP footprint.
+type syntheticPool struct {
+	// Embedded to satisfy the plugin.Plugin surface of SaturationDetector (same pattern as
+	// benchDetector); only Saturation is ever called.
+	flowcontrol.SaturationDetector
+
+	capacity int64
+	profile  sensorProfile
+	evictor  *eviction.RequestEvictor
+	epMeta   *fwkdl.EndpointMetadata
+
+	visibleUnits     atomic.Int64
+	maxObservedUnits atomic.Int64
+
+	// hpWaiting counts HP requests currently blocked in EnqueueAndWait; sampled at eviction-signal
+	// time to attribute evictions fired with no waiting demand.
+	hpWaiting    atomic.Int64
+	maxHPWaiting atomic.Int64
+
+	evictionsSignaled  atomic.Int64
+	evictionsConfirmed atomic.Int64
+	evictionsWhileIdle atomic.Int64
+
+	leaseCtx    context.Context
+	leaseCancel context.CancelFunc
+	wg          sync.WaitGroup
+}
+
+var _ flowcontrol.SaturationDetector = (*syntheticPool)(nil)
+
+func newSyntheticPool(sc evictionScenario, evictor *eviction.RequestEvictor) *syntheticPool {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &syntheticPool{
+		capacity: int64(sc.capacity),
+		profile:  sc.profile,
+		evictor:  evictor,
+		epMeta: &fwkdl.EndpointMetadata{
+			ID:      fwkdl.ID{Name: "sim-pod", Namespace: "default"},
+			Address: "10.0.0.1",
+			Port:    "8000",
+		},
+		leaseCtx:    ctx,
+		leaseCancel: cancel,
+	}
+}
+
+func (p *syntheticPool) Saturation(context.Context, []fwkdl.Endpoint) float64 {
+	return float64(p.visibleUnits.Load()) / float64(p.capacity)
+}
+
+// addUnits adjusts the gauge and maintains the overshoot watermark.
+func (p *syntheticPool) addUnits(delta int64) {
+	v := p.visibleUnits.Add(delta)
+	for {
+		cur := p.maxObservedUnits.Load()
+		if v <= cur || p.maxObservedUnits.CompareAndSwap(cur, v) {
+			return
+		}
+	}
+}
+
+// PreloadSheddable occupies the pool with n sheddable leases tracked in the real RequestEvictor,
+// each with its own lifecycle goroutine reacting to eviction (or natural churn for baselines).
+// churnAfter, when non-nil, returns the lease's natural completion delay (0 = never completes).
+func (p *syntheticPool) PreloadSheddable(b *testing.B, n int, churnAfter func(i int) time.Duration) {
+	b.Helper()
+	for i := range n {
+		id := fmt.Sprintf("shed-%d", i)
+		req := &fwksched.InferenceRequest{
+			RequestID:  id,
+			Headers:    map[string]string{reqcommon.RequestIDHeaderKey: id},
+			Objectives: fwksched.RequestObjectives{Priority: -1},
+		}
+		result := &fwksched.SchedulingResult{
+			PrimaryProfileName: "decode",
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"decode": {TargetEndpoints: []fwksched.Endpoint{
+					fwksched.NewEndpoint(p.epMeta, fwkdl.NewMetrics(), nil),
+				}},
+			},
+		}
+		if err := p.evictor.PreRequest(p.leaseCtx, req, result); err != nil {
+			b.Fatalf("Failed to register sheddable lease %s: %v", id, err)
+		}
+		evictCh := p.evictor.EvictionRegistry().Get(id)
+		p.addUnits(1)
+
+		var churn time.Duration
+		if churnAfter != nil {
+			churn = churnAfter(i)
+		}
+		p.wg.Add(1)
+		go p.leaseLifecycle(req, evictCh, churn)
+	}
+}
+
+// leaseLifecycle waits for eviction, natural churn, or teardown, and walks the freed capacity
+// through the sensor lag stages.
+func (p *syntheticPool) leaseLifecycle(req *fwksched.InferenceRequest, evictCh chan struct{}, churnAfter time.Duration) {
+	defer p.wg.Done()
+
+	var churnCh <-chan time.Time
+	if churnAfter > 0 {
+		timer := time.NewTimer(churnAfter)
+		defer timer.Stop()
+		churnCh = timer.C
+	}
+
+	select {
+	case <-evictCh:
+		p.evictionsSignaled.Add(1)
+		if p.hpWaiting.Load() == 0 {
+			p.evictionsWhileIdle.Add(1)
+		}
+		if !sleepCtx(p.leaseCtx, p.profile.termLatency) {
+			return
+		}
+		// Stream termination: the real cleanup path, which fires the confirmation listener.
+		p.evictor.ResponseBody(p.leaseCtx, req, &fwkrc.Response{EndOfStream: true}, p.epMeta)
+		p.evictionsConfirmed.Add(1)
+	case <-churnCh:
+		// Natural completion frees capacity through the same termination path.
+		p.evictor.ResponseBody(p.leaseCtx, req, &fwkrc.Response{EndOfStream: true}, p.epMeta)
+	case <-p.leaseCtx.Done():
+		return
+	}
+
+	if !sleepCtx(p.leaseCtx, p.profile.freeVisibilityLag) {
+		return
+	}
+	p.addUnits(-1)
+}
+
+// HPEnqueued and HPFinishedWaiting bracket a client's EnqueueAndWait call.
+func (p *syntheticPool) HPEnqueued() {
+	w := p.hpWaiting.Add(1)
+	for {
+		cur := p.maxHPWaiting.Load()
+		if w <= cur || p.maxHPWaiting.CompareAndSwap(cur, w) {
+			return
+		}
+	}
+}
+
+func (p *syntheticPool) HPFinishedWaiting() { p.hpWaiting.Add(-1) }
+
+// HPDispatched claims the dispatched request's footprint immediately (the sensor-lag dimension
+// applies to frees only, which is conservative for the pacing question under test). If
+// serviceTime > 0 the footprint is released through the lagged path after service completes.
+func (p *syntheticPool) HPDispatched(serviceTime time.Duration) {
+	p.addUnits(1)
+	if serviceTime <= 0 {
+		return // Sticky: held until scenario teardown.
+	}
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		if !sleepCtx(p.leaseCtx, serviceTime) {
+			return
+		}
+		if !sleepCtx(p.leaseCtx, p.profile.freeVisibilityLag) {
+			return
+		}
+		p.addUnits(-1)
+	}()
+}
+
+// Close tears the pool down and fails the benchmark if lease goroutines leak.
+func (p *syntheticPool) Close(b *testing.B) {
+	b.Helper()
+	p.leaseCancel()
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		b.Fatal("syntheticPool teardown timed out: lease goroutines leaked")
+	}
+}
+
+// sleepCtx sleeps for d unless ctx is cancelled first; returns false on cancellation. A zero or
+// negative d returns true immediately.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// hpBenchRequest is a FlowControlRequest for the high-priority flow with a unique ID.
+type hpBenchRequest struct {
+	id  string
+	key flowcontrol.FlowKey
+}
+
+func (r *hpBenchRequest) FlowKey() flowcontrol.FlowKey                 { return r.key }
+func (r *hpBenchRequest) ByteSize() uint64                             { return 1024 }
+func (r *hpBenchRequest) InitialEffectiveTTL() time.Duration           { return 5 * time.Minute }
+func (r *hpBenchRequest) ID() string                                   { return r.id }
+func (r *hpBenchRequest) GetMetadata() map[string]any                  { return nil }
+func (r *hpBenchRequest) InferencePoolName() string                    { return "bench-pool" }
+func (r *hpBenchRequest) ModelName() string                            { return "bench-model" }
+func (r *hpBenchRequest) TargetModelName() string                      { return "bench-target" }
+func (r *hpBenchRequest) InferenceRequest() *fwksched.InferenceRequest { return nil }
+func (r *hpBenchRequest) ReceivedTimestamp() time.Time                 { return time.Now() }
+
+// setupEvictionBenchHarness builds the real SUT stack for one scenario: registry with a single
+// priority-0 band, constant HP ceiling, the synthetic pool as the saturation detector, and the
+// full eviction plumbing wired through controller Deps.
+func setupEvictionBenchHarness(
+	ctx context.Context,
+	b *testing.B,
+	sc evictionScenario,
+) (*controller.FlowController, *syntheticPool) {
+	b.Helper()
+
+	handle := testutils.NewTestHandle(ctx)
+	reg := setupRegistryWithDefaultPolicies(b, handle, 1) // Single band at priority 0.
+
+	orderingPlugin, err := evictordering.PriorityThenTimeOrderingFactory(evictordering.PriorityThenTimeOrderingType, nil, nil)
+	if err != nil {
+		b.Fatalf("Failed to create eviction ordering policy: %v", err)
+	}
+	filterPlugin, err := evictfiltering.SheddableFilterFactory(evictfiltering.SheddableFilterType, nil, nil)
+	if err != nil {
+		b.Fatalf("Failed to create eviction filter policy: %v", err)
+	}
+	requestEvictor := eviction.NewRequestEvictor(
+		orderingPlugin.(flowcontrol.EvictionOrderingPolicy),
+		filterPlugin.(flowcontrol.EvictionFilterPolicy),
+		eviction.NewImmediateResponseEvictor(),
+	)
+
+	pool := newSyntheticPool(sc, requestEvictor)
+
+	cfg := &controller.Config{
+		DefaultRequestTTL:           5 * time.Minute,
+		ExpiryCleanupInterval:       1 * time.Hour, // Effectively disabled.
+		EnqueueChannelBufferSize:    2000,
+		EnableEviction:              !sc.evictionOff,
+		MaxRevocationsPerDecision:   sc.maxRevoc,
+		EvictionConfirmationGrace:   sc.grace,
+		EvictionConfirmationTimeout: 10 * time.Second,
+	}
+
+	deps := controller.Deps{
+		Registry:           reg,
+		SaturationDetector: pool,
+		EndpointCandidates: &mocks.MockEndpointCandidates{},
+		UsageLimitPolicy:   usagelimits.NewConstPolicy("evict-bench", sc.hpCeiling),
+	}
+	if !sc.evictionOff {
+		deps.InFlightEvictor = requestEvictor
+	}
+
+	fc := controller.NewFlowController(ctx, "eviction-bench", cfg, deps)
+	return fc, pool
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

The closed-loop simulation harness for the Validation section of the in-flight eviction design (#2061), making the design's quantitative claims reproducible. A synthetic pool with configurable sensor lag drives the real FlowController, registry, RequestEvictor, and ReclamationController end to end. Measurements cover time-to-first-relief, high-priority wait percentiles, goodput, and over-eviction against an analytic minimum, across sensor profiles, grace values, per-decision revocation caps, burst shapes, and eviction-disabled baselines.

Opt-in only: runs via `-bench EvictionDynamics -benchtime=1x`, skipped under `-short`. `EVICTION_BENCH_TABLE=1` prints a markdown summary; `EVICTION_BENCH_FULL=1` runs the full matrix.

**Which issue(s) this PR fixes**:

Part of #1119

**Release note**:
```release-note
NONE
```

**Test plan**:

- [x] Analytic minimum-evictions helper verified against hand-computed scenarios
- [x] Single-scenario smoke and race-detector runs; pruned matrix completes with the expected goodput/over-eviction profile
