### PR TITLE
[CI]: Serialize kind/area label sync per PR and issue

### DIFF
--- a/.github/workflows/issue-kind-label.yaml
+++ b/.github/workflows/issue-kind-label.yaml
@@ -4,6 +4,12 @@ on:
   issues:
     types: [opened, edited, reopened]
 
+# Serializes runs on the same issue so a remove then add label sequence always
+# completes as a unit. Otherwise, cancelling a mid-flight run can leave labels wiped.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   kind-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-kind-label.yaml
+++ b/.github/workflows/pr-kind-label.yaml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
 
+# Serializes runs on the same PR so a remove then add label sequence always
+# completes as a unit. Otherwise, cancelling a mid-flight run can leave labels wiped.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   kind-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Concurrent edits to a PR or issue body could interleave two runs of the label sync workflows. Both remove every `kind/*` and `area/*` label before re-adding from the body and that step isn't atomic. Therefore, an overlapping run could leave labels matching neither edit.

Add a concurrency group per PR/issue, keyed by workflow name with `cancel-in-progress: false`. Queuing instead of cancelling matches the existing `re-run-action.yml` pattern.


**Which issue(s) this PR fixes**:
Fixes #2205 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
