### PR TITLE
add subscriber and pool health metrics

### DIFF
--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -33,6 +33,10 @@ import (
 // aliases so existing scrapers keep working during the migration.
 const routerSubsystem = "llm_d_router_epp"
 
+// podIdentifierLabel is the label key carried by the per-pod kvevents metrics.
+// Keeping it as a constant localizes label-schema changes to this package.
+const podIdentifierLabel = "pod_identifier"
+
 // dualCounter emits a value to both the deprecated kvcache_* counter and the
 // current llm_d_router_epp_* counter. It satisfies prometheus.Collector so both
 // register, and exposes the recording/read methods the call sites use.
@@ -130,6 +134,53 @@ var (
 	DedupRemovedHashesForwarded = newDualCounter("kvevents", "dedup_removed_hashes_forwarded_total",
 		"kv_cache_events_dedup_removed_hashes_forwarded_total",
 		"Block hashes forwarded for eviction after the KV-event dedup filter (block hashes, not BlockRemoved events)")
+
+	// SubscriberActive tracks the number of ZMQ subscribers currently managed by
+	// the SubscriberManager. A subscriber is counted from creation until it is
+	// removed, so the gauge includes subscribers that are retrying a failed
+	// connection; it is a measure of intent, not of live connectivity. Pair it
+	// with SubscriberReconnections and ZMQErrors to spot unhealthy subscribers.
+	SubscriberActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_active_subscribers",
+		Help: metricsutil.HelpMsgWithStability(
+			"Number of ZMQ subscribers currently managed, including those retrying a failed connection",
+			compbasemetrics.ALPHA),
+	})
+	// SubscriberReconnections counts ZMQ subscriber reconnection attempts,
+	// labeled by the pod identifier the subscriber is bound to.
+	SubscriberReconnections = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_subscriber_reconnections_total",
+		Help: metricsutil.HelpMsgWithStability(
+			"Total number of ZMQ subscriber reconnection attempts", compbasemetrics.ALPHA),
+	}, []string{podIdentifierLabel})
+	// MessagesReceived counts raw messages received from ZMQ subscribers. The
+	// rate of message ingestion can be derived via rate() in Prometheus.
+	MessagesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_messages_received_total",
+		Help: metricsutil.HelpMsgWithStability(
+			"Total number of messages received from ZMQ subscribers", compbasemetrics.ALPHA),
+	}, []string{podIdentifierLabel})
+	// ZMQErrors counts errors encountered by ZMQ subscribers, labeled by the
+	// pod identifier and the operation that failed (e.g. "connect", "recv").
+	ZMQErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_zmq_errors_total",
+		Help: metricsutil.HelpMsgWithStability(
+			"Total number of ZMQ subscriber errors", compbasemetrics.ALPHA),
+	}, []string{podIdentifierLabel, "operation"})
+	// PoolQueueDepth tracks the total number of messages queued across all
+	// worker shards of the event processing pool.
+	PoolQueueDepth = prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_pool_queue_depth",
+		Help: metricsutil.HelpMsgWithStability(
+			"Total number of messages queued across all worker shards", compbasemetrics.ALPHA),
+	})
+	// PoolCapacity tracks the number of worker shards (capacity) configured for
+	// the event processing pool.
+	PoolCapacity = prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_pool_capacity",
+		Help: metricsutil.HelpMsgWithStability(
+			"Number of worker shards (capacity) in the event processing pool", compbasemetrics.ALPHA),
+	})
 )
 
 // Collectors returns a slice of all registered Prometheus collectors.
@@ -138,7 +189,19 @@ func Collectors() []prometheus.Collector {
 		Admissions, Evictions,
 		LookupRequests, LookupHits, LookupLatency, MaxPodHitCount,
 		DedupRemovedHashesSuppressed, DedupRemovedHashesForwarded,
+		SubscriberActive, SubscriberReconnections, MessagesReceived, ZMQErrors,
+		PoolQueueDepth, PoolCapacity,
 	}
