### PR TITLE
feat(epp): add error return to PreRequest plugin interface

### DIFF
--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -349,7 +349,7 @@ func BenchmarkFlowController_FullPath(b *testing.B) {
 				Body:      &requesthandling.InferenceRequestBody{TokenizedPrompt: &requesthandling.TokenizedPrompt{PerPromptTokens: [][]uint32{benchTokenIDs}}},
 			}
 			schedResult := &scheduling.SchedulingResult{ProfileResults: profileResults}
-			h.producer.PreRequest(ctx, infReq, schedResult)
+			_ = h.producer.PreRequest(ctx, infReq, schedResult)
 
 			// 3. Response lifecycle: release the in-flight load.
 			infReq.SchedulingResult = schedResult

--- a/pkg/epp/flowcontrol/eviction/request_evictor.go
+++ b/pkg/epp/flowcontrol/eviction/request_evictor.go
@@ -68,21 +68,21 @@ func (p *RequestEvictor) PreRequest(
 	ctx context.Context,
 	request *scheduling.InferenceRequest,
 	result *scheduling.SchedulingResult,
-) {
+) error {
 	if request == nil || result == nil || len(result.ProfileResults) == 0 {
-		return
+		return nil
 	}
 
 	profileResult := result.ProfileResults[result.PrimaryProfileName]
 	if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
-		return
+		return nil
 	}
 
 	targetEndpoint := profileResult.TargetEndpoints[0]
 	metadata := targetEndpoint.GetMetadata()
 	requestID := request.Headers[reqcommon.RequestIDHeaderKey]
 	if requestID == "" {
-		return
+		return nil
 	}
 
 	evictCh := make(chan struct{})
@@ -113,6 +113,7 @@ func (p *RequestEvictor) PreRequest(
 		"priority", item.Priority,
 		"evictable", p.queue.EvictableLen(),
 		"inFlight", p.queue.InFlightLen())
+	return nil
 }
 
 // ResponseBody is called for every response data chunk (streaming) or once (non-streaming).

--- a/pkg/epp/flowcontrol/eviction/request_evictor_test.go
+++ b/pkg/epp/flowcontrol/eviction/request_evictor_test.go
@@ -67,7 +67,7 @@ func TestRequestEvictor_PreRequest_CreatesEvictChannel(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, &NoOpEvictor{})
 
 	ctx := context.Background()
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 
 	evictCh := re.EvictionRegistry().Get("req-1")
 	require.NotNil(t, evictCh, "EvictCh should be registered after PreRequest")
@@ -82,7 +82,7 @@ func TestRequestEvictor_ResponseBody_DeregistersEvictChannel(t *testing.T) {
 
 	ctx := context.Background()
 	request := makeInferenceRequest("req-1", -1)
-	_ = re.PreRequest(ctx, request, makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, request, makeSchedulingResult()))
 	require.NotNil(t, re.EvictionRegistry().Get("req-1"))
 
 	re.ResponseBody(ctx, request, &requestcontrol.Response{EndOfStream: true}, nil)
@@ -97,7 +97,7 @@ func TestRequestEvictor_EvictN_ClosesEvictChannel(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, evictor)
 
 	ctx := context.Background()
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 
 	evictCh := re.EvictionRegistry().Get("req-1")
 	require.NotNil(t, evictCh)
@@ -121,7 +121,7 @@ func TestRequestEvictor_EvictN_ReTracksOnFailure(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, &failingEvictor{})
 
 	ctx := context.Background()
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 
 	evicted, err := re.EvictN(ctx, 1)
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestRequestEvictor_RaceBetweenEvictAndCompletion(t *testing.T) {
 	requests := make([]*scheduling.InferenceRequest, 10)
 	for i := range requests {
 		requests[i] = makeInferenceRequest("req-"+string(rune('a'+i)), -1)
-		_ = re.PreRequest(ctx, requests[i], makeSchedulingResult())
+		require.NoError(t, re.PreRequest(ctx, requests[i], makeSchedulingResult()))
 	}
 
 	var wg sync.WaitGroup
@@ -176,7 +176,7 @@ func TestRequestEvictor_CtxCancellationTriggersCleanup(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, evictor)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 
 	// Verify tracked.
 	assert.Equal(t, 1, re.queue.InFlightLen())
@@ -201,7 +201,7 @@ func TestRequestEvictor_CleanupCallsEvictorCleanup(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, evictor)
 
 	ctx := context.Background()
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 
 	// Evict to create a sync.Once entry in the evictor.
 	_, _ = re.EvictN(ctx, 1)
@@ -211,14 +211,14 @@ func TestRequestEvictor_CleanupCallsEvictorCleanup(t *testing.T) {
 	// We verify this indirectly: if Cleanup wasn't called, the sync.Once map would retain "req-1".
 	// Re-track and re-evict with a new channel — if the old sync.Once is still there,
 	// the new channel won't close (sync.Once already fired).
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 
 	// The ResponseBody from the first eviction fires via defer in real code.
 	// Simulate it here.
 	re.ResponseBody(ctx, makeInferenceRequest("req-1", -1), &requestcontrol.Response{EndOfStream: true}, nil)
 
 	// Re-track and evict again.
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 	evictCh := re.EvictionRegistry().Get("req-1")
 	require.NotNil(t, evictCh)
 
@@ -240,7 +240,7 @@ func TestRequestEvictor_CleanupWorksWithNoOpEvictor(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, &NoOpEvictor{})
 
 	ctx := context.Background()
-	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	require.NoError(t, re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult()))
 	re.ResponseBody(ctx, makeInferenceRequest("req-1", -1), &requestcontrol.Response{EndOfStream: true}, nil)
 
 	assert.Equal(t, 0, re.queue.InFlightLen())

--- a/pkg/epp/flowcontrol/eviction/request_evictor_test.go
+++ b/pkg/epp/flowcontrol/eviction/request_evictor_test.go
@@ -67,7 +67,7 @@ func TestRequestEvictor_PreRequest_CreatesEvictChannel(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, &NoOpEvictor{})
 
 	ctx := context.Background()
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 
 	evictCh := re.EvictionRegistry().Get("req-1")
 	require.NotNil(t, evictCh, "EvictCh should be registered after PreRequest")
@@ -82,7 +82,7 @@ func TestRequestEvictor_ResponseBody_DeregistersEvictChannel(t *testing.T) {
 
 	ctx := context.Background()
 	request := makeInferenceRequest("req-1", -1)
-	re.PreRequest(ctx, request, makeSchedulingResult())
+	_ = re.PreRequest(ctx, request, makeSchedulingResult())
 	require.NotNil(t, re.EvictionRegistry().Get("req-1"))
 
 	re.ResponseBody(ctx, request, &requestcontrol.Response{EndOfStream: true}, nil)
@@ -97,7 +97,7 @@ func TestRequestEvictor_EvictN_ClosesEvictChannel(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, evictor)
 
 	ctx := context.Background()
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 
 	evictCh := re.EvictionRegistry().Get("req-1")
 	require.NotNil(t, evictCh)
@@ -121,7 +121,7 @@ func TestRequestEvictor_EvictN_ReTracksOnFailure(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, &failingEvictor{})
 
 	ctx := context.Background()
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 
 	evicted, err := re.EvictN(ctx, 1)
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestRequestEvictor_RaceBetweenEvictAndCompletion(t *testing.T) {
 	requests := make([]*scheduling.InferenceRequest, 10)
 	for i := range requests {
 		requests[i] = makeInferenceRequest("req-"+string(rune('a'+i)), -1)
-		re.PreRequest(ctx, requests[i], makeSchedulingResult())
+		_ = re.PreRequest(ctx, requests[i], makeSchedulingResult())
 	}
 
 	var wg sync.WaitGroup
@@ -176,7 +176,7 @@ func TestRequestEvictor_CtxCancellationTriggersCleanup(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, evictor)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 
 	// Verify tracked.
 	assert.Equal(t, 1, re.queue.InFlightLen())
@@ -201,7 +201,7 @@ func TestRequestEvictor_CleanupCallsEvictorCleanup(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, evictor)
 
 	ctx := context.Background()
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 
 	// Evict to create a sync.Once entry in the evictor.
 	_, _ = re.EvictN(ctx, 1)
@@ -211,14 +211,14 @@ func TestRequestEvictor_CleanupCallsEvictorCleanup(t *testing.T) {
 	// We verify this indirectly: if Cleanup wasn't called, the sync.Once map would retain "req-1".
 	// Re-track and re-evict with a new channel — if the old sync.Once is still there,
 	// the new channel won't close (sync.Once already fired).
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 
 	// The ResponseBody from the first eviction fires via defer in real code.
 	// Simulate it here.
 	re.ResponseBody(ctx, makeInferenceRequest("req-1", -1), &requestcontrol.Response{EndOfStream: true}, nil)
 
 	// Re-track and evict again.
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 	evictCh := re.EvictionRegistry().Get("req-1")
 	require.NotNil(t, evictCh)
 
@@ -240,7 +240,7 @@ func TestRequestEvictor_CleanupWorksWithNoOpEvictor(t *testing.T) {
 	re := NewRequestEvictor(&testOrdering{}, &acceptAllFilter{}, &NoOpEvictor{})
 
 	ctx := context.Background()
-	re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
+	_ = re.PreRequest(ctx, makeInferenceRequest("req-1", -1), makeSchedulingResult())
 	re.ResponseBody(ctx, makeInferenceRequest("req-1", -1), &requestcontrol.Response{EndOfStream: true}, nil)
 
 	assert.Equal(t, 0, re.queue.InFlightLen())

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -72,6 +72,10 @@ func TestConcurrentSaturationReads(t *testing.T) {
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 
+	// Track PreRequest errors via atomic counter — require/assert must not be
+	// called from non-test goroutines.
+	var preRequestErrs atomic.Int32
+
 	// Writer: track and release 200 requests rapidly.
 	wg.Add(1)
 	go func() {
@@ -90,7 +94,9 @@ func TestConcurrentSaturationReads(t *testing.T) {
 					"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 				},
 			}
-			_ = pd.producer.PreRequest(ctx, req, result)
+			if err := pd.producer.PreRequest(ctx, req, result); err != nil {
+				preRequestErrs.Add(1)
+			}
 			req.SchedulingResult = result
 			pd.producer.ResponseBody(ctx, req,
 				&requestcontrol.Response{EndOfStream: true}, pd.epMeta)
@@ -116,6 +122,8 @@ func TestConcurrentSaturationReads(t *testing.T) {
 	close(start)
 	wg.Wait()
 
+	require.Equal(t, int32(0), preRequestErrs.Load(),
+		"PreRequest returned errors during concurrent tracking")
 	require.Equal(t, int32(0), saturationViolations.Load(),
 		"saturation was outside [0.0, 1.0] during concurrent reads")
 	require.InDelta(t, 0.0, pd.detector.Saturation(ctx, endpoints), 1e-9,
@@ -163,7 +171,7 @@ func TestSaturationFullLoop(t *testing.T) {
 				"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 			},
 		}
-		_ = pd.producer.PreRequest(h.ctx, req, result)
+		require.NoError(t, pd.producer.PreRequest(h.ctx, req, result))
 	}
 
 	// Verify the detector sees saturation via the real Locate->Saturation path.
@@ -452,7 +460,7 @@ func TestUsageLimitThresholdGatesDispatch(t *testing.T) {
 				"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 			},
 		}
-		_ = pd.producer.PreRequest(h.ctx, req, result)
+		require.NoError(t, pd.producer.PreRequest(h.ctx, req, result))
 	}
 
 	// saturation=0.5, threshold=0.5: 0.5 >= 0.5 -> HoL blocking should trigger.
@@ -656,8 +664,8 @@ func TestEvictionPipeline(t *testing.T) {
 	reqCtx, reqCancel := context.WithCancel(ctx)
 	defer reqCancel()
 
-	_ = requestEvictor.PreRequest(reqCtx, sheddableReq, makeResult())
-	_ = requestEvictor.PreRequest(reqCtx, protectedReq, makeResult())
+	require.NoError(t, requestEvictor.PreRequest(reqCtx, sheddableReq, makeResult()))
+	require.NoError(t, requestEvictor.PreRequest(reqCtx, protectedReq, makeResult()))
 
 	inFlight, evictable := requestEvictor.Stats()
 	require.Equal(t, 2, inFlight, "both requests should be tracked in-flight")
@@ -993,7 +1001,7 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 			"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 		},
 	}
-	_ = producer.PreRequest(ctx, oldReq, oldResult)
+	require.NoError(t, producer.PreRequest(ctx, oldReq, oldResult))
 
 	sat := detector.Saturation(ctx, []datalayer.Endpoint{ep})
 	require.Greater(t, sat, 0.0, "saturation should be nonzero with in-flight request")
@@ -1049,7 +1057,7 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 			"decode": {TargetEndpoints: []fwksched.Endpoint{newSchedEp}},
 		},
 	}
-	_ = producer.PreRequest(ctx, newReq, newResult)
+	require.NoError(t, producer.PreRequest(ctx, newReq, newResult))
 	require.Equal(t, int64(1), producer.GetRequests(eid),
 		"new request on re-registered endpoint should be tracked")
 
@@ -1110,7 +1118,7 @@ func TestEndpointIdentityCollisionDuringPodReplacement(t *testing.T) {
 			"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 		},
 	}
-	_ = producer.PreRequest(ctx, req, result)
+	require.NoError(t, producer.PreRequest(ctx, req, result))
 
 	require.Greater(t, detector.Saturation(ctx, []datalayer.Endpoint{newEp}), 0.0,
 		"new endpoint should show in-flight load before stale delete")

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -90,7 +90,7 @@ func TestConcurrentSaturationReads(t *testing.T) {
 					"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 				},
 			}
-			pd.producer.PreRequest(ctx, req, result)
+			_ = pd.producer.PreRequest(ctx, req, result)
 			req.SchedulingResult = result
 			pd.producer.ResponseBody(ctx, req,
 				&requestcontrol.Response{EndOfStream: true}, pd.epMeta)
@@ -163,7 +163,7 @@ func TestSaturationFullLoop(t *testing.T) {
 				"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 			},
 		}
-		pd.producer.PreRequest(h.ctx, req, result)
+		_ = pd.producer.PreRequest(h.ctx, req, result)
 	}
 
 	// Verify the detector sees saturation via the real Locate->Saturation path.
@@ -452,7 +452,7 @@ func TestUsageLimitThresholdGatesDispatch(t *testing.T) {
 				"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 			},
 		}
-		pd.producer.PreRequest(h.ctx, req, result)
+		_ = pd.producer.PreRequest(h.ctx, req, result)
 	}
 
 	// saturation=0.5, threshold=0.5: 0.5 >= 0.5 -> HoL blocking should trigger.
@@ -656,8 +656,8 @@ func TestEvictionPipeline(t *testing.T) {
 	reqCtx, reqCancel := context.WithCancel(ctx)
 	defer reqCancel()
 
-	requestEvictor.PreRequest(reqCtx, sheddableReq, makeResult())
-	requestEvictor.PreRequest(reqCtx, protectedReq, makeResult())
+	_ = requestEvictor.PreRequest(reqCtx, sheddableReq, makeResult())
+	_ = requestEvictor.PreRequest(reqCtx, protectedReq, makeResult())
 
 	inFlight, evictable := requestEvictor.Stats()
 	require.Equal(t, 2, inFlight, "both requests should be tracked in-flight")
@@ -993,7 +993,7 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 			"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 		},
 	}
-	producer.PreRequest(ctx, oldReq, oldResult)
+	_ = producer.PreRequest(ctx, oldReq, oldResult)
 
 	sat := detector.Saturation(ctx, []datalayer.Endpoint{ep})
 	require.Greater(t, sat, 0.0, "saturation should be nonzero with in-flight request")
@@ -1049,7 +1049,7 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 			"decode": {TargetEndpoints: []fwksched.Endpoint{newSchedEp}},
 		},
 	}
-	producer.PreRequest(ctx, newReq, newResult)
+	_ = producer.PreRequest(ctx, newReq, newResult)
 	require.Equal(t, int64(1), producer.GetRequests(eid),
 		"new request on re-registered endpoint should be tracked")
 
@@ -1110,7 +1110,7 @@ func TestEndpointIdentityCollisionDuringPodReplacement(t *testing.T) {
 			"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
 		},
 	}
