### PR TITLE
[Flow Control] Stage-Aware Saturation Gating for disaggregated P/D deployments

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -278,7 +278,10 @@ Exposed when the `flowControl` feature gate is enabled.
 *   **Description:** Number of candidate endpoints whose metrics are missing or older than the
     staleness threshold, as of the most recent saturation evaluation. Recorded by the utilization
     saturation detector; emitted under the `llm_d_epp` prefix only (no deprecated
-    `inference_extension_*` twin).
+    `inference_extension_*` twin). This gauge carries no `stage` label and is written on every
+    detector call, so it reflects the most recently evaluated stage. A reading of 0 does not rule
+    out stale metrics in another stage; per-stage stale accounting is tracked in
+    [#2475](https://github.com/llm-d/llm-d-router/issues/2475).
 *   **Usage:** A nonzero value during a dispatch stall indicates a model-server metrics collection
     problem (scrape path, port, TLS, auth) rather than genuine overload.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -258,15 +258,18 @@ Exposed when the `flowControl` feature gate is enabled.
 #### `flow_control_pool_saturation`
 
 *   **Type:** Gauge
-*   **Labels:** `inference_pool`
-*   **Description:** Pool saturation signal gating dispatch. 1.0 is the gating set point; values
-    above 1.0 indicate the magnitude of oversubscription past it (deliberately not clamped). An
-    empty pool reads as 1.0, and with the default utilization detector, endpoints with missing or
-    stale metrics score as fully saturated (fail-closed).
-*   **Usage:** When saturation reaches the usage limit threshold, the dispatch cycle skips
-    dispatching and requests remain queued. A reading pinned at exactly 1.0 can be fail-closed
-    stale-metrics or an empty pool rather than genuine overload (which typically reads above 1.0);
-    check `flow_control_stale_endpoints` to disambiguate.
+*   **Labels:** `inference_pool`, `stage`
+*   **Description:** Pool saturation signal gating dispatch. The `stage` label partitions by
+    pipeline role: `prefill` and `decode` are per-stage signals, `effective` is
+    `max(prefill, decode)` and is the value used for gating. In monolithic deployments (no role
+    labels) all endpoints land in the decode stage. 1.0 is the gating set point; values above 1.0
+    indicate the magnitude of oversubscription past it (deliberately not clamped). An empty pool
+    reads as 1.0, and with the default utilization detector, endpoints with missing or stale
+    metrics score as fully saturated (fail-closed).
+*   **Usage:** When the effective saturation reaches the usage limit threshold, the dispatch cycle
+    skips dispatching and requests remain queued. A reading pinned at exactly 1.0 can be
+    fail-closed stale-metrics or an empty pool rather than genuine overload (which typically reads
+    above 1.0); check `flow_control_stale_endpoints` to disambiguate.
 
 #### `flow_control_stale_endpoints`
 

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -463,6 +463,7 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 		{"decode", decodePool},
 	} {
 		if len(part.endpoints) == 0 {
+			metrics.DeleteFlowControlPoolSaturation(p.poolName, part.name)
 			continue
 		}
 		stageSat := p.saturationDetector.Saturation(ctx, part.endpoints)

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -447,7 +447,12 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 		p.regime.Store(&regimeSample{empty: empty, since: p.clock.Now()})
 	}
 
