### PR TITLE
epp: add multicluster scheduling plugin variants

### DIFF
--- a/cmd/epp/runner/multicluster_config_test.go
+++ b/cmd/epp/runner/multicluster_config_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	runserver "github.com/llm-d/llm-d-router/pkg/epp/server"
+)
+
+// TestMultiClusterConfigLoads guards the multicluster wiring documented in
+// framework/plugins/README.md: the discovery, metrics source, metrics extractor,
+// and the two metric scorers instantiate against the registry and resolve to their
+// expected types as one EndpointPickerConfig.
+func TestMultiClusterConfigLoads(t *testing.T) {
+	dir := t.TempDir()
+	clustersPath := filepath.Join(dir, "clusters.yaml")
+	require.NoError(t, os.WriteFile(clustersPath, []byte(
+		"endpoints:\n"+
+			"  - name: a\n"+
+			"    address: gw.cluster-a.example.com\n"+
+			"    port: \"443\"\n"), 0o644))
+
+	// Mirrors the example config in framework/plugins/README.md, so this test fails if
+	// that documented wiring stops loading. caCertPath is omitted because it points at a
+	// deploy-specific file. CA loading is covered by the metrics source's own tests.
+	configText := fmt.Sprintf(`apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: multicluster-file-discovery
+    name: discovery
+    parameters:
+      path: %q
+  - type: multicluster-metrics-data-source
+    name: metrics-source
+    parameters:
+      scheme: https
+  - type: multicluster-metrics-extractor
+    name: metrics-extractor
+  - type: multicluster-session-affinity-filter
+    name: session-affinity
+  - type: multicluster-kv-cache-utilization-scorer
+    name: kv-cache
+  - type: multicluster-queue-scorer
+    name: queue
+  - type: max-score-picker
+  - type: single-profile-handler
+dataLayer:
+  discovery:
+    pluginRef: discovery
+  sources:
+    - pluginRef: metrics-source
+      extractors:
+        - pluginRef: metrics-extractor
+`, clustersPath)
+
+	opts := runserver.NewOptions()
+	opts.ConfigText = configText
+	opts.PoolName = "mc-config-pool"
+	opts.PoolNamespace = "mc-config-ns"
+
+	r := NewRunner()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
+	require.NoError(t, err, "documented multicluster config must parse and validate")
+	require.NotNil(t, rawConfig.DataLayer)
+	require.NotNil(t, rawConfig.DataLayer.Discovery)
+	require.Len(t, rawConfig.DataLayer.Sources, 1)
+
+	// Phase two instantiates each plugin against the registry, so it fails if a
+	// multicluster factory is unregistered or a type is misspelled. Phase one alone
+	// only decodes the YAML and would not catch that.
+	ds := datastore.NewDatastore(ctx, r.setupMetricsCollection(opts))
+	_, err = r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+	require.NoError(t, err, "documented multicluster config must instantiate against the registry")
+
+	for name, wantType := range map[string]string{
+		"discovery":         "multicluster-file-discovery",
+		"metrics-source":    "multicluster-metrics-data-source",
+		"metrics-extractor": "multicluster-metrics-extractor",
+		"session-affinity":  "multicluster-session-affinity-filter",
+		"kv-cache":          "multicluster-kv-cache-utilization-scorer",
+		"queue":             "multicluster-queue-scorer",
+	} {
+		p := r.PluginHandle.Plugin(name)
+		require.NotNil(t, p, "plugin %q must resolve", name)
+		require.Equal(t, wantType, p.TypedName().Type, "plugin %q resolved to the wrong type", name)
+	}
+}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -618,6 +618,12 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(endpointattribute.EndpointAttributeScorerType, fwkplugin.StabilityAlpha, endpointattribute.EndpointAttributeScorerFactory)
 	fwkplugin.Register(burstprefix.PluginType, fwkplugin.StabilityAlpha, burstprefix.Factory)
 	fwkplugin.Register(p2psource.PluginType, fwkplugin.StabilityAlpha, p2psource.PluginFactory)
+	// multicluster variants
+	fwkplugin.Register(sessionaffinityfilter.MultiClusterFilterType, fwkplugin.StabilityAlpha, sessionaffinityfilter.MultiClusterFactory)
+	fwkplugin.Register(queuedepth.MultiClusterScorerType, fwkplugin.StabilityAlpha, queuedepth.MultiClusterScorerFactory)
+	fwkplugin.Register(kvcacheutilization.MultiClusterScorerType, fwkplugin.StabilityAlpha, kvcacheutilization.MultiClusterScorerFactory)
+	fwkplugin.Register(prefix.MultiClusterScorerType, fwkplugin.StabilityAlpha, prefix.MultiClusterScorerFactory)
+	fwkplugin.Register(reqdataprodprefix.MultiClusterPluginType, fwkplugin.StabilityAlpha, reqdataprodprefix.MultiClusterFactory)
 
 	// Flow Control plugins
 	// Beta
