### PR TITLE
perf: Reduce allocations on the response-body streaming path

### DIFF
--- a/pkg/common/envoy/metadata.go
+++ b/pkg/common/envoy/metadata.go
@@ -21,11 +21,12 @@ import (
 )
 
 func ExtractMetadataValues(req *extProcPb.ProcessingRequest) map[string]any {
-	metadata := make(map[string]any)
-	if req != nil && req.MetadataContext != nil && req.MetadataContext.FilterMetadata != nil {
-		for key, val := range req.MetadataContext.FilterMetadata {
-			metadata[key] = val.AsMap()
-		}
+	if req == nil || req.MetadataContext == nil || len(req.MetadataContext.FilterMetadata) == 0 {
+		return nil
+	}
+	metadata := make(map[string]any, len(req.MetadataContext.FilterMetadata))
+	for key, val := range req.MetadataContext.FilterMetadata {
+		metadata[key] = val.AsMap()
 	}
 	return metadata
 }

--- a/pkg/common/envoy/metadata_test.go
+++ b/pkg/common/envoy/metadata_test.go
@@ -39,12 +39,35 @@ func TestExtractMetadataValues(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		metadata map[string]*structpb.Struct
+		req      *extProcPb.ProcessingRequest
 		expected map[string]any
 	}{
 		{
-			name:     "Exact match",
-			metadata: makeFilterMetadata(),
+			name:     "Nil request",
+			req:      nil,
+			expected: nil,
+		},
+		{
+			name:     "Nil MetadataContext",
+			req:      &extProcPb.ProcessingRequest{},
+			expected: nil,
+		},
+		{
+			name: "Empty FilterMetadata",
+			req: &extProcPb.ProcessingRequest{
+				MetadataContext: &corev3.Metadata{
+					FilterMetadata: map[string]*structpb.Struct{},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "Populated metadata",
+			req: &extProcPb.ProcessingRequest{
+				MetadataContext: &corev3.Metadata{
+					FilterMetadata: makeFilterMetadata(),
+				},
+			},
 			expected: map[string]any{
 				"key-1": map[string]any{
 					"hello":      "world",
@@ -56,13 +79,7 @@ func TestExtractMetadataValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := &extProcPb.ProcessingRequest{
-				MetadataContext: &corev3.Metadata{
-					FilterMetadata: tt.metadata,
-				},
-			}
-
-			result := ExtractMetadataValues(req)
+			result := ExtractMetadataValues(tt.req)
 			if diff := cmp.Diff(result, tt.expected); diff != "" {
 				t.Errorf("ExtractMetadataValues() unexpected response (-want +got): %v", diff)
 			}

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -406,10 +406,9 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			return status.Errorf(codes.Unknown, "cannot receive stream request: %v", recvErr)
 		}
 
-		reqCtx.Request.Metadata = envoy.ExtractMetadataValues(req)
-
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
+			reqCtx.Request.Metadata = envoy.ExtractMetadataValues(req)
 			requestID := envoy.ExtractHeaderValue(v, reqcommon.RequestIDHeaderKey)
 			// request ID is a must for maintaining a state per request in plugins that hold internal state and use PluginState.
 			// if request id was not supplied as a header, we generate it ourselves.
@@ -439,6 +438,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			// Message is buffered, we can read and decode.
 			if v.RequestBody.EndOfStream {
 				loggerTrace.Info("decoding")
+				reqCtx.Request.Metadata = envoy.ExtractMetadataValues(req)
 				reqCtx.Request.RawBody = make([]byte, buf.Len())
 				copy(reqCtx.Request.RawBody, buf.Bytes())
 
@@ -494,6 +494,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		case *extProcPb.ProcessingRequest_RequestTrailers:
 			// This is currently unused.
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
+			reqCtx.Request.Metadata = envoy.ExtractMetadataValues(req)
 			respHeadersReceivedAt := time.Now()
 			for _, header := range v.ResponseHeaders.Headers.GetHeaders() {
 				value := string(header.RawValue)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -421,7 +421,6 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
-			reqCtx.Request.Metadata = envoy.ExtractMetadataValues(req)
 			requestID := envoy.ExtractHeaderValue(v, reqcommon.RequestIDHeaderKey)
 			// request ID is a must for maintaining a state per request in plugins that hold internal state and use PluginState.
 			// if request id was not supplied as a header, we generate it ourselves.
@@ -507,6 +506,9 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		case *extProcPb.ProcessingRequest_RequestTrailers:
 			// This is currently unused.
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
+			// Overwrites the request-phase value on purpose. Response-received plugins
+			// read this through Response.ReqMetadata to learn which endpoint actually
+			// served the request, and Envoy only reports that at the response phase.
 			reqCtx.Request.Metadata = envoy.ExtractMetadataValues(req)
 			respHeadersReceivedAt := time.Now()
 			for _, header := range v.ResponseHeaders.Headers.GetHeaders() {

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -530,15 +530,7 @@ func (d *Director) HandleResponseHeader(ctx context.Context, reqCtx *handlers.Re
 // plugins run synchronously because they may produce DynamicMetadata that must be attached
 // to the ext_proc response sent back to Envoy.
 func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.RequestContext, endOfStream bool) *handlers.RequestContext {
-	logger := log.FromContext(ctx).WithValues("stage", "bodyChunk")
-	loggerTrace := logger.V(logutil.TRACE)
-	if loggerTrace.Enabled() {
-		loggerTrace.Info("Entering HandleResponseBodyChunk")
-	}
 	if len(d.requestControlPlugins.responseStreamingPlugins) == 0 {
-		if loggerTrace.Enabled() {
-			loggerTrace.Info("Exiting HandleResponseBodyChunk")
-		}
 		return reqCtx
 	}
 
@@ -572,12 +564,11 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 		}
 		q := d.loadOrCreateResponseBodyQueue(reqCtx)
 		if !q.enqueue(work) {
-			logger.V(logutil.DEBUG).Info("Skipping response body chunk because the async queue is closed",
-				"requestID", reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey])
+			// Built here rather than at function entry: this path is per-chunk, and
+			// deriving a logger allocates whether or not anything is emitted.
+			log.FromContext(ctx).V(logutil.DEBUG).Info("Skipping response body chunk because the async queue is closed",
+				"stage", "bodyChunk", "requestID", reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey])
 		}
-	}
-	if loggerTrace.Enabled() {
-		loggerTrace.Info("Exiting HandleResponseBodyChunk")
 	}
 	return reqCtx
 }
@@ -609,12 +600,11 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.I
 	schedulingResult *fwksched.SchedulingResult) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.preRequestPlugins {
-		tn := plugin.TypedName()
-		loggerDebug.Info("Running PreRequest plugin", "plugin", tn)
+		loggerDebug.Info("Running PreRequest plugin", "plugin", plugin.TypedName())
 		before := time.Now()
 		plugin.PreRequest(ctx, request, schedulingResult)
-		metrics.RecordPluginProcessingLatency(fwkrc.PreRequestExtensionPoint, tn.Type, tn.Name, time.Since(before))
-		loggerDebug.Info("Completed running PreRequest plugin successfully", "plugin", tn)
+		metrics.RecordPluginProcessingLatency(fwkrc.PreRequestExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		loggerDebug.Info("Completed running PreRequest plugin successfully", "plugin", plugin.TypedName())
 	}
 }
 
@@ -624,14 +614,13 @@ func (d *Director) runRequestHeaderProcessors(ctx context.Context, request *fwks
 	}
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.requestHeaderPlugins {
-		tn := plugin.TypedName()
-		loggerDebug.Info("Running RequestHeaderProcessor plugin", "plugin", tn)
+		loggerDebug.Info("Running RequestHeaderProcessor plugin", "plugin", plugin.TypedName())
 		before := time.Now()
 		if err := plugin.RequestHeader(ctx, request); err != nil {
 			return err
 		}
-		metrics.RecordPluginProcessingLatency(fwkrc.RequestHeaderExtensionPoint, tn.Type, tn.Name, time.Since(before))
-		loggerDebug.Info("Completed running RequestHeaderProcessor plugin successfully", "plugin", tn)
+		metrics.RecordPluginProcessingLatency(fwkrc.RequestHeaderExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		loggerDebug.Info("Completed running RequestHeaderProcessor plugin successfully", "plugin", plugin.TypedName())
 	}
 	return nil
 }
@@ -656,16 +645,15 @@ func (d *Director) runAdmissionPlugins(ctx context.Context,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.admissionPlugins {
-		tn := plugin.TypedName()
-		loggerDebug.Info("Running Admit plugin", "plugin", tn)
+		loggerDebug.Info("Running Admit plugin", "plugin", plugin.TypedName())
 		before := time.Now()
 		denyReason := plugin.Admit(ctx, request, endpoints)
-		metrics.RecordPluginProcessingLatency(fwkrc.AdmissionExtensionPoint, tn.Type, tn.Name, time.Since(before))
+		metrics.RecordPluginProcessingLatency(fwkrc.AdmissionExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		if denyReason != nil {
-			loggerDebug.Info("Admit plugin denied the request", "plugin", tn, "reason", denyReason.Error())
+			loggerDebug.Info("Admit plugin denied the request", "plugin", plugin.TypedName(), "reason", denyReason.Error())
 			return denyReason
 		}
-		loggerDebug.Info("Completed running Admit plugin successfully", "plugin", tn)
+		loggerDebug.Info("Completed running Admit plugin successfully", "plugin", plugin.TypedName())
 	}
 	return nil
 }
@@ -673,27 +661,29 @@ func (d *Director) runAdmissionPlugins(ctx context.Context,
 func (d *Director) runResponseHeaderPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.responseReceivedPlugins {
-		tn := plugin.TypedName()
-		loggerDebug.Info("Running ResponseReceived plugin", "plugin", tn)
+		loggerDebug.Info("Running ResponseReceived plugin", "plugin", plugin.TypedName())
 		before := time.Now()
 		plugin.ResponseHeader(ctx, request, response, targetEndpoint)
-		metrics.RecordPluginProcessingLatency(fwkrc.ResponseReceivedExtensionPoint, tn.Type, tn.Name, time.Since(before))
-		loggerDebug.Info("Completed running ResponseReceived plugin successfully", "plugin", tn)
+		metrics.RecordPluginProcessingLatency(fwkrc.ResponseReceivedExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		loggerDebug.Info("Completed running ResponseReceived plugin successfully", "plugin", plugin.TypedName())
 	}
 }
 
 func (d *Director) runResponseBodyPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)
 	for _, plugin := range d.requestControlPlugins.responseStreamingPlugins {
-		tn := plugin.TypedName()
+		// This loop runs per response chunk, so unlike the other plugin runners it
+		// caches TypedName and guards the log calls: passing arguments to a
+		// disabled logger still boxes them into a heap-allocated slice.
+		name := plugin.TypedName()
 		if loggerTrace.Enabled() {
-			loggerTrace.Info("Running ResponseStreaming plugin", "plugin", tn)
+			loggerTrace.Info("Running ResponseStreaming plugin", "plugin", name)
 		}
 		before := time.Now()
 		plugin.ResponseBody(ctx, request, response, targetEndpoint)
-		metrics.RecordPluginProcessingLatency(fwkrc.ResponseStreamingExtensionPoint, tn.Type, tn.Name, time.Since(before))
+		metrics.RecordPluginProcessingLatency(fwkrc.ResponseStreamingExtensionPoint, name.Type, name.Name, time.Since(before))
 		if loggerTrace.Enabled() {
-			loggerTrace.Info("Completed running ResponseStreaming plugin successfully", "plugin", tn)
+			loggerTrace.Info("Completed running ResponseStreaming plugin successfully", "plugin", name)
 		}
 	}
 }

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -521,9 +521,14 @@ func (d *Director) HandleResponseHeader(ctx context.Context, reqCtx *handlers.Re
 // to the ext_proc response sent back to Envoy.
 func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.RequestContext, endOfStream bool) *handlers.RequestContext {
 	logger := log.FromContext(ctx).WithValues("stage", "bodyChunk")
-	logger.V(logutil.TRACE).Info("Entering HandleResponseBodyChunk")
+	loggerTrace := logger.V(logutil.TRACE)
+	if loggerTrace.Enabled() {
+		loggerTrace.Info("Entering HandleResponseBodyChunk")
+	}
 	if len(d.requestControlPlugins.responseStreamingPlugins) == 0 {
-		logger.V(logutil.TRACE).Info("Exiting HandleResponseBodyChunk")
+		if loggerTrace.Enabled() {
+			loggerTrace.Info("Exiting HandleResponseBodyChunk")
+		}
 		return reqCtx
 	}
 
@@ -536,7 +541,6 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 		EndOfStream:   endOfStream,
 		Usage:         reqCtx.Usage,
 	}
-	requestID := reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey]
 
 	if endOfStream {
 		// Drain the async queue: close the channel and wait for the goroutine to finish
@@ -558,10 +562,13 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 		}
 		q := d.loadOrCreateResponseBodyQueue(reqCtx)
 		if !q.enqueue(work) {
-			logger.V(logutil.DEBUG).Info("Skipping response body chunk because the async queue is closed", "requestID", requestID)
+			logger.V(logutil.DEBUG).Info("Skipping response body chunk because the async queue is closed",
+				"requestID", reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey])
 		}
 	}
-	logger.V(logutil.TRACE).Info("Exiting HandleResponseBodyChunk")
+	if loggerTrace.Enabled() {
+		loggerTrace.Info("Exiting HandleResponseBodyChunk")
+	}
 	return reqCtx
 }
 
