### PR TITLE
fix: use renamed EndpointMetadata.ID in tests after #2147

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -414,7 +414,7 @@ func TestDetector_StaleEndpointObservability(t *testing.T) {
 		makePodMetric("fresh", 1, 0.1, baseTime),
 		makePodMetric("stale", 1, 0.1, baseTime.Add(-2*time.Hour)),
 		fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-			NamespacedName: types.NamespacedName{Name: "nil-metrics", Namespace: "ns1"},
+			ID: types.NamespacedName{Name: "nil-metrics", Namespace: "ns1"},
 		}, nil),
 	}
 

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -367,29 +367,29 @@ func TestDirector_HandleRequest(t *testing.T) {
 
 	scoredEndpoint1 := &fwksched.ScoredEndpoint{
 		Endpoint: fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-			Address:        "192.168.1.100",
-			Port:           "8000",
-			MetricsHost:    "192.168.1.100:8000",
-			NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
+			Address:     "192.168.1.100",
+			Port:        "8000",
+			MetricsHost: "192.168.1.100:8000",
+			ID:          types.NamespacedName{Name: "pod1", Namespace: "default"},
 		}, nil, nil),
 		Score: 0.91,
 	}
 	scoredEndpoint2 := &fwksched.ScoredEndpoint{
 		Endpoint: fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-			Address:        "192.168.2.100",
-			Port:           "8000",
-			MetricsHost:    "192.168.2.100:8000",
-			NamespacedName: types.NamespacedName{Name: "pod2", Namespace: "default"},
+			Address:     "192.168.2.100",
+			Port:        "8000",
+			MetricsHost: "192.168.2.100:8000",
+			ID:          types.NamespacedName{Name: "pod2", Namespace: "default"},
 		}, nil, nil),
 		Score: 0.74,
 	}
 	// Scored but not selected by the picker; its score is still surfaced.
 	scoredEndpoint3 := &fwksched.ScoredEndpoint{
 		Endpoint: fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
-			Address:        "192.168.3.100",
-			Port:           "8000",
-			MetricsHost:    "192.168.3.100:8000",
-			NamespacedName: types.NamespacedName{Name: "pod3", Namespace: "default"},
+			Address:     "192.168.3.100",
+			Port:        "8000",
+			MetricsHost: "192.168.3.100:8000",
+			ID:          types.NamespacedName{Name: "pod3", Namespace: "default"},
 		}, nil, nil),
 		Score: 0.12,
 	}
@@ -466,10 +466,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				ObjectiveKey:    objectiveName,
 				TargetModelName: model,
 				TargetPod: &fwkdl.EndpointMetadata{
-					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
-					Address:        "192.168.1.100",
-					Port:           "8000",
-					MetricsHost:    "192.168.1.100:8000",
+					ID:          types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:     "192.168.1.100",
+					Port:        "8000",
+					MetricsHost: "192.168.1.100:8000",
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000",
 				TargetEndpointScores: map[string]float64{

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -198,9 +198,9 @@ func TestSchedulerProfileScoredCandidates(t *testing.T) {
 		WithPicker(plugin)
 
 	input := []fwksched.Endpoint{
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
-		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
 	}
 	request := &fwksched.InferenceRequest{TargetModel: "test-model", RequestID: uuid.NewString()}
 
@@ -220,7 +220,7 @@ func TestSchedulerProfileScoredCandidates(t *testing.T) {
 	}
 	gotScores := make(map[string]float64, len(got.ScoredCandidates))
 	for _, candidate := range got.ScoredCandidates {
-		gotScores[candidate.GetMetadata().NamespacedName.String()] = candidate.Score
+		gotScores[candidate.GetMetadata().ID.String()] = candidate.Score
 	}
 	if diff := cmp.Diff(wantScores, gotScores); diff != "" {
 		t.Errorf("Unexpected scored candidates (-want +got): %v", diff)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The `NamespacedName` to `ID` field rename in #2147 merged alongside other PRs that added `EndpointMetadata{NamespacedName: ...}` test usages. They landed without a textual conflict but broke the build (typecheck), so `main` fails `make lint` for every open PR. This updates the affected test field references to `ID`:

- `pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go`
- `pkg/epp/requestcontrol/director_test.go`
- `pkg/epp/scheduling/scheduler_profile_test.go`

Verified with `make lint` (0 issues) and the three packages' tests.

**Which issue(s) this PR fixes**:

**Release note**:
```release-note
NONE
```
