### PR TITLE
test(coordinator): Fix request timeout for multimodal e2e specs

### DIFF
--- a/Makefile.coord.mk
+++ b/Makefile.coord.mk
@@ -116,7 +116,7 @@ endif
 # Env vars forwarded into the e2e test container.
 E2E_ENV_VARS = COORDINATOR_IMAGE VLLM_IMAGE EPP_IMAGE VLLM_RENDER_IMAGE VLLM_RENDER_PORT \
                E2E_GATEWAY_PORT E2E_KEEP_CLUSTER_ON_FAILURE \
-               E2E_PRINT_COORDINATOR_LOGS K8S_CONTEXT READY_TIMEOUT MODEL_NAME
+               E2E_PRINT_LOGS K8S_CONTEXT READY_TIMEOUT MODEL_NAME
 BUILDER_E2E_ENV_FLAGS = $(foreach v,$(E2E_ENV_VARS),$(if $($(v)),-e '$(v)=$($(v))'))
 ifneq ($(filter command line environment,$(origin NAMESPACE)),)
 BUILDER_E2E_ENV_FLAGS += -e NAMESPACE=$(NAMESPACE)

--- a/README.coord.md
+++ b/README.coord.md
@@ -341,7 +341,7 @@ kubectl --context kind-e2e-coordinator-tests get pods
 |---|---|---|
 | `E2E_KEEP_CLUSTER_ON_FAILURE` | `false` | Preserve the Kind cluster when the suite fails |
 | `E2E_GATEWAY_PORT` | `30080` | Host port mapped to the gateway NodePort |
-| `E2E_PRINT_COORDINATOR_LOGS` | `false` | Print coordinator pod logs during the run |
+| `E2E_PRINT_LOGS` | `false` | Print all pod logs (coordinator, EPPs, Envoy, workers) for every spec, not just on failure |
 | `CONTAINER_RUNTIME` | `docker` | Container runtime used to load images into Kind (`docker` or `podman`) |
 | `EPP_IMAGE` | `ghcr.io/llm-d/llm-d-router-endpoint-picker:dev` | EPP image loaded into the Kind cluster |
 | `VLLM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.10.2` | vLLM image loaded into the Kind cluster |

--- a/test/coordinator/e2e/coordinator/configs_test.go
+++ b/test/coordinator/e2e/coordinator/configs_test.go
@@ -23,7 +23,11 @@ server:
   listen_addr: ":8080"
   read_timeout: 30s
   write_timeout: 120s
-  shutdown_timeout: 25s
+  # Recreated per spec behind a suite-lived Envoy; drain fast so a deleted
+  # coordinator stops serving immediately instead of lingering on a stale
+  # endpoint the gateway may still route to. 0s is avoided: it makes the
+  # server Shutdown context expire instantly and the process exit non-zero.
+  shutdown_timeout: 1s
 
 gateway:
   address: "http://envoy.${NAMESPACE}.svc:8081"

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -121,10 +121,11 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		testutils.DeleteObjects(testConfig, encodePool, nsName)
 	})
 
-	// Dump coordinator logs on failure, or always when E2E_PRINT_COORDINATOR_LOGS is
-	// set. Registered second → runs first (LIFO), so the deployment still exists.
+	// Dump all pod logs (coordinator, EPPs, Envoy, workers) on failure, or always
+	// when E2E_PRINT_LOGS is set. Registered second → runs first (LIFO), so the
+	// pods still exist.
 	ginkgo.DeferCleanup(func() {
-		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
+		if !ginkgo.CurrentSpecReport().Failed() && !printLogs {
 			return
 		}
 		testutils.DumpPodsAndLogs(testConfig, nsName, testutils.WithFullLogs())

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -31,15 +31,11 @@ import (
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
-const (
-	// requestTimeout bounds text-only chat completions.
-	requestTimeout = 60 * time.Second
-	// multimodalRequestTimeout bounds multimodal chat completions, which run the
-	// extra replace-media-urls/render/encode stages; 60s times out before they
-	// finish. Long budget so the request completes and the coordinator logs
-	// (dumped at the end of the spec) show where the time actually went.
-	multimodalRequestTimeout = 600 * time.Second
-)
+// requestTimeout is intentionally long (applies to all specs, text-only and
+// multimodal) so the request completes even on the intermittent slow/black-holed
+// path, letting the end-of-spec coordinator log dump show whether and when the
+// request actually reached the coordinator.
+const requestTimeout = 600 * time.Second
 
 // testImageURL and testImageURL2 are publicly accessible images used to
 // exercise multimodal requests that trigger the encode stage.
@@ -135,7 +131,12 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
 			return
 		}
-		dumpCoordinatorLogs(nsName)
+		dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
+		dumpDeploymentLogs(nsName, eppName+"-encode", "epp")
+		dumpDeploymentLogs(nsName, eppName+"-prefill", "epp")
+		dumpDeploymentLogs(nsName, eppName+"-decode", "epp")
+		dumpDeploymentLogs(nsName, "envoy", "envoy")
+		dumpEnvoyClusters(nsName)
 	})
 
 	// Pools first so each EPP can resolve its --pool-name.
@@ -166,11 +167,7 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	req.Header.Set("Content-Type", "application/json")
 
-	timeout := requestTimeout
-	if expectedImages > 0 {
-		timeout = multimodalRequestTimeout
-	}
-	client := &http.Client{Timeout: timeout}
+	client := &http.Client{Timeout: requestTimeout}
 	resp, err := client.Do(req)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer resp.Body.Close()
@@ -183,29 +180,43 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 	gomega.Expect(raw).NotTo(gomega.BeEmpty(), "coordinator returned empty body")
 	verifyCoordinatorSteps(nsName, expectedSteps, expectedImages, true, true)
 
-	// Diagnostic: on multimodal specs, dump the coordinator logs once the request
-	// has completed. The per-step timestamps show when the request reached the
-	// coordinator (relative to when it was sent) and how long each pipeline step
-	// took, so we can tell late-arrival (gateway) from slow processing (pipeline).
-	if expectedImages > 0 {
-		dumpCoordinatorLogs(nsName)
-	}
+	// Diagnostic: dump the coordinator logs once the request has completed. The
+	// per-step timestamps show when the request reached the coordinator (relative
+	// to when it was sent) and how long each pipeline step took, so we can tell
+	// late-arrival (gateway) from slow processing (pipeline).
+	dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
 }
 
-// dumpCoordinatorLogs writes the coordinator deployment's logs to the Ginkgo
-// output. A kubectl error is reported inline rather than failing the spec.
-func dumpCoordinatorLogs(nsName string) {
-	args := []string{"logs", "deployment/llm-d-coordinator",
-		"-c", "coordinator", "--namespace=" + nsName}
+// dumpDeploymentLogs writes a deployment's container logs to the Ginkgo output.
+// A kubectl error is reported inline rather than failing the spec.
+func dumpDeploymentLogs(nsName, deployment, container string) {
+	args := []string{"logs", "deployment/" + deployment, "-c", container, "--namespace=" + nsName}
 	if k8sContext != "" {
 		args = append(args, "--context="+k8sContext)
 	}
 	out, err := exec.Command("kubectl", args...).CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs (kubectl error: %v) ---\n%s\n---\n", err, string(out))
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs (kubectl error: %v) ---\n%s\n---\n", deployment, err, string(out))
 		return
 	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs ---\n%s\n---\n", string(out))
+	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs ---\n%s\n---\n", deployment, string(out))
+}
+
+// dumpEnvoyClusters writes Envoy's admin /clusters (resolved endpoints and health
+// per cluster) to the Ginkgo output. Best-effort; yields nothing if the envoy
+// image lacks a usable HTTP client.
+func dumpEnvoyClusters(nsName string) {
+	args := []string{"exec", "deployment/envoy", "-c", "envoy", "--namespace=" + nsName}
+	if k8sContext != "" {
+		args = append(args, "--context="+k8sContext)
+	}
+	args = append(args, "--", "curl", "-s", "http://localhost:19000/clusters")
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
+		return
+	}
+	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters ---\n%s\n---\n", string(out))
 }
 
 // verifyCoordinatorSteps fetches the coordinator pod logs and asserts that

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -31,11 +31,7 @@ import (
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
-// requestTimeout is intentionally long (applies to all specs, text-only and
-// multimodal) so the request completes even on the intermittent slow/black-holed
-// path, letting the end-of-spec coordinator log dump show whether and when the
-// request actually reached the coordinator.
-const requestTimeout = 600 * time.Second
+const requestTimeout = 60 * time.Second
 
 // testImageURL and testImageURL2 are publicly accessible images used to
 // exercise multimodal requests that trigger the encode stage.

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -93,38 +93,6 @@ const inlineImageDataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAA
 // that the coordinator logs show all expected pipeline steps completed, then
 // tears the workload down. expectedImages is the number of images in the
 // request; when > 0 the encoder log assertions are also verified.
-// dumpDeploymentLogs writes a deployment's container logs to the Ginkgo output
-// for post-mortem diagnosis. A failure to fetch is reported inline, not fatal.
-func dumpDeploymentLogs(nsName, deployment, container string) {
-	args := []string{"logs", "deployment/" + deployment, "-c", container, "--namespace=" + nsName}
-	if k8sContext != "" {
-		args = append(args, "--context="+k8sContext)
-	}
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs (kubectl error: %v) ---\n%s\n---\n", deployment, err, string(out))
-		return
-	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs ---\n%s\n---\n", deployment, string(out))
-}
-
-// dumpEnvoyClusters writes Envoy's admin /clusters (resolved endpoints and health
-// per cluster) to the Ginkgo output. Best-effort: any error is reported inline,
-// and it yields nothing if the envoy image lacks a usable HTTP client.
-func dumpEnvoyClusters(nsName string) {
-	args := []string{"exec", "deployment/envoy", "-c", "envoy", "--namespace=" + nsName}
-	if k8sContext != "" {
-		args = append(args, "--context="+k8sContext)
-	}
-	args = append(args, "--", "curl", "-s", "http://localhost:19000/clusters")
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
-		return
-	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters ---\n%s\n---\n", string(out))
-}
-
 func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages int) {
 	nsName := getNamespace()
 	var (
@@ -153,19 +121,23 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		testutils.DeleteObjects(testConfig, encodePool, nsName)
 	})
 