-	prefillPool, decodePool, interleavedPool := partitionEndpoints(pool)
+	prefillOnly, decodeOnly, interleaved := partitionEndpoints(pool)
+
+	// Interleaved pods serve both stages, so they contribute capacity to both pools,
+	// mirroring how the scheduling filters route requests.
+	prefillPool := append(prefillOnly, interleaved...)
+	decodePool := append(decodeOnly, interleaved...)
 
 	saturation := -1.0
 	for _, part := range []struct {
@@ -456,7 +461,6 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	}{
 		{"prefill", prefillPool},
 		{"decode", decodePool},
-		{"interleaved", interleavedPool},
 	} {
 		if len(part.endpoints) == 0 {
 			continue

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -542,8 +542,10 @@ func (p *Processor) ceilingsBuffer(n int) []float64 {
 }
 
 // partitionEndpoints classifies endpoints into prefill, decode, and interleaved buckets
-// based on the llm-d.ai/role pod label. Endpoints without a role label, without metadata,
-// or with an unrecognized role value default to the decode bucket for monolithic deployment safety.
+// based on the llm-d.ai/role pod label. Endpoints without a role label or without metadata
+// default to the decode bucket, matching the decode-filter's allowsNoLabel convention for
+// monolithic deployment safety. Encode-only pods and unrecognized role values are excluded
+// from all buckets because they are rejected by every role filter and receive no traffic.
 func partitionEndpoints(endpoints []fwkdl.Endpoint) (prefill, decode, interleaved []fwkdl.Endpoint) {
 	for _, ep := range endpoints {
 		if ep == nil {
@@ -558,12 +560,16 @@ func partitionEndpoints(endpoints []fwkdl.Endpoint) (prefill, decode, interleave
 		switch role {
 		case bylabel.RolePrefill, bylabel.RoleEncodePrefill:
 			prefill = append(prefill, ep)
-		case bylabel.RoleDecode:
+		case bylabel.RoleDecode, "":
 			decode = append(decode, ep)
 		case bylabel.RolePrefillDecode, bylabel.RoleBoth, bylabel.RoleEncodePrefillDecode:
 			interleaved = append(interleaved, ep)
+		case bylabel.RoleEncode:
+			// Encode-only pods receive no prefill or decode traffic; excluding them
+			// keeps both stage signals clean.
 		default:
-			decode = append(decode, ep)
+			// Unrecognized role values are rejected by every role filter and receive
+			// no traffic; counting them anywhere dilutes the stage signal.
 		}
 	}
 	return

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -471,7 +471,7 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 		saturation = p.saturationDetector.Saturation(ctx, pool)
 	}
 
-	metrics.RecordFlowControlPoolSaturation(p.poolName, "global", saturation)
+	metrics.RecordFlowControlPoolSaturation(p.poolName, "effective", saturation)
 
 	// Record capacity utilization ratios (the demand-side twin of saturation) from the same periodic sample.
 	p.recordCapacityUtilization()

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -446,7 +446,7 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	saturation := p.saturationDetector.Saturation(ctx, pool)
 
 	// Record pool saturation metric
-	metrics.RecordFlowControlPoolSaturation(p.poolName, saturation)
+	metrics.RecordFlowControlPoolSaturation(p.poolName, "global", saturation)
 
 	// Record capacity utilization ratios (the demand-side twin of saturation) from the same periodic sample.
 	p.recordCapacityUtilization()

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -447,20 +447,20 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 		p.regime.Store(&regimeSample{empty: empty, since: p.clock.Now()})
 	}
 
-	prefillOnly, decodeOnly, interleaved := partitionEndpoints(pool)
+	prefill, decode, interleaved := partitionEndpoints(pool)
 
 	// Interleaved pods serve both stages, so they contribute capacity to both pools,
 	// mirroring how the scheduling filters route requests.
-	prefillPool := append(prefillOnly, interleaved...)
-	decodePool := append(decodeOnly, interleaved...)
+	prefill = append(prefill, interleaved...)
+	decode = append(decode, interleaved...)
 
 	saturation := -1.0
 	for _, part := range []struct {
 		name      string
 		endpoints []fwkdl.Endpoint
 	}{
-		{"prefill", prefillPool},
-		{"decode", decodePool},
+		{"prefill", prefill},
+		{"decode", decode},
 	} {
 		if len(part.endpoints) == 0 {
 			metrics.DeleteFlowControlPoolSaturation(p.poolName, part.name)
@@ -563,7 +563,7 @@ func partitionEndpoints(endpoints []fwkdl.Endpoint) (prefill, decode, interleave
 			prefill = append(prefill, ep)
 		case bylabel.RoleDecode, "":
 			decode = append(decode, ep)
-		case bylabel.RolePrefillDecode, bylabel.RoleBoth, bylabel.RoleEncodePrefillDecode:
+		case bylabel.RolePrefillDecode, bylabel.RoleBoth, bylabel.RoleEncodePrefillDecode: //nolint:staticcheck // RoleBoth is deprecated but must be matched for backward compatibility
 			interleaved = append(interleaved, ep)
 		case bylabel.RoleEncode:
 			// Encode-only pods receive no prefill or decode traffic; excluding them

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -32,7 +32,9 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/types"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
 
@@ -439,13 +441,36 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	}()
 
 	pool := p.endpointCandidates.Locate(ctx, nil)
+
 	// Run is the sole writer, so the load and the store cannot interleave with another write.
 	if empty := len(pool) == 0; empty != p.regime.Load().empty {
 		p.regime.Store(&regimeSample{empty: empty, since: p.clock.Now()})
 	}
-	saturation := p.saturationDetector.Saturation(ctx, pool)
 
-	// Record pool saturation metric
+	prefillPool, decodePool, interleavedPool := partitionEndpoints(pool)
+
+	saturation := -1.0
+	for _, part := range []struct {
+		name      string
+		endpoints []fwkdl.Endpoint
+	}{
+		{"prefill", prefillPool},
+		{"decode", decodePool},
+		{"interleaved", interleavedPool},
+	} {
+		if len(part.endpoints) == 0 {
+			continue
+		}
+		stageSat := p.saturationDetector.Saturation(ctx, part.endpoints)
+		metrics.RecordFlowControlPoolSaturation(p.poolName, part.name, stageSat)
+		if stageSat > saturation {
+			saturation = stageSat
+		}
+	}
+	if saturation < 0 {
+		saturation = p.saturationDetector.Saturation(ctx, pool)
+	}
+
 	metrics.RecordFlowControlPoolSaturation(p.poolName, "global", saturation)
 
 	// Record capacity utilization ratios (the demand-side twin of saturation) from the same periodic sample.
@@ -510,6 +535,34 @@ func (p *Processor) ceilingsBuffer(n int) []float64 {
 		buf[i] = 1.0
 	}
 	return buf
+}
+
+// partitionEndpoints classifies endpoints into prefill, decode, and interleaved buckets
+// based on the llm-d.ai/role pod label. Endpoints without a role label, without metadata,
+// or with an unrecognized role value default to the decode bucket for monolithic deployment safety.
+func partitionEndpoints(endpoints []fwkdl.Endpoint) (prefill, decode, interleaved []fwkdl.Endpoint) {
+	for _, ep := range endpoints {
+		if ep == nil {
+			continue
+		}
+		meta := ep.GetMetadata()
+		if meta == nil || meta.Labels == nil {
+			decode = append(decode, ep)
+			continue
+		}
+		role := meta.Labels[bylabel.RoleLabel]
+		switch role {
+		case bylabel.RolePrefill, bylabel.RoleEncodePrefill:
+			prefill = append(prefill, ep)
+		case bylabel.RoleDecode:
+			decode = append(decode, ep)
+		case bylabel.RolePrefillDecode, bylabel.RoleBoth, bylabel.RoleEncodePrefillDecode:
+			interleaved = append(interleaved, ep)
+		default:
+			decode = append(decode, ep)
+		}
+	}
+	return
 }
 
 // selectItem applies the configured fairness and ordering policies to select a single item.

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1261,6 +1261,39 @@ func TestProcessor(t *testing.T) {
 				assert.True(t, dispatched, "should dispatch when only non-empty partitions are healthy")
 			})
 
+			t.Run("should include interleaved endpoints in both stage pools", func(t *testing.T) {
+				t.Parallel()
+				h := newTestHarness(t, testCleanupTick)
+
+				q := h.addQueue(testFlow)
+				require.NoError(t, q.Add(h.newTestItem("item-1", testFlow, testTTL)))
+
+				h.endpointCandidates.Candidates = []fwkdl.Endpoint{
+					makeEndpoint(bylabel.RolePrefill),
+					makeEndpoint(bylabel.RoleDecode),
+					makeEndpoint(bylabel.RolePrefillDecode), // interleaved
+				}
+
+				// Track which endpoints each Saturation call receives.
+				var calls [][]string
+				h.saturationDetector.SaturationFunc = func(_ context.Context, endpoints []fwkdl.Endpoint) float64 {
+					var roles []string
+					for _, ep := range endpoints {
+						roles = append(roles, ep.GetMetadata().Labels[bylabel.RoleLabel])
+					}
+					calls = append(calls, roles)
+					return 0.2
+				}
+
+				h.processor.dispatchCycle(context.Background())
+
+				require.Len(t, calls, 2, "detector should be called once per stage")
+				// Prefill pool: prefill + interleaved
+				assert.ElementsMatch(t, []string{bylabel.RolePrefill, bylabel.RolePrefillDecode}, calls[0])
+				// Decode pool: decode + interleaved
+				assert.ElementsMatch(t, []string{bylabel.RoleDecode, bylabel.RolePrefillDecode}, calls[1])
+			})
+
 			t.Run("should behave like monolithic when no role labels exist", func(t *testing.T) {
 				t.Parallel()
 				h := newTestHarness(t, testCleanupTick)

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	fwkfcmocks "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol/mocks"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/usagelimits"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 )
 
 const (
@@ -1104,6 +1105,181 @@ func TestProcessor(t *testing.T) {
 					require.True(t, dispatched, "Expected a low-priority dispatch on cycle %d", i+1)
 				}
 				assert.Equal(t, 0, qLow.Len(), "Low-priority queue should be empty")
+			})
+		})
+
+		t.Run("partitionEndpoints", func(t *testing.T) {
+			t.Parallel()
+
+			makeEndpoint := func(labels map[string]string) fwkdl.Endpoint {
+				return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{Labels: labels}, nil)
+			}
+
+			t.Run("should classify endpoints by role label", func(t *testing.T) {
+				t.Parallel()
+				endpoints := []fwkdl.Endpoint{
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RolePrefill}),
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleEncodePrefill}),
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleDecode}),
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RolePrefillDecode}),
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleBoth}),
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleEncodePrefillDecode}),
+				}
+
+				prefill, decode, interleaved := partitionEndpoints(endpoints)
+				assert.Len(t, prefill, 2, "prefill should contain RolePrefill and RoleEncodePrefill")
+				assert.Len(t, decode, 1, "decode should contain RoleDecode")
+				assert.Len(t, interleaved, 3, "interleaved should contain RolePrefillDecode, RoleBoth, RoleEncodePrefillDecode")
+			})
+
+			t.Run("should default unlabeled endpoints to decode", func(t *testing.T) {
+				t.Parallel()
+				endpoints := []fwkdl.Endpoint{
+					makeEndpoint(nil),                                   // no labels map
+					makeEndpoint(map[string]string{}),                   // empty labels
+					makeEndpoint(map[string]string{"other": "value"}),   // unrelated label
+					fwkdl.NewEndpoint(nil, nil),                         // nil metadata gets defaulted by NewEndpoint
+				}
+
+				prefill, decode, interleaved := partitionEndpoints(endpoints)
+				assert.Empty(t, prefill)
+				assert.Len(t, decode, 4, "all unlabeled endpoints should land in decode")
+				assert.Empty(t, interleaved)
+			})
+
+			t.Run("should default unrecognized role to decode", func(t *testing.T) {
+				t.Parallel()
+				endpoints := []fwkdl.Endpoint{
+					makeEndpoint(map[string]string{bylabel.RoleLabel: "unknown-role"}),
+				}
+
+				prefill, decode, interleaved := partitionEndpoints(endpoints)
+				assert.Empty(t, prefill)
+				assert.Len(t, decode, 1)
+				assert.Empty(t, interleaved)
+			})
+
+			t.Run("should skip nil endpoints", func(t *testing.T) {
+				t.Parallel()
+				endpoints := []fwkdl.Endpoint{
+					nil,
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RolePrefill}),
+				}
+
+				prefill, decode, interleaved := partitionEndpoints(endpoints)
+				assert.Len(t, prefill, 1)
+				assert.Empty(t, decode)
+				assert.Empty(t, interleaved)
+			})
+
+			t.Run("should return empty slices for empty input", func(t *testing.T) {
+				t.Parallel()
+				prefill, decode, interleaved := partitionEndpoints(nil)
+				assert.Empty(t, prefill)
+				assert.Empty(t, decode)
+				assert.Empty(t, interleaved)
+			})
+		})
+
+		t.Run("stage-aware saturation gating", func(t *testing.T) {
+			t.Parallel()
+
+			makeEndpoint := func(role string) fwkdl.Endpoint {
+				return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+					Labels: map[string]string{bylabel.RoleLabel: role},
+				}, nil)
+			}
+
+			t.Run("should gate on highest stage saturation", func(t *testing.T) {
+				t.Parallel()
+				h := newTestHarness(t, testCleanupTick)
+
+				q := h.addQueue(testFlow)
+				require.NoError(t, q.Add(h.newTestItem("item-1", testFlow, testTTL)))
+
+				h.endpointCandidates.Candidates = []fwkdl.Endpoint{
+					makeEndpoint(bylabel.RolePrefill),
+					makeEndpoint(bylabel.RoleDecode),
+				}
+
+				// Prefill is healthy but decode is saturated.
+				h.saturationDetector.SaturationFunc = func(_ context.Context, endpoints []fwkdl.Endpoint) float64 {
+					for _, ep := range endpoints {
+						role := ep.GetMetadata().Labels[bylabel.RoleLabel]
+						if role == bylabel.RoleDecode {
+							return 1.0
+						}
+					}
+					return 0.1
+				}
+
+				dispatched := h.processor.dispatchCycle(context.Background())
+				assert.False(t, dispatched, "should block when any stage is saturated")
+			})
+
+			t.Run("should not gate when all stages are healthy", func(t *testing.T) {
+				t.Parallel()
+				h := newTestHarness(t, testCleanupTick)
+
+				q := h.addQueue(testFlow)
+				require.NoError(t, q.Add(h.newTestItem("item-1", testFlow, testTTL)))
+
+				h.endpointCandidates.Candidates = []fwkdl.Endpoint{
+					makeEndpoint(bylabel.RolePrefill),
+					makeEndpoint(bylabel.RoleDecode),
+				}
+
+				h.saturationDetector.SaturationFunc = func(_ context.Context, _ []fwkdl.Endpoint) float64 {
+					return 0.3
+				}
+
+				dispatched := h.processor.dispatchCycle(context.Background())
+				assert.True(t, dispatched, "should dispatch when all stages are healthy")
+			})
+
+			t.Run("should skip empty partitions", func(t *testing.T) {
+				t.Parallel()
+				h := newTestHarness(t, testCleanupTick)
+
+				q := h.addQueue(testFlow)
+				require.NoError(t, q.Add(h.newTestItem("item-1", testFlow, testTTL)))
+
+				// Only decode endpoints, no prefill. Empty prefill partition should
+				// be skipped, not treated as saturated (detector returns 1.0 for empty slices).
+				h.endpointCandidates.Candidates = []fwkdl.Endpoint{
+					makeEndpoint(bylabel.RoleDecode),
+				}
+
+				h.saturationDetector.SaturationFunc = func(_ context.Context, endpoints []fwkdl.Endpoint) float64 {
+					if len(endpoints) == 0 {
+						return 1.0 // Would block if not skipped.
+					}
+					return 0.2
+				}
+
+				dispatched := h.processor.dispatchCycle(context.Background())
+				assert.True(t, dispatched, "should dispatch when only non-empty partitions are healthy")
+			})
+
+			t.Run("should behave like monolithic when no role labels exist", func(t *testing.T) {
+				t.Parallel()
+				h := newTestHarness(t, testCleanupTick)
+
+				q := h.addQueue(testFlow)
+				require.NoError(t, q.Add(h.newTestItem("item-1", testFlow, testTTL)))
+
+				// Unlabeled endpoints all land in decode, behaving like the pre-change single-pool path.
+				h.endpointCandidates.Candidates = []fwkdl.Endpoint{
+					fwkdl.NewEndpoint(nil, nil),
+					fwkdl.NewEndpoint(nil, nil),
+				}
+
+				h.saturationDetector.SaturationFunc = func(_ context.Context, _ []fwkdl.Endpoint) float64 {
+					return 0.4
+				}
+
+				dispatched := h.processor.dispatchCycle(context.Background())
+				assert.True(t, dispatched, "monolithic deployment should dispatch normally")
 			})
 		})
 

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1147,7 +1147,7 @@ func TestProcessor(t *testing.T) {
 				assert.Empty(t, interleaved)
 			})
 
