### PR TITLE
Fix image tags presubmit by pinning zmq image version

### DIFF
--- a/test/perf/config/llm-d-sim-deployment-zmq.yaml
+++ b/test/perf/config/llm-d-sim-deployment-zmq.yaml
@@ -89,7 +89,7 @@ spec:
             cpu: '1'
             memory: 8Gi
       - name: zmq-proxy
-        image: quay.io/mayab/zmq-listener:latest
+        image: quay.io/mayab/zmq-listener@sha256:2427928648d25b1195dc2e226304d3774974058b8f3f6d45099b07d4814430b6
         imagePullPolicy: IfNotPresent
         command: ["python", "-c"]
         args:


### PR DESCRIPTION
fix the check-latest-tags-strict presubmit by pinning the zmq-listener version instead of using latest tag.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind test

**What this PR does / why we need it**:

Fix image tags presubmit.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2181

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