-	// Dump coordinator and EPP logs on failure, or always when
-	// E2E_PRINT_COORDINATOR_LOGS is set. Registered second → runs first (LIFO),
-	// so the deployments still exist.
+	// Dump coordinator logs on failure, or always when E2E_PRINT_COORDINATOR_LOGS is
+	// set. Registered second → runs first (LIFO), so the deployment still exists.
 	ginkgo.DeferCleanup(func() {
 		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
 			return
 		}
-		dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
-		dumpDeploymentLogs(nsName, eppName+"-encode", "epp")
-		dumpDeploymentLogs(nsName, eppName+"-prefill", "epp")
-		dumpDeploymentLogs(nsName, eppName+"-decode", "epp")
-		dumpDeploymentLogs(nsName, "envoy", "envoy")
-		dumpEnvoyClusters(nsName)
+		args := []string{"logs", "deployment/llm-d-coordinator",
+			"-c", "coordinator", "--namespace=" + nsName}
+		if k8sContext != "" {
+			args = append(args, "--context="+k8sContext)
+		}
+		out, err := exec.Command("kubectl", args...).CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs (kubectl error: %v) ---\n%s\n---\n", err, string(out))
+		} else {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs ---\n%s\n---\n", string(out))
+		}
 	})
 
 	// Pools first so each EPP can resolve its --pool-name.

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -93,6 +93,38 @@ const inlineImageDataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAA
 // that the coordinator logs show all expected pipeline steps completed, then
 // tears the workload down. expectedImages is the number of images in the
 // request; when > 0 the encoder log assertions are also verified.
+// dumpDeploymentLogs writes a deployment's container logs to the Ginkgo output
+// for post-mortem diagnosis. A failure to fetch is reported inline, not fatal.
+func dumpDeploymentLogs(nsName, deployment, container string) {
+	args := []string{"logs", "deployment/" + deployment, "-c", container, "--namespace=" + nsName}
+	if k8sContext != "" {
+		args = append(args, "--context="+k8sContext)
+	}
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs (kubectl error: %v) ---\n%s\n---\n", deployment, err, string(out))
+		return
+	}
+	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs ---\n%s\n---\n", deployment, string(out))
+}
+
+// dumpEnvoyClusters writes Envoy's admin /clusters (resolved endpoints and health
+// per cluster) to the Ginkgo output. Best-effort: any error is reported inline,
+// and it yields nothing if the envoy image lacks a usable HTTP client.
+func dumpEnvoyClusters(nsName string) {
+	args := []string{"exec", "deployment/envoy", "-c", "envoy", "--namespace=" + nsName}
+	if k8sContext != "" {
+		args = append(args, "--context="+k8sContext)
+	}
+	args = append(args, "--", "curl", "-s", "http://localhost:19000/clusters")
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
+		return
+	}
+	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters ---\n%s\n---\n", string(out))
+}
+
 func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages int) {
 	nsName := getNamespace()
 	var (
@@ -121,23 +153,19 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		testutils.DeleteObjects(testConfig, encodePool, nsName)
 	})
 
-	// Dump coordinator logs on failure, or always when E2E_PRINT_COORDINATOR_LOGS is
-	// set. Registered second → runs first (LIFO), so the deployment still exists.
+	// Dump coordinator and EPP logs on failure, or always when
+	// E2E_PRINT_COORDINATOR_LOGS is set. Registered second → runs first (LIFO),
+	// so the deployments still exist.
 	ginkgo.DeferCleanup(func() {
 		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
 			return
 		}
-		args := []string{"logs", "deployment/llm-d-coordinator",
-			"-c", "coordinator", "--namespace=" + nsName}
-		if k8sContext != "" {
-			args = append(args, "--context="+k8sContext)
-		}
-		out, err := exec.Command("kubectl", args...).CombinedOutput()
-		if err != nil {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs (kubectl error: %v) ---\n%s\n---\n", err, string(out))
-		} else {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs ---\n%s\n---\n", string(out))
-		}
+		dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
+		dumpDeploymentLogs(nsName, eppName+"-encode", "epp")
+		dumpDeploymentLogs(nsName, eppName+"-prefill", "epp")
+		dumpDeploymentLogs(nsName, eppName+"-decode", "epp")
+		dumpDeploymentLogs(nsName, "envoy", "envoy")
+		dumpEnvoyClusters(nsName)
 	})
 
 	// Pools first so each EPP can resolve its --pool-name.

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -182,8 +182,7 @@ func dumpEnvoyClusters(nsName string) {
 	if k8sContext != "" {
 		args = append(args, "--context="+k8sContext)
 	}
-	args = append(args, "--", "curl", "-s", "http://localhost:19000/clusters")
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	args = append(args, "--", "curl", "-sS", "--connect-timeout", "1", "--max-time", "5", "http://localhost:19000/clusters")
 	if err != nil {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
 		return

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -129,7 +129,6 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 			return
 		}
 		testutils.DumpPodsAndLogs(testConfig, nsName, testutils.WithFullLogs())
-		dumpEnvoyClusters(nsName)
 	})
 
 	// Pools first so each EPP can resolve its --pool-name.
@@ -172,23 +171,6 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		"coordinator returned non-200: body=%s", string(raw))
 	gomega.Expect(raw).NotTo(gomega.BeEmpty(), "coordinator returned empty body")
 	verifyCoordinatorSteps(nsName, expectedSteps, expectedImages, true, true)
-}
-
-// dumpEnvoyClusters writes Envoy's admin /clusters (resolved endpoints and health
-// per cluster) to the Ginkgo output. Best-effort; yields nothing if the envoy
-// image lacks a usable HTTP client.
-func dumpEnvoyClusters(nsName string) {
-	args := []string{"exec", "deployment/envoy", "-c", "envoy", "--namespace=" + nsName}
-	if k8sContext != "" {
-		args = append(args, "--context="+k8sContext)
-	}
-	args = append(args, "--", "curl", "-sS", "--connect-timeout", "1", "--max-time", "5", "http://localhost:19000/clusters")
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
-		return
-	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters ---\n%s\n---\n", string(out))
 }
 
 // verifyCoordinatorSteps fetches the coordinator pod logs and asserts that

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -127,11 +127,7 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
 			return
 		}
-		dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
-		dumpDeploymentLogs(nsName, eppName+"-encode", "epp")
-		dumpDeploymentLogs(nsName, eppName+"-prefill", "epp")
-		dumpDeploymentLogs(nsName, eppName+"-decode", "epp")
-		dumpDeploymentLogs(nsName, "envoy", "envoy")
+		testutils.DumpPodsAndLogs(testConfig, nsName, testutils.WithFullLogs())
 		dumpEnvoyClusters(nsName)
 	})
 
@@ -175,21 +171,6 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		"coordinator returned non-200: body=%s", string(raw))
 	gomega.Expect(raw).NotTo(gomega.BeEmpty(), "coordinator returned empty body")
 	verifyCoordinatorSteps(nsName, expectedSteps, expectedImages, true, true)
