### PR TITLE
fix(sidecar): rank-endpoint P2P pulls and wide-EP port-base compensation

### DIFF
--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -595,13 +595,41 @@ each pod is a complete DP group (the per-pod DP deployment).
   `remote_port` = `--p2p-connector-port` + `r`; a port outside the rank
   range falls back to rank 0.
 - The endpoint port encodes the pod-local rank, which matches the global
-  index only when the pod is a whole DP group. In multi-pod DP groups (for
+  index only when the pod is a whole DP group. Multi-pod DP groups (for
   example LWS wide-EP, where pod `k`'s replicas hold global indices
-  `k*N..k*N+N-1` behind the same serving ports), the global index cannot
-  be read from the port and would have to be supplied with the request, so
-  those deployments are not covered.
+  `k*N..k*N+N-1` behind the same serving ports) must compensate the
+  configured socket base ports per pod; see the wide-EP example below.
 - Every replica maps its own offload region, so the pod's `/dev/shm` must
   exceed N x `cpu_bytes_to_use`.
+
+**Wide-EP (multi-pod DP groups):** vLLM adds the **global**
+`data_parallel_index` to the configured P2P and KV-events base ports, while
+the router addresses an engine by pod IP plus **pod-local** rank. Each pod
+must therefore subtract its global start rank from both configured bases so
+every pod binds the same pod-local ranges and the serving-port offset again
+names the target rank. In an LWS template with `DP_SIZE_LOCAL` ranks per
+pod:
+
+```bash
+START_RANK=$(( ${LWS_WORKER_INDEX:-0} * DP_SIZE_LOCAL ))
+P2P_BASE=$((7777 - START_RANK))
+KV_EVENTS_BASE=$((5557 - START_RANK))
+```
+
+`P2P_BASE` is the P2P secondary tier port:
+
+```json
+"secondary_tiers": [{"type": "p2p", "host": "${POD_IP}", "port": ${P2P_BASE}}]
+```
+
+`KV_EVENTS_BASE` is the KV-events publisher endpoint
+(`"endpoint": "tcp://*:${KV_EVENTS_BASE}"`), so the EPP's per-rank
+subscribers (`precise-prefix-cache-producer` dials
+`podDiscoveryConfig.socketPort` + rank index) reach each rank's socket.
+With `DP_SIZE_LOCAL: 8` every pod binds P2P `7777-7784`, KV events
+`5557-5564`, and serving `8000-8007`. Only the socket bases are
+compensated; `data_parallel_index` and the global rank carried in KV-event
+batches are unchanged.
 
 ### General Sidecar Flags
 