@@ -592,11 +599,12 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.I
 	schedulingResult *fwksched.SchedulingResult) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.preRequestPlugins {
-		loggerDebug.Info("Running PreRequest plugin", "plugin", plugin.TypedName())
+		tn := plugin.TypedName()
+		loggerDebug.Info("Running PreRequest plugin", "plugin", tn)
 		before := time.Now()
 		plugin.PreRequest(ctx, request, schedulingResult)
-		metrics.RecordPluginProcessingLatency(fwkrc.PreRequestExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
-		loggerDebug.Info("Completed running PreRequest plugin successfully", "plugin", plugin.TypedName())
+		metrics.RecordPluginProcessingLatency(fwkrc.PreRequestExtensionPoint, tn.Type, tn.Name, time.Since(before))
+		loggerDebug.Info("Completed running PreRequest plugin successfully", "plugin", tn)
 	}
 }
 
@@ -606,13 +614,14 @@ func (d *Director) runRequestHeaderProcessors(ctx context.Context, request *fwks
 	}
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.requestHeaderPlugins {
-		loggerDebug.Info("Running RequestHeaderProcessor plugin", "plugin", plugin.TypedName())
+		tn := plugin.TypedName()
+		loggerDebug.Info("Running RequestHeaderProcessor plugin", "plugin", tn)
 		before := time.Now()
 		if err := plugin.RequestHeader(ctx, request); err != nil {
 			return err
 		}
-		metrics.RecordPluginProcessingLatency(fwkrc.RequestHeaderExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
-		loggerDebug.Info("Completed running RequestHeaderProcessor plugin successfully", "plugin", plugin.TypedName())
+		metrics.RecordPluginProcessingLatency(fwkrc.RequestHeaderExtensionPoint, tn.Type, tn.Name, time.Since(before))
+		loggerDebug.Info("Completed running RequestHeaderProcessor plugin successfully", "plugin", tn)
 	}
 	return nil
 }