+}
+
+// CleanupSubscriber drops every per-pod kvevents series for podIdentifier so
+// stale time series do not linger after a subscriber is removed. Callers must
+// invoke it only once the subscriber's goroutine has exited, otherwise a late
+// increment resurrects the series.
+func CleanupSubscriber(podIdentifier string) {
+	SubscriberReconnections.DeleteLabelValues(podIdentifier)
+	MessagesReceived.DeleteLabelValues(podIdentifier)
+	ZMQErrors.DeletePartialMatch(prometheus.Labels{podIdentifierLabel: podIdentifier})
 }
 
 var registerMetricsOnce = sync.Once{}

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -52,6 +52,12 @@ func TestCollectorsIncludesAllMetrics(t *testing.T) {
 		{"MaxPodHitCount", MaxPodHitCount},
 		{"DedupRemovedHashesSuppressed", DedupRemovedHashesSuppressed},
 		{"DedupRemovedHashesForwarded", DedupRemovedHashesForwarded},
+		{"SubscriberActive", SubscriberActive},
+		{"SubscriberReconnections", SubscriberReconnections},
+		{"MessagesReceived", MessagesReceived},
+		{"ZMQErrors", ZMQErrors},
+		{"PoolQueueDepth", PoolQueueDepth},
+		{"PoolCapacity", PoolCapacity},
 	}
 
 	for _, e := range expected {
@@ -59,6 +65,92 @@ func TestCollectorsIncludesAllMetrics(t *testing.T) {
 			t.Errorf("Collectors() is missing %s", e.name)
 		}
 	}
+}
+
+func TestKVEventsMetricNames(t *testing.T) {
+	// The kvevents observability metrics must be emitted under the router EPP
+	// subsystem with the kv_cache_events prefix.
+	reg := prometheus.NewRegistry()
+	kvevents := []prometheus.Collector{
+		SubscriberActive, SubscriberReconnections, MessagesReceived,
+		ZMQErrors, PoolQueueDepth, PoolCapacity,
+	}
+	for _, c := range kvevents {
+		reg.MustRegister(c)
+	}
+
+	// Emit a sample for each labeled metric so it appears in the gather output.
+	SubscriberActive.Set(1)
+	SubscriberReconnections.WithLabelValues("pod-a").Inc()
+	MessagesReceived.WithLabelValues("pod-a").Inc()
+	ZMQErrors.WithLabelValues("pod-a", "recv").Inc()
+	PoolQueueDepth.Set(3)
+	PoolCapacity.Set(4)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed: %v", err)
+	}
+
+	got := make(map[string]bool, len(mfs))
+	for _, mf := range mfs {
+		got[mf.GetName()] = true
+	}
+
+	for _, name := range []string{
+		"llm_d_router_epp_kv_cache_events_active_subscribers",
+		"llm_d_router_epp_kv_cache_events_subscriber_reconnections_total",
+		"llm_d_router_epp_kv_cache_events_messages_received_total",
+		"llm_d_router_epp_kv_cache_events_zmq_errors_total",
+		"llm_d_router_epp_kv_cache_events_pool_queue_depth",
+		"llm_d_router_epp_kv_cache_events_pool_capacity",
+	} {
+		if !got[name] {
+			t.Errorf("expected metric %q to be registered, got names: %v", name, got)
+		}
+	}
+}
+
+func TestCleanupSubscriberDropsPerPodSeries(t *testing.T) {
+	// Removing a subscriber must drop only its own series, leaving other pods'
+	// series intact.
+	SubscriberReconnections.WithLabelValues("pod-a").Inc()
+	MessagesReceived.WithLabelValues("pod-a").Inc()
+	ZMQErrors.WithLabelValues("pod-a", "recv").Inc()
+	ZMQErrors.WithLabelValues("pod-a", "connect").Inc()
+	SubscriberReconnections.WithLabelValues("pod-b").Inc()
+	MessagesReceived.WithLabelValues("pod-b").Inc()
+	ZMQErrors.WithLabelValues("pod-b", "recv").Inc()
+
+	CleanupSubscriber("pod-a")
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(SubscriberReconnections, MessagesReceived, ZMQErrors)
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed: %v", err)
+	}
+
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == podIdentifierLabel && l.GetValue() == "pod-a" {
+					t.Errorf("metric %q still has a series for pod-a", mf.GetName())
+				}
+			}
+		}
+	}
+
+	// pod-b must be untouched: three series across the three metrics.
+	remaining := 0
+	for _, mf := range mfs {
+		remaining += len(mf.GetMetric())
+	}
+	if remaining != 3 {
+		t.Errorf("expected 3 remaining pod-b series, got %d", remaining)
+	}
+
+	CleanupSubscriber("pod-b")
 }
 
 func TestLogMetrics(t *testing.T) {

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -20,6 +20,7 @@ import (
 	"hash/fnv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -114,11 +115,19 @@ type Pool struct {
 	// Index.Add succeeds — both of which only the Pool observes.
 	dedup *eventDedupFilter
 	wg    sync.WaitGroup
+	// queueDepth mirrors the number of tasks queued across all shards. It is
+	// tracked incrementally rather than by summing queue.Len() so that the
+	// depth gauge stays O(1) on the enqueue/dequeue hot path.
+	queueDepth atomic.Int64
 }
 
 // NewPool creates a Pool with a sharded worker setup.
 // Subscribers are managed by SubscriberManager which is controlled by the pod
 // reconciler.
+//
+// Side effect: it registers the kvcache metrics with the controller-runtime
+// registry so that the kvevents metrics are scraped wherever a pool runs.
+// Registration is idempotent (guarded by a sync.Once).
 func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProcessor,
 	adapter EngineAdapter,
 ) *Pool {
@@ -140,7 +149,15 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		p.queues[i] = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*RawMessage]())
 	}
 
