### PR TITLE
fix(epp): release prefill request count at StartOfStream in inflight load producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -423,7 +423,10 @@ func (p *InFlightLoadProducer) ResponseBody(
 	// the prompt cost, which is consumed by prefill. As soon as the first chunk
 	// arrives (StartOfStream), prefill is done across all profiles, so free the
 	// token counters for every targeted endpoint regardless of profile name.
-	// Request counters are still released on EndOfStream below via PluginState.Delete.
+	// The prefill profile's entry is released in full (request counter included):
+	// the first chunk means the prefill worker has finished and handed off, so
+	// the request is no longer in flight on that endpoint. Other profiles'
+	// request counters are released on EndOfStream below via PluginState.Delete.
 	if !p.addEstimatedOutputTokens && resp.StartOfStream {
 		for profileName, profileResult := range result.ProfileResults {
 			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
@@ -433,7 +436,11 @@ func (p *InFlightLoadProducer) ResponseBody(
 			if endpoint == nil || endpoint.GetMetadata() == nil {
 				continue
 			}
-			p.releaseTokensEarly(endpoint, request, profileName)
+			if profileName == profilePrefill {
+				p.release(endpoint, request, profileName)
+			} else {
+				p.releaseTokensEarly(endpoint, request, profileName)
+			}
 		}
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -625,6 +625,49 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease(t *testin
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
 }
 
+// TestInFlightLoadProducer_ExcludeOutputTokens_PrefillReleasedAtStartOfStream verifies
+// that when AddEstimatedOutputTokens is false, the prefill profile's request counter is
+// released at StartOfStream (the first chunk means prefill has completed and handed off),
+// while the decode profile's request counter is held until EndOfStream.
+func TestInFlightLoadProducer_ExcludeOutputTokens_PrefillReleasedAtStartOfStream(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t)
+	producer.addEstimatedOutputTokens = false
+	ctx := context.Background()
+	prefillID := fullEndpointName("prefill-endpoint")
+	decodeID := fullEndpointName("decode-endpoint")
+
+	// 4 input tokens per profile. Output tokens are excluded.
+	req := makeTokenRequest("req-pd-no-output", 4)
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "decode",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint("prefill-endpoint")}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint("decode-endpoint")}},
+		},
+	}
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(prefillID))
+	require.Equal(t, int64(1), producer.requestTracker.get(decodeID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(prefillID))
+	require.Equal(t, int64(4), producer.tokenTracker.get(decodeID))
+
+	// First chunk: prefill is fully released (request included), decode keeps its
+	// request counter with tokens released.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(prefillID), "prefill request should be released at StartOfStream")
+	require.Equal(t, int64(0), producer.tokenTracker.get(prefillID))
+	require.Equal(t, int64(1), producer.requestTracker.get(decodeID), "decode request should still be held")
+	require.Equal(t, int64(0), producer.tokenTracker.get(decodeID), "decode tokens should be released at StartOfStream")
+
+	// EndOfStream releases the decode request counter.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(decodeID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(decodeID))
+}
+
 // TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk verifies that a single-chunk
 // response (StartOfStream && EndOfStream both true) releases both tokens and the request.
 func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {


### PR DESCRIPTION


With addEstimatedOutputTokens=false, the prefill profile's request counter was held until EndOfStream, overstating prefill endpoint concurrency for the entire decode phase. The first response chunk means prefill has completed and handed off, so release the prefill entry in full at StartOfStream, matching the addEstimatedOutputTokens=true path.

No current guide or well-lit path is affected: none of the shipped P/D configurations filter or score on the active request count for the prefill profile. The fix matters for deployments that add a utilization filter based on active requests on prefill endpoints, without it, the filter would act on request counts that stay inflated for the full decode duration.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.com/llm-d/llm-d-router/issues/2174
**Release note** _(write `NONE` if no user-facing change)_:
```release-note
`InFlightLoad.Requests` on prefill endpoints now drops at first token instead of staying elevated through decode. No shipped well-lit path filters on it but any deployment with a custom config that scores or filters on active request count for the prefill profile sees different behavior, and the debug state endpoint reports different numbers.
```
