### PR TITLE
feat: add new --model-server-port to replace --vllm-port

### DIFF
--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -132,7 +132,7 @@ type Options struct {
 	// Fields with direct CLI flags are bound here via embedding; derived fields are set in Complete().
 	Config
 
-	// modelServerPort is the port the model server(vLLM, SGLang etc) is listening on; used to compute Config.DecoderURL in Complete().
+	// modelServerPort is the port the model server (vLLM, SGLang, etc.) is listening on; used to compute Config.DecoderURL in Complete().
 	modelServerPort string
 	// vllmPort is the deprecated alias for modelServerPort; migrated in Complete().
 	vllmPort string
@@ -247,7 +247,8 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	// Add Go flags to pflag (for zap options compatibility)
 	fs.AddGoFlagSet(goFlagSet)
 	fs.StringVar(&opts.Port, port, opts.Port, "the port the sidecar is listening on")
-	fs.StringVar(&opts.modelServerPort, modelServerPort, opts.modelServerPort, "the port the model server is listening on")
+	fs.StringVar(&opts.modelServerPort, modelServerPort, opts.modelServerPort,
+		fmt.Sprintf("the port the model server is listening on (default %s)", defaultVLLMPort))
 	fs.StringVar(&opts.vllmPort, vllmPort, opts.vllmPort, "the port the model server is listening on")
 	_ = fs.MarkDeprecated(vllmPort, "use --model-server-port instead; --vllm-port will be removed after the deprecation period")
 	fs.IntVar(&opts.DataParallelSize, dataParallelSize, opts.DataParallelSize, "the model server's data-parallel size")
@@ -339,10 +340,10 @@ func (opts *Options) Complete() error {
 		return err
 	}
 
-	// Migrate deprecated --vllm-port to --model-server-port.
-	// defaults to empty, so an unset value means neither flag nor YAML provided a --model-server-port
-	// fall back to the --vllm-port value.
-	if opts.modelServerPort == "" {
+	// Resolve the effective model server port with flag-over-config precedence:
+	//   --model-server-port flag > --vllm-port flag > model-server-port YAML > vllm-port YAML > default.
+	// The deprecated --vllm-port flag must still override a YAML model-server-port.
+	if (opts.isFlagSet(vllmPort) && !opts.isFlagSet(modelServerPort)) || opts.modelServerPort == "" {
 		opts.modelServerPort = opts.vllmPort
 	}
 

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -54,6 +54,7 @@ const (
 
 	// Flags
 	port                      = "port"
+	modelServerPort           = "model-server-port"
 	vllmPort                  = "vllm-port"
 	dataParallelSize          = "data-parallel-size"
 	kvConnector               = "kv-connector"
@@ -99,6 +100,7 @@ const (
 // yamlConfiguration represents structure of YAML configuration for sidecar proxy
 type yamlConfiguration struct {
 	Port                    int      `json:"port,omitempty"`
+	ModelServerPort         int      `json:"model-server-port,omitempty"`
 	VLLMPort                int      `json:"vllm-port,omitempty"`
 	MooncakeBootstrapPort   int      `json:"mooncake-bootstrap-port,omitempty"`
 	P2PConnectorPort        int      `json:"p2p-connector-port,omitempty"`
@@ -130,7 +132,9 @@ type Options struct {
 	// Fields with direct CLI flags are bound here via embedding; derived fields are set in Complete().
 	Config
 
-	// vllmPort is the port vLLM is listening on; used to compute Config.DecoderURL in Complete().
+	// modelServerPort is the port the model server(vLLM, SGLang etc) is listening on; used to compute Config.DecoderURL in Complete().
+	modelServerPort string
+	// vllmPort is the deprecated alias for modelServerPort; migrated in Complete().
 	vllmPort string
 	// enableTLS is the list of stages to enable TLS for; used to compute Config.UseTLSFor* in Complete().
 	enableTLS []string
@@ -243,8 +247,10 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	// Add Go flags to pflag (for zap options compatibility)
 	fs.AddGoFlagSet(goFlagSet)
 	fs.StringVar(&opts.Port, port, opts.Port, "the port the sidecar is listening on")
-	fs.StringVar(&opts.vllmPort, vllmPort, opts.vllmPort, "the port vLLM is listening on")
-	fs.IntVar(&opts.DataParallelSize, dataParallelSize, opts.DataParallelSize, "the vLLM DATA-PARALLEL-SIZE value")
+	fs.StringVar(&opts.modelServerPort, modelServerPort, opts.modelServerPort, "the port the model server is listening on")
+	fs.StringVar(&opts.vllmPort, vllmPort, opts.vllmPort, "the port the model server is listening on")
+	_ = fs.MarkDeprecated(vllmPort, "use --model-server-port instead; --vllm-port will be removed after the deprecation period")
+	fs.IntVar(&opts.DataParallelSize, dataParallelSize, opts.DataParallelSize, "the model server's data-parallel size")
 	fs.StringVar(&opts.KVConnector, kvConnector, opts.KVConnector,
 		"the KV protocol between prefiller and decoder. Supported: "+supportedKVConnectorNamesStr)
 	fs.StringVar(&opts.ECConnector, ecConnector, opts.ECConnector,
@@ -310,7 +316,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.MaxIdleConnsPerHost, "max-idle-conns-per-host", opts.MaxIdleConnsPerHost, "max idle keep-alive connections per host for reverse proxy transports; set to at least the expected concurrency")
 	fs.IntVar(&opts.PrefillMaxRetries, prefillMaxRetries, opts.PrefillMaxRetries, "max retry attempts when a prefill request fails with a 5xx error; 0 means no retries (default)")
 	fs.DurationVar(&opts.PrefillRetryBackoff, prefillRetryBackoff, opts.PrefillRetryBackoff, "delay between prefill retry attempts")
-	fs.StringVar(&opts.inlineConfiguration, inlineConfiguration, "", "Sidecar configuration in YAML provided as inline specification. Example `--configuration={port: 8085, vllm-port: 8203}. Inline configuration and file configuration are mutually exclusive.`")
+	fs.StringVar(&opts.inlineConfiguration, inlineConfiguration, "", "Sidecar configuration in YAML provided as inline specification. Example `--configuration={port: 8085, model-server-port: 8203}. Inline configuration and file configuration are mutually exclusive.`")
 	fs.StringVar(&opts.fileConfiguration, configurationFile, "", "Path to file which contains sidecar configuration in YAML. Example `--configuration-file=/etc/config/sidecar-config.yaml`. Inline configuration and file configuration are mutually exclusive.")
 }
 
@@ -333,6 +339,13 @@ func (opts *Options) Complete() error {
 		return err
 	}
 
+	// Migrate deprecated --vllm-port to --model-server-port.
+	// defaults to empty, so an unset value means neither flag nor YAML provided a --model-server-port
+	// fall back to the --vllm-port value.
+	if opts.modelServerPort == "" {
+		opts.modelServerPort = opts.vllmPort
+	}
+
 	// Parse inferencePool field (namespace/name or just name) into Config.
 	if opts.inferencePool != "" {
 		parts := strings.SplitN(opts.inferencePool, "/", 2)
@@ -353,13 +366,13 @@ func (opts *Options) Complete() error {
 	opts.InsecureSkipVerifyForEncoder = slices.Contains(opts.tlsInsecureSkipVerify, encodeStage)
 	opts.InsecureSkipVerifyForDecoder = slices.Contains(opts.tlsInsecureSkipVerify, decodeStage)
 
-	// Compute Config.DecoderURL from vllmPort and decoder TLS setting
+	// Compute Config.DecoderURL from modelServerPort and decoder TLS setting
 	scheme := "http"
 	if opts.UseTLSForDecoder {
 		scheme = schemeHTTPS
 	}
 	var err error
-	opts.DecoderURL, err = url.Parse(scheme + "://localhost:" + opts.vllmPort)
+	opts.DecoderURL, err = url.Parse(scheme + "://localhost:" + opts.modelServerPort)
 	if err != nil {
 		return fmt.Errorf("failed to parse target URL: %w", err)
 	}
@@ -472,12 +485,16 @@ func (opts *Options) Validate() error {
 		return fmt.Errorf("--port %w", err)
 	}
 
-	vllmPort, err := strconv.Atoi(opts.vllmPort)
-	if err != nil {
-		return fmt.Errorf("--vllm-port must be a valid integer, got %q", opts.vllmPort)
+	portFlagName := "--" + modelServerPort
+	if opts.isFlagSet(vllmPort) && !opts.isFlagSet(modelServerPort) {
+		portFlagName = "--" + vllmPort
 	}
-	if err := validatePortRange(vllmPort, opts.DataParallelSize); err != nil {
-		return fmt.Errorf("--vllm-port %w", err)
+	msPort, err := strconv.Atoi(opts.modelServerPort)
+	if err != nil {
+		return fmt.Errorf("%s must be a valid integer, got %q", portFlagName, opts.modelServerPort)
+	}
+	if err := validatePortRange(msPort, opts.DataParallelSize); err != nil {
+		return fmt.Errorf("%s %w", portFlagName, err)
 	}
 
 	// Validate KV connector
@@ -649,6 +666,10 @@ func (opts *Options) extractYAMLConfiguration() error {
 func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	if cfg.Port != 0 && !opts.isFlagSet(port) {
 		opts.Port = strconv.Itoa(cfg.Port)
+	}
+	// If both keys may be present, Complete() resolves precedence: modelServerPort wins.
+	if cfg.ModelServerPort != 0 && !opts.isFlagSet(modelServerPort) {
+		opts.modelServerPort = strconv.Itoa(cfg.ModelServerPort)
 	}
 	if cfg.VLLMPort != 0 && !opts.isFlagSet(vllmPort) {
 		opts.vllmPort = strconv.Itoa(cfg.VLLMPort)

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -814,11 +814,11 @@ func TestValidatePorts(t *testing.T) {
 	}{
 		{"valid ports", "8000", "8001", ""},
 		{"invalid port format", "abc", "8001", `--port must be a valid integer, got "abc"`},
-		{"invalid vllm port format", "8000", "xyz", `--vllm-port must be a valid integer, got "xyz"`},
+		{"invalid model server port format", "8000", "xyz", `--model-server-port must be a valid integer, got "xyz"`},
 		{"port too low", "0", "8001", "--port start port 0 is out of valid range [1, 65535]"},
 		{"port too high", "65536", "8001", "--port start port 65536 is out of valid range [1, 65535]"},
-		{"vllm port too low", "8000", "0", "--vllm-port start port 0 is out of valid range [1, 65535]"},
-		{"vllm port too high", "8000", "65536", "--vllm-port start port 65536 is out of valid range [1, 65535]"},
+		{"model server port too low", "8000", "0", "--model-server-port start port 0 is out of valid range [1, 65535]"},
+		{"model server port too high", "8000", "65536", "--model-server-port start port 65536 is out of valid range [1, 65535]"},
 	}
 
 	for _, tt := range tests {
@@ -1128,6 +1128,44 @@ func TestCompleteMoRIIOWriteModeGuards(t *testing.T) {
 		opts.MoRIIOWriteMode = false
 		require.ErrorContains(t, opts.Complete(), "--moriio-write-mode")
 	})
+}
+
+func TestModelServerPortMigration(t *testing.T) {
+	tests := []struct {
+		name               string
+		modelServerPort    string
+		vllmPort           string
+		expectedDecoderURL string
+	}{
+		{"model-server-port set", "9000", "", "http://localhost:9000"},
+		{"deprecated vllm-port migrated", "", "9001", "http://localhost:9001"},
+		{"model-server-port wins over vllm-port when both set", "9000", "9001", "http://localhost:9000"},
+		{"no model-server-port, default falls back to vllm-port default", "", defaultVLLMPort, "http://localhost:" + defaultVLLMPort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.modelServerPort = tt.modelServerPort
+			opts.vllmPort = tt.vllmPort
+
+			require.NoError(t, opts.Complete())
+			require.NoError(t, opts.Validate())
+			require.NotNil(t, opts.DecoderURL)
+			require.Equal(t, tt.expectedDecoderURL, opts.DecoderURL.String())
+		})
+	}
+}
+
+func TestModelServerPortYAML(t *testing.T) {
+	opts, testPFlagSet := newTestOptions(t)
+	yaml := "{model-server-port: 8203}"
+	setFlag(t, testPFlagSet, inlineConfiguration, &yaml)
+	require.NoError(t, testPFlagSet.Parse(nil))
+
+	require.NoError(t, opts.Complete())
+	require.NoError(t, opts.Validate())
+	require.Equal(t, "http://localhost:8203", opts.DecoderURL.String())
 }
 
 func TestCompleteTLSConfiguration(t *testing.T) {

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -1131,9 +1131,9 @@ func TestCompleteMoRIIOWriteModeGuards(t *testing.T) {
 	})
 }
 
-// TestModelServerPortMigration is intentional reference to the deprecated
-// vllm-port flag; it verifies migration to model-server-port.
-// Remove test when we drop vllm-port in v0.12 (see issue 2172).
+// TestModelServerPortMigration verifies that the deprecated vllm-port flag
+// migrates to model-server-port.
+// Remove when vllm-port is dropped in v0.12 (see issue 2172).
 func TestModelServerPortMigration(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -1170,6 +1170,20 @@ func TestModelServerPortYAML(t *testing.T) {
 	require.NoError(t, opts.Complete())
 	require.NoError(t, opts.Validate())
 	require.Equal(t, "http://localhost:8203", opts.DecoderURL.String())
+}
+
+// A CLI flag overrides YAML config, including the deprecated --vllm-port over a
+// model-server-port key.
+func TestModelServerPortFlagBeatsYAML(t *testing.T) {
+	opts, testPFlagSet := newTestOptions(t)
+	yaml := "{model-server-port: 8203}"
+	setFlag(t, testPFlagSet, inlineConfiguration, &yaml)
+	setFlag(t, testPFlagSet, vllmPort, "9001")
+	require.NoError(t, testPFlagSet.Parse(nil))
+
+	require.NoError(t, opts.Complete())
+	require.NoError(t, opts.Validate())
+	require.Equal(t, "http://localhost:9001", opts.DecoderURL.String())
 }
 
 func TestCompleteTLSConfiguration(t *testing.T) {

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -43,7 +43,7 @@ func createConfigWithValidYAML(t *testing.T) string {
 	t.Helper()
 	return writeTempYAML(t, "valid.yaml", fmt.Sprintf(`
 port: 8100
-vllm-port: 8001
+model-server-port: 8001
 data-parallel-size: 5
 kv-connector: %q
 ec-connector: %q
@@ -72,7 +72,7 @@ func createConfigWithUnknownKeys(t *testing.T) string {
 	t.Helper()
 	return writeTempYAML(t, "valid.yaml", `
 port: 8100
-vllm-port: 8001
+model-server-port: 8001
 unknown-key: 1001
 `)
 }
@@ -89,7 +89,7 @@ func TestSidecarConfiguration(t *testing.T) {
 	// --- inline YAML for testing ---
 	inlineYAML := fmt.Sprintf(`{
 		port: 8011,
-		vllm-port: 8021,
+		model-server-port: 8021,
 		data-parallel-size: 3,
 		kv-connector: %s,
 		ec-connector: %s,
@@ -130,7 +130,7 @@ func TestSidecarConfiguration(t *testing.T) {
 			},
 			expected: func(o *Options) {
 				o.Port = "8011"
-				o.vllmPort = "8021"
+				o.modelServerPort = "8021"
 				o.DataParallelSize = 3
 				o.MaxIdleConnsPerHost = 200
 				o.MooncakeBootstrapPort = 9001
@@ -178,7 +178,7 @@ func TestSidecarConfiguration(t *testing.T) {
 			},
 			expected: func(o *Options) {
 				o.Port = "8100"
-				o.vllmPort = "8001"
+				o.modelServerPort = "8001"
 				o.DataParallelSize = 5
 				o.MaxIdleConnsPerHost = 300
 				o.MooncakeBootstrapPort = 9000
@@ -223,7 +223,7 @@ func TestSidecarConfiguration(t *testing.T) {
 			name: "flags override inline YAML",
 			inputFlags: map[string]any{
 				port:                    "8111",
-				vllmPort:                "8222",
+				modelServerPort:         "8222",
 				dataParallelSize:        2,
 				kvConnector:             KVConnectorNIXLV2,
 				ecConnector:             ECExampleConnector,
@@ -240,7 +240,7 @@ func TestSidecarConfiguration(t *testing.T) {
 			},
 			expected: func(o *Options) {
 				o.Port = "8111"
-				o.vllmPort = "8222"
+				o.modelServerPort = "8222"
 				o.DataParallelSize = 2
 				o.MaxIdleConnsPerHost = 200
 				o.MooncakeBootstrapPort = 9001
@@ -287,6 +287,7 @@ func TestSidecarConfiguration(t *testing.T) {
 				ecConnector: ECConnectorNIXL,
 			},
 			expected: func(o *Options) {
+				o.modelServerPort = defaultVLLMPort
 				o.KVConnector = KVConnectorNIXLV2
 				o.ECConnector = ECConnectorNIXL
 			},
@@ -296,7 +297,7 @@ func TestSidecarConfiguration(t *testing.T) {
 			name: "flags override file YAML",
 			inputFlags: map[string]any{
 				port:                      "8111",
-				vllmPort:                  "8222",
+				modelServerPort:           "8222",
 				dataParallelSize:          2,
 				kvConnector:               KVConnectorNIXLV2,
 				ecConnector:               ECExampleConnector,
@@ -314,7 +315,7 @@ func TestSidecarConfiguration(t *testing.T) {
 			},
 			expected: func(o *Options) {
 				o.Port = "8111"
-				o.vllmPort = "8222"
+				o.modelServerPort = "8222"
 				o.DataParallelSize = 2
 				o.MaxIdleConnsPerHost = 400
 				o.MooncakeBootstrapPort = 9002
@@ -453,7 +454,7 @@ func compareOptions(t *testing.T, expected, actual *Options) {
 	}
 
 	assertEqual(port, expected.Port, actual.Port)
-	assertEqual(vllmPort, expected.vllmPort, actual.vllmPort)
+	assertEqual(modelServerPort, expected.modelServerPort, actual.modelServerPort)
 	assertEqual(dataParallelSize, expected.DataParallelSize, actual.DataParallelSize)
 	assertEqual(maxIdleConnsPerHost, expected.MaxIdleConnsPerHost, actual.MaxIdleConnsPerHost)
 
@@ -492,7 +493,7 @@ func compareOptions(t *testing.T, expected, actual *Options) {
 	assertEqual(inlineConfiguration, expected.inlineConfiguration, actual.inlineConfiguration)
 	assertEqual(configurationFile, expected.fileConfiguration, actual.fileConfiguration)
 
-	assertEqual("decoderURL", calculateURL(t, expected.UseTLSForDecoder, expected.vllmPort), actual.DecoderURL)
+	assertEqual("decoderURL", calculateURL(t, expected.UseTLSForDecoder, expected.modelServerPort), actual.DecoderURL)
 }
 
 // setEnv sets environment variables for testing and ensures they are cleaned up after the test finishes
@@ -781,7 +782,7 @@ func TestValidateDataParallelPortRange(t *testing.T) {
 	tests := []struct {
 		name             string
 		port             string
-		vllmPort         string
+		modelServerPort  string
 		dataParallelSize int
 		wantErr          bool
 	}{
@@ -794,7 +795,7 @@ func TestValidateDataParallelPortRange(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := NewOptions()
 			opts.Port = tt.port
-			opts.vllmPort = tt.vllmPort
+			opts.modelServerPort = tt.modelServerPort
 			opts.DataParallelSize = tt.dataParallelSize
 			_ = opts.Complete()
 			err := opts.Validate()
@@ -807,10 +808,10 @@ func TestValidateDataParallelPortRange(t *testing.T) {
 
 func TestValidatePorts(t *testing.T) {
 	tests := []struct {
-		name     string
-		port     string
-		vllmPort string
-		wantErr  string
+		name            string
+		port            string
+		modelServerPort string
+		wantErr         string
 	}{
 		{"valid ports", "8000", "8001", ""},
 		{"invalid port format", "abc", "8001", `--port must be a valid integer, got "abc"`},
@@ -825,7 +826,7 @@ func TestValidatePorts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := NewOptions()
 			opts.Port = tt.port
-			opts.vllmPort = tt.vllmPort
+			opts.modelServerPort = tt.modelServerPort
 			_ = opts.Complete()
 			err := opts.Validate()
 			if tt.wantErr == "" {
@@ -1130,6 +1131,9 @@ func TestCompleteMoRIIOWriteModeGuards(t *testing.T) {
 	})
 }
 
+// TestModelServerPortMigration is intentional reference to the deprecated
+// vllm-port flag; it verifies migration to model-server-port.
+// Remove test when we drop vllm-port in v0.12 (see issue 2172).
 func TestModelServerPortMigration(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -1173,7 +1177,7 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 		name                         string
 		enableTLS                    []string
 		tlsInsecureSkipVerify        []string
-		vllmPort                     string
+		modelServerPort              string
 		expectedDecoderURL           string
 		expectedUseTLSForPrefiller   bool
 		expectedUseTLSForDecoder     bool
@@ -1184,7 +1188,7 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			name:                         "no TLS configuration",
 			enableTLS:                    []string{},
 			tlsInsecureSkipVerify:        []string{},
-			vllmPort:                     "8001",
+			modelServerPort:              "8001",
 			expectedDecoderURL:           "http://localhost:8001",
 			expectedUseTLSForPrefiller:   false,
 			expectedUseTLSForDecoder:     false,
@@ -1195,7 +1199,7 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			name:                         "prefiller TLS only",
 			enableTLS:                    []string{"prefiller"},
 			tlsInsecureSkipVerify:        []string{},
-			vllmPort:                     "8001",
+			modelServerPort:              "8001",
 			expectedDecoderURL:           "http://localhost:8001",
 			expectedUseTLSForPrefiller:   true,
 			expectedUseTLSForDecoder:     false,
@@ -1206,7 +1210,7 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			name:                         "decoder TLS only",
 			enableTLS:                    []string{"decoder"},
 			tlsInsecureSkipVerify:        []string{},
-			vllmPort:                     "8001",
+			modelServerPort:              "8001",
 			expectedDecoderURL:           "https://localhost:8001",
 			expectedUseTLSForPrefiller:   false,
 			expectedUseTLSForDecoder:     true,
@@ -1217,7 +1221,7 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			name:                         "both stages TLS",
 			enableTLS:                    []string{"prefiller", "decoder"},
 			tlsInsecureSkipVerify:        []string{},
-			vllmPort:                     "9000",
+			modelServerPort:              "9000",
 			expectedDecoderURL:           "https://localhost:9000",
 			expectedUseTLSForPrefiller:   true,
 			expectedUseTLSForDecoder:     true,
@@ -1228,7 +1232,7 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			name:                         "TLS with insecure skip verify",
 			enableTLS:                    []string{"prefiller", "decoder"},
 			tlsInsecureSkipVerify:        []string{"prefiller", "decoder"},
-			vllmPort:                     "8001",
+			modelServerPort:              "8001",
 			expectedDecoderURL:           "https://localhost:8001",
 			expectedUseTLSForPrefiller:   true,
 			expectedUseTLSForDecoder:     true,
@@ -1242,7 +1246,7 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			opts := NewOptions()
 			opts.enableTLS = tt.enableTLS
 			opts.tlsInsecureSkipVerify = tt.tlsInsecureSkipVerify
-			opts.vllmPort = tt.vllmPort
+			opts.modelServerPort = tt.modelServerPort
 
 			err := opts.Complete()
 			if err != nil {

--- a/test/sidecar/config/base/pod-qwen.yaml
+++ b/test/sidecar/config/base/pod-qwen.yaml
@@ -8,7 +8,7 @@ spec:
       image: routing-proxy
       args:
         - "--port=8000"
-        - "--vllm-port=8001"
+        - "--model-server-port=8001"
       restartPolicy: Always
       # readinessProbe:
       #   exec:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- disagg-sidecar expose vllm specific flag name which should be model server neutral. add --model-server-port to replace --vllm-port which stays as a deprecated alias until final removal.
- update usage text on --data-parallel-size

**Which issue(s) this PR fixes**:
ref #https://github.com/llm-d/llm-d-router/issues/2039

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The pd-sidecar `--vllm-port` flag is deprecated in favor of the vendor-neutral `--model-server-port` and will be removed in a future release. `--vllm-port` continues to work as an alias meanwhile. The same rename applies to the sidecar YAML configuration key: `vllm-port` -> `model-server-port`.
```

cc @rahulgurnani