+	metrics.Register()
+
 	return p
+}
+
+// addQueueDepth adjusts the tracked queue depth by delta and publishes the new
+// total to the depth gauge.
+func (p *Pool) addQueueDepth(delta int64) {
+	metrics.PoolQueueDepth.Set(float64(p.queueDepth.Add(delta)))
 }
 
 // GroupCatalog returns the KV cache group metadata learned from events.
@@ -153,6 +170,8 @@ func (p *Pool) GroupCatalog() *kvblock.GroupCatalog {
 func (p *Pool) Start(ctx context.Context) {
 	logger := log.FromContext(ctx)
 	logger.Info("Starting sharded event processing pool", "workers", p.concurrency)
+
+	metrics.PoolCapacity.Set(float64(p.concurrency))
 
 	p.wg.Add(p.concurrency)
 	for i := 0; i < p.concurrency; i++ {
@@ -171,6 +190,12 @@ func (p *Pool) Shutdown(ctx context.Context) {
 	}
 
 	p.wg.Wait()
+
+	// Tasks still queued at shutdown are dropped with the queues, so reset the
+	// depth rather than leaving the gauge pinned at the undrained count.
+	p.queueDepth.Store(0)
+	metrics.PoolQueueDepth.Set(0)
+
 	logger.Info("event processing pool shut down.")
 }
 
@@ -189,6 +214,7 @@ func (p *Pool) AddTask(task *RawMessage) {
 	//nolint:gosec // if concurrency overflows then the world is in trouble anyway
 	queueIndex := h.Sum32() % uint32(p.concurrency)
 	p.queues[queueIndex].Add(task)
+	p.addQueueDepth(1)
 }
 
 // worker is the main processing loop for a single worker goroutine.
@@ -209,6 +235,7 @@ func (p *Pool) worker(ctx context.Context, workerIndex int) {
 			// Task succeeded, remove it from the queue.
 			queue.Forget(task)
 		}(task)
+		p.addQueueDepth(-1)
 
 		// Check if context was cancelled after processing a task.
 		select {

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -3,6 +3,7 @@ package kvevents //nolint:testpackage // tests use unexported processEventBatch
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -1094,6 +1095,64 @@ func TestPool_DedupMetricsCountBlockHashes(t *testing.T) {
 		"first of two duplicate removes must suppress all 4 constituent block hashes")
 	assert.Equal(t, 4.0, counterValue(t, metrics.DedupRemovedHashesForwarded)-forwardedBefore,
 		"second remove must forward all 4 constituent block hashes")
+}
+
+// stubAdapter is a minimal EngineAdapter that shards every message onto the
+// same key and decodes to an empty batch, so tasks flow through the pool
+// without exercising any engine-specific parsing.
+type stubAdapter struct{}
+
+//nolint:gocritic // unnamed results match the EngineAdapter implementations
+func (stubAdapter) ParseMessage(_ *RawMessage) (string, string, EventBatch, error) {
+	return "pod-1", "model-1", EventBatch{}, nil
+}
+
+func (stubAdapter) ShardingKey(_ *RawMessage) string { return "pod-1" }
+
+// TestPool_QueueDepthAccounting verifies that the queue depth gauge tracks
+// enqueues and dequeues, and is reset once the pool shuts down.
+func TestPool_QueueDepthAccounting(t *testing.T) {
+	idx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+
+	tp, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
+		BlockSizeTokens: 4, HashSeed: "test",
+	})
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Concurrency = 2
+	pool := NewPool(cfg, idx, tp, stubAdapter{})
+
+	const tasks = 3
+	for i := range uint64(tasks) {
+		pool.AddTask(&RawMessage{Topic: "kv@pod-1@model-1", Sequence: i})
+	}
+
+	assert.Equal(t, int64(tasks), pool.queueDepth.Load(), "every enqueued task must be counted")
+	assert.InDelta(t, float64(tasks), gaugeValue(t, metrics.PoolQueueDepth), 0.001)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	assert.Eventually(t, func() bool {
+		return pool.queueDepth.Load() == 0
+	}, 5*time.Second, 10*time.Millisecond, "workers must decrement the depth as tasks drain")
+
+	pool.Shutdown(ctx)
+	assert.Equal(t, int64(0), pool.queueDepth.Load())
+	assert.InDelta(t, 0.0, gaugeValue(t, metrics.PoolQueueDepth), 0.001)
+	assert.InDelta(t, float64(cfg.Concurrency), gaugeValue(t, metrics.PoolCapacity), 0.001)
+}
+
+// gaugeValue reads the current value of a prometheus.Gauge without touching the
+// global registry.
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, g.Write(&m))
+	return m.GetGauge().GetValue()
 }
 
 // counterValue reads the current value of a plain prometheus.Counter without