-}
-
-// dumpDeploymentLogs writes a deployment's container logs to the Ginkgo output.
-// A kubectl error is reported inline rather than failing the spec.
-func dumpDeploymentLogs(nsName, deployment, container string) {
-	args := []string{"logs", "deployment/" + deployment, "-c", container, "--namespace=" + nsName}
-	if k8sContext != "" {
-		args = append(args, "--context="+k8sContext)
-	}
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs (kubectl error: %v) ---\n%s\n---\n", deployment, err, string(out))
-		return
-	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs ---\n%s\n---\n", deployment, string(out))
 }
 
 // dumpEnvoyClusters writes Envoy's admin /clusters (resolved endpoints and health

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -31,16 +31,7 @@ import (
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
-const (
-	// requestTimeout bounds text-only chat completions (prefill, decode).
-	requestTimeout = 60 * time.Second
-	// multimodalRequestTimeout bounds multimodal chat completions, which add the
-	// replace-media-urls, render, and encode stages: each image is fetched (e.g.
-	// from S3) and run through the encoder, so the round-trip runs well past the
-	// text-only budget. 600s matches the default client request timeout vLLM
-	// applies to its multimodal and chat-completion serving tests.
-	multimodalRequestTimeout = 600 * time.Second
-)
+const requestTimeout = 60 * time.Second
 
 // testImageURL and testImageURL2 are publicly accessible images used to
 // exercise multimodal requests that trigger the encode stage.
@@ -177,11 +168,7 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	req.Header.Set("Content-Type", "application/json")
 
-	timeout := requestTimeout
-	if expectedImages > 0 {
-		timeout = multimodalRequestTimeout
-	}
-	client := &http.Client{Timeout: timeout}
+	client := &http.Client{Timeout: requestTimeout}
 	resp, err := client.Do(req)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer resp.Body.Close()

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -127,17 +127,12 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
 			return
 		}
-		args := []string{"logs", "deployment/llm-d-coordinator",
-			"-c", "coordinator", "--namespace=" + nsName}
-		if k8sContext != "" {
-			args = append(args, "--context="+k8sContext)
-		}
-		out, err := exec.Command("kubectl", args...).CombinedOutput()
-		if err != nil {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs (kubectl error: %v) ---\n%s\n---\n", err, string(out))
-		} else {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs ---\n%s\n---\n", string(out))
-		}
+		dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
+		dumpDeploymentLogs(nsName, eppName+"-encode", "epp")
+		dumpDeploymentLogs(nsName, eppName+"-prefill", "epp")
+		dumpDeploymentLogs(nsName, eppName+"-decode", "epp")
+		dumpDeploymentLogs(nsName, "envoy", "envoy")
+		dumpEnvoyClusters(nsName)
 	})
 
 	// Pools first so each EPP can resolve its --pool-name.
@@ -180,6 +175,38 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		"coordinator returned non-200: body=%s", string(raw))
 	gomega.Expect(raw).NotTo(gomega.BeEmpty(), "coordinator returned empty body")
 	verifyCoordinatorSteps(nsName, expectedSteps, expectedImages, true, true)
+}
+
+// dumpDeploymentLogs writes a deployment's container logs to the Ginkgo output.
+// A kubectl error is reported inline rather than failing the spec.
+func dumpDeploymentLogs(nsName, deployment, container string) {
+	args := []string{"logs", "deployment/" + deployment, "-c", container, "--namespace=" + nsName}
+	if k8sContext != "" {
+		args = append(args, "--context="+k8sContext)
+	}
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs (kubectl error: %v) ---\n%s\n---\n", deployment, err, string(out))
+		return
+	}
+	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs ---\n%s\n---\n", deployment, string(out))
+}
+
+// dumpEnvoyClusters writes Envoy's admin /clusters (resolved endpoints and health
+// per cluster) to the Ginkgo output. Best-effort; yields nothing if the envoy
+// image lacks a usable HTTP client.
+func dumpEnvoyClusters(nsName string) {
+	args := []string{"exec", "deployment/envoy", "-c", "envoy", "--namespace=" + nsName}
+	if k8sContext != "" {
+		args = append(args, "--context="+k8sContext)
+	}
+	args = append(args, "--", "curl", "-s", "http://localhost:19000/clusters")
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
+		return
+	}
+	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters ---\n%s\n---\n", string(out))
 }
 
 // verifyCoordinatorSteps fetches the coordinator pod logs and asserts that

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -127,12 +127,17 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
 			return
 		}
-		dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
-		dumpDeploymentLogs(nsName, eppName+"-encode", "epp")
-		dumpDeploymentLogs(nsName, eppName+"-prefill", "epp")
-		dumpDeploymentLogs(nsName, eppName+"-decode", "epp")
-		dumpDeploymentLogs(nsName, "envoy", "envoy")
-		dumpEnvoyClusters(nsName)
+		args := []string{"logs", "deployment/llm-d-coordinator",
+			"-c", "coordinator", "--namespace=" + nsName}
+		if k8sContext != "" {
+			args = append(args, "--context="+k8sContext)
+		}
+		out, err := exec.Command("kubectl", args...).CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs (kubectl error: %v) ---\n%s\n---\n", err, string(out))
+		} else {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs ---\n%s\n---\n", string(out))
+		}
 	})
 
 	// Pools first so each EPP can resolve its --pool-name.
@@ -175,47 +180,6 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		"coordinator returned non-200: body=%s", string(raw))
 	gomega.Expect(raw).NotTo(gomega.BeEmpty(), "coordinator returned empty body")
 	verifyCoordinatorSteps(nsName, expectedSteps, expectedImages, true, true)
-
-	// Diagnostic: dump the coordinator logs once the request has completed. The
-	// per-step timestamps show when the request reached the coordinator (relative
-	// to when it was sent) and how long each pipeline step took, so we can tell
-	// late-arrival (gateway) from slow processing (pipeline). Also dump Envoy's
-	// access log so each request's gateway view (code/flags/cluster/upstream) is
-	// visible even on green runs, as a baseline to compare against a failure.
-	dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
-	dumpDeploymentLogs(nsName, "envoy", "envoy")
-}
-
-// dumpDeploymentLogs writes a deployment's container logs to the Ginkgo output.
-// A kubectl error is reported inline rather than failing the spec.
-func dumpDeploymentLogs(nsName, deployment, container string) {
-	args := []string{"logs", "deployment/" + deployment, "-c", container, "--namespace=" + nsName}
-	if k8sContext != "" {
-		args = append(args, "--context="+k8sContext)
-	}
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs (kubectl error: %v) ---\n%s\n---\n", deployment, err, string(out))
-		return
-	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- %s logs ---\n%s\n---\n", deployment, string(out))
-}
-
-// dumpEnvoyClusters writes Envoy's admin /clusters (resolved endpoints and health
-// per cluster) to the Ginkgo output. Best-effort; yields nothing if the envoy
-// image lacks a usable HTTP client.
-func dumpEnvoyClusters(nsName string) {
-	args := []string{"exec", "deployment/envoy", "-c", "envoy", "--namespace=" + nsName}
-	if k8sContext != "" {
-		args = append(args, "--context="+k8sContext)
-	}
-	args = append(args, "--", "curl", "-s", "http://localhost:19000/clusters")
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
-		return
-	}
-	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters ---\n%s\n---\n", string(out))
 }
 
 // verifyCoordinatorSteps fetches the coordinator pod logs and asserts that

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -183,8 +183,11 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 	// Diagnostic: dump the coordinator logs once the request has completed. The
 	// per-step timestamps show when the request reached the coordinator (relative
 	// to when it was sent) and how long each pipeline step took, so we can tell
-	// late-arrival (gateway) from slow processing (pipeline).
+	// late-arrival (gateway) from slow processing (pipeline). Also dump Envoy's
+	// access log so each request's gateway view (code/flags/cluster/upstream) is
+	// visible even on green runs, as a baseline to compare against a failure.
 	dumpDeploymentLogs(nsName, "llm-d-coordinator", "coordinator")
+	dumpDeploymentLogs(nsName, "envoy", "envoy")
 }
 
 // dumpDeploymentLogs writes a deployment's container logs to the Ginkgo output.

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -31,7 +31,16 @@ import (
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
-const requestTimeout = 60 * time.Second
+const (
+	// requestTimeout bounds text-only chat completions (prefill, decode).
+	requestTimeout = 60 * time.Second
+	// multimodalRequestTimeout bounds multimodal chat completions, which add the
+	// replace-media-urls, render, and encode stages: each image is fetched (e.g.
+	// from S3) and run through the encoder, so the round-trip runs well past the
+	// text-only budget. 600s matches the default client request timeout vLLM
+	// applies to its multimodal and chat-completion serving tests.
+	multimodalRequestTimeout = 600 * time.Second
+)
 
 // testImageURL and testImageURL2 are publicly accessible images used to
 // exercise multimodal requests that trigger the encode stage.
@@ -168,7 +177,11 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: requestTimeout}
+	timeout := requestTimeout
+	if expectedImages > 0 {
+		timeout = multimodalRequestTimeout
+	}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer resp.Body.Close()

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -31,7 +31,15 @@ import (
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
-const requestTimeout = 60 * time.Second
+const (
+	// requestTimeout bounds text-only chat completions.
+	requestTimeout = 60 * time.Second
+	// multimodalRequestTimeout bounds multimodal chat completions, which run the
+	// extra replace-media-urls/render/encode stages; 60s times out before they
+	// finish. Long budget so the request completes and the coordinator logs
+	// (dumped at the end of the spec) show where the time actually went.
+	multimodalRequestTimeout = 600 * time.Second
+)
 
 // testImageURL and testImageURL2 are publicly accessible images used to
 // exercise multimodal requests that trigger the encode stage.
@@ -127,17 +135,7 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		if !ginkgo.CurrentSpecReport().Failed() && !printCoordinatorLogs {
 			return
 		}
-		args := []string{"logs", "deployment/llm-d-coordinator",
-			"-c", "coordinator", "--namespace=" + nsName}
-		if k8sContext != "" {
-			args = append(args, "--context="+k8sContext)
-		}
-		out, err := exec.Command("kubectl", args...).CombinedOutput()
-		if err != nil {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs (kubectl error: %v) ---\n%s\n---\n", err, string(out))
-		} else {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs ---\n%s\n---\n", string(out))
-		}
+		dumpCoordinatorLogs(nsName)
 	})
 
 	// Pools first so each EPP can resolve its --pool-name.
