### PR TITLE
refactor(flowcontrol): make queue statistics single-owner and remove the invariant panic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - durationcheck
     - errcheck
     - fatcontext
+    - forbidigo
     - ginkgolinter
     - goconst
     - gocritic
@@ -53,7 +54,18 @@ linters:
           - goconst
           - dupword
           - prealloc
+      # The panic ban applies only to pkg/epp/flowcontrol (non-test files); see that package's doc.go.
+      - path-except: pkg/epp/flowcontrol/
+        linters:
+          - forbidigo
+      - path: _test\.go$
+        linters:
+          - forbidigo
   settings:
+    forbidigo:
+      forbid:
+        - pattern: ^panic$
+          msg: "pkg/epp/flowcontrol is panic-free by design (see its doc.go); validate at the boundary and return an error"
     importas:
       no-unaliased: false # unaliased imports are allowed; only enforce when an alias is used
       alias:

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -116,6 +116,9 @@ type FlowRegistryDataPlane interface {
 	// numeric value).
 	// The returned slice provides a definitive, ordered list of priority levels for iteration, for example, by a
 	// `controller.FlowController` worker's dispatch loop.
+	//
+	// Contract: the returned slice is a shared, immutable snapshot. Callers MUST NOT mutate it.
+	// Implementations may publish it copy-on-write, so reads are lock-free and allocation-free.
 	AllOrderedPriorityLevels() []int
 }
 

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/clock"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
@@ -183,6 +184,9 @@ func (p *Processor) SubmitOrBlock(ctx context.Context, item *FlowItem) error {
 // It uses a `select` statement to interleave accepting new requests with dispatching existing ones, balancing
 // responsiveness with throughput.
 func (p *Processor) Run(ctx context.Context) {
+	// Log any panic with processor context before the default handlers repanic; the process
+	// fail-stops rather than continuing on state a panicked goroutine may have left inconsistent.
+	defer utilruntime.HandleCrashWithLogger(p.logger)
 	p.logger.V(logutil.DEFAULT).Info("Processor run loop starting.")
 	defer p.logger.V(logutil.DEFAULT).Info("Processor run loop stopped.")
 
@@ -463,7 +467,11 @@ func (p *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
 		return nil
 	}
 
-	removedItem := removedItemAcc.(*FlowItem)
+	removedItem, ok := removedItemAcc.(*FlowItem)
+	if !ok {
+		// Nothing to finalize on an unknown type; surface the error so the cycle moves to the next band.
+		return fmt.Errorf("internal error: item %q for flow %s has unexpected type %T", req.ID(), key, removedItemAcc)
+	}
 	p.logger.V(logutil.TRACE).Info("Item dispatched.", "flowKey", req.FlowKey(), "requestID", req.ID())
 	removedItem.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
 	return nil
@@ -474,6 +482,7 @@ func (p *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
 func (p *Processor) runCleanupSweep(ctx context.Context) {
 	defer p.wg.Done()
 	logger := p.logger.WithName("runCleanupSweep")
+	defer utilruntime.HandleCrashWithLogger(logger)
 	logger.V(logutil.DEFAULT).Info("Cleanup sweep goroutine starting.")
 	defer logger.V(logutil.DEFAULT).Info("Cleanup sweep goroutine stopped.")
 
@@ -496,7 +505,8 @@ func (p *Processor) runCleanupSweep(ctx context.Context) {
 func (p *Processor) sweepFinalizedItems() {
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		predicate := func(itemAcc flowcontrol.QueueItemAccessor) bool {
-			return itemAcc.(*FlowItem).FinalState() != nil
+			item, ok := itemAcc.(*FlowItem)
+			return ok && item.FinalState() != nil
 		}
 		removedItems := managedQ.Cleanup(predicate)
 		if len(removedItems) > 0 {
@@ -644,6 +654,7 @@ func (p *Processor) processAllQueuesConcurrently(
 	var wg sync.WaitGroup
 	for range numWorkers {
 		wg.Go(func() {
+			defer utilruntime.HandleCrashWithLogger(logger)
 			for task := range tasks {
 				processFn(task.mq, task.logger)
 			}

--- a/pkg/epp/flowcontrol/doc.go
+++ b/pkg/epp/flowcontrol/doc.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package flowcontrol wires the flow control system: the FlowController data plane and the
+// FlowRegistry control plane.
+//
+// The package tree is panic-free, enforced by a lint rule. Statistics have a single owner per
+// level, so there is no duplicated state for an invariant check to guard (see
+// registry/managedqueue.go and queue/priorityqueue.go); caller- and plugin-supplied values are
+// validated at the boundary and surfaced as errors; long-lived goroutines defer
+// utilruntime.HandleCrashWithLogger so an unknown bug is logged with component context before the
+// process exits. Recover-and-continue is not used: a goroutine that panicked mid-mutation cannot
+// prove its state is consistent.
+//
+// If SafeQueue ever becomes an injectable extension point again, queue-reported stats become
+// plugin output and accounting must move to booked-charge, settle-at-most-once validation at the
+// managedQueue boundary.
+package flowcontrol

--- a/pkg/epp/flowcontrol/queue/priorityqueue.go
+++ b/pkg/epp/flowcontrol/queue/priorityqueue.go
@@ -45,7 +45,11 @@ func New(policy flowcontrol.OrderingPolicy) contracts.SafeQueue {
 // item's flowcontrol.QueueItemHandle, allowing O(log n) removal by index without a side lookup
 // table.
 type heapItem struct {
-	item          flowcontrol.QueueItemAccessor
+	item flowcontrol.QueueItemAccessor
+	// byteSize is the item's byte size as reported at Add time. Removal paths debit this booked
+	// value rather than re-reading the request, so the queue's byte accounting stays exact even if
+	// a caller-implemented FlowControlRequest.ByteSize() is not stable across calls.
+	byteSize      uint64
 	index         int // position in itemHeap.items; set to -1 once removed.
 	isInvalidated bool
 }
@@ -102,8 +106,14 @@ func (h *itemHeap) Pop() any {
 // priorityQueue implements the SafeQueue interface using a container/heap.
 // The heap is ordered by the provided policy, with higher priority considered closer to the head.
 // This implementation is concurrent-safe.
+//
+// The queue owns its statistics. len and byteSize are published snapshots of the heap's state,
+// assigned in the same critical section as every mutation: len is stored from len(heap.items) and
+// byteSize credits/debits each item's booked size exactly once. Neither can drift from the heap's
+// actual contents, so both are non-negative by construction.
 type priorityQueue struct {
 	heap     *itemHeap
+	len      atomic.Int64
 	byteSize atomic.Uint64
 	mu       sync.RWMutex
 }
@@ -122,9 +132,7 @@ func newPriorityQueue(policy flowcontrol.OrderingPolicy) *priorityQueue {
 
 // Len returns the number of items in the queue.
 func (pq *priorityQueue) Len() int {
-	pq.mu.RLock()
-	defer pq.mu.RUnlock()
-	return len(pq.heap.items)
+	return int(pq.len.Load())
 }
 
 // ByteSize returns the total byte size of all items in the queue.
@@ -147,14 +155,14 @@ func (pq *priorityQueue) Peek() flowcontrol.QueueItemAccessor {
 // Add adds an item to the queue.
 // Time complexity: O(log n).
 func (pq *priorityQueue) Add(item flowcontrol.QueueItemAccessor) {
-	hi := &heapItem{item: item}
+	hi := &heapItem{item: item, byteSize: item.OriginalRequest().ByteSize()}
 	item.SetHandle(hi)
 
 	pq.mu.Lock()
 	heap.Push(pq.heap, hi)
+	pq.len.Store(int64(len(pq.heap.items)))
+	pq.byteSize.Add(hi.byteSize)
 	pq.mu.Unlock()
-
-	pq.byteSize.Add(item.OriginalRequest().ByteSize())
 }
 
 // Remove removes an item from the queue.
@@ -185,7 +193,8 @@ func (pq *priorityQueue) Remove(handle flowcontrol.QueueItemHandle) (flowcontrol
 	}
 
 	heap.Remove(pq.heap, i)
-	pq.byteSize.Add(^hi.item.OriginalRequest().ByteSize() + 1) // Atomic subtraction.
+	pq.len.Store(int64(len(pq.heap.items)))
+	pq.byteSize.Add(^hi.byteSize + 1) // Atomic subtraction of the booked size.
 	hi.Invalidate()
 	return hi.item, nil
 }
@@ -206,7 +215,7 @@ func (pq *priorityQueue) Cleanup(predicate contracts.PredicateFunc) []flowcontro
 			removedItems = append(removedItems, hi.item)
 			hi.Invalidate()
 			hi.index = -1
-			pq.byteSize.Add(^hi.item.OriginalRequest().ByteSize() + 1) // Atomic subtraction.
+			pq.byteSize.Add(^hi.byteSize + 1) // Atomic subtraction of the booked size.
 			continue
 		}
 		items[kept] = hi
@@ -220,6 +229,7 @@ func (pq *priorityQueue) Cleanup(predicate contracts.PredicateFunc) []flowcontro
 			items[i] = nil
 		}
 		pq.heap.items = items[:kept]
+		pq.len.Store(int64(len(pq.heap.items)))
 		// Re-establish the heap property on the remaining items.
 		heap.Init(pq.heap)
 	}
@@ -240,6 +250,7 @@ func (pq *priorityQueue) Drain() []flowcontrol.QueueItemAccessor {
 	}
 
 	pq.heap.items = make([]*heapItem, 0)
+	pq.len.Store(0)
 	pq.byteSize.Store(0)
 
 	return drainedItems

--- a/pkg/epp/flowcontrol/queue/priorityqueue_test.go
+++ b/pkg/epp/flowcontrol/queue/priorityqueue_test.go
@@ -445,3 +445,43 @@ func assertHeapProperty(t *testing.T, q *priorityQueue, msgAndArgs ...any) {
 		}
 	}
 }
+
+// TestPriorityQueue_ByteSize_BookedAtAdd verifies that byte accounting settles against the size
+// booked at Add time. A caller-implemented FlowControlRequest whose ByteSize() changes between Add
+// and removal must not be able to drift the queue's byte counter.
+func TestPriorityQueue_ByteSize_BookedAtAdd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Remove", func(t *testing.T) {
+		t.Parallel()
+		q := newPriorityQueue(enqueueTimePolicy)
+		item := mocks.NewMockQueueItemAccessor(100, "req-unstable", testFlowKey)
+		q.Add(item)
+		require.Equal(t, uint64(100), q.ByteSize(), "Byte size must reflect the size booked at Add")
+
+		// The request misreports its size after admission; removal must debit the booked 100.
+		item.OriginalRequestV.(*mocks.MockFlowControlRequest).ByteSizeV = 5000
+		_, err := q.Remove(item.Handle())
+		require.NoError(t, err)
+		assert.Zero(t, q.ByteSize(), "Removal must debit the booked size, not the re-read size")
+		assert.Zero(t, q.Len())
+	})
+
+	t.Run("Cleanup", func(t *testing.T) {
+		t.Parallel()
+		q := newPriorityQueue(enqueueTimePolicy)
+		itemA := mocks.NewMockQueueItemAccessor(50, "req-a", testFlowKey)
+		itemB := mocks.NewMockQueueItemAccessor(75, "req-b", testFlowKey)
+		q.Add(itemA)
+		q.Add(itemB)
+		require.Equal(t, uint64(125), q.ByteSize())
+
+		itemA.OriginalRequestV.(*mocks.MockFlowControlRequest).ByteSizeV = 1
+		removed := q.Cleanup(func(i flowcontrol.QueueItemAccessor) bool {
+			return i.OriginalRequest().ID() == "req-a"
+		})
+		require.Len(t, removed, 1)
+		assert.Equal(t, uint64(75), q.ByteSize(), "Cleanup must debit the booked size, not the re-read size")
+		assert.Equal(t, 1, q.Len())
+	})
+}

--- a/pkg/epp/flowcontrol/registry/managedqueue.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue.go
@@ -17,9 +17,7 @@ limitations under the License.
 package registry
 
 import (
-	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/go-logr/logr"
 
@@ -28,30 +26,20 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 )
 
-// managedQueue implements `contracts.ManagedQueue`. It acts as a stateful decorator around a SafeQueue.
+// managedQueue implements `contracts.ManagedQueue`. It decorates a SafeQueue with registry
+// integration: aggregate statistics propagation and a read-only policy-facing accessor.
 //
-// # Role: The Stateful Statistics Decorator
+// # Statistics Ownership
 //
-// Its sole responsibility is to augment a generic queue with strictly consistent, atomic statistics tracking.
-// All mutating operations (`Add`, `Remove`, etc.) are wrapped to ensure that the queue's internal state and its
-// externally visible statistics (`Len`, `ByteSize`) are always perfectly synchronized.
-//
-// # Concurrency Model: Mutex for Writes, Atomics for Reads
-//
-// The `managedQueue` employs a hybrid locking strategy to guarantee strict consistency while maintaining high read
-// performance.
-//
-//  1. Mutex-Protected Writes (`sync.Mutex`): A single mutex protects all mutating operations.
-//     This ensures the update to the underlying queue and the update to the internal counters occur as a single, atomic
-//     transaction.
-//  2. Synchronous Propagation: Statistics deltas are propagated synchronously within this critical section,
-//     guaranteeing a non-negativity invariant across the entire system (registry aggregates).
-//  3. Lock-Free Reads (Atomics): The counters use `atomic.Int64`, allowing high-frequency accessors (`Len()`,
-//     `ByteSize()`) to read statistics without acquiring the mutex.
+// Per-queue statistics (`Len`, `ByteSize`) have a single owner: the underlying SafeQueue. This
+// wrapper does not keep its own copy; reads delegate to the queue. Registry aggregates are updated
+// with deltas measured from the queue's reported stats before and after each mutation, all within
+// the same critical section, so the aggregates are sums of true per-queue histories and cannot go
+// negative. There is no duplicated state and therefore no cross-copy invariant to enforce.
 //
 // # Invariant Protection
 //
-// To guarantee statistical integrity, the following invariants must be upheld:
+// To keep aggregates consistent with queue state, the following must be upheld:
 //  1. Exclusive Access: All mutations on the underlying `SafeQueue` MUST be performed exclusively through this wrapper.
 //  2. Non-Autonomous State: The underlying queue must not change state autonomously (e.g., no internal TTL eviction).
 type managedQueue struct {
@@ -65,22 +53,14 @@ type managedQueue struct {
 
 	// --- State Protected by `mu` ---
 
-	// mu protects all mutating operations. It ensures that any changes to the underlying `queue` and the updates to the
-	// atomic counters occur as a single, atomic transaction.
+	// mu protects all mutating operations. It ensures that the mutation of the underlying `queue`
+	// and the propagation of the measured statistics delta occur as a single, atomic transaction.
 	mu sync.Mutex
 	// queue is the underlying, concurrency-safe queue implementation that this `managedQueue` decorates.
 	// Its state must only be modified while holding `mu`.
 	queue contracts.SafeQueue
 
 	flowQueueAccessor *flowQueueAccessor
-
-	// --- Concurrent-Safe State (Atomics) ---
-
-	// Queue-level statistics.
-	// These are written under the protection of `mu` but can be read lock-free at any time using atomic operations.
-	// They are guaranteed to be non-negative.
-	byteSize atomic.Int64
-	len      atomic.Int64
 }
 
 var _ contracts.ManagedQueue = &managedQueue{}
@@ -110,42 +90,41 @@ func (mq *managedQueue) FlowQueueAccessor() flowcontrol.FlowQueueAccessor {
 	return mq.flowQueueAccessor
 }
 
-// Add enqueues an item into the underlying queue and atomically updates the queue's statistics under the lock.
+// Add enqueues an item into the underlying queue and propagates the measured statistics delta.
 func (mq *managedQueue) Add(item flowcontrol.QueueItemAccessor) error {
 	mq.mu.Lock()
 	defer mq.mu.Unlock()
 
-	mq.queue.Add(item)
-
-	mq.propagateStatsDeltaLocked(1, int64(item.OriginalRequest().ByteSize()))
+	mq.applyAndPropagateLocked(func() { mq.queue.Add(item) })
 	mq.logger.V(logging.TRACE).Info("Request added to queue", "requestID", item.OriginalRequest().ID())
 	return nil
 }
 
-// Remove wraps the underlying SafeQueue.Remove and updates statistics.
+// Remove wraps the underlying SafeQueue.Remove and propagates the measured statistics delta.
 func (mq *managedQueue) Remove(handle flowcontrol.QueueItemHandle) (flowcontrol.QueueItemAccessor, error) {
 	mq.mu.Lock()
 	defer mq.mu.Unlock()
 
-	removedItem, err := mq.queue.Remove(handle)
+	var removedItem flowcontrol.QueueItemAccessor
+	var err error
+	mq.applyAndPropagateLocked(func() { removedItem, err = mq.queue.Remove(handle) })
 	if err != nil {
 		return nil, err
 	}
-	mq.propagateStatsDeltaLocked(-1, -int64(removedItem.OriginalRequest().ByteSize()))
 	mq.logger.V(logging.TRACE).Info("Request removed from queue", "requestID", removedItem.OriginalRequest().ID())
 	return removedItem, nil
 }
 
-// Cleanup wraps the underlying SafeQueue.Cleanup and updates statistics.
+// Cleanup wraps the underlying SafeQueue.Cleanup and propagates the measured statistics delta.
 func (mq *managedQueue) Cleanup(predicate contracts.PredicateFunc) []flowcontrol.QueueItemAccessor {
 	mq.mu.Lock()
 	defer mq.mu.Unlock()
 
-	cleanedItems := mq.queue.Cleanup(predicate)
+	var cleanedItems []flowcontrol.QueueItemAccessor
+	mq.applyAndPropagateLocked(func() { cleanedItems = mq.queue.Cleanup(predicate) })
 	if len(cleanedItems) == 0 {
 		return nil
 	}
-	mq.propagateStatsDeltaForRemovedItemsLocked(cleanedItems)
 	if v := mq.logger.V(logging.DEBUG); v.Enabled() {
 		reqIDs := make([]string, 0, len(cleanedItems))
 		for _, item := range cleanedItems {
@@ -160,16 +139,16 @@ func (mq *managedQueue) Cleanup(predicate contracts.PredicateFunc) []flowcontrol
 	return cleanedItems
 }
 
-// Drain wraps the underlying SafeQueue.Drain and updates statistics.
+// Drain wraps the underlying SafeQueue.Drain and propagates the measured statistics delta.
 func (mq *managedQueue) Drain() []flowcontrol.QueueItemAccessor {
 	mq.mu.Lock()
 	defer mq.mu.Unlock()
 
-	drainedItems := mq.queue.Drain()
+	var drainedItems []flowcontrol.QueueItemAccessor
+	mq.applyAndPropagateLocked(func() { drainedItems = mq.queue.Drain() })
 	if len(drainedItems) == 0 {
 		return nil
 	}
-	mq.propagateStatsDeltaForRemovedItemsLocked(drainedItems)
 	if v := mq.logger.V(logging.DEBUG); v.Enabled() {
 		reqIDs := make([]string, 0, len(drainedItems))
 		for _, item := range drainedItems {
@@ -186,41 +165,30 @@ func (mq *managedQueue) Drain() []flowcontrol.QueueItemAccessor {
 
 // Len returns the current number of items in the queue.
 func (mq *managedQueue) Len() int {
-	return int(mq.len.Load())
+	return mq.queue.Len()
 }
 
 // ByteSize returns the current total byte size of all items in the queue.
 func (mq *managedQueue) ByteSize() uint64 {
-	return uint64(mq.byteSize.Load())
+	return mq.queue.ByteSize()
 }
 
-// propagateStatsDeltaLocked updates the queue's statistics and propagates the delta to the registry.
+// applyAndPropagateLocked runs mutate on the underlying queue and propagates the statistics delta
+// measured across it, keeping the registry aggregates consistent with the queue's actual state.
 // It must be called while holding the `managedQueue.mu` lock.
-//
-// Invariant Check: This function panics if a statistic becomes negative. This enforces the non-negative invariant
-// locally, which mathematically guarantees that the aggregated statistics (registry level) also remain
-// non-negative.
-func (mq *managedQueue) propagateStatsDeltaLocked(lenDelta, byteSizeDelta int64) {
-	newLen := mq.len.Add(lenDelta)
-	if newLen < 0 {
-		panic(fmt.Sprintf("invariant violation: managedQueue length for flow %s became negative (%d)", mq.key, newLen))
-	}
-	mq.byteSize.Add(byteSizeDelta)
+func (mq *managedQueue) applyAndPropagateLocked(mutate func()) {
+	beforeLen := mq.queue.Len()
+	beforeBytes := mq.queue.ByteSize()
 
+	mutate()
+
+	lenDelta := int64(mq.queue.Len() - beforeLen)
+	byteSizeDelta := int64(mq.queue.ByteSize()) - int64(beforeBytes)
+	if lenDelta == 0 && byteSizeDelta == 0 {
+		return
+	}
 	// Propagate the delta up to the registry. This propagation is lock-free and eventually consistent.
 	mq.onStatsDelta(mq.key.Priority, lenDelta, byteSizeDelta)
-}
-
-// propagateStatsDeltaForRemovedItemsLocked calculates the total stat changes for a slice of removed items and applies
-// them. It must be called while holding the `managedQueue.mu` lock.
-func (mq *managedQueue) propagateStatsDeltaForRemovedItemsLocked(items []flowcontrol.QueueItemAccessor) {
-	var lenDelta int64
-	var byteSizeDelta int64
-	for _, item := range items {
-		lenDelta--
-		byteSizeDelta -= int64(item.OriginalRequest().ByteSize())
-	}
-	mq.propagateStatsDeltaLocked(lenDelta, byteSizeDelta)
 }
 
 // --- `flowQueueAccessor` ---

--- a/pkg/epp/flowcontrol/registry/managedqueue_test.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue_test.go
@@ -129,9 +129,13 @@ func TestManagedQueue_Add(t *testing.T) {
 		expectedByteSizeDelta int64
 	}{
 		{
-			name: "ShouldSucceed_AndIncrementStats",
+			name: "ShouldSucceed_AndPropagateMeasuredDelta",
 			setupMock: func(q *mocks.MockSafeQueue) {
-				q.AddFunc = func(flowcontrol.QueueItemAccessor) {}
+				q.AddFunc = func(flowcontrol.QueueItemAccessor) {
+					// Deltas are measured from queue-reported stats, so the mock reports the change.
+					q.LenV = 1
+					q.ByteSizeV = 100
+				}
 			},
 			expectErr:             false,
 			expectedLenDelta:      1,
@@ -179,9 +183,15 @@ func TestManagedQueue_Remove(t *testing.T) {
 		expectedByteSizeDelta int64
 	}{
 		{
-			name: "ShouldSucceed_AndDecrementStats",
+			name: "ShouldSucceed_AndPropagateMeasuredDelta",
 			setupMock: func(q *mocks.MockSafeQueue, item flowcontrol.QueueItemAccessor) {
+				// Deltas are measured from queue-reported stats: prime the pre-mutation state and
+				// have the mock report the post-mutation state.
+				q.LenV = 1
+				q.ByteSizeV = 100
 				q.RemoveFunc = func(_ flowcontrol.QueueItemHandle) (flowcontrol.QueueItemAccessor, error) {
+					q.LenV = 0
+					q.ByteSizeV = 0
 					return item, nil
 				}
 			},
@@ -192,6 +202,8 @@ func TestManagedQueue_Remove(t *testing.T) {
 		{
 			name: "ShouldFail_AndNotChangeStats_WhenUnderlyingQueueFails",
 			setupMock: func(q *mocks.MockSafeQueue, item flowcontrol.QueueItemAccessor) {
+				q.LenV = 1
+				q.ByteSizeV = 100
 				q.RemoveFunc = func(_ flowcontrol.QueueItemHandle) (flowcontrol.QueueItemAccessor, error) {
 					return nil, errors.New("remove failed")
 				}
@@ -238,9 +250,13 @@ func TestManagedQueue_Cleanup(t *testing.T) {
 		expectedByteSizeDelta int64
 	}{
 		{
-			name: "ShouldSucceed_AndDecrementStats_WhenItemsRemoved",
+			name: "ShouldSucceed_AndPropagateMeasuredDelta_WhenItemsRemoved",
 			setupMock: func(q *mocks.MockSafeQueue, items []flowcontrol.QueueItemAccessor) {
+				q.LenV = 2
+				q.ByteSizeV = 125
 				q.CleanupFunc = func(_ contracts.PredicateFunc) []flowcontrol.QueueItemAccessor {
+					q.LenV = 0
+					q.ByteSizeV = 0
 					return items
 				}
 			},
@@ -250,6 +266,8 @@ func TestManagedQueue_Cleanup(t *testing.T) {
 		{
 			name: "ShouldSucceed_AndNotChangeStats_WhenNoItemsRemoved",
 			setupMock: func(q *mocks.MockSafeQueue, items []flowcontrol.QueueItemAccessor) {
+				q.LenV = 2
+				q.ByteSizeV = 125
 				q.CleanupFunc = func(_ contracts.PredicateFunc) []flowcontrol.QueueItemAccessor {
 					return nil // Simulate no items matching predicate.
 				}
@@ -290,9 +308,13 @@ func TestManagedQueue_Drain(t *testing.T) {
 		expectedByteSizeDelta int64
 	}{
 		{
-			name: "ShouldSucceed_AndDecrementStats",
+			name: "ShouldSucceed_AndPropagateMeasuredDelta",
 			setupMock: func(q *mocks.MockSafeQueue, items []flowcontrol.QueueItemAccessor) {
+				q.LenV = 2
+				q.ByteSizeV = 125
 				q.DrainFunc = func() []flowcontrol.QueueItemAccessor {
+					q.LenV = 0
+					q.ByteSizeV = 0
 					return items
 				}
 			},
@@ -401,30 +423,34 @@ func TestManagedQueue_Concurrency_StatsIntegrity(t *testing.T) {
 		"The net byte size delta propagated across all operations must be exactly zero")
 }
 
-// --- Invariant Test ---
+// --- Structural Invariant Test ---
 
-func TestManagedQueue_InvariantPanics_OnUnderflow(t *testing.T) {
+// TestManagedQueue_MeasuredDeltas_CannotUnderflow verifies the structural non-negativity property:
+// because aggregate deltas are measured from queue-reported stats rather than derived from returned
+// items, a queue that hands back the same item repeatedly (without its stats changing) produces no
+// delta at all. There is no independent counter to underflow and nothing to panic about.
+func TestManagedQueue_MeasuredDeltas_CannotUnderflow(t *testing.T) {
 	t.Parallel()
 	flowKey := flowcontrol.FlowKey{ID: "flow", Priority: 1}
 	item := fwkfcmocks.NewMockQueueItemAccessor(100, "req", flowKey)
 	q := &mocks.MockSafeQueue{}
 	q.AddFunc = func(flowcontrol.QueueItemAccessor) {}
 	q.RemoveFunc = func(flowcontrol.QueueItemHandle) (flowcontrol.QueueItemAccessor, error) {
+		// Logically inconsistent mock: always "succeeds" but never changes its reported stats.
 		return item, nil
 	}
 	h := newMockedMqHarness(t, q, flowKey)
 
 	require.NoError(t, h.mq.Add(item), "Test setup: Initial Add must succeed")
-	_, err := h.mq.Remove(item.Handle())
-	require.NoError(t, err, "Test setup: First Remove must succeed")
+	h.propagator.reset()
 
-	// This remove call should cause the stats to go negative.
-	assert.Panics(t,
-		func() {
-			// Mock the underlying queue to succeed on the second remove, even though it's logically inconsistent.
-			// This isolates the panic to the `managedQueue`'s decorator logic.
-			_, _ = h.mq.Remove(item.Handle())
-		},
-		"Attempting to remove an item that results in negative statistics must trigger an invariant violation panic",
-	)
+	for range 3 {
+		_, err := h.mq.Remove(item.Handle())
+		require.NoError(t, err, "Remove against the misreporting mock should surface no error")
+	}
+
+	assert.Equal(t, int64(0), h.propagator.lenDelta.Load(),
+		"A queue whose reported stats never change must produce zero length delta, however many items it returns")
+	assert.Equal(t, int64(0), h.propagator.byteSizeDelta.Load(),
+		"A queue whose reported stats never change must produce zero byte size delta")
 }

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -111,13 +111,15 @@ type FlowRegistry struct {
 	// Key: int (priority), Value: *priorityBand
 	priorityBands sync.Map
 
+	// orderedPriorityLevels is a sorted list of active priority levels, published copy-on-write.
+	// Writers (band provisioning and removal, serialized by fr.mu) build a fresh slice and swap the
+	// pointer; a published slice is never mutated. Readers load the pointer and iterate the shared
+	// slice directly, with no lock and no per-call copy on the dispatch hot path.
+	orderedPriorityLevels atomic.Pointer[[]int]
+
 	// --- Administrative state (protected by `mu`) ---
 
 	mu sync.RWMutex
-
-	// orderedPriorityLevels is a sorted list of active priority levels.
-	// It is updated dynamically when new bands are provisioned.
-	orderedPriorityLevels []int
 
 	// initialPriorities tracks priority bands provisioned at startup.
 	// These are never removed by control-plane sync or garbage collection.
@@ -161,6 +163,7 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 		desiredPriorities:    make(map[int]struct{}),
 		priorityBandUpdateCh: make(chan map[int]struct{}, 1),
 	}
+	fr.orderedPriorityLevels.Store(&[]int{})
 
 	for _, opt := range opts {
 		opt(fr)
@@ -176,7 +179,7 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 	}
 
 	fr.logger.V(logging.DEFAULT).Info("FlowRegistry initialized successfully",
-		"orderedPriorities", fr.orderedPriorityLevels)
+		"orderedPriorities", fr.AllOrderedPriorityLevels())
 	return fr
 }
 
@@ -425,8 +428,8 @@ func (fr *FlowRegistry) Stats() contracts.AggregateStats {
 	fr.mu.RLock()
 	defer fr.mu.RUnlock()
 
-	// Casts from `int64` to `uint64` are safe because the non-negativity invariant is strictly enforced at the
-	// `managedQueue` level.
+	// Casts from `int64` to `uint64` are safe: aggregates are sums of deltas measured from
+	// queue-reported stats (see managedQueue), and per-queue stats are non-negative by construction.
 	stats := contracts.AggregateStats{
 		TotalCapacityBytes:    fr.config.MaxBytes,
 		TotalCapacityRequests: fr.config.MaxRequests,
@@ -545,7 +548,9 @@ func (fr *FlowRegistry) cleanupPriorityBandResourcesLocked(priority int) {
 	fr.perPriorityBandStats.Delete(priority)
 	fr.priorityBands.Delete(priority)
 
-	fr.orderedPriorityLevels = slices.DeleteFunc(fr.orderedPriorityLevels, func(p int) bool { return p == priority })
+	// Copy-on-write: the published slice is shared with lock-free readers and must not be mutated.
+	updated := slices.DeleteFunc(slices.Clone(*fr.orderedPriorityLevels.Load()), func(p int) bool { return p == priority })
+	fr.orderedPriorityLevels.Store(&updated)
 
 	fr.logger.V(logging.DEFAULT).Info("Successfully deleted priority band", "priority", priority)
 }

--- a/pkg/epp/flowcontrol/registry/registry_helpers.go
+++ b/pkg/epp/flowcontrol/registry/registry_helpers.go
@@ -54,7 +54,7 @@ type priorityBand struct {
 
 // initPriorityBand constructs the runtime state for a single priority level and registers it within the registry.
 // This is used during registry initialization and by addPriorityBand (dynamic provisioning).
-// The caller MUST hold fr.mu (Write Lock) as this method modifies the orderedPriorityLevels slice.
+// The caller MUST hold fr.mu (Write Lock) as this method republishes the orderedPriorityLevels slice.
 func (fr *FlowRegistry) initPriorityBand(bandConfig *PriorityBandConfig) {
 	policyState := bandConfig.FairnessPolicy.NewState(context.Background())
 	band := &priorityBand{
@@ -65,10 +65,13 @@ func (fr *FlowRegistry) initPriorityBand(bandConfig *PriorityBandConfig) {
 	}
 	band.priorityBandAccessor = &priorityBandAccessor{registry: fr, band: band}
 	fr.priorityBands.Store(bandConfig.Priority, band)
-	fr.orderedPriorityLevels = append(fr.orderedPriorityLevels, bandConfig.Priority)
-	sort.Slice(fr.orderedPriorityLevels, func(i, j int) bool {
-		return fr.orderedPriorityLevels[i] > fr.orderedPriorityLevels[j]
-	})
+
+	// Copy-on-write: the published slice is shared with lock-free readers and must not be mutated.
+	current := *fr.orderedPriorityLevels.Load()
+	updated := make([]int, 0, len(current)+1)
+	updated = append(append(updated, current...), bandConfig.Priority)
+	sort.Slice(updated, func(i, j int) bool { return updated[i] > updated[j] })
+	fr.orderedPriorityLevels.Store(&updated)
 }
 
 // addPriorityBand dynamically provisions a new priority band.
@@ -128,15 +131,11 @@ func (fr *FlowRegistry) PriorityBandAccessor(priority int) (flowcontrol.Priority
 	return band.priorityBandAccessor, nil
 }
 
-// AllOrderedPriorityLevels returns a snapshot of all configured priority levels,
-// sorted in descending order. The returned slice is a copy, safe for the caller to iterate
-// without holding any lock.
+// AllOrderedPriorityLevels returns all configured priority levels, sorted in descending order.
+// The returned slice is the shared, immutable published snapshot: callers MUST treat it as
+// read-only. The read is a single atomic pointer load, with no lock and no allocation.
 func (fr *FlowRegistry) AllOrderedPriorityLevels() []int {
-	fr.mu.RLock()
-	defer fr.mu.RUnlock()
-	result := make([]int, len(fr.orderedPriorityLevels))
-	copy(result, fr.orderedPriorityLevels)
-	return result
+	return *fr.orderedPriorityLevels.Load()
 }
 
 //  --- Internal Administrative/Lifecycle Methods ---

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -772,10 +772,7 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 		assert.False(t, ok, "Band should be removed from config")
 
 		// Verify removed from ordered list
-		h.fr.mu.RLock()
-		orderedList := h.fr.orderedPriorityLevels
-		h.fr.mu.RUnlock()
-		for _, p := range orderedList {
+		for _, p := range h.fr.AllOrderedPriorityLevels() {
 			assert.NotEqual(t, dynamicPrio, p, "Band priority should be removed from ordered list in registry")
 		}
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes the last panic in `pkg/epp/flowcontrol` by removing the duplicated state it guarded.

The managedQueue kept atomic copies of Len and ByteSize that the queue already owns, and panicked if they went negative. Now the queue is the single owner: it books each item's byte size at Add and debits the booked value on removal (so an unstable caller-implemented `ByteSize()` can't drift the counter), and publishes its length from `len(heap.items)` in the same critical section as each mutation. managedQueue delegates reads and propagates aggregate deltas measured from the queue's own stats. With one copy of the state there is nothing left to check, so the panic is deleted rather than recovered.

Also in this PR:

- `AllOrderedPriorityLevels()` becomes a lock-free pointer load over a copy-on-write slice, removing a per-dispatch-cycle copy.
- `dispatchItem` and the sweep predicate use comma-ok downcasts, matching `evictAll`.
- The processor run loop, cleanup sweep, and sweep workers defer `utilruntime.HandleCrashWithLogger`, so an unknown bug logs with component context before the process exits.
- The package doc records the posture, and a `forbidigo` rule bans `panic(` in the package with no allowlist.

**Which issue(s) this PR fixes**:

Fixes #2098

**Release note**:

```release-note
Flow control no longer contains panic-based invariant guards: queue statistics are single-owner by construction, and flow-control goroutines log panics with component context before the process exits.
```