@@ -666,6 +672,9 @@ func (r *Runner) registerInTreePlugins() {
 	// Beta
 	fwkplugin.Register(sourcemetrics.MetricsDataSourceType, fwkplugin.StabilityBeta, sourcemetrics.MetricsDataSourceFactory)
 	fwkplugin.Register(extractormetrics.MetricsExtractorType, fwkplugin.StabilityBeta, extractormetrics.CoreMetricsExtractorFactory)
+	// multicluster variants: a pool-aggregate metrics source and extractor
+	fwkplugin.Register(sourcemetrics.MultiClusterMetricsDataSourceType, fwkplugin.StabilityAlpha, sourcemetrics.MultiClusterMetricsDataSourceFactory)
+	fwkplugin.Register(extractormetrics.MultiClusterMetricsExtractorType, fwkplugin.StabilityAlpha, extractormetrics.MultiClusterMetricsExtractorFactory)
 
 	// register datalayer notification source plugins
 	// Beta
@@ -690,6 +699,8 @@ func (r *Runner) registerInTreePlugins() {
 	// register discovery plugins
 	// Beta
 	fwkplugin.Register(discoveryfile.PluginType, fwkplugin.StabilityBeta, discoveryfile.Factory)
+	// multicluster variant
+	fwkplugin.Register(discoveryfile.MultiClusterPluginType, fwkplugin.StabilityAlpha, discoveryfile.MultiClusterFactory)
 
 	// register request header processor plugins
 	// Alpha

--- a/pkg/epp/framework/plugins/README.md
+++ b/pkg/epp/framework/plugins/README.md
@@ -25,6 +25,52 @@ epp --allow-experimental-plugins
 
 If an Alpha plugin is configured while `--allow-experimental-plugins` is not set (the default), the EPP runner will fail initialization with an explicit error.
 
+## Multi-cluster variants
+
+A few plugins ship a multi-cluster variant beside the stock plugin, for a cluster-scoped EPP whose candidate endpoints are clusters. The scheduling variants are `multicluster-kv-cache-utilization-scorer`, `multicluster-queue-scorer`, `multicluster-session-affinity-filter`, and `multicluster-prefix-cache-scorer`. The `multicluster-approx-prefix-cache-producer` is the matching request-control data producer. They rely on three datalayer variants: `multicluster-file-discovery` discovers peer clusters as endpoints, and `multicluster-metrics-data-source` with `multicluster-metrics-extractor` scrape each cluster and write its pool-aggregate metrics into the attributes the scorers read.
+
+The pure-delegation variants (`multicluster-session-affinity-filter`, `multicluster-prefix-cache-scorer`, `multicluster-approx-prefix-cache-producer`) reuse the stock plugin's behavior and only rename the type, so their per-plugin Prometheus metrics report under the stock type label rather than the multicluster one.
+
+### Dependencies
+
+The metric scorers are not standalone. `multicluster-kv-cache-utilization-scorer` and `multicluster-queue-scorer` read the `llm-d.ai/multicluster-kv-cache-utilization` and `llm-d.ai/multicluster-queue-size` attributes, which only exist if `multicluster-metrics-extractor` is configured to write them from what `multicluster-metrics-data-source` scrapes. Without the source and extractor in `dataLayer`, those scorers see no pool metrics and return no score.
+
+### Example
+
+```yaml
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: multicluster-file-discovery
+    name: discovery
+    parameters:
+      path: /etc/epp/clusters.yaml
+  - type: multicluster-metrics-data-source
+    name: metrics-source
+    parameters:
+      scheme: https
+      caCertPath: /etc/epp/tls/ca.crt
+  - type: multicluster-metrics-extractor
+    name: metrics-extractor
+  - type: multicluster-session-affinity-filter
+    name: session-affinity
+  - type: multicluster-kv-cache-utilization-scorer
+    name: kv-cache
+  - type: multicluster-queue-scorer
+    name: queue
+  - type: max-score-picker
+  - type: single-profile-handler
+dataLayer:
+  discovery:
+    pluginRef: discovery
+  sources:
+    - pluginRef: metrics-source
+      extractors:
+        - pluginRef: metrics-extractor
+```
+
+`clusters.yaml` follows the same format as the pod file discovery, except an `address` may be a hostname.
+
 ## Related Documentation
 
 - [Architecture Overview](../../../../docs/architecture.md)

--- a/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types_multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types_multicluster.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+// Pool-aggregate attribute keys, read by the multicluster scorers and written by the
+// multicluster metrics extractor. A cluster-endpoint has no per-pod metrics, so it
+// carries the pool's aggregate instead.
+const (
+	// MultiClusterKVCacheUtilizationKey holds a pool's aggregate KV-cache utilization.
+	MultiClusterKVCacheUtilizationKey = "llm-d.ai/multicluster-kv-cache-utilization"
+	// MultiClusterQueueSizeKey holds a pool's aggregate waiting-queue size.
+	MultiClusterQueueSizeKey = "llm-d.ai/multicluster-queue-size"
+)

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/README.md
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/README.md
@@ -105,3 +105,9 @@ endpoints:
 ## Related Documentation
 
 - [Plugins Index](../../../README.md)
+
+## Multi-cluster support
+
+`multicluster-file-discovery` is the cluster-scoped variant: it discovers peer clusters as endpoints, differing from the pod file discovery only in address validation. A cluster is reached by its gateway host, so an address may be an RFC-1123 hostname or an IP, not only an IPv4 pod address.
+
+A peer may serve its pool metrics on a different host or port than its routable address. Set a `metricsAddress` label (and an optional `metricsPort` label, defaulting to the endpoint port) on the entry, and the metrics source scrapes there instead of the endpoint address.

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// MultiClusterPluginType discovers peer clusters as endpoints for a cluster-scoped EPP.
+const MultiClusterPluginType = "multicluster-file-discovery"
+
+// MultiClusterFactory builds a file discovery whose endpoints are peer clusters. A
+// cluster is reached by its gateway host, so the address may be a hostname or an IP,
+// unlike the pod file discovery which requires an IPv4 pod address.
+func MultiClusterFactory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	fd, err := newFileDiscovery(MultiClusterPluginType, name, parameters, validateHostOrIP)
+	if err != nil {
+		return nil, err
+	}
+	return &multiClusterFileDiscovery{FileDiscovery: fd}, nil
+}
+
+// multiClusterFileDiscovery adds cluster-endpoint behavior the stock file discovery does not
+// carry, so the pod discovery never interprets cluster-only labels.
+type multiClusterFileDiscovery struct {
+	*FileDiscovery
+}
+
+var _ fwkdl.EndpointDiscovery = (*multiClusterFileDiscovery)(nil)
+
+// Start wraps the notifier so each endpoint's metrics host is resolved from its labels before
+// it reaches the datastore, on the initial load and every reload.
+func (m *multiClusterFileDiscovery) Start(ctx context.Context, notifier fwkdl.DiscoveryNotifier) error {
+	return m.FileDiscovery.Start(ctx, metricsHostNotifier{notifier})
+}
+
+// metricsHostNotifier resolves the metrics host from labels on each upsert.
+type metricsHostNotifier struct {
+	fwkdl.DiscoveryNotifier
+}
+
+func (n metricsHostNotifier) Upsert(meta *fwkdl.EndpointMetadata) {
+	metricsHostFromLabels(meta)
+	n.DiscoveryNotifier.Upsert(meta)
+}
+
+// metricsHostFromLabels lets a peer publish its metrics endpoint apart from its routable
+// address, via a metricsAddress label (and an optional metricsPort label, defaulting to the
+// endpoint port). A peer whose EPP serves pool metrics on a different host or port than its
+// gateway needs this. Without the label the metrics host stays the endpoint's own address.
+func metricsHostFromLabels(meta *fwkdl.EndpointMetadata) {
+	addr := meta.Labels["metricsAddress"]
+	if addr == "" {
+		return
+	}
+	port := meta.Labels["metricsPort"]
+	if port == "" {
+		port = meta.Port
+	}
+	meta.MetricsHost = net.JoinHostPort(addr, port)
+}
+
+// validateHostOrIP accepts an IP literal (v4 or v6) or an RFC-1123 DNS hostname, since a
+// cluster gateway may be reached by either.
+func validateHostOrIP(address string) error {
+	if net.ParseIP(address) != nil {
+		return nil
+	}
+	if isValidHostname(address) {
+		return nil
+	}
+	return fmt.Errorf("invalid host %q", address)
+}
+
+// isValidHostname reports whether h is an RFC-1123 hostname: dot-separated LDH labels
+// (letters, digits, hyphen) of 1-63 chars, no label starting or ending with a hyphen, an
+// optional trailing dot, and at least one letter so a numeric string cannot pass as a
+// host. It is a character scan rather than a regexp, mirroring net.isDomainName.
+func isValidHostname(h string) bool {
+	l := len(h)
+	if l == 0 || l > 254 || (l == 254 && h[l-1] != '.') {
+		return false
+	}
+	last := byte('.')
+	hasLetter := false
+	partLen := 0
+	for i := 0; i < len(h); i++ {
+		c := h[i]
+		switch {
+		default:
+			return false
+		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z':
+			hasLetter = true
+			partLen++
+		case '0' <= c && c <= '9':
+			partLen++
+		case c == '-':
+			if last == '.' { // label cannot start with a hyphen
+				return false
+			}
+			partLen++
+		case c == '.':
+			if last == '.' || last == '-' { // empty label or trailing hyphen
+				return false
+			}
+			if partLen > 63 {
+				return false
+			}
+			partLen = 0
+		}
+		last = c
+	}
+	if last == '-' || partLen > 63 {
+		return false
+	}
+	return hasLetter
+}

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// isValidHostname is exercised through TestValidateHostOrIP for character rules. This
+// covers the length boundaries directly, since net.ParseIP masks them via validateHostOrIP.
+func TestIsValidHostname(t *testing.T) {
+	label63 := strings.Repeat("a", 63)
+	label64 := strings.Repeat("a", 64)
+	name253 := strings.Join([]string{label63, label63, label63, strings.Repeat("a", 61)}, ".") // 63*3 + 61 + 3 dots
+
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "max-length label ok", host: label63, want: true},
+		{name: "label over 63 rejected", host: label64, want: false},
+		{name: "253-char name ok", host: name253, want: true},
+		{name: "254-char name without trailing dot rejected", host: name253 + "a", want: false},
+		{name: "254-char fqdn with trailing dot ok", host: name253 + ".", want: true},
+		{name: "over-length name rejected", host: strings.Repeat(label63+".", 5), want: false},
+		{name: "bare ipv4 is not a hostname", host: "10.0.0.1", want: false},
+		{name: "empty rejected", host: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isValidHostname(tc.host))
+		})
+	}
+}
+
+const clusterYAML = `
+endpoints:
+  - name: cluster-a
+    address: "gw.cluster-a.example.com"
+    port: "443"
+`
+
+func TestMultiClusterFactory_Type(t *testing.T) {
+	path := writeTemp(t, clusterYAML)
+	p, err := MultiClusterFactory("mc", fwkplugin.StrictDecoder(json.RawMessage(`{"path":"`+path+`"}`)), nil)
+	require.NoError(t, err)
+	assert.Equal(t, MultiClusterPluginType, p.TypedName().Type)
+	assert.Equal(t, "mc", p.TypedName().Name)
+}
+
+// A cluster gateway hostname is accepted and its MetricsHost is host:port.
+func TestMultiClusterFactory_AcceptsHostname(t *testing.T) {
+	path := writeTemp(t, clusterYAML)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p, err := MultiClusterFactory("mc", fwkplugin.StrictDecoder(json.RawMessage(`{"path":"`+path+`"}`)), nil)
+	require.NoError(t, err)
+	require.NoError(t, p.(fwkdl.EndpointDiscovery).Start(ctx, notifier))
+
+	require.Len(t, notifier.upserted, 1)
+	assert.Equal(t, "gw.cluster-a.example.com:443", notifier.upserted[0].MetricsHost)
+}
+
+// metricsAddress/metricsPort labels move the scrape target off the routable address, so a
+// peer can serve pool metrics on a different host or port than its gateway.
+func TestMetricsHostFromLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{name: "both labels set the metrics host", labels: map[string]string{"metricsAddress": "10.0.0.11", "metricsPort": "9090"}, want: "10.0.0.11:9090"},
+		{name: "metricsAddress alone defaults to the endpoint port", labels: map[string]string{"metricsAddress": "10.0.0.11"}, want: "10.0.0.11:8080"},
+		{name: "metricsPort alone is ignored", labels: map[string]string{"metricsPort": "9090"}, want: "10.0.0.12:8080"},
+		{name: "no labels keep the endpoint address", labels: nil, want: "10.0.0.12:8080"},
+		{name: "hostname metrics address", labels: map[string]string{"metricsAddress": "gw.example.com", "metricsPort": "443"}, want: "gw.example.com:443"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := &fwkdl.EndpointMetadata{Address: "10.0.0.12", Port: "8080", MetricsHost: "10.0.0.12:8080", Labels: tc.labels}
+			metricsHostFromLabels(meta)
+			assert.Equal(t, tc.want, meta.MetricsHost)
+		})
+	}
+}
+
+// The wrapper applies the label resolution on the upsert path, so it reaches the datastore.
+func TestMultiClusterFactory_MetricsHostFromLabels(t *testing.T) {
+	const yaml = `
+endpoints:
+  - name: split
+    address: "10.0.0.12"
+    port: "8080"
+    labels: { metricsAddress: "10.0.0.11", metricsPort: "9090" }
+`
+	path := writeTemp(t, yaml)
+	notifier := &recordingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p, err := MultiClusterFactory("mc", fwkplugin.StrictDecoder(json.RawMessage(`{"path":"`+path+`"}`)), nil)
+	require.NoError(t, err)
+	require.NoError(t, p.(fwkdl.EndpointDiscovery).Start(ctx, notifier))
+
+	require.Len(t, notifier.upserted, 1)
+	assert.Equal(t, "10.0.0.11:9090", notifier.upserted[0].MetricsHost)
+}
+
+// The stock pod discovery still rejects a hostname.
+func TestFileDiscovery_StockRejectsHostname(t *testing.T) {
+	path := writeTemp(t, clusterYAML)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := newFD(path, false).Start(ctx, &recordingNotifier{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid IPv4 address")
+}
+
+func TestValidateIPv4Address(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{name: "ipv4 ok", address: "10.0.0.1"},
+		{name: "hostname rejected", address: "gw.example.com", wantErr: true},
+		{name: "ipv6 rejected", address: "::1", wantErr: true},
+		{name: "empty rejected", address: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateIPv4Address(tc.address)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateHostOrIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{name: "ipv4 ok", address: "10.0.0.1"},
+		{name: "ipv6 ok", address: "::1"},
+		{name: "dns hostname ok", address: "gw.cluster-a.example.com"},
+		{name: "single label ok", address: "gateway"},
+		{name: "trailing dot fqdn ok", address: "gw.example.com."},
+		{name: "digit-led label ok", address: "3com.example.com"},
+		{name: "empty rejected", address: "", wantErr: true},
+		{name: "underscore rejected", address: "gw_1.example.com", wantErr: true},
+		{name: "numeric only rejected", address: "12345", wantErr: true},
+		{name: "host with colon rejected", address: "gw:443", wantErr: true},
+		{name: "control char rejected", address: "gw\x00.example.com", wantErr: true},
+		{name: "at sign rejected", address: "user@host", wantErr: true},
+		{name: "leading hyphen label rejected", address: "-bad.example.com", wantErr: true},
+		{name: "empty label rejected", address: "gw..example.com", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateHostOrIP(tc.address)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -72,6 +72,9 @@ type FileDiscovery struct {
 	typedName fwkplugin.TypedName
 	path      string
 	watchFile bool
+	// validateAddress checks an endpoint address. Injected at construction so a
+	// variant can loosen it without load() branching on the plugin type.
+	validateAddress func(string) error
 	// mu guards endpoints, which DumpState reads concurrently with load.
 	mu sync.RWMutex
 	// endpoints is the set of endpoint identities applied to the datastore
@@ -89,9 +92,15 @@ var (
 	_ fwkplugin.StateDumper   = (*FileDiscovery)(nil)
 )
 
-// Factory is the plugin factory for file-discovery.
+// Factory is the plugin factory for file-discovery. Endpoint addresses must be IPv4.
 func Factory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
-	p := &params{WatchFile: false}
+	return newFileDiscovery(PluginType, name, parameters, validateIPv4Address)
+}
+
+// newFileDiscovery decodes the shared file-discovery parameters and builds a
+// FileDiscovery with the given address validator. name defaults to pluginType.
+func newFileDiscovery(pluginType, name string, parameters *json.Decoder, validateAddress func(string) error) (*FileDiscovery, error) {
+	p := &params{}
 	if parameters != nil {
 		if err := parameters.Decode(p); err != nil {
 			return nil, fmt.Errorf("file-discovery: failed to parse parameters: %w", err)
@@ -101,15 +110,25 @@ func Factory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplug
 		return nil, errors.New("file-discovery: 'path' parameter is required")
 	}
 	if name == "" {
-		name = PluginType
+		name = pluginType
 	}
 	return &FileDiscovery{
-		typedName: fwkplugin.TypedName{Type: PluginType, Name: name},
-		path:      p.Path,
-		watchFile: p.WatchFile,
-		endpoints: make(map[types.NamespacedName]struct{}),
-		ready:     make(chan struct{}),
+		typedName:       fwkplugin.TypedName{Type: pluginType, Name: name},
+		path:            p.Path,
+		watchFile:       p.WatchFile,
+		validateAddress: validateAddress,
+		endpoints:       make(map[types.NamespacedName]struct{}),
+		ready:           make(chan struct{}),
 	}, nil
+}
+
+// validateIPv4Address requires the address to be an IPv4 literal, matching the pod
+// discovery contract.
+func validateIPv4Address(address string) error {
+	if ip := net.ParseIP(address); ip == nil || ip.To4() == nil {
+		return fmt.Errorf("invalid IPv4 address %q", address)
+	}
+	return nil
 }
 
 func (f *FileDiscovery) TypedName() fwkplugin.TypedName { return f.typedName }
@@ -238,8 +257,8 @@ func (f *FileDiscovery) load(notifier fwkdl.DiscoveryNotifier) error {
 	incoming := make(map[types.NamespacedName]struct{}, len(ef.Endpoints))
 	var errs []error
 	for _, e := range ef.Endpoints {
-		if ip := net.ParseIP(e.Address); ip == nil || ip.To4() == nil {
-			errs = append(errs, fmt.Errorf("endpoint %q: invalid IPv4 address %q", e.Name, e.Address))
+		if err := f.validateAddress(e.Address); err != nil {
+			errs = append(errs, fmt.Errorf("endpoint %q: %w", e.Name, err))
 			continue
 		}
 		if portNum, err := strconv.Atoi(e.Port); err != nil || portNum < 1 || portNum > 65535 {

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
@@ -75,10 +75,11 @@ func writeTemp(t *testing.T, content string) string {
 
 func newFD(path string, watch bool) *FileDiscovery {
 	return &FileDiscovery{
-		path:      path,
-		watchFile: watch,
-		endpoints: make(map[types.NamespacedName]struct{}),
-		ready:     make(chan struct{}),
+		path:            path,
+		watchFile:       watch,
+		validateAddress: validateIPv4Address,
+		endpoints:       make(map[types.NamespacedName]struct{}),
+		ready:           make(chan struct{}),
 	}
 }
 
@@ -337,7 +338,7 @@ func TestDumpStateCaps(t *testing.T) {
 
 func TestDumpStateConcurrentWithLoad(t *testing.T) {
 	path := writeTemp(t, "endpoints:\n- name: ep1\n  address: 10.0.0.1\n  port: \"8000\"\n")
-	f := &FileDiscovery{path: path, endpoints: map[types.NamespacedName]struct{}{}}
+	f := &FileDiscovery{path: path, validateAddress: validateIPv4Address, endpoints: map[types.NamespacedName]struct{}{}}
 	notifier := &recordingNotifier{}
 
 	var wg sync.WaitGroup

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
@@ -87,3 +87,7 @@ metadata:
 ```
 
 ```
+
+## Multi-cluster support
+
+`multicluster-metrics-extractor` is the cluster-scoped variant. It reads only a pool's aggregate metrics (`llm_d_epp_average_kv_cache_utilization`, `llm_d_epp_average_queue_size`) into the `llm-d.ai/multicluster-*` attributes the multicluster scorers read, rather than running per-pod engine extraction. Pair it with `multicluster-metrics-data-source`. See the [wiring example](../../../README.md#example).

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+)
+
+const (
+	// MultiClusterMetricsExtractorType reads only a pool's aggregate metrics, not engine metrics.
+	MultiClusterMetricsExtractorType = "multicluster-metrics-extractor"
+
+	defaultKVCacheUtilizationMetric = "llm_d_epp_average_kv_cache_utilization"
+	defaultQueueSizeMetric          = "llm_d_epp_average_queue_size"
+)
+
+type multiClusterMetricsExtractorParams struct {
+	KVCacheUtilizationMetric string `json:"kvCacheUtilizationMetric"`
+	QueueSizeMetric          string `json:"queueSizeMetric"`
+}
+
+type poolMetric struct {
+	spec *Spec
+	key  string
+}
+
+// MultiClusterMetricsExtractor writes a pool's aggregate KV-cache utilization and queue
+// size to the attributes the multicluster scorers read. The stock per-pod fields are empty
+// on a cluster-endpoint.
+type MultiClusterMetricsExtractor struct {
+	typedName fwkplugin.TypedName
+	metrics   []poolMetric
+}
+
+func NewMultiClusterMetricsExtractor(name string, params *multiClusterMetricsExtractorParams) (*MultiClusterMetricsExtractor, error) {
+	if params == nil {
+		params = &multiClusterMetricsExtractorParams{}
+	}
+	kvSpec, err := parseStringToSpec(orDefault(params.KVCacheUtilizationMetric, defaultKVCacheUtilizationMetric))
+	if err != nil {
+		return nil, fmt.Errorf("kv-cache utilization metric: %w", err)
+	}
+	queueSpec, err := parseStringToSpec(orDefault(params.QueueSizeMetric, defaultQueueSizeMetric))
+	if err != nil {
+		return nil, fmt.Errorf("queue size metric: %w", err)
+	}
+	return &MultiClusterMetricsExtractor{
+		typedName: fwkplugin.TypedName{Type: MultiClusterMetricsExtractorType, Name: name},
+		metrics: []poolMetric{
+			{spec: kvSpec, key: attrmetrics.MultiClusterKVCacheUtilizationKey},
+			{spec: queueSpec, key: attrmetrics.MultiClusterQueueSizeKey},
+		},
+	}, nil
+}
+
+func (e *MultiClusterMetricsExtractor) TypedName() fwkplugin.TypedName {
+	return e.typedName
+}
+
+// Extract writes each pool aggregate to its attribute. A missing metric is reported
+// but does not stop the others.
+func (e *MultiClusterMetricsExtractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]) error {
+	ep := in.Endpoint
+	var errs []error
+	for _, m := range e.metrics {
+		metric, err := m.spec.getLatestMetric(in.Payload)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", m.key, err))
+			continue
+		}
+		ep.GetAttributes().Put(m.key, attrmetrics.ScalarMetricValue(extractValue(metric)))
+	}
+	return errors.Join(errs...)
+}
+
+// MultiClusterMetricsExtractorFactory instantiates the extractor from configuration.
+func MultiClusterMetricsExtractorFactory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	params := &multiClusterMetricsExtractorParams{}
+	if parameters != nil {
+		if err := parameters.Decode(params); err != nil {
+			return nil, err
+		}
+	}
+	return NewMultiClusterMetricsExtractor(name, params)
+}
+
+func orDefault(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+)
+
+// TestMultiClusterMetricsPipeline is the end-to-end path: a peer cluster's pool
+// aggregates, served over httptest, flow through the multicluster source and
+// extractor into the pool attributes the multicluster scorers read. Turning those
+// attributes into scores is covered by the scorers' own tests.
+func TestMultiClusterMetricsPipeline(t *testing.T) {
+	srv := createMockServer([]MetricMock{
+		{Name: defaultKVCacheUtilizationMetric, Value: 0.62},
+		{Name: defaultQueueSizeMetric, Value: 4},
+	})
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	source, err := sourcemetrics.NewHTTPMultiClusterMetricsDataSource(u.Scheme, u.Path, "mc-source")
+	require.NoError(t, err)
+	ext, err := NewMultiClusterMetricsExtractor("mc-extractor", nil)
+	require.NoError(t, err)
+	require.NoError(t, source.AppendExtractor(ext))
+
+	ep := newEndpointAt(mustHost(t, srv.URL), nil)
+	require.NoError(t, source.Dispatch(context.Background(), ep))
+
+	kv, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), attrmetrics.MultiClusterKVCacheUtilizationKey)
+	require.True(t, ok, "pool KV-cache utilization attribute")
+	require.InDelta(t, 0.62, float64(kv), 1e-9)
+	q, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), attrmetrics.MultiClusterQueueSizeKey)
+	require.True(t, ok, "pool queue size attribute")
+	require.InDelta(t, 4, float64(q), 1e-9)
+}
+
+func gauge(v float64) *dto.MetricFamily {
+	return &dto.MetricFamily{
+		Type:   dto.MetricType_GAUGE.Enum(),
+		Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: ptr.To(v)}}},
+	}
+}
+
+func TestMultiClusterMetricsExtractor(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    sourcemetrics.PrometheusMetricMap
+		wantErr bool
+		wantKV  *float64 // nil = attribute expected absent
+		wantQ   *float64
+	}{
+		{
+			name: "both aggregates present",
+			data: sourcemetrics.PrometheusMetricMap{
+				defaultKVCacheUtilizationMetric: gauge(0.42),
+				defaultQueueSizeMetric:          gauge(7),
+			},
+			wantKV: ptr.To(0.42),
+			wantQ:  ptr.To(7.0),
+		},
+		{
+			name: "missing queue still writes kv and errors",
+			data: sourcemetrics.PrometheusMetricMap{
+				defaultKVCacheUtilizationMetric: gauge(0.9),
+			},
+			wantErr: true,
+			wantKV:  ptr.To(0.9),
+		},
+		{
+			name:    "empty map errors and writes nothing",
+			data:    sourcemetrics.PrometheusMetricMap{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ext, err := NewMultiClusterMetricsExtractor("multicluster-metrics", nil)
+			require.NoError(t, err)
+			require.Equal(t, MultiClusterMetricsExtractorType, ext.TypedName().Type)
+
+			ep := fwkdl.NewEndpoint(nil, nil)
+			err = ext.Extract(context.Background(), fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: tc.data, Endpoint: ep})
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assertAttr(t, ep, attrmetrics.MultiClusterKVCacheUtilizationKey, tc.wantKV)
+			assertAttr(t, ep, attrmetrics.MultiClusterQueueSizeKey, tc.wantQ)
+		})
+	}
+}
+
+func assertAttr(t *testing.T, ep fwkdl.Endpoint, key string, want *float64) {
+	t.Helper()
+	got, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), key)
+	if want == nil {
+		require.False(t, ok, "expected %s absent", key)
+		return
+	}
+	require.True(t, ok, "expected %s present", key)
+	require.InDelta(t, *want, float64(got), 1e-9)
+}
+
+// A custom metric name resolves to the same attribute key.
+func TestMultiClusterMetricsExtractorCustomNames(t *testing.T) {
+	ext, err := NewMultiClusterMetricsExtractor("multicluster-metrics", &multiClusterMetricsExtractorParams{
+		KVCacheUtilizationMetric: "custom_kv",
+		QueueSizeMetric:          "custom_queue",
+	})
+	require.NoError(t, err)
+
+	ep := fwkdl.NewEndpoint(nil, nil)
+	data := sourcemetrics.PrometheusMetricMap{"custom_kv": gauge(0.3), "custom_queue": gauge(2)}
+	require.NoError(t, ext.Extract(context.Background(), fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep}))
+
+	kv, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), attrmetrics.MultiClusterKVCacheUtilizationKey)
+	require.True(t, ok)
+	require.InDelta(t, 0.3, float64(kv), 1e-9)
+}
+
+func TestMultiClusterMetricsExtractorInvalidMetricName(t *testing.T) {
+	_, err := NewMultiClusterMetricsExtractor("multicluster-metrics", &multiClusterMetricsExtractorParams{KVCacheUtilizationMetric: "1_bad"})
+	require.Error(t, err)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
@@ -40,3 +40,7 @@ parameters:
   insecureSkipVerify: true
   interval: "1s"
 ```
+
+## Multi-cluster support
+
+`multicluster-metrics-data-source` is the cluster-scoped variant. It scrapes a peer cluster's metrics like the pod source, and a distinct type lets a config pair it with `multicluster-metrics-extractor` independently of the pod pipeline. Because it crosses a cluster trust boundary it verifies the peer certificate by default, unlike the pod source. Set a `caCertPath` for a private cluster CA, or `insecureSkipVerify` to opt out. The response payload is size-capped. See the [wiring example](../../../README.md#example).

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"encoding/json"
+	"io"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
+)
+
+const (
+	// MultiClusterMetricsDataSourceType scrapes like the pod metrics source. A distinct type
+	// lets a config pair it with the multicluster extractor, separate from the pod pipeline.
+	MultiClusterMetricsDataSourceType = "multicluster-metrics-data-source"
+
+	// maxResponseBytes caps the metrics payload read from a peer cluster, so a hostile or
+	// broken peer across the cross-cluster boundary cannot exhaust memory in the parser.
+	maxResponseBytes = 8 << 20 // 8 MiB
+
+	// defaultMultiClusterScheme is https, not the pod source's http: a cross-cluster scrape
+	// crosses a trust boundary, so it is encrypted and verified by default.
+	defaultMultiClusterScheme = "https"
+)
+
+// parseBoundedMetrics parses the metrics payload under maxResponseBytes.
+func parseBoundedMetrics(r io.Reader) (PrometheusMetricMap, error) {
+	return parseMetrics(io.LimitReader(r, maxResponseBytes))
+}
+
+// NewHTTPMultiClusterMetricsDataSource constructs the source with the given scheme and path.
+// Use directly in tests to bypass JSON parameter marshaling.
+func NewHTTPMultiClusterMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource[PrometheusMetricMap], error) {
+	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{},
+		MultiClusterMetricsDataSourceType, name, parseBoundedMetrics)
+}
+
+// MultiClusterMetricsDataSourceFactory instantiates the source. Unlike the pod source it
+// verifies the peer's certificate by default, given the cross-cluster trust boundary. Set
+// a caCertPath (or insecureSkipVerify) for a private cluster CA. Endpoint targeting is
+// unchanged from the pod source.
+func MultiClusterMetricsDataSourceFactory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	cfg := &metricsDatasourceParams{Scheme: defaultMultiClusterScheme, Path: defaultMetricsPath}
+
+	if parameters != nil { // overlay the defaults with configured values
+		if err := parameters.Decode(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	intervalOpt, err := http.ParseIntervalOption(cfg.Interval)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
+		http.TLSOptions{
+			SkipVerify:     cfg.InsecureSkipVerify,
+			CACertPath:     cfg.CACertPath,
+			ClientCertPath: cfg.ClientCertPath,
+			ClientKeyPath:  cfg.ClientKeyPath,
+		},
+		MultiClusterMetricsDataSourceType, name, parseBoundedMetrics, intervalOpt)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_security_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_security_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	sourcehttp "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
+)
+
+// countingReader serves n whitespace bytes and records how many were read.
+type countingReader struct {
+	n    int
+	read int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	if c.n <= 0 {
+		return 0, io.EOF
+	}
+	k := min(len(p), c.n)
+	for i := 0; i < k; i++ {
+		p[i] = ' '
+	}
+	c.n -= k
+	c.read += k
+	return k, nil
+}
+
+// A response larger than the cap is read only up to maxResponseBytes.
+func TestParseBoundedMetricsCapsResponse(t *testing.T) {
+	cr := &countingReader{n: maxResponseBytes + 4096}
+	_, err := parseBoundedMetrics(cr)
+	require.NoError(t, err)
+	require.LessOrEqual(t, cr.read, maxResponseBytes, "must not read past the cap")
+}
+
+type noopExtractor struct{}
+
+func (noopExtractor) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "noop", Name: "noop"}
+}
+
+func (noopExtractor) Extract(context.Context, fwkdl.PollInput[PrometheusMetricMap]) error {
+	return nil
+}
+
+func newSource(t *testing.T, params string) *sourcehttp.HTTPDataSource[PrometheusMetricMap] {
+	t.Helper()
+	var dec *json.Decoder
+	if params != "" {
+		dec = json.NewDecoder(strings.NewReader(params))
+	}
+	p, err := MultiClusterMetricsDataSourceFactory("mc", dec, nil)
+	require.NoError(t, err)
+	src := p.(*sourcehttp.HTTPDataSource[PrometheusMetricMap])
+	require.NoError(t, src.AppendExtractor(noopExtractor{}))
+	return src
+}
+
+// The cross-cluster source verifies the peer certificate by default (rejecting a
+// self-signed server), and honors insecureSkipVerify to opt out.
+func TestMultiClusterMetricsSourceVerifiesByDefault(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# no metrics\n"))
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	endpoint := func() fwkdl.Endpoint {
+		return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{MetricsHost: u.Host}, fwkdl.NewMetrics())
+	}
+
+	// Default: https + verify, so the self-signed cert is rejected.
+	require.Error(t, newSource(t, "").Dispatch(context.Background(), endpoint()),
+		"self-signed peer must be rejected by default")
+
+	// insecureSkipVerify opts out.
+	require.NoError(t, newSource(t, `{"insecureSkipVerify":true}`).Dispatch(context.Background(), endpoint()))
+}
+
+// A configured caCertPath flows through to the client, so a peer presenting a cert
+// signed by that CA is accepted while verification stays on.
+func TestMultiClusterMetricsSourceCACertPath(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# no metrics\n"))
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caPath,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw}), 0o600))
+
+	endpoint := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{MetricsHost: u.Host}, fwkdl.NewMetrics())
+	src := newSource(t, fmt.Sprintf(`{"caCertPath":%q}`, caPath))
+	require.NoError(t, src.Dispatch(context.Background(), endpoint),
+		"peer cert signed by the configured CA must be accepted with verification on")
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
+)
+
+// The factory returns an HTTP metrics source under the distinct multicluster type.
+func TestMultiClusterMetricsDataSourceFactory(t *testing.T) {
+	p, err := MultiClusterMetricsDataSourceFactory("multicluster-metrics", nil, nil)
+	require.NoError(t, err)
+	require.IsType(t, &http.HTTPDataSource[PrometheusMetricMap]{}, p)
+	require.Equal(t, MultiClusterMetricsDataSourceType, p.TypedName().Type)
+	require.Equal(t, "multicluster-metrics", p.TypedName().Name)
+}
+
+// A malformed interval is rejected at construction rather than silently dropped.
+func TestMultiClusterMetricsDataSourceFactoryRejectsBadInterval(t *testing.T) {
+	dec := json.NewDecoder(strings.NewReader(`{"interval":"nope"}`))
+	_, err := MultiClusterMetricsDataSourceFactory("multicluster-metrics", dec, nil)
+	require.Error(t, err)
+}
+
+// A valid interval is parsed and reaches the source.
+func TestMultiClusterMetricsDataSourceFactoryHonorsInterval(t *testing.T) {
+	dec := json.NewDecoder(strings.NewReader(`{"interval":"2s"}`))
+	p, err := MultiClusterMetricsDataSourceFactory("multicluster-metrics", dec, nil)
+	require.NoError(t, err)
+	src := p.(*http.HTTPDataSource[PrometheusMetricMap])
+	require.Equal(t, 2*time.Second, src.Interval())
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
@@ -56,3 +56,7 @@ plugins:
 ## Related Documentation
 - [Prefix Cache Scorer](../../../scheduling/scorer/prefix/README.md)
 - [Prefix Cache Affinity Filter](../../../scheduling/filter/prefixcacheaffinity/README.md)
+
+## Multi-cluster support
+
+`multicluster-approx-prefix-cache-producer` is the cluster-scoped variant. Its indexer keys on endpoint identity, so over cluster-endpoints it tracks (cluster, block) and routes a repeated prefix back to its cluster. It hashes 64-token blocks, so a shared prefix must be at least about 64 tokens to match.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package approximateprefix
+
+import (
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// MultiClusterPluginType is the explicit cluster-scoped approx-prefix producer.
+const MultiClusterPluginType = "multicluster-approx-prefix-cache-producer"
+
+// MultiClusterProducer tracks (cluster, block) instead of (pod, block): with
+// cluster-endpoints as the candidate set the stock indexer already keys on
+// endpoint identity, so this delegates without change. It exists as an explicit
+// cluster-scoped type for a complete multicluster plugin family.
+type MultiClusterProducer struct {
+	*dataProducer
+	name string
+}
+
+// MultiClusterFactory builds the cluster-scoped approx-prefix producer.
+func MultiClusterFactory(name string, rawParameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
+	inner, err := ApproxPrefixCacheFactory(name, rawParameters, handle)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiClusterProducer{dataProducer: inner.(*dataProducer), name: name}, nil
+}
+
+// TypedName reports the multi-cluster type with this instance's name. The
+// published data key stays name-based, so the prefix scorer binds unchanged.
+func (p *MultiClusterProducer) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: MultiClusterPluginType, Name: p.name}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package approximateprefix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// The factory must delegate to the stock producer (the inner.(*dataProducer)
+// type assertion) and report the multi-cluster type. A name-based data key
+// (verified elsewhere) means the delegate binds to the prefix scorer unchanged.
+func TestMultiClusterFactory(t *testing.T) {
+	h := plugin.NewEppHandle(context.Background(), nil, plugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	p, err := MultiClusterFactory("mc", nil, h)
+	require.NoError(t, err)
+	require.IsType(t, &MultiClusterProducer{}, p)
+	require.Equal(t, MultiClusterPluginType, p.TypedName().Type)
+	require.Equal(t, "mc", p.TypedName().Name)
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/README.md
@@ -52,3 +52,7 @@ Configuring both the filter and the scorer is unnecessary:
 - If they use **different** `headerName` values, the configuration is misleading: the response carries the same token under two different headers (both encode the chosen pod), so the client cannot tell which header to echo back.
 
 Choose one: the filter for a hard pin, or the scorer for a soft preference that can be outweighed by other scorers.
+
+## Multi-cluster support
+
+`multicluster-session-affinity-filter` is the cluster-scoped variant. Cluster identity comes from discovery, so it delegates to this filter unchanged and pins a session to its cluster.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sessionaffinity
+
+import (
+	"encoding/json"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+// MultiClusterFilterType is the cross-cluster session-affinity filter.
+const MultiClusterFilterType = "multicluster-session-affinity-filter"
+
+var _ fwksched.Filter = &MultiClusterFilter{}
+
+// MultiClusterFactory builds the cross-cluster session-affinity filter.
+func MultiClusterFactory(name string, params *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	inner, err := Factory(name, params, handle)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiClusterFilter{SessionAffinity: inner.(*SessionAffinity), name: name}, nil
+}
+
+// MultiClusterFilter is the explicit cluster-scoped session-affinity filter.
+// Cluster identity comes from discovery, so the stock filter already pins to the
+// right cluster-endpoint and this delegates without translation.
+type MultiClusterFilter struct {
+	*SessionAffinity
+	name string
+}
+
+// TypedName reports the multi-cluster type with this instance's name.
+func (f *MultiClusterFilter) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: MultiClusterFilterType, Name: f.name}
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sessionaffinity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// The factory must delegate to the stock filter (the inner.(*SessionAffinity)
+// type assertion) and report the multi-cluster type.
+func TestMultiClusterFactory(t *testing.T) {
+	h := fwkplugin.NewEppHandle(context.Background(), nil, fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	p, err := MultiClusterFactory("mc", nil, h)
+	require.NoError(t, err)
+	require.IsType(t, &MultiClusterFilter{}, p)
+	require.Equal(t, MultiClusterFilterType, p.TypedName().Type)
+	require.Equal(t, "mc", p.TypedName().Name)
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/README.md
@@ -45,3 +45,7 @@ schedulingProfiles:
       - pluginRef: kv-cache-util
         weight: 1
 ```
+
+## Multi-cluster support
+
+`multicluster-kv-cache-utilization-scorer` is the cluster-scoped variant. The stock per-pod KV field is empty on a cluster-endpoint, so it scores on the `llm-d.ai/multicluster-kv-cache-utilization` attribute. The `multicluster-metrics-data-source` scrapes the peer cluster and the `multicluster-metrics-extractor` writes that attribute from the pool's aggregate KV metric. Configure both in `dataLayer`, otherwise this scorer sees no pool metric and returns no score. See the [wiring example](../../../README.md#example).

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcacheutilization
+
+import (
+	"context"
+	"encoding/json"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+// MultiClusterScorerType is the cross-cluster kv-cache-utilization scorer.
+const MultiClusterScorerType = "multicluster-kv-cache-utilization-scorer"
+
+var _ fwksched.Scorer = &MultiClusterScorer{}
+
+// MultiClusterScorerFactory builds the cross-cluster kv-cache-utilization scorer.
+func MultiClusterScorerFactory(name string, params *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	inner, err := KvCacheUtilizationScorerFactory(name, params, handle)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiClusterScorer{KVCacheUtilizationScorer: inner.(*KVCacheUtilizationScorer), name: name}, nil
+}
+
+// MultiClusterScorer scores cluster endpoints from a pool-level KV-cache
+// utilization summary, read by name, instead of a single pod's scrape.
+type MultiClusterScorer struct {
+	*KVCacheUtilizationScorer
+	name string
+}
+
+// TypedName reports the multi-cluster type with this instance's name.
+func (s *MultiClusterScorer) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.name}
+}
+
+// Consumes declares the pool KV-cache utilization attribute this scorer reads.
+func (s *MultiClusterScorer) Consumes() map[string]any {
+	return map[string]any{attrmetrics.MultiClusterKVCacheUtilizationKey: attrmetrics.ScalarMetricValue(0)}
+}
+
+// Score scores each cluster endpoint as 1 - its pool KV-cache utilization.
+// Endpoints without the attribute are left unscored.
+func (s *MultiClusterScorer) Score(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
+	for _, ep := range endpoints {
+		util, ok := attrmetrics.ReadScalarMetricValue(ep, attrmetrics.MultiClusterKVCacheUtilizationKey)
+		if !ok {
+			continue
+		}
+		scores[ep] = 1 - float64(util)
+	}
+	return scores
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcacheutilization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+// The factory delegates to the stock scorer, reports the multi-cluster type, and the
+// Consumes override advertises the pool key (not the stock per-pod key).
+func TestMultiClusterScorerFactory(t *testing.T) {
+	h := fwkplugin.NewEppHandle(context.Background(), nil, fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	p, err := MultiClusterScorerFactory("mc", nil, h)
+	require.NoError(t, err)
+	require.IsType(t, &MultiClusterScorer{}, p)
+	require.Equal(t, MultiClusterScorerType, p.TypedName().Type)
+	require.Equal(t, "mc", p.TypedName().Name)
+
+	_, ok := p.(*MultiClusterScorer).Consumes()[attrmetrics.MultiClusterKVCacheUtilizationKey]
+	require.True(t, ok, "Consumes must advertise the pool KV-cache utilization key")
+}
+
+func TestMultiClusterScorer_Score(t *testing.T) {
+	newEP := func(util float64, set bool) fwksched.Endpoint {
+		attr := fwkdl.NewAttributes()
+		if set {
+			attr.Put(attrmetrics.MultiClusterKVCacheUtilizationKey, attrmetrics.ScalarMetricValue(util))
+		}
+		return fwksched.NewEndpoint(nil, nil, attr)
+	}
+
+	tests := []struct {
+		name       string
+		util       float64
+		set        bool
+		wantScore  float64
+		wantAbsent bool // absent from the result map
+	}{
+		{name: "low utilization scores high", util: 0.2, set: true, wantScore: 0.8},
+		{name: "high utilization scores low", util: 0.9, set: true, wantScore: 0.1},
+		{name: "missing attribute is unscored", set: false, wantAbsent: true},
+	}
+
+	s := &MultiClusterScorer{name: "mc"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := newEP(tt.util, tt.set)
+			scores := s.Score(context.Background(), nil, []fwksched.Endpoint{ep})
+			got, ok := scores[ep]
+			if tt.wantAbsent {
+				assert.False(t, ok)
+				return
+			}
+			assert.True(t, ok)
+			assert.InDelta(t, tt.wantScore, got, 1e-9)
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/README.md
@@ -58,3 +58,7 @@ plugins:
 
 *   **Tuning `matchLengthScaleTokens`**: This should be set to reflect your workload. A good rule of thumb is to set it to the **P95 prompt length** of your typical requests. Setting it too high (e.g., to the model's maximum limit when actual requests are short) will compress the score range and make the scorer less effective.
 *   The scorer is stateless; it does not manage cache state or hash prompts itself. It relies entirely on the data producer.
+
+## Multi-cluster support
+
+`multicluster-prefix-cache-scorer` is the cluster-scoped variant. Over cluster-endpoints it homes a repeated prefix to the cluster that served it, scoring from the per-cluster match info produced by `multicluster-approx-prefix-cache-producer`.

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefix
+
+import (
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+// MultiClusterScorerType is the explicit cluster-scoped prefix-cache scorer.
+const MultiClusterScorerType = "multicluster-prefix-cache-scorer"
+
+var _ fwksched.Scorer = &MultiClusterScorer{}
+
+// MultiClusterScorer scores cluster endpoints by prefix-cache affinity. With
+// cluster-endpoints the stock scorer already routes a repeated prefix back to
+// the cluster that served it, so this delegates without change. It exists as an
+// explicit cluster-scoped type for a complete multicluster plugin family.
+type MultiClusterScorer struct {
+	*Plugin
+	name string
+}
+
+// MultiClusterScorerFactory builds the cluster-scoped prefix-cache scorer.
+func MultiClusterScorerFactory(name string, decoder *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
+	inner, err := PrefixCachePluginFactory(name, decoder, handle)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiClusterScorer{Plugin: inner.(*Plugin), name: name}, nil
+}
+
+// TypedName reports the multi-cluster type with this instance's name.
+func (s *MultiClusterScorer) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: MultiClusterScorerType, Name: s.name}
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// The factory must delegate to the stock scorer (the inner.(*Plugin) type
+// assertion) and report the multi-cluster type.
+func TestMultiClusterScorerFactory(t *testing.T) {
+	h := plugin.NewEppHandle(context.Background(), nil, plugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	p, err := MultiClusterScorerFactory("mc", nil, h)
+	require.NoError(t, err)
+	require.IsType(t, &MultiClusterScorer{}, p)
+	require.Equal(t, MultiClusterScorerType, p.TypedName().Type)
+	require.Equal(t, "mc", p.TypedName().Name)
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/README.md
@@ -46,3 +46,7 @@ schedulingProfiles:
       - pluginRef: queue-depth
         weight: 1
 ```
+
+## Multi-cluster support
+
+`multicluster-queue-scorer` is the cluster-scoped variant. The stock per-pod queue field is empty on a cluster-endpoint, so it scores on the `llm-d.ai/multicluster-queue-size` attribute. The `multicluster-metrics-data-source` scrapes the peer cluster and the `multicluster-metrics-extractor` writes that attribute from the pool's aggregate queue metric. Configure both in `dataLayer`, otherwise this scorer sees no pool metric and returns no score. See the [wiring example](../../../README.md#example).

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queuedepth
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+// MultiClusterScorerType is the cross-cluster queue scorer.
+const MultiClusterScorerType = "multicluster-queue-scorer"
+
+var _ fwksched.Scorer = &MultiClusterScorer{}
+
+// MultiClusterScorerFactory builds the cross-cluster queue scorer.
+func MultiClusterScorerFactory(name string, params *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	inner, err := QueueScorerFactory(name, params, handle)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiClusterScorer{QueueScorer: inner.(*QueueScorer), name: name}, nil
+}
+
+// MultiClusterScorer scores cluster endpoints from a pool-level queue-depth
+// summary, read by name, instead of a single pod's scrape.
+type MultiClusterScorer struct {
+	*QueueScorer
+	name string
+}
+
+// TypedName reports the multi-cluster type with this instance's name.
+func (s *MultiClusterScorer) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.name}
+}
+
+// Consumes declares the pool queue-size attribute this scorer reads.
+func (s *MultiClusterScorer) Consumes() map[string]any {
+	return map[string]any{attrmetrics.MultiClusterQueueSizeKey: attrmetrics.ScalarMetricValue(0)}
+}
+
+// Score scores each cluster endpoint by its pool queue depth, min-max normalized
+// across the cluster candidates: the shortest queue scores 1, the longest 0, and
+// equal queues score a neutral 1. Endpoints without the attribute are unscored.
+func (s *MultiClusterScorer) Score(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	queues := make(map[fwksched.Endpoint]float64, len(endpoints))
+	minQ, maxQ := math.MaxFloat64, -math.MaxFloat64
+	for _, ep := range endpoints {
+		q, ok := attrmetrics.ReadScalarMetricValue(ep, attrmetrics.MultiClusterQueueSizeKey)
+		if !ok {
+			continue
+		}
+		queues[ep] = float64(q)
+		minQ = math.Min(minQ, float64(q))
+		maxQ = math.Max(maxQ, float64(q))
+	}
+
+	scores := make(map[fwksched.Endpoint]float64, len(queues))
+	for ep, q := range queues {
+		if maxQ == minQ {
+			scores[ep] = 1.0
+			continue
+		}
+		scores[ep] = (maxQ - q) / (maxQ - minQ)
+	}
+	return scores
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queuedepth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+// The factory delegates to the stock scorer, reports the multi-cluster type, and the
+// Consumes override advertises the pool key (not the stock per-pod key).
+func TestMultiClusterScorerFactory(t *testing.T) {
+	h := fwkplugin.NewEppHandle(context.Background(), nil, fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	p, err := MultiClusterScorerFactory("mc", nil, h)
+	require.NoError(t, err)
+	require.IsType(t, &MultiClusterScorer{}, p)
+	require.Equal(t, MultiClusterScorerType, p.TypedName().Type)
+	require.Equal(t, "mc", p.TypedName().Name)
+
+	_, ok := p.(*MultiClusterScorer).Consumes()[attrmetrics.MultiClusterQueueSizeKey]
+	require.True(t, ok, "Consumes must advertise the pool queue-size key")
+}
+
+func newQueueEP(q float64, set bool) fwksched.Endpoint {
+	attr := fwkdl.NewAttributes()
+	if set {
+		attr.Put(attrmetrics.MultiClusterQueueSizeKey, attrmetrics.ScalarMetricValue(q))
+	}
+	return fwksched.NewEndpoint(nil, nil, attr)
+}
+
+func TestMultiClusterScorer_Score(t *testing.T) {
+	q := func(v float64) *float64 { return &v }
+
+	// queues gives each endpoint's pool queue size, nil meaning the attribute is unset.
+	// want gives the expected score per endpoint, nil meaning absent from the result.
+	tests := []struct {
+		name   string
+		queues []*float64
+		want   []*float64
+	}{
+		{
+			name:   "min-max normalizes across clusters",
+			queues: []*float64{q(2), q(6), q(10)},
+			want:   []*float64{q(1.0), q(0.5), q(0.0)},
+		},
+		{
+			name:   "equal queues score neutral",
+			queues: []*float64{q(4), q(4)},
+			want:   []*float64{q(1.0), q(1.0)},
+		},
+		{
+			name:   "missing attribute is unscored",
+			queues: []*float64{nil},
+			want:   []*float64{nil},
+		},
+		{
+			name:   "unscored endpoint is ignored in normalization",
+			queues: []*float64{q(2), nil, q(10)},
+			want:   []*float64{q(1.0), nil, q(0.0)},
+		},
+	}
+
+	s := &MultiClusterScorer{name: "mc"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eps := make([]fwksched.Endpoint, len(tt.queues))
+			for i, v := range tt.queues {
+				eps[i] = newQueueEP(deref(v), v != nil)
+			}
+			scores := s.Score(context.Background(), nil, eps)
+			for i, w := range tt.want {
+				got, ok := scores[eps[i]]
+				if w == nil {
+					assert.False(t, ok, "endpoint %d should be unscored", i)
+					continue
+				}
+				assert.True(t, ok, "endpoint %d should be scored", i)
+				assert.InDelta(t, *w, got, 1e-9)
+			}
+		})
+	}
+}
+
+func deref(p *float64) float64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}


### PR DESCRIPTION
**Big thank you to @yehuditkerido and @liavweiss for your contributions to this PR. Without those PR's we would not be where we are.**


**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a multicluster plugin family for a cluster-scoped EPP whose candidate endpoints are clusters rather than pods. Each variant is co-located beside its stock plugin.

Scheduling variants:
- `multicluster-kv-cache-utilization-scorer` and `multicluster-queue-scorer` score on pool-aggregate attributes (`llm-d.ai/multicluster-kv-cache-utilization`, `llm-d.ai/multicluster-queue-size`), read by name and normalized as the stock scorers do, since the per-pod metric fields are empty on a cluster-endpoint.
- `multicluster-session-affinity-filter`, `multicluster-prefix-cache-scorer`, and `multicluster-approx-prefix-cache-producer` delegate to their stock plugins. Cluster identity comes from discovery, and the approx indexer already keys on endpoint identity, so pointing it at cluster-endpoints tracks `(cluster, block)` with no change.

Datalayer variants that populate those attributes:
- `multicluster-file-discovery` discovers peer clusters as endpoints. A cluster is reached by its gateway host, so an address may be an RFC-1123 hostname or an IP, unlike the IPv4-only pod discovery.
- `multicluster-metrics-data-source` scrapes a peer cluster and `multicluster-metrics-extractor` writes only the pool aggregates (`llm_d_epp_average_kv_cache_utilization`, `llm_d_epp_average_queue_size`) into the attributes the scorers read. Because it crosses a cluster trust boundary, the source verifies the peer certificate by default and caps the response size.

The metric scorers depend on the source and extractor being configured. See `pkg/epp/framework/plugins/README.md` for the wiring and a config example.

**Which issue(s) this PR fixes**:
Fixes https://github.com/llm-d/llm-d-router/issues/2244

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