--- a/pkg/kvevents/subscriber_manager.go
+++ b/pkg/kvevents/subscriber_manager.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -36,6 +37,8 @@ type subscriberEntry struct {
 	subscriber *zmqSubscriber
 	cancel     context.CancelFunc
 	endpoint   string
+	// done is closed once the subscriber's goroutine has returned.
+	done chan struct{}
 }
 
 // NewSubscriberManager creates a new subscriber manager.
@@ -71,22 +74,30 @@ func (sm *SubscriberManager) EnsureSubscriber(ctx context.Context, podIdentifier
 			"newEndpoint", endpoint)
 		entry.cancel()
 		delete(sm.subscribers, podIdentifier)
+		// The replacement subscriber below reuses podIdentifier, so its series
+		// are kept rather than cleaned up.
 	}
 
 	// Create new subscriber
 	debugLogger.Info("Creating new subscriber", "podIdentifier", podIdentifier, "endpoint", endpoint)
-	subscriber := newZMQSubscriber(sm.pool, endpoint, topicFilter, remoteSocket)
+	subscriber := newZMQSubscriber(sm.pool, podIdentifier, endpoint, topicFilter, remoteSocket)
 
 	// Create a context and start subscriber
 	subCtx, cancel := context.WithCancel(ctx)
-	go subscriber.Start(subCtx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		subscriber.Start(subCtx)
+	}()
 
 	// Update subscribers
 	sm.subscribers[podIdentifier] = &subscriberEntry{
 		subscriber: subscriber,
 		cancel:     cancel,
 		endpoint:   endpoint,
+		done:       done,
 	}
