### PR TITLE
ci(coordinator): Align coordinator CI image build with the router's m…

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -33,6 +33,10 @@ inputs:
     required: false
     description: Git commit SHA to embed via COMMIT_SHA build arg
     default: ''
+  build-ref:
+    required: false
+    description: Human-readable build ref embedded via BUILD_REF build arg. Falls back to tag when unset.
+    default: ''
   additional-tags:
     required: false
     description: Additional image tags to push
@@ -66,6 +70,6 @@ runs:
         build-args: |
           LDFLAGS=-s -w
           COMMIT_SHA=${{ inputs.commit-sha || 'unknown' }}
-          BUILD_REF=${{ inputs.tag || 'unknown' }}
+          BUILD_REF=${{ inputs.build-ref || inputs.tag || 'unknown' }}
         cache-from: type=gha,scope=${{ inputs.image-name }}
         cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}

--- a/.github/workflows/ci-coordinator.yaml
+++ b/.github/workflows/ci-coordinator.yaml
@@ -1,7 +1,9 @@
 name: CI - Coordinator Test
 
 # Runs coordinator unit tests and e2e tests. Path filter excludes paths not
-# exercised by the coordinator.
+# exercised by the coordinator. The e2e-images matrix job is followed by an
+# e2e-images-status job that aggregates its result, since GitHub required
+# status checks cannot reference individual matrix legs.
 on:
   push:
     branches:
@@ -40,6 +42,7 @@ jobs:
               - scripts/**
               - hack/**
               - test/**
+              - .github/actions/docker-build-and-push/action.yml
               - .github/actions/e2e-runner-setup/action.yml
               - .github/workflows/ci-coordinator.yaml
               - '!Dockerfile.sidecar'
@@ -85,8 +88,83 @@ jobs:
           GO_BUILD_CACHE_VOL: ${{ steps.go-cache.outputs.build }}
         run: make -f Makefile.coord.mk test-unit
 
-  e2e-tests:
+  e2e-images:
     needs: check-changes
+    if: ${{ needs.check-changes.outputs.src == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: builder
+            source: build
+            docker-file: Dockerfile.builder
+            image-name: llm-d-builder
+            archive: llm-d-builder
+          - name: coordinator
+            source: build
+            docker-file: Dockerfile.coordinator
+            image-name: llm-d-coordinator
+            archive: llm-d-coordinator
+          - name: epp
+            source: build
+            docker-file: Dockerfile.epp
+            image-name: llm-d-router-endpoint-picker
+            archive: llm-d-router-endpoint-picker
+          - name: simulator
+            source: pull
+            image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
+            archive: llm-d-inference-sim
+    name: e2e-images (${{ matrix.image.name }})
+    steps:
+      - name: Checkout source
+        if: ${{ matrix.image.source == 'build' }}
+        uses: actions/checkout@v7
+
+      - name: Build ${{ matrix.image.name }} image
+        if: ${{ matrix.image.source == 'build' }}
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: ${{ matrix.image.docker-file }}
+          image-name: ${{ matrix.image.image-name }}
+          tag: dev
+          registry: ghcr.io/llm-d
+          push: 'false'
+          buildx-outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image.archive }}.tar
+          commit-sha: ${{ github.sha }}
+
+      - name: Pull ${{ matrix.image.name }} image
+        if: ${{ matrix.image.source == 'pull' }}
+        run: |
+          docker pull --platform linux/amd64 "${{ matrix.image.image }}"
+          docker save "${{ matrix.image.image }}" -o "${{ runner.temp }}/${{ matrix.image.archive }}.tar"
+
+      - name: Upload ${{ matrix.image.name }} image
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-coord-image-${{ matrix.image.name }}
+          path: ${{ runner.temp }}/${{ matrix.image.archive }}.tar
+          retention-days: 1
+          compression-level: 0
+
+  e2e-images-status:
+    needs: e2e-images
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e-images result
+        run: |
+          result="${{ needs.e2e-images.result }}"
+          if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+            echo "::error::e2e-images failed for at least one matrix image"
+            exit 1
+          fi
+
+  e2e-tests:
+    needs:
+      - check-changes
+      - e2e-images
     if: ${{ needs.check-changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -98,9 +176,40 @@ jobs:
         id: e2e-setup
         uses: ./.github/actions/e2e-runner-setup
 
+      - name: Download builder image
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-coord-image-builder
+          path: ${{ runner.temp }}/e2e-images
+
+      - name: Download coordinator image
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-coord-image-coordinator
+          path: ${{ runner.temp }}/e2e-images
+
+      - name: Download EPP image
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-coord-image-epp
+          path: ${{ runner.temp }}/e2e-images
+
+      - name: Download simulator image
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-coord-image-simulator
+          path: ${{ runner.temp }}/e2e-images
+
+      - name: Load e2e images
+        shell: bash
+        run: |
+          for image in "${RUNNER_TEMP}"/e2e-images/*.tar; do
+            docker load --input "$image"
+          done
+
       - name: Run coordinator e2e tests
         shell: bash
         env:
           GO_MOD_CACHE_VOL: ${{ steps.e2e-setup.outputs.go-mod-cache }}
           GO_BUILD_CACHE_VOL: ${{ steps.e2e-setup.outputs.go-build-cache }}
-        run: make -f Makefile.coord.mk test-e2e-coordinator
+        run: make -f Makefile.coord.mk test-e2e-coordinator-run

--- a/.github/workflows/ci-coordinator.yaml
+++ b/.github/workflows/ci-coordinator.yaml
@@ -42,6 +42,7 @@ jobs:
               - scripts/**
               - hack/**
               - test/**
+              - config/coordinator/**
               - .github/actions/docker-build-and-push/action.yml
               - .github/actions/e2e-runner-setup/action.yml
               - .github/workflows/ci-coordinator.yaml
@@ -133,6 +134,7 @@ jobs:
           push: 'false'
           buildx-outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image.archive }}.tar
           commit-sha: ${{ github.sha }}
+          build-ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Pull ${{ matrix.image.name }} image
         if: ${{ matrix.image.source == 'pull' }}

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -259,6 +259,7 @@ jobs:
           push: 'false'
           buildx-outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image.archive }}.tar
           commit-sha: ${{ github.sha }}
+          build-ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Pull ${{ matrix.image.name }} image
         if: ${{ matrix.image.source == 'pull' }}
@@ -322,6 +323,7 @@ jobs:
           push: 'false'
           buildx-outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image.archive }}.tar
           commit-sha: ${{ github.sha }}
+          build-ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Pull ${{ matrix.image.name }} image
         if: ${{ matrix.image.source == 'pull' }}

--- a/Dockerfile.coordinator
+++ b/Dockerfile.coordinator
@@ -25,10 +25,11 @@ RUN go mod download
 # Copy the go source
 COPY cmd/ cmd/
 COPY pkg/ pkg/
+COPY version/ version/
 COPY config/coordinator/ config/coordinator/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags="${LDFLAGS}" \
+    -ldflags="${LDFLAGS} -X github.com/llm-d/llm-d-router/version.CommitSHA=${COMMIT_SHA} -X github.com/llm-d/llm-d-router/version.BuildRef=${BUILD_REF}" \
     -o bin/coordinator ./cmd/coordinator/...
 
 # Runtime stage

--- a/Makefile.coord.mk
+++ b/Makefile.coord.mk
@@ -4,7 +4,7 @@ SHELL := /usr/bin/env bash
 TARGETOS ?= $(shell command -v go >/dev/null 2>&1 && go env GOOS || uname -s | tr '[:upper:]' '[:lower:]')
 TARGETARCH ?= $(shell command -v go >/dev/null 2>&1 && go env GOARCH || uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/; s/armv7l/arm/')
 PROJECT_NAME ?= llm-d-coordinator
-BUILDER_IMAGE_NAME ?= llm-d-coordinator-builder
+BUILDER_IMAGE_NAME ?= llm-d-builder
 IMAGE_REGISTRY ?= ghcr.io/llm-d
 
 # Image tags

--- a/Makefile.coord.mk
+++ b/Makefile.coord.mk
@@ -196,7 +196,7 @@ test-unit: image-build-builder
 	$(BUILDER_RUN) "go test -v -race $(TEST_PACKAGES)"
 
 .PHONY: test-e2e-coordinator-run
-test-e2e-coordinator-run: image-pull ## Ensure images are present, then run coordinator e2e tests
+test-e2e-coordinator-run: image-pull ## Run coordinator e2e tests against pre-loaded builder/coordinator/epp images (CI entry point; use test-e2e-coordinator locally)
 	@printf "\033[33;1m==== Running Coordinator End to End Tests ====\033[0m\n"
 	$(CONTAINER_RUNTIME) run $(BUILDER_RUN_FLAGS) $(BUILDER_E2E_FLAGS) \
 		$(BUILDER_IMAGE) test/coordinator/scripts/run_e2e_coordinator.sh

--- a/README.coord.md
+++ b/README.coord.md
@@ -307,6 +307,8 @@ make -f Makefile.coord.mk test-e2e-coordinator
 
 This creates a temporary Kind cluster named `e2e-coordinator-tests`, runs the coordinator e2e suite against it, and deletes the cluster on completion.
 
+`test-e2e-coordinator` is the local entry point: it builds the builder, coordinator, and epp images first. CI invokes `test-e2e-coordinator-run` instead, which expects those images to be already built and loaded into the container daemon (`image-pull` fetches only the simulator). Running `test-e2e-coordinator-run` directly without prebuilt images will use stale or missing ones.
+
 **Keeping the cluster on failure**
 
 Set `E2E_KEEP_CLUSTER_ON_FAILURE=true` to preserve the cluster when any test fails. This is useful for inspecting pod logs, events, or cluster state after a failure.

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/version"
 
 	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
@@ -47,6 +48,8 @@ func main() {
 
 	logutil.InitSetupLogging()
 	log := ctrl.Log.WithName("coordinator")
+
+	log.Info("coordinator build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
 
 	cfg, err := config.Load(*configPath)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test


**What this PR does / why we need it**:
Aligns the coordinator CI image build (`ci-coordinator.yaml`) with the router's
matrixed, cached pattern in `ci-pr-checks.yaml`, instead of building the images
serially in one job.

- Replaces the single serial build job with a `strategy.matrix` job
  (`e2e-images`), one leg per image (builder, coordinator, epp built;
  simulator pulled). Each leg exports its image as a `.tar` artifact.
- Adds an `e2e-images-status` aggregator job so a single required status
  check can gate the matrix (individual matrix legs cannot be marked required
  in branch protection).
- The `e2e-tests` job now downloads and `docker load`s the artifacts, then
  runs the non-rebuilding target `test-e2e-coordinator-run` instead of
  rebuilding images inline.
- Builds go through the shared `.github/actions/docker-build-and-push` action
  with `push: 'false'` and `type=gha` layer caching (`scope=<image-name>`),
  matching the router.
- Unifies the builder image name to `llm-d-builder` (the coordinator and
  router share a single `Dockerfile.builder`), so both reuse one builder image
  and one build cache scope instead of duplicating an identical image under
  `llm-d-coordinator-builder`. `BUILDER_IMAGE_NAME` in `Makefile.coord.mk`
  moves in lockstep so the e2e run container resolves.

This addresses a review comment from
https://github.com/llm-d/llm-d-router/pull/1975#issuecomment-4979754959,
which flagged the serial build as a follow-up for a separate PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2154

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