-			t.Run("should default unrecognized role to decode", func(t *testing.T) {
+			t.Run("should exclude unrecognized role from all buckets", func(t *testing.T) {
 				t.Parallel()
 				endpoints := []fwkdl.Endpoint{
 					makeEndpoint(map[string]string{bylabel.RoleLabel: "unknown-role"}),
@@ -1155,7 +1155,19 @@ func TestProcessor(t *testing.T) {
 
 				prefill, decode, interleaved := partitionEndpoints(endpoints)
 				assert.Empty(t, prefill)
-				assert.Len(t, decode, 1)
+				assert.Empty(t, decode)
+				assert.Empty(t, interleaved)
+			})
+
+			t.Run("should exclude encode-only endpoints from all buckets", func(t *testing.T) {
+				t.Parallel()
+				endpoints := []fwkdl.Endpoint{
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleEncode}),
+				}
+
+				prefill, decode, interleaved := partitionEndpoints(endpoints)
+				assert.Empty(t, prefill)
+				assert.Empty(t, decode)
 				assert.Empty(t, interleaved)
 			})
 

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1122,7 +1122,7 @@ func TestProcessor(t *testing.T) {
 					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleEncodePrefill}),
 					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleDecode}),
 					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RolePrefillDecode}),
-					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleBoth}),
+					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleBoth}), //nolint:staticcheck // testing backward compat
 					makeEndpoint(map[string]string{bylabel.RoleLabel: bylabel.RoleEncodePrefillDecode}),
 				}
 