+	metrics.SubscriberActive.Set(float64(len(sm.subscribers)))
 
 	debugLogger.Info("Subscriber created and started", "podIdentifier", podIdentifier, "endpoint", endpoint)
 	return nil
@@ -108,6 +119,18 @@ func (sm *SubscriberManager) RemoveSubscriber(ctx context.Context, podIdentifier
 	debugLogger.Info("Removing subscriber", "podIdentifier", podIdentifier, "endpoint", entry.endpoint)
 	entry.cancel()
 	delete(sm.subscribers, podIdentifier)
+	metrics.SubscriberActive.Set(float64(len(sm.subscribers)))
+	cleanupSubscriberMetrics(podIdentifier, entry.done)
+}
+
+// cleanupSubscriberMetrics drops the per-pod series for a removed subscriber
+// once its goroutine has exited. Cancellation is asynchronous, so cleaning up
+// eagerly would let a final message or error increment resurrect the series.
+func cleanupSubscriberMetrics(podIdentifier string, done <-chan struct{}) {
+	go func() {
+		<-done
+		metrics.CleanupSubscriber(podIdentifier)
+	}()
 }
 
 // Shutdown shuts down all subscribers.
@@ -121,9 +144,11 @@ func (sm *SubscriberManager) Shutdown(ctx context.Context) {
 	for podIdentifier, entry := range sm.subscribers {
 		debugLogger.Info("Shutting down subscriber", "podIdentifier", podIdentifier)
 		entry.cancel()
+		cleanupSubscriberMetrics(podIdentifier, entry.done)
 	}
 
 	sm.subscribers = make(map[string]*subscriberEntry)
+	metrics.SubscriberActive.Set(0)
 	debugLogger.Info("All subscribers shut down")
 }
 