-	producer.PreRequest(ctx, req, result)
+	_ = producer.PreRequest(ctx, req, result)
 
 	require.Greater(t, detector.Saturation(ctx, []datalayer.Endpoint{newEp}), 0.0,
 		"new endpoint should show in-flight load before stale delete")

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -49,6 +49,10 @@ type Screener interface {
 // A non-nil error indicates the plugin could not complete its work; the director runs
 // every registered PreRequest plugin and aggregates their errors before failing the request.
 //
+// Return a github.com/llm-d/llm-d-router/pkg/common/error.Error so the director can map
+// the failure to the intended HTTP status; any other error type is reported to the client
+// as an Internal error.
+//
 // Every registered plugin runs even when a peer has already failed the request, so any
 // side effect published here outlives the failure. Plugins must ensure such state is
 // cleaned up by HandleResponseBody, which the director invokes on abort for every

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -48,6 +48,12 @@ type Screener interface {
 // before a request is sent to the selected model server.
 // A non-nil error indicates the plugin could not complete its work; the director runs
 // every registered PreRequest plugin and aggregates their errors before failing the request.
+//
+// Every registered plugin runs even when a peer has already failed the request, so any
+// side effect published here outlives the failure. Plugins must ensure such state is
+// cleaned up by HandleResponseBody, which the director invokes on abort for every
+// request that picked a pod but never marked the response complete. Otherwise the
+// plugin must not have side effects at this extension point.
 type PreRequest interface {
 	plugin.Plugin
 	PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) error

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -46,9 +46,11 @@ type Screener interface {
 
 // PreRequest is called by the director after a getting result from scheduling layer and
 // before a request is sent to the selected model server.
+// A non-nil error indicates the plugin could not complete its work; the director runs
+// every registered PreRequest plugin and aggregates their errors before failing the request.
 type PreRequest interface {
 	plugin.Plugin
-	PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult)
+	PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) error
 }
 
 // ResponseHeaderProcessor is called by the director after the response headers are successfully received

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
@@ -232,9 +232,9 @@ func (p *ProgramAwarePlugin) Pick(_ context.Context, band flowcontrol.PriorityBa
 	return best, nil
 }
 
-func (p *ProgramAwarePlugin) PreRequest(_ context.Context, request *fwksched.InferenceRequest, _ *fwksched.SchedulingResult) {
+func (p *ProgramAwarePlugin) PreRequest(_ context.Context, request *fwksched.InferenceRequest, _ *fwksched.SchedulingResult) error {
 	if request == nil {
-		return
+		return nil
 	}
 	id := programIDFor(request)
 	metrics := p.getOrCreateMetrics(id)
@@ -244,6 +244,7 @@ func (p *ProgramAwarePlugin) PreRequest(_ context.Context, request *fwksched.Inf
 	avgWaitTimeMs.WithLabelValues(id).Set(metrics.AverageWaitTime())
 
 	p.getStrategy().OnPreRequest(metrics, request)
+	return nil
 }
 
 // ResponseBody acts on the final stream chunk only; intermediate chunks are

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
@@ -107,7 +107,7 @@ func TestPreRequest_RecordsDispatchAndWait(t *testing.T) {
 	req.PutAttribute(enqueueTimeAttributeKey, enqueue)
 
 	p := &ProgramAwarePlugin{}
-	p.PreRequest(context.Background(), req, nil)
+	_ = p.PreRequest(context.Background(), req, nil)
 
 	m := p.getOrCreateMetrics("alpha")
 	assert.Equal(t, int64(1), m.DispatchedCount())
@@ -119,7 +119,7 @@ func TestPreRequest_RecordsDispatchAndWait(t *testing.T) {
 func TestPreRequest_NoEnqueueAttribute_StillDispatches(t *testing.T) {
 	req := &fwksched.InferenceRequest{FairnessID: "alpha"}
 	p := &ProgramAwarePlugin{}
-	p.PreRequest(context.Background(), req, nil)
+	_ = p.PreRequest(context.Background(), req, nil)
 
 	m := p.getOrCreateMetrics("alpha")
 	assert.Equal(t, int64(1), m.DispatchedCount())
@@ -130,7 +130,7 @@ func TestPreRequest_NoEnqueueAttribute_StillDispatches(t *testing.T) {
 func TestPreRequest_NoFairnessID_FallsBackToDefault(t *testing.T) {
 	req := &fwksched.InferenceRequest{}
 	p := &ProgramAwarePlugin{}
-	p.PreRequest(context.Background(), req, nil)
+	_ = p.PreRequest(context.Background(), req, nil)
 
 	got, ok := p.programMetrics.Load(metadata.DefaultFairnessID)
 	require.True(t, ok, "default fairness ID entry should be created")

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -255,12 +255,12 @@ func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceR
 
 // PreRequest records in the shared indexer the result of the scheduling selection.
 // It updates the indexer with the prefix hashes for the selected endpoint(s).
-func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
+func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) error {
 	// Delete the state to avoid memory leak.
 	defer p.pluginState.Delete(request.RequestID)
 	primaryProfileResult := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
 	if len(primaryProfileResult.TargetEndpoints) == 0 {
-		return
+		return nil
 	}
 
 	targetEndpoint := primaryProfileResult.TargetEndpoints[0]
@@ -275,7 +275,7 @@ func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.Inferen
 	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.pluginState, request.RequestID, plugin.StateKey(p.typedName.Name))
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to read prefix plugin state", "requestID", request.RequestID)
-		return
+		return nil
 	}
 
 	// Update indexer asynchronously to avoid blocking the request path.
@@ -296,6 +296,7 @@ func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.Inferen
 	blockSize := p.GetBlockSize(primaryProfileResult.TargetEndpoints)
 	const averageCharactersPerToken = 4
 	recordPrefixCacheMatch(p.typedName.Name, p.typedName.Type, matchLen*blockSize*averageCharactersPerToken, total*blockSize*averageCharactersPerToken)
+	return nil
 }
 
 func (p *dataProducer) makeserver(targetEndpoint fwksched.Endpoint) server {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -133,7 +133,7 @@ func TestPreRequest(t *testing.T) {
 		}
 
 		// 3. Call PreRequest
-		p.PreRequest(context.Background(), req1, res)
+		_ = p.PreRequest(context.Background(), req1, res)
 
 		// Wait for async update
 		p.wg.Wait()
@@ -180,7 +180,7 @@ func TestPreRequest(t *testing.T) {
 					},
 				},
 			}
-			p.PreRequest(context.Background(), req, res)
+			_ = p.PreRequest(context.Background(), req, res)
 			p.wg.Wait()
 
 			perPromptHashes := prefixhash.GetBlockHashes(context.Background(), req, config.BlockSizeTokens, defaultMaxPrefixBlocks)
@@ -258,7 +258,7 @@ func TestPrefixPluginPartialPrefixMatch(t *testing.T) {
 			experimentalDefaultPrefillProfile: {TargetEndpoints: []fwksched.Endpoint{endpoint3}},
 		},
 	}
-	p.PreRequest(context.Background(), req1, schedulingResult)
+	_ = p.PreRequest(context.Background(), req1, schedulingResult)
 	p.wg.Wait()
 
 	// Second request shares the first token but diverges on the second.
@@ -318,7 +318,7 @@ func TestPrefixPluginPrefixGrowth(t *testing.T) {
 			"default": {TargetEndpoints: []fwksched.Endpoint{endpoint1}},
 		},
 	}
-	p.PreRequest(context.Background(), req1, schedulingResult)
+	_ = p.PreRequest(context.Background(), req1, schedulingResult)
 	p.wg.Wait()
 
 	// Second request extends the first one's token prefix.
@@ -381,7 +381,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 			"default": {TargetEndpoints: []fwksched.Endpoint{endpoint}},
 		},
 	}