@@ -1135,10 +1135,10 @@ func TestProcessor(t *testing.T) {
 			t.Run("should default unlabeled endpoints to decode", func(t *testing.T) {
 				t.Parallel()
 				endpoints := []fwkdl.Endpoint{
-					makeEndpoint(nil),                                   // no labels map
-					makeEndpoint(map[string]string{}),                   // empty labels
-					makeEndpoint(map[string]string{"other": "value"}),   // unrelated label
-					fwkdl.NewEndpoint(nil, nil),                         // nil metadata gets defaulted by NewEndpoint
+					makeEndpoint(nil),                                 // no labels map
+					makeEndpoint(map[string]string{}),                 // empty labels
+					makeEndpoint(map[string]string{"other": "value"}), // unrelated label
+					fwkdl.NewEndpoint(nil, nil),                       // nil metadata gets defaulted by NewEndpoint
 				}
 
 				prefill, decode, interleaved := partitionEndpoints(endpoints)
@@ -1289,7 +1289,7 @@ func TestProcessor(t *testing.T) {
 				// Track which endpoints each Saturation call receives.
 				var calls [][]string
 				h.saturationDetector.SaturationFunc = func(_ context.Context, endpoints []fwkdl.Endpoint) float64 {
-					var roles []string
+					roles := make([]string, 0, len(endpoints))
 					for _, ep := range endpoints {
 						roles = append(roles, ep.GetMetadata().Labels[bylabel.RoleLabel])
 					}

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1214,15 +1214,15 @@ func TestProcessor(t *testing.T) {
 					makeEndpoint(bylabel.RoleDecode),
 				}
 
-				// Prefill is healthy but decode is saturated.
 				h.saturationDetector.SaturationFunc = func(_ context.Context, endpoints []fwkdl.Endpoint) float64 {
 					for _, ep := range endpoints {
-						role := ep.GetMetadata().Labels[bylabel.RoleLabel]
-						if role == bylabel.RoleDecode {
-							return 1.0
+						if ep.GetMetadata().Labels[bylabel.RoleLabel] != bylabel.RolePrefill {
+							// Any mixed or decode set reads healthy: the flat average is
+							// diluted by idle decode workers.
+							return 0.3
 						}
 					}
-					return 0.1
+					return 1.5 // homogeneous prefill subset: stage saturated
 				}
 
 				dispatched := h.processor.dispatchCycle(context.Background())

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -388,9 +388,11 @@ var (
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
 			Name:      "flow_control_pool_saturation",
 			Help: metricsutil.HelpMsgWithStability(
-				"Pool saturation signal gating Flow Control dispatch. 1.0 is the gating set point; values above 1.0 "+
-					"indicate the magnitude of oversubscription past it. An empty pool reads as 1.0. With the default "+
-					"utilization detector, endpoints with missing or stale metrics score as fully saturated "+
+				"Pool saturation signal gating Flow Control dispatch. The stage label partitions by pipeline role: "+
+					"'prefill' and 'decode' are per-stage signals, 'effective' is max(prefill, decode) and is the "+
+					"value used for gating. 1.0 is the gating set point; values above 1.0 indicate the magnitude of "+
+					"oversubscription past it. An empty pool reads as 1.0. With the default utilization detector, "+
+					"endpoints with missing or stale metrics score as fully saturated "+
 					"(fail-closed; see flow_control_stale_endpoints).",
 				compbasemetrics.ALPHA),
 		},

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -407,7 +407,10 @@ var (
 				"Number of candidate endpoints whose metrics are missing or older than the staleness threshold, as of "+
 					"the most recent saturation evaluation. Recorded by the utilization saturation detector, which scores "+
 					"these endpoints as fully saturated in flow_control_pool_saturation (fail-closed): a nonzero value "+
-					"during a dispatch stall indicates a metrics collection problem rather than genuine overload.",
+					"during a dispatch stall indicates a metrics collection problem rather than genuine overload. "+
+					"This gauge carries no stage label and is written on every detector call, so it reflects the most "+
+					"recently evaluated stage; a reading of 0 does not rule out stale metrics in another stage. "+
+					"Per-stage stale accounting is tracked in #2475.",
 				compbasemetrics.ALPHA),
 		},
 		[]string{"detector"},

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -394,7 +394,7 @@ var (
 					"(fail-closed; see flow_control_stale_endpoints).",
 				compbasemetrics.ALPHA),
 		},
-		[]string{"inference_pool"},
+		[]string{"inference_pool", "stage"},
 	)
 
 	llmdFlowControlStaleEndpoints = prometheus.NewGaugeVec(

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -957,6 +957,12 @@ func RecordFlowControlPoolSaturation(inferencePool, stage string, saturation flo
 	llmdFlowControlPoolSaturation.WithLabelValues(inferencePool, stage).Set(saturation)
 }
 
+// DeleteFlowControlPoolSaturation removes the saturation gauge series for a pool/stage pair.
+func DeleteFlowControlPoolSaturation(inferencePool, stage string) {
+	flowControlPoolSaturation.DeleteLabelValues(inferencePool, stage)
+	llmdFlowControlPoolSaturation.DeleteLabelValues(inferencePool, stage)
+}
+
 // RecordFlowControlStaleEndpoints records how many candidate endpoints the given saturation
 // detector scored as fully saturated because their metrics were missing or stale.
 func RecordFlowControlStaleEndpoints(detector string, count int) {

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -370,7 +370,9 @@ var (
 			Name:      "flow_control_pool_saturation",
 			Help: metricsutil.HelpMsgWithStability(
 				"[Deprecated: Use llm_d_epp_flow_control_pool_saturation] Pool saturation signal gating Flow Control "+
-					"dispatch. 1.0 is the gating set point; values above 1.0 indicate the magnitude of oversubscription "+
+					"dispatch. The stage label partitions by pipeline role: 'prefill' and 'decode' are per-stage "+
+					"signals, 'effective' is max(prefill, decode) and is the value used for gating. "+
+					"1.0 is the gating set point; values above 1.0 indicate the magnitude of oversubscription "+
 					"past it. An empty pool reads as 1.0. With the default utilization detector, endpoints with missing "+
 					"or stale metrics score as fully saturated (fail-closed; see "+
 					"llm_d_epp_flow_control_stale_endpoints).",

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -951,7 +951,7 @@ func SubFlowControlQueueBytes(fairnessID, priority, inferencePool, modelName, ta
 }
 
 // RecordFlowControlPoolSaturation records the current saturation level for an inference pool
-// partitioned by pipeline stage ("prefill", "decode", "interleaved", or "global").
+// partitioned by pipeline stage ("prefill", "decode", "interleaved", or "effective").
 func RecordFlowControlPoolSaturation(inferencePool, stage string, saturation float64) {
 	flowControlPoolSaturation.WithLabelValues(inferencePool, stage).Set(saturation)
 	llmdFlowControlPoolSaturation.WithLabelValues(inferencePool, stage).Set(saturation)

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -951,7 +951,7 @@ func SubFlowControlQueueBytes(fairnessID, priority, inferencePool, modelName, ta
 }
 
 // RecordFlowControlPoolSaturation records the current saturation level for an inference pool
-// partitioned by pipeline stage ("prefill", "decode", "interleaved", or "effective").
+// partitioned by pipeline stage ("prefill", "decode", or "effective").
 func RecordFlowControlPoolSaturation(inferencePool, stage string, saturation float64) {
 	flowControlPoolSaturation.WithLabelValues(inferencePool, stage).Set(saturation)
 	llmdFlowControlPoolSaturation.WithLabelValues(inferencePool, stage).Set(saturation)

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -376,7 +376,7 @@ var (
 					"llm_d_epp_flow_control_stale_endpoints).",
 				compbasemetrics.ALPHA),
 		},
-		[]string{"inference_pool"},
+		[]string{"inference_pool", "stage"},
 	)
 )
 
@@ -950,10 +950,11 @@ func SubFlowControlQueueBytes(fairnessID, priority, inferencePool, modelName, ta
 	llmdFlowControlQueueBytes.WithLabelValues(fairnessID, priority, inferencePool, modelName, targetModelName).Sub(float64(bytes))
 }
 
-// RecordFlowControlPoolSaturation records the current saturation level for an inference pool.
-func RecordFlowControlPoolSaturation(inferencePool string, saturation float64) {
-	flowControlPoolSaturation.WithLabelValues(inferencePool).Set(saturation)
-	llmdFlowControlPoolSaturation.WithLabelValues(inferencePool).Set(saturation)
+// RecordFlowControlPoolSaturation records the current saturation level for an inference pool
+// partitioned by pipeline stage ("prefill", "decode", "interleaved", or "global").
+func RecordFlowControlPoolSaturation(inferencePool, stage string, saturation float64) {
+	flowControlPoolSaturation.WithLabelValues(inferencePool, stage).Set(saturation)
+	llmdFlowControlPoolSaturation.WithLabelValues(inferencePool, stage).Set(saturation)
 }
 
 // RecordFlowControlStaleEndpoints records how many candidate endpoints the given saturation

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1375,14 +1375,24 @@ func TestFlowControlPoolSaturationMetric(t *testing.T) {
 
 	const pool = "test-pool"
 
-	RecordFlowControlPoolSaturation(pool, 0.5)
-	val, err := testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool))
+	RecordFlowControlPoolSaturation(pool, "global", 0.5)
+	val, err := testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "global"))
 	require.NoError(t, err)
 	require.Equal(t, 0.5, val)
 
-	valNew, err := testutil.GetGaugeMetricValue(llmdFlowControlPoolSaturation.WithLabelValues(pool))
+	valNew, err := testutil.GetGaugeMetricValue(llmdFlowControlPoolSaturation.WithLabelValues(pool, "global"))
 	require.NoError(t, err)
 	require.Equal(t, 0.5, valNew)
+
+	RecordFlowControlPoolSaturation(pool, "prefill", 0.3)
+	val, err = testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "prefill"))
+	require.NoError(t, err)
+	require.Equal(t, 0.3, val)
+
+	RecordFlowControlPoolSaturation(pool, "decode", 0.7)
+	val, err = testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "decode"))
+	require.NoError(t, err)
+	require.Equal(t, 0.7, val)
 }
 
 func TestFlowControlRequestsTotalMetric(t *testing.T) {

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1393,11 +1393,6 @@ func TestFlowControlPoolSaturationMetric(t *testing.T) {
 	val, err = testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "decode"))
 	require.NoError(t, err)
 	require.Equal(t, 0.7, val)
