### PR TITLE
Increase default refresh-metrics-interval from 50ms to 60s

### DIFF
--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -62,7 +62,7 @@ type Runtime struct {
 }
 
 const (
-	defaultRefreshInterval = 50 * time.Millisecond
+	defaultRefreshInterval = 60 * time.Second
 )
 
 // NewRuntime creates a new Runtime with the given polling interval.

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -129,7 +129,7 @@ func NewOptions() *Options {
 		PoolGroup:                        routing.InferencePoolAPIGroup,
 		EndpointTargetPorts:              []int{},
 		DisableEndpointSubsetFilter:      false,
-		RefreshMetricsInterval:           50 * time.Millisecond,
+		RefreshMetricsInterval:           60 * time.Second,
 		RefreshPrometheusMetricsInterval: 5 * time.Second,
 		MetricsStalenessThreshold:        2 * time.Second,
 		TotalQueuedRequestsMetric:        "vllm:num_requests_waiting",


### PR DESCRIPTION


**What type of PR is this?**
<!--
/kind cleanup
-->

**What this PR does / why we need it**:

The 50ms default causes excessive memory allocations from the Prometheus TextParser on every scrape cycle, leading to OOM under production workloads. By default, none of the plugins recommended in the optimized baseline use the scraped metrics, with the expection of `KVCacheBlockSize`, which is constant. Therefore, it makes sense to increase the polling interval to 60s, to prevent memory strains.

This is coupled with [this](https://github.com/llm-d/llm-d/pull/2118) PR in llm-d to update documentation.

**Which issue(s) this PR fixes**:
TBD

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