-	p.PreRequest(context.Background(), req, schedulingResult)
+	_ = p.PreRequest(context.Background(), req, schedulingResult)
 	p.wg.Wait()
 
 	// Check indexer state - should be in tracked pods
@@ -712,7 +712,7 @@ func TestMultiPromptMatchAggregation(t *testing.T) {
 		},
 	}
 	_ = p.Produce(context.Background(), req1, endpoints)
-	p.PreRequest(context.Background(), req1, &fwksched.SchedulingResult{
+	_ = p.PreRequest(context.Background(), req1, &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
 		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"default": {TargetEndpoints: endpoints},
@@ -765,7 +765,7 @@ func TestMultiPromptPartialMatch(t *testing.T) {
 		},
 	}
 	_ = p.Produce(context.Background(), req1, endpoints)
-	p.PreRequest(context.Background(), req1, &fwksched.SchedulingResult{
+	_ = p.PreRequest(context.Background(), req1, &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
 		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"default": {TargetEndpoints: endpoints},

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -373,24 +373,24 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.Infe
 	return nil
 }
 
-func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, result *fwksched.SchedulingResult) {
+func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, result *fwksched.SchedulingResult) error {
 	if result == nil || len(result.ProfileResults) == 0 {
-		return
+		return nil
 	}
 
 	if request == nil {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("Skipping in-flight load tracking: request is nil")
-		return
+		return nil
 	}
 
 	if request.RequestID == "" {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("Skipping in-flight load tracking: missing RequestID")
-		return
+		return nil
 	}
 
 	if p.PluginState == nil {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("Skipping in-flight load tracking: PluginState is nil", "requestID", request.RequestID)
-		return
+		return nil
 	}
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
@@ -427,6 +427,7 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 			entry,
 		)
 	}
+	return nil
 }
 
 func (p *InFlightLoadProducer) estimateRequestTokens(endpoint fwksched.Endpoint, request *fwksched.InferenceRequest, inputTokens int64) int64 {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -183,7 +183,7 @@ func TestInFlightLoadProducer_Lifecycle(t *testing.T) {
 	// 1. PreRequest (Inc)
 	req := makeTokenRequest("req1", 4) // 4 input + 6 output = 10 tokens
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
@@ -216,7 +216,7 @@ func TestInFlightLoadProducer_MultiPodLifecycle(t *testing.T) {
 		},
 	}
 
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(1), producer.requestTracker.get(idA))
 	require.Equal(t, int64(1), producer.requestTracker.get(idB))
 
@@ -374,7 +374,7 @@ func TestInFlightLoadProducer_FlapDoesNotUnderflow(t *testing.T) {
 			extract(t, producer, datalayer.EventAddOrUpdate, epA)
 			reqA := makeTokenRequest("req-A", tc.inputA)
 			resA := makeSchedulingResult(endpointName)
-			producer.PreRequest(ctx, reqA, resA)
+			_ = producer.PreRequest(ctx, reqA, resA)
 			require.Equal(t, tc.liveAfterA, tc.read(producer, endpointID))
 
 			// E flaps and rejoins under the same NamespacedName; B recreates a fresh counter instance.
@@ -384,7 +384,7 @@ func TestInFlightLoadProducer_FlapDoesNotUnderflow(t *testing.T) {
 			extract(t, producer, datalayer.EventAddOrUpdate, epB)
 			reqB := makeTokenRequest("req-B", tc.inputB)
 			resB := makeSchedulingResult(endpointName)
-			producer.PreRequest(ctx, reqB, resB)
+			_ = producer.PreRequest(ctx, reqB, resB)
 			require.Equal(t, tc.liveAfterB, tc.read(producer, endpointID), "B recreated the counter")
 
 			// A releases. It must hit the orphaned counter, not B's live one.
@@ -426,7 +426,7 @@ func TestInFlightLoadProducer_CrashWithHighLoadDoesNotUnderflow(t *testing.T) {
 	for i := 0; i < inFlight; i++ {
 		reqs[i] = makeTokenRequest(fmt.Sprintf("crash-req-%d", i), 4)
 		results[i] = makeSchedulingResult(endpointName)
-		producer.PreRequest(ctx, reqs[i], results[i])
+		_ = producer.PreRequest(ctx, reqs[i], results[i])
 	}
 	require.Equal(t, int64(inFlight), producer.requestTracker.get(endpointID))
 
@@ -445,7 +445,7 @@ func TestInFlightLoadProducer_CrashWithHighLoadDoesNotUnderflow(t *testing.T) {
 	}))
 	reqNew := makeTokenRequest("post-crash-req", 4)
 	resNew := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, reqNew, resNew)
+	_ = producer.PreRequest(ctx, reqNew, resNew)
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 
 	// The crashed requests drain late. Each release must hit the orphaned counter, so the live
@@ -527,7 +527,7 @@ func TestInFlightLoadProducer_ConcurrencyStress(t *testing.T) {
 				res := makeSchedulingResult(endpointName)
 				req := &fwksched.InferenceRequest{RequestID: reqID, SchedulingResult: res}
 
-				producer.PreRequest(ctx, req, res)
+				_ = producer.PreRequest(ctx, req, res)
 				producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
 			}
 		}(i)
@@ -609,7 +609,7 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testin
 	// 4 input tokens. Output tokens are excluded.
 	req := makeTokenRequest("req-no-output", 4)
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID), "only input tokens should be tracked")
 
@@ -681,7 +681,7 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
 
 	req := makeTokenRequest("req-single", 4)
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
 
 	req.SchedulingResult = res
@@ -716,7 +716,7 @@ func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
 		},
 	}
 
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(16), producer.tokenTracker.get(endpointID),
 		"only uncached input (4) plus output (12) should be tracked")
@@ -757,7 +757,7 @@ func TestInFlightLoadProducer_PrefixCacheDiscount_PerEndpoint(t *testing.T) {
 		},
 	}
 
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(0+12), producer.tokenTracker.get(idA), "fully cached: only output tokens")
 	require.Equal(t, int64(8+12), producer.tokenTracker.get(idB), "uncached: input + output")
 
@@ -794,7 +794,7 @@ func TestInFlightLoadProducer_BalancedAddRelease_MultipleProfilesSameEndpoint(t 
 		},
 	}
 
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(2), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(20), producer.tokenTracker.get(endpointID))
 
@@ -833,7 +833,7 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_EndOfStreamWithoutStart(t *tes
 		},
 	}
 
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(4), producer.tokenTracker.get(endpointID))
 
@@ -862,7 +862,7 @@ func TestInFlightLoadProducer_Eviction(t *testing.T) {
 	// 1. PreRequest: Adds load
 	req := makeTokenRequest("req-eviction", 4) // 4 input + 6 output = 10 tokens
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
@@ -884,7 +884,7 @@ func TestInFlightLoadProducer_Touch(t *testing.T) {
 
 	req := makeTokenRequest("req-touch", 4)
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 
 	// Get initial access time
 	t1, ok := producer.PluginState.LastAccessTime(req.RequestID)
@@ -911,7 +911,7 @@ func TestInFlightLoadProducer_LateResponseAfterReap(t *testing.T) {
 
 	req := makeTokenRequest("req-late", 4) // 4 input + 6 output = 10 tokens
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
@@ -937,7 +937,7 @@ func TestInFlightLoadProducer_AtomicTokenRelease_Concurrent(t *testing.T) {
 
 	req := makeTokenRequest("req-race", 4) // 4 input + 6 output = 10 tokens
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
 
 	// Fire releaseTokensEarly and an explicit Delete concurrently. Whichever
@@ -1017,7 +1017,7 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 	t.Run("PreRequest", func(t *testing.T) {
 		// 1. Nil Result
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, nil, nil)
+			_ = producer.PreRequest(ctx, nil, nil)
 		})
 
 		// 2. Nil Request, non-nil Result
@@ -1027,14 +1027,14 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 			},
 		}
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, nil, res)
+			_ = producer.PreRequest(ctx, nil, res)
 		})
 		require.Equal(t, int64(0), producer.requestTracker.get(fullEndpointName("ep1")), "should not increment counters without request")
 
 		// 3. Empty ProfileResults
 		resEmpty := &fwksched.SchedulingResult{ProfileResults: map[string]*fwksched.ProfileRunResult{}}
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, &fwksched.InferenceRequest{}, resEmpty)
+			_ = producer.PreRequest(ctx, &fwksched.InferenceRequest{}, resEmpty)
 		})
 
 		// 4. Nil ProfileResult
