### PR TITLE
fix(EPP): stream base64 image decoding to reduce memory

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
@@ -157,7 +157,7 @@ func imageDimensionsFromBase64(url string) (width, height int, ok bool) {
 // returns its pixel dimensions.
 func imageDimensionsFromBase64Payload(rawB64 string) (width, height int, ok bool) {
 	// Image decoding is streamed to reduce memory overhead, since
-	// only headers are necessary
+	// only headers are necessary.
 	r := base64.NewDecoder(base64.StdEncoding, strings.NewReader(rawB64))
 	cfg, _, err := image.DecodeConfig(r)
 	if err != nil || cfg.Width <= 0 || cfg.Height <= 0 {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tokenizer
 
 import (
-	"bytes"
 	"encoding/base64"
 	"image"
 	"strings"
@@ -157,11 +156,10 @@ func imageDimensionsFromBase64(url string) (width, height int, ok bool) {
 // imageDimensionsFromBase64Payload decodes a bare base64 image payload and
 // returns its pixel dimensions.
 func imageDimensionsFromBase64Payload(rawB64 string) (width, height int, ok bool) {
-	decoded, err := base64.StdEncoding.DecodeString(rawB64)
-	if err != nil {
-		return 0, 0, false
-	}
-	cfg, _, err := image.DecodeConfig(bytes.NewReader(decoded))
+	// Image decoding is streamed to reduce memory overhead, since
+	// only headers are necessary
+	r := base64.NewDecoder(base64.StdEncoding, strings.NewReader(rawB64))
+	cfg, _, err := image.DecodeConfig(r)
 	if err != nil || cfg.Width <= 0 || cfg.Height <= 0 {
 		return 0, 0, false
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Under high multimodal load, EPP can face OOM, due to holding multiple decoded image buffers for concurrent requests. For this function, we only care about the image sizes, so we can safely 'lazily' decode the image, get only the header we're interested in, and stop right there, avoiding decoding the entire image. 
Use base64.NewDecoder streaming instead of DecodeString, so image.DecodeConfig only reads the header bytes. Avoids allocating the full decoded image payload just to read dimensions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2196 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