@@ -168,7 +166,11 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: requestTimeout}
+	timeout := requestTimeout
+	if expectedImages > 0 {
+		timeout = multimodalRequestTimeout
+	}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer resp.Body.Close()
@@ -180,6 +182,30 @@ func runCoordinatorPipeline(body []byte, expectedSteps []string, expectedImages 
 		"coordinator returned non-200: body=%s", string(raw))
 	gomega.Expect(raw).NotTo(gomega.BeEmpty(), "coordinator returned empty body")
 	verifyCoordinatorSteps(nsName, expectedSteps, expectedImages, true, true)
+
+	// Diagnostic: on multimodal specs, dump the coordinator logs once the request
+	// has completed. The per-step timestamps show when the request reached the
+	// coordinator (relative to when it was sent) and how long each pipeline step
+	// took, so we can tell late-arrival (gateway) from slow processing (pipeline).
+	if expectedImages > 0 {
+		dumpCoordinatorLogs(nsName)
+	}
+}
+
+// dumpCoordinatorLogs writes the coordinator deployment's logs to the Ginkgo
+// output. A kubectl error is reported inline rather than failing the spec.
+func dumpCoordinatorLogs(nsName string) {
+	args := []string{"logs", "deployment/llm-d-coordinator",
+		"-c", "coordinator", "--namespace=" + nsName}
+	if k8sContext != "" {
+		args = append(args, "--context="+k8sContext)
+	}
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs (kubectl error: %v) ---\n%s\n---\n", err, string(out))
+		return
+	}
+	fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- coordinator logs ---\n%s\n---\n", string(out))
 }
 
 // verifyCoordinatorSteps fetches the coordinator pod logs and asserts that

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -183,6 +183,7 @@ func dumpEnvoyClusters(nsName string) {
 		args = append(args, "--context="+k8sContext)
 	}
 	args = append(args, "--", "curl", "-sS", "--connect-timeout", "1", "--max-time", "5", "http://localhost:19000/clusters")
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "\n--- envoy /clusters (kubectl error: %v) ---\n%s\n---\n", err, string(out))
 		return

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -97,9 +97,10 @@ var (
 
 	readyTimeout = env.GetEnvDuration("READY_TIMEOUT", defaultReadyTimeout, ginkgo.GinkgoLogr)
 
-	portForwardSessions []*gexec.Session
-	rendererObjects     []string
-	createdNameSpace    bool
+	portForwardSessions  []*gexec.Session
+	rendererObjects      []string
+	stableServiceObjects []string
+	createdNameSpace     bool
 )
 
 func TestCoordinatorE2E(t *testing.T) {
@@ -131,6 +132,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 
 	rendererObjects = createRenderer()
+
+	// Coordinator and EPP Services are created once and kept stable across specs
+	// so Envoy's STRICT_DNS clusters never have to re-resolve a rotated ClusterIP.
+	stableServiceObjects = createStableServices()
 })
 
 var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
@@ -147,6 +152,9 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 	nsName := getNamespace()
 	if len(rendererObjects) > 0 {
 		testutils.DeleteObjects(testConfig, rendererObjects, nsName)
+	}
+	if len(stableServiceObjects) > 0 {
+		testutils.DeleteObjects(testConfig, stableServiceObjects, nsName)
 	}
 	for _, session := range portForwardSessions {
 		session.Terminate()

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -97,10 +97,10 @@ var (
 
 	readyTimeout = env.GetEnvDuration("READY_TIMEOUT", defaultReadyTimeout, ginkgo.GinkgoLogr)
 
-	portForwardSessions  []*gexec.Session
-	rendererObjects      []string
-	stableServiceObjects []string
-	createdNameSpace     bool
+	portForwardSessions []*gexec.Session
+	rendererObjects     []string
+	stableInfraObjects  []string
+	createdNameSpace    bool
 )
 
 func TestCoordinatorE2E(t *testing.T) {
@@ -133,9 +133,10 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	rendererObjects = createRenderer()
 
-	// Coordinator and EPP Services are created once and kept stable across specs
-	// so Envoy's STRICT_DNS clusters never have to re-resolve a rotated ClusterIP.
-	stableServiceObjects = createStableServices()
+	// Coordinator and EPP Services, ServiceAccounts, and RoleBindings are created
+	// once and kept stable across specs so Envoy's STRICT_DNS clusters never have
+	// to re-resolve a rotated ClusterIP.
+	stableInfraObjects = createStableInfra()
 })
 
 var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
@@ -153,8 +154,8 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 	if len(rendererObjects) > 0 {
 		testutils.DeleteObjects(testConfig, rendererObjects, nsName)
 	}
-	if len(stableServiceObjects) > 0 {
-		testutils.DeleteObjects(testConfig, stableServiceObjects, nsName)
+	if len(stableInfraObjects) > 0 {
+		testutils.DeleteObjects(testConfig, stableInfraObjects, nsName)
 	}
 	for _, session := range portForwardSessions {
 		session.Terminate()

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -79,7 +79,7 @@ var (
 	testConfig *testutils.TestConfig
 
 	keepClusterOnFailure = env.GetEnvBool("E2E_KEEP_CLUSTER_ON_FAILURE", false, ginkgo.GinkgoLogr)
-	printCoordinatorLogs = env.GetEnvBool("E2E_PRINT_COORDINATOR_LOGS", false, ginkgo.GinkgoLogr)
+	printLogs            = env.GetEnvBool("E2E_PRINT_LOGS", false, ginkgo.GinkgoLogr)
 
 	containerRuntime = env.GetEnvString("CONTAINER_RUNTIME", "docker", ginkgo.GinkgoLogr)
 	eppImage         = env.GetEnvString("EPP_IMAGE", "ghcr.io/llm-d/llm-d-router-endpoint-picker:dev", ginkgo.GinkgoLogr)

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -97,10 +97,9 @@ var (
 
 	readyTimeout = env.GetEnvDuration("READY_TIMEOUT", defaultReadyTimeout, ginkgo.GinkgoLogr)
 
-	portForwardSessions  []*gexec.Session
-	rendererObjects      []string
-	stableServiceObjects []string
-	createdNameSpace     bool
+	portForwardSessions []*gexec.Session
+	rendererObjects     []string
+	createdNameSpace    bool
 )
 
 func TestCoordinatorE2E(t *testing.T) {
@@ -132,10 +131,6 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 
 	rendererObjects = createRenderer()
-
-	// Coordinator and EPP Services are created once and kept stable across specs
-	// so Envoy's STRICT_DNS clusters never have to re-resolve a rotated ClusterIP.
-	stableServiceObjects = createStableServices()
 })
 
 var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
@@ -152,9 +147,6 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 	nsName := getNamespace()
 	if len(rendererObjects) > 0 {
 		testutils.DeleteObjects(testConfig, rendererObjects, nsName)
-	}
-	if len(stableServiceObjects) > 0 {
-		testutils.DeleteObjects(testConfig, stableServiceObjects, nsName)
 	}
 	for _, session := range portForwardSessions {
 		session.Terminate()

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -135,7 +135,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	// Coordinator and EPP Services/RBAC are created once and kept stable across
 	// specs (see createStableInfra).
-	stableInfraObjects = createStableInfra()
+	createStableInfra()
 })
 
 var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -133,9 +133,8 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	rendererObjects = createRenderer()
 
-	// Coordinator and EPP Services, ServiceAccounts, and RoleBindings are created
-	// once and kept stable across specs so Envoy's STRICT_DNS clusters never have
-	// to re-resolve a rotated ClusterIP.
+	// Coordinator and EPP Services/RBAC are created once and kept stable across
+	// specs (see createStableInfra).
 	stableInfraObjects = createStableInfra()
 })
 

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -96,9 +96,9 @@ func createEndPointPicker(phase, config string) []string {
 
 	objects := make([]string, 1, 8)
 	objects[0] = "ConfigMap/" + cmName
-	// The Service is created once by createStableServices; recreate only the
-	// rest (ServiceAccount, RoleBinding, Deployment) per spec.
-	objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Service")...)
+	// The Service, ServiceAccount, and RoleBinding are created once by
+	// createStableInfra; recreate only the Deployment per spec.
+	objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Service", "ServiceAccount", "RoleBinding")...)
 	podsInDeploymentsReady(objects)
 	return objects
 }
