### PR TITLE
cicd/bug: query live labels in hold gate instead of (stale) event payload

### DIFF
--- a/.github/workflows/pr-hold-gate.yml
+++ b/.github/workflows/pr-hold-gate.yml
@@ -27,7 +27,12 @@ jobs:
           labels=$(gh pr view "$PR_URL" --json labels -q '.labels[].name')
           for label in "${blocking_labels[@]}"; do
             if grep -qxF "$label" <<< "$labels"; then
-              echo "::error::A hold label is present (hold or do-not-merge/hold). Remove it (/hold cancel) to allow merge."
+              if [ "$label" = hold ]; then
+                howto="run /hold cancel"
+              else
+                howto="remove it from the PR"
+              fi
+              echo "::error::Blocking label '$label' is present. To allow merge, $howto."
               exit 1
             fi
           done

--- a/.github/workflows/pr-hold-gate.yml
+++ b/.github/workflows/pr-hold-gate.yml
@@ -1,6 +1,10 @@
-# Fails a required check while a hold label is present, so the `hold` label and
-# the release branch auto-hold (`do-not-merge/hold`) block GitHub native
-# auto-merge. Re-runs on label changes.
+# Fails a required check while a hold label is present, so /hold (label `hold`)
+# and the release-branch auto-hold (label `do-not-merge/hold`) block
+# GitHub-native auto-merge. Re-runs on label changes.
+#
+# Queries current labels via the API rather than github.event.pull_request.labels:
+# that field is frozen at trigger time, so a manual rerun of a stale failed run
+# would otherwise keep failing even after the hold label is removed.
 
 name: Hold gate
 
@@ -10,13 +14,19 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   hold:
     runs-on: ubuntu-latest
     steps:
       - name: Block merge while held
-        if: contains(github.event.pull_request.labels.*.name, 'hold') || contains(github.event.pull_request.labels.*.name, 'do-not-merge/hold')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          echo "::error::A hold label is present (hold or do-not-merge/hold). Remove the label to allow merge."
-          exit 1
+          labels=$(gh pr view "$PR_URL" --json labels -q '.labels[].name')
+          if grep -qxE 'hold|do-not-merge/hold' <<< "$labels"; then
+            echo "::error::A hold label is present (hold or do-not-merge/hold). Remove it (/hold cancel) to allow merge."
+            exit 1
+          fi

--- a/.github/workflows/pr-hold-gate.yml
+++ b/.github/workflows/pr-hold-gate.yml
@@ -21,9 +21,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          # re-fetch labels; github.event.pull_request.labels is stale on rerun
+          blocking_labels=(hold do-not-merge/hold)
+
+          # fetch current labels
           labels=$(gh pr view "$PR_URL" --json labels -q '.labels[].name')
-          if grep -qxE 'hold|do-not-merge/hold' <<< "$labels"; then
-            echo "::error::A hold label is present (hold or do-not-merge/hold). Remove it (/hold cancel) to allow merge."
-            exit 1
-          fi
+          for label in "${blocking_labels[@]}"; do
+            if grep -qxF "$label" <<< "$labels"; then
+              echo "::error::A hold label is present (hold or do-not-merge/hold). Remove it (/hold cancel) to allow merge."
+              exit 1
+            fi
+          done

--- a/.github/workflows/pr-hold-gate.yml
+++ b/.github/workflows/pr-hold-gate.yml
@@ -1,10 +1,6 @@
 # Fails a required check while a hold label is present, so /hold (label `hold`)
 # and the release-branch auto-hold (label `do-not-merge/hold`) block
 # GitHub-native auto-merge. Re-runs on label changes.
-#
-# Queries current labels via the API rather than github.event.pull_request.labels:
-# that field is frozen at trigger time, so a manual rerun of a stale failed run
-# would otherwise keep failing even after the hold label is removed.
 
 name: Hold gate
 
@@ -25,6 +21,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          # re-fetch labels; github.event.pull_request.labels is stale on rerun
           labels=$(gh pr view "$PR_URL" --json labels -q '.labels[].name')
           if grep -qxE 'hold|do-not-merge/hold' <<< "$labels"; then
             echo "::error::A hold label is present (hold or do-not-merge/hold). Remove it (/hold cancel) to allow merge."

--- a/.github/workflows/pr-hold-gate.yml
+++ b/.github/workflows/pr-hold-gate.yml
@@ -27,12 +27,7 @@ jobs:
           labels=$(gh pr view "$PR_URL" --json labels -q '.labels[].name')
           for label in "${blocking_labels[@]}"; do
             if grep -qxF "$label" <<< "$labels"; then
-              if [ "$label" = hold ]; then
-                howto="run /hold cancel"
-              else
-                howto="remove it from the PR"
-              fi
-              echo "::error::Blocking label '$label' is present. To allow merge, $howto."
+              echo "::error::Blocking label '$label' is present. Remove it to allow merge (e.g., /hold cancel for hold)."
               exit 1
             fi
           done


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The Hold gate workflow checked `github.event.pull_request.labels.*.name`, which is frozen at the time the run was triggered. Re-running a failed hold-gate job (via the Actions UI) replays that stale payload instead of refetching current labels, so the check keeps failing even after the `hold`/`do-not-merge/hold` label is removed. Only a brand-new triggering event (e.g. a new commit) would produce a fresh payload and let it pass.

Instead of using the labels from the (stale) payload, this PR queries current labels via `gh pr view` inside the step, so reruns reflect the PR's actual current state.

**Which issue(s) this PR fixes**:

Fixes #2199

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