@@ -1042,7 +1042,7 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 			ProfileResults: map[string]*fwksched.ProfileRunResult{"default": nil},
 		}
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilProfile)
+			_ = producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilProfile)
 		})
 
 		// 5. Empty TargetEndpoints
@@ -1052,7 +1052,7 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 			},
 		}
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resEmptyEndpoints)
+			_ = producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resEmptyEndpoints)
 		})
 
 		// 6. Nil Endpoint in TargetEndpoints
@@ -1062,7 +1062,7 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 			},
 		}
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilEndpoint)
+			_ = producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilEndpoint)
 		})
 
 		// 7. Endpoint with nil metadata
@@ -1074,7 +1074,7 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 			},
 		}
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilMeta)
+			_ = producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: "req1"}, resNilMeta)
 		})
 
 		// 8. Missing RequestID (Leak check)
@@ -1084,7 +1084,7 @@ func TestInFlightLoadProducer_PanicSafety(t *testing.T) {
 			},
 		}
 		require.NotPanics(t, func() {
-			producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: ""}, resLeak)
+			_ = producer.PreRequest(ctx, &fwksched.InferenceRequest{RequestID: ""}, resLeak)
 		})
 		require.Equal(t, int64(0), producer.requestTracker.get(fullEndpointName("ep-leak")), "should not increment counters with empty RequestID")
 	})

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -647,7 +647,7 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_PrefillReleasedAtStartOfStream
 			"decode":  {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint("decode-endpoint")}},
 		},
 	}
-	producer.PreRequest(ctx, req, res)
+	_ = producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(1), producer.requestTracker.get(prefillID))
 	require.Equal(t, int64(1), producer.requestTracker.get(decodeID))
 	require.Equal(t, int64(4), producer.tokenTracker.get(prefillID))

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
@@ -27,23 +27,23 @@ import (
 )
 
 // PreRequest records the selected endpoint(s) for each hash in the current request.
-func (p *Producer) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+func (p *Producer) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) error {
 	logger := log.FromContext(ctx).V(logging.DEBUG)
 	if request == nil || request.RequestID == "" {
-		return
+		return nil
 	}
 	defer p.pluginState.Delete(request.RequestID)
 
 	state, err := plugin.ReadPluginStateKey[*requestState](p.pluginState, request.RequestID, plugin.StateKey(ProducerType))
 	if err != nil || len(state.items) == 0 {
 		logger.Info("No multimodal request state found, skipping encoder-cache update")
-		return
+		return nil
 	}
 
 	targets := targetEndpoints(schedulingResult)
 	if len(targets) == 0 {
 		logger.Info("No target endpoints found, skipping encoder-cache update")
-		return
+		return nil
 	}
 
 	items := state.items
@@ -62,6 +62,7 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 			}
 		}
 	})
+	return nil
 }
 
 func targetEndpoints(schedulingResult *scheduling.SchedulingResult) []scheduling.Endpoint {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -134,7 +134,7 @@ func TestProduceMatchesMultiplePodsAndPreRequestUpdatesPlacement(t *testing.T) {
 		nil,
 		[]attrmm.MatchItem{{Hash: "hash-a", Size: 1, Modality: img}, {Hash: "hash-c", Size: 1, Modality: img}})
 
-	producer.PreRequest(context.Background(), request, schedulingResult(endpointC))
+	_ = producer.PreRequest(context.Background(), request, schedulingResult(endpointC))
 	producer.wg.Wait()
 
 	cache := producer.cacheSnapshot()
@@ -151,7 +151,7 @@ func TestLRUEviction(t *testing.T) {
 	for _, hash := range []string{"hash-1", "hash-2", "hash-3"} {
 		request := requestWithHashes(hash, map[string]int{hash: 1})
 		require.NoError(t, producer.Produce(context.Background(), request, []scheduling.Endpoint{endpoint}))
-		producer.PreRequest(context.Background(), request, schedulingResult(endpoint))
+		_ = producer.PreRequest(context.Background(), request, schedulingResult(endpoint))
 		producer.wg.Wait()
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
@@ -253,14 +253,14 @@ func requestSpreadFraction(requestID string) float64 {
 // PreRequest sets routing.KVCacheSourceHeader to the best-match peer stashed
 // by Produce when it out-caches the pod computing the prefix by at least
 // minCachedTokenDelta tokens. Any inbound value of the header is removed.
-func (p *Producer) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+func (p *Producer) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) error {
 	logger := log.FromContext(ctx).WithName(p.typedName.String()).V(logging.TRACE)
 	delete(request.Headers, routing.KVCacheSourceHeader)
 
 	best, ok := scheduling.ReadRequestAttribute[*bestMatchPeer](request, p.attrKey())
 	if !ok {
 		logger.Info("no best-match peer stashed", "requestID", request.RequestID)
-		return
+		return nil
 	}
 
 	computing := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
@@ -268,12 +268,12 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 		computing = pr
 	}
 	if computing == nil || len(computing.TargetEndpoints) == 0 {
-		return
+		return nil
 	}
 	endpoint := computing.TargetEndpoints[0]
 	md := endpoint.GetMetadata()
 	if md == nil {
-		return
+		return nil
 	}
 	computingHostPort := net.JoinHostPort(md.Address, md.Port)
 	computingCached := p.cachedTokenCount(endpoint)
@@ -284,10 +284,10 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 	// with the delta check below while minCachedTokenDelta >= 1 (a self-match
 	// is delta 0), but explicit against a future lower floor.
 	if best.hostPort == computingHostPort {
-		return
+		return nil
 	}
 	if best.cachedTokens-computingCached < p.minCachedTokenDelta {
-		return
+		return nil
 	}
 
 	if request.Headers == nil {
@@ -295,6 +295,7 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 	}
 	request.Headers[routing.KVCacheSourceHeader] = best.hostPort
 	logger.Info("set KV cache source header", "requestID", request.RequestID, "value", best.hostPort)
+	return nil
 }
 
 // cachedTokens returns the endpoint's cached prompt tokens (unweighted

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
@@ -168,7 +168,7 @@ func TestPreRequest_SetsKVCacheSourceHeader(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-hdr", Headers: map[string]string{}}
 	req.PutAttribute(p.attrKey(), &bestMatchPeer{hostPort: "10.0.0.2:8080", cachedTokens: 48})
 
-	p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 1)))
+	_ = p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 1)))
 
 	assert.Equal(t, "10.0.0.2:8080", req.Headers[routing.KVCacheSourceHeader])
 }
@@ -181,7 +181,7 @@ func TestPreRequest_DeltaBelowThreshold_NoHeader(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-low", Headers: map[string]string{}}
 	req.PutAttribute(p.attrKey(), &bestMatchPeer{hostPort: "10.0.0.2:8080", cachedTokens: 32})
 
-	p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 1)))
+	_ = p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 1)))
 
 	assert.NotContains(t, req.Headers, routing.KVCacheSourceHeader)
 }
@@ -194,7 +194,7 @@ func TestPreRequest_BestIsChosen_NoHeader(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-self", Headers: map[string]string{}}
 	req.PutAttribute(p.attrKey(), &bestMatchPeer{hostPort: "10.0.0.1:8080", cachedTokens: 32})
 
-	p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 2)))
+	_ = p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 2)))
 
 	assert.NotContains(t, req.Headers, routing.KVCacheSourceHeader)
 }
@@ -215,7 +215,7 @@ func TestPreRequest_PrefillProfile_BestIsPrefill_NoHeader(t *testing.T) {
 			"prefill": {TargetEndpoints: []scheduling.Endpoint{endpoint(p, "pod-b", "10.0.0.2", 3)}},
 		},
 	}
-	p.PreRequest(ctx, req, result)
+	_ = p.PreRequest(ctx, req, result)
 
 	assert.NotContains(t, req.Headers, routing.KVCacheSourceHeader)
 }
@@ -235,7 +235,7 @@ func TestPreRequest_PrefillProfile_HeaderFromThirdPod(t *testing.T) {
 			"prefill": {TargetEndpoints: []scheduling.Endpoint{endpoint(p, "pod-b", "10.0.0.2", 1)}},
 		},
 	}
-	p.PreRequest(ctx, req, result)
+	_ = p.PreRequest(ctx, req, result)
 
 	assert.Equal(t, "10.0.0.3:8080", req.Headers[routing.KVCacheSourceHeader])
 }
@@ -251,7 +251,7 @@ func TestPreRequest_DeletesInboundHeader(t *testing.T) {
 		Headers:   map[string]string{routing.KVCacheSourceHeader: "evil:1234"},
 	}
 
-	p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 0)))
+	_ = p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "10.0.0.1", 0)))
 
 	assert.NotContains(t, req.Headers, routing.KVCacheSourceHeader)
 }
@@ -276,7 +276,7 @@ func TestPreRequest_IPv6HeaderBracketed(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-ipv6", Headers: map[string]string{}}
 	req.PutAttribute(p.attrKey(), &bestMatchPeer{hostPort: best, cachedTokens: 48})
 
-	p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "fd00::1", 1)))
+	_ = p.PreRequest(ctx, req, decodeOnly(endpoint(p, "pod-a", "fd00::1", 1)))
 
 	assert.Equal(t, best, req.Headers[routing.KVCacheSourceHeader])
 	// Round-trips through the same validation the sidecar applies.
@@ -314,7 +314,7 @@ func TestPreRequest_ConfiguredPrefillProfileName(t *testing.T) {
 			"P":      {TargetEndpoints: []scheduling.Endpoint{endpoint(p, "pod-b", "10.0.0.2", 3)}},
 		},
 	}
