### PR TITLE
docs: update probabilistic-admitter-epp-config.yaml header for flow c…

### DIFF
--- a/deploy/config/probabilistic-admitter-epp-config.yaml
+++ b/deploy/config/probabilistic-admitter-epp-config.yaml
@@ -1,9 +1,14 @@
 # EPP configuration for the probabilistic-admitter plugin.
 #
-# The probabilistic-admitter handles all saturation-based admission decisions,
-# so the system-level utilization-detector is configured with effectively
-# infinite thresholds to prevent it from gating requests before the admitter
-# can evaluate them.
+# The probabilistic-admitter handles all saturation-based admission decisions
+# at the admission extension point. To let it own admission exclusively, the
+# system-level utilization-detector is configured with effectively infinite
+# thresholds (queueDepthThreshold: 999999999, kvCacheUtilThreshold: 1.0).
+# This prevents the flow control dispatch gate from queueing requests before
+# the admitter can evaluate them.
+#
+# Note: If these utilization-detector thresholds are raised, requests will
+# undergo flow control queueing before reaching the probabilistic-admitter.
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it

Updates the header comment in `deploy/config/probabilistic-admitter-epp-config.yaml` to accurately describe the flow control dispatch gate behavior and threshold layering after the `flowControl` feature gate was enabled by default (#2180).

## Which issue(s) this PR fixes

Fixes #2182

## Release note

```release-note
NONE
```