### PR TITLE
feat(epp): add active request filter

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -106,6 +106,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vertexai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
+	activerequestfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/activerequest"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	endpointattributefilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/endpointattribute"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity"
@@ -558,6 +559,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(bylabel.PrefillRoleType, bylabel.PrefillRoleFactory)
 	fwkplugin.Register(endpointattributefilter.EndpointAttributeFilterType, endpointattributefilter.EndpointAttributeFilterFactory)
 	fwkplugin.Register(sessionaffinityfilter.SessionAffinityType, sessionaffinityfilter.Factory)
+	fwkplugin.Register(activerequestfilter.ActiveRequestFilterType, activerequestfilter.Factory)
 
 	// dataparallel profile handler
 	fwkplugin.Register(dataparallel.DataParallelProfileHandlerType, dataparallel.ProfileHandlerFactory)

--- a/pkg/epp/framework/plugins/scheduling/filter/activerequest/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/activerequest/README.md
@@ -1,0 +1,43 @@
+# Active Request Filter Plugin
+
+**Type:** `active-request-filter`
+
+This plugin filters candidate endpoints by the in-flight request count the EPP tracks for each endpoint.
+
+## What it does
+
+For each scheduling cycle, the plugin reads the in-flight load attribute produced by the `inflight-load-producer` data producer from each candidate endpoint and keeps only the endpoints whose in-flight request count is at most `maxRequests`. Endpoints without the attribute are treated as having zero in-flight requests and kept.
+
+When every endpoint is filtered out and `fallbackOnEmpty` is `true`, the original candidate list is returned unchanged, so the request can still be routed somewhere.
+
+## Inputs consumed
+
+The plugin consumes:
+
+- `InFlightLoadDataKey` (`InFlightLoad`) — the per-endpoint in-flight load snapshot maintained by the `inflight-load-producer` data producer.
+
+## Configuration
+
+| Parameter                  | Required | Description                                                                                   |
+|----------------------------|----------|-----------------------------------------------------------------------------------------------|
+| `maxRequests`              | yes      | Maximum in-flight request count an endpoint may have and still be kept. Must be positive.      |
+| `fallbackOnEmpty`          | no       | When `true`, return the unfiltered candidates if every endpoint was dropped. Default `false`.  |
+| `inFlightLoadProducerName` | no       | Name of the in-flight load producer instance to consume from. Defaults to the default producer. |
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: active-request-filter
+    name: drop-busy-endpoints
+    parameters:
+      maxRequests: 10
+      fallbackOnEmpty: true
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: drop-busy-endpoints
+```
+
+## See also
+
+The `active-request-scorer` plugin is the scoring counterpart of this filter: instead of dropping endpoints, it ranks them by the same in-flight request count.

--- a/pkg/epp/framework/plugins/scheduling/filter/activerequest/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/activerequest/README.md
@@ -6,7 +6,7 @@ This plugin filters candidate endpoints by the in-flight request count the EPP t
 
 ## What it does
 
-For each scheduling cycle, the plugin reads the in-flight load attribute produced by the `inflight-load-producer` data producer from each candidate endpoint and keeps only the endpoints whose in-flight request count is at most `maxRequests`. Endpoints without the attribute are treated as having zero in-flight requests and kept.
+For each scheduling cycle, the plugin reads the in-flight load attribute produced by the `inflight-load-producer` data producer from each candidate endpoint and keeps only the endpoints whose in-flight request count is at most `maxRequests`. The count covers every request the EPP has routed to the endpoint and not yet seen complete, so it includes both running and queued requests; the EPP does not distinguish the two. Endpoints without the attribute are treated as having zero in-flight requests and kept.
 
 When every endpoint is filtered out and `fallbackOnEmpty` is `true`, the original candidate list is returned unchanged, so the request can still be routed somewhere.
 

--- a/pkg/epp/framework/plugins/scheduling/filter/activerequest/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/activerequest/doc.go
@@ -1,0 +1,3 @@
+// Package activerequest provides a filter that drops endpoints whose
+// EPP-tracked in-flight request count exceeds a configured maximum.
+package activerequest

--- a/pkg/epp/framework/plugins/scheduling/filter/activerequest/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/activerequest/filter.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activerequest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+)
+
+const (
+	// ActiveRequestFilterType is the type of the ActiveRequestFilter.
+	ActiveRequestFilterType = "active-request-filter"
+)
+
+// parameters defines the parameters for ActiveRequestFilter.
+type parameters struct {
+	// MaxRequests is the maximum number of in-flight requests an endpoint may
+	// have and still pass the filter. Endpoints with a request count greater
+	// than MaxRequests are dropped.
+	MaxRequests int64 `json:"maxRequests"`
+
+	// FallbackOnEmpty returns the unfiltered candidates when every endpoint
+	// was filtered out, so the request can still be routed somewhere.
+	FallbackOnEmpty bool `json:"fallbackOnEmpty"`
+
+	InFlightLoadProducerName string `json:"inFlightLoadProducerName,omitempty"`
+}
+
+// compile-time type assertion
+var _ scheduling.Filter = &ActiveRequestFilter{}
+var _ plugin.ConsumerPlugin = &ActiveRequestFilter{}
+
+// Factory defines the factory function for ActiveRequestFilter.
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	params := parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", ActiveRequestFilterType, err)
+		}
+	}
+
+	return NewActiveRequestFilter(name, params)
+}
+
+// NewActiveRequestFilter validates the given parameters and returns a new
+// ActiveRequestFilter with the given name.
+func NewActiveRequestFilter(name string, params parameters) (*ActiveRequestFilter, error) {
+	if name == "" {
+		name = ActiveRequestFilterType
+	}
+	if params.MaxRequests <= 0 {
+		return nil, fmt.Errorf("active request filter requires a positive maxRequests, got %d", params.MaxRequests)
+	}
+
+	return &ActiveRequestFilter{
+		typedName:           plugin.TypedName{Type: ActiveRequestFilterType, Name: name},
+		maxRequests:         params.MaxRequests,
+		fallbackOnEmpty:     params.FallbackOnEmpty,
+		inFlightLoadDataKey: attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(params.InFlightLoadProducerName),
+	}, nil
+}
+
+// ActiveRequestFilter filters candidate endpoints by the in-flight request
+// count produced by the inflight-load-producer data producer. Endpoints whose
+// count exceeds the configured maximum are dropped. Endpoints without the
+// attribute are treated as having zero in-flight requests and kept.
+type ActiveRequestFilter struct {
+	typedName           plugin.TypedName
+	inFlightLoadDataKey plugin.DataKey
+
+	// maxRequests is the maximum in-flight request count an endpoint may have
+	// and still be kept.
+	maxRequests int64
+	// fallbackOnEmpty returns the unfiltered candidates when every endpoint
+	// was filtered out.
+	fallbackOnEmpty bool
+}
+
+// TypedName returns the typed name of the plugin.
+func (f *ActiveRequestFilter) TypedName() plugin.TypedName {
+	return f.typedName
+}
+
+// Consumes returns the in-flight load attribute required for filtering.
+func (f *ActiveRequestFilter) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
+		Required: map[plugin.DataKey]any{f.inFlightLoadDataKey: attrconcurrency.InFlightLoad{}},
+	}
+}
+
+// Filter keeps the endpoints whose in-flight request count is at most
+// maxRequests. When all endpoints are filtered out and fallbackOnEmpty is set,
+// the original candidates are returned.
+func (f *ActiveRequestFilter) Filter(ctx context.Context, _ *scheduling.InferenceRequest,
+	endpoints []scheduling.Endpoint) []scheduling.Endpoint {
+	filtered := make([]scheduling.Endpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if f.requestCount(ctx, endpoint) <= f.maxRequests {
+			filtered = append(filtered, endpoint)
+		}
+	}
+
+	log.FromContext(ctx).V(logutil.TRACE).Info("Filtered endpoints by active request count",
+		"maxRequests", f.maxRequests, "candidates", len(endpoints), "kept", len(filtered))
+
+	if len(filtered) == 0 && f.fallbackOnEmpty {
+		return endpoints
+	}
+	return filtered
+}
+
+func (f *ActiveRequestFilter) requestCount(ctx context.Context, endpoint scheduling.Endpoint) int64 {
+	val, ok := endpoint.Get(f.inFlightLoadDataKey.String())
+	if !ok {
+		return 0
+	}
+
+	switch load := val.(type) {
+	case *attrconcurrency.InFlightLoad:
+		if load == nil {
+			log.FromContext(ctx).V(logutil.TRACE).Info("Ignoring nil in-flight load attribute",
+				"endpoint", endpoint.GetMetadata().NamespacedName.String())
+			return 0
+		}
+		return load.Requests
+	default:
+		log.FromContext(ctx).V(logutil.TRACE).Info("Ignoring in-flight load attribute with unexpected type",
+			"endpoint", endpoint.GetMetadata().NamespacedName.String(),
+			"attributeType", fmt.Sprintf("%T", val))
+		return 0
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/activerequest/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/activerequest/filter_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activerequest
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	testutils "github.com/llm-d/llm-d-router/test/utils"
+)
+
+type stubEndpoint struct {
+	metadata *datalayer.EndpointMetadata
+	attr     datalayer.AttributeMap
+}
+
+func newStubEndpoint(name string) *stubEndpoint {
+	return &stubEndpoint{
+		metadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
+		attr:     datalayer.NewAttributes(),
+	}
+}
+
+func (f *stubEndpoint) GetMetadata() *datalayer.EndpointMetadata   { return f.metadata }
+func (f *stubEndpoint) UpdateMetadata(*datalayer.EndpointMetadata) {}
+func (f *stubEndpoint) GetMetrics() *datalayer.Metrics             { return &datalayer.Metrics{} }
+func (f *stubEndpoint) UpdateMetrics(*datalayer.Metrics)           {}
+func (f *stubEndpoint) GetAttributes() datalayer.AttributeMap      { return f.attr }
+func (f *stubEndpoint) String() string                             { return f.metadata.NamespacedName.String() }
+func (f *stubEndpoint) Put(key string, val datalayer.Cloneable)    { f.attr.Put(key, val) }
+func (f *stubEndpoint) Get(key string) (datalayer.Cloneable, bool) {
+	return f.attr.Get(key)
+}
+func (f *stubEndpoint) Keys() []string                { return f.attr.Keys() }
+func (f *stubEndpoint) Clone() datalayer.AttributeMap { return f.attr.Clone() }
+
+func newTestEndpoint(name string) scheduling.Endpoint {
+	return newStubEndpoint(name)
+}
+
+func newTestEndpointWithLoad(name string, requests int64) scheduling.Endpoint {
+	ep := newStubEndpoint(name)
+	ep.Put(attrconcurrency.InFlightLoadDataKey.String(), &attrconcurrency.InFlightLoad{Requests: requests})
+	return ep
+}
+
+func endpointNames(endpoints []scheduling.Endpoint) []string {
+	names := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		names = append(names, ep.GetMetadata().NamespacedName.Name)
+	}
+	return names
+}
+
+func TestActiveRequestFilter_Filter(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    parameters
+		endpoints func() []scheduling.Endpoint
+		want      []string
+	}{
+		{
+			name:   "keeps endpoints at or below maxRequests",
+			params: parameters{MaxRequests: 2},
+			endpoints: func() []scheduling.Endpoint {
+				return []scheduling.Endpoint{
+					newTestEndpointWithLoad("pod-a", 1),
+					newTestEndpointWithLoad("pod-b", 2),
+					newTestEndpointWithLoad("pod-c", 3),
+				}
+			},
+			want: []string{"pod-a", "pod-b"},
+		},
+		{
+			name:   "endpoints without load attribute are kept",
+			params: parameters{MaxRequests: 1},
+			endpoints: func() []scheduling.Endpoint {
+				return []scheduling.Endpoint{
+					newTestEndpoint("pod-a"),
+					newTestEndpointWithLoad("pod-b", 5),
+				}
+			},
+			want: []string{"pod-a"},
+		},
+		{
+			name:   "all filtered out without fallback returns empty",
+			params: parameters{MaxRequests: 1},
+			endpoints: func() []scheduling.Endpoint {
+				return []scheduling.Endpoint{
+					newTestEndpointWithLoad("pod-a", 2),
+					newTestEndpointWithLoad("pod-b", 3),
+				}
+			},
+			want: []string{},
+		},
+		{
+			name:   "all filtered out with fallback returns original candidates",
+			params: parameters{MaxRequests: 1, FallbackOnEmpty: true},
+			endpoints: func() []scheduling.Endpoint {
+				return []scheduling.Endpoint{
+					newTestEndpointWithLoad("pod-a", 2),
+					newTestEndpointWithLoad("pod-b", 3),
+				}
+			},
+			want: []string{"pod-a", "pod-b"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := testutils.NewTestContext(t)
+			filter, err := NewActiveRequestFilter("", test.params)
+			require.NoError(t, err)
+
+			got := filter.Filter(ctx, nil, test.endpoints())
+
+			assert.Equal(t, test.want, endpointNames(got))
+		})
+	}
+}
+
+func TestNewActiveRequestFilter_InvalidMaxRequests(t *testing.T) {
+	for _, maxRequests := range []int64{0, -1} {
+		_, err := NewActiveRequestFilter("", parameters{MaxRequests: maxRequests})
+		assert.Error(t, err, "maxRequests=%d must be rejected", maxRequests)
+	}
+}
+
+func TestActiveRequestFilter_Factory(t *testing.T) {
+	ctx := testutils.NewTestContext(t)
+
+	decoder := json.NewDecoder(bytes.NewBufferString(`{"maxRequests": 5}`))
+	p, err := Factory("test-filter", decoder, testutils.NewTestHandle(ctx))
+	require.NoError(t, err)
+
+	filter, ok := p.(*ActiveRequestFilter)
+	require.True(t, ok)
+	assert.Equal(t, ActiveRequestFilterType, filter.TypedName().Type)
+	assert.Equal(t, "test-filter", filter.TypedName().Name)
+	assert.Equal(t, int64(5), filter.maxRequests)
+}
+
+func TestActiveRequestFilter_FactoryRejectsMissingMaxRequests(t *testing.T) {
+	ctx := testutils.NewTestContext(t)
+
+	_, err := Factory("test-filter", nil, testutils.NewTestHandle(ctx))
+	assert.Error(t, err)
+}
+
+func TestActiveRequestFilter_Consumes(t *testing.T) {
+	filter, err := NewActiveRequestFilter("", parameters{MaxRequests: 1})
+	require.NoError(t, err)
+
+	consumes := filter.Consumes()
+
+	require.Len(t, consumes.Required, 1)
+	assert.Equal(t, attrconcurrency.InFlightLoad{}, consumes.Required[attrconcurrency.InFlightLoadDataKey])
+}


### PR DESCRIPTION
Add an active-request-filter scheduling plugin that drops endpoints whose EPP-tracked in-flight request count exceeds a configured maximum. Consumes the same inflight-load-producer attribute as the active-request-scorer.

Note: 
What happens when all endpoint filtered out?


Default (fallbackOnEmpty: false) — the request fails with a 500. The filter returns an empty list, and the scheduler aborts the profile run at [scheduler_profile.go:123-125](vscode-webview://1khdmomatp9kcfcasr0i3djq6duf8absgc5h493qlqbk8va54jkd/pkg/epp/scheduling/scheduler_profile.go#L123-L125) with "no endpoints available for the given request" (code Internal). That maps to HTTP 500 InternalServerError back to the client ([error.go:104-105](vscode-webview://1khdmomatp9kcfcasr0i3djq6duf8absgc5h493qlqbk8va54jkd/pkg/common/error/error.go#L104-L105)). In a multi-profile setup, only that profile fails — its entry in the results map is nil and the profile handler decides what to do; if it's the only/primary profile, the request errors out.

With fallbackOnEmpty: true — the filter steps aside. It returns the original unfiltered candidate list, so the request still routes: downstream scorers (e.g. active-request-scorer, queue-depth) rank the overloaded endpoints and the picker chooses the least-bad one. The filter is effectively a no-op for that cycle.

So the choice is between two intents:

Hard admission cap (false): "if everyone is too busy, reject." Caveat: it surfaces as a 500, not a 429, so clients can't distinguish "saturated, retry later" from a real server error. If backpressure under saturation is the actual goal, the flow-control/saturation-detector layer is the purpose-built mechanism — it queues or sheds with proper semantics rather than failing the scheduling cycle.
Soft preference (true): "avoid busy endpoints when possible, but never fail a request because of it." This is the safer default for most routing setups, which is why the README example sets it.
