### PR TITLE
refactor(flowcontrol): UsageLimitPolicy fills a framework-owned ceilings buffer

### DIFF
--- a/pkg/epp/config/loader/flowcontrol_test.go
+++ b/pkg/epp/config/loader/flowcontrol_test.go
@@ -448,13 +448,12 @@ func TestBuildFlowControlConfig(t *testing.T) {
 	handle := newFlowControlTestHandle(t)
 
 	const funcPolicyName = "func-policy"
-	handle.AddPlugin(funcPolicyName, usagelimits.NewPolicyFunc(funcPolicyName, func(_ context.Context, _ float64, priorities []int) []float64 {
-		result := make([]float64, len(priorities))
-		for i := range result {
-			result[i] = 0.8
-		}
-		return result
-	}))
+	handle.AddPlugin(funcPolicyName, usagelimits.NewPolicyFunc(funcPolicyName,
+		func(_ context.Context, _ float64, _ []int, ceilings []float64) {
+			for i := range ceilings {
+				ceilings[i] = 0.8
+			}
+		}))
 
 	const structPolicyName = "struct-policy"
 	handle.AddPlugin(structPolicyName, &constantPointEightPolicy{})
@@ -490,7 +489,7 @@ func TestBuildFlowControlConfig(t *testing.T) {
 			apiConfig: nil,
 			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
 				require.NotNil(t, cfg.UsageLimitPolicy, "UsageLimitPolicy should be resolved even when not explicitly configured")
-				ceilings := cfg.UsageLimitPolicy.ComputeLimit(context.Background(), 0.5, []int{0})
+				ceilings := computeLimits(t, cfg.UsageLimitPolicy, 0.5, []int{0})
 				assert.Equal(t, []float64{1.0}, ceilings, "Default noop policy should return 1.0 (no gating)")
 			},
 		},
@@ -501,7 +500,7 @@ func TestBuildFlowControlConfig(t *testing.T) {
 			},
 			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
 				require.NotNil(t, cfg.UsageLimitPolicy, "UsageLimitPolicy should be resolved from the handle")
-				ceilings := cfg.UsageLimitPolicy.ComputeLimit(context.Background(), 0.5, []int{0})
+				ceilings := computeLimits(t, cfg.UsageLimitPolicy, 0.5, []int{0})
 				assert.Equal(t, []float64{1.0}, ceilings, "Noop policy should return 1.0 (no gating)")
 			},
 		},
@@ -512,7 +511,6 @@ func TestBuildFlowControlConfig(t *testing.T) {
 			},
 			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
 				require.NotNil(t, cfg.UsageLimitPolicy)
