### PR TITLE
ci: Add `/area` and `/milestone` commands to PR label sync

### DIFF
--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -50,8 +50,7 @@ jobs:
             done
 
           # Extract /area values from PR body and apply labels
-          printf '%s' "$PR_BODY" | tr -d '\r' | grep '^/area ' | \
-            sed 's|^/area ||' | sort -u | \
+          printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/area ||p' | sort -u | \
             while IFS= read -r area; do
               [ -z "$area" ] && continue
               gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "area/$area" || \

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -27,8 +27,7 @@ jobs:
             done
 
           # Extract /kind values from PR body and apply labels
-          printf '%s' "$PR_BODY" | tr -d '\r' | grep '^/kind ' | \
-            sed 's|^/kind ||' | sort -u | \
+          printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/kind[[:space:]][[:space:]]*||p' | sed 's|[[:space:]]*$||' | sort -u | \
             while IFS= read -r kind; do
               [ -z "$kind" ] && continue
               gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "kind/$kind" || \
@@ -65,8 +64,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Use the last /milestone directive in the PR body
-          milestone=$(printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/milestone ||p' | \
-            tail -n 1)
+          milestone=$(printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/milestone[[:space:]][[:space:]]*||p' | \
+             sed 's|[[:space:]]*$||' | tail -n 1)
           [ -z "$milestone" ] && exit 0
           gh pr edit "$PR_NUMBER" --repo "$REPO" --milestone "$milestone" || \
             echo "::warning::Milestone '$milestone' not found in repository"

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -1,4 +1,4 @@
-name: Apply kind labels from PR body
+name: Apply kind/area labels and milestone from PR body
 
 on:
   pull_request_target:
@@ -34,3 +34,40 @@ jobs:
               gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "kind/$kind" || \
                 echo "::warning::Label 'kind/$kind' not found in repository"
             done
+
+      - name: Sync area labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Remove existing area/* labels
+          gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            -q '.labels[].name | select(startswith("area/"))' | \
+            while IFS= read -r label; do
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label"
+            done
+
+          # Extract /area values from PR body and apply labels
+          printf '%s' "$PR_BODY" | tr -d '\r' | grep '^/area ' | \
+            sed 's|^/area ||' | sort -u | \
+            while IFS= read -r area; do
+              [ -z "$area" ] && continue
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "area/$area" || \
+                echo "::warning::Label 'area/$area' not found in repository"
+            done
+
+      - name: Set milestone
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Use the last /milestone directive in the PR body
+          milestone=$(printf '%s' "$PR_BODY" | tr -d '\r' | grep '^/milestone ' | \
+            sed 's|^/milestone ||' | tail -n 1)
+          [ -z "$milestone" ] && exit 0
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --milestone "$milestone" || \
+            echo "::warning::Milestone '$milestone' not found in repository"

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -65,8 +65,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Use the last /milestone directive in the PR body
-          milestone=$(printf '%s' "$PR_BODY" | tr -d '\r' | grep '^/milestone ' | \
-            sed 's|^/milestone ||' | tail -n 1)
+          milestone=$(printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/milestone ||p' | \
+            tail -n 1)
           [ -z "$milestone" ] && exit 0
           gh pr edit "$PR_NUMBER" --repo "$REPO" --milestone "$milestone" || \
             echo "::warning::Milestone '$milestone' not found in repository"

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -50,7 +50,7 @@ jobs:
             done
 
           # Extract /area values from PR body and apply labels
-          printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/area ||p' | sort -u | \
+          printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/area[[:space:]][[:space:]]*||p' | sed 's|[[:space:]]*$||' | sort -u | \
             while IFS= read -r area; do
               [ -z "$area" ] && continue
               gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "area/$area" || \

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -34,13 +34,19 @@ jobs:
                 echo "::warning::Label 'kind/$kind' not found in repository"
             done
 
-      - name: Sync area labels
+      - name: Set area labels
         env:
           GH_TOKEN: ${{ github.token }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          # Absence of a directive is a no-op. Area labels are also set by the
+          # /area comment command and clearing here would wipe those.
+          areas=$(printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/area[[:space:]][[:space:]]*||p' | \
+            sed 's|[[:space:]]*$||' | sed '/^$/d' | sort -u)
+          [ -z "$areas" ] && exit 0
+
           # Remove existing area/* labels
           gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
             -q '.labels[].name | select(startswith("area/"))' | \
@@ -48,10 +54,8 @@ jobs:
               gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label"
             done
 
-          # Extract /area values from PR body and apply labels
-          printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/area[[:space:]][[:space:]]*||p' | sed 's|[[:space:]]*$||' | sort -u | \
+          printf '%s\n' "$areas" | \
             while IFS= read -r area; do
-              [ -z "$area" ] && continue
               gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "area/$area" || \
                 echo "::warning::Label 'area/$area' not found in repository"
             done
@@ -65,7 +69,7 @@ jobs:
         run: |
           # Use the last /milestone directive in the PR body
           milestone=$(printf '%s' "$PR_BODY" | tr -d '\r' | sed -n 's|^/milestone[[:space:]][[:space:]]*||p' | \
-             sed 's|[[:space:]]*$||' | tail -n 1)
+             sed 's|[[:space:]]*$||' | sed '/^$/d' | tail -n 1)
           [ -z "$milestone" ] && exit 0
           gh pr edit "$PR_NUMBER" --repo "$REPO" --milestone "$milestone" || \
             echo "::warning::Milestone '$milestone' not found in repository"

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -51,7 +51,7 @@ jobs:
           gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
             -q '.labels[].name | select(startswith("area/"))' | \
             while IFS= read -r label; do
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label"
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" || echo "::warning::Failed to remove label '$label'"
             done
 
           printf '%s\n' "$areas" | \

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -23,7 +23,7 @@ jobs:
           gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
             -q '.labels[].name | select(startswith("kind/"))' | \
             while IFS= read -r label; do
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label"
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" || echo "::warning::Failed to remove label '$label'"
             done
 
           # Extract /kind values from PR body and apply labels


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Extends `pr-kind-label.yaml` to sync `/area <x>` and `/milestone <x>` directives from the PR body, in addition to the existing `/kind <x>` handling. Set only pattern is used for milestone and area as clearing on absence would let any contributor body edit silently wipe a maintainer's milestone assignment. 

There is no new external action and no new permissions.

This gives contributors a native GitHub way to set area labels and milestones without the `prow-github-actions` integration.

/cc @elevran 

**Which issue(s) this PR fixes**:
Part of #956 (Part 2, Remove obsolete Prow workflows)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
