### PR TITLE
fix: skip TPOT recording for non-streaming requests

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -90,7 +90,7 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		metrics.RecordRequestLatencies(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)
 		metrics.RecordResponseSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.ResponseSize)
 		metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.modelServerStreaming, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp)
-		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
+		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.modelServerStreaming, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 	}
 	return s.director.HandleResponseBody(ctx, reqCtx, endOfStream)
 }

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -677,8 +677,16 @@ func RecordRequestTTFT(ctx context.Context, modelName, targetModelName, fairness
 	return true
 }
 
-// RecordRequestTPOT records the average time per output token.
-func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, received time.Time, firstToken time.Time, complete time.Time, outputTokenCount int) bool {
+// RecordRequestTPOT records the average time per output token. TPOT is only
+// derivable for streaming responses: a non-streaming response arrives as a
+// single body chunk, so the first-token and completion timestamps coincide and
+// no inter-token timing exists. Such requests are skipped silently instead of
+// being logged as invalid (they would otherwise emit an error-level line per
+// request on non-streaming workloads).
+func RecordRequestTPOT(ctx context.Context, modelName, targetModelName, fairnessID, priority string, streaming bool, received time.Time, firstToken time.Time, complete time.Time, outputTokenCount int) bool {
+	if !streaming {
+		return false
+	}
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
 	if firstToken.IsZero() || outputTokenCount <= 1 {

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1442,7 +1442,7 @@ func TestRecordRequestTPOT(t *testing.T) {
 		received := timeBaseline
 		firstToken := timeBaseline.Add(500 * time.Millisecond)
 		complete := timeBaseline.Add(2000 * time.Millisecond)
-		require.True(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", received, firstToken, complete, 11))
+		require.True(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", true, received, firstToken, complete, 11))
 
 		h, err := getHistogramVecLabelValues(t, llmdRequestTPOT, "m10", "t10", "tenant-a", "3")
 		require.NoError(t, err)
@@ -1450,24 +1450,31 @@ func TestRecordRequestTPOT(t *testing.T) {
 		require.InDelta(t, 0.15, h.GetSampleSum(), 0.001)
 	})
 
+	t.Run("non-streaming skipped without error log", func(t *testing.T) {
+		received := timeBaseline
+		firstToken := timeBaseline.Add(500 * time.Millisecond)
+		// Non-streaming: the whole body arrives at once, so complete == firstToken.
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", false, received, firstToken, firstToken, 11))
+	})
+
 	t.Run("single token skipped", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 1))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 1))
 	})
 
 	t.Run("zero tokens skipped", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 0))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline, timeBaseline.Add(100*time.Millisecond), timeBaseline.Add(200*time.Millisecond), 0))
 	})
 
 	t.Run("zero first token timestamp", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, time.Time{}, timeBaseline.Add(200*time.Millisecond), 10))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline, time.Time{}, timeBaseline.Add(200*time.Millisecond), 10))
 	})
 
 	t.Run("first token before received", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline.Add(100*time.Millisecond), timeBaseline, timeBaseline.Add(200*time.Millisecond), 10))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline.Add(100*time.Millisecond), timeBaseline, timeBaseline.Add(200*time.Millisecond), 10))
 	})
 
 	t.Run("complete before first token", func(t *testing.T) {
-		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", timeBaseline, timeBaseline.Add(200*time.Millisecond), timeBaseline.Add(100*time.Millisecond), 10))
+		require.False(t, RecordRequestTPOT(ctx, "m10", "t10", "tenant-a", "3", true, timeBaseline, timeBaseline.Add(200*time.Millisecond), timeBaseline.Add(100*time.Millisecond), 10))
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

For a non-streaming completion, the entire body arrives as one chunk — `FirstTokenTimestamp` is stamped on that chunk and coincides with `ResponseCompleteTimestamp`, so `RecordRequestTPOT`'s validity check (`!complete.After(firstToken)`) fires and logs an **error-level** `Request latency values are invalid for TPOT calculation` line on **every** non-streaming request (~24K lines/day at our modest production traffic, all at error severity — log-indexing cost plus real-error masking). The values aren't invalid; TPOT is simply undefined without inter-token timing.

This PR threads the same `streaming` flag `RecordRequestTTFT` already takes into `RecordRequestTPOT` (same parameter position), returning early — no metric, no log — when the response was not streamed:

- `pkg/epp/metrics/metrics.go`: add `streaming bool` to `RecordRequestTPOT`; return `false` before any computation when not streaming.
- `pkg/epp/handlers/response.go`: pass `reqCtx.modelServerStreaming` at the sole call site.
- `pkg/epp/metrics/metrics_test.go`: existing cases updated to `streaming=true`; new subtest asserting the non-streaming shape (`complete == firstToken`) is skipped without an error.

`go build ./pkg/epp/...` and `go test ./pkg/epp/metrics/... ./pkg/epp/handlers/...` pass.

**Which issue(s) this PR fixes**:

Fixes #2166

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
TPOT is no longer computed or error-logged for non-streaming requests; the per-request "Request latency values are invalid for TPOT calculation" error line is gone for non-streaming workloads.
```

---

_Disclosure: this PR was authored by Claude (Anthropic's AI assistant, via Claude Code) on behalf of @HipHoff, who reviewed and takes responsibility for the change._
