### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,2 @@
+# Security
+Please see the [llm-d Security Policy](https://github.com/llm-d/llm-d/blob/main/SECURITY.md) in the main repository for vulnerability reporting and disclosure information.


### PR DESCRIPTION
## Summary

Adds SECURITY.md that references the main llm-d security policy for vulnerability reporting.

## Changes

- Added SECURITY.md pointing to the llm-d org-wide security policy at https://github.com/llm-d/llm-d/blob/main/SECURITY.md

## Testing

Verified by visual inspection — standard org template applied.