--- a/pkg/kvevents/zmq_subscriber.go
+++ b/pkg/kvevents/zmq_subscriber.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/metrics"
 )
 
 const (
@@ -32,19 +33,21 @@ const (
 
 // zmqSubscriber connects to a ZMQ publisher and forwards messages to a pool.
 type zmqSubscriber struct {
-	pool        *Pool
-	endpoint    string
-	remote      bool
-	topicFilter string
+	pool          *Pool
+	podIdentifier string
+	endpoint      string
+	remote        bool
+	topicFilter   string
 }
 
 // newZMQSubscriber creates a new ZMQ subscriber.
-func newZMQSubscriber(pool *Pool, endpoint, topicFilter string, remote bool) *zmqSubscriber {
+func newZMQSubscriber(pool *Pool, podIdentifier, endpoint, topicFilter string, remote bool) *zmqSubscriber {
 	return &zmqSubscriber{
-		pool:        pool,
-		endpoint:    endpoint,
-		remote:      remote,
-		topicFilter: topicFilter,
+		pool:          pool,
+		podIdentifier: podIdentifier,
+		endpoint:      endpoint,
+		remote:        remote,
+		topicFilter:   topicFilter,
 	}
 }
 
@@ -66,6 +69,7 @@ func (z *zmqSubscriber) Start(ctx context.Context) {
 			// wait before retrying, unless the context has been canceled.
 			select {
 			case <-time.After(retryInterval):
+				metrics.SubscriberReconnections.WithLabelValues(z.podIdentifier).Inc()
 				logger.Info("retrying zmq-subscriber")
 			case <-ctx.Done():
 				logger.Info("shutting down zmq-subscriber")
@@ -90,12 +94,14 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 	// Bind for local endpoints, connect for remote ones.
 	if !z.remote {
 		if err := sub.Listen(z.endpoint); err != nil {
+			metrics.ZMQErrors.WithLabelValues(z.podIdentifier, "bind").Inc()
 			logger.Error(err, "Failed to bind subscriber socket", "endpoint", z.endpoint)
 			return
 		}
 		logger.Info("Bound subscriber socket", "endpoint", z.endpoint)
 	} else {
 		if err := sub.Dial(z.endpoint); err != nil {
+			metrics.ZMQErrors.WithLabelValues(z.podIdentifier, "connect").Inc()
 			logger.Error(err, "Failed to connect subscriber socket", "endpoint", z.endpoint)
 			return
 		}
@@ -103,6 +109,7 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 	}
 
 	if err := sub.SetOption(zmq4.OptionSubscribe, z.topicFilter); err != nil {
+		metrics.ZMQErrors.WithLabelValues(z.podIdentifier, "subscribe").Inc()
 		logger.Error(err, "Failed to subscribe to topic filter", "topic", z.topicFilter)
 		return
 	}
@@ -115,9 +122,11 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 			if ctx.Err() != nil {
 				return // context cancelled, clean shutdown
 			}
+			metrics.ZMQErrors.WithLabelValues(z.podIdentifier, "recv").Inc()
 			debugLogger.Error(err, "Failed to receive message from zmq subscriber", "endpoint", z.endpoint)
 			return // exit to trigger reconnect
 		}
+		metrics.MessagesReceived.WithLabelValues(z.podIdentifier).Inc()
 		parts := msg.Frames
 		if len(parts) != 3 {
 			debugLogger.Error(nil, "Unexpected frame count", "got", len(parts), "want", 3)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds Prometheus observability for the kvevents ZMQ subscriber subsystem and event processing pool, which previously had no instrumentation: subscriber liveness, message throughput, and pool saturation were invisible in production.

Six new metrics under the `llm_d_router_epp` subsystem (ALPHA stability):

- `llm_d_router_epp_kv_cache_events_active_subscribers` (gauge): subscribers currently managed, including those retrying a failed connection
- `llm_d_router_epp_kv_cache_events_subscriber_reconnections_total` (counter, by `pod_identifier`)
- `llm_d_router_epp_kv_cache_events_messages_received_total` (counter, by pod_identifier`)
- `llm_d_router_epp_kv_cache_events_zmq_errors_total` (counter, by `pod_identifier` and `operation`: bind, connect, subscribe, recv)
- `llm_d_router_epp_kv_cache_events_pool_queue_depth` (gauge): tasks queued across all worker shards, tracked O(1) on the hot path
- `llm_d_router_epp_kv_cache_events_pool_capacity` (gauge): worker shard count

Metrics register with the controller-runtime registry on pool creation (idempotent). Per-pod series are dropped when a subscriber is removed, after its goroutine has exited, so a late increment cannot resurrect the series.

This ports llm-d/llm-d-kv-cache#646 (reviewed there before the library migration; see llm-d/llm-d-kv-cache#701) to this repository. Two adaptations from the original PR:

- Metrics follow this repository's convention of emitting new metrics under the `llm_d_router_epp` subsystem with stability annotations, instead of the legacy `kvcache_kvevents_*` names. No deprecated aliases are added since these names never shipped.
- The reconnect-loop timer-reuse micro-optimization was dropped to keep the change minimal.

**Which issue(s) this PR fixes**:

Fixes llm-d/llm-d-kv-cache#641

**Test plan**:

- [x] Metric naming convention enforced for all six metrics
- [x] Per-pod series cleanup removes only the removed subscriber's series
- [x] Queue depth gauge tracks enqueue/dequeue and resets on pool shutdown
- [x] Unit tests for `./pkg/kvevents/` and `./pkg/kvcache/metrics/` pass with `-race`
- [x] Lint (`make lint LINT_NEW_ONLY=true`) passes

**Release note**:
```release-note
Added Prometheus metrics for KV-event subscriber health and pool saturation: active subscribers, per-pod reconnection/message/ZMQ-error counters, and event pool queue depth and capacity, under the llm_d_router_epp subsystem.
```