-	p.PreRequest(ctx, req, result)
+	_ = p.PreRequest(ctx, req, result)
 	assert.NotContains(t, req.Headers, routing.KVCacheSourceHeader)
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest.go
@@ -118,9 +118,9 @@ func buildSpeculativeCache(ctx context.Context, config PluginConfig,
 // is disabled.
 func (p *Producer) PreRequest(ctx context.Context,
 	request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult,
-) {
+) error {
 	if !p.speculativeEnabled {
-		return
+		return nil
 	}
 
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
@@ -130,7 +130,7 @@ func (p *Producer) PreRequest(ctx context.Context,
 	if err != nil {
 		logger.V(logging.TRACE).Info("No plugin state for PreRequest, skipping speculative indexing",
 			"requestID", request.RequestID)
-		return
+		return nil
 	}
 	p.pluginState.Delete(request.RequestID)
 
@@ -142,17 +142,17 @@ func (p *Producer) PreRequest(ctx context.Context,
 		}
 	}
 	if !hasKeys {
-		return
+		return nil
 	}
 
 	primary := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
 	if primary == nil || len(primary.TargetEndpoints) == 0 {
-		return
+		return nil
 	}
 	targetEndpoint := primary.TargetEndpoints[0]
 	targetMeta := targetEndpoint.GetMetadata()
 	if targetMeta == nil {
-		return
+		return nil
 	}
 	speculativePod := kvblock.PodEntry{
 		PodIdentifier: fmt.Sprintf("%s:%s", targetMeta.Address, targetMeta.Port),
@@ -197,4 +197,5 @@ func (p *Producer) PreRequest(ctx context.Context,
 		"pod", speculativePod.PodIdentifier,
 		"prompts", len(state.perPromptKeys),
 		"ttl", p.speculativeTTL)
+	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/prerequest_test.go
@@ -78,7 +78,7 @@ func TestPreRequest_SeedsSpeculativeForPrimary(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-pre-1"}
 	p.pluginState.Write(req.RequestID, blockKeysStateKey, &blockKeysState{perPromptKeys: [][]kvblock.BlockHash{blockKeys}})
 
-	p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
+	_ = p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
 
 	require.Len(t, calls, 1)
 	assert.Equal(t, blockKeys, calls[0].keys)
@@ -109,7 +109,7 @@ func TestPreRequest_EmptyBlockKeys_NoAdd(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-pre-empty"}
 	p.pluginState.Write(req.RequestID, blockKeysStateKey, &blockKeysState{perPromptKeys: nil})
 
-	p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
+	_ = p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
 
 	assert.Nil(t, p.speculativeCache.Get(req.RequestID))
 }
@@ -139,7 +139,7 @@ func TestPreRequest_PrefillProfile_SeedsBoth(t *testing.T) {
 			experimentalPrefillProfile: {TargetEndpoints: []scheduling.Endpoint{testEndpoints[1]}},
 		},
 	}
-	p.PreRequest(ctx, req, result)
+	_ = p.PreRequest(ctx, req, result)
 
 	require.Len(t, calls, 2)
 	assert.Equal(t, "10.0.0.1:8080", calls[0].entries[0].PodIdentifier)
@@ -169,7 +169,7 @@ func TestPreRequest_SpeculativeDisabled_NoOp(t *testing.T) {
 	p.pluginState.Write(req.RequestID, blockKeysStateKey,
 		&blockKeysState{perPromptKeys: [][]kvblock.BlockHash{{0xDD}}})
 
-	p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
+	_ = p.PreRequest(ctx, req, primaryOnly("default", testEndpoints[0]))
 
 	assert.Nil(t, p.speculativeCache.Get(req.RequestID))
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -39,21 +39,21 @@ var _ requestcontrol.ResponseBodyProcessor = &PredictedLatency{}
 
 // --- RequestControl Hooks ---
 
-func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
+func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) error {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: request is nil, skipping")
-		return
+		return nil
 	}
 
 	if schedulingResult == nil || len(schedulingResult.ProfileResults) == 0 {
 		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping PreRequest because no scheduling result was provided.")
-		return
+		return nil
 	}
 
 	targetMetadata := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName].TargetEndpoints[0].GetMetadata()
 	if !pl.checkPredictor(logger, targetMetadata) {
-		return
+		return nil
 	}
 
 	endpointName := types.NamespacedName{
@@ -64,7 +64,7 @@ func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.In
 	logger.V(logutil.TRACE).Info("request ID for SLO tracking", "requestID", request.Headers[reqcommon.RequestIDHeaderKey], "endpointName", endpointName)
 	if request.Headers[reqcommon.RequestIDHeaderKey] == "" {
 		logger.V(logutil.DEBUG).Error(errors.New("missing request ID"), "PredictedLatency.PreRequest: Request is missing request ID header")
-		return
+		return nil
 	}
 
 	id := request.Headers[reqcommon.RequestIDHeaderKey]
@@ -76,7 +76,7 @@ func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.In
 	if err != nil {
 		id := request.Headers[reqcommon.RequestIDHeaderKey]
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: Failed to get SLO context for request", "error", err, "requestID", id)
-		return
+		return nil
 	}
 
 	added := endpointRequestList.Add(id, predictedLatencyCtx.avgTPOTSLO)
@@ -118,6 +118,7 @@ func (pl *PredictedLatency) PreRequest(ctx context.Context, request *fwksched.In
 	predictedLatencyCtx.decodeTokensAtDispatch = 0
 
 	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
+	return nil
 }
 
 func (pl *PredictedLatency) ResponseHeader(ctx context.Context, request *fwksched.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -166,7 +166,7 @@ func TestPredictedLatency_PreRequest_NoSchedulingResult(t *testing.T) {
 	request := createTestInferenceRequest("test", 100, 50)
 
 	// Call PreRequest with nil scheduling result
-	router.PreRequest(ctx, request, nil)
+	_ = router.PreRequest(ctx, request, nil)
 
 	// Should not create SLO context
 	_, err := router.getPredictedLatencyContextForRequest(request)
@@ -183,7 +183,7 @@ func TestPredictedLatency_PreRequest_EmptySchedulingResult(t *testing.T) {
 	}
 
 	// Call PreRequest with empty scheduling result
-	router.PreRequest(ctx, request, schedulingResult)
+	_ = router.PreRequest(ctx, request, schedulingResult)
 
 	// Should not create SLO context
 	_, err := router.getPredictedLatencyContextForRequest(request)
@@ -209,7 +209,7 @@ func TestPredictedLatency_PreRequest_Success(t *testing.T) {
 	router.runningRequestLists.Store(endpoint.GetMetadata().ID, newRequestPriorityQueue())
 
 	beforeTime := time.Now()
-	router.PreRequest(ctx, request, schedulingResult)
+	_ = router.PreRequest(ctx, request, schedulingResult)
 	afterTime := time.Now()
 
 	// Verify SLO context was updated
@@ -239,7 +239,7 @@ func TestPredictedLatency_PreRequest_AddsToQueue(t *testing.T) {
 	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 
 	// PreRequest should create the queue
-	router.PreRequest(ctx, request, schedulingResult)
+	_ = router.PreRequest(ctx, request, schedulingResult)
 
 	// Verify queue was created and request was added
 	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().ID)
@@ -269,10 +269,10 @@ func TestPredictedLatency_PreRequest_QueueAlreadyExists(t *testing.T) {
 	predictedLatencyCtx2.avgTPOTSLO = 50
 	router.setPredictedLatencyContextForRequest(request2, predictedLatencyCtx2)
 	// Add first request
-	router.PreRequest(ctx, request1, schedulingResult)
+	_ = router.PreRequest(ctx, request1, schedulingResult)
 
 	// Add second request to same pod
-	router.PreRequest(ctx, request2, schedulingResult)
+	_ = router.PreRequest(ctx, request2, schedulingResult)
 
 	// Verify both are in the same queue
 	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().ID)
@@ -970,9 +970,9 @@ func TestPredictedLatency_MultipleRequests_SamePod(t *testing.T) {
 	}
 
 	// Add all requests
-	router.PreRequest(ctx, request1, schedulingResult)
-	router.PreRequest(ctx, request2, schedulingResult)
-	router.PreRequest(ctx, request3, schedulingResult)
+	_ = router.PreRequest(ctx, request1, schedulingResult)
+	_ = router.PreRequest(ctx, request2, schedulingResult)
+	_ = router.PreRequest(ctx, request3, schedulingResult)
 
 	// Verify queue has all requests
 	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().ID)
@@ -998,7 +998,7 @@ func TestPredictedLatency_RequestLifecycle_ResponseEndOfStream(t *testing.T) {
 	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 
 	// 1. PreRequest
-	router.PreRequest(ctx, request, schedulingResult)
+	_ = router.PreRequest(ctx, request, schedulingResult)
 
 	// Verify context exists
 	retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
@@ -1055,8 +1055,8 @@ func TestPredictedLatency_MultipleRequests_DifferentPods(t *testing.T) {
 	predictedLatencyCtx2.avgTPOTSLO = 50
 	router.setPredictedLatencyContextForRequest(request2, predictedLatencyCtx2)
 	// Add requests to different pods
-	router.PreRequest(ctx, request1, schedulingResult1)
-	router.PreRequest(ctx, request2, schedulingResult2)
+	_ = router.PreRequest(ctx, request1, schedulingResult1)
+	_ = router.PreRequest(ctx, request2, schedulingResult2)
 
 	// Verify separate queues were created
 	value1, exists1 := router.runningRequestLists.Load(endpoint1.GetMetadata().ID)
@@ -1132,7 +1132,7 @@ func BenchmarkPredictedLatency_PreRequest(b *testing.B) {
 		predictedLatencyCtx := newPredictedLatencyContext(request)
 		predictedLatencyCtx.avgTPOTSLO = 50
 		router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
-		router.PreRequest(ctx, request, schedulingResult)
+		_ = router.PreRequest(ctx, request, schedulingResult)
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -152,8 +152,9 @@ func (s *SessionAffinity) Filter(ctx context.Context, request *scheduling.Infere
 }
 
 // PreRequest records the picked pod for the session.
-func (s *SessionAffinity) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+func (s *SessionAffinity) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) error {
 	s.strategy.preRequest(ctx, request, schedulingResult)
+	return nil
 }
 
 // ResponseHeader sets the session header on the response sent to the client.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
@@ -88,7 +88,7 @@ func (p *HeadersHandler) WithName(name string) *HeadersHandler {
 }
 
 // PreRequest wires prefill and encode SchedulerProfile results into headers to indicate disaggregation workers.
-func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) error {
 	tracer := tracing.Tracer(schedplugins.TracerScope)
 	_, span := tracer.Start(ctx, "prepare_disaggregation",
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -101,7 +101,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.Inf
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.disagg.reason", "request_is_nil"),
 		)
-		return
+		return nil
 	}
 	if schedulingResult == nil {
 		span.SetAttributes(
@@ -109,7 +109,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.Inf
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.disagg.reason", "scheduling_result_is_nil"),
 		)
-		return
+		return nil
 	}
 
 	if request.TargetModel != "" {
@@ -151,7 +151,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.Inf
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.encode.reason", "no_encode_profile_result"),
 		)
-		return // encode profile failed to run or we chose not to run it, no-op in this case
+		return nil // encode profile failed to run or we chose not to run it, no-op in this case
 	}
 
 	// Collect all target endpoints as comma-separated host:port pairs
@@ -166,7 +166,7 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.Inf
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.encode.reason", "no_encode_profile_target_endpoints"),
 		)
-		return // no target endpoints, no-op in this case
+		return nil // no target endpoints, no-op in this case
 	}
 
 	request.Headers[routing.EncoderEndpointsHeader] = strings.Join(encodeHostPorts, ",")
@@ -174,4 +174,5 @@ func (p *HeadersHandler) PreRequest(ctx context.Context, request *scheduling.Inf
 		attribute.Bool("llm_d.epp.encode.disaggregation_used", true),
 		attribute.String("llm_d.epp.encode.endpoints", strings.Join(encodeHostPorts, ",")),
 	)
+	return nil
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
@@ -135,7 +135,7 @@ func TestPreRequestNilRequest(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		handler.PreRequest(ctx, nil, result)
+		_ = handler.PreRequest(ctx, nil, result)
 	})
 }
 
@@ -149,7 +149,7 @@ func TestPreRequestNilSchedulingResult(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		handler.PreRequest(ctx, request, nil)
+		_ = handler.PreRequest(ctx, request, nil)
 	})
 }
 