--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -578,10 +578,11 @@ Both prefill and decode pods require the following `--kv-transfer-config`:
 }
 ```
 
-`host` must be the pod's own IP at runtime (use the Kubernetes downward API env var `status.podIP`). `port` must match `--p2p-connector-port` (default `7777`). `cpu_bytes_to_use` controls the CPU KV offload buffer size; size it to hold the KV for the expected concurrent in-flight transfers. `OffloadingConnector` is available in vLLM nightly builds from 2026-06-30 onward (commit `bec232a`, [PR #42285](https://github.com/vllm-project/vllm/pull/42285)).
+`host` must be the pod's own IP at runtime (use the Kubernetes downward API env var `status.podIP`). `port` must match `--p2p-connector-port` (default `7777`) when each pod is a complete DP group; wide-EP worker pods instead set the compensated `P2P_BASE` (see the wide-EP paragraph below). `cpu_bytes_to_use` controls the CPU KV offload buffer size; size it to hold the KV for the expected concurrent in-flight transfers. `OffloadingConnector` is available in vLLM nightly builds from 2026-06-30 onward (commit `bec232a`, [PR #42285](https://github.com/vllm-project/vllm/pull/42285)).
 
 **Data parallelism:** the P2P tier supports `--data-parallel-size` N > 1 when
-each pod is a complete DP group (the per-pod DP deployment).
+each pod is a complete DP group (the per-pod DP deployment), or a multi-pod
+(wide-EP) group with compensated socket bases (below).
 
 - vLLM gives each DP replica its own P2P listener and offload region:
   replica `i` serves on `<p2p-connector-port>+i`, where `i` is the

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -232,11 +233,33 @@ func (s *Server) p2pPullAvailable() bool {
 // routes it to the OffloadingConnector and the NIXL fields to the
 // NixlConnector.
 func (s *Server) addP2PPullToPrefill(prefillKVParams map[string]any, kvCacheSource, prefillPodHostPort string) {
-	source, _ := strings.CutPrefix(kvCacheSource, "http://")
-	prefiller, _ := strings.CutPrefix(prefillPodHostPort, "http://")
+	source := normalizeEndpoint(kvCacheSource)
+	prefiller := normalizeEndpoint(prefillPodHostPort)
 	if source != "" && source != prefiller {
 		prefillKVParams[requestFieldRemoteKVSource] = s.p2pSourceParams(kvCacheSource)
 	}
+}
+
+// normalizeEndpoint canonicalizes an endpoint for equality comparison.
+// Scheme-qualified values (any scheme, not only http) are parsed as URLs
+// and reduced to their host:port; bare values are treated as host:port
+// directly. Both forms are re-joined through the net package so IPv6
+// literals compare consistently; values without a parseable port are
+// returned scheme-stripped, matching extractHost's fallback.
+func normalizeEndpoint(s string) string {
+	hostport := s
+	if scheme, rest, ok := strings.Cut(s, "://"); ok && scheme != "" {
+		if u, err := url.Parse(s); err == nil && u.Host != "" {
+			hostport = u.Host
+		} else {
+			hostport = rest
+		}
+	}
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return hostport
+	}
+	return net.JoinHostPort(host, port)
 }
 
 // p2pSourceParams builds the kv_transfer_params.remote_kv_source block for a

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -226,13 +226,15 @@ func (s *Server) p2pPullAvailable() bool {
 // addP2PPullToPrefill adds the OffloadingConnector P2P pull block to a prefill
 // leg's kv_transfer_params so the prefiller pulls cached prefix from
 // kvCacheSource while keeping its own computed blocks available for the
-// decoder. It is a no-op when no source is set or the source resolves to the
-// prefiller itself, since there is nothing to pull from oneself. The
+// decoder. It is a no-op when no source is set or the source is the selected
+// prefill endpoint, since there is nothing to pull from oneself. The
 // remote_kv_source key composes with NIXL params: vLLM's MultiConnector
 // routes it to the OffloadingConnector and the NIXL fields to the
 // NixlConnector.
 func (s *Server) addP2PPullToPrefill(prefillKVParams map[string]any, kvCacheSource, prefillPodHostPort string) {
-	if kvCacheSource != "" && extractHost(kvCacheSource) != extractHost(prefillPodHostPort) {
+	source, _ := strings.CutPrefix(kvCacheSource, "http://")
+	prefiller, _ := strings.CutPrefix(prefillPodHostPort, "http://")
+	if source != "" && source != prefiller {
 		prefillKVParams[requestFieldRemoteKVSource] = s.p2pSourceParams(kvCacheSource)
 	}
 }

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -236,7 +236,7 @@ func (s *Server) addP2PPullToPrefill(prefillKVParams map[string]any, kvCacheSour
 	source := normalizeEndpoint(kvCacheSource)
 	prefiller := normalizeEndpoint(prefillPodHostPort)
 	if source != "" && source != prefiller {
-		prefillKVParams[requestFieldRemoteKVSource] = s.p2pSourceParams(kvCacheSource)
+		prefillKVParams[requestFieldRemoteKVSource] = s.p2pSourceParams(source)
 	}
 }
 
@@ -275,13 +275,15 @@ func (s *Server) p2pSourceParams(sourceHostPort string) map[string]any {
 
 // p2pPortFor resolves the P2P tier control port on the target endpoint. The
 // sidecar serves rank r on <base port>+r (data_parallel.go), so the routed
-// endpoint's port encodes the pod-local rank. vLLM binds the tier at
-// <p2p-connector-port> + the global data_parallel_index, so the mapping is
-// correct when each pod is its own DP group (local rank == global index).
-// Multi-pod DP groups (e.g. LWS wide-EP) need the source's global rank
-// supplied per request instead; this derivation is the per-pod fallback. A
-// port outside the rank range (or unparsable) falls back to the base P2P
-// port, which is rank 0's tier.
+// endpoint's port encodes the pod-local rank. vLLM binds the tier at the
+// engine's configured P2P base + the global data_parallel_index, so the
+// mapping is correct when each pod is its own DP group (local rank ==
+// global index). Multi-pod DP groups (e.g. LWS wide-EP) preserve it by
+// compensating the engine's per-pod base (P2P_BASE = <p2p-connector-port>
+// - START_RANK; see docs/disaggregation.md), so every pod binds local rank
+// r at <p2p-connector-port>+r and this pod-local derivation is the
+// contract there too. A port outside the rank range (or unparsable) falls
+// back to the base P2P port, which is rank 0's tier.
 func (s *Server) p2pPortFor(targetHostPort string) int {
 	base := s.config.P2PConnectorPort
 	if s.config.DataParallelSize <= 1 || s.dpBasePort == 0 {
@@ -316,28 +318,32 @@ func (s *Server) p2pPortFor(targetHostPort string) int {
 // cached prefix blocks from the peer at sourceHostPort instead of recomputing
 // them. It replaces any client-supplied kv_transfer_params (the sidecar owns
 // that field) and routes through dispatchDecode so chunked decode still
-// applies. When sourceHostPort resolves to this pod, injecting would tell the
-// engine to pull the prefix it is already computing, so it decodes normally.
+// applies. When sourceHostPort resolves to this rank's own serving endpoint,
+// injecting would tell the engine to pull the prefix it is already
+// computing, so it decodes normally; another rank on the same pod is a
+// valid peer and does get the injection.
 func (s *Server) decodeWithP2PSource(w http.ResponseWriter, r *http.Request, sourceHostPort string) {
 	raw, requestData, ok := s.readJSONBody(r, w)
 	if !ok {
 		return
 	}
 
-	if extractHost(sourceHostPort) == os.Getenv("POD_IP") {
-		s.logger.V(logging.DEBUG).Info("KV cache source is the local pod, skipping p2p injection",
-			"source", sourceHostPort)
+	source := normalizeEndpoint(sourceHostPort)
+	self := normalizeEndpoint(net.JoinHostPort(os.Getenv("POD_IP"), s.config.Port))
+	if source == self {
+		s.logger.V(logging.DEBUG).Info("KV cache source is this rank's endpoint, skipping p2p injection",
+			"source", sourceHostPort, "self", self)
 		s.dispatchDecode(w, cloneRequestWithBody(r.Context(), r, raw), requestData)
 		return
 	}
 
-	p2pParams := s.p2pSourceParams(sourceHostPort)
+	p2pParams := s.p2pSourceParams(source)
 	// Rebuild kv_transfer_params from scratch: the sidecar owns this field, so
 	// client-supplied keys are dropped rather than forwarded to vLLM.
 	requestData[requestFieldKVTransferParams] = map[string]any{requestFieldRemoteKVSource: p2pParams}
 
 	s.logger.Info("running P2P source protocol",
-		"source_host", extractHost(sourceHostPort),
+		"source_host", extractHost(source),
 		"kv_request_id", p2pParams[requestFieldKVRequestID],
 		"p2p_connector_port", p2pParams[requestFieldRemotePort])
 

--- a/pkg/sidecar/proxy/connector_p2p_source_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_source_test.go
@@ -222,15 +222,37 @@ var _ = Describe("P2P KV cache source header", func() {
 		<-testInfo.stoppedCh
 	})
 
-	It("should not inject remote_kv_source params when the source is the local pod", func() {
+	It("should not inject remote_kv_source params when the source is this rank's endpoint", func() {
 		GinkgoT().Setenv("POD_IP", "10.9.9.9")
 		proxyBaseAddr := testInfo.startProxy()
 
-		sendRequest(proxyBaseAddr, map[string]string{routing.KVCacheSourceHeader: kvCacheSource})
+		// Self is POD_IP:<config.Port>; the harness config uses port "0", so
+		// a source of POD_IP:0 is this rank's own serving endpoint.
+		sendRequest(proxyBaseAddr, map[string]string{routing.KVCacheSourceHeader: "10.9.9.9:0"})
 
 		decodeReqs := testInfo.decodeHandler.GetCompletionRequests()
 		Expect(decodeReqs).To(HaveLen(1))
 		Expect(decodeReqs[0]).ToNot(HaveKey(requestFieldKVTransferParams))
+
+		testInfo.cancelFn()
+		<-testInfo.stoppedCh
+	})
+
+	It("should inject remote_kv_source params when the source is another rank on the local pod", func() {
+		GinkgoT().Setenv("POD_IP", "10.9.9.9")
+		proxyBaseAddr := testInfo.startProxy()
+
+		// Same pod IP, different serving port: a peer rank's cache is a valid
+		// pull source, so the guard must not collapse identity to the pod.
+		sendRequest(proxyBaseAddr, map[string]string{routing.KVCacheSourceHeader: kvCacheSource})
+
+		decodeReqs := testInfo.decodeHandler.GetCompletionRequests()
+		Expect(decodeReqs).To(HaveLen(1))
+		kvParams, ok := decodeReqs[0][requestFieldKVTransferParams].(map[string]any)
+		Expect(ok).To(BeTrue())
+		p2p, ok := kvParams[requestFieldRemoteKVSource].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(p2p[requestFieldRemoteHost]).To(Equal("10.9.9.9"))
 
 		testInfo.cancelFn()
 		<-testInfo.stoppedCh

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -199,3 +199,20 @@ var _ = Describe("p2pSourceParams", func() {
 		Expect(params[requestFieldRemotePort]).To(Equal(7779))
 	})
 })
+
+var _ = Describe("addP2PPullToPrefill", func() {
+	It("injects a pull when source and prefiller are different ranks on the same pod", func() {
+		s := &Server{
+			dpBasePort: 8000,
+			config:     Config{P2PConnectorPort: 7777, DataParallelSize: 8},
+		}
+		params := map[string]any{}
+
+		s.addP2PPullToPrefill(params, "10.0.6.107:8003", "10.0.6.107:8007")
+
+		p2p, ok := params[requestFieldRemoteKVSource].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(p2p[requestFieldRemoteHost]).To(Equal("10.0.6.107"))
+		Expect(p2p[requestFieldRemotePort]).To(Equal(7780))
+	})
+})

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -227,4 +227,42 @@ var _ = Describe("addP2PPullToPrefill", func() {
 
 		Expect(params).NotTo(HaveKey(requestFieldRemoteKVSource))
 	})
+
+	It("skips the pull when the endpoints differ only by scheme", func() {
+		s := &Server{
+			dpBasePort: 8000,
+			config:     Config{P2PConnectorPort: 7777, DataParallelSize: 8},
+		}
+		params := map[string]any{}
+
+		s.addP2PPullToPrefill(params, "https://10.0.6.107:8003", "10.0.6.107:8003")
+
+		Expect(params).NotTo(HaveKey(requestFieldRemoteKVSource))
+	})
+
+	It("still injects across ranks when the source is scheme-qualified", func() {
+		s := &Server{
+			dpBasePort: 8000,
+			config:     Config{P2PConnectorPort: 7777, DataParallelSize: 8},
+		}
+		params := map[string]any{}
+
+		s.addP2PPullToPrefill(params, "http://10.0.6.107:8003", "10.0.6.107:8007")
+
+		p2p, ok := params[requestFieldRemoteKVSource].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(p2p[requestFieldRemotePort]).To(Equal(7780))
+	})
 })
+
+var _ = DescribeTable("normalizeEndpoint",
+	func(in, want string) {
+		Expect(normalizeEndpoint(in)).To(Equal(want))
+	},
+	Entry("bare host:port unchanged", "10.0.6.107:8003", "10.0.6.107:8003"),
+	Entry("http scheme stripped", "http://10.0.6.107:8003", "10.0.6.107:8003"),
+	Entry("https scheme stripped", "https://10.0.6.107:8003", "10.0.6.107:8003"),
+	Entry("IPv6 literal canonicalized", "[::1]:8003", "[::1]:8003"),
+	Entry("portless value returned as-is", "10.0.6.107", "10.0.6.107"),
+	Entry("portless URL reduced to host", "http://10.0.6.107", "10.0.6.107"),
+)

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -215,4 +215,16 @@ var _ = Describe("addP2PPullToPrefill", func() {
 		Expect(p2p[requestFieldRemoteHost]).To(Equal("10.0.6.107"))
 		Expect(p2p[requestFieldRemotePort]).To(Equal(7780))
 	})
+
+	It("skips the pull when source and prefiller are the same endpoint", func() {
+		s := &Server{
+			dpBasePort: 8000,
+			config:     Config{P2PConnectorPort: 7777, DataParallelSize: 8},
+		}
+		params := map[string]any{}
+
+		s.addP2PPullToPrefill(params, "10.0.6.107:8003", "10.0.6.107:8003")
+
+		Expect(params).NotTo(HaveKey(requestFieldRemoteKVSource))
+	})
 })

--- a/pkg/sidecar/proxy/connector_p2p_test.go
+++ b/pkg/sidecar/proxy/connector_p2p_test.go
@@ -247,10 +247,13 @@ var _ = Describe("addP2PPullToPrefill", func() {
 		}
 		params := map[string]any{}
 
-		s.addP2PPullToPrefill(params, "http://10.0.6.107:8003", "10.0.6.107:8007")
+		// https exercises the normalized passthrough: the injected params must
+		// derive from the bare host:port, not the scheme-qualified original.
+		s.addP2PPullToPrefill(params, "https://10.0.6.107:8003", "10.0.6.107:8007")
 
 		p2p, ok := params[requestFieldRemoteKVSource].(map[string]any)
 		Expect(ok).To(BeTrue())
+		Expect(p2p[requestFieldRemoteHost]).To(Equal("10.0.6.107"))
 		Expect(p2p[requestFieldRemotePort]).To(Equal(7780))
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind documentation

**What this PR does / why we need it**:

Two changes that make the P2P source pull work on multi-rank pods:

1. The self-pull guards compared only hosts, so two DP ranks on the same pod (`10.0.6.107:8003` vs `10.0.6.107:8007`) were treated as one engine and the pull was skipped exactly where it is needed - `addP2PPullToPrefill` on the prefill leg, and `decodeWithP2PSource` on the decoder-only path (which collapsed identity to `POD_IP`). Both guards now compare full serving endpoints through a scheme-agnostic `normalizeEndpoint`: a same-pod cross-rank source is a valid peer and injects, while the selected rank's own endpoint still skips. The injected `remote_kv_source` params derive from the normalized endpoint, so scheme-qualified sources produce a bare `remote_host` and the rank-correct `remote_port`.

2. `docs/disaggregation.md` documented multi-pod DP groups (LWS wide-EP) as not covered. vLLM binds the P2P and KV-events listeners at `configured base + global data_parallel_index`, while the router addresses `pod IP + pod-local rank`; the docs now state the compensation contract that reconciles the two - each pod subtracts its global start rank from both configured bases (`P2P_BASE=$((7777 - START_RANK))`, `KV_EVENTS_BASE=$((5557 - START_RANK))`) - with the LWS formulas and the resulting per-pod port ranges. The base-port formulas themselves belong in deployment sources (guides), not router code.

**Which issue(s) this PR fixes**:
Fixes #2227

**Test plan**:
- [x] Prefill and decoder-only guards skip same-endpoint pulls and inject `remote_kv_source` for same-pod different-rank sources; scheme-qualified sources produce the correct `remote_host` and rank-specific `remote_port` (ginkgo, `-race`)
- [x] Live on a GLM-5.2 wide-EP cell with compensated bases: every pod binds P2P `7777-7784` / KV events `5557-5564` / serving `8000-8007`; a same-pod cross-rank pull (global rank 11 -> 14) completed end to end - source accept on the rank-correct port, one consumer load of tokens x 92.6 KB/token, HTTP 200 in 2.9 s

**Release note**:
```release-note
NONE
```

