### PR TITLE
epp: generalize endpoint identity

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -706,7 +706,7 @@ func makePodListFunc(ds datastore.Datastore) func() []types.NamespacedName {
 		names := make([]types.NamespacedName, 0, len(pods))
 
 		for _, p := range pods {
-			names = append(names, p.GetMetadata().NamespacedName)
+			names = append(names, p.GetMetadata().ID)
 		}
 		return names
 	}

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -105,7 +105,7 @@ type EndpointDiscovery interface {
 type DiscoveryNotifier interface {
     // Upsert adds or updates an endpoint in the datastore.
     Upsert(endpoint *EndpointMetadata)
-    // Delete removes an endpoint by its namespaced name.
+    // Delete removes an endpoint by its ID.
     Delete(id types.NamespacedName)
 }
 ```
@@ -114,7 +114,7 @@ type DiscoveryNotifier interface {
 
 | Field | Type | Description |
 |---|---|---|
-| `NamespacedName` | `types.NamespacedName` | Unique identity of the endpoint. |
+| `ID` | `types.NamespacedName` | Unique identity of the endpoint. Each discovery source must set it uniquely across the endpoints it reports. |
 | `Name` | `string` | Name of the workload behind the endpoint. |
 | `Address` | `string` | IP address of the inference server. |
 | `Port` | `string` | Port as a string (e.g. `"8000"`). |
@@ -555,9 +555,9 @@ func (d *MyDiscovery) TypedName() fwkplugin.TypedName { return d.typedName }
 func (d *MyDiscovery) Start(ctx context.Context, notifier fwkdl.DiscoveryNotifier) error {
     // 1. Enumerate existing endpoints.
     notifier.Upsert(&fwkdl.EndpointMetadata{
-        NamespacedName: types.NamespacedName{Name: "ep0", Namespace: "default"},
-        Address:        "10.0.0.1",
-        Port:           "8000",
+        ID:      types.NamespacedName{Name: "ep0", Namespace: "default"},
+        Address: "10.0.0.1",
+        Port:    "8000",
         MetricsHost:    "10.0.0.1:8000",
     })
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -115,7 +115,7 @@ type DiscoveryNotifier interface {
 | Field | Type | Description |
 |---|---|---|
 | `NamespacedName` | `types.NamespacedName` | Unique identity of the endpoint. |
-| `PodName` | `string` | Logical name (used in metrics). |
+| `Name` | `string` | Name of the workload behind the endpoint. |
 | `Address` | `string` | IP address of the inference server. |
 | `Port` | `string` | Port as a string (e.g. `"8000"`). |
 | `MetricsHost` | `string` | `host:port` for metrics scraping. Defaults to `address:port` if empty. |

--- a/pkg/epp/controller/inferencepool_reconciler_test.go
+++ b/pkg/epp/controller/inferencepool_reconciler_test.go
@@ -204,7 +204,7 @@ func diffStore(store datastore.Datastore, params diffStoreParams) string {
 	}
 	gotEndpoints := []string{}
 	for _, em := range store.PodList(datastore.AllPodsPredicate) {
-		gotEndpoints = append(gotEndpoints, em.GetMetadata().NamespacedName.Name)
+		gotEndpoints = append(gotEndpoints, em.GetMetadata().ID.Name)
 	}
 	if diff := cmp.Diff(params.wantEndpoints, gotEndpoints, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 		return "endpoints:" + diff

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -219,7 +219,7 @@ func TestPodReconciler(t *testing.T) {
 				gotPods := make([]*corev1.Pod, len(podList))
 				for idx, pm := range podList {
 					gotPods[idx] = &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().PodName, Namespace: pm.GetMetadata().NamespacedName.Namespace},
+						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().Name, Namespace: pm.GetMetadata().NamespacedName.Namespace},
 						Status:     corev1.PodStatus{PodIP: pm.GetMetadata().GetIPAddress()},
 					}
 				}

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -219,7 +219,7 @@ func TestPodReconciler(t *testing.T) {
 				gotPods := make([]*corev1.Pod, len(podList))
 				for idx, pm := range podList {
 					gotPods[idx] = &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().Name, Namespace: pm.GetMetadata().NamespacedName.Namespace},
+						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().Name, Namespace: pm.GetMetadata().ID.Namespace},
 						Status:     corev1.PodStatus{PodIP: pm.GetMetadata().GetIPAddress()},
 					}
 				}

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -38,7 +38,7 @@ import (
 
 func defaultEndpoint() fwkdl.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{
+		ID: types.NamespacedName{
 			Name:      "pod-name",
 			Namespace: "default",
 		},

--- a/pkg/epp/datalayer/factory_test.go
+++ b/pkg/epp/datalayer/factory_test.go
@@ -31,7 +31,7 @@ func TestFactory(t *testing.T) {
 	runtime := NewTestRuntime(t, 100*time.Millisecond)
 
 	pod1 := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{
+		ID: types.NamespacedName{
 			Name:      "pod1",
 			Namespace: "default",
 		},
@@ -44,7 +44,7 @@ func TestFactory(t *testing.T) {
 	assert.Nil(t, dup, "expected to fail to create a duplicate collector")
 
 	pod2 := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{
+		ID: types.NamespacedName{
 			Name:      "pod2",
 			Namespace: "default",
 		},

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -84,10 +84,10 @@ func TestLogger(t *testing.T) {
 
 	logOutput := b.read()
 	assert.Contains(t, logOutput, "Refreshing Prometheus Metrics	{\"ReadyPods\": 2}")
-	assert.Contains(t, logOutput, "Current Pods and metrics gathered	{\"Fresh metrics\": \"[Metadata: {NamespacedName:default/pod1 PodName: Address:1.2.3.4:5678")
+	assert.Contains(t, logOutput, "Current Pods and metrics gathered	{\"Fresh metrics\": \"[Metadata: {NamespacedName:default/pod1 Name: Address:1.2.3.4:5678")
 	assert.Contains(t, logOutput, "Metrics: {ActiveModels:map[modelA:1] WaitingModels:map[modelB:2] MaxActiveModels:5")
 	assert.Contains(t, logOutput, "RunningRequestsSize:3 WaitingQueueSize:7 KVCacheUsagePercent:42.5 KvCacheMaxTokenCapacity:2048")
-	assert.Contains(t, logOutput, "Metadata: {NamespacedName:default/pod2 PodName: Address:1.2.3.4:5679")
+	assert.Contains(t, logOutput, "Metadata: {NamespacedName:default/pod2 Name: Address:1.2.3.4:5679")
 	assert.Contains(t, logOutput, "\"Stale metrics\": \"[]\"")
 }
 

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -84,10 +84,10 @@ func TestLogger(t *testing.T) {
 
 	logOutput := b.read()
 	assert.Contains(t, logOutput, "Refreshing Prometheus Metrics	{\"ReadyPods\": 2}")
-	assert.Contains(t, logOutput, "Current Pods and metrics gathered	{\"Fresh metrics\": \"[Metadata: {NamespacedName:default/pod1 Name: Address:1.2.3.4:5678")
+	assert.Contains(t, logOutput, "Current Pods and metrics gathered	{\"Fresh metrics\": \"[Metadata: {ID:default/pod1 Name: Address:1.2.3.4:5678")
 	assert.Contains(t, logOutput, "Metrics: {ActiveModels:map[modelA:1] WaitingModels:map[modelB:2] MaxActiveModels:5")
 	assert.Contains(t, logOutput, "RunningRequestsSize:3 WaitingQueueSize:7 KVCacheUsagePercent:42.5 KvCacheMaxTokenCapacity:2048")
-	assert.Contains(t, logOutput, "Metadata: {NamespacedName:default/pod2 Name: Address:1.2.3.4:5679")
+	assert.Contains(t, logOutput, "Metadata: {ID:default/pod2 Name: Address:1.2.3.4:5679")
 	assert.Contains(t, logOutput, "\"Stale metrics\": \"[]\"")
 }
 
@@ -221,14 +221,14 @@ func (f *FakeOddMetricsDataStore) PodList(predicate func(fwkdl.Endpoint) bool) [
 }
 
 var pod1 = &fwkdl.EndpointMetadata{
-	NamespacedName: types.NamespacedName{
+	ID: types.NamespacedName{
 		Name:      "pod1",
 		Namespace: "default",
 	},
 	Address: "1.2.3.4:5678",
 }
 var pod2 = &fwkdl.EndpointMetadata{
-	NamespacedName: types.NamespacedName{
+	ID: types.NamespacedName{
 		Name:      "pod2",
 		Namespace: "default",
 	},

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -405,7 +405,7 @@ func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
 // NewEndpoint sets up data polling on the provided endpoint.
 func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.EndpointMetadata) fwkdl.Endpoint {
 	logger, _ := logr.FromContext(ctx)
-	logger = logger.WithValues("endpoint", endpointMetadata.GetNamespacedName())
+	logger = logger.WithValues("endpoint", endpointMetadata.GetID())
 
 	endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
 
@@ -424,7 +424,7 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 
 	collector := NewCollector()
 
-	key := endpointMetadata.GetNamespacedName()
+	key := endpointMetadata.GetID()
 	if !r.collectors.Register(key, collector) {
 		logger.V(logging.DEFAULT).Info("collector already running for endpoint", "endpoint", key)
 		return nil
@@ -445,7 +445,7 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 	r.dispatchEndpointEvent(context.Background(), r.logger, fwkdl.EndpointEvent{Type: fwkdl.EventDelete, Endpoint: ep})
 
-	key := ep.GetMetadata().GetNamespacedName()
+	key := ep.GetMetadata().GetID()
 	if collector, ok := r.collectors.Remove(key); ok {
 		collector.Stop()
 	}
@@ -454,7 +454,7 @@ func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
 // UpdateEndpoint dispatches an add/update lifecycle event for an existing endpoint.
 func (r *Runtime) UpdateEndpoint(ctx context.Context, ep fwkdl.Endpoint) {
 	logger, _ := logr.FromContext(ctx)
-	logger = logger.WithValues("endpoint", ep.GetMetadata().GetNamespacedName())
+	logger = logger.WithValues("endpoint", ep.GetMetadata().GetID())
 	r.dispatchEndpointEvent(ctx, logger, fwkdl.EndpointEvent{Type: fwkdl.EventAddOrUpdate, Endpoint: ep})
 }
 

--- a/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
+++ b/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
@@ -51,8 +51,8 @@ func TestNewEndpointDispatchesEventWithNoPollers(t *testing.T) {
 	assert.NoError(t, r.Configure(cfg, logger))
 
 	pod := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
-		Address:        "1.2.3.4:5678",
+		ID:      types.NamespacedName{Name: "pod1", Namespace: "default"},
+		Address: "1.2.3.4:5678",
 	}
 
 	endpoint := r.NewEndpoint(context.Background(), pod)
@@ -86,12 +86,12 @@ func TestUpdateEndpointDispatchesEvent(t *testing.T) {
 	require.NoError(t, r.Configure(cfg, logger))
 
 	endpoint := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
-		Address:        "1.2.3.4",
+		ID:      types.NamespacedName{Name: "pod1", Namespace: "default"},
+		Address: "1.2.3.4",
 	}, nil)
 	endpoint.UpdateMetadata(&fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
-		Address:        "5.6.7.8",
+		ID:      types.NamespacedName{Name: "pod1", Namespace: "default"},
+		Address: "5.6.7.8",
 	})
 
 	r.UpdateEndpoint(context.Background(), endpoint)

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -335,14 +335,14 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 		}
 		pods = append(pods,
 			&fwkdl.EndpointMetadata{
-				NamespacedName: createEndpointNamespacedName(pod, idx),
-				Name:           pod.Name,
-				Address:        pod.Status.PodIP,
-				NodeAddress:    pod.Status.HostIP,
-				Port:           strconv.Itoa(port),
-				MetricsHost:    net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(port)),
-				Labels:         labels,
-				RankIndex:      idx,
+				ID:          createEndpointNamespacedName(pod, idx),
+				Name:        pod.Name,
+				Address:     pod.Status.PodIP,
+				NodeAddress: pod.Status.HostIP,
+				Port:        strconv.Itoa(port),
+				MetricsHost: net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(port)),
+				Labels:      labels,
+				RankIndex:   idx,
 			})
 	}
 
@@ -356,7 +356,7 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 	var errs []error
 	existingEpSet := sets.Set[types.NamespacedName]{}
 	for _, endpointMetadata := range pods {
-		existingEpSet.Insert(endpointMetadata.NamespacedName)
+		existingEpSet.Insert(endpointMetadata.ID)
 		created, err := ds.upsertEndpoint(ctx, endpointMetadata)
 		if err != nil {
 			errs = append(errs, err)
@@ -404,7 +404,7 @@ func (ds *datastore) PodDelete(podName string) {
 
 func (ds *datastore) EndpointUpsert(ctx context.Context, meta *fwkdl.EndpointMetadata) {
 	if _, err := ds.upsertEndpoint(ctx, meta); err != nil {
-		log.FromContext(ctx).Error(err, "failed to register endpoint", "endpoint", meta.NamespacedName)
+		log.FromContext(ctx).Error(err, "failed to register endpoint", "endpoint", meta.ID)
 	}
 }
 
@@ -426,7 +426,7 @@ func (ds *datastore) EndpointDelete(id types.NamespacedName) {
 // or the collector failed to start), the endpoint is untracked and the caller must retry.
 func (ds *datastore) upsertEndpoint(ctx context.Context, meta *fwkdl.EndpointMetadata) (bool, error) {
 	for {
-		if existing, ok := ds.pods.Load(meta.NamespacedName); ok {
+		if existing, ok := ds.pods.Load(meta.ID); ok {
 			ep := existing.(fwkdl.Endpoint)
 			if ep.GetMetadata().Equal(meta) {
 				return false, nil
@@ -437,14 +437,14 @@ func (ds *datastore) upsertEndpoint(ctx context.Context, meta *fwkdl.EndpointMet
 		}
 		ep := ds.epf.NewEndpoint(ds.parentCtx, meta)
 		if ep == nil {
-			if _, ok := ds.pods.Load(meta.NamespacedName); ok {
+			if _, ok := ds.pods.Load(meta.ID); ok {
 				// A concurrent upsert won the registration; apply this call's metadata through
 				// the update path above.
 				continue
 			}
-			return false, fmt.Errorf("endpoint %s: %w", meta.NamespacedName, errRegistrationDropped)
+			return false, fmt.Errorf("endpoint %s: %w", meta.ID, errRegistrationDropped)
 		}
-		ds.pods.Store(meta.NamespacedName, ep)
+		ds.pods.Store(meta.ID, ep)
 		return true, nil
 	}
 }
@@ -480,7 +480,7 @@ func (ds *datastore) podResyncAll(ctx context.Context, reader client.Reader) err
 	// Remove endpoints that don't belong to the pool, are not ready, or are orphaned ranks.
 	ds.pods.Range(func(k, v any) bool {
 		ep := v.(fwkdl.Endpoint)
-		endpointName := ep.GetMetadata().NamespacedName
+		endpointName := ep.GetMetadata().ID
 		if !activeEndpoints.Has(endpointName) {
 			logger.V(logutil.VERBOSE).Info("Removing endpoint", "endpoint", endpointName)
 			ds.pods.Delete(k)

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -336,7 +336,7 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 		pods = append(pods,
 			&fwkdl.EndpointMetadata{
 				NamespacedName: createEndpointNamespacedName(pod, idx),
-				PodName:        pod.Name,
+				Name:           pod.Name,
 				Address:        pod.Status.PodIP,
 				NodeAddress:    pod.Status.HostIP,
 				Port:           strconv.Itoa(port),
@@ -394,7 +394,7 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 func (ds *datastore) PodDelete(podName string) {
 	ds.pods.Range(func(k, v any) bool {
 		ep := v.(fwkdl.Endpoint)
-		if ep.GetMetadata().PodName == podName {
+		if ep.GetMetadata().Name == podName {
 			ds.pods.Delete(k)
 			ds.epf.ReleaseEndpoint(ep)
 		}

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -514,7 +514,7 @@ func TestPods(t *testing.T) {
 				gotPods := make([]*corev1.Pod, len(podList))
 				for idx, pm := range podList {
 					gotPods[idx] = &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().PodName, Namespace: pm.GetMetadata().NamespacedName.Namespace},
+						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().Name, Namespace: pm.GetMetadata().NamespacedName.Namespace},
 						Status: corev1.PodStatus{
 							PodIP:  pm.GetMetadata().GetIPAddress(),
 							HostIP: pm.GetMetadata().GetNodeAddress(),
@@ -659,7 +659,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod1.Namespace,
 					},
 
-					PodName:     pod1.Name,
+					Name:        pod1.Name,
 					Address:     pod1.Status.PodIP,
 					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolTargetPort,
@@ -682,7 +682,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod1.Namespace,
 					},
 
-					PodName:     pod1.Name,
+					Name:        pod1.Name,
 					Address:     pod1.Status.PodIP,
 					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
@@ -695,7 +695,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod1.Namespace,
 					},
 
-					PodName:     pod1.Name,
+					Name:        pod1.Name,
 					Address:     pod1.Status.PodIP,
 					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,
@@ -719,7 +719,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod1.Namespace,
 					},
 
-					PodName:     pod1.Name,
+					Name:        pod1.Name,
 					Address:     pod1.Status.PodIP,
 					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
@@ -732,7 +732,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod1.Namespace,
 					},
 
-					PodName:     pod1.Name,
+					Name:        pod1.Name,
 					Address:     pod1.Status.PodIP,
 					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,
@@ -746,7 +746,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod2.Namespace,
 					},
 
-					PodName:     pod2.Name,
+					Name:        pod2.Name,
 					Address:     pod2.Status.PodIP,
 					NodeAddress: pod2.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
@@ -759,7 +759,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod2.Namespace,
 					},
 
-					PodName:     pod2.Name,
+					Name:        pod2.Name,
 					Address:     pod2.Status.PodIP,
 					NodeAddress: pod2.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,
@@ -783,7 +783,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod1.Namespace,
 					},
 
-					PodName:     pod1.Name,
+					Name:        pod1.Name,
 					Address:     pod1.Status.PodIP,
 					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort0,
@@ -796,7 +796,7 @@ func TestEndpointMetadata(t *testing.T) {
 						Namespace: pod1.Namespace,
 					},
 
-					PodName:     pod1.Name,
+					Name:        pod1.Name,
 					Address:     pod1.Status.PodIP,
 					NodeAddress: pod1.Status.HostIP,
 					Port:        inferencePoolMultiTargetPort1,

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -514,7 +514,7 @@ func TestPods(t *testing.T) {
 				gotPods := make([]*corev1.Pod, len(podList))
 				for idx, pm := range podList {
 					gotPods[idx] = &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().Name, Namespace: pm.GetMetadata().NamespacedName.Namespace},
+						ObjectMeta: metav1.ObjectMeta{Name: pm.GetMetadata().Name, Namespace: pm.GetMetadata().ID.Namespace},
 						Status: corev1.PodStatus{
 							PodIP:  pm.GetMetadata().GetIPAddress(),
 							HostIP: pm.GetMetadata().GetNodeAddress(),
@@ -631,7 +631,7 @@ func TestTargetPortsChange(t *testing.T) {
 				// Verify endpoint names
 				gotNames := make([]string, 0, len(finalEndpoints))
 				for _, ep := range finalEndpoints {
-					gotNames = append(gotNames, ep.GetMetadata().NamespacedName.Name)
+					gotNames = append(gotNames, ep.GetMetadata().ID.Name)
 				}
 				if diff := cmp.Diff(test.wantEndpointNames, gotNames, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 					t.Errorf("Endpoint names mismatch (-want +got):\n%s", diff)
@@ -654,7 +654,7 @@ func TestEndpointMetadata(t *testing.T) {
 			existingPods: []*corev1.Pod{},
 			wantEndpointMetas: []*fwkdl.EndpointMetadata{
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod1.Name + "-rank-0",
 						Namespace: pod1.Namespace,
 					},
@@ -677,7 +677,7 @@ func TestEndpointMetadata(t *testing.T) {
 			existingPods: []*corev1.Pod{},
 			wantEndpointMetas: []*fwkdl.EndpointMetadata{
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod1.Name + "-rank-0",
 						Namespace: pod1.Namespace,
 					},
@@ -690,7 +690,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Labels:      map[string]string{},
 				},
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod1.Name + "-rank-1",
 						Namespace: pod1.Namespace,
 					},
@@ -714,7 +714,7 @@ func TestEndpointMetadata(t *testing.T) {
 			existingPods: []*corev1.Pod{pod1},
 			wantEndpointMetas: []*fwkdl.EndpointMetadata{
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod1.Name + "-rank-0",
 						Namespace: pod1.Namespace,
 					},
@@ -727,7 +727,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Labels:      map[string]string{},
 				},
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod1.Name + "-rank-1",
 						Namespace: pod1.Namespace,
 					},
@@ -741,7 +741,7 @@ func TestEndpointMetadata(t *testing.T) {
 					RankIndex:   1,
 				},
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod2.Name + "-rank-0",
 						Namespace: pod2.Namespace,
 					},
@@ -754,7 +754,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Labels:      map[string]string{},
 				},
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod2.Name + "-rank-1",
 						Namespace: pod2.Namespace,
 					},
@@ -778,7 +778,7 @@ func TestEndpointMetadata(t *testing.T) {
 			existingPods: []*corev1.Pod{pod1, pod2},
 			wantEndpointMetas: []*fwkdl.EndpointMetadata{
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod1.Name + "-rank-0",
 						Namespace: pod1.Namespace,
 					},
@@ -791,7 +791,7 @@ func TestEndpointMetadata(t *testing.T) {
 					Labels:      map[string]string{},
 				},
 				{
-					NamespacedName: types.NamespacedName{
+					ID: types.NamespacedName{
 						Name:      pod1.Name + "-rank-1",
 						Namespace: pod1.Namespace,
 					},
@@ -835,7 +835,7 @@ func TestEndpointMetadata(t *testing.T) {
 				for idx, pm := range podList {
 					gotMetadata[idx] = pm.GetMetadata()
 				}
-				if diff := cmp.Diff(test.wantEndpointMetas, gotMetadata, cmpopts.SortSlices(func(a, b *fwkdl.EndpointMetadata) bool { return a.NamespacedName.Name < b.NamespacedName.Name })); diff != "" {
+				if diff := cmp.Diff(test.wantEndpointMetas, gotMetadata, cmpopts.SortSlices(func(a, b *fwkdl.EndpointMetadata) bool { return a.ID.Name < b.ID.Name })); diff != "" {
 					t.Errorf("ConvertTo() mismatch (-want +got):\n%s", diff)
 				}
 			})
@@ -998,7 +998,7 @@ func TestActivePortFiltering(t *testing.T) {
 				if test.wantEndpointNames != nil {
 					gotNames := make([]string, 0, len(finalEndpoints))
 					for _, ep := range finalEndpoints {
-						gotNames = append(gotNames, ep.GetMetadata().NamespacedName.Name)
+						gotNames = append(gotNames, ep.GetMetadata().ID.Name)
 					}
 					if diff := cmp.Diff(test.wantEndpointNames, gotNames, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 						t.Errorf("Endpoint names mismatch (-want +got):\n%s", diff)
@@ -1391,7 +1391,7 @@ func TestEndpointUpsert_NewEndpoint(t *testing.T) {
 	ds := NewDatastore(ctx, &mockEndpointFactory{})
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr, Port: port})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr, Port: port})
 
 	eps := ds.PodList(AllPodsPredicate)
 	assert.Len(t, eps, 1)
@@ -1404,8 +1404,8 @@ func TestEndpointUpsert_UpdateExisting(t *testing.T) {
 	ds := NewDatastore(ctx, &mockEndpointFactory{})
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr1})
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr2})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr1})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr2})
 
 	eps := ds.PodList(AllPodsPredicate)
 	assert.Len(t, eps, 1)
@@ -1419,16 +1419,16 @@ func TestEndpointUpsert_UpdateExistingNotifiesEndpointFactory(t *testing.T) {
 	ds := NewDatastore(ctx, factory)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr1})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr1})
 	assert.Empty(t, factory.updateEvents())
 
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr2})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr2})
 
 	updates := factory.updateEvents()
 	assert.Len(t, updates, 1)
 	assert.Equal(t, addr2, updates[0].GetMetadata().Address)
 
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr2})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr2})
 	assert.Len(t, factory.updateEvents(), 1)
 }
 
@@ -1439,8 +1439,8 @@ func TestEndpointUpsert_SemanticallyEqualMetadataDoesNotNotify(t *testing.T) {
 	ds := NewDatastore(ctx, factory)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr, Labels: nil})
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: addr, Labels: map[string]string{}})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr, Labels: nil})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id, Address: addr, Labels: map[string]string{}})
 
 	assert.Empty(t, factory.updateEvents())
 }
@@ -1448,7 +1448,7 @@ func TestEndpointUpsert_SemanticallyEqualMetadataDoesNotNotify(t *testing.T) {
 func TestEndpointUpsert_NewEndpointFactoryReturnsNil(t *testing.T) {
 	ctx := context.Background()
 	ds := NewDatastore(ctx, &mockEndpointFactory{returnNil: true})
-	meta := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Name: "ep1", Namespace: "default"}}
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "ep1", Namespace: "default"}}
 
 	assert.NotPanics(t, func() { ds.EndpointUpsert(ctx, meta) })
 	assert.Empty(t, ds.PodList(AllPodsPredicate))
@@ -1459,7 +1459,7 @@ func TestEndpointDelete_Existing(t *testing.T) {
 	ds := NewDatastore(ctx, &mockEndpointFactory{})
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: id})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: id})
 	assert.Len(t, ds.PodList(AllPodsPredicate), 1)
 
 	ds.EndpointDelete(id)
@@ -1534,14 +1534,14 @@ func TestUpsertEndpoint_ConcurrentStoreDuringNilAppliesMetadata(t *testing.T) {
 	var ds *datastore
 	factory := &datalayer.FakeEndpointFactory{
 		NewEndpointFn: func(_ context.Context, _ *fwkdl.EndpointMetadata) fwkdl.Endpoint {
-			staleMeta := &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.1"}
+			staleMeta := &fwkdl.EndpointMetadata{ID: id, Address: "10.0.0.1"}
 			ds.pods.Store(id, fwkdl.NewEndpoint(staleMeta, fwkdl.NewMetrics()))
 			return nil
 		},
 	}
 	ds = NewDatastore(ctx, factory).(*datastore)
 
-	created, err := ds.upsertEndpoint(ctx, &fwkdl.EndpointMetadata{NamespacedName: id, Address: "10.0.0.2"})
+	created, err := ds.upsertEndpoint(ctx, &fwkdl.EndpointMetadata{ID: id, Address: "10.0.0.2"})
 
 	require.NoError(t, err)
 	assert.False(t, created)
@@ -1565,17 +1565,17 @@ func TestDatastore_ConcurrentAddRemoveCompleteness(t *testing.T) {
 		NewEndpointFn: func(_ context.Context, meta *fwkdl.EndpointMetadata) fwkdl.Endpoint {
 			mu.Lock()
 			defer mu.Unlock()
-			if registered[meta.NamespacedName] {
+			if registered[meta.ID] {
 				return nil
 			}
-			registered[meta.NamespacedName] = true
+			registered[meta.ID] = true
 			return fwkdl.NewEndpoint(meta, fwkdl.NewMetrics())
 		},
 		ReleaseEndpointFn: func(ep fwkdl.Endpoint) {
 			time.Sleep(50 * time.Microsecond)
 			mu.Lock()
 			defer mu.Unlock()
-			delete(registered, ep.GetMetadata().NamespacedName)
+			delete(registered, ep.GetMetadata().ID)
 		},
 	}
 	ds := NewDatastore(ctx, factory)
@@ -1610,12 +1610,12 @@ func TestDiscoveryNotifier_WorksAlongsideDirectUpsert(t *testing.T) {
 
 	// Populate one endpoint directly (simulates the K8s reconciler path).
 	directID := types.NamespacedName{Name: "direct-ep", Namespace: "default"}
-	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{NamespacedName: directID, Address: "10.0.0.1"})
+	ds.EndpointUpsert(ctx, &fwkdl.EndpointMetadata{ID: directID, Address: "10.0.0.1"})
 
 	// Add a second endpoint via DiscoveryNotifier (the file-discovery path).
 	notifier := fwkdl.NewDiscoveryNotifier(ds)
 	notifID := types.NamespacedName{Name: "notif-ep", Namespace: "default"}
-	notifier.Upsert(&fwkdl.EndpointMetadata{NamespacedName: notifID, Address: "10.0.0.2"})
+	notifier.Upsert(&fwkdl.EndpointMetadata{ID: notifID, Address: "10.0.0.2"})
 
 	// Both endpoints must coexist.
 	assert.Len(t, ds.PodList(AllPodsPredicate), 2)

--- a/pkg/epp/flowcontrol/benchmark/helpers_test.go
+++ b/pkg/epp/flowcontrol/benchmark/helpers_test.go
@@ -350,7 +350,7 @@ func setupFullPathBenchmark(ctx context.Context, b *testing.B, name string, numP
 	realDetector := detectorPlugin.(flowcontrol.SaturationDetector)
 
 	epMeta := &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "default"},
+		ID: k8stypes.NamespacedName{Name: "pod-1", Namespace: "default"},
 	}
 	ep := fwkdl.NewEndpoint(epMeta, fwkdl.NewMetrics())
 	if err := producer.Extract(ctx, fwkdl.EndpointEvent{

--- a/pkg/epp/flowcontrol/integration_helpers_test.go
+++ b/pkg/epp/flowcontrol/integration_helpers_test.go
@@ -210,7 +210,7 @@ func newProducerAndDetector(ctx context.Context, t *testing.T, maxConcurrency in
 	det := detectorPlugin.(flowcontrol.SaturationDetector)
 
 	epMeta := &datalayer.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod-1", Namespace: "default"},
+		ID: types.NamespacedName{Name: "pod-1", Namespace: "default"},
 	}
 	ep := datalayer.NewEndpoint(epMeta, datalayer.NewMetrics())
 	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -626,9 +626,9 @@ func TestEvictionPipeline(t *testing.T) {
 	)
 
 	epMeta := &datalayer.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod-1", Namespace: "default"},
-		Address:        "10.0.0.1",
-		Port:           "8000",
+		ID:      types.NamespacedName{Name: "pod-1", Namespace: "default"},
+		Address: "10.0.0.1",
+		Port:    "8000",
 	}
 	schedEndpoint := fwksched.NewEndpoint(epMeta, datalayer.NewMetrics(), nil)
 	makeResult := func() *fwksched.SchedulingResult {
@@ -973,7 +973,7 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 	detector := detectorPlugin.(flowcontrol.SaturationDetector)
 
 	epMeta := &datalayer.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod-1", Namespace: "default"},
+		ID: types.NamespacedName{Name: "pod-1", Namespace: "default"},
 	}
 	ep := datalayer.NewEndpoint(epMeta, datalayer.NewMetrics())
 	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{
@@ -1028,7 +1028,7 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 		"old request completion should not affect re-registered endpoint's tracker")
 
 	// Verify the deleted endpoint's tracker is clean.
-	eid := epMeta.NamespacedName.String()
+	eid := epMeta.ID.String()
 	require.Equal(t, int64(0), producer.GetRequests(eid),
 		"deleted endpoint tracker should report 0 requests")
 
@@ -1085,7 +1085,7 @@ func TestEndpointIdentityCollisionDuringPodReplacement(t *testing.T) {
 	detector := detectorPlugin.(flowcontrol.SaturationDetector)
 
 	epMeta := &datalayer.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod-1", Namespace: "default"},
+		ID: types.NamespacedName{Name: "pod-1", Namespace: "default"},
 	}
 
 	oldEp := datalayer.NewEndpoint(epMeta, datalayer.NewMetrics())

--- a/pkg/epp/framework/interface/datalayer/discovery_test.go
+++ b/pkg/epp/framework/interface/datalayer/discovery_test.go
@@ -42,8 +42,8 @@ func TestNewDiscoveryNotifier_Upsert(t *testing.T) {
 	store := &fakeStore{}
 	notifier := NewDiscoveryNotifier(store)
 	meta := &EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "ep1", Namespace: "default"},
-		Address:        "10.0.0.1",
+		ID:      types.NamespacedName{Name: "ep1", Namespace: "default"},
+		Address: "10.0.0.1",
 	}
 
 	notifier.Upsert(meta)
@@ -70,7 +70,7 @@ func TestNewDiscoveryNotifier_UpsertThenDelete(t *testing.T) {
 	notifier := NewDiscoveryNotifier(store)
 	id := types.NamespacedName{Name: "ep1", Namespace: "default"}
 
-	notifier.Upsert(&EndpointMetadata{NamespacedName: id})
+	notifier.Upsert(&EndpointMetadata{ID: id})
 	notifier.Delete(id)
 
 	assert.Len(t, store.upserted, 1)

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -23,10 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// EndpointMetadata represents the relevant Kubernetes Pod state of an inference server.
+// EndpointMetadata describes an inference endpoint.
 type EndpointMetadata struct {
 	NamespacedName types.NamespacedName
-	PodName        string
+	Name           string
 	Address        string
 	// NodeAddress is the node IP hosting this pod (pod.Status.HostIP).
 	// Empty for non-Kubernetes discovery sources (e.g. file discovery).
@@ -60,7 +60,7 @@ func (epm *EndpointMetadata) Clone() *EndpointMetadata {
 			Name:      epm.NamespacedName.Name,
 			Namespace: epm.NamespacedName.Namespace,
 		},
-		PodName:     epm.PodName,
+		Name:        epm.Name,
 		Address:     epm.Address,
 		NodeAddress: epm.NodeAddress,
 		Port:        epm.Port,
@@ -77,7 +77,7 @@ func (epm *EndpointMetadata) Equal(other *EndpointMetadata) bool {
 		return epm == other
 	}
 	return epm.NamespacedName == other.NamespacedName &&
-		epm.PodName == other.PodName &&
+		epm.Name == other.Name &&
 		epm.Address == other.Address &&
 		epm.NodeAddress == other.NodeAddress &&
 		epm.Port == other.Port &&

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -23,11 +23,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// ID uniquely identifies an endpoint. It aliases types.NamespacedName so the identity
+// can later move off the Kubernetes-specific type without churning datastore keys.
+// Every discovery source must set it uniquely.
+type ID = types.NamespacedName
+
 // EndpointMetadata describes an inference endpoint.
 type EndpointMetadata struct {
-	NamespacedName types.NamespacedName
-	Name           string
-	Address        string
+	// ID is the endpoint's unique identity, and the datastore key.
+	ID      ID
+	Name    string
+	Address string
 	// NodeAddress is the node IP hosting this pod (pod.Status.HostIP).
 	// Empty for non-Kubernetes discovery sources (e.g. file discovery).
 	NodeAddress string
@@ -56,9 +62,9 @@ func (epm *EndpointMetadata) Clone() *EndpointMetadata {
 	clonedLabels := make(map[string]string, len(epm.Labels))
 	maps.Copy(clonedLabels, epm.Labels)
 	return &EndpointMetadata{
-		NamespacedName: types.NamespacedName{
-			Name:      epm.NamespacedName.Name,
-			Namespace: epm.NamespacedName.Namespace,
+		ID: types.NamespacedName{
+			Name:      epm.ID.Name,
+			Namespace: epm.ID.Namespace,
 		},
 		Name:        epm.Name,
 		Address:     epm.Address,
@@ -76,7 +82,7 @@ func (epm *EndpointMetadata) Equal(other *EndpointMetadata) bool {
 	if epm == nil || other == nil {
 		return epm == other
 	}
-	return epm.NamespacedName == other.NamespacedName &&
+	return epm.ID == other.ID &&
 		epm.Name == other.Name &&
 		epm.Address == other.Address &&
 		epm.NodeAddress == other.NodeAddress &&
@@ -95,9 +101,9 @@ func (epm *EndpointMetadata) GetRankIndex() int {
 	return epm.RankIndex
 }
 
-// GetNamespacedName gets the namespace name of the Endpoint.
-func (epm *EndpointMetadata) GetNamespacedName() types.NamespacedName {
-	return epm.NamespacedName
+// GetID returns the endpoint's unique identity.
+func (epm *EndpointMetadata) GetID() ID {
+	return epm.ID
 }
 
 // GetIPAddress returns the Endpoint's IP address.

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata_test.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata_test.go
@@ -49,9 +49,9 @@ var (
 		},
 	}
 	expected = &EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: name, Namespace: namespace},
-		Address:        podip,
-		Labels:         labels,
+		ID:      types.NamespacedName{Name: name, Namespace: namespace},
+		Address: podip,
+		Labels:  labels,
 	}
 )
 
@@ -68,13 +68,13 @@ func TestEndpointMetadataClone(t *testing.T) {
 
 func TestEndpointMetadataEqual(t *testing.T) {
 	base := &EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "pod-a-rank-0", Namespace: "default"},
-		Name:           "pod-a",
-		Address:        "10.0.0.1",
-		Port:           "8000",
-		MetricsHost:    "10.0.0.1:9000",
-		Labels:         map[string]string{"app": "vllm"},
-		RankIndex:      1,
+		ID:          types.NamespacedName{Name: "pod-a-rank-0", Namespace: "default"},
+		Name:        "pod-a",
+		Address:     "10.0.0.1",
+		Port:        "8000",
+		MetricsHost: "10.0.0.1:9000",
+		Labels:      map[string]string{"app": "vllm"},
+		RankIndex:   1,
 	}
 
 	assert.True(t, base.Equal(base.Clone()))
@@ -95,7 +95,7 @@ func TestEndpointMetadataEqual(t *testing.T) {
 		{
 			name: "namespaced name",
 			mutate: func(meta *EndpointMetadata) {
-				meta.NamespacedName.Name = "pod-b-rank-0"
+				meta.ID.Name = "pod-b-rank-0"
 			},
 		},
 		{
@@ -147,7 +147,7 @@ func TestEndpointMetadataEqual(t *testing.T) {
 
 func TestEndpointMetadataString(t *testing.T) {
 	endpointMetadata := EndpointMetadata{
-		NamespacedName: types.NamespacedName{
+		ID: types.NamespacedName{
 			Name:      pod.Name,
 			Namespace: pod.Namespace,
 		},

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata_test.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata_test.go
@@ -69,7 +69,7 @@ func TestEndpointMetadataClone(t *testing.T) {
 func TestEndpointMetadataEqual(t *testing.T) {
 	base := &EndpointMetadata{
 		NamespacedName: types.NamespacedName{Name: "pod-a-rank-0", Namespace: "default"},
-		PodName:        "pod-a",
+		Name:           "pod-a",
 		Address:        "10.0.0.1",
 		Port:           "8000",
 		MetricsHost:    "10.0.0.1:9000",
@@ -99,9 +99,9 @@ func TestEndpointMetadataEqual(t *testing.T) {
 			},
 		},
 		{
-			name: "pod name",
+			name: "endpoint name",
 			mutate: func(meta *EndpointMetadata) {
-				meta.PodName = "pod-b"
+				meta.Name = "pod-b"
 			},
 		},
 		{
@@ -151,7 +151,7 @@ func TestEndpointMetadataString(t *testing.T) {
 			Name:      pod.Name,
 			Namespace: pod.Namespace,
 		},
-		PodName:     pod.Name,
+		Name:        pod.Name,
 		Address:     pod.Status.PodIP,
 		Port:        "8000",
 		MetricsHost: "127.0.0.1:8000",

--- a/pkg/epp/framework/interface/scheduling/types_test.go
+++ b/pkg/epp/framework/interface/scheduling/types_test.go
@@ -33,7 +33,7 @@ func (s cloneableString) Clone() fwkdl.Cloneable { return s }
 func newTestMetadata(name string) *fwkdl.EndpointMetadata {
 	return &fwkdl.EndpointMetadata{
 		NamespacedName: types.NamespacedName{Namespace: "ns", Name: name},
-		PodName:        name,
+		Name:           name,
 		Address:        "10.0.0.1",
 		Port:           "8000",
 		MetricsHost:    "10.0.0.1:9100",

--- a/pkg/epp/framework/interface/scheduling/types_test.go
+++ b/pkg/epp/framework/interface/scheduling/types_test.go
@@ -32,12 +32,12 @@ func (s cloneableString) Clone() fwkdl.Cloneable { return s }
 
 func newTestMetadata(name string) *fwkdl.EndpointMetadata {
 	return &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Namespace: "ns", Name: name},
-		Name:           name,
-		Address:        "10.0.0.1",
-		Port:           "8000",
-		MetricsHost:    "10.0.0.1:9100",
-		Labels:         map[string]string{"app": "inference"},
+		ID:          types.NamespacedName{Namespace: "ns", Name: name},
+		Name:        name,
+		Address:     "10.0.0.1",
+		Port:        "8000",
+		MetricsHost: "10.0.0.1:9100",
+		Labels:      map[string]string{"app": "inference"},
 	}
 }
 

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -251,14 +251,14 @@ func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 			ns = "default"
 		}
 		meta := &fwkdl.EndpointMetadata{
-			NamespacedName: types.NamespacedName{Name: e.Name, Namespace: ns},
-			Name:           e.Name,
-			Address:        e.Address,
-			Port:           e.Port,
-			MetricsHost:    net.JoinHostPort(e.Address, e.Port),
-			Labels:         e.Labels,
+			ID:          types.NamespacedName{Name: e.Name, Namespace: ns},
+			Name:        e.Name,
+			Address:     e.Address,
+			Port:        e.Port,
+			MetricsHost: net.JoinHostPort(e.Address, e.Port),
+			Labels:      e.Labels,
 		}
-		incoming[meta.NamespacedName] = struct{}{}
+		incoming[meta.ID] = struct{}{}
 		notifier.Upsert(meta)
 	}
 

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -252,7 +252,7 @@ func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 		}
 		meta := &fwkdl.EndpointMetadata{
 			NamespacedName: types.NamespacedName{Name: e.Name, Namespace: ns},
-			PodName:        e.Name,
+			Name:           e.Name,
 			Address:        e.Address,
 			Port:           e.Port,
 			MetricsHost:    net.JoinHostPort(e.Address, e.Port),

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
@@ -58,7 +58,7 @@ func (r *recordingNotifier) upsertedNames() []string {
 	defer r.mu.Unlock()
 	names := make([]string, len(r.upserted))
 	for i, m := range r.upserted {
-		names[i] = m.NamespacedName.String()
+		names[i] = m.ID.String()
 	}
 	return names
 }
@@ -164,7 +164,7 @@ endpoints:
 	cancel()
 
 	require.NoError(t, newFD(path, false).Start(ctx, notifier))
-	assert.Equal(t, "default", notifier.upserted[0].NamespacedName.Namespace)
+	assert.Equal(t, "default", notifier.upserted[0].ID.Namespace)
 }
 
 func TestStart_MetricsHostIsAddressPort(t *testing.T) {
@@ -283,7 +283,7 @@ endpoints:
 		notifier.mu.Lock()
 		defer notifier.mu.Unlock()
 		for _, m := range notifier.upserted {
-			if m.NamespacedName.Name == "ep3" {
+			if m.ID.Name == "ep3" {
 				return true
 			}
 		}

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/README.md
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/README.md
@@ -12,7 +12,7 @@ the generic `endpoint-attribute-filter` and `endpoint-attribute-scorer`
 1. Receives the parsed Prometheus metric families forwarded by `dcgm-data-source`.
 2. Looks up the `DCGM_FI_DEV_GPU_UTIL` metric family.
 3. Keeps samples that belong to this endpoint:
-   - If a sample has a `pod` label and the endpoint has a `PodName`, only
+   - If a sample has a `pod` label and the endpoint has a `Name`, only
      matching samples are kept (DaemonSet multi-pod payloads).
    - If the sample has no `pod` label, it is kept (sidecar / unlabeled payloads).
 4. Aggregates matching samples using `max` (highest-utilized GPU for the pod).

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
@@ -80,7 +80,7 @@ func (e *Extractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.
 
 	podName := ""
 	if meta := in.Endpoint.GetMetadata(); meta != nil {
-		podName = meta.PodName
+		podName = meta.Name
 	}
 
 	maxUtil := 0.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor_test.go
@@ -190,7 +190,7 @@ func TestExtractorExtract(t *testing.T) {
 				}
 			}()
 
-			meta := &fwkdl.EndpointMetadata{PodName: tt.podName}
+			meta := &fwkdl.EndpointMetadata{Name: tt.podName}
 			ep := fwkdl.NewEndpoint(meta, nil)
 			attr := ep.GetAttributes()
 			before, _ := attr.Get(key)

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -182,7 +182,7 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 		updated = true
 	}
 
-	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().NamespacedName)
+	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().ID)
 	if updated {
 		clone.UpdateTime = time.Now()
 		logger.V(logutil.TRACE).Info("Refreshed metrics",

--- a/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
@@ -90,7 +90,7 @@ type TopologyExtractor struct {
 	// mu guards endpoints and hostnames.
 	mu sync.Mutex
 	// endpoints maps pod identity to all live Endpoints for that pod.
-	// Outer key: {PodName, Namespace}; inner key: endpoint NamespacedName.
+	// Outer key: {Name, Namespace}; inner key: endpoint NamespacedName.
 	// One pod may have N rank endpoints, each with a distinct inner key.
 	// Only endpoints whose hostname label was absent are tracked here.
 	endpoints map[types.NamespacedName]map[types.NamespacedName]fwkdl.Endpoint
@@ -168,7 +168,7 @@ func (e *TopologyExtractor) RegisterDependencies(r fwkdl.Registrar) error {
 // podKey returns the pod identity key from endpoint metadata.
 // One pod may produce multiple endpoints (one per rank), all sharing the same key.
 func podKey(meta *fwkdl.EndpointMetadata) types.NamespacedName {
-	return types.NamespacedName{Name: meta.PodName, Namespace: meta.NamespacedName.Namespace}
+	return types.NamespacedName{Name: meta.Name, Namespace: meta.NamespacedName.Namespace}
 }
 
 // endpointHandler handles endpoint lifecycle events.

--- a/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
@@ -168,7 +168,7 @@ func (e *TopologyExtractor) RegisterDependencies(r fwkdl.Registrar) error {
 // podKey returns the pod identity key from endpoint metadata.
 // One pod may produce multiple endpoints (one per rank), all sharing the same key.
 func podKey(meta *fwkdl.EndpointMetadata) types.NamespacedName {
-	return types.NamespacedName{Name: meta.Name, Namespace: meta.NamespacedName.Namespace}
+	return types.NamespacedName{Name: meta.Name, Namespace: meta.ID.Namespace}
 }
 
 // endpointHandler handles endpoint lifecycle events.
@@ -205,7 +205,7 @@ func (h *endpointHandler) Extract(_ context.Context, event fwkdl.EndpointEvent) 
 	if hn == "" {
 		// Hostname label absent: track endpoint for spec.hostname fallback via pod notification.
 		key := podKey(meta)
-		epKey := meta.GetNamespacedName()
+		epKey := meta.GetID()
 		h.ext.mu.Lock()
 		if h.ext.endpoints[key] == nil {
 			h.ext.endpoints[key] = make(map[types.NamespacedName]fwkdl.Endpoint)
@@ -229,7 +229,7 @@ func (h *endpointHandler) Extract(_ context.Context, event fwkdl.EndpointEvent) 
 
 func (h *endpointHandler) removeEndpoint(meta *fwkdl.EndpointMetadata, _ fwkdl.Endpoint) {
 	key := podKey(meta)
-	epKey := meta.GetNamespacedName()
+	epKey := meta.GetID()
 
 	h.ext.mu.Lock()
 	defer h.ext.mu.Unlock()

--- a/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor_test.go
@@ -85,7 +85,7 @@ func newRankEndpoint(podName string, rank int, labels map[string]string) fwkdl.E
 	epName := fmt.Sprintf("%s-rank-%d", podName, rank)
 	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 		NamespacedName: types.NamespacedName{Name: epName, Namespace: testNamespace},
-		PodName:        podName,
+		Name:           podName,
 		Labels:         labels,
 	}, nil)
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor_test.go
@@ -84,9 +84,9 @@ func readTopology(ep fwkdl.Endpoint) (*attrtopology.Topology, bool) {
 func newRankEndpoint(podName string, rank int, labels map[string]string) fwkdl.Endpoint {
 	epName := fmt.Sprintf("%s-rank-%d", podName, rank)
 	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: epName, Namespace: testNamespace},
-		Name:           podName,
-		Labels:         labels,
+		ID:     types.NamespacedName{Name: epName, Namespace: testNamespace},
+		Name:   podName,
+		Labels: labels,
 	}, nil)
 }
 

--- a/pkg/epp/framework/plugins/datalayer/source/http/client.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/client.go
@@ -38,7 +38,7 @@ type Addressable interface {
 	GetNodeAddress() string
 	GetPort() string
 	GetMetricsHost() string
-	GetNamespacedName() types.NamespacedName
+	GetID() types.NamespacedName
 }
 
 const (
@@ -77,14 +77,14 @@ func (cl *client) Get(ctx context.Context, target *url.URL, ep Addressable,
 	}
 	resp, err := cl.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch data from %s: %w", ep.GetNamespacedName(), err)
+		return nil, fmt.Errorf("failed to fetch data from %s: %w", ep.GetID(), err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code from %s: %v", ep.GetNamespacedName(), resp.StatusCode)
+		return nil, fmt.Errorf("unexpected status code from %s: %v", ep.GetID(), resp.StatusCode)
 	}
 
 	return parser(resp.Body)

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -67,7 +67,7 @@ func TestDatasource(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{
+		ID: types.NamespacedName{
 			Name:      "pod1",
 			Namespace: "default",
 		},

--- a/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
+++ b/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
@@ -76,7 +76,7 @@ func (fds *MetricsDataSource) Dispatch(_ context.Context, ep fwkdl.Endpoint) err
 	atomic.AddInt64(&fds.CallCount, 1)
 	fds.mu.RLock()
 	defer fds.mu.RUnlock()
-	nn := ep.GetMetadata().Clone().NamespacedName
+	nn := ep.GetMetadata().Clone().ID
 	if metrics, ok := fds.metrics[nn]; ok {
 		if _, ok := fds.errors[nn]; !ok {
 			clone := metrics.Clone()

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -68,7 +68,7 @@ func TestDatasource(t *testing.T) {
 
 	ctx := context.Background()
 	pod := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{
+		ID: types.NamespacedName{
 			Name:      "pod1",
 			Namespace: "default",
 		},

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -199,7 +199,7 @@ func TestDetector_Configuration(t *testing.T) {
 				newStubSchedulingEndpoint(reg, cleanEndpoint),
 			})
 			require.Len(t, kept, 1, "Filter should drop the overloaded endpoint")
-			require.Equal(t, cleanEndpoint, kept[0].GetMetadata().NamespacedName.Name)
+			require.Equal(t, cleanEndpoint, kept[0].GetMetadata().ID.Name)
 		})
 	})
 }
@@ -675,7 +675,7 @@ func TestDetector_NilMetadataEndpoint(t *testing.T) {
 // --- Test Helpers & Mocks ---
 
 func simulatePreRequest(_ context.Context, reg *localRegistry, req *fwksched.InferenceRequest, result *fwksched.SchedulingResult) {
-	endpointName := result.ProfileResults[result.PrimaryProfileName].TargetEndpoints[0].GetMetadata().NamespacedName.Name
+	endpointName := result.ProfileResults[result.PrimaryProfileName].TargetEndpoints[0].GetMetadata().ID.Name
 	id := fullEndpointName(endpointName)
 	reg.update(id, func(load *attrconcurrency.InFlightLoad) {
 		load.Requests++
@@ -689,7 +689,7 @@ func simulateResponseBody(_ context.Context, reg *localRegistry, req *fwksched.I
 	if metadata == nil || resp == nil || !resp.EndOfStream {
 		return
 	}
-	id := metadata.NamespacedName.String()
+	id := metadata.ID.String()
 	reg.update(id, func(load *attrconcurrency.InFlightLoad) {
 		load.Requests--
 		if req != nil {
@@ -765,7 +765,7 @@ func (e *liveEndpoint) Clone() datalayer.AttributeMap   { return e }
 func newFakeEndpoint(reg *localRegistry, name string) datalayer.Endpoint {
 	id := fullEndpointName(name)
 	return &liveEndpoint{
-		metadata: &datalayer.EndpointMetadata{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}},
+		metadata: &datalayer.EndpointMetadata{ID: types.NamespacedName{Name: name, Namespace: "default"}},
 		reg:      reg,
 		id:       id,
 	}
@@ -781,7 +781,7 @@ type liveSchedulingEndpoint struct {
 
 func newStubSchedulingEndpoint(reg *localRegistry, name string) *liveSchedulingEndpoint {
 	return &liveSchedulingEndpoint{
-		metadata: &datalayer.EndpointMetadata{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}},
+		metadata: &datalayer.EndpointMetadata{ID: types.NamespacedName{Name: name, Namespace: "default"}},
 		reg:      reg,
 		id:       fullEndpointName(name),
 	}

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -32,7 +32,7 @@ import (
 
 func makePodMetric(name string, queueDepth int, kvUsage float64, updateTime time.Time) fwkdl.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: name, Namespace: "ns1"},
+		ID: types.NamespacedName{Name: name, Namespace: "ns1"},
 	}
 	metrics := fwkdl.NewMetrics()
 	metrics.WaitingQueueSize = queueDepth
@@ -48,7 +48,7 @@ func makeSchedulingEndpoint(
 	updateTime time.Time,
 ) fwksched.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: name, Namespace: "ns1"},
+		ID: types.NamespacedName{Name: name, Namespace: "ns1"},
 	}
 	metrics := fwkdl.NewMetrics()
 	metrics.WaitingQueueSize = queueDepth
@@ -203,7 +203,7 @@ func TestDetector_Saturation(t *testing.T) {
 			name: "Single pod with nil metrics",
 			pods: []fwkdl.Endpoint{
 				fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "ns1"},
+					ID: types.NamespacedName{Name: "pod1", Namespace: "ns1"},
 				}, nil),
 			},
 			wantSaturation: 1.0,

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
@@ -30,7 +30,7 @@ import (
 
 func makeLatencyAdmissionEndpoint(name string, kvCache float64, runningRequests int) fwksched.Endpoint {
 	return fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}},
 		&fwkdl.Metrics{
 			KVCacheUsagePercent: kvCache,
 			RunningRequestsSize: runningRequests,

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
@@ -32,7 +32,7 @@ import (
 
 func newEndpoint(name string, queueSize int, kvFraction float64) fwksched.Endpoint {
 	return fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}},
 		&fwkdl.Metrics{
 			WaitingQueueSize:    queueSize,
 			KVCacheUsagePercent: kvFraction,
@@ -163,7 +163,7 @@ func TestDroppableAdmittedAtZeroSaturation(t *testing.T) {
 
 func TestNilMetricsTreatedAsSaturated(t *testing.T) {
 	pod := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "stale"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "stale"}},
 		nil,
 		nil,
 	)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -239,7 +239,7 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 	}
 
 	for _, pod := range pods {
-		matchLen := prefixCacheServers[ServerID(pod.GetMetadata().NamespacedName)]
+		matchLen := prefixCacheServers[ServerID(pod.GetMetadata().ID)]
 		pod.Put(p.dk.String(), attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, blockSize))
 	}
 
@@ -292,7 +292,7 @@ func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.Inferen
 	for _, hashes := range state.PerPromptHashes {
 		total += len(hashes)
 	}
-	matchLen := state.PrefixCacheServers[ServerID(targetEndpoint.GetMetadata().NamespacedName)]
+	matchLen := state.PrefixCacheServers[ServerID(targetEndpoint.GetMetadata().ID)]
 	blockSize := p.GetBlockSize(primaryProfileResult.TargetEndpoints)
 	const averageCharactersPerToken = 4
 	recordPrefixCacheMatch(p.typedName.Name, p.typedName.Type, matchLen*blockSize*averageCharactersPerToken, total*blockSize*averageCharactersPerToken)
@@ -306,7 +306,7 @@ func (p *dataProducer) makeserver(targetEndpoint fwksched.Endpoint) server {
 		gpuBlocks = p.config.LRUCapacityPerServer
 	}
 	return server{
-		ServerID:       ServerID(targetEndpoint.GetMetadata().NamespacedName),
+		ServerID:       ServerID(targetEndpoint.GetMetadata().ID),
 		NumOfGPUBlocks: gpuBlocks,
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -69,8 +69,8 @@ func TestProduce(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, p.PluginState())
 
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
-	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2}
 
 	// First request to populate cache.
@@ -112,7 +112,7 @@ func TestPreRequest(t *testing.T) {
 		}
 		p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, config, testHandle())
 
-		endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
+		endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 		req1 := &fwksched.InferenceRequest{
 			RequestID:   uuid.NewString(),
 			TargetModel: "test-model1",
@@ -143,7 +143,7 @@ func TestPreRequest(t *testing.T) {
 		for _, promptHashes := range perPromptHashes {
 			for _, hash := range promptHashes {
 				pods := p.indexer().Get(hash)
-				assert.Contains(t, pods, ServerID(endpoint1.GetMetadata().NamespacedName))
+				assert.Contains(t, pods, ServerID(endpoint1.GetMetadata().ID))
 			}
 		}
 	})
@@ -157,7 +157,7 @@ func TestPreRequest(t *testing.T) {
 		}
 		p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, config, testHandle())
 
-		endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
+		endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 
 		// Three requests with distinct token IDs generate distinct hashes.
 		// BlockSizeTokens is 1, so each single-token request yields one block.
@@ -235,9 +235,9 @@ func TestPrefixPluginPartialPrefixMatch(t *testing.T) {
 	}
 	p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, config, testHandle())
 
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
-	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
-	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
+	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2, endpoint3}
 
 	// First request: tokens [1, 2].
@@ -297,7 +297,7 @@ func TestPrefixPluginPrefixGrowth(t *testing.T) {
 	}
 	p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, config, testHandle())
 
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint1}
 
 	// First request with an initial token prefix.
@@ -341,7 +341,7 @@ func TestPrefixPluginPrefixGrowth(t *testing.T) {
 
 func TestPrefixPluginAutoTune(t *testing.T) {
 	podName := "pod-autotune"
-	endpoint := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: podName}},
+	endpoint := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: podName}},
 		&fwkdl.Metrics{
 			// Pod reports a block size above minBlockSizeTokens so the autotune
 			// path passes the metric through unclamped. (Metric values below the
@@ -385,7 +385,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	p.wg.Wait()
 
 	// Check indexer state - should be in tracked pods
-	assert.Contains(t, p.indexer().Pods(), ServerID(endpoint.GetMetadata().NamespacedName))
+	assert.Contains(t, p.indexer().Pods(), ServerID(endpoint.GetMetadata().ID))
 }
 
 func TestMaxPrefixTokensToMatch(t *testing.T) {
@@ -401,7 +401,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 
@@ -459,7 +459,7 @@ func TestMaxPrefixBothCapsZeroMatchesEverything(t *testing.T) {
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 
@@ -489,7 +489,7 @@ func TestGetBlockSize_AutotuneClampsBelowMinimum(t *testing.T) {
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 		&fwkdl.Metrics{CacheBlockSize: 16}, // model server uses small blocks
 		fwkdl.NewAttributes(),
 	)
@@ -507,7 +507,7 @@ func TestGetBlockSize_AutotuneAboveMinimumPassesThrough(t *testing.T) {
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 		&fwkdl.Metrics{CacheBlockSize: 128},
 		fwkdl.NewAttributes(),
 	)
@@ -577,7 +577,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 				tokenIDs[i] = uint32(i)
 			}
 			endpoint := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-				NamespacedName: k8stypes.NamespacedName{Name: "pod1"},
+				ID: k8stypes.NamespacedName{Name: "pod1"},
 			}, nil, fwkdl.NewAttributes())
 			endpoints := []fwksched.Endpoint{endpoint}
 			req := &fwksched.InferenceRequest{
@@ -654,7 +654,7 @@ func TestProduce_MultiPrompt(t *testing.T) {
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 	endpoints := []fwksched.Endpoint{endpoint}
@@ -696,7 +696,7 @@ func TestMultiPromptMatchAggregation(t *testing.T) {
 	p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 	endpoints := []fwksched.Endpoint{endpoint}
@@ -749,7 +749,7 @@ func TestMultiPromptPartialMatch(t *testing.T) {
 	p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 	endpoints := []fwksched.Endpoint{endpoint}
@@ -803,7 +803,7 @@ func TestPrefixPluginTokenizedRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 	endpoints := []fwksched.Endpoint{endpoint}
@@ -841,7 +841,7 @@ func TestPrefixPluginMatchesSameTokens(t *testing.T) {
 	p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
 
 	endpoint := fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 	endpoints := []fwksched.Endpoint{endpoint}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -245,7 +245,7 @@ func placeGroup(members []*entry, replicas []fwksched.Endpoint, k, minColocateBl
 	i := 0
 	for i < len(members) {
 		target := pickReplica(replicas, perReplica, k, load, matches, minColocateBlocks, maxShare, preferMatch)
-		name := target.GetMetadata().NamespacedName.String()
+		name := target.GetMetadata().ID.String()
 
 		run := len(members) - i
 		if k != unlimitedPerReplica {
@@ -280,7 +280,7 @@ func placeGroup(members []*entry, replicas []fwksched.Endpoint, k, minColocateBl
 
 	for _, m := range members {
 		if m.assigned != nil {
-			idx.add(hashes, m.assigned.GetMetadata().NamespacedName.String())
+			idx.add(hashes, m.assigned.GetMetadata().ID.String())
 		}
 	}
 }
@@ -297,7 +297,7 @@ func pickReplica(replicas []fwksched.Endpoint, perReplica map[string]int, k int,
 		var bestName string
 		bestMatch := 0
 		for _, r := range replicas {
-			name := r.GetMetadata().NamespacedName.String()
+			name := r.GetMetadata().ID.String()
 			if k != unlimitedPerReplica && perReplica[name] >= k {
 				continue
 			}
@@ -326,7 +326,7 @@ func pickLeastLoaded(replicas []fwksched.Endpoint, perReplica map[string]int, k 
 	var best fwksched.Endpoint
 	var bestName string
 	for _, r := range replicas {
-		name := r.GetMetadata().NamespacedName.String()
+		name := r.GetMetadata().ID.String()
 		if k != unlimitedPerReplica && perReplica[name] >= k {
 			continue
 		}
@@ -338,7 +338,7 @@ func pickLeastLoaded(replicas []fwksched.Endpoint, perReplica map[string]int, k 
 		return best
 	}
 	for _, r := range replicas {
-		name := r.GetMetadata().NamespacedName.String()
+		name := r.GetMetadata().ID.String()
 		if best == nil || less(r, name, load, best, bestName) {
 			best, bestName = r, name
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
@@ -29,7 +29,7 @@ import (
 
 func testEndpoint(name string) fwksched.Endpoint {
 	return fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}},
 		fwkdl.NewMetrics(), fwkdl.NewAttributes())
 }
 
@@ -37,7 +37,7 @@ func assignedName(e *entry) string {
 	if e.assigned == nil {
 		return ""
 	}
-	return e.assigned.GetMetadata().NamespacedName.Name
+	return e.assigned.GetMetadata().ID.Name
 }
 
 // group builds n entries sharing one prompt prefix over the given replicas.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -167,7 +167,7 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 	matched := false
 	for _, pod := range pods {
 		matchLen := 0
-		if e.assigned != nil && pod.GetMetadata().NamespacedName == e.assigned.GetMetadata().NamespacedName {
+		if e.assigned != nil && pod.GetMetadata().ID == e.assigned.GetMetadata().ID {
 			matchLen = total
 			matched = true
 		}
@@ -178,7 +178,7 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 		// scale event): the assigned replica is not among this request's pods, so
 		// no affinity is produced. Surface it rather than degrading silently.
 		log.FromContext(ctx).V(logutil.DEBUG).Info("assigned replica absent from request pods; producing zero affinity",
-			"assigned", e.assigned.GetMetadata().NamespacedName.String())
+			"assigned", e.assigned.GetMetadata().ID.String())
 	}
 	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
@@ -47,7 +47,7 @@ func (p *dataProducer) assignedReplica(t *testing.T, endpoints []fwksched.Endpoi
 		info, ok := v.(*attrprefix.PrefixCacheMatchInfo)
 		require.True(t, ok)
 		if info.MatchBlocks() > 0 {
-			return ep.GetMetadata().NamespacedName.Name
+			return ep.GetMetadata().ID.Name
 		}
 	}
 	return ""

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -284,7 +284,7 @@ func (p *InFlightLoadProducer) Extract(ctx context.Context, event datalayer.Endp
 		return nil
 	}
 
-	id := event.Endpoint.GetMetadata().NamespacedName.String()
+	id := event.Endpoint.GetMetadata().ID.String()
 
 	switch event.Type {
 	case datalayer.EventDelete:
@@ -365,7 +365,7 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 		if endpoint == nil || endpoint.GetMetadata() == nil {
 			continue
 		}
-		eid := endpoint.GetMetadata().NamespacedName.String()
+		eid := endpoint.GetMetadata().ID.String()
 		requestCounter := p.requestTracker.inc(eid)
 
 		// Compute the uncached prompt portion this endpoint must actually compute.
@@ -479,7 +479,7 @@ func (p *InFlightLoadProducer) release(endpoint fwksched.Endpoint, request *fwks
 	if meta == nil {
 		return
 	}
-	eid := meta.NamespacedName.String()
+	eid := meta.ID.String()
 	key := fwkplugin.StateKey(addedTokensKey(eid, profileName))
 
 	// DeleteKey triggers OnEvicted, which decrements the counters exactly once.
@@ -499,7 +499,7 @@ func (p *InFlightLoadProducer) releaseTokensEarly(endpoint fwksched.Endpoint, re
 	if meta == nil {
 		return
 	}
-	eid := meta.NamespacedName.String()
+	eid := meta.ID.String()
 
 	key := fwkplugin.StateKey(addedTokensKey(eid, profileName))
 	if entry, err := fwkplugin.ReadPluginStateKey[*addedTokensEntry](p.PluginState, request.RequestID, key); err == nil {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -564,7 +564,7 @@ type stubSchedulingEndpoint struct {
 
 func newStubSchedulingEndpoint(name string) *stubSchedulingEndpoint {
 	return &stubSchedulingEndpoint{
-		metadata: &datalayer.EndpointMetadata{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}},
+		metadata: &datalayer.EndpointMetadata{ID: types.NamespacedName{Name: name, Namespace: "default"}},
 		attr:     datalayer.NewAttributes(),
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
@@ -56,7 +56,7 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 			if metadata == nil {
 				continue
 			}
-			podCache := p.getOrCreatePodCache(metadata.NamespacedName.String())
+			podCache := p.getOrCreatePodCache(metadata.ID.String())
 			for _, item := range items {
 				podCache.Add(item.Hash, struct{}{})
 			}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -283,7 +283,7 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 		if metadata == nil {
 			continue
 		}
-		matchedItems := p.matchedItemsForPod(metadata.NamespacedName.String(), requestItems)
+		matchedItems := p.matchedItemsForPod(metadata.ID.String(), requestItems)
 		p.recordHitRatio(len(matchedItems), len(requestItems))
 		endpoint.Put(p.dk.String(), attrmm.NewEncoderCacheMatchInfo(
 			matchedItems,
@@ -399,12 +399,12 @@ func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error
 		return nil
 	}
 	metadata := event.Endpoint.GetMetadata()
-	if metadata == nil || metadata.NamespacedName.Name == "" {
+	if metadata == nil || metadata.ID.Name == "" {
 		return nil
 	}
-	p.removePod(metadata.NamespacedName.String())
+	p.removePod(metadata.ID.String())
 	log.FromContext(ctx).V(logging.DEBUG).Info("Removed stale pod from multimodal encoder-cache state",
-		"pod", metadata.NamespacedName.String())
+		"pod", metadata.ID.String())
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -200,7 +200,7 @@ func TestExtractEndpointRemovesDeletedPod(t *testing.T) {
 
 	err := producer.Extract(context.Background(), fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
-		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podB}, nil),
+		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{ID: podB}, nil),
 	})
 
 	require.NoError(t, err)
@@ -254,7 +254,7 @@ func newTestProducer(t *testing.T, params *Parameters, podList func() []k8stypes
 
 func newEndpoint(name k8stypes.NamespacedName) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: name},
+		&fwkdl.EndpointMetadata{ID: name},
 		&fwkdl.Metrics{},
 		nil,
 	)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
@@ -40,9 +40,9 @@ const testBlockSize = 16
 // with the given unweighted cached-block count.
 func endpoint(p *Producer, name, address string, cachedBlocks int) scheduling.Endpoint {
 	e := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: name},
-		Address:        address,
-		Port:           "8080",
+		ID:      k8stypes.NamespacedName{Name: name},
+		Address: address,
+		Port:    "8080",
 	}, nil, nil)
 	e.Put(p.prefixMatchDataKey.String(),
 		attrprefix.NewPrefixCacheMatchInfo(cachedBlocks, 4, testBlockSize).WithCachedBlockCount(cachedBlocks))
@@ -128,9 +128,9 @@ func TestProduce_MissingMatchInfo_TreatedAsZero(t *testing.T) {
 	p := New("test", Config{MinCachedTokenDelta: 1})
 
 	bare := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: "pod-bare"},
-		Address:        "10.0.0.9",
-		Port:           "8080",
+		ID:      k8stypes.NamespacedName{Name: "pod-bare"},
+		Address: "10.0.0.9",
+		Port:    "8080",
 	}, nil, nil)
 
 	req := &scheduling.InferenceRequest{RequestID: "req-bare"}
@@ -334,9 +334,9 @@ func TestPluginFactory_PrefillProfileName(t *testing.T) {
 // a waiting-queue depth.
 func endpointWithLoad(p *Producer, name, address string, cachedBlocks, waiting int) scheduling.Endpoint {
 	e := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: name},
-		Address:        address,
-		Port:           "8080",
+		ID:      k8stypes.NamespacedName{Name: name},
+		Address: address,
+		Port:    "8080",
 	}, &fwkdl.Metrics{WaitingQueueSize: waiting}, nil)
 	e.Put(p.prefixMatchDataKey.String(),
 		attrprefix.NewPrefixCacheMatchInfo(cachedBlocks, 4, testBlockSize).WithCachedBlockCount(cachedBlocks))

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -37,12 +37,12 @@ func (p *Producer) Extract(ctx context.Context, event fwkdl.EndpointEvent) error
 		return nil
 	}
 	meta := event.Endpoint.GetMetadata()
-	if meta == nil || meta.NamespacedName.Name == "" {
+	if meta == nil || meta.ID.Name == "" {
 		return nil
 	}
 
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
-	endpointKey := meta.NamespacedName.String()
+	endpointKey := meta.ID.String()
 
 	switch event.Type {
 	case fwkdl.EventAddOrUpdate:
@@ -70,7 +70,7 @@ func (p *Producer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMet
 	if meta == nil || meta.Address == "" {
 		return nil
 	}
-	endpointKey := meta.NamespacedName.String()
+	endpointKey := meta.ID.String()
 	port := p.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
 	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
 	sourceEndpoint := fmt.Sprintf("%s:%s", meta.Address, meta.Port)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
@@ -56,9 +56,9 @@ func newExtractorProducer(discoverPods bool) *Producer {
 
 func newEndpoint(name, addr string) fwkdl.Endpoint {
 	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: name},
-		Address:        addr,
-		Port:           "8080",
+		ID:      k8stypes.NamespacedName{Namespace: "ns", Name: name},
+		Address: addr,
+		Port:    "8080",
 	}, nil)
 }
 
@@ -125,7 +125,7 @@ func TestProducer_ExtractEndpoint_IgnoresMissingMetadata(t *testing.T) {
 	defer p.subscribersManager.Shutdown(ctx)
 
 	ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+		ID: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
 	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
@@ -145,8 +145,8 @@ func TestProducer_EnsureSubscriber_SurvivesRequestCtxCancel(t *testing.T) {
 	reqCtx, cancel := context.WithCancel(context.Background())
 
 	require.NoError(t, p.ensureSubscriber(reqCtx, &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
-		Address:        "10.0.0.1", Port: "8080",
+		ID:      k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+		Address: "10.0.0.1", Port: "8080",
 	}))
 
 	cancel()
@@ -176,10 +176,10 @@ func TestProducer_ExtractEndpoint_OffsetsZMQPortByRankIndex(t *testing.T) {
 		require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 			Type: fwkdl.EventAddOrUpdate,
 			Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-				NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: ep.name},
-				Address:        ep.address,
-				Port:           "8080",
-				RankIndex:      ep.rank,
+				ID:        k8stypes.NamespacedName{Namespace: "ns", Name: ep.name},
+				Address:   ep.address,
+				Port:      "8080",
+				RankIndex: ep.rank,
 			}, nil),
 		}))
 	}
@@ -211,10 +211,10 @@ func TestProducer_EnsureSubscriber_PassesServingEndpoint(t *testing.T) {
 	}
 
 	require.NoError(t, p.ensureSubscriber(context.Background(), &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a-rank-3"},
-		Address:        "10.0.0.1",
-		Port:           "8003",
-		RankIndex:      3,
+		ID:        k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a-rank-3"},
+		Address:   "10.0.0.1",
+		Port:      "8003",
+		RankIndex: 3,
 	}))
 
 	assert.Equal(t, []string{"ns/pod-a-rank-3"}, subscribers.ids)
@@ -231,9 +231,9 @@ func TestProducer_ExtractEndpoint_SingleRankUsesBaseSocketPort(t *testing.T) {
 	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{
 		Type: fwkdl.EventAddOrUpdate,
 		Endpoint: fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
-			Address:        "10.0.0.1",
-			Port:           "8080",
+			ID:      k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+			Address: "10.0.0.1",
+			Port:    "8080",
 			// RankIndex stays at its zero value.
 		}, nil),
 	}))
@@ -303,7 +303,7 @@ func TestProducer_ExtractEndpoint_DeleteWithMissingAddressRemovesExistingSubscri
 	require.Len(t, ids, 1)
 
 	deleteEndpoint := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
+		ID: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a"},
 	}, nil)
 
 	require.NoError(t, p.Extract(ctx, fwkdl.EndpointEvent{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -106,15 +106,15 @@ func (f *fakeKVBlockScorer) Score(ctx context.Context, keys []kvblock.BlockHash,
 var testEndpoints = []scheduling.Endpoint{
 	scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
-			Address:        "10.0.0.1",
-			Port:           "8080",
+			ID:      k8stypes.NamespacedName{Name: "pod-a"},
+			Address: "10.0.0.1",
+			Port:    "8080",
 		}, nil, nil),
 	scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
-			Address:        "10.0.0.2",
-			Port:           "8080",
+			ID:      k8stypes.NamespacedName{Name: "pod-b"},
+			Address: "10.0.0.2",
+			Port:    "8080",
 		}, nil, nil),
 }
 
@@ -124,15 +124,15 @@ func freshEndpoints() []scheduling.Endpoint {
 	return []scheduling.Endpoint{
 		scheduling.NewEndpoint(
 			&fwkdl.EndpointMetadata{
-				NamespacedName: k8stypes.NamespacedName{Name: "pod-a"},
-				Address:        "10.0.0.1",
-				Port:           "8080",
+				ID:      k8stypes.NamespacedName{Name: "pod-a"},
+				Address: "10.0.0.1",
+				Port:    "8080",
 			}, nil, nil),
 		scheduling.NewEndpoint(
 			&fwkdl.EndpointMetadata{
-				NamespacedName: k8stypes.NamespacedName{Name: "pod-b"},
-				Address:        "10.0.0.2",
-				Port:           "8080",
+				ID:      k8stypes.NamespacedName{Name: "pod-b"},
+				Address: "10.0.0.2",
+				Port:    "8080",
 			}, nil, nil),
 	}
 }
@@ -717,9 +717,9 @@ func TestNew_BlockSizeFlowsViaTokenProcessor(t *testing.T) {
 				tokens[i] = uint32(i + 1)
 			}
 			endpoint := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
-				NamespacedName: k8stypes.NamespacedName{Name: "pod-x"},
-				Address:        "10.0.0.9",
-				Port:           "8080",
+				ID:      k8stypes.NamespacedName{Name: "pod-x"},
+				Address: "10.0.0.9",
+				Port:    "8080",
 			}, nil, nil)
 			req := &scheduling.InferenceRequest{
 				RequestID:   "r",

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
@@ -49,16 +49,16 @@ func (pl *PredictedLatency) Produce(ctx context.Context, request *fwksched.Infer
 			prefixCacheInfo := prefixCacheInfoRaw.(*attrprefix.PrefixCacheMatchInfo)
 			prefixCacheScore = float64(prefixCacheInfo.MatchBlocks()) / float64(prefixCacheInfo.TotalBlocks())
 			if !math.IsNaN(prefixCacheScore) {
-				logger.V(logutil.DEBUG).Info("Found prefix cache score in pod attribute", "pod", endpoint.GetMetadata().NamespacedName.Name, "score", prefixCacheScore)
+				logger.V(logutil.DEBUG).Info("Found prefix cache score in pod attribute", "pod", endpoint.GetMetadata().ID.Name, "score", prefixCacheScore)
 			} else {
 				prefixCacheScore = 0.0
-				logger.V(logutil.DEBUG).Info("Prefix cache score is NaN, defaulting to 0", "pod", endpoint.GetMetadata().NamespacedName.Name)
+				logger.V(logutil.DEBUG).Info("Prefix cache score is NaN, defaulting to 0", "pod", endpoint.GetMetadata().ID.Name)
 			}
 		} else {
-			logger.V(logutil.DEBUG).Info("No prefix cache score found in pod attribute, defaulting to 0", "pod", endpoint.GetMetadata().NamespacedName.Name)
+			logger.V(logutil.DEBUG).Info("No prefix cache score found in pod attribute, defaulting to 0", "pod", endpoint.GetMetadata().ID.Name)
 			prefixCacheScore = 0.0
 		}
-		predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().NamespacedName.Name] = prefixCacheScore
+		predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().ID.Name] = prefixCacheScore
 
 		if pl.config.UseEncoderCacheFeatures {
 			pl.captureEncoderCacheSizes(ctx, predictedLatencyCtx, endpoint)
@@ -68,7 +68,7 @@ func (pl *PredictedLatency) Produce(ctx context.Context, request *fwksched.Infer
 		// reuse it for both the prediction features and the dispatch-time training
 		// features. Re-reading the live attribute in PreRequest would make the
 		// value depend on undefined PreRequest hook ordering.
-		predictedLatencyCtx.inFlightLoadForEndpoints[endpoint.GetMetadata().NamespacedName.String()] = pl.readInFlightLoad(endpoint)
+		predictedLatencyCtx.inFlightLoadForEndpoints[endpoint.GetMetadata().ID.String()] = pl.readInFlightLoad(endpoint)
 	}
 	if !pl.config.PredictInProduce {
 		logger.V(logutil.DEBUG).Info("PredictInProduce disabled, skipping predictions")
@@ -97,7 +97,7 @@ func (pl *PredictedLatency) Produce(ctx context.Context, request *fwksched.Infer
 				)
 				pred.Endpoint.Put(pl.latencyPredictionInfoDataKey.String(), latencyInfo)
 				logger.V(logutil.DEBUG).Info("Stored latency prediction in endpoint",
-					"pod", pred.Endpoint.GetMetadata().NamespacedName.Name,
+					"pod", pred.Endpoint.GetMetadata().ID.Name,
 					"ttft", pred.TTFT,
 					"tpot", pred.TPOT,
 					"ttftValid", pred.TTFTValid,
@@ -146,7 +146,7 @@ func (pl *PredictedLatency) captureEncoderCacheSizes(ctx context.Context, predic
 		matchedSize = inputSize
 	}
 	predictedLatencyCtx.encoderInputSize = inputSize
-	predictedLatencyCtx.encoderMatchedSizeForEndpoints[endpoint.GetMetadata().NamespacedName.Name] = matchedSize
+	predictedLatencyCtx.encoderMatchedSizeForEndpoints[endpoint.GetMetadata().ID.Name] = matchedSize
 	logger.V(logutil.DEBUG).Info("Encoder cache sizes for pod",
 		"pod", endpoint.GetMetadata().String(),
 		"encoderInputSize", inputSize,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -491,7 +491,7 @@ func (pl *PredictedLatency) parseSLOHeaders(ctx context.Context, request *fwksch
 // --- Running request queue helpers ---
 
 func (pl *PredictedLatency) getEndpointMinTPOTSLO(endpoint fwksched.Endpoint) float64 {
-	endpointName := endpoint.GetMetadata().NamespacedName
+	endpointName := endpoint.GetMetadata().ID
 	if runningReqs := pl.getRunningRequestList(endpointName); runningReqs != nil && runningReqs.GetSize() > 0 {
 		if min := runningReqs.Peek(); min != nil {
 			return min.tpot
@@ -501,7 +501,7 @@ func (pl *PredictedLatency) getEndpointMinTPOTSLO(endpoint fwksched.Endpoint) fl
 }
 
 func (pl *PredictedLatency) getEndpointRunningRequestCount(endpoint fwksched.Endpoint) int {
-	endpointName := endpoint.GetMetadata().NamespacedName
+	endpointName := endpoint.GetMetadata().ID
 	if runningReqs := pl.getRunningRequestList(endpointName); runningReqs != nil {
 		return runningReqs.GetSize()
 	}
@@ -529,8 +529,8 @@ func (pl *PredictedLatency) removeRequestFromQueue(requestID string, ctx *predic
 		return
 	}
 	endpointName := types.NamespacedName{
-		Name:      ctx.targetMetadata.NamespacedName.Name,
-		Namespace: ctx.targetMetadata.NamespacedName.Namespace,
+		Name:      ctx.targetMetadata.ID.Name,
+		Namespace: ctx.targetMetadata.ID.Namespace,
 	}
 	pl.removeRequestFromEndpoint(endpointName, requestID)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -129,7 +129,7 @@ func TestReadInFlightLoad(t *testing.T) {
 
 func createTestEndpoint(name string, kvCacheUsage float64, runningRequestsSize, waitingQueueSize int) fwksched.Endpoint {
 	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{
+		ID: types.NamespacedName{
 			Name:      name,
 			Namespace: "default",
 		}},
@@ -270,8 +270,8 @@ func TestPredictedLatency_GetPodRunningRequestCount(t *testing.T) {
 			name: "One running request",
 			setupRequests: func(r *PredictedLatency, p fwksched.Endpoint) {
 				podName := types.NamespacedName{
-					Name:      p.GetMetadata().NamespacedName.Name,
-					Namespace: p.GetMetadata().NamespacedName.Namespace,
+					Name:      p.GetMetadata().ID.Name,
+					Namespace: p.GetMetadata().ID.Namespace,
 				}
 				queue := newRequestPriorityQueue()
 				queue.Add("req1", 0.04)
@@ -283,8 +283,8 @@ func TestPredictedLatency_GetPodRunningRequestCount(t *testing.T) {
 			name: "Multiple running requests",
 			setupRequests: func(r *PredictedLatency, p fwksched.Endpoint) {
 				endpointName := types.NamespacedName{
-					Name:      p.GetMetadata().NamespacedName.Name,
-					Namespace: p.GetMetadata().NamespacedName.Namespace,
+					Name:      p.GetMetadata().ID.Name,
+					Namespace: p.GetMetadata().ID.Namespace,
 				}
 				queue := newRequestPriorityQueue()
 				queue.Add("req1", 0.04)
@@ -326,8 +326,8 @@ func TestPredictedLatency_GetPodMinTPOTSLO(t *testing.T) {
 			name: "One running request",
 			setupRequests: func(r *PredictedLatency, e fwksched.Endpoint) {
 				endpointName := types.NamespacedName{
-					Name:      e.GetMetadata().NamespacedName.Name,
-					Namespace: e.GetMetadata().NamespacedName.Namespace,
+					Name:      e.GetMetadata().ID.Name,
+					Namespace: e.GetMetadata().ID.Namespace,
 				}
 				queue := newRequestPriorityQueue()
 				queue.Add("req1", 0.04)
@@ -339,8 +339,8 @@ func TestPredictedLatency_GetPodMinTPOTSLO(t *testing.T) {
 			name: "Multiple running requests - should return minimum",
 			setupRequests: func(r *PredictedLatency, e fwksched.Endpoint) {
 				endpointName := types.NamespacedName{
-					Name:      e.GetMetadata().NamespacedName.Name,
-					Namespace: e.GetMetadata().NamespacedName.Namespace,
+					Name:      e.GetMetadata().ID.Name,
+					Namespace: e.GetMetadata().ID.Namespace,
 				}
 				queue := newRequestPriorityQueue()
 				queue.Add("req1", 0.05)
@@ -473,7 +473,7 @@ func TestSloContextStoreEviction(t *testing.T) {
 	}
 
 	metadata := &fwkdl.EndpointMetadata{
-		NamespacedName: endpointName,
+		ID: endpointName,
 	}
 
 	sloCtx := newPredictedLatencyContext(req)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
@@ -61,7 +61,7 @@ func (pl *PredictedLatency) generatePredictions(ctx context.Context, predictedLa
 		logger.V(logutil.TRACE).Info("Candidate pod for scheduling", "endpoint", endpoint.GetMetadata().String(), "metrics", endpoint.GetMetrics().String())
 
 		// Get prefix cache score for the pod
-		prefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().NamespacedName.Name]
+		prefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().ID.Name]
 
 		logger.V(logutil.DEBUG).Info("Prefix cache score for pod", "pod", endpoint.GetMetadata().String(), "prefixCacheScore", prefixCacheScore)
 
@@ -71,12 +71,12 @@ func (pl *PredictedLatency) generatePredictions(ctx context.Context, predictedLa
 		generatedTokenCounts[i] = 1
 		prefixCacheScores[i] = prefixCacheScore
 		encoderInputSizes[i] = predictedLatencyCtx.encoderInputSize
-		encoderMatchedSizes[i] = predictedLatencyCtx.encoderMatchedSizeForEndpoints[endpoint.GetMetadata().NamespacedName.Name]
+		encoderMatchedSizes[i] = predictedLatencyCtx.encoderMatchedSizeForEndpoints[endpoint.GetMetadata().ID.Name]
 
 		// Reuse the in-flight load captured for this endpoint earlier in Produce,
 		// so the prediction features are identical to the dispatch-time training
 		// features and neither depends on PreRequest hook ordering.
-		snapshot, ok := predictedLatencyCtx.inFlightLoadForEndpoints[endpoint.GetMetadata().NamespacedName.String()]
+		snapshot, ok := predictedLatencyCtx.inFlightLoadForEndpoints[endpoint.GetMetadata().ID.String()]
 		if !ok {
 			snapshot = pl.readInFlightLoad(endpoint)
 		}
@@ -140,7 +140,7 @@ func (pl *PredictedLatency) updateRequestContextWithPredictions(predictedLatency
 	predMap := make(map[string]endpointPredictionResult, len(predictions))
 	for _, pred := range predictions {
 		if pred.Endpoint != nil && pred.Endpoint.GetMetadata() != nil {
-			predMap[pred.Endpoint.GetMetadata().NamespacedName.Name] = pred
+			predMap[pred.Endpoint.GetMetadata().ID.Name] = pred
 		}
 	}
 	predictedLatencyCtx.predictionsForScheduling = predMap

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
@@ -29,8 +29,8 @@ import (
 
 func createTestEndpointWithLabels(name string, kvCacheUsage float64, runningRequestsSize, waitingQueueSize int, labels map[string]string) fwksched.Endpoint {
 	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
-		Labels:         labels,
+		ID:     types.NamespacedName{Name: name, Namespace: "default"},
+		Labels: labels,
 	}, &fwkdl.Metrics{
 		KVCacheUsagePercent: kvCacheUsage,
 		RunningRequestsSize: runningRequestsSize,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -57,8 +57,8 @@ func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.In
 	}
 
 	endpointName := types.NamespacedName{
-		Name:      targetMetadata.NamespacedName.Name,
-		Namespace: targetMetadata.NamespacedName.Namespace,
+		Name:      targetMetadata.ID.Name,
+		Namespace: targetMetadata.ID.Namespace,
 	}
 
 	logger.V(logutil.TRACE).Info("request ID for SLO tracking", "requestID", request.Headers[reqcommon.RequestIDHeaderKey], "endpointName", endpointName)
@@ -91,7 +91,7 @@ func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.In
 		prefillEndpoint = prefillResult.TargetEndpoints[0]
 		prefillMetadata := prefillEndpoint.GetMetadata()
 		predictedLatencyCtx.prefillTargetMetadata = prefillMetadata
-		logger.V(logutil.DEBUG).Info("Prefill target identified for request", "requestID", id, "prefillEndpoint", prefillMetadata.NamespacedName.String())
+		logger.V(logutil.DEBUG).Info("Prefill target identified for request", "requestID", id, "prefillEndpoint", prefillMetadata.ID.String())
 	} else {
 		logger.V(logutil.DEBUG).Info("No prefill target identified for request", "requestID", id)
 	}
@@ -105,12 +105,12 @@ func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.In
 	// PreRequest hooks have no defined order, re-reading it here would make the
 	// training features depend on hook ordering. Produce is DAG-ordered, so the
 	// value captured there is well defined and matches the prediction features.
-	if snapshot, ok := predictedLatencyCtx.inFlightLoadForEndpoints[decodeEndpoint.GetMetadata().NamespacedName.String()]; ok {
+	if snapshot, ok := predictedLatencyCtx.inFlightLoadForEndpoints[decodeEndpoint.GetMetadata().ID.String()]; ok {
 		predictedLatencyCtx.prefillTokensAtDispatch = snapshot.tokens
 		predictedLatencyCtx.requestsAtDispatch = snapshot.requests
 	}
 	if prefillEndpoint != nil {
-		if snapshot, ok := predictedLatencyCtx.inFlightLoadForEndpoints[prefillEndpoint.GetMetadata().NamespacedName.String()]; ok {
+		if snapshot, ok := predictedLatencyCtx.inFlightLoadForEndpoints[prefillEndpoint.GetMetadata().ID.String()]; ok {
 			predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = snapshot.tokens
 			predictedLatencyCtx.requestsAtDispatchOnPrefill = snapshot.requests
 		}
@@ -227,9 +227,9 @@ func (pl *PredictedLatency) checkPredictor(logger logr.Logger, metadata *fwkdl.E
 // processPreRequestForLatencyPrediction looks up the stored prediction for the target endpoint.
 func processPreRequestForLatencyPrediction(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx) {
 	logger := log.FromContext(ctx)
-	targetName := predictedLatencyCtx.targetMetadata.NamespacedName.Name
+	targetName := predictedLatencyCtx.targetMetadata.ID.Name
 	if m := predictedLatencyCtx.prefillTargetMetadata; m != nil {
-		targetName = m.NamespacedName.Name
+		targetName = m.ID.Name
 	}
 	if storedPred, ok := predictedLatencyCtx.predictionsForScheduling[targetName]; ok {
 		logger.V(logutil.DEBUG).Info("PreRequest TTFT from stored prediction", "value_ms", storedPred.TTFT, "endpoint", targetName)
@@ -261,11 +261,11 @@ func processFirstTokenForLatencyPrediction(
 	if prefillTargetMetadata := predictedLatencyCtx.prefillTargetMetadata; prefillTargetMetadata != nil {
 		prefillMetrics, err := getLatestMetricsForProfile(predictedLatencyCtx, ExperimentalDefaultPrefillProfile)
 		if err == nil {
-			prefillPrefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[prefillTargetMetadata.NamespacedName.Name]
-			prefillEncoderMatchedSize := predictedLatencyCtx.encoderMatchedSizeForEndpoints[prefillTargetMetadata.NamespacedName.Name]
+			prefillPrefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[prefillTargetMetadata.ID.Name]
+			prefillEncoderMatchedSize := predictedLatencyCtx.encoderMatchedSizeForEndpoints[prefillTargetMetadata.ID.Name]
 			logger.V(logutil.DEBUG).Info("Recording prefill TTFT training data",
 				"ttft_ms", predictedLatencyCtx.ttft,
-				"prefillPod", prefillTargetMetadata.NamespacedName.Name,
+				"prefillPod", prefillTargetMetadata.ID.Name,
 				"prefixCacheScore", prefillPrefixCacheScore)
 			recordTTFTTrainingData(ctx, predictor, endpointRoleLabel, predictedLatencyCtx, prefillMetrics, prefillTargetMetadata, now, prefillPrefixCacheScore, prefillEncoderMatchedSize)
 		}
@@ -276,8 +276,8 @@ func processFirstTokenForLatencyPrediction(
 			return
 		}
 		targetEndpointMetadata := predictedLatencyCtx.targetMetadata
-		prefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[targetEndpointMetadata.NamespacedName.Name]
-		encoderMatchedSize := predictedLatencyCtx.encoderMatchedSizeForEndpoints[targetEndpointMetadata.NamespacedName.Name]
+		prefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[targetEndpointMetadata.ID.Name]
+		encoderMatchedSize := predictedLatencyCtx.encoderMatchedSizeForEndpoints[targetEndpointMetadata.ID.Name]
 		logger.V(logutil.DEBUG).Info("Recording TTFT training data", "ttft_ms", predictedLatencyCtx.ttft, "predicted_ttft_ms", predictedLatencyCtx.predictedTTFT, "prefixCacheScore", prefixCacheScore)
 		recordTTFTTrainingData(ctx, predictor, endpointRoleLabel, predictedLatencyCtx, m, targetEndpointMetadata, now, prefixCacheScore, encoderMatchedSize)
 	}
@@ -301,7 +301,7 @@ func initializeSampler(ctx context.Context, predictedLatencyCtx *predictedLatenc
 
 func predictFirstTPOT(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx) {
 	logger := log.FromContext(ctx)
-	targetName := predictedLatencyCtx.targetMetadata.NamespacedName.Name
+	targetName := predictedLatencyCtx.targetMetadata.ID.Name
 	if storedPred, ok := predictedLatencyCtx.predictionsForScheduling[targetName]; ok {
 		logger.V(logutil.DEBUG).Info("first TPOT from stored prediction", "value_ms", storedPred.TPOT)
 		predictedLatencyCtx.predictedTPOTObservations = append(predictedLatencyCtx.predictedTPOTObservations, storedPred.TPOT)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -46,7 +46,7 @@ const (
 
 func createTestSchedulingResult(metadata *fwkdl.EndpointMetadata) *fwksched.SchedulingResult {
 
-	mockPod := createTestEndpoint(metadata.NamespacedName.Name, kvUsage, runningRequests, waitingQueue)
+	mockPod := createTestEndpoint(metadata.ID.Name, kvUsage, runningRequests, waitingQueue)
 
 	return &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
@@ -206,7 +206,7 @@ func TestPredictedLatency_PreRequest_Success(t *testing.T) {
 	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 
 	// Initialize the request priority queue
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, newRequestPriorityQueue())
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, newRequestPriorityQueue())
 
 	beforeTime := time.Now()
 	router.PreRequest(ctx, request, schedulingResult)
@@ -242,7 +242,7 @@ func TestPredictedLatency_PreRequest_AddsToQueue(t *testing.T) {
 	router.PreRequest(ctx, request, schedulingResult)
 
 	// Verify queue was created and request was added
-	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().NamespacedName)
+	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().ID)
 	assert.True(t, exists, "Queue should be created for endpoint")
 	assert.NotNil(t, value)
 	queue := value.(*requestPriorityQueue)
@@ -275,7 +275,7 @@ func TestPredictedLatency_PreRequest_QueueAlreadyExists(t *testing.T) {
 	router.PreRequest(ctx, request2, schedulingResult)
 
 	// Verify both are in the same queue
-	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().NamespacedName)
+	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().ID)
 	assert.True(t, exists)
 	assert.NotNil(t, value)
 }
@@ -393,7 +393,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FirstToken(t *testing.T) {
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 
 	beforeTime := time.Now()
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
@@ -480,7 +480,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SubsequentTokens(t *testing
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
 
@@ -506,7 +506,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_QueueNotFound(t 
 	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 
 	// Create an EMPTY queue (not nil, but empty) to test queue.Remove behavior
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, newRequestPriorityQueue())
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, newRequestPriorityQueue())
 
 	// Should handle gracefully when request is not in queue
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
@@ -544,7 +544,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_Success(t *testi
 
 	// Create queue and add request
 	queue := newRequestPriorityQueue()
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -634,7 +634,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_WithMetrics(t *t
 
 	// Create queue
 	queue := newRequestPriorityQueue()
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -667,7 +667,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoSLOs(t *testin
 
 	// Create queue
 	queue := newRequestPriorityQueue()
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 0)
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -708,7 +708,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken(t *testing.T) {
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
 
@@ -741,7 +741,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SingleChunk(t *testing.T) {
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
 
@@ -774,7 +774,7 @@ func TestPredictedLatency_NonStreamingMode_ResponseBody_FinalToken(t *testing.T)
 	// Initialize the queue and add the request
 	queue := newRequestPriorityQueue()
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
 
@@ -813,7 +813,7 @@ func TestPredictedLatency_ResponseBody_CleansUpContext_WhenPreRequestSkipped(t *
 
 	queue := newRequestPriorityQueue()
 	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
-	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
 
 	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
 
@@ -975,7 +975,7 @@ func TestPredictedLatency_MultipleRequests_SamePod(t *testing.T) {
 	router.PreRequest(ctx, request3, schedulingResult)
 
 	// Verify queue has all requests
-	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().NamespacedName)
+	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().ID)
 	assert.True(t, exists)
 	assert.NotNil(t, value)
 }
@@ -1059,8 +1059,8 @@ func TestPredictedLatency_MultipleRequests_DifferentPods(t *testing.T) {
 	router.PreRequest(ctx, request2, schedulingResult2)
 
 	// Verify separate queues were created
-	value1, exists1 := router.runningRequestLists.Load(endpoint1.GetMetadata().NamespacedName)
-	value2, exists2 := router.runningRequestLists.Load(endpoint2.GetMetadata().NamespacedName)
+	value1, exists1 := router.runningRequestLists.Load(endpoint1.GetMetadata().ID)
+	value2, exists2 := router.runningRequestLists.Load(endpoint2.GetMetadata().ID)
 
 	assert.True(t, exists1)
 	assert.True(t, exists2)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -46,10 +46,10 @@ func TestBulkPredictWithMetrics(t *testing.T) {
 	}
 	pods := []*fwkdl.EndpointMetadata{
 		{
-			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+			ID: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 		{
-			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod2"},
+			ID: types.NamespacedName{Namespace: "default", Name: "pod2"},
 		},
 	}
 	inputTokenLengths := []int{1, 1}
@@ -84,8 +84,8 @@ func TestBulkPredictWithMetrics_PropagatesInFlightOverrides(t *testing.T) {
 		{KVCacheUsagePercent: 0.6, RunningRequestsSize: 2},
 	}
 	pods := []*fwkdl.EndpointMetadata{
-		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}},
-		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod2"}},
+		{ID: types.NamespacedName{Namespace: "default", Name: "pod1"}},
+		{ID: types.NamespacedName{Namespace: "default", Name: "pod2"}},
 	}
 	inputTokenLengths := []int{1, 1}
 	generatedTokenCounts := []int{1, 1}
@@ -121,8 +121,8 @@ func TestBulkPredictWithMetrics_PropagatesEncoderSizes(t *testing.T) {
 		{KVCacheUsagePercent: 0.6},
 	}
 	pods := []*fwkdl.EndpointMetadata{
-		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}},
-		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod2"}},
+		{ID: types.NamespacedName{Namespace: "default", Name: "pod1"}},
+		{ID: types.NamespacedName{Namespace: "default", Name: "pod2"}},
 	}
 	inputTokenLengths := []int{1, 1}
 	generatedTokenCounts := []int{1, 1}
@@ -154,7 +154,7 @@ func TestBulkPredictWithMetrics_ClampsMatchedWithoutInputSizes(t *testing.T) {
 
 	metricsStates := []*fwkdl.Metrics{{KVCacheUsagePercent: 0.5}}
 	pods := []*fwkdl.EndpointMetadata{
-		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}},
+		{ID: types.NamespacedName{Namespace: "default", Name: "pod1"}},
 	}
 
 	_, err := bulkPredictWithMetrics(context.Background(), "test-plugin", "test-type", nil, mockPredictor,
@@ -169,7 +169,7 @@ func TestBulkPredictWithMetrics_ClampsMatchedWithoutInputSizes(t *testing.T) {
 
 func TestBuildPredictionRequestAndTrainingEntry_EncoderSizes(t *testing.T) {
 	m := &fwkdl.Metrics{KVCacheUsagePercent: 0.5}
-	pod := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}}
+	pod := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "default", Name: "pod1"}}
 
 	req := buildPredictionRequest("", pod, m, 10, 1, 0.0, 5, 4)
 	assert.Equal(t, 5, req.EncoderInputSize)
@@ -190,7 +190,7 @@ func TestBulkPredictWithMetrics_Error(t *testing.T) {
 	}
 	pods := []*fwkdl.EndpointMetadata{
 		{
-			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+			ID: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
 	inputTokenLengths := []int{1}
@@ -208,7 +208,7 @@ func TestBulkPredictWithMetrics_InputMismatch(t *testing.T) {
 	metricsStates := []*fwkdl.Metrics{{}}
 	pods := []*fwkdl.EndpointMetadata{
 		{
-			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+			ID: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
 	inputTokenLengths := []int{1, 1} // Mismatch length
@@ -234,7 +234,7 @@ func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
 	}
 	pods := []*fwkdl.EndpointMetadata{
 		{
-			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+			ID: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
 	inputTokenLengths := []int{1}
@@ -265,7 +265,7 @@ func TestBulkPredictWithMetrics_ChatCompletionsInputTokenLength(t *testing.T) {
 
 	metricsStates := []*fwkdl.Metrics{{KVCacheUsagePercent: 0.5}}
 	pods := []*fwkdl.EndpointMetadata{
-		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}},
+		{ID: types.NamespacedName{Namespace: "default", Name: "pod1"}},
 	}
 
 	inputTokenLengths := []int{2}
@@ -284,7 +284,7 @@ func TestBulkPredictWithMetrics_NilMetricsState(t *testing.T) {
 	metricsStates := []*fwkdl.Metrics{nil} // Nil metrics state
 	pods := []*fwkdl.EndpointMetadata{
 		{
-			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+			ID: types.NamespacedName{Namespace: "default", Name: "pod1"},
 		},
 	}
 	inputTokenLengths := []int{1}

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
@@ -142,9 +142,9 @@ func TestFactoryInvalidJSON(t *testing.T) {
 func createEndpoint(nsn k8stypes.NamespacedName, ipaddr string, labels map[string]string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: nsn,
-			Address:        ipaddr,
-			Labels:         labels,
+			ID:      nsn,
+			Address: ipaddr,
+			Labels:  labels,
 		},
 		&fwkdl.Metrics{},
 		nil,
@@ -252,7 +252,7 @@ func TestByLabelFiltering(t *testing.T) {
 
 			actualEndpointNames := make([]string, len(filteredEndpoints))
 			for idx, endpoint := range filteredEndpoints {
-				actualEndpointNames[idx] = endpoint.GetMetadata().NamespacedName.Name
+				actualEndpointNames[idx] = endpoint.GetMetadata().ID.Name
 			}
 
 			assert.ElementsMatch(t, tt.expectedPods, actualEndpointNames,

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles_test.go
@@ -40,7 +40,7 @@ func TestRoleFilterDecodeRole(t *testing.T) {
 
 	names := make([]string, len(filtered))
 	for i, ep := range filtered {
-		names[i] = ep.GetMetadata().NamespacedName.Name
+		names[i] = ep.GetMetadata().ID.Name
 	}
 
 	assert.ElementsMatch(t, []string{
@@ -76,7 +76,7 @@ func TestRoleFilterPrefillRole(t *testing.T) {
 
 	names := make([]string, len(filtered))
 	for i, ep := range filtered {
-		names[i] = ep.GetMetadata().NamespacedName.Name
+		names[i] = ep.GetMetadata().ID.Name
 	}
 
 	assert.ElementsMatch(t, []string{
@@ -107,7 +107,7 @@ func TestRoleFilterEncodeRole(t *testing.T) {
 
 	names := make([]string, len(filtered))
 	for i, ep := range filtered {
-		names[i] = ep.GetMetadata().NamespacedName.Name
+		names[i] = ep.GetMetadata().ID.Name
 	}
 
 	assert.ElementsMatch(t, []string{

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
@@ -305,7 +305,7 @@ func TestLabelSelectorFilterFiltering(t *testing.T) {
 
 			actualEndpointNames := make([]string, len(filteredEndpoints))
 			for idx, endpoint := range filteredEndpoints {
-				actualEndpointNames[idx] = endpoint.GetMetadata().NamespacedName.Name
+				actualEndpointNames[idx] = endpoint.GetMetadata().ID.Name
 			}
 
 			assert.ElementsMatch(t, tt.expectedPods, actualEndpointNames,
@@ -424,9 +424,9 @@ func ExamplePrefillDecodeRolesInLWS() {
 func createEndpoint(nsn k8stypes.NamespacedName, ipaddr string, labels map[string]string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: nsn,
-			Address:        ipaddr,
-			Labels:         labels,
+			ID:      nsn,
+			Address: ipaddr,
+			Labels:  labels,
 		},
 		&fwkdl.Metrics{},
 		nil,
@@ -459,5 +459,5 @@ func TestDeprecatedSelectorFactoryBackwardCompat(t *testing.T) {
 
 	filtered := blf.Filter(ctx, nil, endpoints)
 	require.Len(t, filtered, 1)
-	assert.Equal(t, "nginx-1", filtered[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "nginx-1", filtered[0].GetMetadata().ID.Name)
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -35,7 +35,7 @@ import (
 // (prefixMatch out of 100 total blocks), predicted TTFT, and in-flight tokens.
 func makeEndpoint(name string, prefixMatch int, ttft float64, tokens int64) fwksched.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+		ID: types.NamespacedName{Name: name, Namespace: "default"},
 	}
 	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	if prefixMatch >= 0 {
@@ -129,7 +129,7 @@ func TestFilter_ThroughputTTFTWithinThreshold(t *testing.T) {
 	}
 	result := p.Filter(context.Background(), nil, endpoints)
 	assert.Equal(t, 1, len(result), "throughput-derived TTFT within threshold should NOT break stickiness")
-	assert.Equal(t, "a", result[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "a", result[0].GetMetadata().ID.Name)
 }
 
 func TestFilter_TTFTPenaltyDisabled(t *testing.T) {
@@ -140,7 +140,7 @@ func TestFilter_TTFTPenaltyDisabled(t *testing.T) {
 	}
 	result := p.Filter(context.Background(), nil, endpoints)
 	assert.Equal(t, 1, len(result), "maxTTFTPenaltyMs=0 should NOT break stickiness")
-	assert.Equal(t, "a", result[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "a", result[0].GetMetadata().ID.Name)
 }
 
 func TestFilter_ExplorationProbability(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -97,7 +97,7 @@ func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.Infere
 	}
 
 	for _, endpoint := range endpoints {
-		if endpoint.GetMetadata().NamespacedName.String() == podName {
+		if endpoint.GetMetadata().ID.String() == podName {
 			return []scheduling.Endpoint{endpoint}
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
@@ -34,12 +34,12 @@ import (
 
 func TestSessionAffinity_Filter(t *testing.T) {
 	endpointA := scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-a"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-a"}},
 		&fwkdl.Metrics{},
 		nil,
 	)
 	endpointB := scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-b"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-b"}},
 		&fwkdl.Metrics{},
 		nil,
 	)
@@ -47,7 +47,7 @@ func TestSessionAffinity_Filter(t *testing.T) {
 	inputEndpoints := []scheduling.Endpoint{endpointA, endpointB}
 
 	// valid session token for endpointB
-	validSessionTokenForEndpointB := base64.StdEncoding.EncodeToString([]byte(endpointB.GetMetadata().NamespacedName.String()))
+	validSessionTokenForEndpointB := base64.StdEncoding.EncodeToString([]byte(endpointB.GetMetadata().ID.String()))
 	// valid token whose pod is not among the candidates
 	tokenForMissingPod := base64.StdEncoding.EncodeToString([]byte("pod-missing"))
 
@@ -130,7 +130,7 @@ func TestSessionAffinity_Filter(t *testing.T) {
 
 			gotPods := make([]string, len(got))
 			for idx, endpoint := range got {
-				gotPods[idx] = endpoint.GetMetadata().NamespacedName.Name
+				gotPods[idx] = endpoint.GetMetadata().ID.Name
 			}
 
 			assert.ElementsMatch(t, test.wantPods, gotPods, "filtered endpoints should match expected endpoints")
@@ -141,12 +141,12 @@ func TestSessionAffinity_Filter(t *testing.T) {
 
 func TestSessionAffinity_ResponseHeader(t *testing.T) {
 	targetEndpoint := &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "pod1"},
-		Address:        "1.2.3.4",
+		ID:      k8stypes.NamespacedName{Namespace: "default", Name: "pod1"},
+		Address: "1.2.3.4",
 	}
 
 	// expected token to be set in response header
-	wantToken := base64.StdEncoding.EncodeToString([]byte(targetEndpoint.NamespacedName.String()))
+	wantToken := base64.StdEncoding.EncodeToString([]byte(targetEndpoint.ID.String()))
 
 	tests := []struct {
 		name            string
@@ -200,7 +200,7 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 						"prefill": {
 							TargetEndpoints: []scheduling.Endpoint{
 								scheduling.NewEndpoint(
-									&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"}},
+									&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"}},
 									&fwkdl.Metrics{},
 									nil,
 								),

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
@@ -31,7 +31,7 @@ import (
 
 func makeEndpoint(name string, ttftHeadroom, tpotHeadroom float64, hasPrediction bool) fwksched.Endpoint {
 	meta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+		ID: types.NamespacedName{Name: name, Namespace: "default"},
 	}
 	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 	if hasPrediction {
@@ -95,7 +95,7 @@ func TestFilter_BothTiers_SelectPositive(t *testing.T) {
 	}
 	result := p.Filter(context.Background(), nil, endpoints)
 	assert.Equal(t, 2, len(result), "should select positive tier")
-	assert.Equal(t, "pos1", result[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "pos1", result[0].GetMetadata().ID.Name)
 }
 
 func TestFilter_BothTiers_EpsilonExploreNeg(t *testing.T) {
@@ -106,7 +106,7 @@ func TestFilter_BothTiers_EpsilonExploreNeg(t *testing.T) {
 	}
 	result := p.Filter(context.Background(), nil, endpoints)
 	assert.Equal(t, 1, len(result), "should select negative tier")
-	assert.Equal(t, "neg1", result[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "neg1", result[0].GetMetadata().ID.Name)
 }
 
 func TestFilter_NoPredictionGoesToNegative(t *testing.T) {
@@ -118,7 +118,7 @@ func TestFilter_NoPredictionGoesToNegative(t *testing.T) {
 	result := p.Filter(context.Background(), nil, endpoints)
 	// nopred goes to negative, epsilon selects negative
 	assert.Equal(t, 1, len(result))
-	assert.Equal(t, "nopred", result[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "nopred", result[0].GetMetadata().ID.Name)
 }
 
 // Note: Deficit bucketing tests are in the slo-deficit-bucket-filter package.

--- a/pkg/epp/framework/plugins/scheduling/filter/utilization/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/utilization/filter.go
@@ -225,13 +225,13 @@ func (f *UtilizationFilter) activeRequestCount(ctx context.Context, endpoint sch
 	case *attrconcurrency.InFlightLoad:
 		if load == nil {
 			log.FromContext(ctx).V(logutil.TRACE).Info("Ignoring nil in-flight load attribute",
-				"endpoint", endpoint.GetMetadata().NamespacedName.String())
+				"endpoint", endpoint.GetMetadata().ID.String())
 			return 0
 		}
 		return load.Requests
 	default:
 		log.FromContext(ctx).V(logutil.TRACE).Info("Ignoring in-flight load attribute with unexpected type",
-			"endpoint", endpoint.GetMetadata().NamespacedName.String(),
+			"endpoint", endpoint.GetMetadata().ID.String(),
 			"attributeType", fmt.Sprintf("%T", val))
 		return 0
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/utilization/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/utilization/filter_test.go
@@ -45,7 +45,7 @@ type stubEndpoint struct {
 
 func newStubEndpoint(name string) *stubEndpoint {
 	return &stubEndpoint{
-		metadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
+		metadata: &datalayer.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
 		metrics:  &datalayer.Metrics{},
 		attr:     datalayer.NewAttributes(),
 	}
@@ -56,7 +56,7 @@ func (f *stubEndpoint) UpdateMetadata(*datalayer.EndpointMetadata) {}
 func (f *stubEndpoint) GetMetrics() *datalayer.Metrics             { return f.metrics }
 func (f *stubEndpoint) UpdateMetrics(*datalayer.Metrics)           {}
 func (f *stubEndpoint) GetAttributes() datalayer.AttributeMap      { return f.attr }
-func (f *stubEndpoint) String() string                             { return f.metadata.NamespacedName.String() }
+func (f *stubEndpoint) String() string                             { return f.metadata.ID.String() }
 func (f *stubEndpoint) Put(key string, val datalayer.Cloneable)    { f.attr.Put(key, val) }
 func (f *stubEndpoint) Get(key string) (datalayer.Cloneable, bool) {
 	return f.attr.Get(key)
@@ -83,7 +83,7 @@ func newTestEndpointWithMetrics(name string, metrics datalayer.Metrics) scheduli
 func endpointNames(endpoints []scheduling.Endpoint) []string {
 	names := make([]string, 0, len(endpoints))
 	for _, ep := range endpoints {
-		names = append(names, ep.GetMetadata().NamespacedName.Name)
+		names = append(names, ep.GetMetadata().ID.Name)
 	}
 	return names
 }

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 func TestPickMaxScorePicker(t *testing.T) {
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
-	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)
-	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil)
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)
+	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil)
 
 	tests := []struct {
 		name               string

--- a/pkg/epp/framework/plugins/scheduling/picker/random/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/random/picker_test.go
@@ -33,9 +33,9 @@ func TestPickRandomPicker(t *testing.T) {
 		tolerance      = 0.05 // Verify within tolerance ±5%
 	)
 
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
-	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)
-	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil)
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)
+	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil)
 
 	tests := []struct {
 		name    string
@@ -97,13 +97,13 @@ func TestPickRandomPicker(t *testing.T) {
 			// should be min(numPods/numCandidates, 1.0), regardless of scores.
 			selectionCounts := make(map[string]int)
 			for _, ep := range test.input {
-				selectionCounts[ep.GetMetadata().NamespacedName.Name] = 0
+				selectionCounts[ep.GetMetadata().ID.Name] = 0
 			}
 
 			for range testIterations {
 				res := test.picker.Pick(context.Background(), test.input)
 				for _, ep := range res.TargetEndpoints {
-					selectionCounts[ep.GetMetadata().NamespacedName.Name]++
+					selectionCounts[ep.GetMetadata().ID.Name]++
 				}
 			}
 

--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker_test.go
@@ -33,11 +33,11 @@ func TestPickWeightedRandomPicker(t *testing.T) {
 		tolerance      = 0.05 // Verify within tolerance ±5%
 	)
 
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
-	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)
-	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil)
-	endpoint4 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod4"}}, nil, nil)
-	endpoint5 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod5"}}, nil, nil)
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)
+	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil)
+	endpoint4 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod4"}}, nil, nil)
+	endpoint5 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod5"}}, nil, nil)
 
 	// A-Res algorithm uses U^(1/w) transformation which introduces statistical variance
 	// beyond simple proportional sampling. Generous tolerance is required to prevent
@@ -98,7 +98,7 @@ func TestPickWeightedRandomPicker(t *testing.T) {
 			// Calculate expected probabilities based on scores
 			expectedProbabilities := make(map[string]float64)
 			for _, endpoint := range test.input {
-				podName := endpoint.GetMetadata().NamespacedName.Name
+				podName := endpoint.GetMetadata().ID.Name
 				if totalScore > 0 {
 					expectedProbabilities[podName] = endpoint.Score / totalScore
 				} else {
@@ -109,7 +109,7 @@ func TestPickWeightedRandomPicker(t *testing.T) {
 			// Initialize selection counters for each pod
 			selectionCounts := make(map[string]int)
 			for _, endpoint := range test.input {
-				endpointName := endpoint.GetMetadata().NamespacedName.Name
+				endpointName := endpoint.GetMetadata().ID.Name
 				selectionCounts[endpointName] = 0
 			}
 
@@ -118,7 +118,7 @@ func TestPickWeightedRandomPicker(t *testing.T) {
 				result := picker.Pick(context.Background(), test.input)
 
 				// Count selections for probability analysis
-				selectedEndpointName := result.TargetEndpoints[0].GetMetadata().NamespacedName.Name
+				selectedEndpointName := result.TargetEndpoints[0].GetMetadata().ID.Name
 				selectionCounts[selectedEndpointName]++
 			}
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
@@ -23,10 +23,10 @@ const DefaultTestPodPort = "8000"
 func createEndpoint(nsn k8stypes.NamespacedName, ipaddr, port string, labels map[string]string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: nsn,
-			Address:        ipaddr,
-			Port:           port,
-			Labels:         labels,
+			ID:      nsn,
+			Address: ipaddr,
+			Port:    port,
+			Labels:  labels,
 		},
 		nil,
 		fwkdl.NewAttributes(),

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
@@ -33,9 +33,9 @@ const (
 func makeEndpointByAddr(addr string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"},
-			Address:        addr,
-			Port:           testPort,
+			ID:      k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"},
+			Address: addr,
+			Port:    testPort,
 		},
 		&fwkdl.Metrics{},
 		nil,
@@ -45,9 +45,9 @@ func makeEndpointByAddr(addr string) scheduling.Endpoint {
 func makeEncodeEndpoint(addr string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "encode-pod"},
-			Address:        addr,
-			Port:           testPort,
+			ID:      k8stypes.NamespacedName{Namespace: "default", Name: "encode-pod"},
+			Address: addr,
+			Port:    testPort,
 		},
 		&fwkdl.Metrics{},
 		nil,

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -36,7 +36,7 @@ const (
 
 func makeEndpoint(nsn k8stypes.NamespacedName, ip, port string, labels map[string]string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: nsn, Address: ip, Port: port, Labels: labels},
+		&fwkdl.EndpointMetadata{ID: nsn, Address: ip, Port: port, Labels: labels},
 		nil,
 		fwkdl.NewAttributes(),
 	)
@@ -1347,9 +1347,9 @@ func TestBothProfileAndHeadersHandlerPreRequest(t *testing.T) {
 	podPort := "8080"
 	ep := scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"},
-			Address:        podAddr,
-			Port:           podPort,
+			ID:      k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"},
+			Address: podAddr,
+			Port:    podPort,
 		},
 		&fwkdl.Metrics{},
 		nil,

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
@@ -177,10 +177,10 @@ const DefaultTestPodPort = "8000"
 func createEndpoint(nsn k8stypes.NamespacedName, ipaddr, port string, labels map[string]string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: nsn,
-			Address:        ipaddr,
-			Port:           port,
-			Labels:         labels,
+			ID:      nsn,
+			Address: ipaddr,
+			Port:    port,
+			Labels:  labels,
 		},
 		nil,
 		fwkdl.NewAttributes(),

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -39,9 +39,9 @@ const (
 func makeTestEndpointBase() scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "test-pod"},
-			Address:        testEndpointAddr,
-			Port:           testEndpointPort,
+			ID:      k8stypes.NamespacedName{Namespace: "default", Name: "test-pod"},
+			Address: testEndpointAddr,
+			Port:    testEndpointPort,
 		},
 		nil,
 		fwkdl.NewAttributes(),

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
@@ -48,26 +48,26 @@ func completionsBody(prompt string) *fwkrh.InferenceRequestBody {
 func TestPDSchedule(t *testing.T) {
 	endpoint1 := fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Name: "endpoint1"},
-			Address:        "1.2.3.4",
-			Labels:         map[string]string{bylabel.RoleLabel: bylabel.RolePrefill},
+			ID:      k8stypes.NamespacedName{Name: "endpoint1"},
+			Address: "1.2.3.4",
+			Labels:  map[string]string{bylabel.RoleLabel: bylabel.RolePrefill},
 		},
 		&fwkdl.Metrics{WaitingQueueSize: 0},
 		fwkdl.NewAttributes(),
 	)
 	endpoint2 := fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Name: "endpoint2"},
-			Address:        "5.6.7.8",
-			Labels:         map[string]string{bylabel.RoleLabel: bylabel.RoleDecode},
+			ID:      k8stypes.NamespacedName{Name: "endpoint2"},
+			Address: "5.6.7.8",
+			Labels:  map[string]string{bylabel.RoleLabel: bylabel.RoleDecode},
 		},
 		&fwkdl.Metrics{WaitingQueueSize: 0},
 		fwkdl.NewAttributes(),
 	)
 	noRoleEndpoint1 := fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Name: "noRoleEndpoint1"},
-			Address:        "1.1.1.1",
+			ID:      k8stypes.NamespacedName{Name: "noRoleEndpoint1"},
+			Address: "1.1.1.1",
 		},
 		&fwkdl.Metrics{WaitingQueueSize: 2},
 		fwkdl.NewAttributes(),

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -49,7 +49,7 @@ type endpointScores map[scheduling.Endpoint]float64
 func (s endpointScores) MarshalLog() interface{} {
 	result := make(map[string]float64, len(s))
 	for ep, score := range s {
-		result[ep.GetMetadata().NamespacedName.String()] = score
+		result[ep.GetMetadata().ID.String()] = score
 	}
 	return result
 }
@@ -158,7 +158,7 @@ func (s *ActiveRequest) Score(ctx context.Context, _ *scheduling.InferenceReques
 	maxCount := int64(0)
 
 	for _, endpoint := range endpoints {
-		endpointName := endpoint.GetMetadata().NamespacedName.String()
+		endpointName := endpoint.GetMetadata().ID.String()
 		count := s.requestCount(ctx, endpoint)
 		requestCounts[endpoint] = count
 		logCounts[endpointName] = count
@@ -196,13 +196,13 @@ func (s *ActiveRequest) requestCount(ctx context.Context, endpoint scheduling.En
 	case *attrconcurrency.InFlightLoad:
 		if load == nil {
 			log.FromContext(ctx).V(logutil.TRACE).Info("Ignoring nil in-flight load attribute",
-				"endpoint", endpoint.GetMetadata().NamespacedName.String())
+				"endpoint", endpoint.GetMetadata().ID.String())
 			return 0
 		}
 		return load.Requests
 	default:
 		log.FromContext(ctx).V(logutil.TRACE).Info("Ignoring in-flight load attribute with unexpected type",
-			"endpoint", endpoint.GetMetadata().NamespacedName.String(),
+			"endpoint", endpoint.GetMetadata().ID.String(),
 			"attributeType", fmt.Sprintf("%T", val))
 		return 0
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -27,7 +27,7 @@ type stubEndpoint struct {
 
 func newStubEndpoint(name string, queueSize int) *stubEndpoint {
 	return &stubEndpoint{
-		metadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
+		metadata: &datalayer.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
 		metrics: &datalayer.Metrics{
 			WaitingQueueSize: queueSize,
 		},
@@ -40,7 +40,7 @@ func (f *stubEndpoint) UpdateMetadata(*datalayer.EndpointMetadata) {}
 func (f *stubEndpoint) GetMetrics() *datalayer.Metrics             { return f.metrics }
 func (f *stubEndpoint) UpdateMetrics(*datalayer.Metrics)           {}
 func (f *stubEndpoint) GetAttributes() datalayer.AttributeMap      { return f.attr }
-func (f *stubEndpoint) String() string                             { return f.metadata.NamespacedName.String() }
+func (f *stubEndpoint) String() string                             { return f.metadata.ID.String() }
 func (f *stubEndpoint) Put(key string, val datalayer.Cloneable)    { f.attr.Put(key, val) }
 func (f *stubEndpoint) Get(key string) (datalayer.Cloneable, bool) {
 	return f.attr.Get(key)

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
@@ -142,7 +142,7 @@ func (p *ContextLengthAware) Filter(ctx context.Context, request *scheduling.Inf
 
 		r, err := parseContextRange(rangeStr)
 		if err != nil {
-			logger.Error(err, "Failed to parse context range label", "endpoint", metadata.NamespacedName, "rangeStr", rangeStr)
+			logger.Error(err, "Failed to parse context range label", "endpoint", metadata.ID, "rangeStr", rangeStr)
 			continue
 		}
 
@@ -181,7 +181,7 @@ func (p *ContextLengthAware) Score(ctx context.Context, request *scheduling.Infe
 
 		r, err := parseContextRange(rangeStr)
 		if err != nil {
-			logger.Error(err, "Failed to parse context range label", "endpoint", metadata.NamespacedName, "rangeStr", rangeStr)
+			logger.Error(err, "Failed to parse context range label", "endpoint", metadata.ID, "rangeStr", rangeStr)
 			scoredEndpoints[endpoint] = 0.0
 			continue
 		}

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -21,9 +21,9 @@ import (
 func createEndpoint(nsn k8stypes.NamespacedName, ipaddr string, labels map[string]string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: nsn,
-			Address:        ipaddr,
-			Labels:         labels,
+			ID:      nsn,
+			Address: ipaddr,
+			Labels:  labels,
 		},
 		nil,
 		nil,
@@ -112,7 +112,7 @@ func TestContextLengthAwareFilter(t *testing.T) {
 
 	gotNames := make([]string, len(filteredEndpoints))
 	for i, endpoint := range filteredEndpoints {
-		gotNames[i] = endpoint.GetMetadata().NamespacedName.Name
+		gotNames[i] = endpoint.GetMetadata().ID.Name
 	}
 
 	expectedEndpoints := []string{"short-range", "wide-range", "no-label"}
@@ -279,7 +279,7 @@ func TestContextLengthAwareWithTokenizedPromptOnRequest(t *testing.T) {
 
 	filteredEndpoints := plugin.Filter(ctx, request, endpoints)
 	assert.Equal(t, 1, len(filteredEndpoints))
-	assert.Equal(t, "tight-match", filteredEndpoints[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "tight-match", filteredEndpoints[0].GetMetadata().ID.Name)
 }
 
 func TestContextLengthAwareNilTokenizedPromptIsZero(t *testing.T) {
@@ -309,5 +309,5 @@ func TestContextLengthAwareNilTokenizedPromptIsZero(t *testing.T) {
 
 	filteredEndpoints := plugin.Filter(ctx, request, endpoints)
 	assert.Equal(t, 1, len(filteredEndpoints))
-	assert.Equal(t, "matching-range", filteredEndpoints[0].GetMetadata().NamespacedName.Name)
+	assert.Equal(t, "matching-range", filteredEndpoints[0].GetMetadata().ID.Name)
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -320,7 +320,7 @@ func (s *Plugin) scoreBucket(ctx context.Context, data []epData, scores map[fwks
 		scores[d.endpoint] = w / float64(wMax)
 
 		logger.V(logutil.TRACE).Info("LatencyScorer: scored endpoint",
-			"endpoint", d.endpoint.GetMetadata().NamespacedName.Name,
+			"endpoint", d.endpoint.GetMetadata().ID.Name,
 			"ttftHeadroom", d.ttftHeadroom, "tpotHeadroom", d.tpotHeadroom,
 			"nTTFT", nTTFT, "nTPOT", nTPOT, "combined", combined, "score", scores[d.endpoint])
 	}
@@ -368,7 +368,7 @@ func (s *Plugin) compositeScores(ctx context.Context, endpoints []fwksched.Endpo
 
 		scores[ep] = score
 		logger.V(logutil.TRACE).Info("LatencyScorer: composite",
-			"endpoint", ep.GetMetadata().NamespacedName.Name,
+			"endpoint", ep.GetMetadata().ID.Name,
 			"kvFree", kvFree, "relQueue", relQueue, "prefix", prefix, "score", score)
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin_test.go
@@ -29,7 +29,7 @@ import (
 
 func makeLatencyScorerEndpoint(name string, kvCache float64, queueSize, runningReqs int) fwksched.Endpoint {
 	return fwksched.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}},
 		&fwkdl.Metrics{
 			KVCacheUsagePercent: kvCache,
 			WaitingQueueSize:    queueSize,
@@ -179,7 +179,7 @@ func TestScoreHierarchicalBuckets(t *testing.T) {
 	// All should have non-zero scores (they're all in the negative tier).
 	for _, ep := range endpoints {
 		if scores[ep] == 0 {
-			t.Errorf("%s should have non-zero score", ep.GetMetadata().NamespacedName.Name)
+			t.Errorf("%s should have non-zero score", ep.GetMetadata().ID.Name)
 		}
 	}
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware_test.go
@@ -15,21 +15,21 @@ import (
 
 func TestLoadBasedScorer(t *testing.T) {
 	endpointA := scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-a"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-a"}},
 		&fwkdl.Metrics{
 			WaitingQueueSize: 2,
 		},
 		nil,
 	)
 	endpointB := scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-b"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-b"}},
 		&fwkdl.Metrics{
 			WaitingQueueSize: 0,
 		},
 		nil,
 	)
 	endpointC := scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-c"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-c"}},
 		&fwkdl.Metrics{
 			WaitingQueueSize: 15,
 		},

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
@@ -39,7 +39,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-1": 1},
 						WaitingModels:   map[string]int{},
@@ -55,7 +55,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 2},
 						WaitingModels:   map[string]int{"active-model-1": 1},
@@ -71,14 +71,14 @@ func TestLoraAffinityScorer(t *testing.T) {
 			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 2},
 						WaitingModels:   map[string]int{"active-model-3": 1},
 						MaxActiveModels: 2,
 					}, nil),
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{},
 						WaitingModels:   map[string]int{},
@@ -95,35 +95,35 @@ func TestLoraAffinityScorer(t *testing.T) {
 			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-1": 1},
 						WaitingModels:   map[string]int{},
 						MaxActiveModels: 5,
 					}, nil),
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 4},
 						WaitingModels:   map[string]int{"active-model-1": 1},
 						MaxActiveModels: 5,
 					}, nil),
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 1},
 						WaitingModels:   map[string]int{},
 						MaxActiveModels: 2,
 					}, nil),
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod4"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod4"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-3": 1},
 						WaitingModels:   map[string]int{"active-model-1": 1},
 						MaxActiveModels: 2,
 					}, nil),
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod5"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod5"}},
 					&fwkdl.Metrics{
 						ActiveModels:    map[string]int{"active-model-4": 1, "active-model-5": 1},
 						WaitingModels:   map[string]int{},
@@ -152,11 +152,11 @@ func TestLoraAffinityScorer(t *testing.T) {
 			scores := scorer.Score(context.Background(), test.request, test.endpoints)
 
 			for _, endpoint := range test.endpoints {
-				expectedScore, ok := test.expectedScoresEndpoint[endpoint.GetMetadata().NamespacedName.Name]
+				expectedScore, ok := test.expectedScoresEndpoint[endpoint.GetMetadata().ID.Name]
 				if !ok {
-					t.Fatalf("Expected score not found for endpoint %s in test %s", endpoint.GetMetadata().NamespacedName, test.name)
+					t.Fatalf("Expected score not found for endpoint %s in test %s", endpoint.GetMetadata().ID, test.name)
 				}
-				assert.InDelta(t, expectedScore, scores[endpoint], 0.0001, "Endpoint %s should have score %f", endpoint.GetMetadata().NamespacedName.Name, expectedScore)
+				assert.InDelta(t, expectedScore, scores[endpoint], 0.0001, "Endpoint %s should have score %f", endpoint.GetMetadata().ID.Name, expectedScore)
 			}
 			assert.Len(t, scores, len(test.expectedScoresEndpoint), "Number of scored endpoints should match expected")
 		})

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer.go
@@ -104,7 +104,7 @@ func (s *Scorer) Score(ctx context.Context, req *scheduling.InferenceRequest, en
 		scores[endpoint] = 0
 		pod := ""
 		if meta := endpoint.GetMetadata(); meta != nil {
-			pod = meta.PodName
+			pod = meta.Name
 		}
 		info, ok := endpoint.Get(s.mmMatchDataKey.String())
 		if !ok {

--- a/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/scorer_test.go
@@ -79,7 +79,7 @@ func TestScoreMissingOrInvalidMatchInfoReturnsZero(t *testing.T) {
 func newEndpoint(name string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
 		&fwkdl.EndpointMetadata{
-			NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: name},
+			ID: k8stypes.NamespacedName{Namespace: "default", Name: name},
 		},
 		&fwkdl.Metrics{},
 		nil,

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -175,7 +175,7 @@ func (s *NoHitLRU) isColdRequest(ctx context.Context, endpoints []scheduling.End
 		}
 		info, ok := attr.(*attrprefix.PrefixCacheMatchInfo)
 		if ok && info.MatchBlocks() > 0 {
-			logger.Info("Cache hit detected on endpoint", "endpoint", ep.GetMetadata().NamespacedName)
+			logger.Info("Cache hit detected on endpoint", "endpoint", ep.GetMetadata().ID)
 			return false
 		}
 	}
@@ -210,7 +210,7 @@ func (s *NoHitLRU) getLRUPositions() map[string]int {
 // (usedPods) and those that have never received cold requests (neverUsedPods).
 func (s *NoHitLRU) partitionPodsByUsage(endpoints []scheduling.Endpoint, lruPosition map[string]int) (usedEndpoints, neverUsedEndpoints []scheduling.Endpoint) {
 	for _, endpoint := range endpoints {
-		endpointName := endpoint.GetMetadata().NamespacedName.String()
+		endpointName := endpoint.GetMetadata().ID.String()
 		if _, exists := lruPosition[endpointName]; exists {
 			usedEndpoints = append(usedEndpoints, endpoint)
 		} else {
@@ -242,7 +242,7 @@ func (s *NoHitLRU) scoreUsedPods(scoredEndpoints map[scheduling.Endpoint]float64
 		return
 	}
 	for _, endpoint := range usedPods {
-		endpointName := endpoint.GetMetadata().NamespacedName.String()
+		endpointName := endpoint.GetMetadata().ID.String()
 		lruPos := lruPosition[endpointName]
 		// LRU keys are oldest to newest so rank 0 = oldest
 		// The never used endpoint count is added to the rank so that
@@ -339,7 +339,7 @@ func (s *NoHitLRU) moveTargetPodToFront(ctx context.Context, request *scheduling
 	logger := log.FromContext(ctx).V(logging.DEBUG)
 
 	targetPod := targetProfile.TargetEndpoints[0]
-	endpointName := targetPod.GetMetadata().NamespacedName.String()
+	endpointName := targetPod.GetMetadata().ID.String()
 
 	// Move the endpoint to the front of the LRU.
 	var present struct{} // dummy value

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -74,7 +74,7 @@ func (p *stubPlugin) TypedName() plugin.TypedName {
 // newCold returns an endpoint without any prefix-cache match info (cold).
 func newCold(name string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}},
 		&fwkdl.Metrics{},
 		nil,
 	)
@@ -83,7 +83,7 @@ func newCold(name string) scheduling.Endpoint {
 // newColdNS returns a cold endpoint in the "default" namespace.
 func newColdNS(name string) scheduling.Endpoint {
 	return scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
 		&fwkdl.Metrics{},
 		nil,
 	)
@@ -243,7 +243,7 @@ func TestNoHitLRUBasicFunctionality(t *testing.T) {
 
 	for endpoint, score := range scores {
 		if score < 0 || score > 1 {
-			t.Errorf("Invalid score %f for endpoint %s", score, endpoint.GetMetadata().NamespacedName.String())
+			t.Errorf("Invalid score %f for endpoint %s", score, endpoint.GetMetadata().ID.String())
 		}
 	}
 
@@ -283,7 +283,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	// The NamespacedName matches the cold endpoints, so LRU tracking is shared.
 	warmEndpoints := func() []scheduling.Endpoint {
 		w := scheduling.NewEndpoint(
-			&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-a", Namespace: "default"}},
+			&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-a", Namespace: "default"}},
 			&fwkdl.Metrics{},
 			nil,
 		)
@@ -316,10 +316,10 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 			}
 		}
 
-		if highestEndpoint.GetMetadata().NamespacedName.String() != expectedEndpoint.GetMetadata().NamespacedName.String() {
+		if highestEndpoint.GetMetadata().ID.String() != expectedEndpoint.GetMetadata().ID.String() {
 			t.Fatalf("expected %s to have highest score for LRU behavior, but %s had highest score (%f). All scores: %+v",
-				expectedEndpoint.GetMetadata().NamespacedName.String(),
-				highestEndpoint.GetMetadata().NamespacedName.String(),
+				expectedEndpoint.GetMetadata().ID.String(),
+				highestEndpoint.GetMetadata().ID.String(),
 				highestScore,
 				scores)
 		}

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -41,7 +41,7 @@ func TestAnyMMHit(t *testing.T) {
 	const producerName = "test-producer"
 	key := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(producerName).String()
 	makeEndpoint := func(name string, info *attrprefix.PrefixCacheMatchInfo) scheduling.Endpoint {
-		ep := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}}, fwkdl.NewMetrics(), nil)
+		ep := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}}, fwkdl.NewMetrics(), nil)
 		if info != nil {
 			ep.Put(key, info)
 		}
@@ -278,9 +278,9 @@ func TestLegacyProducer_TokensFlowToEndpointAttribute(t *testing.T) {
 		},
 	}
 	endpoint := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Name: "pod1"},
-		Address:        "10.0.0.1",
-		Port:           "8000",
+		ID:      k8stypes.NamespacedName{Name: "pod1"},
+		Address: "10.0.0.1",
+		Port:    "8000",
 	}, nil, nil)
 
 	require.NoError(t, lp.Produce(ctx, req, []scheduling.Endpoint{endpoint}))

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin_test.go
@@ -37,10 +37,10 @@ func TestPrefixPluginScore(t *testing.T) {
 
 	key := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(producerName).String()
 
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), nil)
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), nil)
 	endpoint1.Put(key, attrprefix.NewPrefixCacheMatchInfo(5, 10, 1))
 
-	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), nil)
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), nil)
 	endpoint2.Put(key, attrprefix.NewPrefixCacheMatchInfo(2, 10, 1))
 
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2}
@@ -63,14 +63,14 @@ func TestPrefixPluginScoreWithWeights(t *testing.T) {
 	// matchRatio = 5/10 = 0.5
 	// matchLengthRatio = min(1.0, 5*1/100) = 0.05 -> squared = 0.0025
 	// score = 0.5 * 0.0025 + 0.5 * 0.5 = 0.25125
-	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), nil)
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, fwkdl.NewMetrics(), nil)
 	endpoint1.Put(key, attrprefix.NewPrefixCacheMatchInfo(5, 10, 1))
 
 	// Endpoint 2: match 50, total 100, block size 1
 	// matchRatio = 50/100 = 0.5
 	// matchLengthRatio = min(1.0, 50*1/100) = 0.5 -> squared = 0.25
 	// score = 0.5 * 0.25 + 0.5 * 0.5 = 0.375
-	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), nil)
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, fwkdl.NewMetrics(), nil)
 	endpoint2.Put(key, attrprefix.NewPrefixCacheMatchInfo(50, 100, 1))
 
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2}

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -99,7 +99,7 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 
 	for _, endpoint := range endpoints {
 		scoredEndpoints[endpoint] = 0.0 // initial value
-		if endpoint.GetMetadata().NamespacedName.String() == podName {
+		if endpoint.GetMetadata().ID.String() == podName {
 			scoredEndpoints[endpoint] = 1.0
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -33,12 +33,12 @@ import (
 
 func TestSessionAffinity_Score(t *testing.T) {
 	endpointA := scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-a"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-a"}},
 		&fwkdl.Metrics{},
 		nil,
 	)
 	endpointB := scheduling.NewEndpoint(
-		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod-b"}},
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod-b"}},
 		&fwkdl.Metrics{},
 		nil,
 	)
@@ -46,7 +46,7 @@ func TestSessionAffinity_Score(t *testing.T) {
 	inputEndpoints := []scheduling.Endpoint{endpointA, endpointB}
 
 	// valid session token for endpointB
-	validSessionTokenForEndpointB := base64.StdEncoding.EncodeToString([]byte(endpointB.GetMetadata().NamespacedName.String()))
+	validSessionTokenForEndpointB := base64.StdEncoding.EncodeToString([]byte(endpointB.GetMetadata().ID.String()))
 
 	sessionAffinityScorer := sessionaffinity.NewSessionAffinity("test-scorer", "", "")
 	customHeaderScorer := sessionaffinity.NewSessionAffinity("test-scorer", "x-custom-session", "")
@@ -143,12 +143,12 @@ func TestSessionAffinity_Score(t *testing.T) {
 
 func TestSessionAffinity_ResponseHeader(t *testing.T) {
 	targetEndpoint := &fwkdl.EndpointMetadata{
-		NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "pod1"},
-		Address:        "1.2.3.4",
+		ID:      k8stypes.NamespacedName{Namespace: "default", Name: "pod1"},
+		Address: "1.2.3.4",
 	}
 
 	// expected token to be set in response header
-	wantToken := base64.StdEncoding.EncodeToString([]byte(targetEndpoint.NamespacedName.String()))
+	wantToken := base64.StdEncoding.EncodeToString([]byte(targetEndpoint.ID.String()))
 
 	tests := []struct {
 		name            string
@@ -202,7 +202,7 @@ func TestSessionAffinity_ResponseHeader(t *testing.T) {
 						"prefill": {
 							TargetEndpoints: []scheduling.Endpoint{
 								scheduling.NewEndpoint(
-									&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"}},
+									&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Namespace: "default", Name: "prefill-pod"}},
 									&fwkdl.Metrics{},
 									nil,
 								),

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -95,7 +95,7 @@ func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.InferenceReques
 	logger := log.FromContext(ctx)
 
 	for _, endpoint := range endpoints {
-		endpointID := endpoint.GetMetadata().NamespacedName.String()
+		endpointID := endpoint.GetMetadata().ID.String()
 		tokenLoad := 0.0
 
 		// Read both accumulated in-flight load and the projected impact of the

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -45,9 +45,9 @@ func TestTokenLoadScorer(t *testing.T) {
 		pod3NN := types.NamespacedName{Namespace: "default", Name: "pod3"}
 
 		endpoints := []fwksched.Endpoint{
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod1NN}, &fwkdl.Metrics{}, nil),
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod2NN}, &fwkdl.Metrics{}, nil),
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod3NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: pod1NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: pod2NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: pod3NN}, &fwkdl.Metrics{}, nil),
 		}
 
 		// pod1: 0 in-flight, no current-request impact. Score = 1 - 0/1000 = 1.0
@@ -69,9 +69,9 @@ func TestTokenLoadScorer(t *testing.T) {
 		pod3NN := types.NamespacedName{Namespace: "default", Name: "pod3"}
 
 		endpoints := []fwksched.Endpoint{
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod1NN}, &fwkdl.Metrics{}, nil),
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod2NN}, &fwkdl.Metrics{}, nil),
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: pod3NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: pod1NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: pod2NN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: pod3NN}, &fwkdl.Metrics{}, nil),
 		}
 
 		// pod1: 0 in-flight + 250 current = 250. Score = 1 - 250/1000 = 0.75
@@ -96,7 +96,7 @@ func TestTokenLoadScorer(t *testing.T) {
 	t.Run("missing data key degrades gracefully", func(t *testing.T) {
 		podNN := types.NamespacedName{Namespace: "default", Name: "pod-no-data"}
 		endpoints := []fwksched.Endpoint{
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podNN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: podNN}, &fwkdl.Metrics{}, nil),
 		}
 
 		// No key set; should score as if 0 token load
@@ -107,7 +107,7 @@ func TestTokenLoadScorer(t *testing.T) {
 	t.Run("typed nil attribute handles gracefully", func(t *testing.T) {
 		podNN := types.NamespacedName{Namespace: "default", Name: "pod-typed-nil"}
 		endpoints := []fwksched.Endpoint{
-			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: podNN}, &fwkdl.Metrics{}, nil),
+			fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: podNN}, &fwkdl.Metrics{}, nil),
 		}
 
 		var nilLoad *attrconcurrency.InFlightLoad

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
@@ -80,7 +80,7 @@ func WriteResponseHeader(ctx context.Context, pluginType, sessionHeader string, 
 		response.Headers = make(map[string]string)
 	}
 
-	response.Headers[sessionHeader] = base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
+	response.Headers[sessionHeader] = base64.StdEncoding.EncodeToString([]byte(targetPod.ID.String()))
 }
 
 // ResolvePodToWrite looks up the target pod from the scheduling results if profileName is set.

--- a/pkg/epp/metrics/collectors/inference_pool.go
+++ b/pkg/epp/metrics/collectors/inference_pool.go
@@ -75,14 +75,14 @@ func (c *inferencePoolMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			float64(pod.GetMetrics().WaitingQueueSize),
 			pool.Name,
-			pod.GetMetadata().NamespacedName.Name,
+			pod.GetMetadata().ID.Name,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			eppmetrics.DescInferencePoolPerEndpointQueueSize,
 			prometheus.GaugeValue,
 			float64(pod.GetMetrics().WaitingQueueSize),
 			pool.Name,
-			pod.GetMetadata().NamespacedName.Name,
+			pod.GetMetadata().ID.Name,
 		)
 	}
 }

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -805,8 +805,8 @@ func RecordSchedulerAttempt(err error, targetModelName string, result *fwksched.
 			if len(primaryResults.TargetEndpoints) > 0 {
 				metadata := primaryResults.TargetEndpoints[0].GetMetadata()
 				if metadata != nil {
-					schedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.Name, metadata.NamespacedName.Namespace, metadata.Port).Inc()
-					llmdSchedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.Name, metadata.NamespacedName.Namespace, metadata.Port).Inc()
+					schedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.Name, metadata.ID.Namespace, metadata.Port).Inc()
+					llmdSchedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.Name, metadata.ID.Namespace, metadata.Port).Inc()
 					return
 				}
 			}

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -805,8 +805,8 @@ func RecordSchedulerAttempt(err error, targetModelName string, result *fwksched.
 			if len(primaryResults.TargetEndpoints) > 0 {
 				metadata := primaryResults.TargetEndpoints[0].GetMetadata()
 				if metadata != nil {
-					schedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.PodName, metadata.NamespacedName.Namespace, metadata.Port).Inc()
-					llmdSchedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.PodName, metadata.NamespacedName.Namespace, metadata.Port).Inc()
+					schedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.Name, metadata.NamespacedName.Namespace, metadata.Port).Inc()
+					llmdSchedulerAttemptsTotal.WithLabelValues(SchedulerStatusSuccess, targetModelName, metadata.Name, metadata.NamespacedName.Namespace, metadata.Port).Inc()
 					return
 				}
 			}

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1098,7 +1098,7 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
-								PodName:        "pod-1",
+								Name:           "pod-1",
 								Port:           "8080",
 							},
 							nil, nil,
@@ -1123,7 +1123,7 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
-								PodName:        "pod-1",
+								Name:           "pod-1",
 								Port:           "8080",
 							},
 							nil, nil,
@@ -1131,7 +1131,7 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
-								PodName:        "pod-2",
+								Name:           "pod-2",
 								Port:           "9090",
 							},
 							nil, nil,
@@ -1156,7 +1156,7 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
-								PodName:        "pod-1",
+								Name:           "pod-1",
 								Port:           "8080",
 							},
 							nil, nil,
@@ -1173,7 +1173,7 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
 								NamespacedName: k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
-								PodName:        "pod-2",
+								Name:           "pod-2",
 								Port:           "9090",
 							},
 							nil, nil,

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1097,9 +1097,9 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 					TargetEndpoints: []fwksched.Endpoint{
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
-								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
-								Name:           "pod-1",
-								Port:           "8080",
+								ID:   k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
+								Name: "pod-1",
+								Port: "8080",
 							},
 							nil, nil,
 						),
@@ -1122,17 +1122,17 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 					TargetEndpoints: []fwksched.Endpoint{
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
-								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
-								Name:           "pod-1",
-								Port:           "8080",
+								ID:   k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
+								Name: "pod-1",
+								Port: "8080",
 							},
 							nil, nil,
 						),
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
-								NamespacedName: k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
-								Name:           "pod-2",
-								Port:           "9090",
+								ID:   k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
+								Name: "pod-2",
+								Port: "9090",
 							},
 							nil, nil,
 						),
@@ -1155,9 +1155,9 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 					TargetEndpoints: []fwksched.Endpoint{
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
-								NamespacedName: k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
-								Name:           "pod-1",
-								Port:           "8080",
+								ID:   k8stypes.NamespacedName{Name: "pod-1", Namespace: "ns-1"},
+								Name: "pod-1",
+								Port: "8080",
 							},
 							nil, nil,
 						),
@@ -1172,9 +1172,9 @@ func TestSchedulerAttemptsTotal(t *testing.T) {
 					TargetEndpoints: []fwksched.Endpoint{
 						fwksched.NewEndpoint(
 							&fwkdl.EndpointMetadata{
-								NamespacedName: k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
-								Name:           "pod-2",
-								Port:           "9090",
+								ID:   k8stypes.NamespacedName{Name: "pod-2", Namespace: "ns-2"},
+								Name: "pod-2",
+								Port: "9090",
 							},
 							nil, nil,
 						),

--- a/pkg/epp/requestcontrol/candidates_test.go
+++ b/pkg/epp/requestcontrol/candidates_test.go
@@ -304,8 +304,8 @@ func (m *mockEndpointCandidates) callCount() int {
 
 func makeMockEndpoint(name, ip string) fwkdl.Endpoint {
 	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Namespace: "default", Name: name},
-		Address:        ip,
+		ID:      types.NamespacedName{Namespace: "default", Name: name},
+		Address: ip,
 	}, nil)
 }
 

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -337,26 +337,26 @@ func TestDirector_HandleRequest(t *testing.T) {
 				TargetEndpoints: []fwksched.Endpoint{
 					&fwksched.ScoredEndpoint{
 						Endpoint: fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-							Address:        "192.168.1.100",
-							Port:           "8000",
-							MetricsHost:    "192.168.1.100:8000",
-							NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
+							Address:     "192.168.1.100",
+							Port:        "8000",
+							MetricsHost: "192.168.1.100:8000",
+							ID:          types.NamespacedName{Name: "pod1", Namespace: "default"},
 						}, nil, nil),
 					},
 					&fwksched.ScoredEndpoint{
 						Endpoint: fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-							Address:        "192.168.2.100",
-							Port:           "8000",
-							MetricsHost:    "192.168.2.100:8000",
-							NamespacedName: types.NamespacedName{Name: "pod2", Namespace: "default"},
+							Address:     "192.168.2.100",
+							Port:        "8000",
+							MetricsHost: "192.168.2.100:8000",
+							ID:          types.NamespacedName{Name: "pod2", Namespace: "default"},
 						}, nil, nil),
 					},
 					&fwksched.ScoredEndpoint{
 						Endpoint: fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-							Address:        "192.168.4.100",
-							Port:           "8000",
-							MetricsHost:    "192.168.4.100:8000",
-							NamespacedName: types.NamespacedName{Name: "pod4", Namespace: "default"},
+							Address:     "192.168.4.100",
+							Port:        "8000",
+							MetricsHost: "192.168.4.100:8000",
+							ID:          types.NamespacedName{Name: "pod4", Namespace: "default"},
 						}, nil, nil),
 					},
 				},
@@ -400,10 +400,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				ObjectiveKey:    objectiveName,
 				TargetModelName: model,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -496,10 +496,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				ObjectiveKey:    objectiveName,
 				TargetModelName: model,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -532,10 +532,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				ObjectiveKey:    model,
 				TargetModelName: modelRewritten,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -564,10 +564,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantReqCtx: &handlers.RequestContext{
 				TargetModelName: model,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -601,10 +601,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantReqCtx: &handlers.RequestContext{
 				TargetModelName: model,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -638,10 +638,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantReqCtx: &handlers.RequestContext{
 				TargetModelName: model,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -709,10 +709,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				ObjectiveKey:    objectiveName,
 				TargetModelName: model,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -732,10 +732,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				ObjectiveKey:    objectiveNameResolve,
 				TargetModelName: "resolved-target-model-A",
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -755,10 +755,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				ObjectiveKey:    "food-review-1",
 				TargetModelName: "food-review-1",
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -799,10 +799,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantReqCtx: &handlers.RequestContext{
 				TargetModelName: genericRewriteTarget,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
@@ -1371,7 +1371,7 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 			Headers: map[string]string{"X-Test-Response-Header": "TestValue"},
 		},
 
-		TargetPod: &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}},
+		TargetPod: &fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}},
 	}
 
 	director.HandleResponseHeader(ctx, reqCtx)
@@ -1391,8 +1391,8 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 // session-affinity scorer and filter, registered as response-received plugins,
 // set the session token header when the director runs the response-header hook.
 func TestDirector_HandleResponseHeader_SessionAffinity(t *testing.T) {
-	targetPod := &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}}
-	wantToken := base64.StdEncoding.EncodeToString([]byte(targetPod.NamespacedName.String()))
+	targetPod := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}}
+	wantToken := base64.StdEncoding.EncodeToString([]byte(targetPod.ID.String()))
 
 	tests := []struct {
 		name       string
@@ -1468,7 +1468,7 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 		Response: &handlers.Response{
 			Headers: map[string]string{"X-Test-Streaming-Header": "StreamValue"},
 		},
-		TargetPod: &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}},
+		TargetPod: &fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}},
 	}
 
 	director.HandleResponseBody(ctx, reqCtx, false)
@@ -1674,18 +1674,18 @@ func (p *testResponseReceived) ResponseHeader(_ context.Context, _ *fwksched.Inf
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.lastRespOnResponse = response
-	p.lastTargetPodOnResponse = targetPod.NamespacedName.String()
+	p.lastTargetPodOnResponse = targetPod.ID.String()
 }
 
 func (p *testResponseStreaming) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, response *fwkrc.Response, targetPod *fwkdl.EndpointMetadata) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.respsOnStreaming = append(p.respsOnStreaming, response)
-	p.targetPodsOnStreaming = append(p.targetPodsOnStreaming, targetPod.NamespacedName.String())
+	p.targetPodsOnStreaming = append(p.targetPodsOnStreaming, targetPod.ID.String())
 
 	// Maintain legacy fields for compatibility
 	p.lastRespOnStreaming = response
-	p.lastTargetPodOnStreaming = targetPod.NamespacedName.String()
+	p.lastTargetPodOnStreaming = targetPod.ID.String()
 }
 
 func TestResponseBodyQueue_CloseWaitsForBlockedEnqueue(t *testing.T) {
@@ -1807,13 +1807,13 @@ func TestPrimaryEndpointHasCachedPrefix(t *testing.T) {
 		attrs.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(),
 			attrprefix.NewPrefixCacheMatchInfo(matched, total, 1))
 		return fwksched.NewEndpoint(
-			&fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "default", Name: "p"}},
+			&fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "default", Name: "p"}},
 			nil, attrs,
 		)
 	}
 	endpointBare := func() fwksched.Endpoint {
 		return fwksched.NewEndpoint(
-			&fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "default", Name: "p"}},
+			&fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "default", Name: "p"}},
 			nil, fwkdl.NewAttributes(),
 		)
 	}
@@ -1821,7 +1821,7 @@ func TestPrimaryEndpointHasCachedPrefix(t *testing.T) {
 		attrs := fwkdl.NewAttributes()
 		attrs.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), wrongTypeAttr{})
 		return fwksched.NewEndpoint(
-			&fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Namespace: "default", Name: "p"}},
+			&fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "default", Name: "p"}},
 			nil, attrs,
 		)
 	}
@@ -1915,10 +1915,10 @@ func TestDirector_HandleRequest_ConditionalDecode(t *testing.T) {
 			ProfileResults: map[string]*fwksched.ProfileRunResult{
 				"decode": {TargetEndpoints: []fwksched.Endpoint{
 					fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-						Address:        "192.168.1.100",
-						Port:           "8000",
-						MetricsHost:    "192.168.1.100:8000",
-						NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
+						Address:     "192.168.1.100",
+						Port:        "8000",
+						MetricsHost: "192.168.1.100:8000",
+						ID:          types.NamespacedName{Name: "pod1", Namespace: "default"},
 					}, nil, attrs),
 				}},
 			},

--- a/pkg/epp/scheduling/scheduler_bench_test.go
+++ b/pkg/epp/scheduling/scheduler_bench_test.go
@@ -130,7 +130,7 @@ func makeBenchmarkEndpoints(n int) []fwksched.Endpoint {
 		}
 		endpoints[i] = fwksched.NewEndpoint(
 			&fwkdl.EndpointMetadata{
-				NamespacedName: k8stypes.NamespacedName{Name: fmt.Sprintf("pod%d", i)},
+				ID: k8stypes.NamespacedName{Name: fmt.Sprintf("pod%d", i)},
 			},
 			&fwkdl.Metrics{
 				WaitingQueueSize:    i % 8,              // 0..7

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -192,7 +192,7 @@ func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *fwksch
 		metrics.RecordPluginProcessingLatency(scorerExtensionPoint, scorer.TypedName().Type, scorer.TypedName().Name, time.Since(before))
 		for endpoint, score := range scores { // weight is relative to the sum of weights
 			if debugEnabled {
-				debug.Info("Calculated score", "plugin", scorer.TypedName(), "endpoint", endpoint.GetMetadata().NamespacedName, "score", score)
+				debug.Info("Calculated score", "plugin", scorer.TypedName(), "endpoint", endpoint.GetMetadata().ID, "score", score)
 			}
 			weightedScorePerEndpoint[endpoint] += enforceScoreRange(score) * scorer.Weight()
 		}
@@ -268,8 +268,8 @@ func topScoredEndpoints(scored []*fwksched.ScoredEndpoint, limit int) ([]string,
 		if ranked[i].Score != ranked[j].Score {
 			return ranked[i].Score > ranked[j].Score
 		}
-		return ranked[i].GetMetadata().NamespacedName.String() <
-			ranked[j].GetMetadata().NamespacedName.String()
+		return ranked[i].GetMetadata().ID.String() <
+			ranked[j].GetMetadata().ID.String()
 	})
 	if limit < len(ranked) {
 		ranked = ranked[:limit]
@@ -277,7 +277,7 @@ func topScoredEndpoints(scored []*fwksched.ScoredEndpoint, limit int) ([]string,
 	names := make([]string, len(ranked))
 	scores := make([]float64, len(ranked))
 	for i, se := range ranked {
-		names[i] = se.GetMetadata().NamespacedName.String()
+		names[i] = se.GetMetadata().ID.String()
 		scores[i] = se.Score
 	}
 	return names, scores

--- a/pkg/epp/scheduling/scheduler_profile_picker_tracing_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_picker_tracing_test.go
@@ -67,7 +67,7 @@ func newWeightedScores(names ...string) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(names))
 	for i, name := range names {
 		endpoint := fwksched.NewEndpoint(
-			&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}}, nil, nil)
+			&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}}, nil, nil)
 		scores[endpoint] = float64(i)
 	}
 	return scores

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -67,9 +67,9 @@ func TestSchedulePlugins(t *testing.T) {
 				WithScorers(NewWeightedScorer(tp1, 1), NewWeightedScorer(tp2, 1)).
 				WithPicker(pickerPlugin),
 			input: []fwksched.Endpoint{
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
 			},
 			wantTargetEndpoint:  k8stypes.NamespacedName{Name: "pod1"},
 			targetEndpointScore: 1.1,
@@ -83,9 +83,9 @@ func TestSchedulePlugins(t *testing.T) {
 				WithScorers(NewWeightedScorer(tp1, 60), NewWeightedScorer(tp2, 40)).
 				WithPicker(pickerPlugin),
 			input: []fwksched.Endpoint{
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
 			},
 			wantTargetEndpoint:  k8stypes.NamespacedName{Name: "pod1"},
 			targetEndpointScore: 50,
@@ -99,9 +99,9 @@ func TestSchedulePlugins(t *testing.T) {
 				WithScorers(NewWeightedScorer(tp1, 1), NewWeightedScorer(tp2, 1)).
 				WithPicker(pickerPlugin),
 			input: []fwksched.Endpoint{
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
 			},
 			numEndpointsToScore: 0,
 			err:                 true, // no available endpoints to server after filter all
@@ -139,7 +139,7 @@ func TestSchedulePlugins(t *testing.T) {
 			// Validate output
 			wantRes := &fwksched.ProfileRunResult{
 				TargetEndpoints: []fwksched.Endpoint{
-					fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: test.wantTargetEndpoint}, nil, nil),
+					fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: test.wantTargetEndpoint}, nil, nil),
 				},
 			}
 
@@ -226,7 +226,7 @@ func (tp *testPlugin) Pick(_ context.Context, scoredEndpoints []*fwksched.Scored
 
 	winnerEndpoints := []fwksched.Endpoint{}
 	for _, scoredEndpoint := range scoredEndpoints {
-		if scoredEndpoint.GetMetadata().NamespacedName.String() == tp.PickRes.String() {
+		if scoredEndpoint.GetMetadata().ID.String() == tp.PickRes.String() {
 			winnerEndpoints = append(winnerEndpoints, scoredEndpoint.Endpoint)
 			tp.WinnerEndpointScore = scoredEndpoint.Score
 		}
@@ -393,7 +393,7 @@ func TestRunWithOutOfRangeScores(t *testing.T) {
 		WithPicker(pickerPlugin)
 
 	input := []fwksched.Endpoint{
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
 	}
 
 	request := &fwksched.InferenceRequest{
@@ -444,8 +444,8 @@ func TestFilterExecutionOrder(t *testing.T) {
 		WithPicker(pickerPlugin)
 
 	input := []fwksched.Endpoint{
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
 	}
 
 	request := &fwksched.InferenceRequest{
@@ -489,7 +489,7 @@ func TestFilterExecutionOrderViaAddPlugins(t *testing.T) {
 	profile.WithPicker(pickerPlugin)
 
 	input := []fwksched.Endpoint{
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
 	}
 
 	request := &fwksched.InferenceRequest{
@@ -539,9 +539,9 @@ func TestFilterChainReceivesPreviousOutput(t *testing.T) {
 		WithPicker(pickerPlugin)
 
 	input := []fwksched.Endpoint{
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
 	}
 
 	request := &fwksched.InferenceRequest{
@@ -607,7 +607,7 @@ func findEndpoints(endpoints []fwksched.Endpoint, names ...k8stypes.NamespacedNa
 	res := []fwksched.Endpoint{}
 	for _, endpoint := range endpoints {
 		for _, name := range names {
-			if endpoint.GetMetadata().NamespacedName.String() == name.String() {
+			if endpoint.GetMetadata().ID.String() == name.String() {
 				res = append(res, endpoint)
 			}
 		}

--- a/pkg/epp/scheduling/scheduler_profile_tracing_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_tracing_test.go
@@ -66,7 +66,7 @@ func newTestEndpoints(names ...string) []fwksched.Endpoint {
 	endpoints := make([]fwksched.Endpoint, len(names))
 	for i, name := range names {
 		endpoints[i] = fwksched.NewEndpoint(
-			&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}}, nil, nil)
+			&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name}}, nil, nil)
 	}
 	return endpoints
 }

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -83,7 +83,7 @@ func TestSchedule(t *testing.T) {
 			// model being active, and has low KV cache.
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
 					&fwkdl.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -94,7 +94,7 @@ func TestSchedule(t *testing.T) {
 						},
 					}, nil),
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}},
 					&fwkdl.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -105,7 +105,7 @@ func TestSchedule(t *testing.T) {
 						},
 					}, nil),
 				fwksched.NewEndpoint(
-					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}},
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}},
 					&fwkdl.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.8,
@@ -121,7 +121,7 @@ func TestSchedule(t *testing.T) {
 						TargetEndpoints: []fwksched.Endpoint{
 							&fwksched.ScoredEndpoint{
 								Endpoint: fwksched.NewEndpoint(
-									&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+									&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}},
 									&fwkdl.Metrics{
 										WaitingQueueSize:    0,
 										KVCacheUsagePercent: 0.2,

--- a/test/integration/epp/runtime_polling_test.go
+++ b/test/integration/epp/runtime_polling_test.go
@@ -102,9 +102,9 @@ func TestRuntimePollingDispatch(t *testing.T) {
 			t.Cleanup(cancel)
 
 			endpointMeta := &fwkdl.EndpointMetadata{
-				NamespacedName: types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
-				MetricsHost:    srv.Listener.Addr().String(),
-				Port:           "8000",
+				ID:          types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
+				MetricsHost: srv.Listener.Addr().String(),
+				Port:        "8000",
 			}
 
 			ep := r.NewEndpoint(ctx, endpointMeta)
@@ -154,9 +154,9 @@ func TestRuntimePollingMultipleExtractors(t *testing.T) {
 	t.Cleanup(cancel)
 
 	endpointMeta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
-		MetricsHost:    srv.Listener.Addr().String(),
-		Port:           "8000",
+		ID:          types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
+		MetricsHost: srv.Listener.Addr().String(),
+		Port:        "8000",
 	}
 
 	ep := r.NewEndpoint(ctx, endpointMeta)
@@ -203,9 +203,9 @@ func TestRuntimePollingEndpointLifecycle(t *testing.T) {
 	t.Cleanup(cancel)
 
 	endpointMeta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
-		MetricsHost:    srv.Listener.Addr().String(),
-		Port:           "8000",
+		ID:          types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
+		MetricsHost: srv.Listener.Addr().String(),
+		Port:        "8000",
 	}
 
 	ep := r.NewEndpoint(ctx, endpointMeta)
@@ -257,9 +257,9 @@ func TestRuntimePollingWithoutExtractors(t *testing.T) {
 	t.Cleanup(cancel)
 
 	endpointMeta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
-		MetricsHost:    srv.Listener.Addr().String(),
-		Port:           "8000",
+		ID:          types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
+		MetricsHost: srv.Listener.Addr().String(),
+		Port:        "8000",
 	}
 
 	ep := r.NewEndpoint(ctx, endpointMeta)
@@ -296,9 +296,9 @@ func TestRuntimePollingHTTPError(t *testing.T) {
 	t.Cleanup(cancel)
 
 	endpointMeta := &fwkdl.EndpointMetadata{
-		NamespacedName: types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
-		MetricsHost:    srv.Listener.Addr().String(),
-		Port:           "8000",
+		ID:          types.NamespacedName{Name: "test-pod", Namespace: "test-ns"},
+		MetricsHost: srv.Listener.Addr().String(),
+		Port:        "8000",
 	}
 
 	ep := r.NewEndpoint(ctx, endpointMeta)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Rename `EndpointMetadata.PodName` to `Name`. The endpoint model is not
Kubernetes-only: file-discovered endpoints have no pod, and `NamespacedName` is the
identity. `Name` is always set, so an endpoint has a name regardless of discovery
source.

followup from https://github.com/llm-d/llm-d-router/pull/1927

**Which issue(s) this PR fixes**:

Fixes #

**Release note**:
```release-note
NONE
```
