### PR TITLE
fix(kvevents): honor configured engine adapter in precise prefix cache

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
@@ -36,6 +36,9 @@ upstream. No-op otherwise.
 | `speculativeIndexing` | bool | `false` | Seed predicted entries on routing decisions. |
 | `speculativeTTL` | duration | `2s` | TTL for speculative entries. |
 
+Set `kvEventsConfig.engineType` to `sglang` for SGLang KV-events. It defaults
+to `vllm` when omitted.
+
 See [llm-d-kv-cache/docs/configuration.md](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/configuration.md)
 for nested parameter details.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -80,7 +80,7 @@ type subscriberManager interface {
 }
 
 // Producer is a DataProducer plugin that maintains a KV-block prefix-cache
-// index by subscribing to vLLM KV-events and writes per-endpoint
+// index by subscribing to engine KV-events and writes per-endpoint
 // PrefixCacheMatchInfo for each request. Operators pair it with the
 // generic prefix-cache-scorer (set prefixMatchInfoProducerName to this
 // producer's instance name) to route requests by precise cache locality.
@@ -178,7 +178,11 @@ func New(ctx context.Context, name string, config PluginConfig) (*Producer, erro
 		return nil, fmt.Errorf("failed to create KVBlockScorer: %w", err)
 	}
 
-	pool := kvevents.NewPool(config.KVEventsConfig, indexer.KVBlockIndex(), tokenProcessor, engineadapter.NewVLLMAdapter())
+	adapter, err := engineadapter.NewAdapter(config.KVEventsConfig.EngineType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create KV-events engine adapter: %w", err)
+	}
+	pool := kvevents.NewPool(config.KVEventsConfig, indexer.KVBlockIndex(), tokenProcessor, adapter)
 	pool.Start(ctx)
 
 	subscribersManager := kvevents.NewSubscriberManager(pool)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -740,6 +740,22 @@ func TestNew_BlockSizeFlowsViaTokenProcessor(t *testing.T) {
 	}
 }
 
+func TestNewRejectsUnsupportedKVEventEngineType(t *testing.T) {
+	ctx, cancel := context.WithCancel(utils.NewTestContext(t))
+	t.Cleanup(cancel)
+
+	idxCfg, err := kvcache.NewDefaultConfig()
+	require.NoError(t, err)
+	kvEventsCfg := kvevents.DefaultConfig()
+	kvEventsCfg.EngineType = "unsupported"
+
+	_, err = New(ctx, "unsupported-engine", PluginConfig{
+		IndexerConfig:  idxCfg,
+		KVEventsConfig: kvEventsCfg,
+	})
+	require.ErrorContains(t, err, `unsupported engine type: "unsupported"`)
+}
+
 type fakeSubscriberManager struct {
 	ids       []string
 	endpoints []string


### PR DESCRIPTION
What type of PR is this?

/kind bug

**What this PR does / why we need it**:

Enable precise prefix-cache routing for SGLang KV events.

The repository already provides an SGLang KV-event adapter and the
`kvEventsConfig.engineType` option, but the precise-prefix-cache producer
always instantiated the vLLM adapter. As a result, `engineType: sglang`
was not applied by the producer.

SGLang may also emit KV events with a page size smaller than the EPP
canonical block size. Processing each page independently produces no
canonical request key, which leaves subsequent `parent_block_hash`
references unresolved.

This change:

- Selects the KV-event adapter using `kvEventsConfig.engineType`.
- Accumulates sub-canonical SGLang pages before indexing.
- Preserves immutable parent-page chains for radix-tree branches.
- Cleans pending page state on block removal and cache reset.
- Documents the SGLang engine configuration.

**Validation**:

- Added a producer wiring test for unsupported engine types.
- Added cross-batch SGLang page accumulation coverage.
- Added radix-tree branch coverage.
- Passed unit tests for `pkg/kvevents`, `pkg/kvevents/engineadapter`, and
  `preciseprefixcache`.
- Cross-compiled and deployed the EPP as a Linux/amd64 binary.
- Validated a 2-prefill/2-decode SGLang deployment.
- First request produced 7 precise-index admissions.
- Repeated prefix produced 7 lookup hits and a max pod hit count of 7.
- No tokenizer or parent-chain errors were observed.

EPP restart replay of pre-existing SGLang KV events is outside the scope
of this PR.

**Which issue(s) this PR fixes**:

N/A

**Release note**:

```release-note
Enable precise prefix-cache routing for SGLang KV events.