@@ -183,7 +183,7 @@ func TestPrefillHeaderHandlerBackwardCompat(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
 	_, encodeSet := request.Headers[routing.EncoderEndpointsHeader]
@@ -213,7 +213,7 @@ func TestPreRequestPrefillProfileExists(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
@@ -231,7 +231,7 @@ func TestPreRequestPrefillProfileNotExists(t *testing.T) {
 		ProfileResults:     map[string]*scheduling.ProfileRunResult{},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	_, exists := request.Headers[routing.PrefillEndpointHeader]
 	assert.False(t, exists)
@@ -258,7 +258,7 @@ func TestPreRequestClearsExistingPrefillHeader(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
@@ -278,7 +278,7 @@ func TestPreRequestClearsHeaderWhenNoPrefillResult(t *testing.T) {
 		ProfileResults:     map[string]*scheduling.ProfileRunResult{},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	val := request.Headers[routing.PrefillEndpointHeader]
 	assert.Equal(t, "", val)
@@ -303,7 +303,7 @@ func TestPreRequestCustomPrefillProfile(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
@@ -327,7 +327,7 @@ func TestPreRequestPrefillProfileNilResult(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		handler.PreRequest(ctx, request, result)
+		_ = handler.PreRequest(ctx, request, result)
 	})
 	_, exists := request.Headers[routing.PrefillEndpointHeader]
 	assert.False(t, exists)
@@ -350,7 +350,7 @@ func TestPreRequestPrefillEmptyTargetEndpoints(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		handler.PreRequest(ctx, request, result)
+		_ = handler.PreRequest(ctx, request, result)
 	})
 	_, exists := request.Headers[routing.PrefillEndpointHeader]
 	assert.False(t, exists)
@@ -375,7 +375,7 @@ func TestPreRequestPrefillIPv6Address(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testIPv6Addr, testPort), request.Headers[routing.PrefillEndpointHeader])
 }
@@ -403,7 +403,7 @@ func TestPreRequestEncodeProfileExists(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
@@ -422,7 +422,7 @@ func TestPreRequestEncodeProfileNotExists(t *testing.T) {
 		ProfileResults:     map[string]*scheduling.ProfileRunResult{},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	_, exists := request.Headers[routing.EncoderEndpointsHeader]
 	assert.False(t, exists)
@@ -450,7 +450,7 @@ func TestPreRequestEncodeClearsExistingHeader(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
@@ -471,7 +471,7 @@ func TestPreRequestEncodeClearsHeaderWhenNoEncodeResult(t *testing.T) {
 		ProfileResults:     map[string]*scheduling.ProfileRunResult{},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	val := request.Headers[routing.EncoderEndpointsHeader]
 	assert.Equal(t, "", val)
@@ -497,7 +497,7 @@ func TestPreRequestEncodeCustomProfile(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testAddr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
@@ -522,7 +522,7 @@ func TestPreRequestEncodeIPv6Address(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	assert.Equal(t, net.JoinHostPort(testIPv6Addr, testPort), request.Headers[routing.EncoderEndpointsHeader])
 }
@@ -546,7 +546,7 @@ func TestPreRequestEncodeProfileNilResult(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		handler.PreRequest(ctx, request, result)
+		_ = handler.PreRequest(ctx, request, result)
 	})
 	_, exists := request.Headers[routing.EncoderEndpointsHeader]
 	assert.False(t, exists)
@@ -571,7 +571,7 @@ func TestPreRequestEncodeEmptyTargetEndpoints(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		handler.PreRequest(ctx, request, result)
+		_ = handler.PreRequest(ctx, request, result)
 	})
 	val := request.Headers[routing.EncoderEndpointsHeader]
 	assert.Equal(t, "", val)
@@ -599,7 +599,7 @@ func TestPreRequestEncodeMultipleEndpoints(t *testing.T) {
 		},
 	}
 
-	handler.PreRequest(ctx, request, result)
+	_ = handler.PreRequest(ctx, request, result)
 
 	expected := strings.Join([]string{
 		net.JoinHostPort(testAddr, testPort),

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -389,7 +389,7 @@ func (h *Handler) ProcessResults(
 
 // PreRequest wires prefill and encode SchedulerProfile results into headers
 // so the sidecar knows which pods to contact for disaggregated work.
-func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) error {
 	tracer := tracing.Tracer(schedplugins.TracerScope)
 	_, span := tracer.Start(ctx, "prepare_disaggregation",
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -402,7 +402,7 @@ func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceR
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.disagg.reason", "request_is_nil"),
 		)
-		return
+		return nil
 	}
 	if schedulingResult == nil {
 		span.SetAttributes(
@@ -410,7 +410,7 @@ func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceR
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.disagg.reason", "scheduling_result_is_nil"),
 		)
-		return
+		return nil
 	}
 
 	if request.TargetModel != "" {
@@ -452,7 +452,7 @@ func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceR
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.encode.reason", "no_encode_profile_result"),
 		)
-		return
+		return nil
 	}
 
 	var encodeHostPorts []string
@@ -466,7 +466,7 @@ func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceR
 			attribute.Bool("llm_d.epp.encode.disaggregation_used", false),
 			attribute.String("llm_d.epp.encode.reason", "no_encode_profile_target_endpoints"),
 		)
-		return
+		return nil
 	}
 
 	request.Headers[routing.EncoderEndpointsHeader] = strings.Join(encodeHostPorts, ",")
@@ -474,4 +474,5 @@ func (h *Handler) PreRequest(ctx context.Context, request *scheduling.InferenceR
 		attribute.Bool("llm_d.epp.encode.disaggregation_used", true),
 		attribute.String("llm_d.epp.encode.endpoints", strings.Join(encodeHostPorts, ",")),
 	)
+	return nil
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -1366,8 +1366,8 @@ func TestBothProfileAndHeadersHandlerPreRequest(t *testing.T) {
 		},
 	}
 
-	profileHandler.PreRequest(ctx, request, result)
-	headersHandler.PreRequest(ctx, request, result)
+	_ = profileHandler.PreRequest(ctx, request, result)
+	_ = headersHandler.PreRequest(ctx, request, result)
 
 	expected := net.JoinHostPort(podAddr, podPort)
 	assert.Equal(t, expected, request.Headers[routing.PrefillEndpointHeader],
@@ -1390,7 +1390,7 @@ func TestHandler_PreRequest_EncodeMultipleEndpoints(t *testing.T) {
 		},
 	}
 
-	h.PreRequest(ctx, request, result)
+	_ = h.PreRequest(ctx, request, result)
 
 	want := net.JoinHostPort("10.0.0.1", "8000") + "," + net.JoinHostPort("10.0.0.2", "8000")
 	assert.Equal(t, want, request.Headers[routing.EncoderEndpointsHeader])

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -142,7 +142,7 @@ func TestActiveRequestScorer_UsesInFlightLoadProducerLifecycle(t *testing.T) {
 		},
 	}
 
-	producer.PreRequest(ctx, req, result)
+	_ = producer.PreRequest(ctx, req, result)
 	require.NoError(t, producer.Produce(ctx, req, endpoints))
 
 	require.Equal(t, int64(1), inFlightRequests(t, podA))

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -304,12 +304,12 @@ func (s *NoHitLRU) Score(ctx context.Context, request *scheduling.InferenceReque
 
 // PreRequest is called before a request is sent to the target endpoint.
 // For cold requests, it updates the LRU cache to track which endpoints have been used recently.
-func (s *NoHitLRU) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+func (s *NoHitLRU) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) error {
 	logger := log.FromContext(ctx).V(logging.DEBUG)
 
 	if schedulingResult == nil || len(schedulingResult.ProfileResults) == 0 {
 		logger.Info("No scheduling result available")
-		return
+		return nil
 	}
 
 	// Read the cold request state we stored in Score
@@ -319,12 +319,12 @@ func (s *NoHitLRU) PreRequest(ctx context.Context, request *scheduling.Inference
 
 	if err != nil {
 		logger.Info("No cold request state found, treating as non-cold request", "error", err)
-		return
+		return nil
 	}
 
 	if !coldState.isCold {
 		logger.Info("Not a cold request, skipping LRU update")
-		return
+		return nil
 	}
 
 	if targetProfile, ok := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]; ok && targetProfile != nil && len(targetProfile.TargetEndpoints) != 0 {
@@ -333,6 +333,7 @@ func (s *NoHitLRU) PreRequest(ctx context.Context, request *scheduling.Inference
 	if targetProfile, ok := schedulingResult.ProfileResults[defaultPrefillProfile]; ok && targetProfile != nil && len(targetProfile.TargetEndpoints) != 0 {
 		s.moveTargetPodToFront(ctx, request, targetProfile, defaultPrefillProfile)
 	}
+	return nil
 }
 
 func (s *NoHitLRU) moveTargetPodToFront(ctx context.Context, request *scheduling.InferenceRequest, targetProfile *scheduling.ProfileRunResult, profileName string) {

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -328,7 +328,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	t.Run("initial cold request seeds cache", func(_ *testing.T) {
 		coldReqA := &scheduling.InferenceRequest{RequestID: "cold-1"}
 		scorer.Score(ctx, coldReqA, endpoints)
-		scorer.PreRequest(ctx, coldReqA, requestToEndpoint(endpointA))
+		_ = scorer.PreRequest(ctx, coldReqA, requestToEndpoint(endpointA))
 		assertHighestScoredPod(endpointB, "after-endpointA-used")
 	})
 
@@ -354,7 +354,7 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 				t.Fatalf("expected neutral score for warm request, got %f", score)
 			}
 		}
-		scorer.PreRequest(ctx, warmReq, requestToEndpoint(endpointB))
+		_ = scorer.PreRequest(ctx, warmReq, requestToEndpoint(endpointB))
 		postWarmReq := &scheduling.InferenceRequest{RequestID: "cold-after-warm"}
 		postWarmScores := scorer.Score(ctx, postWarmReq, endpoints)
 		if postWarmScores[endpointB] <= postWarmScores[endpointA] {
@@ -365,14 +365,14 @@ func TestNoHitLRUPreferLeastRecentlyUsedAfterColdRequests(t *testing.T) {
 	t.Run("second cold request rotates to endpointB", func(_ *testing.T) {
 		coldReqB := &scheduling.InferenceRequest{RequestID: "cold-2"}
 		scorer.Score(ctx, coldReqB, endpoints)
-		scorer.PreRequest(ctx, coldReqB, requestToEndpoint(endpointB))
+		_ = scorer.PreRequest(ctx, coldReqB, requestToEndpoint(endpointB))
 		assertHighestScoredPod(endpointC, "after-endpointB-used")
 	})
 
 	t.Run("third cold request rotates back to endpointA", func(_ *testing.T) {
 		coldReqC := &scheduling.InferenceRequest{RequestID: "cold-3"}
 		scorer.Score(ctx, coldReqC, endpoints)
-		scorer.PreRequest(ctx, coldReqC, requestToEndpoint(endpointC))
+		_ = scorer.PreRequest(ctx, coldReqC, requestToEndpoint(endpointC))
 		assertHighestScoredPod(endpointA, "after-endpointC-used")
 	})
 }
@@ -440,7 +440,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 				},
 			},
 		}