-
-	RecordFlowControlPoolSaturation(pool, "interleaved", 0.6)
-	val, err = testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "interleaved"))
-	require.NoError(t, err)
-	require.Equal(t, 0.6, val)
 }
 
 func TestFlowControlRequestsTotalMetric(t *testing.T) {

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1393,6 +1393,11 @@ func TestFlowControlPoolSaturationMetric(t *testing.T) {
 	val, err = testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "decode"))
 	require.NoError(t, err)
 	require.Equal(t, 0.7, val)
+
+	RecordFlowControlPoolSaturation(pool, "interleaved", 0.6)
+	val, err = testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "interleaved"))
+	require.NoError(t, err)
+	require.Equal(t, 0.6, val)
 }
 
 func TestFlowControlRequestsTotalMetric(t *testing.T) {

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1375,12 +1375,12 @@ func TestFlowControlPoolSaturationMetric(t *testing.T) {
 
 	const pool = "test-pool"
 
-	RecordFlowControlPoolSaturation(pool, "global", 0.5)
-	val, err := testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "global"))
+	RecordFlowControlPoolSaturation(pool, "effective", 0.5)
+	val, err := testutil.GetGaugeMetricValue(flowControlPoolSaturation.WithLabelValues(pool, "effective"))
 	require.NoError(t, err)
 	require.Equal(t, 0.5, val)
 
