### PR TITLE
docs: require monotone ceilings in UsageLimitPolicy contract

### DIFF
--- a/pkg/epp/framework/interface/flowcontrol/plugins.go
+++ b/pkg/epp/framework/interface/flowcontrol/plugins.go
@@ -148,9 +148,9 @@ type SaturationDetector interface {
 // considered on that call.
 //
 // Conformance: Implementations MUST ensure all methods are goroutine-safe. Returned ceilings MUST be
-// monotonically non-increasing in the given priority order: because the dispatch loop stops at the first
-// gated band, a lower band whose ceiling exceeds that of a higher band can be marked open on calls where
-// it is unreachable, starving it.
+// monotonically non-increasing in the given priority order (highest priority first): because the
+// dispatch loop stops at the first gated band, a lower band whose ceiling exceeds that of a higher band
+// can be marked open on calls where it is unreachable, starving it.
 type UsageLimitPolicy interface {
 	plugin.Plugin
 

--- a/pkg/epp/framework/interface/flowcontrol/plugins.go
+++ b/pkg/epp/framework/interface/flowcontrol/plugins.go
@@ -143,9 +143,14 @@ type SaturationDetector interface {
 // Integration:
 // This policy is called during dispatch decision-making, before a request is allowed to proceed. For each
 // priority band, the returned ceiling is compared against current saturation. If saturation exceeds the
-// ceiling for a given priority, requests at that priority are gated (not dispatched).
+// ceiling for a given priority, requests at that priority are gated (not dispatched). The dispatch loop
+// visits bands from highest to lowest priority and stops at the first gated band; lower bands are not
+// considered on that call.
 //
-// Conformance: Implementations MUST ensure all methods are goroutine-safe.
+// Conformance: Implementations MUST ensure all methods are goroutine-safe. Returned ceilings MUST be
+// monotonically non-increasing in the given priority order: because the dispatch loop stops at the first
+// gated band, a lower band whose ceiling exceeds that of a higher band can be marked open on calls where
+// it is unreachable, starving it.
 type UsageLimitPolicy interface {
 	plugin.Plugin
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Documents a conformance requirement on `UsageLimitPolicy` implementations: returned ceilings must be monotonically non-increasing in the given priority order. The flow controller's dispatch loop visits bands from highest to lowest priority and stops at the first gated band, so a lower band whose ceilin g exceeds a higher band's can report itself open on calls where the dispatch loop never reaches it, starving that band. The requirement previously existed only implicitly in the dispatch loop's behavior; this states it in the interface contract where implementers will see it.

**Which issue(s) this PR fixes**:

N/A (doc-comment-only change). Related to #1956.

 **Release note** _(write `NONE` if no user-facing change)_:

 ```release-note
 NONE
```