@@ -637,15 +646,16 @@ func (d *Director) runAdmissionPlugins(ctx context.Context,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.admissionPlugins {
-		loggerDebug.Info("Running Admit plugin", "plugin", plugin.TypedName())
+		tn := plugin.TypedName()
+		loggerDebug.Info("Running Admit plugin", "plugin", tn)
 		before := time.Now()
 		denyReason := plugin.Admit(ctx, request, endpoints)
-		metrics.RecordPluginProcessingLatency(fwkrc.AdmissionExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		metrics.RecordPluginProcessingLatency(fwkrc.AdmissionExtensionPoint, tn.Type, tn.Name, time.Since(before))
 		if denyReason != nil {
-			loggerDebug.Info("Admit plugin denied the request", "plugin", plugin.TypedName(), "reason", denyReason.Error())
+			loggerDebug.Info("Admit plugin denied the request", "plugin", tn, "reason", denyReason.Error())
 			return denyReason
 		}
-		loggerDebug.Info("Completed running Admit plugin successfully", "plugin", plugin.TypedName())
+		loggerDebug.Info("Completed running Admit plugin successfully", "plugin", tn)
 	}
 	return nil
 }
@@ -653,22 +663,28 @@ func (d *Director) runAdmissionPlugins(ctx context.Context,
 func (d *Director) runResponseHeaderPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.responseReceivedPlugins {
-		loggerDebug.Info("Running ResponseReceived plugin", "plugin", plugin.TypedName())
+		tn := plugin.TypedName()
+		loggerDebug.Info("Running ResponseReceived plugin", "plugin", tn)
 		before := time.Now()
 		plugin.ResponseHeader(ctx, request, response, targetEndpoint)
-		metrics.RecordPluginProcessingLatency(fwkrc.ResponseReceivedExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
-		loggerDebug.Info("Completed running ResponseReceived plugin successfully", "plugin", plugin.TypedName())
+		metrics.RecordPluginProcessingLatency(fwkrc.ResponseReceivedExtensionPoint, tn.Type, tn.Name, time.Since(before))
+		loggerDebug.Info("Completed running ResponseReceived plugin successfully", "plugin", tn)
 	}
 }
 
 func (d *Director) runResponseBodyPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)
 	for _, plugin := range d.requestControlPlugins.responseStreamingPlugins {
-		loggerTrace.Info("Running ResponseStreaming plugin", "plugin", plugin.TypedName())
+		tn := plugin.TypedName()
+		if loggerTrace.Enabled() {
+			loggerTrace.Info("Running ResponseStreaming plugin", "plugin", tn)
+		}
 		before := time.Now()
 		plugin.ResponseBody(ctx, request, response, targetEndpoint)
-		metrics.RecordPluginProcessingLatency(fwkrc.ResponseStreamingExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
-		loggerTrace.Info("Completed running ResponseStreaming plugin successfully", "plugin", plugin.TypedName())
+		metrics.RecordPluginProcessingLatency(fwkrc.ResponseStreamingExtensionPoint, tn.Type, tn.Name, time.Since(before))
+		if loggerTrace.Enabled() {
+			loggerTrace.Info("Completed running ResponseStreaming plugin successfully", "plugin", tn)
+		}
 	}
 }
 

--- a/pkg/epp/requestcontrol/director_bench_test.go
+++ b/pkg/epp/requestcontrol/director_bench_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestcontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
+)
+
+const (
+	benchChunksPerOp = 10
+	// maxAllocsPerResponse is the allocation ceiling for one complete
+	// response (benchChunksPerOp intermediate chunks + 1 end-of-stream).
+	// Bump this intentionally when a change adds justified allocations.
+	maxAllocsPerResponse = 60
+)
+
+func TestHandleResponseBodyAllocs(t *testing.T) {
+	plugin := newTestResponseStreaming("alloc-plugin")
+	director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil,
+		NewConfig().WithResponseStreamingPlugins(plugin))
+
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+
+	avg := testing.AllocsPerRun(100, func() {
+		reqCtx := &handlers.RequestContext{
+			Request: &handlers.Request{
+				Headers: map[string]string{
+					reqcommon.RequestIDHeaderKey: "alloc-request",
+				},
+			},
+			Response: &handlers.Response{
+				Headers: map[string]string{},
+			},
+			TargetPod: &fwkdl.EndpointMetadata{
+				NamespacedName: types.NamespacedName{Namespace: "ns", Name: "pod"},
+			},
+			Usage: fwkrh.Usage{},
+		}
+		for chunk := 0; chunk < benchChunksPerOp; chunk++ {
+			director.HandleResponseBody(ctx, reqCtx, false)
+		}
+		director.HandleResponseBody(ctx, reqCtx, true)
+
+		plugin.mu.Lock()
+		plugin.respsOnStreaming = plugin.respsOnStreaming[:0]
+		plugin.targetPodsOnStreaming = plugin.targetPodsOnStreaming[:0]
+		plugin.mu.Unlock()
+	})
+	if avg > maxAllocsPerResponse {
+		t.Errorf("HandleResponseBody allocations regressed: got %.0f, ceiling %d", avg, maxAllocsPerResponse)
+	}
+}
+
+// BenchmarkHandleResponseBody measures the per-response cost of
+// Director.HandleResponseBody with one streaming plugin registered.
+// Each operation simulates 10 intermediate chunks followed by one
+// end-of-stream chunk.
+//
+// Run:
+//
+//	go test -run='^$' -bench=BenchmarkHandleResponseBody -benchmem -count=10 \
+//	    ./pkg/epp/requestcontrol/ | tee bench.out
+//	benchstat bench.out
+func BenchmarkHandleResponseBody(b *testing.B) {
+	plugin := newTestResponseStreaming("bench-plugin")
+	director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil,
+		NewConfig().WithResponseStreamingPlugins(plugin))
+
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reqCtx := &handlers.RequestContext{
+			Request: &handlers.Request{
+				Headers: map[string]string{
+					reqcommon.RequestIDHeaderKey: "bench-request",
+				},
+			},
+			Response: &handlers.Response{
+				Headers: map[string]string{},
+			},
+			TargetPod: &fwkdl.EndpointMetadata{
+				NamespacedName: types.NamespacedName{Namespace: "ns", Name: "pod"},
+			},
+			Usage: fwkrh.Usage{},
+		}
+
+		for chunk := 0; chunk < benchChunksPerOp; chunk++ {
+			director.HandleResponseBody(ctx, reqCtx, false)
+		}
+		// Wait for async queue to drain before the final synchronous chunk.
+		director.HandleResponseBody(ctx, reqCtx, true)
+
+		// Reset plugin state for the next iteration.
+		plugin.mu.Lock()
+		plugin.respsOnStreaming = plugin.respsOnStreaming[:0]
+		plugin.targetPodsOnStreaming = plugin.targetPodsOnStreaming[:0]
+		plugin.mu.Unlock()
+	}
+}