-	valNew, err := testutil.GetGaugeMetricValue(llmdFlowControlPoolSaturation.WithLabelValues(pool, "global"))
+	valNew, err := testutil.GetGaugeMetricValue(llmdFlowControlPoolSaturation.WithLabelValues(pool, "effective"))
 	require.NoError(t, err)
 	require.Equal(t, 0.5, valNew)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The flow control system currently computes a single saturation value across all endpoints. In disaggregated prefill/decode (P/D) deployments, this masks stage-specific bottlenecks: a prefill surge can overwhelm prefill workers while the global average stays low because idle decode workers dilute the signal, so backpressure never kicks in when it should.

This PR makes the dispatch cycle stage-aware by:

1. Adding a `partitionEndpoints` helper that classifies endpoints into prefill, decode, and interleaved buckets using the `llm-d.ai/role` pod label (reusing role constants from `bylabel/roles.go`). Endpoints without a role label or without metadata default to the decode bucket, matching the existing `NewDecodeRole(allowsNoLabel: true)` convention for monolithic deployment safety. Encode-only pods and unrecognized role values are excluded from all buckets because they are rejected by every role filter and receive no traffic.
2. Interleaved endpoints (`prefill-decode`, `both`, `encode-prefill-decode`) are included in both the prefill and decode pools, mirroring how the scheduling filters route requests. Saturation is computed independently per non-empty stage, then `max(S_prefill, S_decode)` is used as the effective saturation fed into priority ceilings and HoL blocking. Empty partitions delete their gauge series to prevent stale readings. When all partitions are empty, the detector is called on the full pool to preserve existing empty-pool behavior.
3. Adding a `"stage"` label to both `flow_control_pool_saturation` Prometheus gauges, emitting per-stage (`"prefill"`, `"decode"`) and `"effective"` values each dispatch cycle. The gauge help text and `docs/metrics.md` are updated to document the new label.

The existing gating logic (priority ceilings, HoL blocking) is unchanged -- it uses the effective saturation value as before. Monolithic deployments (no role labels) behave identically to before: all endpoints land in the decode bucket, producing a single-stage saturation equal to the previous flat-pool value.

**Which issue(s) this PR fixes**:

Fixes #1186

**Release note**:

```release-note
Flow control saturation gating is now stage-aware in disaggregated prefill/decode deployments. Endpoints are partitioned by the `llm-d.ai/role` pod label, with interleaved pods included in both stage pools. Saturation is computed per stage, and backpressure triggers on the worst stage (`max(S_prefill, S_decode)`). A new `"stage"` label on the `flow_control_pool_saturation` metric enables per-stage observability (`"prefill"`, `"decode"`, `"effective"`). Monolithic deployments are unaffected.
```