-		scorer.PreRequest(ctx, req1, pdResult)
+		_ = scorer.PreRequest(ctx, req1, pdResult)
 
 		req2 := &scheduling.InferenceRequest{RequestID: "pd-request-2"}
 		prefillScores := scorer.Score(ctx, req2, prefillEndpoints)
@@ -468,7 +468,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 				},
 			},
 		}
-		scorer.PreRequest(ctx, req, result)
+		_ = scorer.PreRequest(ctx, req, result)
 
 		req2 := &scheduling.InferenceRequest{RequestID: "non-pd-request-2"}
 		scores := scorer.Score(ctx, req2, decodeEndpoints)
@@ -482,7 +482,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 		req := &scheduling.InferenceRequest{RequestID: "nil-result"}
 		scorer := nohitlru.NewNoHitLRU(ctx, nohitlru.NoHitLRUType, nil)
 		scorer.Score(ctx, req, decodeEndpoints)
-		scorer.PreRequest(ctx, req, nil)
+		_ = scorer.PreRequest(ctx, req, nil)
 	})
 
 	t.Run("empty profile results - graceful handling", func(_ *testing.T) {
@@ -494,7 +494,7 @@ func TestNoHitLRUPrefillDecodeTracking(t *testing.T) {
 			PrimaryProfileName: "decode",
 			ProfileResults:     map[string]*scheduling.ProfileRunResult{},
 		}
-		scorer.PreRequest(ctx, req, result)
+		_ = scorer.PreRequest(ctx, req, result)
 	})
 }
 
