### PR TITLE
epp: add multicluster feature gate and endpoint attribute

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -685,6 +685,7 @@ func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver
 
 	loader.RegisterFeatureGate(flowcontrol.FeatureGate, false)
 	loader.RegisterFeatureGate(runserver.HAPopulateNonLeaderDatastoreFeatureGate, true)
+	loader.RegisterFeatureGate(fwkdl.MultiClusterFeatureGate, false)
 
 	r.registerInTreePlugins()
 
@@ -784,7 +785,8 @@ func (r *Runner) configureAndStartDatalayer(ctx context.Context, cfg *datalayer.
 }
 
 func (r *Runner) setupMetricsCollection(opts *runserver.Options) datalayer.EndpointFactory {
-	r.dlRuntime = datalayer.NewRuntime(opts.RefreshMetricsInterval)
+	r.dlRuntime = datalayer.NewRuntime(opts.RefreshMetricsInterval,
+		datalayer.WithMultiCluster(r.featureGates[fwkdl.MultiClusterFeatureGate]))
 	return r.dlRuntime
 }
 

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -59,20 +59,30 @@ type Runtime struct {
 
 	collectors *collectorManager // per-endpoint poller, keyed by namespaced name
 	logger     logr.Logger       // Set in Configure; used where no context is available (e.g. ReleaseEndpoint).
+
+	multiCluster bool // multi-cluster mode is enabled
 }
 
 const (
 	defaultRefreshInterval = 50 * time.Millisecond
 )
 
+// RuntimeOption configures a Runtime at construction.
+type RuntimeOption func(*Runtime)
+
+// WithMultiCluster enables multi-cluster mode on the Runtime.
+func WithMultiCluster(v bool) RuntimeOption {
+	return func(r *Runtime) { r.multiCluster = v }
+}
+
 // NewRuntime creates a new Runtime with the given polling interval.
 // If duration is <= 0, uses the defaultRefreshInterval.
-func NewRuntime(pollingInterval time.Duration) *Runtime {
+func NewRuntime(pollingInterval time.Duration, opts ...RuntimeOption) *Runtime {
 	interval := defaultRefreshInterval
 	if pollingInterval > 0 {
 		interval = pollingInterval
 	}
-	return &Runtime{
+	r := &Runtime{
 		pollingInterval: interval,
 		dispatchers:     newPollingDispatchers(),
 		notification:    newNotificationManager(),
@@ -81,6 +91,10 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 		collectors:      newCollectorManager(),
 		logger:          logr.Discard(),
 	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
 }
 
 // Configure is called to transform the configuration information into the Runtime's
@@ -372,6 +386,9 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 	logger = logger.WithValues("endpoint", endpointMetadata.GetNamespacedName())
 
 	endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
+	if r.multiCluster {
+		fwkdl.SetMultiCluster(endpoint)
+	}
 
 	dispatchers := make([]fwkdl.PollingDispatcher, 0, r.dispatchers.Count())
 	for _, d := range r.dispatchers.Dispatchers() {

--- a/pkg/epp/framework/interface/datalayer/multicluster.go
+++ b/pkg/epp/framework/interface/datalayer/multicluster.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+// MultiClusterFeatureGate enables multi-cluster mode.
+const MultiClusterFeatureGate = "multicluster"
+
+// MultiClusterAttrKey marks an endpoint in another cluster.
+const MultiClusterAttrKey = "llm-d.ai/multicluster"
+
+type multiClusterAttr bool
+
+func (m multiClusterAttr) Clone() Cloneable { return m }
+
+// SetMultiCluster marks ep as a cross-cluster endpoint.
+func SetMultiCluster(ep Endpoint) {
+	ep.GetAttributes().Put(MultiClusterAttrKey, multiClusterAttr(true))
+}
+
+// IsMultiCluster reports whether ep is in another cluster. Absence is false.
+func IsMultiCluster(ep Endpoint) bool {
+	if v, ok := ep.GetAttributes().Get(MultiClusterAttrKey); ok {
+		if m, ok := v.(multiClusterAttr); ok {
+			return bool(m)
+		}
+	}
+	return false
+}

--- a/pkg/epp/framework/interface/datalayer/multicluster_test.go
+++ b/pkg/epp/framework/interface/datalayer/multicluster_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiClusterAttribute(t *testing.T) {
+	tests := []struct {
+		name string
+		mark bool
+		want bool
+	}{
+		{name: "unmarked reads as not cross-cluster", mark: false, want: false},
+		{name: "marked reads as cross-cluster", mark: true, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := NewEndpoint(nil, nil)
+			if tt.mark {
+				SetMultiCluster(ep)
+			}
+			assert.Equal(t, tt.want, IsMultiCluster(ep))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds multi-cluster mode to the EPP, behind the `multicluster` feature gate. Builds on #2147.

- With the gate on, the datalayer Runtime tags every endpoint it creates with a multi-cluster attribute, covering all discovery sources including non-pod endpoints.
- Plugins branch on `IsMultiCluster(ep)`, reading it off the endpoint rather than the global config.
- The Runtime takes one `WithMultiCluster` option, leaving room to promote to a `multiCluster` section on `EndpointPickerConfig` later.

Follow-up: promote `multiCluster` section on `EndpointPickerConfig` once feature matures/stabalizes.

**Which issue(s) this PR fixes**:

Fixes #

**Release note**:
```release-note
NONE
```