--- a/pkg/epp/requestcontrol/director_bench_test.go
+++ b/pkg/epp/requestcontrol/director_bench_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-logr/logr"
+	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
@@ -32,43 +34,61 @@ import (
 
 const (
 	benchChunksPerOp = 10
-	// maxAllocsPerResponse is the allocation ceiling for one complete
-	// response (benchChunksPerOp intermediate chunks + 1 end-of-stream).
-	// Bump this intentionally when a change adds justified allocations.
-	maxAllocsPerResponse = 60
+	// maxAllocsPerResponse caps allocations per response; a failure is a
+	// regression to investigate, not a number to raise.
+	maxAllocsPerResponse = 65
 )
 
-func TestHandleResponseBodyAllocs(t *testing.T) {
-	plugin := newTestResponseStreaming("alloc-plugin")
+// newStreamingDirectorFixture builds a Director with one streaming plugin and
+// a production-verbosity logger (DEBUG/TRACE disabled) so the benchmark
+// measures the allocation cost production actually pays.
+func newStreamingDirectorFixture(name string) (*Director, *testResponseStreaming, context.Context) {
+	plugin := newTestResponseStreaming(name)
 	director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil,
 		NewConfig().WithResponseStreamingPlugins(plugin))
+	// Info level leaves V(DEBUG) and V(TRACE) disabled, as in production. A
+	// discarding logger would hide the cost of deriving one, which is exactly
+	// what this benchmark exists to track.
+	logger := crzap.New(crzap.Level(uberzap.NewAtomicLevelAt(zapcore.InfoLevel)))
+	ctx := log.IntoContext(context.Background(), logger)
+	return director, plugin, ctx
+}
 
-	ctx := log.IntoContext(context.Background(), logr.Discard())
+func newStreamingRequestContext(requestID string) *handlers.RequestContext {
+	return &handlers.RequestContext{
+		Request: &handlers.Request{
+			Headers: map[string]string{reqcommon.RequestIDHeaderKey: requestID},
+		},
+		Response: &handlers.Response{
+			Headers: map[string]string{},
+		},
+		TargetPod: &fwkdl.EndpointMetadata{
+			ID: types.NamespacedName{Namespace: "ns", Name: "pod"},
+		},
+		Usage: fwkrh.Usage{},
+	}
+}
+
+// streamOneResponse runs one full response and resets state for reuse.
+func streamOneResponse(ctx context.Context, director *Director, reqCtx *handlers.RequestContext, plugin *testResponseStreaming) {
+	for chunk := 0; chunk < benchChunksPerOp; chunk++ {
+		director.HandleResponseBody(ctx, reqCtx, false)
+	}
+	director.HandleResponseBody(ctx, reqCtx, true)
+
+	reqCtx.ResponseBodyStarted = false
+	plugin.mu.Lock()
+	plugin.respsOnStreaming = plugin.respsOnStreaming[:0]
+	plugin.targetPodsOnStreaming = plugin.targetPodsOnStreaming[:0]
+	plugin.mu.Unlock()
+}
+
+func TestHandleResponseBodyAllocs(t *testing.T) {
+	director, plugin, ctx := newStreamingDirectorFixture("alloc-plugin")
+	reqCtx := newStreamingRequestContext("alloc-request")
 
 	avg := testing.AllocsPerRun(100, func() {
-		reqCtx := &handlers.RequestContext{
-			Request: &handlers.Request{
-				Headers: map[string]string{
-					reqcommon.RequestIDHeaderKey: "alloc-request",
-				},
-			},
-			Response: &handlers.Response{
-				Headers: map[string]string{},
-			},
-			TargetPod: &fwkdl.EndpointMetadata{
-				ID: types.NamespacedName{Namespace: "ns", Name: "pod"},
-			},
-			Usage: fwkrh.Usage{},
-		}
-		for chunk := 0; chunk < benchChunksPerOp; chunk++ {
-			director.HandleResponseBody(ctx, reqCtx, false)
-		}
-		director.HandleResponseBody(ctx, reqCtx, true)
-
-		plugin.mu.Lock()
-		plugin.respsOnStreaming = plugin.respsOnStreaming[:0]
-		plugin.targetPodsOnStreaming = plugin.targetPodsOnStreaming[:0]
-		plugin.mu.Unlock()
+		streamOneResponse(ctx, director, reqCtx, plugin)
 	})
 	if avg > maxAllocsPerResponse {
 		t.Errorf("HandleResponseBody allocations regressed: got %.0f, ceiling %d", avg, maxAllocsPerResponse)
@@ -86,40 +106,12 @@ func TestHandleResponseBodyAllocs(t *testing.T) {
 //	    ./pkg/epp/requestcontrol/ | tee bench.out
 //	benchstat bench.out
 func BenchmarkHandleResponseBody(b *testing.B) {
-	plugin := newTestResponseStreaming("bench-plugin")
-	director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil,
-		NewConfig().WithResponseStreamingPlugins(plugin))
-
-	ctx := log.IntoContext(context.Background(), logr.Discard())
+	director, plugin, ctx := newStreamingDirectorFixture("bench-plugin")
+	reqCtx := newStreamingRequestContext("bench-request")
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		reqCtx := &handlers.RequestContext{
-			Request: &handlers.Request{
-				Headers: map[string]string{
-					reqcommon.RequestIDHeaderKey: "bench-request",
-				},
-			},
-			Response: &handlers.Response{
-				Headers: map[string]string{},
-			},
-			TargetPod: &fwkdl.EndpointMetadata{
-				ID: types.NamespacedName{Namespace: "ns", Name: "pod"},
-			},
-			Usage: fwkrh.Usage{},
-		}
-
-		for chunk := 0; chunk < benchChunksPerOp; chunk++ {
-			director.HandleResponseBody(ctx, reqCtx, false)
-		}
-		// Wait for async queue to drain before the final synchronous chunk.
-		director.HandleResponseBody(ctx, reqCtx, true)
-
-		// Reset plugin state for the next iteration.
-		plugin.mu.Lock()
-		plugin.respsOnStreaming = plugin.respsOnStreaming[:0]
-		plugin.targetPodsOnStreaming = plugin.targetPodsOnStreaming[:0]
-		plugin.mu.Unlock()
+		streamOneResponse(ctx, director, reqCtx, plugin)
 	}
 }

--- a/pkg/epp/requestcontrol/director_bench_test.go
+++ b/pkg/epp/requestcontrol/director_bench_test.go
@@ -56,7 +56,7 @@ func TestHandleResponseBodyAllocs(t *testing.T) {
 				Headers: map[string]string{},
 			},
 			TargetPod: &fwkdl.EndpointMetadata{
-				NamespacedName: types.NamespacedName{Namespace: "ns", Name: "pod"},
+				ID: types.NamespacedName{Namespace: "ns", Name: "pod"},
 			},
 			Usage: fwkrh.Usage{},
 		}
@@ -105,7 +105,7 @@ func BenchmarkHandleResponseBody(b *testing.B) {
 				Headers: map[string]string{},
 			},
 			TargetPod: &fwkdl.EndpointMetadata{
-				NamespacedName: types.NamespacedName{Namespace: "ns", Name: "pod"},
+				ID: types.NamespacedName{Namespace: "ns", Name: "pod"},
 			},
 			Usage: fwkrh.Usage{},
 		}

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -24,9 +24,11 @@ import (
 	"strconv"
 	"testing"
 
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -48,6 +50,15 @@ const (
 	poolPort   = int32(5678)
 	namespace  = "ns1"
 )
+
+func testMetadataContext(t *testing.T, phase string) *corev3.Metadata {
+	t.Helper()
+	value, err := structpb.NewStruct(map[string]any{"phase": phase})
+	require.NoError(t, err)
+	return &corev3.Metadata{
+		FilterMetadata: map[string]*structpb.Struct{"test": value},
+	}
+}
 
 func TestServer(t *testing.T) {
 	tests := []struct {
@@ -152,6 +163,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 		Request: &pb.ProcessingRequest_RequestHeaders{
 			RequestHeaders: headers,
 		},
+		MetadataContext: testMetadataContext(t, "headers"),
 	}
 	err := process.Send(request)
 	if err != nil {
@@ -170,6 +182,7 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 				EndOfStream: true,
 			},
 		},
+		MetadataContext: testMetadataContext(t, "body"),
 	}
 	err = process.Send(request)
 	if err != nil {
@@ -218,6 +231,9 @@ func runStreamingTest(t *testing.T, streamInRequest bool, streamingResponse bool
 			t.Errorf("Incorrect value for header %s, want %s got %s", expectedKey, expectedValue, got)
 		}
 	}