@@ -511,7 +511,7 @@ type dumpedLRUState struct {
 func seedCold(ctx context.Context, scorer *nohitlru.NoHitLRU, target scheduling.Endpoint, id string) {
 	req := &scheduling.InferenceRequest{RequestID: id}
 	scorer.Score(ctx, req, []scheduling.Endpoint{target})
-	scorer.PreRequest(ctx, req, &scheduling.SchedulingResult{
+	_ = scorer.PreRequest(ctx, req, &scheduling.SchedulingResult{
 		PrimaryProfileName: "p",
 		ProfileResults: map[string]*scheduling.ProfileRunResult{
 			"p": {TargetEndpoints: []scheduling.Endpoint{target}},

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -262,8 +262,8 @@ func (p *Plugin) Produce(ctx context.Context,
 
 func (p *Plugin) PreRequest(ctx context.Context,
 	req *scheduling.InferenceRequest, result *scheduling.SchedulingResult,
-) {
-	p.producer.PreRequest(ctx, req, result)
+) error {
+	return p.producer.PreRequest(ctx, req, result)
 }
 
 func (p *Plugin) Extract(ctx context.Context, event fwkdl.EndpointEvent) error {

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -148,8 +148,9 @@ func (s *SessionAffinity) Score(ctx context.Context, request *scheduling.Inferen
 	return s.strategy.score(ctx, request, endpoints)
 }
 
-func (s *SessionAffinity) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) {
+func (s *SessionAffinity) PreRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult) error {
 	s.strategy.preRequest(ctx, request, schedulingResult)
+	return nil
 }
 
 func (s *SessionAffinity) ResponseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata) {

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -500,14 +500,19 @@ func (d *Director) prepareRequest(ctx context.Context, reqCtx *handlers.RequestC
 	}
 
 	if err := d.runPreRequestPlugins(ctx, reqCtx.SchedulingRequest, result); err != nil {
-		// Preserve a typed errcommon.Error from a plugin so its status code
-		// (e.g. PreconditionFailed) reaches Envoy intact, even after the
-		// wrapping applied by runPreRequestPlugins (fmt.Errorf + errors.Join).
-		// Fall through to Internal for untyped/multiple errors so response
-		// building does not fall through to Unknown in BuildErrResponse.
-		var e errcommon.Error
-		if errors.As(err, &e) {
-			return reqCtx, e
+		// Preserve a typed errcommon.Error from a single failing plugin so its
+		// status code (e.g. PreconditionFailed) reaches Envoy intact, even
+		// after the wrapping applied by runPreRequestPlugins (fmt.Errorf +
+		// errors.Join). Multiple failures collapse to Internal so all their
+		// messages reach the client via the joined error text; picking one
+		// typed code arbitrarily would drop the others. Untyped failures also
+		// collapse to Internal so response building does not fall through to
+		// Unknown in BuildErrResponse.
+		if u, ok := err.(interface{ Unwrap() []error }); ok && len(u.Unwrap()) == 1 {
+			var e errcommon.Error
+			if errors.As(err, &e) {
+				return reqCtx, e
+			}
 		}
 		return reqCtx, errcommon.Error{Code: errcommon.Internal, Msg: err.Error()}
 	}

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -500,7 +500,16 @@ func (d *Director) prepareRequest(ctx context.Context, reqCtx *handlers.RequestC
 	}
 
 	if err := d.runPreRequestPlugins(ctx, reqCtx.SchedulingRequest, result); err != nil {
-		return reqCtx, err
+		// Preserve a typed errcommon.Error from a plugin so its status code
+		// (e.g. PreconditionFailed) reaches Envoy intact, even after the
+		// wrapping applied by runPreRequestPlugins (fmt.Errorf + errors.Join).
+		// Fall through to Internal for untyped/multiple errors so response
+		// building does not fall through to Unknown in BuildErrResponse.
+		var e errcommon.Error
+		if errors.As(err, &e) {
+			return reqCtx, e
+		}
+		return reqCtx, errcommon.Error{Code: errcommon.Internal, Msg: err.Error()}
 	}
 
 	return reqCtx, nil

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -499,7 +499,9 @@ func (d *Director) prepareRequest(ctx context.Context, reqCtx *handlers.RequestC
 		reqCtx.TargetEndpointScores = scores
 	}
 
-	d.runPreRequestPlugins(ctx, reqCtx.SchedulingRequest, result)
+	if err := d.runPreRequestPlugins(ctx, reqCtx.SchedulingRequest, result); err != nil {
+		return reqCtx, err
+	}
 
 	return reqCtx, nil
 }
@@ -604,16 +606,27 @@ func (d *Director) GetRandomEndpoint() *fwkdl.EndpointMetadata {
 	return pod.GetMetadata()
 }
 
+// runPreRequestPlugins invokes every registered PreRequest plugin, wraps each non-nil
+// error with the plugin's typed name, and returns the joined result. Plugins are not
+// short-circuited: a failure in one does not skip the rest, so every plugin still runs
+// its side effects and the caller sees all failures.
 func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.InferenceRequest,
-	schedulingResult *fwksched.SchedulingResult) {
+	schedulingResult *fwksched.SchedulingResult) error {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
+	var errs []error
 	for _, plugin := range d.requestControlPlugins.preRequestPlugins {
 		loggerDebug.Info("Running PreRequest plugin", "plugin", plugin.TypedName())
 		before := time.Now()
-		plugin.PreRequest(ctx, request, schedulingResult)
+		err := plugin.PreRequest(ctx, request, schedulingResult)
 		metrics.RecordPluginProcessingLatency(fwkrc.PreRequestExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		if err != nil {
+			loggerDebug.Info("PreRequest plugin failed", "plugin", plugin.TypedName(), "error", err.Error())
+			errs = append(errs, fmt.Errorf("PreRequest %q failed: %w", plugin.TypedName().String(), err))
+			continue
+		}
 		loggerDebug.Info("Completed running PreRequest plugin successfully", "plugin", plugin.TypedName())
 	}
+	return errors.Join(errs...)
 }
 
 func (d *Director) runRequestHeaderProcessors(ctx context.Context, request *fwksched.InferenceRequest) error {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -587,7 +587,44 @@ func TestDirector_HandleRequest(t *testing.T) {
 					}
 				},
 			},
-		}, {
+		},
+		{
+			name: "preRequest plugin returns typed error surfaces as its status code",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			initialTargetModelName: model,
+			inferenceObjectiveName: objectiveName,
+			preRequestPlugin: &mockPreRequestPlugin{
+				name: "failing-pre-request-plugin",
+				err:  errcommon.Error{Code: errcommon.PreconditionFailed, Msg: "plugin rejected request"},
+			},
+			wantErrCode: errcommon.PreconditionFailed,
+		},
+		{
+			name: "preRequest plugin returns untyped error collapses to Internal",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			initialTargetModelName: model,
+			inferenceObjectiveName: objectiveName,
+			preRequestPlugin: &mockPreRequestPlugin{
+				name: "failing-untyped-pre-request-plugin",
+				err:  errors.New("plugin exploded"),
+			},
+			wantErrCode: errcommon.Internal,
+		},
+		{
 			name: "successful request with model rewrite",
 			reqBodyMap: map[string]any{
 				"model":  modelToBeRewritten,

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -2100,6 +2100,39 @@ func TestDirector_HandleRequest_ConditionalDecode(t *testing.T) {
 	}
 }
 
+// TestRunPreRequestPlugins_NoPlugins verifies that runPreRequestPlugins returns
+// nil when no PreRequest plugins are registered.
+func TestRunPreRequestPlugins_NoPlugins(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	dir := &Director{requestControlPlugins: *NewConfig()}
+
+	err := dir.runPreRequestPlugins(ctx, &fwksched.InferenceRequest{RequestID: "req-none"}, &fwksched.SchedulingResult{})
+	assert.NoError(t, err)
+}
+
+// TestRunPreRequestPlugins_AllSucceed verifies that runPreRequestPlugins invokes
+// every registered PreRequest plugin and returns nil when none fail.
+func TestRunPreRequestPlugins_AllSucceed(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	var invoked []string
+	record := func(name string) func(*fwksched.InferenceRequest) {
+		return func(*fwksched.InferenceRequest) { invoked = append(invoked, name) }
+	}
+	plugins := []fwkrc.PreRequest{
+		&mockPreRequestPlugin{name: "first", modifyFn: record("first")},
+		&mockPreRequestPlugin{name: "second", modifyFn: record("second")},
+		&mockPreRequestPlugin{name: "third", modifyFn: record("third")},
+	}
+
+	dir := &Director{requestControlPlugins: *NewConfig().WithPreRequestPlugins(plugins...)}
+
+	err := dir.runPreRequestPlugins(ctx, &fwksched.InferenceRequest{RequestID: "req-ok"}, &fwksched.SchedulingResult{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"first", "second", "third"}, invoked, "every plugin must run")
+}
+
 // TestRunPreRequestPlugins_AggregatesErrors verifies that runPreRequestPlugins
 // invokes every registered PreRequest plugin regardless of individual failures
 // and returns the joined error covering all failed plugins.

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -185,16 +185,18 @@ func (m *mockRequestHeaderPlugin) RequestHeader(_ context.Context, request *fwks
 type mockPreRequestPlugin struct {
 	name     string
 	modifyFn func(request *fwksched.InferenceRequest)
+	err      error
 }
 
 func (m *mockPreRequestPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockPreRequestPlugin) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
+func (m *mockPreRequestPlugin) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) error {
 	if m.modifyFn != nil {
 		m.modifyFn(request)
 	}
+	return m.err
 }
 
 type mockProducedDataType struct {
@@ -2059,4 +2061,37 @@ func TestDirector_HandleRequest_ConditionalDecode(t *testing.T) {
 			assert.Equal(t, tt.wantErrCode, e.Code)
 		})
 	}
+}
+
+// TestRunPreRequestPlugins_AggregatesErrors verifies that runPreRequestPlugins
+// invokes every registered PreRequest plugin regardless of individual failures
+// and returns the joined error covering all failed plugins.
+func TestRunPreRequestPlugins_AggregatesErrors(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	firstErr := errors.New("first plugin boom")
+	thirdErr := errors.New("third plugin boom")
+
+	var invoked []string
+	record := func(name string) func(*fwksched.InferenceRequest) {
+		return func(*fwksched.InferenceRequest) { invoked = append(invoked, name) }
+	}
+	plugins := []fwkrc.PreRequest{
+		&mockPreRequestPlugin{name: "first", modifyFn: record("first"), err: firstErr},
+		&mockPreRequestPlugin{name: "second", modifyFn: record("second")},
+		&mockPreRequestPlugin{name: "third", modifyFn: record("third"), err: thirdErr},
+	}
+
+	dir := &Director{requestControlPlugins: *NewConfig().WithPreRequestPlugins(plugins...)}
+
+	request := &fwksched.InferenceRequest{RequestID: "req-multi-err"}
+	err := dir.runPreRequestPlugins(ctx, request, &fwksched.SchedulingResult{})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, firstErr, "aggregated error must wrap the first plugin's error")
+	assert.ErrorIs(t, err, thirdErr, "aggregated error must wrap the third plugin's error")
+	assert.Contains(t, err.Error(), `PreRequest "first/mock" failed`)
+	assert.Contains(t, err.Error(), `PreRequest "third/mock" failed`)
+	assert.Equal(t, []string{"first", "second", "third"}, invoked,
+		"every plugin must run; a failure in one must not short-circuit the rest")
 }

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -419,7 +419,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		admitRequestDenialError error                    // Expected denial error from admission plugin
 		dataProducerPlugin      *mockDataProducerPlugin
 		screener                *mockScreener
-		preRequestPlugin        *mockPreRequestPlugin
+		preRequestPlugins       []*mockPreRequestPlugin
 		requestHeaderPlugin     *mockRequestHeaderPlugin
 		wantMutatedBody         map[string]any
 		fairnessIDHeader        string // If non-empty, set as metadata.FlowFairnessIDKey on the incoming request.
@@ -579,14 +579,14 @@ func TestDirector_HandleRequest(t *testing.T) {
 				"new_key": "new_value",
 			},
 			inferenceObjectiveName: objectiveName,
-			preRequestPlugin: &mockPreRequestPlugin{
+			preRequestPlugins: []*mockPreRequestPlugin{{
 				name: "test-pre-request-plugin",
 				modifyFn: func(request *fwksched.InferenceRequest) {
 					if payloadMap, ok := request.Body.Payload.(fwkrh.PayloadMap); ok {
 						payloadMap["new_key"] = "new_value"
 					}
 				},
-			},
+			}},
 		},
 		{
 			name: "preRequest plugin returns typed error surfaces as its status code",
@@ -600,10 +600,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 			},
 			initialTargetModelName: model,
 			inferenceObjectiveName: objectiveName,
-			preRequestPlugin: &mockPreRequestPlugin{
+			preRequestPlugins: []*mockPreRequestPlugin{{
 				name: "failing-pre-request-plugin",
 				err:  errcommon.Error{Code: errcommon.PreconditionFailed, Msg: "plugin rejected request"},
-			},
+			}},
 			wantErrCode: errcommon.PreconditionFailed,
 		},
 		{
@@ -618,9 +618,57 @@ func TestDirector_HandleRequest(t *testing.T) {
 			},
 			initialTargetModelName: model,
 			inferenceObjectiveName: objectiveName,
-			preRequestPlugin: &mockPreRequestPlugin{
+			preRequestPlugins: []*mockPreRequestPlugin{{
 				name: "failing-untyped-pre-request-plugin",
 				err:  errors.New("plugin exploded"),
+			}},
+			wantErrCode: errcommon.Internal,
+		},
+		{
+			name: "multiple typed preRequest plugin failures collapse to Internal",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			initialTargetModelName: model,
+			inferenceObjectiveName: objectiveName,
+			preRequestPlugins: []*mockPreRequestPlugin{
+				{
+					name: "failing-typed-a",
+					err:  errcommon.Error{Code: errcommon.PreconditionFailed, Msg: "a rejected"},
+				},
+				{
+					name: "failing-typed-b",
+					err:  errcommon.Error{Code: errcommon.BadRequest, Msg: "b rejected"},
+				},
+			},
+			wantErrCode: errcommon.Internal,
+		},
+		{
+			name: "mixed typed and untyped preRequest failures collapse to Internal",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			initialTargetModelName: model,
+			inferenceObjectiveName: objectiveName,
+			preRequestPlugins: []*mockPreRequestPlugin{
+				{
+					name: "failing-typed",
+					err:  errcommon.Error{Code: errcommon.PreconditionFailed, Msg: "typed rejected"},
+				},
+				{
+					name: "failing-untyped",
+					err:  errors.New("untyped exploded"),
+				},
 			},
 			wantErrCode: errcommon.Internal,
 		},
@@ -1025,8 +1073,12 @@ func TestDirector_HandleRequest(t *testing.T) {
 				if test.screener != nil {
 					config = config.WithScreeners(test.screener)
 				}
-				if test.preRequestPlugin != nil {
-					config = config.WithPreRequestPlugins(test.preRequestPlugin)
+				if len(test.preRequestPlugins) > 0 {
+					plugins := make([]fwkrc.PreRequest, len(test.preRequestPlugins))
+					for i, p := range test.preRequestPlugins {
+						plugins[i] = p
+					}
+					config = config.WithPreRequestPlugins(plugins...)
 				}
 				if test.requestHeaderPlugin != nil {
 					config = config.WithRequestHeaderPlugins(test.requestHeaderPlugin)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an `error` return to the `PreRequest` plugin interface so plugins can signal failure to the director. The director's runner now invokes every registered `PreRequest` plugin regardless of individual failures and returns their aggregated errors via `errors.Join`, so a caller sees all failures at once rather than only the first.

This is groundwork for #1686 (conditional-decode routing), where a new plugin at the `PreRequest` extension point needs to be able to fail a request. Per @elevran's [comment on the issue](https://github.com/llm-d/llm-d-router/issues/1686#issuecomment-3626229587), this preliminary PR lands the interface change on its own so the conditional-decode work can build on it.

Every existing implementation of `PreRequest` returns `nil` today; behavior is unchanged. Individual plugins that currently log-and-swallow errors (e.g. `preciseprefixcache` calling `index.Add`) are left as-is here — surfacing those errors is a follow-up.

Note on aggregation strategy: this diverges from the first-error-wins pattern used by `runAdmissionPlugins` and `runRequestHeaderProcessors`. Every `PreRequest` plugin runs its side effects even if a peer plugin has already failed, and the joined error covers all of them.

**Which issue(s) this PR fixes**:

Issue #2216

**Release note**:
The `PreRequest` plugin interface now returns an `error`. Existing built-in plugins return `nil` and are unaffected; out-of-tree plugin authors implementing `PreRequest` must update their method signatures.
