### PR TITLE
fix(kvevents): attribute KV events to the subscriber serving endpoint

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -73,12 +73,13 @@ func (p *Producer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMet
 	endpointKey := meta.NamespacedName.String()
 	port := p.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
 	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
+	sourceEndpoint := fmt.Sprintf("%s:%s", meta.Address, meta.Port)
 
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
 	// subscriberCtx is plugin-lifetime; caller ctx would tear subscribers
 	// down on request completion.
 	if err := p.subscribersManager.EnsureSubscriber(p.subscriberCtx, endpointKey,
-		zmqEndpoint, p.kvEventsConfig.TopicFilter, true); err != nil {
+		sourceEndpoint, zmqEndpoint, p.kvEventsConfig.TopicFilter, true); err != nil {
 		logger.Error(err, "Failed to ensure KV-events subscriber for endpoint",
 			"endpoint", endpointKey, "address", meta.Address)
 		return fmt.Errorf("ensure subscriber for %s: %w", endpointKey, err)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
@@ -196,6 +196,32 @@ func TestProducer_ExtractEndpoint_OffsetsZMQPortByRankIndex(t *testing.T) {
 	}
 }
 
+func TestProducer_EnsureSubscriber_PassesServingEndpoint(t *testing.T) {
+	cfg := kvevents.DefaultConfig()
+	cfg.DiscoverPods = true
+	cfg.PodDiscoveryConfig = kvevents.DefaultPodReconcilerConfig()
+	cfg.PodDiscoveryConfig.SocketPort = 5557
+
+	subscribers := &fakeSubscriberManager{}
+	p := &Producer{
+		typedName:          plugin.TypedName{Type: PluginType, Name: PluginType},
+		subscribersManager: subscribers,
+		kvEventsConfig:     cfg,
+		subscriberCtx:      context.Background(),
+	}
+
+	require.NoError(t, p.ensureSubscriber(context.Background(), &fwkdl.EndpointMetadata{
+		NamespacedName: k8stypes.NamespacedName{Namespace: "ns", Name: "pod-a-rank-3"},
+		Address:        "10.0.0.1",
+		Port:           "8003",
+		RankIndex:      3,
+	}))
+
+	assert.Equal(t, []string{"ns/pod-a-rank-3"}, subscribers.ids)
+	assert.Equal(t, []string{"10.0.0.1:8003"}, subscribers.sourceEndpoints)
+	assert.Equal(t, []string{"tcp://10.0.0.1:5560"}, subscribers.endpoints)
+}
+
 // RankIndex=0 must dial the base SocketPort unchanged.
 func TestProducer_ExtractEndpoint_SingleRankUsesBaseSocketPort(t *testing.T) {
 	ctx := discardCtx(t)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -73,7 +73,11 @@ var (
 // subscriberManager is the subset of kvevents.SubscriberManager the producer
 // relies on, narrowed so tests can substitute a fake.
 type subscriberManager interface {
-	EnsureSubscriber(ctx context.Context, podIdentifier, endpoint, topicFilter string, remoteSocket bool) error
+	EnsureSubscriber(
+		ctx context.Context,
+		podIdentifier, sourceEndpoint, endpoint, topicFilter string,
+		remoteSocket bool,
+	) error
 	RemoveSubscriber(ctx context.Context, podIdentifier string)
 	GetActiveSubscribers() ([]string, []string)
 	Shutdown(ctx context.Context)
@@ -183,7 +187,7 @@ func New(ctx context.Context, name string, config PluginConfig) (*Producer, erro
 
 	subscribersManager := kvevents.NewSubscriberManager(pool)
 	if config.KVEventsConfig.ZMQEndpoint != "" {
-		if err := subscribersManager.EnsureSubscriber(ctx, "local-subscriber",
+		if err := subscribersManager.EnsureSubscriber(ctx, "local-subscriber", "",
 			config.KVEventsConfig.ZMQEndpoint, config.KVEventsConfig.TopicFilter, false); err != nil {
 			return nil, fmt.Errorf("failed to create local subscriber for global socket mode: %w", err)
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -741,11 +741,19 @@ func TestNew_BlockSizeFlowsViaTokenProcessor(t *testing.T) {
 }
 
 type fakeSubscriberManager struct {
-	ids       []string
-	endpoints []string
+	ids             []string
+	sourceEndpoints []string
+	endpoints       []string
 }
 
-func (f *fakeSubscriberManager) EnsureSubscriber(_ context.Context, _, _, _ string, _ bool) error {
+func (f *fakeSubscriberManager) EnsureSubscriber(
+	_ context.Context,
+	id, sourceEndpoint, endpoint, _ string,
+	_ bool,
+) error {
+	f.ids = append(f.ids, id)
+	f.sourceEndpoints = append(f.sourceEndpoints, sourceEndpoint)
+	f.endpoints = append(f.endpoints, endpoint)
 	return nil
 }
 func (f *fakeSubscriberManager) RemoveSubscriber(_ context.Context, _ string) {}

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -63,6 +63,8 @@ type RawMessage struct {
 	Sequence uint64
 	// Payload is the raw encoded event batch bytes, not yet decoded.
 	Payload []byte
+	// SourceEndpoint is the serving endpoint associated with the subscriber.
+	SourceEndpoint string
 }
 
 // EngineAdapter defines the interface for engine-specific message parsers.

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -201,9 +201,12 @@ func (p *Pool) Shutdown(ctx context.Context) {
 
 // AddTask is called by the subscriber to add a message to the processing queue.
 // It hashes the sharding key to select a queue, ensuring messages for the
-// same pod always go to the same worker (ordered queue).
+// same source endpoint always go to the same worker (ordered queue).
 func (p *Pool) AddTask(task *RawMessage) {
-	key := p.adapter.ShardingKey(task)
+	key := task.SourceEndpoint
+	if key == "" {
+		key = p.adapter.ShardingKey(task)
+	}
 	// Use an FNV-1a hash to deterministically select a queue.
 	h := fnv.New32a()
 	_, err := h.Write([]byte(key))
@@ -254,6 +257,9 @@ func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 	if err != nil {
 		logger.Error(err, "Failed to parse message")
 		return
+	}
+	if msg.SourceEndpoint != "" {
+		podID = msg.SourceEndpoint
 	}
 
 	p.processEventBatch(ctx, &batch, podID, modelName)

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -56,6 +56,73 @@ func makeEngineKeys(n int, base uint64) []uint64 {
 	return keys
 }
 
+type sourceEndpointAdapter struct{}
+
+func (a *sourceEndpointAdapter) ParseMessage(msg *RawMessage) (string, string, EventBatch, error) {
+	return "10.0.0.1:8000", "test-model", EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{uint64(msg.Payload[0])},
+				Tokens:      makeTokens(16),
+			},
+		},
+	}, nil
+}
+
+func (a *sourceEndpointAdapter) ShardingKey(*RawMessage) string {
+	return "10.0.0.1:8000"
+}
+
+func TestProcessRawMessage_UsesSubscriberSourceEndpoint(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tokenProcessor := newTestPool(t, 16)
+	pool.adapter = &sourceEndpointAdapter{}
+
+	for i, sourceEndpoint := range []string{"10.0.0.1:8000", "10.0.0.1:8003"} {
+		pool.processRawMessage(ctx, &RawMessage{
+			Topic:          "kv@10.0.0.1:8000@test-model",
+			Payload:        []byte{byte(i + 1)},
+			SourceEndpoint: sourceEndpoint,
+		})
+	}
+
+	keys, err := tokenProcessor.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, makeTokens(16), "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	result, err := idx.Lookup(ctx, keys, nil)
+	require.NoError(t, err)
+	require.Len(t, result[keys[0]], 2)
+
+	got := []string{
+		result[keys[0]][0].PodIdentifier,
+		result[keys[0]][1].PodIdentifier,
+	}
+	assert.ElementsMatch(t, []string{"10.0.0.1:8000", "10.0.0.1:8003"}, got)
+}
+
+func TestProcessRawMessage_FallsBackToTopicEndpoint(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tokenProcessor := newTestPool(t, 16)
+	pool.adapter = &sourceEndpointAdapter{}
+
+	pool.processRawMessage(ctx, &RawMessage{
+		Topic:   "kv@10.0.0.1:8000@test-model",
+		Payload: []byte{1},
+	})
+
+	keys, err := tokenProcessor.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, makeTokens(16), "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	result, err := idx.Lookup(ctx, keys, nil)
+	require.NoError(t, err)
+	require.Len(t, result[keys[0]], 1)
+	assert.Equal(t, "10.0.0.1:8000", result[keys[0]][0].PodIdentifier)
+}
+
 // TestCanonicalWritePath_FallbackLegacy verifies that when BlockSize equals
 // the engine block size, the pool takes the 1:1 path: engine keys are passed
 // directly to Index.Add with 1:1 mapping.

--- a/pkg/kvevents/subscriber_manager.go
+++ b/pkg/kvevents/subscriber_manager.go
@@ -34,9 +34,10 @@ type SubscriberManager struct {
 
 // subscriberEntry represents a single subscriber and its cancellation.
 type subscriberEntry struct {
-	subscriber *zmqSubscriber
-	cancel     context.CancelFunc
-	endpoint   string
+	subscriber     *zmqSubscriber
+	cancel         context.CancelFunc
+	endpoint       string
+	sourceEndpoint string
 	// done is closed once the subscriber's goroutine has returned.
 	done chan struct{}
 }
@@ -50,9 +51,12 @@ func NewSubscriberManager(pool *Pool) *SubscriberManager {
 }
 
 // EnsureSubscriber ensures a subscriber exists for the given pod.
-// If the subscriber already exists with the same endpoint, it's a no-op.
-// If the endpoint changed, the old subscriber is removed and a new one is created.
-func (sm *SubscriberManager) EnsureSubscriber(ctx context.Context, podIdentifier, endpoint, topicFilter string,
+// If the subscriber already exists with the same transport and source
+// endpoints, it's a no-op. If either endpoint changed, the old subscriber is
+// removed and a new one is created.
+func (sm *SubscriberManager) EnsureSubscriber(
+	ctx context.Context,
+	podIdentifier, sourceEndpoint, endpoint, topicFilter string,
 	remoteSocket bool,
 ) error {
 	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
@@ -62,7 +66,7 @@ func (sm *SubscriberManager) EnsureSubscriber(ctx context.Context, podIdentifier
 
 	// Check if subscriber already exists
 	if entry, exists := sm.subscribers[podIdentifier]; exists {
-		if entry.endpoint == endpoint {
+		if entry.endpoint == endpoint && entry.sourceEndpoint == sourceEndpoint {
 			// Subscriber already exists with the same endpoint, nothing to do
 			debugLogger.V(logging.TRACE).Info("Subscriber already exists", "podIdentifier", podIdentifier, "endpoint", endpoint)
 			return nil
@@ -71,7 +75,9 @@ func (sm *SubscriberManager) EnsureSubscriber(ctx context.Context, podIdentifier
 		debugLogger.Info("Endpoint changed, removing old subscriber",
 			"podIdentifier", podIdentifier,
 			"oldEndpoint", entry.endpoint,
-			"newEndpoint", endpoint)
+			"newEndpoint", endpoint,
+			"oldSourceEndpoint", entry.sourceEndpoint,
+			"newSourceEndpoint", sourceEndpoint)
 		entry.cancel()
 		delete(sm.subscribers, podIdentifier)
 		// The replacement subscriber below reuses podIdentifier, so its series
@@ -80,7 +86,7 @@ func (sm *SubscriberManager) EnsureSubscriber(ctx context.Context, podIdentifier
 
 	// Create new subscriber
 	debugLogger.Info("Creating new subscriber", "podIdentifier", podIdentifier, "endpoint", endpoint)
-	subscriber := newZMQSubscriber(sm.pool, podIdentifier, endpoint, topicFilter, remoteSocket)
+	subscriber := newZMQSubscriber(sm.pool, podIdentifier, sourceEndpoint, endpoint, topicFilter, remoteSocket)
 
 	// Create a context and start subscriber
 	subCtx, cancel := context.WithCancel(ctx)
@@ -92,10 +98,11 @@ func (sm *SubscriberManager) EnsureSubscriber(ctx context.Context, podIdentifier
 
 	// Update subscribers
 	sm.subscribers[podIdentifier] = &subscriberEntry{
-		subscriber: subscriber,
-		cancel:     cancel,
-		endpoint:   endpoint,
-		done:       done,
+		subscriber:     subscriber,
+		cancel:         cancel,
+		endpoint:       endpoint,
+		sourceEndpoint: sourceEndpoint,
+		done:           done,
 	}
 	metrics.SubscriberActive.Set(float64(len(sm.subscribers)))
 

--- a/pkg/kvevents/subscriber_manager_test.go
+++ b/pkg/kvevents/subscriber_manager_test.go
@@ -47,7 +47,7 @@ func TestSubscriberManager_EnsureSubscriber(t *testing.T) {
 	endpoint := "tcp://127.0.0.1:5557"
 	topicFilter := "kv@"
 
-	err = sm.EnsureSubscriber(ctx, podID, endpoint, topicFilter, true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, topicFilter, true)
 	assert.NoError(t, err)
 
 	identifiers, endpoints := sm.GetActiveSubscribers()
@@ -56,7 +56,7 @@ func TestSubscriberManager_EnsureSubscriber(t *testing.T) {
 	assert.Contains(t, endpoints, endpoint)
 
 	// Ensure with same endpoint should be no-op
-	err = sm.EnsureSubscriber(ctx, podID, endpoint, topicFilter, true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, topicFilter, true)
 	assert.NoError(t, err)
 	identifiers, _ = sm.GetActiveSubscribers()
 	assert.Len(t, identifiers, 1)
@@ -84,7 +84,7 @@ func TestSubscriberManager_RemoveSubscriber(t *testing.T) {
 	endpoint := "tcp://127.0.0.1:5557"
 	topicFilter := "kv@"
 
-	err = sm.EnsureSubscriber(ctx, podID, endpoint, topicFilter, true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint, topicFilter, true)
 	require.NoError(t, err)
 
 	sm.RemoveSubscriber(ctx, podID)
@@ -121,7 +121,7 @@ func TestSubscriberManager_MultipleSubscribers(t *testing.T) {
 	}
 
 	for _, pod := range pods {
-		err := sm.EnsureSubscriber(ctx, pod.id, pod.endpoint, "kv@", true)
+		err := sm.EnsureSubscriber(ctx, pod.id, "", pod.endpoint, "kv@", true)
 		require.NoError(t, err)
 	}
 
@@ -163,12 +163,12 @@ func TestSubscriberManager_EndpointChange(t *testing.T) {
 	endpoint1 := "tcp://10.0.0.1:5557"
 	endpoint2 := "tcp://10.0.0.2:5557"
 
-	err = sm.EnsureSubscriber(ctx, podID, endpoint1, "kv@", true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint1, "kv@", true)
 	require.NoError(t, err)
 	identifiers, _ := sm.GetActiveSubscribers()
 	assert.Len(t, identifiers, 1)
 
-	err = sm.EnsureSubscriber(ctx, podID, endpoint2, "kv@", true)
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint2, "kv@", true)
 	require.NoError(t, err)
 
 	identifiers, endpoints := sm.GetActiveSubscribers()
@@ -202,7 +202,7 @@ func TestSubscriberManager_ConcurrentOperations(t *testing.T) {
 			defer func() { done <- true }()
 			podID := fmt.Sprintf("default/pod-%d", id)
 			endpoint := fmt.Sprintf("tcp://10.0.0.%d:5557", id)
-			if err := sm.EnsureSubscriber(ctx, podID, endpoint, "kv@", true); err != nil {
+			if err := sm.EnsureSubscriber(ctx, podID, "", endpoint, "kv@", true); err != nil {
 				t.Errorf("failed to add subscriber %s: %v", podID, err)
 			}
 		}(i)

--- a/pkg/kvevents/zmq_subscriber.go
+++ b/pkg/kvevents/zmq_subscriber.go
@@ -33,21 +33,23 @@ const (
 
 // zmqSubscriber connects to a ZMQ publisher and forwards messages to a pool.
 type zmqSubscriber struct {
-	pool          *Pool
-	podIdentifier string
-	endpoint      string
-	remote        bool
-	topicFilter   string
+	pool           *Pool
+	podIdentifier  string
+	sourceEndpoint string
+	endpoint       string
+	remote         bool
+	topicFilter    string
 }
 
 // newZMQSubscriber creates a new ZMQ subscriber.
-func newZMQSubscriber(pool *Pool, podIdentifier, endpoint, topicFilter string, remote bool) *zmqSubscriber {
+func newZMQSubscriber(pool *Pool, podIdentifier, sourceEndpoint, endpoint, topicFilter string, remote bool) *zmqSubscriber {
 	return &zmqSubscriber{
-		pool:          pool,
-		podIdentifier: podIdentifier,
-		endpoint:      endpoint,
-		remote:        remote,
-		topicFilter:   topicFilter,
+		pool:           pool,
+		podIdentifier:  podIdentifier,
+		sourceEndpoint: sourceEndpoint,
+		endpoint:       endpoint,
+		remote:         remote,
+		topicFilter:    topicFilter,
 	}
 }
 
@@ -148,9 +150,10 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 			"payloadSize", len(payload))
 
 		z.pool.AddTask(&RawMessage{
-			Topic:    topic,
-			Sequence: seq,
-			Payload:  payload,
+			Topic:          topic,
+			Sequence:       seq,
+			Payload:        payload,
+			SourceEndpoint: z.sourceEndpoint,
 		})
 	}
 }

--- a/pkg/kvevents/zmq_subscriber_test.go
+++ b/pkg/kvevents/zmq_subscriber_test.go
@@ -56,6 +56,48 @@ func buildEventBatchPayload(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
+func buildBlockStoredEventBatchPayload(t *testing.T, blockHashBase uint64, dataParallelRank int) []byte {
+	t.Helper()
+
+	tokens := make([]uint32, 64)
+	blockHashes := make([]any, 4)
+	for i := range tokens {
+		tokens[i] = uint32(i + 1) // #nosec G115 -- test data
+	}
+	for i := range blockHashes {
+		blockHashes[i] = blockHashBase + uint64(i) // #nosec G115 -- test data
+	}
+
+	blockStored := []any{
+		string(kvevents.EventTypeBlockStored),
+		blockHashes,
+		uint64(0),
+		tokens,
+		16,
+		nil,
+		"gpu",
+		nil,
+		nil,
+	}
+	payload, err := msgpack.Marshal([]any{
+		1234567890.0,
+		[]any{blockStored},
+		dataParallelRank,
+	})
+	require.NoError(t, err)
+	return payload
+}
+
+func availableEndpoint(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	ln, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	endpoint := fmt.Sprintf("tcp://%s", ln.Addr().String())
+	require.NoError(t, ln.Close())
+	return endpoint
+}
+
 // TestZMQPubSub verifies that the pure-Go ZMQ library correctly implements
 // the PUB/SUB pattern used by the zmqSubscriber.
 func TestZMQPubSub(t *testing.T) {
@@ -126,7 +168,7 @@ func TestZMQSubscriber_ReceivesMessages(t *testing.T) {
 	// Start subscriber — remote=false means it binds (Listen).
 	endpoint := "tcp://127.0.0.1:15559"
 	subManager := kvevents.NewSubscriberManager(pool)
-	err = subManager.EnsureSubscriber(ctx, "test-pod", endpoint, "kv@", false)
+	err = subManager.EnsureSubscriber(ctx, "test-pod", "", endpoint, "kv@", false)
 	require.NoError(t, err)
 
 	// Give subscriber time to bind.
@@ -154,6 +196,83 @@ func TestZMQSubscriber_ReceivesMessages(t *testing.T) {
 	subManager.Shutdown(ctx)
 }
 
+func TestZMQSubscribers_SameTopicUsesServingEndpointIdentity(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	index, err := kvblock.NewIndex(ctx, kvblock.DefaultIndexConfig())
+	require.NoError(t, err)
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
+	require.NoError(t, err)
+	pool := kvevents.NewPool(kvevents.DefaultConfig(), index, tokenProcessor, engineadapter.NewVLLMAdapter())
+	pool.Start(ctx)
+
+	subManager := kvevents.NewSubscriberManager(pool)
+	defer subManager.Shutdown(ctx)
+
+	sourceEndpoints := []string{"10.0.0.1:8000", "10.0.0.1:8003"}
+	zmqEndpoints := []string{availableEndpoint(t, ctx), availableEndpoint(t, ctx)}
+	for i := range sourceEndpoints {
+		require.NoError(t, subManager.EnsureSubscriber(
+			ctx,
+			fmt.Sprintf("test-rank-%d", i),
+			sourceEndpoints[i],
+			zmqEndpoints[i],
+			"kv@",
+			false,
+		))
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	publishers := make([]zmq4.Socket, len(zmqEndpoints))
+	for i, endpoint := range zmqEndpoints {
+		publishers[i] = zmq4.NewPub(ctx)
+		defer publishers[i].Close()
+		require.NoError(t, publishers[i].Dial(endpoint))
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	topic := []byte("kv@10.0.0.1:8000@TestModel")
+	payloads := [][]byte{
+		buildBlockStoredEventBatchPayload(t, 100, 8),
+		buildBlockStoredEventBatchPayload(t, 200, 11),
+	}
+	tokens := make([]uint32, 64)
+	for i := range tokens {
+		tokens[i] = uint32(i + 1) // #nosec G115 -- test data
+	}
+	keys, err := tokenProcessor.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, tokens, "TestModel", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, keys)
+	firstKey := keys[0]
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		for i, publisher := range publishers {
+			seq := make([]byte, 8)
+			binary.BigEndian.PutUint64(seq, uint64(i+1))
+			require.NoError(t, publisher.Send(zmq4.NewMsgFrom(topic, seq, payloads[i])))
+		}
+
+		time.Sleep(50 * time.Millisecond)
+		result, lookupErr := index.Lookup(ctx, keys, nil)
+		require.NoError(t, lookupErr)
+		if len(result[firstKey]) != 2 {
+			continue
+		}
+
+		got := []string{
+			result[firstKey][0].PodIdentifier,
+			result[firstKey][1].PodIdentifier,
+		}
+		assert.ElementsMatch(t, sourceEndpoints, got)
+		return
+	}
+
+	t.Fatal("timed out waiting for blocks from both serving endpoints")
+}
+
 // TestZMQSubscriber_ShortSequenceFrameSkipped verifies that a message with a
 // truncated sequence frame (< 8 bytes) is skipped instead of panicking.
 func TestZMQSubscriber_ShortSequenceFrameSkipped(t *testing.T) {
@@ -174,7 +293,7 @@ func TestZMQSubscriber_ShortSequenceFrameSkipped(t *testing.T) {
 	endpoint := fmt.Sprintf("tcp://%s", ln.Addr().String())
 	ln.Close()
 	subManager := kvevents.NewSubscriberManager(pool)
-	err = subManager.EnsureSubscriber(ctx, "test-pod", endpoint, "kv@", false)
+	err = subManager.EnsureSubscriber(ctx, "test-pod", "", endpoint, "kv@", false)
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

A pod running N DP ranks publishes KV events on N rank-specific ZMQ sockets that share one topic (`kv@podIP:8000@model`), and the index derives the holder identity from the topic, so all ranks' blocks collapse onto one endpoint entry. Precise scoring looks up per-rank identities (`podIP:8003`), so every rank except the topic one scores zero and `p2p-source-producer` cannot select the engine that holds the prefix.

Each per-rank subscriber already represents exactly one serving endpoint (`ensureSubscriber` registers `Address`, `Port`, `RankIndex`), so the fix binds that identity to every message it forwards: `kvevents.RawMessage.SourceEndpoint` carries the subscriber's serving endpoint, `Pool` uses it as the KV-index identity and the ordered-sharding key, and `SubscriberManager` recreates a subscriber when either its transport or source endpoint changes. The topic-derived identity remains the fallback for global-socket subscribers (`ZMQEndpoint` mode), which pass an empty source endpoint.

The identity string is `fmt.Sprintf("%s:%s", Address, Port)`, matching the read-side convention in `utils.go` and `prerequest.go` on any address family.

**Which issue(s) this PR fixes**:
Fixes #2229

**Test plan**:
- [x] Two subscribers sharing one publisher topic index their blocks under two distinct serving endpoints (real-ZMQ regression, `-race`)
- [x] Source-endpoint propagation through subscriber, pool sharding, and index identity; topic fallback when no source endpoint is set
- [x] Live on a GLM-5.2 wide-EP cell (2 pods x 8 ranks per role): a prefix seeded only on worker global rank 11 produced `scores:{"<workerIP>:8003": 45}` (45/45 block keys), `p2p-source-producer` emitted that endpoint, and the routed request completed with a verified P2P pull (consumer `kv_offload` load = tokens x 92.6 KB/token) in 2.9 s

**Release note**:
```release-note
NONE
```
