### PR TITLE
feat(chart): allow extra args, init containers, and volumes for token…

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -332,9 +332,12 @@ The sidecar runs vLLM's `vllm launch render <modelName>` and exposes `/v1/comple
 | `router.tokenizer.port` | Container port the sidecar listens on. | `8000` |
 | `router.tokenizer.command` | Override container command. Empty renders `["vllm", "launch", "render"]`. | `[]` |
 | `router.tokenizer.args` | Override container args. Empty renders `["<modelName>", "--port=<port>"]`. | `[]` |
+| `router.tokenizer.extraArgs` | Extra args appended to the tokenizer container after the default or overridden args. | `[]` |
+| `router.tokenizer.initContainers` | Pod-level init containers rendered when the tokenizer is enabled. | `[]` |
 | `router.tokenizer.env` | Extra environment variables (e.g., HuggingFace token). | `[HF_TOKEN]` |
 | `router.tokenizer.resources` | Tokenizer container resource requests and limits. | `requests.cpu: "4"`, `requests.memory: 8Gi` |
 | `router.tokenizer.volumeMounts` | Extra volume mounts for the tokenizer container. | `[]` |
+| `router.tokenizer.volumes` | Pod-level volumes rendered alongside `model-cache` when the tokenizer is enabled. | `[]` |
 | `router.tokenizer.readinessProbe` | Readiness probe spec. | `httpGet /health on the render-http named port` |
 
 #### Complete Tokenizer Render Sidecar Example

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -43,6 +43,10 @@ spec:
       serviceAccountName: {{ include "llm-d-router.name" . }}
       # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
       terminationGracePeriodSeconds: 130
+      {{- if and .Values.router.tokenizer.enabled .Values.router.tokenizer.initContainers }}
+      initContainers:
+        {{- toYaml .Values.router.tokenizer.initContainers | nindent 8 }}
+      {{- end }}
       containers:
       {{- if $proxySidecar }}
         - name: {{ $proxy.name }}
@@ -253,6 +257,9 @@ spec:
             - {{ $tokenizer.modelName | quote }}
             - {{ printf "--port=%d" $renderPort | quote }}
           {{- end }}
+          {{- with $tokenizer.extraArgs }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: render-http
               containerPort: {{ $renderPort }}
@@ -283,6 +290,9 @@ spec:
       {{- if .Values.router.tokenizer.enabled }}
         - name: model-cache
           emptyDir: {}
+        {{- with .Values.router.tokenizer.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- if and $proxySidecar (eq $proxyType "agentgateway") $proxyConfigMapName }}
         - name: agentgateway-config-template

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -91,6 +91,12 @@ tokenizer:
   port: 8000
   command: []
   args: []
+  # Extra args appended to the vllm-render container after the default or overridden args.
+  extraArgs: []
+  # Pod-level init containers rendered when the tokenizer is enabled.
+  initContainers: []
+  # Pod-level volumes rendered alongside model-cache when the tokenizer is enabled.
+  volumes: []
   env:
     - name: HF_TOKEN
       valueFrom:


### PR DESCRIPTION
**What type of PR is this?**

  /kind feature

  **What this PR does / why we need it**:

  The tokenizer render sidecar (`router.tokenizer.*`) in the router Helm chart
  could only be customized through its `args` and `volumeMounts`. There was no
  way to append extra flags on top of the default args, run pod-level init
  containers, or declare additional pod-level volumes.

  This adds three fields to the tokenizer configuration:

  - `router.tokenizer.extraArgs` - args appended to the `vllm-render` container
    after the default (or overridden) args.
  - `router.tokenizer.initContainers` - pod-level init containers, rendered only
    when the tokenizer is enabled (e.g. to prewarm the model cache).
  - `router.tokenizer.volumes` - pod-level volumes rendered alongside the
    built-in `model-cache` volume, so an init container and the sidecar can
    share storage.

  All three default to empty and render nothing when unset, so existing
  deployments are unaffected. `config/charts/README.md` documents the new fields.

  **Which issue(s) this PR fixes**:
  Fixes #