+	require.Equal(t, map[string]any{
+		"test": map[string]any{"phase": "body"},
+	}, director.requestMetadata)
 
 	// Send response headers
 	if streamingResponse {
@@ -346,12 +362,14 @@ func recvResponseTrailers(stream pb.ExternalProcessor_ProcessClient) error {
 
 type testDirector struct {
 	requestHeaders                   map[string]string
+	requestMetadata                  map[string]any
 	handleResponseBodyEndStreamCount int
 	lastInferenceRequestBody         *fwkrh.InferenceRequestBody
 }
 
 func (ts *testDirector) HandleRequest(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (*handlers.RequestContext, error) {
 	ts.requestHeaders = reqCtx.Request.Headers
+	ts.requestMetadata = reqCtx.Request.Metadata
 	ts.lastInferenceRequestBody = inferenceRequestBody
 
 	bodyMap := make(map[string]any)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The EPP response-body hot path allocates on every streaming chunk for operations that are either unnecessary at that phase or can be simply avoided. Under sustained load (~40 req/s, streaming, `gpt-oss-120b`) GC dominates the CPU profile (`lfstack.pop`, `gcDrainN`, and `getempty` together consume over 50% of total CPU time). 

**Which issue(s) this PR fixes**:

This PR targets the three cheapest wins on that path:

1. Per-phase metadata extraction instead of every-request: `ExtractMetadataValues` was called unconditionally before the phase switch, allocating a map on every message including intermediate response-body chunks that never use metadata. Moved the call into the three cases that consume it (request headers, end-of-stream body, response headers) so intermediate chunks pay nothing.

2. Guarded TRACE logging with `.Enabled()` checks: `HandleResponseBody` and `runResponseBodyPlugins` are called per chunk. Unconditional `logger.V(TRACE).Info(...)` calls allocate zap encoder clones even when TRACE is disabled. Added `.Enabled()` guards on the per-chunk path.

3. Cached `plugin.TypedName()` into a local variable: Each `run*Plugins` loop called `plugin.TypedName()` 2-4 times per plugin per request (for logging and metrics). `TypedName()` is an interface method returning a two-string struct; caching it in a local avoids repeated virtual dispatch and copies.

**Test plan**: All existing and new added tests pass. 

Profiles (30s window, ~1,090-1,170 requests, openai/gpt-oss-120b) collected on the same node under the same load (~40 req/s steady-state). PRE uses the upstream v0.9.0 image; POST uses the `perf/reduce-response-streaming-allocs` build.

*Runtime metrics (go_memstats, 30s delta):*

| Metric | PRE (v0.9.0) | POST (`perf/reduce-response-streaming-allocs`) | Delta |
|--------|-------------|---------------|-------|
| Bytes allocated | 8.02 GB | 5.24 GB | **-34.7%** |
| Malloc count | 91.5M | 72.8M | **-20.5%** |
| GC cycles | 43 | 23 | **-46.5%** |
| GC wall time | 43.8 ms | 21.8 ms | **-50.1%** |
| Total CPU (all cores) | 243.1 s | 144.2 s | **-40.7%** |

*Response-body path allocations (pprof alloc_objects, focused on HandleResponseBody + related):*

| Function | PRE (v0.9.0) | POST (`perf/reduce-response-streaming-allocs`) | Delta |
|----------|-----|------|-------|
| `ExtractMetadataValues` (flat) | 1,518,320 | 0 | **-100%** |
| `Director.HandleResponseBody` (cum) | 17,110,843 | 0 | **-100%** |
| `HandleResponseBody` full path (cum) | 26,797,938 | 8,598,881 | **-67.9%** |
| `zapLogger.WithValues` (flat) | 4,718,807 | 1,693,089 | **-64.1%** |

*CPU breakdown: GC + memory management (`lfstack.pop`, `gcDrainN`, `getempty`, `gcDrain`):*

| | PRE (v0.9.0) | POST (`perf/reduce-response-streaming-allocs`) | Delta |
|---|-----|------|-------|
| GC-related CPU | 103.1 s | 17.3 s | **-83.2%** |

The response-body path fires per chunk (high frequency), so small per-call savings compound across millions of chunks per window. The net effect is an 83% reduction in GC CPU and 46.5% fewer GC cycles under comparable load.

**Release note** _(write `NONE` if no user-facing change)_:
`NONE`