-				ctx := context.Background()
 				for _, tc := range []struct {
 					name       string
 					priority   int
@@ -522,7 +520,7 @@ func TestBuildFlowControlConfig(t *testing.T) {
 					{"half saturation", 1, 0.5},
 					{"full saturation", 5, 1.0},
 				} {
-					assert.Equal(t, []float64{0.8}, cfg.UsageLimitPolicy.ComputeLimit(ctx, tc.saturation, []int{tc.priority}),
+					assert.Equal(t, []float64{0.8}, computeLimits(t, cfg.UsageLimitPolicy, tc.saturation, []int{tc.priority}),
 						"func-based policy should return 0.8 at %s", tc.name)
 				}
 			},
@@ -534,7 +532,6 @@ func TestBuildFlowControlConfig(t *testing.T) {
 			},
 			assertion: func(t *testing.T, cfg *flowcontrol.Config) {
 				require.NotNil(t, cfg.UsageLimitPolicy)
-				ctx := context.Background()
 				for _, tc := range []struct {
 					name       string
 					priority   int
@@ -544,7 +541,7 @@ func TestBuildFlowControlConfig(t *testing.T) {
 					{"half saturation", 1, 0.5},
 					{"full saturation", 5, 1.0},
 				} {
-					assert.Equal(t, []float64{0.8}, cfg.UsageLimitPolicy.ComputeLimit(ctx, tc.saturation, []int{tc.priority}),
+					assert.Equal(t, []float64{0.8}, computeLimits(t, cfg.UsageLimitPolicy, tc.saturation, []int{tc.priority}),
 						"struct-based policy should return 0.8 at %s", tc.name)
 				}
 			},
@@ -608,12 +605,22 @@ func (p *constantPointEightPolicy) TypedName() fwkplugin.TypedName {
 	}
 }
 
-func (p *constantPointEightPolicy) ComputeLimit(_ context.Context, _ float64, priorities []int) []float64 {
-	result := make([]float64, len(priorities))
-	for i := range result {
-		result[i] = 0.8
+func (p *constantPointEightPolicy) ComputeLimit(_ context.Context, _ float64, _ []int, ceilings []float64) {
+	for i := range ceilings {
+		ceilings[i] = 0.8
 	}
-	return result
 }
 
 var _ fwkfc.UsageLimitPolicy = (*constantPointEightPolicy)(nil)
+
+// computeLimits invokes a UsageLimitPolicy with a framework-style output buffer (pre-filled with
+// 1.0, sized to priorities) and returns the filled ceilings.
+func computeLimits(t *testing.T, p fwkfc.UsageLimitPolicy, saturation float64, priorities []int) []float64 {
+	t.Helper()
+	ceilings := make([]float64, len(priorities))
+	for i := range ceilings {
+		ceilings[i] = 1.0
+	}
+	p.ComputeLimit(context.Background(), saturation, priorities, ceilings)
+	return ceilings
+}

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -87,6 +87,11 @@ type Processor struct {
 	// it needs no synchronization.
 	poolEmpty bool
 
+	// ceilings is the reusable output buffer handed to the UsageLimitPolicy each dispatch cycle,
+	// avoiding a per-cycle allocation. Only accessed from the Run goroutine, so it needs no
+	// synchronization.
+	ceilings []float64
+
 	// wg is used to wait for background tasks (cleanup sweep) to complete on shutdown.
 	wg             sync.WaitGroup
 	isShuttingDown atomic.Bool
@@ -381,7 +386,8 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	metrics.RecordFlowControlPoolSaturation(p.poolName, saturation)
 
 	priorities := p.registry.AllOrderedPriorityLevels()
-	ceilings := p.usageLimitPolicy.ComputeLimit(ctx, saturation, priorities)
+	ceilings := p.ceilingsBuffer(len(priorities))
+	p.usageLimitPolicy.ComputeLimit(ctx, saturation, priorities, ceilings)
 
 	for i, priority := range priorities {
 		// --- Viability Check (Saturation/HoL Blocking) ---
@@ -421,6 +427,20 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 		return true
 	}
 	return false
+}
+
+// ceilingsBuffer returns the reusable ceilings buffer sized to n, every element reset to 1.0 (no
+// gating). Pre-filling guarantees that an entry the policy does not write fails open rather than
+// carrying a stale value from the previous cycle.
+func (p *Processor) ceilingsBuffer(n int) []float64 {
+	if cap(p.ceilings) < n {
+		p.ceilings = make([]float64, n)
+	}
+	buf := p.ceilings[:n]
+	for i := range buf {
+		buf[i] = 1.0
+	}
+	return buf
 }
 
 // selectItem applies the configured fairness and ordering policies to select a single item.

--- a/pkg/epp/framework/interface/flowcontrol/plugins.go
+++ b/pkg/epp/framework/interface/flowcontrol/plugins.go
@@ -143,12 +143,17 @@ type SaturationDetector interface {
 //
 // Integration:
 // This policy is called during dispatch decision-making, before a request is allowed to proceed. For each
-// priority band, the returned ceiling is compared against current saturation. If saturation exceeds the
+// priority band, the computed ceiling is compared against current saturation. If saturation exceeds the
 // ceiling for a given priority, requests at that priority are gated (not dispatched). The dispatch loop
 // visits bands from highest to lowest priority and stops at the first gated band; lower bands are not
 // considered on that call.
 //
-// Conformance: Implementations MUST ensure all methods are goroutine-safe. Returned ceilings MUST be
+// The framework calls ComputeLimit exactly once per dispatch cycle. This is a contract term, not an
+// implementation detail: dispatch-spreading policies use the call itself as their time base (one tick
+// per cycle), and computing all ceilings in one call is what lets every gated band observe the same
+// open/closed decision within a cycle. The batch shape exists to preserve both properties.
+//
+// Conformance: Implementations MUST ensure all methods are goroutine-safe. Computed ceilings MUST be
 // monotonically non-increasing in the given priority order (highest priority first): because the
 // dispatch loop stops at the first gated band, a lower band whose ceiling exceeds that of a higher band
 // can be marked open on calls where it is unreachable, starving it.
@@ -156,19 +161,24 @@ type UsageLimitPolicy interface {
 	plugin.Plugin
 
 	// ComputeLimit calculates usage ceilings for all currently active priority levels based on current
-	// saturation. The plugin observes the active priority domain (which changes dynamically as workloads
-	// come and go) and computes relative ceilings from scratch on each call.
+	// saturation, writing the ceiling for the n-th priority into the n-th element of the
+	// caller-provided ceilings buffer. The plugin observes the active priority domain (which changes
+	// dynamically as workloads come and go) and computes relative ceilings from scratch on each call.
+	//
+	// The framework guarantees len(ceilings) == len(priorities) and pre-fills every element with 1.0
+	// (no gating), so an entry the plugin does not write fails open. Writing into the framework-owned
+	// buffer means a result of the wrong size cannot exist; there is no return value to validate.
 	//
 	// Parameters:
 	//   - ctx: Request context for logging, tracing, etc.
 	//   - saturation: Current pool-wide resource saturation as a fraction [0.0, 1.0]
-	//   - priorities: Ordered list of currently active priority levels (highest first)
-	//
-	// Returns:
-	//   - ceilings: Computed ceiling for each given priority (n-th ceiling is assigned to the given n-th priority)
+	//   - priorities: Ordered list of currently active priority levels (highest first).
+	//     The slice is a shared snapshot owned by the framework: read-only, and it MUST NOT be
+	//     retained after the call returns.
+	//   - ceilings: Output buffer owned by the framework, valid only for the duration of the call.
+	//     Ceiling semantics per element:
 	//     - 0.0 = fully gated (cannot dispatch regardless of current saturation)
 	//     - 1.0 = no gating (can dispatch until fully saturated)
 	//     - Values between 0.0 and 1.0 reserve capacity headroom
-	//
-	ComputeLimit(ctx context.Context, saturation float64, priorities []int) (ceilings []float64)
+	ComputeLimit(ctx context.Context, saturation float64, priorities []int, ceilings []float64)
 }

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback.go
@@ -56,13 +56,13 @@ type priorityHoldbackPolicy struct {
 	name      string
 	cMax      float64
 	cMin      float64
-	computeFn func(cMin, cMax float64, priorities []int) (ceilings []float64)
+	computeFn func(cMin, cMax float64, priorities []int, ceilings []float64)
 }
 
 var _ flowcontrol.UsageLimitPolicy = &priorityHoldbackPolicy{}
 
 func newPriorityHoldbackPolicy(cfg config) *priorityHoldbackPolicy {
-	var fn func(cMin, cMax float64, priorities []int) (ceilings []float64)
+	var fn func(cMin, cMax float64, priorities []int, ceilings []float64)
 	switch cfg.domain {
 	case domainRank:
 		fn = computeLimitStepwiseSpread
@@ -95,37 +95,36 @@ func (p *priorityHoldbackPolicy) TypedName() plugin.TypedName {
 	}
 }
 
-// ComputeLimit returns an admission ceiling for each priority. With a single active priority,
-// holdback is bypassed (ceiling = cMax) to preserve work-conserving behavior.
-func (p *priorityHoldbackPolicy) ComputeLimit(_ context.Context, _ float64, priorities []int) (ceilings []float64) {
+// ComputeLimit writes an admission ceiling for each priority into the caller-provided buffer.
+// With a single active priority, holdback is bypassed (ceiling = cMax) to preserve
+// work-conserving behavior.
+func (p *priorityHoldbackPolicy) ComputeLimit(_ context.Context, _ float64, priorities []int, ceilings []float64) {
 	if len(priorities) == 0 {
-		return []float64{}
+		return
 	}
 	if len(priorities) == 1 {
-		return []float64{p.cMax}
+		ceilings[0] = p.cMax
+		return
 	}
 	// Ceilings are monotonically decreasing as priorities are ordered from highest to lowest per UsageLimitPolicy contract.
 	// New strategies (e.g. sigmoid/static definition) could require explicit monotizing sweep.
-	return p.computeFn(p.cMin, p.cMax, priorities)
+	p.computeFn(p.cMin, p.cMax, priorities, ceilings)
 }
 
 // computeLimitStepwiseSpread divides [cMin, cMax] into equal steps by rank.
 // c_i = cMax - i * (cMax - cMin) / (N - 1)
-func computeLimitStepwiseSpread(cMin, cMax float64, priorities []int) (ceilings []float64) {
-	ceilings = make([]float64, len(priorities))
+func computeLimitStepwiseSpread(cMin, cMax float64, priorities []int, ceilings []float64) {
 	spread := cMax - cMin
 	n := float64(len(priorities) - 1)
 	for i := range priorities {
 		ceilings[i] = cMax - float64(i)*spread/n
 	}
-	return ceilings
 }
 
 // computeLimitLinearProportional scales ceilings proportionally to numerical priority values.
 // r_i = (p_i - pMin) / (pMax - pMin)
 // c_i = cMin + r_i * (cMax - cMin)
-func computeLimitLinearProportional(cMin, cMax float64, priorities []int) (ceilings []float64) {
-	ceilings = make([]float64, len(priorities))
+func computeLimitLinearProportional(cMin, cMax float64, priorities []int, ceilings []float64) {
 	pMin := float64(priorities[len(priorities)-1])
 	pMax := float64(priorities[0])
 	pRange := pMax - pMin
@@ -135,12 +134,11 @@ func computeLimitLinearProportional(cMin, cMax float64, priorities []int) (ceili
 		for i := range priorities {
 			ceilings[i] = cMax
 		}
-		return ceilings
+		return
 	}
 	spread := cMax - cMin
 	for i := range priorities {
 		r := (float64(priorities[i]) - pMin) / pRange
 		ceilings[i] = cMin + r*spread
 	}
-	return ceilings
 }

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback_test.go
@@ -178,7 +178,7 @@ func TestComputeLimit_EmptyPriorities(t *testing.T) {
 		maxCeiling: 1.0,
 	})
 
-	ceilings := policy.ComputeLimit(t.Context(), 0.5, []int{})
+	ceilings := computeLimits(t, policy, 0.5, []int{})
 	assert.Empty(t, ceilings)
 	assert.NotNil(t, ceilings, "should return empty slice, not nil")
 }
@@ -205,7 +205,7 @@ func TestComputeLimit_SinglePriority(t *testing.T) {
 				minCeiling: 0.5,
 				maxCeiling: tc.cMax,
 			})
-			ceilings := policy.ComputeLimit(t.Context(), 0.5, []int{10})
+			ceilings := computeLimits(t, policy, 0.5, []int{10})
 			require.Len(t, ceilings, 1)
 			assert.Equal(t, tc.cMax, ceilings[0], "single priority should bypass holdback with cMax")
 		})
@@ -218,7 +218,7 @@ func TestComputeLimit_SinglePriority(t *testing.T) {
 
 func TestStepwiseSpread_TwoPriorities(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitStepwiseSpread(0.5, 1.0, []int{100, 10})
+	ceilings := runSpread(computeLimitStepwiseSpread, 0.5, 1.0, []int{100, 10})
 	require.Len(t, ceilings, 2)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9, "highest priority gets cMax")
 	assert.InDelta(t, 0.5, ceilings[1], 1e-9, "lowest priority gets cMin")
@@ -226,7 +226,7 @@ func TestStepwiseSpread_TwoPriorities(t *testing.T) {
 
 func TestStepwiseSpread_ThreePriorities(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitStepwiseSpread(0.5, 1.0, []int{100, 50, 10})
+	ceilings := runSpread(computeLimitStepwiseSpread, 0.5, 1.0, []int{100, 50, 10})
 	require.Len(t, ceilings, 3)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9)
 	assert.InDelta(t, 0.75, ceilings[1], 1e-9)
@@ -235,7 +235,7 @@ func TestStepwiseSpread_ThreePriorities(t *testing.T) {
 
 func TestStepwiseSpread_FourPriorities(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitStepwiseSpread(0.5, 1.0, []int{100, 75, 50, 10})
+	ceilings := runSpread(computeLimitStepwiseSpread, 0.5, 1.0, []int{100, 75, 50, 10})
 	require.Len(t, ceilings, 4)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9)
 	assert.InDelta(t, 0.8333333, ceilings[1], 1e-6)
@@ -248,8 +248,8 @@ func TestStepwiseSpread_IgnoresNumericalValues(t *testing.T) {
 
 	// Stepwise should produce the same ceilings regardless of priority values,
 	// as long as the count and order are the same.
-	ceilingsA := computeLimitStepwiseSpread(0.5, 1.0, []int{100, 50, 10})
-	ceilingsB := computeLimitStepwiseSpread(0.5, 1.0, []int{1000, 2, 1})
+	ceilingsA := runSpread(computeLimitStepwiseSpread, 0.5, 1.0, []int{100, 50, 10})
+	ceilingsB := runSpread(computeLimitStepwiseSpread, 0.5, 1.0, []int{1000, 2, 1})
 
 	require.Len(t, ceilingsA, 3)
 	require.Len(t, ceilingsB, 3)
@@ -261,7 +261,7 @@ func TestStepwiseSpread_IgnoresNumericalValues(t *testing.T) {
 
 func TestStepwiseSpread_MonotonicallyDecreasing(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitStepwiseSpread(0.2, 0.9, []int{50, 40, 30, 20, 10})
+	ceilings := runSpread(computeLimitStepwiseSpread, 0.2, 0.9, []int{50, 40, 30, 20, 10})
 	for i := 1; i < len(ceilings); i++ {
 		assert.Greater(t, ceilings[i-1], ceilings[i],
 			"ceiling[%d] (%f) should be greater than ceiling[%d] (%f)", i-1, ceilings[i-1], i, ceilings[i])
@@ -270,14 +270,14 @@ func TestStepwiseSpread_MonotonicallyDecreasing(t *testing.T) {
 
 func TestStepwiseSpread_BoundaryValues(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitStepwiseSpread(0.0, 1.0, []int{10, 5, 1})
+	ceilings := runSpread(computeLimitStepwiseSpread, 0.0, 1.0, []int{10, 5, 1})
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9, "highest priority gets cMax")
 	assert.InDelta(t, 0.0, ceilings[len(ceilings)-1], 1e-9, "lowest priority gets cMin")
 }
 
 func TestStepwiseSpread_NarrowRange(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitStepwiseSpread(0.8, 0.9, []int{10, 5, 1})
+	ceilings := runSpread(computeLimitStepwiseSpread, 0.8, 0.9, []int{10, 5, 1})
 	require.Len(t, ceilings, 3)
 	assert.InDelta(t, 0.9, ceilings[0], 1e-9)
 	assert.InDelta(t, 0.85, ceilings[1], 1e-9)
@@ -290,7 +290,7 @@ func TestStepwiseSpread_NarrowRange(t *testing.T) {
 
 func TestLinearProportional_TwoPriorities(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitLinearProportional(0.5, 1.0, []int{100, 10})
+	ceilings := runSpread(computeLimitLinearProportional, 0.5, 1.0, []int{100, 10})
 	require.Len(t, ceilings, 2)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9, "highest priority gets cMax")
 	assert.InDelta(t, 0.5, ceilings[1], 1e-9, "lowest priority gets cMin")
@@ -299,7 +299,7 @@ func TestLinearProportional_TwoPriorities(t *testing.T) {
 func TestLinearProportional_ThreePriorities_EvenSpacing(t *testing.T) {
 	t.Parallel()
 	// Priorities {90, 50, 10}: 50 is equidistant from both endpoints.
-	ceilings := computeLimitLinearProportional(0.5, 1.0, []int{90, 50, 10})
+	ceilings := runSpread(computeLimitLinearProportional, 0.5, 1.0, []int{90, 50, 10})
 	require.Len(t, ceilings, 3)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9)
 	assert.InDelta(t, 0.75, ceilings[1], 1e-9)
@@ -309,7 +309,7 @@ func TestLinearProportional_ThreePriorities_EvenSpacing(t *testing.T) {
 func TestLinearProportional_ThreePriorities_SkewedLow(t *testing.T) {
 	t.Parallel()
 	// Priorities {100, 50, 10}: 50 is numerically closer to 10 than to 100.
-	ceilings := computeLimitLinearProportional(0.5, 1.0, []int{100, 50, 10})
+	ceilings := runSpread(computeLimitLinearProportional, 0.5, 1.0, []int{100, 50, 10})
 	require.Len(t, ceilings, 3)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9)
 	assert.InDelta(t, 0.7222222, ceilings[1], 1e-6)
@@ -319,7 +319,7 @@ func TestLinearProportional_ThreePriorities_SkewedLow(t *testing.T) {
 func TestLinearProportional_SkewedDistribution(t *testing.T) {
 	t.Parallel()
 	// Priorities {1, 2, 100}: 2 is nearly indistinguishable from 1.
-	ceilings := computeLimitLinearProportional(0.5, 1.0, []int{100, 2, 1})
+	ceilings := runSpread(computeLimitLinearProportional, 0.5, 1.0, []int{100, 2, 1})
 	require.Len(t, ceilings, 3)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9)
 	assert.InDelta(t, 0.505050, ceilings[1], 1e-5, "priority 2 should be close to cMin")
@@ -329,7 +329,7 @@ func TestLinearProportional_SkewedDistribution(t *testing.T) {
 func TestLinearProportional_DuplicatePriorities(t *testing.T) {
 	t.Parallel()
 	// All same value: pRange = 0, should return cMax for all.
-	ceilings := computeLimitLinearProportional(0.5, 1.0, []int{10, 10, 10})
+	ceilings := runSpread(computeLimitLinearProportional, 0.5, 1.0, []int{10, 10, 10})
 	require.Len(t, ceilings, 3)
 	for i, c := range ceilings {
 		assert.InDelta(t, 1.0, c, 1e-9, "ceiling[%d] should be cMax when all priorities are equal", i)
@@ -339,7 +339,7 @@ func TestLinearProportional_DuplicatePriorities(t *testing.T) {
 func TestLinearProportional_TwoDuplicatePriorities(t *testing.T) {
 	t.Parallel()
 	// Two same values at the bottom.
-	ceilings := computeLimitLinearProportional(0.5, 1.0, []int{100, 10, 10})
+	ceilings := runSpread(computeLimitLinearProportional, 0.5, 1.0, []int{100, 10, 10})
 	require.Len(t, ceilings, 3)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9)
 	assert.InDelta(t, 0.5, ceilings[1], 1e-9, "duplicate lowest priorities get cMin")
@@ -348,7 +348,7 @@ func TestLinearProportional_TwoDuplicatePriorities(t *testing.T) {
 
 func TestLinearProportional_MonotonicallyDecreasing(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitLinearProportional(0.2, 0.9, []int{50, 40, 30, 20, 10})
+	ceilings := runSpread(computeLimitLinearProportional, 0.2, 0.9, []int{50, 40, 30, 20, 10})
 	for i := 1; i < len(ceilings); i++ {
 		assert.GreaterOrEqual(t, ceilings[i-1], ceilings[i],
 			"ceiling[%d] (%f) should be >= ceiling[%d] (%f)", i-1, ceilings[i-1], i, ceilings[i])
@@ -357,7 +357,7 @@ func TestLinearProportional_MonotonicallyDecreasing(t *testing.T) {
 
 func TestLinearProportional_NegativePriorities(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitLinearProportional(0.5, 1.0, []int{10, -5, -20})
+	ceilings := runSpread(computeLimitLinearProportional, 0.5, 1.0, []int{10, -5, -20})
 	require.Len(t, ceilings, 3)
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9, "highest priority gets cMax")
 	assert.InDelta(t, 0.5, ceilings[2], 1e-9, "lowest priority gets cMin")
@@ -367,7 +367,7 @@ func TestLinearProportional_NegativePriorities(t *testing.T) {
 
 func TestLinearProportional_BoundaryValues(t *testing.T) {
 	t.Parallel()
-	ceilings := computeLimitLinearProportional(0.0, 1.0, []int{10, 5, 1})
+	ceilings := runSpread(computeLimitLinearProportional, 0.0, 1.0, []int{10, 5, 1})
 	assert.InDelta(t, 1.0, ceilings[0], 1e-9, "highest priority gets cMax")
 	assert.InDelta(t, 0.0, ceilings[len(ceilings)-1], 1e-9, "lowest priority gets cMin")
 }
@@ -381,8 +381,8 @@ func TestDomains_ConvergeOnEvenSpacing(t *testing.T) {
 	// When priorities are evenly distributed relative to their range, both domains
 	// should produce the same ceilings.
 	priorities := []int{100, 55, 10}
-	rank := computeLimitStepwiseSpread(0.5, 1.0, priorities)
-	value := computeLimitLinearProportional(0.5, 1.0, priorities)
+	rank := runSpread(computeLimitStepwiseSpread, 0.5, 1.0, priorities)
+	value := runSpread(computeLimitLinearProportional, 0.5, 1.0, priorities)
 
 	require.Len(t, rank, 3)
 	require.Len(t, value, 3)
@@ -397,8 +397,8 @@ func TestDomains_DivergeOnSkewedSpacing(t *testing.T) {
 	// When priorities are skewed, value domain should give the middle priority a different
 	// ceiling than rank domain.
 	priorities := []int{100, 2, 1}
-	rank := computeLimitStepwiseSpread(0.5, 1.0, priorities)
-	value := computeLimitLinearProportional(0.5, 1.0, priorities)
+	rank := runSpread(computeLimitStepwiseSpread, 0.5, 1.0, priorities)
+	value := runSpread(computeLimitLinearProportional, 0.5, 1.0, priorities)
 
 	// Endpoints should be the same.
 	assert.InDelta(t, rank[0], value[0], 1e-9, "highest priority should match")
@@ -516,3 +516,23 @@ func TestBuildConfig_ValidConfigs(t *testing.T) {
 
 func ptrStr(s string) *string     { return &s }
 func ptrFloat(f float64) *float64 { return &f }
+
+// computeLimits invokes ComputeLimit with a framework-style output buffer (pre-filled with 1.0,
+// sized to priorities) and returns the filled ceilings.
+func computeLimits(t *testing.T, p *priorityHoldbackPolicy, saturation float64, priorities []int) []float64 {
+	t.Helper()
+	ceilings := make([]float64, len(priorities))
+	for i := range ceilings {
+		ceilings[i] = 1.0
+	}
+	p.ComputeLimit(t.Context(), saturation, priorities, ceilings)
+	return ceilings
+}
+
+// runSpread applies a fill-style compute function to a fresh buffer, mirroring the framework's
+// contract, and returns the filled ceilings.
+func runSpread(fn func(cMin, cMax float64, priorities []int, ceilings []float64), cMin, cMax float64, priorities []int) []float64 {
+	ceilings := make([]float64, len(priorities))
+	fn(cMin, cMax, priorities, ceilings)
+	return ceilings
+}

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy.go
@@ -25,9 +25,11 @@ limitations under the License.
 // ceiling is open on 1/period of calls, where
 // period = round(saturation/(1-saturation)).
 //
-// A single policy-wide tick counter drives the alternation. All gated bands
-// share it, so on any given call either every gated band's ceiling is open
-// or every gated band's ceiling is closed. This monotonicity is required by
+// A single policy-wide tick counter drives the alternation. The framework
+// calls ComputeLimit exactly once per dispatch cycle, so the tick counts
+// cycles: the duty cycle is a share of dispatch opportunities, not of wall
+// time. All gated bands share the tick, so on any given call either every
+// gated band's ceiling is open or every gated band's ceiling is closed. This monotonicity is required by
 // the dispatch loop, which stops at the first band whose ceiling is at or
 // below current saturation. Per-band counters would drift out of phase as
 // bands enter gating at different saturations, so a lower gated band's
@@ -100,19 +102,18 @@ func (p *policy) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: PolicyType, Name: p.name}
 }
 
-// ComputeLimit returns per-band ceilings. priorities[0] is the highest
-// priority band and receives ceiling=1.0. Lower bands whose reflective
-// ceiling has been reached alternate between 1.0 and 0.0 with period
-// round(saturation/(1-saturation)), producing a proportional duty cycle.
-func (p *policy) ComputeLimit(_ context.Context, saturation float64, priorities []int) []float64 {
+// ComputeLimit writes per-band ceilings into the caller-provided buffer. priorities[0] is the
+// highest priority band and receives ceiling=1.0. Lower bands whose reflective ceiling has been
+// reached alternate between 1.0 and 0.0 with period round(saturation/(1-saturation)), producing a
+// proportional duty cycle.
+func (p *policy) ComputeLimit(_ context.Context, saturation float64, priorities []int, ceilings []float64) {
 	n := len(priorities)
-	ceilings := make([]float64, n)
 	if n == 0 {
-		return ceilings
+		return
 	}
 	if n == 1 {
 		ceilings[0] = 1.0
-		return ceilings
+		return
 	}
 
 	// Ceilings decrease monotonically with rank, so any band is at or past
@@ -150,6 +151,4 @@ func (p *policy) ComputeLimit(_ context.Context, saturation float64, priorities 
 			}
 		}
 	}
-
-	return ceilings
 }

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy_test.go
@@ -91,7 +91,7 @@ func TestPolicyType(t *testing.T) {
 
 func TestComputeLimit_NoBands(t *testing.T) {
 	p := newTestPolicy()
-	got := p.ComputeLimit(context.Background(), 0.9, nil)
+	got := computeLimits(p, 0.9, nil)
 	if len(got) != 0 {
 		t.Errorf("expected empty ceilings, got %v", got)
 	}
@@ -100,7 +100,7 @@ func TestComputeLimit_NoBands(t *testing.T) {
 func TestComputeLimit_SingleBand(t *testing.T) {
 	p := newTestPolicy()
 	for _, sat := range []float64{0.0, 0.5, 0.99, 1.0} {
-		got := p.ComputeLimit(context.Background(), sat, []int{100})
+		got := computeLimits(p, sat, []int{100})
 		if len(got) != 1 || got[0] != 1.0 {
 			t.Errorf("saturation=%.2f single-band ceilings=%v, want [1.0]", sat, got)
 		}
@@ -111,7 +111,7 @@ func TestComputeLimit_CriticalBandNeverGated(t *testing.T) {
 	p := newTestPolicy()
 	priorities := []int{100, 0, -50}
 	for _, sat := range []float64{0.0, 0.3, 0.5, 0.7, 0.99, 1.0, 1.5} {
-		got := p.ComputeLimit(context.Background(), sat, priorities)
+		got := computeLimits(p, sat, priorities)
 		if got[0] != 1.0 {
 			t.Errorf("saturation=%.2f: ceilings[0]=%v, want 1.0", sat, got[0])
 		}
@@ -123,7 +123,7 @@ func TestComputeLimit_BelowCeilingAllOpen(t *testing.T) {
 	//   [1.0, 1-0.15=0.85, 1-0.30=0.70].
 	// Saturation is below all ceilings, so every band returns 1.0.
 	p := newTestPolicy()
-	got := p.ComputeLimit(context.Background(), 0.3, []int{100, 0, -50})
+	got := computeLimits(p, 0.3, []int{100, 0, -50})
 	for i, c := range got {
 		if c != 1.0 {
 			t.Errorf("band %d: got %v, want 1.0 (below ceiling)", i, c)
@@ -134,7 +134,7 @@ func TestComputeLimit_BelowCeilingAllOpen(t *testing.T) {
 func TestComputeLimit_FullySaturated(t *testing.T) {
 	// At saturation>=1.0, non-critical bands hard-block (ceiling=0.0).
 	p := newTestPolicy()
-	got := p.ComputeLimit(context.Background(), 1.0, []int{100, 0, -50})
+	got := computeLimits(p, 1.0, []int{100, 0, -50})
 	if got[0] != 1.0 {
 		t.Errorf("ceilings[0]=%v, want 1.0 (critical band)", got[0])
 	}
@@ -152,7 +152,7 @@ func TestComputeLimit_ReflectiveFormula(t *testing.T) {
 	// Band 1 is below its ceiling (open), bands 2 and 3 are at/over their
 	// ceilings (gated). This exercises both branches of the formula.
 	p := newTestPolicy()
-	got := p.ComputeLimit(context.Background(), 0.7, []int{100, 50, 0, -50})
+	got := computeLimits(p, 0.7, []int{100, 50, 0, -50})
 
 	if got[0] != 1.0 {
 		t.Errorf("band 0: got %v, want 1.0 (critical)", got[0])
@@ -175,7 +175,7 @@ func TestComputeLimit_Alternation(t *testing.T) {
 	p := newTestPolicy()
 	want := []float64{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}
 	for i, w := range want {
-		got := p.ComputeLimit(context.Background(), 0.7, []int{100, -50})
+		got := computeLimits(p, 0.7, []int{100, -50})
 		if got[0] != 1.0 {
 			t.Errorf("call %d: critical band gated unexpectedly: %v", i, got[0])
 		}
@@ -191,7 +191,7 @@ func TestComputeLimit_AlternationLongerPeriod(t *testing.T) {
 	p := newTestPolicy()
 	want := []float64{0.0, 0.0, 1.0, 0.0, 0.0, 1.0}
 	for i, w := range want {
-		got := p.ComputeLimit(context.Background(), 0.75, []int{100, -50})
+		got := computeLimits(p, 0.75, []int{100, -50})
 		if got[1] != w {
 			t.Errorf("call %d: ceilings[1]=%v, want %v (period=3)", i, got[1], w)
 		}
@@ -202,8 +202,8 @@ func TestComputeLimit_GrowingPriorities(t *testing.T) {
 	// The active priority domain can expand mid-flight without panic and
 	// band 0 stays ungated.
 	p := newTestPolicy()
-	_ = p.ComputeLimit(context.Background(), 0.7, []int{100, -50})
-	got := p.ComputeLimit(context.Background(), 0.7, []int{100, 50, 0, -50})
+	_ = computeLimits(p, 0.7, []int{100, -50})
+	got := computeLimits(p, 0.7, []int{100, 50, 0, -50})
 	if len(got) != 4 {
 		t.Fatalf("len(ceilings)=%d, want 4", len(got))
 	}
@@ -229,14 +229,14 @@ func TestComputeLimit_NoStarvationUnderRisingSaturation(t *testing.T) {
 	priorities := []int{100, 0, -50}
 
 	for i := 0; i < 3; i++ {
-		p.ComputeLimit(context.Background(), 0.6, priorities)
+		computeLimits(p, 0.6, priorities)
 	}
 
 	band1Open := 0
 	band2Open := 0
 	const iterations = 100
 	for i := 0; i < iterations; i++ {
-		got := p.ComputeLimit(context.Background(), 0.7, priorities)
+		got := computeLimits(p, 0.7, priorities)
 		if got[1] == 1.0 {
 			band1Open++
 		}
@@ -258,4 +258,15 @@ func TestComputeLimit_NoStarvationUnderRisingSaturation(t *testing.T) {
 	if band2Open == 0 {
 		t.Errorf("band 2 opened %d times over %d calls; expected non-zero (starvation regression)", band2Open, iterations)
 	}
+}
+
+// computeLimits invokes ComputeLimit with a framework-style output buffer (pre-filled with 1.0,
+// sized to priorities) and returns the filled ceilings.
+func computeLimits(p *policy, saturation float64, priorities []int) []float64 {
+	ceilings := make([]float64, len(priorities))
+	for i := range ceilings {
+		ceilings[i] = 1.0
+	}
+	p.ComputeLimit(context.Background(), saturation, priorities, ceilings)
+	return ceilings
 }

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/usagelimitpolicy.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/usagelimitpolicy.go
@@ -56,19 +56,20 @@ func DefaultPolicy() flowcontrol.UsageLimitPolicy {
 	return NewConstPolicy(StaticUsageLimitPolicyType, 1.0)
 }
 
-// NewConstPolicy implements a UsageLimitPolicy that returns a fixed threshold for all priorities.
+// NewConstPolicy implements a UsageLimitPolicy that applies a fixed threshold to all priorities.
 func NewConstPolicy(usageLimitName string, threshold float64) flowcontrol.UsageLimitPolicy {
-	return NewPolicyFunc(usageLimitName, func(_ context.Context, _ float64, priorities []int) []float64 {
-		result := make([]float64, len(priorities))
-		for i := range result {
-			result[i] = threshold
+	return NewPolicyFunc(usageLimitName, func(_ context.Context, _ float64, _ []int, ceilings []float64) {
+		for i := range ceilings {
+			ceilings[i] = threshold
 		}
-		return result
 	})
 }
 
 // NewPolicyFunc implements a UsageLimitPolicy with a single func.
-func NewPolicyFunc(usageLimitName string, f func(ctx context.Context, saturation float64, priorities []int) (ceilings []float64)) flowcontrol.UsageLimitPolicy {
+func NewPolicyFunc(
+	usageLimitName string,
+	f func(ctx context.Context, saturation float64, priorities []int, ceilings []float64),
+) flowcontrol.UsageLimitPolicy {
 	return &usageLimitPolicyFunc{
 		typeName: fmt.Sprint(usageLimitName, "-type"),
 		name:     usageLimitName,
@@ -79,7 +80,7 @@ func NewPolicyFunc(usageLimitName string, f func(ctx context.Context, saturation
 type usageLimitPolicyFunc struct {
 	typeName string
 	name     string
-	f        func(ctx context.Context, saturation float64, priorities []int) (ceilings []float64)
+	f        func(ctx context.Context, saturation float64, priorities []int, ceilings []float64)
 }
 
 func (u usageLimitPolicyFunc) TypedName() plugin.TypedName {
@@ -89,6 +90,6 @@ func (u usageLimitPolicyFunc) TypedName() plugin.TypedName {
 	}
 }
 
-func (u usageLimitPolicyFunc) ComputeLimit(ctx context.Context, saturation float64, priorities []int) (ceilings []float64) {
-	return u.f(ctx, saturation, priorities)
+func (u usageLimitPolicyFunc) ComputeLimit(ctx context.Context, saturation float64, priorities []int, ceilings []float64) {
+	u.f(ctx, saturation, priorities, ceilings)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`UsageLimitPolicy.ComputeLimit` returned a slice parallel to the priorities argument, and the dispatch loop indexed it unchecked: a policy returning a short slice panicked the processor. The policy now writes into a buffer the framework sizes to `len(priorities)` and pre-fills with 1.0, so a short result cannot exist and a skipped entry fails open instead of keeping a stale value. The processor reuses one buffer across cycles, removing a per-cycle allocation on the 1ms dispatch path.

The call stays batch-shaped rather than per-band, and the interface doc now states why: the framework calls ComputeLimit exactly once per dispatch cycle, duty-cycle policies (soft-reflective-ceiling) use that call as their tick, and computing all ceilings together is what lets every gated band see the same open/closed decision within a cycle.

Breaking SDK change for out-of-tree `UsageLimitPolicy` implementations; part of the panic-posture cleanup in #2098.

**Which issue(s) this PR fixes**:

Part of #2098

**Release note**:

```release-note
ACTION REQUIRED for out-of-tree UsageLimitPolicy plugins: ComputeLimit now fills a framework-provided ceilings buffer instead of returning a slice.
```