@@ -179,9 +179,9 @@ func createCoordinator(config string) []string {
 	objects[0] = "ConfigMap/llm-d-coordinator-config"
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	// The Service is created once by createStableServices so its ClusterIP is
-	// stable across specs; recreate only the Deployment (and SA) per spec.
-	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Service")
+	// The Service and ServiceAccount are created once by createStableInfra so the
+	// ClusterIP is stable across specs; recreate only the Deployment per spec.
+	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Service", "ServiceAccount")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, nsName)...)
@@ -194,7 +194,7 @@ func createCoordinator(config string) []string {
 // waitForCoordinatorReady polls /readyz through Envoy until it returns 200,
 // confirming the freshly recreated coordinator pod is reachable through the
 // gateway before the test sends its request. The gateway Service is stable
-// across specs (see createStableServices), so this waits for the new pod to
+// across specs (see createStableInfra), so this waits for the new pod to
 // appear behind it, not for Envoy to re-resolve a rotated ClusterIP.
 // (podsInDeploymentsReady already confirms the coordinator pod itself is ready.)
 func waitForCoordinatorReady() {
@@ -239,25 +239,24 @@ func applyManifest(path string, subs map[string]string, excludeKinds ...string) 
 	return testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
 }
 
-// createStableServices creates the coordinator and per-phase EPP Services once,
-// up front, and returns their ids for suite teardown. Envoy fronts these via
-// STRICT_DNS clusters and outlives the per-spec workload; recreating the
-// Services each spec would rotate their ClusterIPs and force Envoy to
-// re-resolve, so only the Deployments behind them churn per spec. Mirrors the
-// non-coordinator e2e, which creates the EPP Services once in its per-container
-// setup and recreates only the Deployment per test.
-func createStableServices() []string {
-	objects := make([]string, 0, 4)
+// createStableInfra creates the coordinator and per-phase EPP Services,
+// ServiceAccounts, and RoleBindings once, up front, and returns their ids for
+// suite teardown. Envoy fronts the Services via STRICT_DNS clusters and outlives
+// the per-spec workload; recreating a Service each spec would rotate its
+// ClusterIP and force Envoy to re-resolve, so only the Deployments behind them
+// churn per spec. Mirrors the non-coordinator e2e, which creates the EPP
+// Services and RBAC once in its setup and recreates only the Deployment per test.
+func createStableInfra() []string {
+	objects := make([]string, 0, 12)
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment", "ServiceAccount")
+	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
 
 	for _, manifest := range []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest} {
-		objects = append(objects,
-			applyManifest(manifest, eppSubstitutions(), "ServiceAccount", "RoleBinding", "Deployment")...)
+		objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Deployment")...)
 	}
 	return objects
 }

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -80,10 +80,10 @@ func createCRDs() {
 	_ = testutils.CreateObjsFromYaml(testConfig, gieCRDs, "")
 }
 
-// createEndPointPicker creates the scheduling ConfigMap and EPP Deployment (plus
-// its ServiceAccount, RoleBinding, and Service) for the given phase from the
-// supplied EPP config and waits for the EPP Deployment to become ready. Returns
-// the created object ids for cleanup.
+// createEndPointPicker creates the scheduling ConfigMap and EPP Deployment for
+// the given phase from the supplied EPP config and waits for the EPP Deployment
+// to become ready. Its ServiceAccount, RoleBinding, and Service are created once
+// by createStableInfra. Returns the created object ids for cleanup.
 func createEndPointPicker(phase, config string) []string {
 	manifest := map[string]string{
 		"encode":  encodeEPPManifest,
@@ -156,8 +156,8 @@ func createModelServers(encodeReplicas, prefillReplicas, decodeReplicas int) []s
 }
 
 // createCoordinator builds the coordinator ConfigMap from the given pipeline
-// config, deploys the coordinator component (Deployment + Service + SA), and
-// waits for readiness.
+// config, deploys the coordinator Deployment, and waits for readiness. Its
+// Service and ServiceAccount are created once by createStableInfra.
 func createCoordinator(config string) []string {
 	nsName := getNamespace()
 	coordinatorYAML := e2eutil.SubstituteMany([]string{config}, map[string]string{
@@ -233,9 +233,7 @@ func applyManifest(path string, subs map[string]string, excludeKinds ...string) 
 	docs := testutils.ReadYaml(path)
 	docs = e2eutil.SubstituteMany(docs, subs)
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	if len(excludeKinds) > 0 {
-		docs = e2eutil.FilterKinds(docs, excludeKinds...)
-	}
+	docs = e2eutil.FilterKinds(docs, excludeKinds...)
 	return testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
 }
 

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -96,7 +96,9 @@ func createEndPointPicker(phase, config string) []string {
 
 	objects := make([]string, 1, 8)
 	objects[0] = "ConfigMap/" + cmName
-	objects = append(objects, applyManifest(manifest, eppSubstitutions())...)
+	// The Service is created once by createStableServices; recreate only the
+	// rest (ServiceAccount, RoleBinding, Deployment) per spec.
+	objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Service")...)
 	podsInDeploymentsReady(objects)
 	return objects
 }
@@ -177,7 +179,9 @@ func createCoordinator(config string) []string {
 	objects[0] = "ConfigMap/llm-d-coordinator-config"
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	docs = e2eutil.FilterKinds(docs, "ConfigMap")
+	// The Service is created once by createStableServices so its ClusterIP is
+	// stable across specs; recreate only the Deployment (and SA) per spec.
+	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Service")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, nsName)...)
@@ -188,8 +192,11 @@ func createCoordinator(config string) []string {
 }
 
 // waitForCoordinatorReady polls /readyz through Envoy until it returns 200,
-// catching Envoy's STRICT_DNS resolution lagging behind the per-test Service
-// (podsInDeploymentsReady already confirms the coordinator pod itself is ready).
+// confirming the freshly recreated coordinator pod is reachable through the
+// gateway before the test sends its request. The gateway Service is stable
+// across specs (see createStableServices), so this waits for the new pod to
+// appear behind it, not for Envoy to re-resolve a rotated ClusterIP.
+// (podsInDeploymentsReady already confirms the coordinator pod itself is ready.)
 func waitForCoordinatorReady() {
 	ginkgo.By("Waiting for coordinator to be reachable via gateway")
 	gomega.Eventually(func() bool {
@@ -222,11 +229,37 @@ func createEPPConfigMap(name, content string) {
 	}
 }
 
-func applyManifest(path string, subs map[string]string) []string {
+func applyManifest(path string, subs map[string]string, excludeKinds ...string) []string {
 	docs := testutils.ReadYaml(path)
 	docs = e2eutil.SubstituteMany(docs, subs)
 	docs = e2eutil.RemoveEmptyArgs(docs)
+	if len(excludeKinds) > 0 {
+		docs = e2eutil.FilterKinds(docs, excludeKinds...)
+	}
 	return testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
+}
+
+// createStableServices creates the coordinator and per-phase EPP Services once,
+// up front, and returns their ids for suite teardown. Envoy fronts these via
+// STRICT_DNS clusters and outlives the per-spec workload; recreating the
+// Services each spec would rotate their ClusterIPs and force Envoy to
+// re-resolve, so only the Deployments behind them churn per spec. Mirrors the
+// non-coordinator e2e, which creates the EPP Services once in its per-container
+// setup and recreates only the Deployment per test.
+func createStableServices() []string {
+	var objects []string
+
+	docs := e2eutil.RunKustomize(coordinatorComponentDir)
+	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment", "ServiceAccount")
+	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
+	docs = e2eutil.RemoveEmptyArgs(docs)
+	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
+
+	for _, manifest := range []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest} {
+		objects = append(objects,
+			applyManifest(manifest, eppSubstitutions(), "ServiceAccount", "RoleBinding", "Deployment")...)
+	}
+	return objects
 }
 
 func eppSubstitutions() map[string]string {

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -245,7 +245,10 @@ func applyManifest(path string, subs map[string]string, excludeKinds ...string) 
 // churn per spec. Mirrors the non-coordinator e2e, which creates the EPP
 // Services and RBAC once in its setup and recreates only the Deployment per test.
 func createStableInfra() []string {
-	objects := make([]string, 0, 12)
+	eppManifests := []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest}
+	// Coordinator Service + ServiceAccount, plus Service + ServiceAccount +
+	// RoleBinding per EPP.
+	objects := make([]string, 0, 2+len(eppManifests)*3)
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
 	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment")
@@ -253,7 +256,7 @@ func createStableInfra() []string {
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
 
-	for _, manifest := range []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest} {
+	for _, manifest := range eppManifests {
 		objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Deployment")...)
 	}
 	return objects

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -247,7 +247,7 @@ func applyManifest(path string, subs map[string]string, excludeKinds ...string) 
 // non-coordinator e2e, which creates the EPP Services once in its per-container
 // setup and recreates only the Deployment per test.
 func createStableServices() []string {
-	var objects []string
+	objects := make([]string, 0, 4)
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
 	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment", "ServiceAccount")

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -96,7 +96,9 @@ func createEndPointPicker(phase, config string) []string {
 
 	objects := make([]string, 1, 8)
 	objects[0] = "ConfigMap/" + cmName
-	objects = append(objects, applyManifest(manifest, eppSubstitutions())...)
+	// The Service is created once by createStableServices; recreate only the
+	// rest (ServiceAccount, RoleBinding, Deployment) per spec.
+	objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Service")...)
 	podsInDeploymentsReady(objects)
 	return objects
 }
@@ -177,7 +179,9 @@ func createCoordinator(config string) []string {
 	objects[0] = "ConfigMap/llm-d-coordinator-config"
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	docs = e2eutil.FilterKinds(docs, "ConfigMap")
+	// The Service is created once by createStableServices so its ClusterIP is
+	// stable across specs; recreate only the Deployment (and SA) per spec.
+	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Service")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, nsName)...)
@@ -187,23 +191,17 @@ func createCoordinator(config string) []string {
 	return objects
 }
 
-// waitForCoordinatorReady polls /readyz through Envoy and requires several
-// consecutive successes: right after the per-spec coordinator is recreated, a
-// single probe can succeed while Envoy is still converging on the new endpoint,
-// so the next request would hit a stale one and hang.
+// waitForCoordinatorReady polls /readyz through Envoy until it returns 200,
+// confirming the freshly recreated coordinator pod is reachable through the
+// gateway before the test sends its request. The gateway Service is stable
+// across specs (see createStableServices), so this waits for the new pod to
+// appear behind it, not for Envoy to re-resolve a rotated ClusterIP.
+// (podsInDeploymentsReady already confirms the coordinator pod itself is ready.)
 func waitForCoordinatorReady() {
 	ginkgo.By("Waiting for coordinator to be reachable via gateway")
-	const requiredConsecutive = 3
-	consecutive := 0
 	gomega.Eventually(func() bool {
-		if !pollReady(gatewayBaseURL() + "/readyz") {
-			consecutive = 0
-			return false
-		}
-		consecutive++
-		return consecutive >= requiredConsecutive
-	}, readyTimeout, defaultInterval).Should(gomega.BeTrue(),
-		"coordinator should be reachable via gateway within the ready timeout")
+		return pollReady(gatewayBaseURL() + "/readyz")
+	}, readyTimeout, defaultInterval).Should(gomega.BeTrue(), "coordinator should be reachable via gateway within the ready timeout")
 }
 
 // pollReady reports whether a GET on url returns HTTP 200 within the client timeout.
@@ -231,11 +229,37 @@ func createEPPConfigMap(name, content string) {
 	}
 }
 
-func applyManifest(path string, subs map[string]string) []string {
+func applyManifest(path string, subs map[string]string, excludeKinds ...string) []string {
 	docs := testutils.ReadYaml(path)
 	docs = e2eutil.SubstituteMany(docs, subs)
 	docs = e2eutil.RemoveEmptyArgs(docs)
+	if len(excludeKinds) > 0 {
+		docs = e2eutil.FilterKinds(docs, excludeKinds...)
+	}
 	return testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
+}
+
+// createStableServices creates the coordinator and per-phase EPP Services once,
+// up front, and returns their ids for suite teardown. Envoy fronts these via
+// STRICT_DNS clusters and outlives the per-spec workload; recreating the
+// Services each spec would rotate their ClusterIPs and force Envoy to
+// re-resolve, so only the Deployments behind them churn per spec. Mirrors the
+// non-coordinator e2e, which creates the EPP Services once in its per-container
+// setup and recreates only the Deployment per test.
+func createStableServices() []string {
+	var objects []string
+
+	docs := e2eutil.RunKustomize(coordinatorComponentDir)
+	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment", "ServiceAccount")
+	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
+	docs = e2eutil.RemoveEmptyArgs(docs)
+	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
+
+	for _, manifest := range []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest} {
+		objects = append(objects,
+			applyManifest(manifest, eppSubstitutions(), "ServiceAccount", "RoleBinding", "Deployment")...)
+	}
+	return objects
 }
 
 func eppSubstitutions() map[string]string {

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -187,14 +187,23 @@ func createCoordinator(config string) []string {
 	return objects
 }
 
-// waitForCoordinatorReady polls /readyz through Envoy until it returns 200,
-// catching Envoy's STRICT_DNS resolution lagging behind the per-test Service
-// (podsInDeploymentsReady already confirms the coordinator pod itself is ready).
+// waitForCoordinatorReady polls /readyz through Envoy and requires several
+// consecutive successes: right after the per-spec coordinator is recreated, a
+// single probe can succeed while Envoy is still converging on the new endpoint,
+// so the next request would hit a stale one and hang.
 func waitForCoordinatorReady() {
 	ginkgo.By("Waiting for coordinator to be reachable via gateway")
+	const requiredConsecutive = 3
+	consecutive := 0
 	gomega.Eventually(func() bool {
-		return pollReady(gatewayBaseURL() + "/readyz")
-	}, readyTimeout, defaultInterval).Should(gomega.BeTrue(), "coordinator should be reachable via gateway within the ready timeout")
+		if !pollReady(gatewayBaseURL() + "/readyz") {
+			consecutive = 0
+			return false
+		}
+		consecutive++
+		return consecutive >= requiredConsecutive
+	}, readyTimeout, defaultInterval).Should(gomega.BeTrue(),
+		"coordinator should be reachable via gateway within the ready timeout")
 }
 
 // pollReady reports whether a GET on url returns HTTP 200 within the client timeout.

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -179,8 +179,8 @@ func createCoordinator(config string) []string {
 	objects[0] = "ConfigMap/llm-d-coordinator-config"
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	// The Service and ServiceAccount are created once by createStableInfra so the
-	// ClusterIP is stable across specs; recreate only the Deployment per spec.
+	// Service and ServiceAccount are created once by createStableInfra; recreate
+	// only the Deployment per spec.
 	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Service", "ServiceAccount")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
@@ -194,9 +194,9 @@ func createCoordinator(config string) []string {
 // waitForCoordinatorReady polls /readyz through Envoy until it returns 200,
 // confirming the freshly recreated coordinator pod is reachable through the
 // gateway before the test sends its request. The gateway Service is stable
-// across specs (see createStableInfra), so this waits for the new pod to
-// appear behind it, not for Envoy to re-resolve a rotated ClusterIP.
-// (podsInDeploymentsReady already confirms the coordinator pod itself is ready.)
+// across specs (see createStableInfra), so this waits only for the new pod to
+// appear behind it. (podsInDeploymentsReady already confirms the coordinator
+// pod itself is ready.)
 func waitForCoordinatorReady() {
 	ginkgo.By("Waiting for coordinator to be reachable via gateway")
 	gomega.Eventually(func() bool {

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -238,28 +238,24 @@ func applyManifest(path string, subs map[string]string, excludeKinds ...string) 
 }
 
 // createStableInfra creates the coordinator and per-phase EPP Services,
-// ServiceAccounts, and RoleBindings once, up front, and returns their ids for
-// suite teardown. Envoy fronts the Services via STRICT_DNS clusters and outlives
-// the per-spec workload; recreating a Service each spec would rotate its
-// ClusterIP and force Envoy to re-resolve, so only the Deployments behind them
-// churn per spec. Mirrors the non-coordinator e2e, which creates the EPP
-// Services and RBAC once in its setup and recreates only the Deployment per test.
-func createStableInfra() []string {
-	eppManifests := []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest}
-	// Coordinator Service + ServiceAccount, plus Service + ServiceAccount +
-	// RoleBinding per EPP.
-	objects := make([]string, 0, 2+len(eppManifests)*3)
-
+// ServiceAccounts, and RoleBindings once, up front. It appends each created id to
+// stableInfraObjects as it goes rather than returning them at the end, so a
+// partial failure still leaves the already-created objects tracked for suite
+// teardown. Envoy fronts the Services via STRICT_DNS clusters and outlives the
+// per-spec workload; recreating a Service each spec would rotate its ClusterIP and
+// force Envoy to re-resolve, so only the Deployments behind them churn per spec.
+// Mirrors the non-coordinator e2e, which creates the EPP Services and RBAC once in
+// its setup and recreates only the Deployment per test.
+func createStableInfra() {
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
 	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
+	stableInfraObjects = append(stableInfraObjects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
 
-	for _, manifest := range eppManifests {
-		objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Deployment")...)
+	for _, manifest := range []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest} {
+		stableInfraObjects = append(stableInfraObjects, applyManifest(manifest, eppSubstitutions(), "Deployment")...)
 	}
-	return objects
 }
 
 func eppSubstitutions() map[string]string {

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -96,9 +96,7 @@ func createEndPointPicker(phase, config string) []string {
 
 	objects := make([]string, 1, 8)
 	objects[0] = "ConfigMap/" + cmName
-	// The Service is created once by createStableServices; recreate only the
-	// rest (ServiceAccount, RoleBinding, Deployment) per spec.
-	objects = append(objects, applyManifest(manifest, eppSubstitutions(), "Service")...)
+	objects = append(objects, applyManifest(manifest, eppSubstitutions())...)
 	podsInDeploymentsReady(objects)
 	return objects
 }
@@ -179,9 +177,7 @@ func createCoordinator(config string) []string {
 	objects[0] = "ConfigMap/llm-d-coordinator-config"
 
 	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	// The Service is created once by createStableServices so its ClusterIP is
-	// stable across specs; recreate only the Deployment (and SA) per spec.
-	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Service")
+	docs = e2eutil.FilterKinds(docs, "ConfigMap")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, nsName)...)
@@ -192,11 +188,8 @@ func createCoordinator(config string) []string {
 }
 
 // waitForCoordinatorReady polls /readyz through Envoy until it returns 200,
-// confirming the freshly recreated coordinator pod is reachable through the
-// gateway before the test sends its request. The gateway Service is stable
-// across specs (see createStableServices), so this waits for the new pod to
-// appear behind it, not for Envoy to re-resolve a rotated ClusterIP.
-// (podsInDeploymentsReady already confirms the coordinator pod itself is ready.)
+// catching Envoy's STRICT_DNS resolution lagging behind the per-test Service
+// (podsInDeploymentsReady already confirms the coordinator pod itself is ready).
 func waitForCoordinatorReady() {
 	ginkgo.By("Waiting for coordinator to be reachable via gateway")
 	gomega.Eventually(func() bool {
@@ -229,37 +222,11 @@ func createEPPConfigMap(name, content string) {
 	}
 }
 
-func applyManifest(path string, subs map[string]string, excludeKinds ...string) []string {
+func applyManifest(path string, subs map[string]string) []string {
 	docs := testutils.ReadYaml(path)
 	docs = e2eutil.SubstituteMany(docs, subs)
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	if len(excludeKinds) > 0 {
-		docs = e2eutil.FilterKinds(docs, excludeKinds...)
-	}
 	return testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
-}
-
-// createStableServices creates the coordinator and per-phase EPP Services once,
-// up front, and returns their ids for suite teardown. Envoy fronts these via
-// STRICT_DNS clusters and outlives the per-spec workload; recreating the
-// Services each spec would rotate their ClusterIPs and force Envoy to
-// re-resolve, so only the Deployments behind them churn per spec. Mirrors the
-// non-coordinator e2e, which creates the EPP Services once in its per-container
-// setup and recreates only the Deployment per test.
-func createStableServices() []string {
-	var objects []string
-
-	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment", "ServiceAccount")
-	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
-	docs = e2eutil.RemoveEmptyArgs(docs)
-	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
-
-	for _, manifest := range []string{encodeEPPManifest, prefillEPPManifest, decodeEPPManifest} {
-		objects = append(objects,
-			applyManifest(manifest, eppSubstitutions(), "ServiceAccount", "RoleBinding", "Deployment")...)
-	}
-	return objects
 }
 
 func eppSubstitutions() map[string]string {

--- a/test/coordinator/e2e/coordinator/testdata/envoy.yaml
+++ b/test/coordinator/e2e/coordinator/testdata/envoy.yaml
@@ -86,7 +86,7 @@ data:
                           "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                           log_format:
                             text_format_source:
-                              inline_string: "[envoy] %REQ(:METHOD)% %REQ(:PATH)% code=%RESPONSE_CODE% flags=%RESPONSE_FLAGS% cluster=%UPSTREAM_CLUSTER% upstream=%UPSTREAM_HOST% epp-phase=%REQ(EPP-PHASE)% id=%REQ(X-REQUEST-ID)% dur=%DURATION%\n"
+                              inline_string: "[envoy] %START_TIME(%s.%3f)% %REQ(:METHOD)% %REQ(:PATH)% code=%RESPONSE_CODE% flags=%RESPONSE_FLAGS% cluster=%UPSTREAM_CLUSTER% upstream=%UPSTREAM_HOST% epp-phase=%REQ(EPP-PHASE)% id=%REQ(X-REQUEST-ID)% dur=%DURATION%\n"
                     route_config:
                       name: vllm
                       virtual_hosts:

--- a/test/coordinator/e2e/coordinator/testdata/envoy.yaml
+++ b/test/coordinator/e2e/coordinator/testdata/envoy.yaml
@@ -80,6 +80,13 @@ data:
                     "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     stat_prefix: http-8081
                     preserve_external_request_id: true
+                    access_log:
+                      - name: envoy.access_loggers.stdout
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                          log_format:
+                            text_format_source:
+                              inline_string: "[envoy] %REQ(:METHOD)% %REQ(:PATH)% code=%RESPONSE_CODE% flags=%RESPONSE_FLAGS% cluster=%UPSTREAM_CLUSTER% upstream=%UPSTREAM_HOST% epp-phase=%REQ(EPP-PHASE)% id=%REQ(X-REQUEST-ID)% dur=%DURATION%\n"
                     route_config:
                       name: vllm
                       virtual_hosts:

--- a/test/coordinator/e2e/coordinator/testdata/envoy.yaml
+++ b/test/coordinator/e2e/coordinator/testdata/envoy.yaml
@@ -174,6 +174,14 @@ data:
                                 cluster: coordinator
                                 timeout: 86400s
                                 idle_timeout: 86400s
+                                # Retry a failed upstream connection on a fresh one so a
+                                # transient connect hiccup to the coordinator ClusterIP is
+                                # ridden out instead of hanging the request. connect-failure
+                                # is safe for the non-idempotent POST: the connect never
+                                # completed, so no bytes reached the coordinator.
+                                retry_policy:
+                                  retry_on: "connect-failure"
+                                  num_retries: 3
                                 upgrade_configs:
                                   - upgrade_type: websocket
                               typed_per_filter_config:
@@ -247,7 +255,10 @@ data:
         # the default (no EPP-Phase) route as the pipeline entry point.
         - name: coordinator
           type: STRICT_DNS
-          connect_timeout: 1000s
+          # Fail a stuck connect quickly (paired with the route retry_policy) so a
+          # transient inability to open a connection to the coordinator ClusterIP is
+          # retried on a fresh connection instead of hanging until the client times out.
+          connect_timeout: 5s
           lb_policy: LEAST_REQUEST
           load_assignment:
             cluster_name: coordinator

--- a/test/coordinator/e2e/coordinator/testdata/envoy.yaml
+++ b/test/coordinator/e2e/coordinator/testdata/envoy.yaml
@@ -80,13 +80,6 @@ data:
                     "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     stat_prefix: http-8081
                     preserve_external_request_id: true
-                    access_log:
-                      - name: envoy.access_loggers.stdout
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-                          log_format:
-                            text_format_source:
-                              inline_string: "[envoy] %REQ(:METHOD)% %REQ(:PATH)% code=%RESPONSE_CODE% flags=%RESPONSE_FLAGS% cluster=%UPSTREAM_CLUSTER% upstream=%UPSTREAM_HOST% epp-phase=%REQ(EPP-PHASE)% id=%REQ(X-REQUEST-ID)% dur=%DURATION%\n"
                     route_config:
                       name: vllm
                       virtual_hosts:

--- a/test/coordinator/e2e/coordinator/testdata/envoy.yaml
+++ b/test/coordinator/e2e/coordinator/testdata/envoy.yaml
@@ -87,6 +87,11 @@ data:
                           log_format:
                             text_format_source:
                               inline_string: "[envoy] %START_TIME(%s.%3f)% %REQ(:METHOD)% %REQ(:PATH)% code=%RESPONSE_CODE% flags=%RESPONSE_FLAGS% cluster=%UPSTREAM_CLUSTER% upstream=%UPSTREAM_HOST% epp-phase=%REQ(EPP-PHASE)% id=%REQ(X-REQUEST-ID)% dur=%DURATION%\n"
+                    access_log_options:
+                      # Emit periodic access-log entries for in-flight streams so a
+                      # request that hangs (never terminates) is still recorded,
+                      # instead of only being logged on completion/disconnect.
+                      access_log_flush_interval: 5s
                     route_config:
                       name: vllm
                       virtual_hosts:

--- a/test/utils/dump.go
+++ b/test/utils/dump.go
@@ -37,13 +37,34 @@ const (
 	dumpLimitBytes = int64(1 << 20) // 1MiB
 )
 
+// dumpConfig controls how much container log DumpPodsAndLogs fetches.
+type dumpConfig struct {
+	tailLines  int64
+	limitBytes int64
+}
+
+// DumpOption overrides DumpPodsAndLogs defaults.
+type DumpOption func(*dumpConfig)
+
+// WithFullLogs streams complete container logs instead of the default tail, for
+// callers that need the entire log (e.g. a gateway access log). A non-positive
+// tail/limit disables that cap.
+func WithFullLogs() DumpOption {
+	return func(c *dumpConfig) { c.tailLines, c.limitBytes = 0, 0 }
+}
+
 // DumpPodsAndLogs prints pod statuses and container logs for the given namespace
 // to the Ginkgo writer. Call this before cleanup to ensure the information is
 // available when CI tests fail.
-func DumpPodsAndLogs(cfg *TestConfig, nsName string) {
+func DumpPodsAndLogs(cfg *TestConfig, nsName string, opts ...DumpOption) {
 	if cfg == nil || cfg.KubeCli == nil {
 		ginkgo.GinkgoWriter.Println("Skipping pod dump: cluster not initialized")
 		return
+	}
+
+	dc := dumpConfig{tailLines: dumpTailLines, limitBytes: dumpLimitBytes}
+	for _, opt := range opts {
+		opt(&dc)
 	}
 
 	ginkgo.GinkgoWriter.Printf("\n=== Dumping pod states and logs (namespace: %s) ===\n", nsName)
@@ -113,15 +134,15 @@ func DumpPodsAndLogs(cfg *TestConfig, nsName string) {
 
 		for _, c := range pod.Spec.InitContainers {
 			if restarted[c.Name] {
-				dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, true)
+				dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, true, dc)
 			}
-			dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, false)
+			dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, false, dc)
 		}
 		for _, c := range pod.Spec.Containers {
 			if restarted[c.Name] {
-				dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, true)
+				dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, true, dc)
 			}
-			dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, false)
+			dumpContainerLogs(ctx, cfg, pod.Namespace, pod.Name, c.Name, false, dc)
 		}
 	}
 	ginkgo.GinkgoWriter.Println("=== End of pod dump ===")
@@ -138,15 +159,15 @@ func printContainerStatus(kind string, cs corev1.ContainerStatus) {
 	ginkgo.GinkgoWriter.Println(status)
 }
 
-func dumpContainerLogs(ctx context.Context, cfg *TestConfig, nsName, podName, containerName string, previous bool) {
-	tailLines := dumpTailLines
-	limitBytes := dumpLimitBytes
-	req := cfg.KubeCli.CoreV1().Pods(nsName).GetLogs(podName, &corev1.PodLogOptions{
-		Container:  containerName,
-		TailLines:  &tailLines,
-		LimitBytes: &limitBytes,
-		Previous:   previous,
-	})
+func dumpContainerLogs(ctx context.Context, cfg *TestConfig, nsName, podName, containerName string, previous bool, dc dumpConfig) {
+	logOpts := &corev1.PodLogOptions{Container: containerName, Previous: previous}
+	if dc.tailLines > 0 {
+		logOpts.TailLines = &dc.tailLines
+	}
+	if dc.limitBytes > 0 {
+		logOpts.LimitBytes = &dc.limitBytes
+	}
+	req := cfg.KubeCli.CoreV1().Pods(nsName).GetLogs(podName, logOpts)
 	stream, err := req.Stream(ctx)
 	if err != nil {
 		ginkgo.GinkgoWriter.Printf("  [logs] %s/%s: failed to stream logs: %v\n", podName, containerName, err)
@@ -163,9 +184,12 @@ func dumpContainerLogs(ctx context.Context, cfg *TestConfig, nsName, podName, co
 		ginkgo.GinkgoWriter.Printf("  [logs] %s/%s: failed to read logs: %v\n", podName, containerName, err)
 		return
 	}
-	label := fmt.Sprintf("last %d lines", dumpTailLines)
-	if previous {
-		label = fmt.Sprintf("previous instance, last %d lines", dumpTailLines)
+	scope := "full log"
+	if dc.tailLines > 0 {
+		scope = fmt.Sprintf("last %d lines", dc.tailLines)
 	}
-	ginkgo.GinkgoWriter.Printf("  [logs] %s/%s (%s):\n%s\n", podName, containerName, label, buf.String())
+	if previous {
+		scope = "previous instance, " + scope
+	}
+	ginkgo.GinkgoWriter.Printf("  [logs] %s/%s (%s):\n%s\n", podName, containerName, scope, buf.String())
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/kind bug

**What this PR does / why we need it**:

Fixes the intermittent coordinator e2e failure where the client
`POST /v1/chat/completions` fails with `context deadline exceeded` while
the coordinator only logs health probes (the request never reaches it).

[e2e_failure_log.txt](https://github.com/user-attachments/files/30258973/e2e_failure_log.txt)


Root cause (confirmed from the Envoy access log): the client
POST reaches Envoy and matches the `coordinator` STRICT_DNS cluster, but
Envoy momentarily cannot open a new upstream connection to the coordinator
Service ClusterIP (a transient kube-proxy/conntrack settling window in the
kind cluster). Because that cluster used `connect_timeout: 1000s` and the
route had no retry, the single connect attempt was held far past the
client's 60s timeout, turning a few-second transient into a hung request.
The gateway view proves it: the POST logs `cluster=coordinator upstream=-`
for the full ~55s, while a `/readyz` to the same ClusterIP succeeded 2ms
earlier and the transient cleared ~7s later (the readiness poll rides it
out by retrying; the POST had no such resilience).

Fix: on the coordinator cluster/route, fail a stuck connect fast and retry
it on a fresh connection.
- coordinator cluster `connect_timeout: 1000s -> 5s`
- default route `retry_policy: { retry_on: "connect-failure", num_retries: 3 }`
`connect-failure` is safe for the non-idempotent POST: the connection never
established, so nothing reached the coordinator.

Also included (hardening, same failure surface):
- Create the coordinator and per-phase EPP Services, ServiceAccounts, and
  RoleBindings once in BeforeSuite (`createStableInfra`) and recreate only
  the Deployments per spec, mirroring the non-coordinator e2e. This removes
  per-spec Service ClusterIP churn (a real problem, though not the root
  cause of this flake).
- `shutdown_timeout: 25s -> 1s` so a torn-down coordinator stops serving
  promptly instead of lingering during the brief pod-drain overlap between
  specs.
- Add failure-only diagnostics (Envoy stdout access log, per-deployment
  log dumps, and Envoy `/clusters`) so a future failure records the
  gateway's view of the hung request. These print only on spec failure
  (or with `E2E_PRINT_COORDINATOR_LOGS=true`).

### Here is a streamlined breakdown of the logs proving the exact point of failure in the request flow:

Fact 1 — the POST reached Envoy. Envoy's access log contains it (Envoy only logs requests it received):
[envoy] 1784703989.516 POST /v1/chat/completions code=0 flags=- cluster=coordinator upstream=- epp-phase=- id=431f407b… dur=5000
epp-phase=- = no EPP-Phase header → this is the external client POST, and cluster=coordinator = Envoy matched it to the default route → coordinator cluster. Proven: the POST arrived at Envoy and was routed to the coordinator cluster.

Fact 2 — Envoy never obtained an upstream connection to the coordinator. The same request is flushed every 5s (because of access_log_flush_interval), 11 snapshots, and in every one the upstream field is empty:
… upstream=- … dur=5000
… upstream=- … dur=9999
… upstream=- … dur=15000
… (20000, 25000, 30001, 35000, 40000, 45001, 50001) …
… upstream=- … dur=55001
upstream=- from dur=5000 to dur=55001 means Envoy never bound the request to an upstream host/connection for ~55 seconds. Contrast with a working request, whose field is populated: upstream=10.96.23.10:8080. Proven: no upstream connection was ever established for the POST.

Fact 3 — it never reached the coordinator. The coordinator logs every request on entry (server.go:67). Across the whole failing spec its log contains only:
14 × "method":"GET","path":"/healthz"
18 × "method":"GET","path":"/readyz"
Zero POST. Proven: the POST did not reach the coordinator process — consistent with Fact 2.

Fact 4 — the coordinator was reachable at that instant (so this is not "coordinator down"). 0.5 ms before the POST started, a /readyz connected to the same ClusterIP and succeeded:
- coordinator log: ts=1784703989.5154674 … "method":"GET","path":"/readyz" … x-request-id:"b90897a8…" (the coordinator received it)
- Envoy access log for that id: GET /readyz code=200 upstream=10.96.23.10:8080 dur=0

POST START_TIME is 1784703989.516. So: at …989.5155 a request connected to 10.96.23.10 and got 200; at …989.516 the POST began and never got an upstream for 55s. Proven: the endpoint was connectable immediately before the POST.

Proven from the logs: the POST reached Envoy, was routed to the coordinator cluster, and Envoy never obtained an upstream connection to the coordinator for the full ~55 s (upstream=-), so nothing reached the coordinator, even though the coordinator answered a request on the same ClusterIP 0.5 ms earlier. It hung in the pending/connecting state (code=0, flags=- — no terminal UF/UH/DC) because connect_timeout: 1000s meant the attempt never failed; the client's 60 s deadline fired first.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2112

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
