### PR TITLE
Plugin: add request-control Screener extension point

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,16 +60,21 @@ The design enables:
 
 See the upstream [Request Scheduler](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/scheduling.md) doc for the canonical scheduling model.
 
-1. **Filtering**
+1. **Pre-scheduling candidate filtering**
+   - Global `PreSchedulingCandidateFilter` plugins receive the same located endpoint set
+   - Their returned subsets are intersected before data producers and scheduling profiles run
+   - Use this stage for mandatory routing constraints that every profile must observe
+
+2. **Filtering**
    - Pods in an `InferencePool` go through a sequential chain of filters
    - Pods may be excluded based on criteria like model compatibility, resource usage, or custom logic
 
-2. **Scoring**
+3. **Scoring**
    - Filtered pods are scored using a weighted set of scorers
    - Scorers currently run sequentially (future: parallel execution)
    - Scorers access a shared datastore populated by the data layer
 
-3. **Pod Selection**
+4. **Pod Selection**
    - The highest-scored pod is selected
    - If multiple pods share the same score, one is selected at random
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,9 +66,10 @@ Request control runs once per request before any scheduling profiles:
 
 1. Request headers are processed and flow-control admission completes
 2. Endpoint candidates are located
-3. Global `PreSchedulingCandidateFilter` plugins receive independent copies of the same located endpoint set
-   - Their returned subsets are intersected
-   - Use this stage for mandatory routing constraints that every profile must observe
+3. Global `Screener` plugins perform preliminary filtering of located endpoints
+   - Each screener receives an independent copy of the same endpoint set, and their returned subsets are intersected
+   - Most endpoint-selection plugins should implement a scheduling `Filter`, not a `Screener`
+   - Use a `Screener` only for mandatory constraints that must apply to every scheduling profile
 4. Data producers prepare per-request data using the filtered candidate set
 5. Admission plugins may reject the request
 6. The scheduler runs the configured scheduling profiles using the filtered candidate set

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,21 +60,33 @@ The design enables:
 
 See the upstream [Request Scheduler](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/scheduling.md) doc for the canonical scheduling model.
 
-1. **Pre-scheduling candidate filtering**
-   - Global `PreSchedulingCandidateFilter` plugins receive the same located endpoint set
-   - Their returned subsets are intersected before data producers and scheduling profiles run
-   - Use this stage for mandatory routing constraints that every profile must observe
+#### Request Control
 
-2. **Filtering**
+Request control runs once per request before any scheduling profiles:
+
+1. Request headers are processed and flow-control admission completes
+2. Endpoint candidates are located
+3. Global `PreSchedulingCandidateFilter` plugins receive independent copies of the same located endpoint set
+   - Their returned subsets are intersected
+   - Use this stage for mandatory routing constraints that every profile must observe
+4. Data producers prepare per-request data using the filtered candidate set
+5. Admission plugins may reject the request
+6. The scheduler runs the configured scheduling profiles using the filtered candidate set
+
+#### Scheduling
+
+Each scheduling profile runs the following stages. Multiple profiles may run for one request, such as separate prefill and decode profiles.
+
+1. **Filtering**
    - Pods in an `InferencePool` go through a sequential chain of filters
    - Pods may be excluded based on criteria like model compatibility, resource usage, or custom logic
 
-3. **Scoring**
+2. **Scoring**
    - Filtered pods are scored using a weighted set of scorers
    - Scorers currently run sequentially (future: parallel execution)
    - Scorers access a shared datastore populated by the data layer
 
-4. **Pod Selection**
+3. **Pod Selection**
    - The highest-scored pod is selected
    - If multiple pods share the same score, one is selected at random
 

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -26,14 +26,23 @@ import (
 )
 
 const (
-	RequestHeaderExtensionPoint     = "RequestHeader"
-	AdmissionExtensionPoint         = "Admission"
-	DataProducerExtensionPoint      = "DataProducer"
-	PreRequestExtensionPoint        = "PreRequest"
-	ResponseReceivedExtensionPoint  = "ResponseReceived"
-	ResponseStreamingExtensionPoint = "ResponseStreaming"
-	ResponseCompleteExtensionPoint  = "ResponseComplete"
+	RequestHeaderExtensionPoint                = "RequestHeader"
+	PreSchedulingCandidateFilterExtensionPoint = "PreSchedulingCandidateFilter"
+	AdmissionExtensionPoint                    = "Admission"
+	DataProducerExtensionPoint                 = "DataProducer"
+	PreRequestExtensionPoint                   = "PreRequest"
+	ResponseReceivedExtensionPoint             = "ResponseReceived"
+	ResponseStreamingExtensionPoint            = "ResponseStreaming"
+	ResponseCompleteExtensionPoint             = "ResponseComplete"
 )
+
+// PreSchedulingCandidateFilter returns a subset of the located endpoints before
+// data production, admission, and scheduling profiles run. Every filter sees
+// the same input set, and the framework intersects their results.
+type PreSchedulingCandidateFilter interface {
+	plugin.Plugin
+	FilterCandidates(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint
+}
 
 // PreRequest is called by the director after a getting result from scheduling layer and
 // before a request is sent to the selected model server.

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -26,22 +26,22 @@ import (
 )
 
 const (
-	RequestHeaderExtensionPoint                = "RequestHeader"
-	PreSchedulingCandidateFilterExtensionPoint = "PreSchedulingCandidateFilter"
-	AdmissionExtensionPoint                    = "Admission"
-	DataProducerExtensionPoint                 = "DataProducer"
-	PreRequestExtensionPoint                   = "PreRequest"
-	ResponseReceivedExtensionPoint             = "ResponseReceived"
-	ResponseStreamingExtensionPoint            = "ResponseStreaming"
-	ResponseCompleteExtensionPoint             = "ResponseComplete"
+	RequestHeaderExtensionPoint     = "RequestHeader"
+	ScreenerExtensionPoint          = "Screener"
+	AdmissionExtensionPoint         = "Admission"
+	DataProducerExtensionPoint      = "DataProducer"
+	PreRequestExtensionPoint        = "PreRequest"
+	ResponseReceivedExtensionPoint  = "ResponseReceived"
+	ResponseStreamingExtensionPoint = "ResponseStreaming"
+	ResponseCompleteExtensionPoint  = "ResponseComplete"
 )
 
-// PreSchedulingCandidateFilter returns a subset of the located endpoints before
-// data production, admission, and scheduling profiles run. Every filter sees
-// the same input set, and the framework intersects their results.
-type PreSchedulingCandidateFilter interface {
+// Screener performs preliminary filtering of located endpoints before data
+// production, admission, and scheduling profiles run. Every screener sees the
+// same input set, and the framework intersects their results.
+type Screener interface {
 	plugin.Plugin
-	FilterCandidates(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint
+	Screen(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint
 }
 
 // PreRequest is called by the director after a getting result from scheduling layer and

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -305,6 +305,13 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 
 	snapshotOfCandidatePods := d.toSchedulerEndpoints(endpointCandidates)
+	snapshotOfCandidatePods = d.runPreSchedulingCandidateFilters(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
+	if len(snapshotOfCandidatePods) == 0 {
+		return reqCtx, errcommon.Error{
+			Code: errcommon.ServiceUnavailable,
+			Msg:  "pre-scheduling candidate filters eliminated all endpoint candidates",
+		}
+	}
 	// Prepare per request data by running DataProducer plugins.
 	err = d.runDataProducerPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if err != nil {
@@ -641,6 +648,33 @@ func (d *Director) runDataProducerPlugins(ctx context.Context,
 		}
 	}
 	return nil
+}
+
+func (d *Director) runPreSchedulingCandidateFilters(ctx context.Context,
+	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
+	filteredEndpoints := endpoints
+	for _, plugin := range d.requestControlPlugins.preSchedulingCandidateFilters {
+		loggerDebug.Info("Running PreSchedulingCandidateFilter plugin", "plugin", plugin.TypedName())
+		before := time.Now()
+		pluginEndpoints := plugin.FilterCandidates(ctx, request, endpoints)
+		metrics.RecordPluginProcessingLatency(fwkrc.PreSchedulingCandidateFilterExtensionPoint,
+			plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		allowed := make(map[fwksched.Endpoint]struct{}, len(pluginEndpoints))
+		for _, endpoint := range pluginEndpoints {
+			allowed[endpoint] = struct{}{}
+		}
+		intersection := make([]fwksched.Endpoint, 0, min(len(filteredEndpoints), len(allowed)))
+		for _, endpoint := range filteredEndpoints {
+			if _, ok := allowed[endpoint]; ok {
+				intersection = append(intersection, endpoint)
+			}
+		}
+		filteredEndpoints = intersection
+		loggerDebug.Info("Completed running PreSchedulingCandidateFilter plugin successfully",
+			"plugin", plugin.TypedName(), "remainingEndpoints", len(filteredEndpoints))
+	}
+	return filteredEndpoints
 }
 
 func (d *Director) runAdmissionPlugins(ctx context.Context,

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -657,7 +658,7 @@ func (d *Director) runPreSchedulingCandidateFilters(ctx context.Context,
 	for _, plugin := range d.requestControlPlugins.preSchedulingCandidateFilters {
 		loggerDebug.Info("Running PreSchedulingCandidateFilter plugin", "plugin", plugin.TypedName())
 		before := time.Now()
-		pluginEndpoints := plugin.FilterCandidates(ctx, request, endpoints)
+		pluginEndpoints := plugin.FilterCandidates(ctx, request, slices.Clone(endpoints))
 		metrics.RecordPluginProcessingLatency(fwkrc.PreSchedulingCandidateFilterExtensionPoint,
 			plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		allowed := make(map[fwksched.Endpoint]struct{}, len(pluginEndpoints))

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -306,11 +306,11 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 
 	snapshotOfCandidatePods := d.toSchedulerEndpoints(endpointCandidates)
-	snapshotOfCandidatePods = d.runPreSchedulingCandidateFilters(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
+	snapshotOfCandidatePods = d.runScreeners(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if len(snapshotOfCandidatePods) == 0 {
 		return reqCtx, errcommon.Error{
 			Code: errcommon.ServiceUnavailable,
-			Msg:  "pre-scheduling candidate filters eliminated all endpoint candidates",
+			Msg:  "screeners eliminated all endpoint candidates",
 		}
 	}
 	// Prepare per request data by running DataProducer plugins.
@@ -651,15 +651,15 @@ func (d *Director) runDataProducerPlugins(ctx context.Context,
 	return nil
 }
 
-func (d *Director) runPreSchedulingCandidateFilters(ctx context.Context,
+func (d *Director) runScreeners(ctx context.Context,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	filteredEndpoints := endpoints
-	for _, plugin := range d.requestControlPlugins.preSchedulingCandidateFilters {
-		loggerDebug.Info("Running PreSchedulingCandidateFilter plugin", "plugin", plugin.TypedName())
+	for _, plugin := range d.requestControlPlugins.screeners {
+		loggerDebug.Info("Running Screener plugin", "plugin", plugin.TypedName())
 		before := time.Now()
-		pluginEndpoints := plugin.FilterCandidates(ctx, request, slices.Clone(endpoints))
-		metrics.RecordPluginProcessingLatency(fwkrc.PreSchedulingCandidateFilterExtensionPoint,
+		pluginEndpoints := plugin.Screen(ctx, request, slices.Clone(endpoints))
+		metrics.RecordPluginProcessingLatency(fwkrc.ScreenerExtensionPoint,
 			plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		allowed := make(map[fwksched.Endpoint]struct{}, len(pluginEndpoints))
 		for _, endpoint := range pluginEndpoints {
@@ -672,7 +672,7 @@ func (d *Director) runPreSchedulingCandidateFilters(ctx context.Context,
 			}
 		}
 		filteredEndpoints = intersection
-		loggerDebug.Info("Completed running PreSchedulingCandidateFilter plugin successfully",
+		loggerDebug.Info("Completed running Screener plugin successfully",
 			"plugin", plugin.TypedName(), "remainingEndpoints", len(filteredEndpoints))
 	}
 	return filteredEndpoints

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -416,7 +416,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		targetModelName         string                   // Expected model name after target model resolution
 		admitRequestDenialError error                    // Expected denial error from admission plugin
 		dataProducerPlugin      *mockDataProducerPlugin
-		preSchedulingFilter     *mockPreSchedulingCandidateFilter
+		screener                *mockScreener
 		preRequestPlugin        *mockPreRequestPlugin
 		requestHeaderPlugin     *mockRequestHeaderPlugin
 		wantMutatedBody         map[string]any
@@ -894,7 +894,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantErrCode: errcommon.BadRequest,
 		},
 		{
-			name: "pre-scheduling candidate filter eliminates all candidates",
+			name: "screener eliminates all candidates",
 			reqBodyMap: map[string]any{
 				"model":  model,
 				"prompt": "critical prompt",
@@ -902,7 +902,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 			mockAdmissionController: &mockAdmissionController{admitErr: nil},
 			initialTargetModelName:  model,
 			inferenceObjectiveName:  objectiveName,
-			preSchedulingFilter: &mockPreSchedulingCandidateFilter{name: "eliminate-all", filter: func([]fwksched.Endpoint) []fwksched.Endpoint {
+			screener: &mockScreener{name: "eliminate-all", screen: func([]fwksched.Endpoint) []fwksched.Endpoint {
 				return nil
 			}},
 			wantErrCode: errcommon.ServiceUnavailable,
@@ -983,8 +983,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 				if test.dataProducerPlugin != nil {
 					config = config.WithDataProducerPlugins(test.dataProducerPlugin)
 				}
-				if test.preSchedulingFilter != nil {
-					config = config.WithPreSchedulingCandidateFilters(test.preSchedulingFilter)
+				if test.screener != nil {
+					config = config.WithScreeners(test.screener)
 				}
 				if test.preRequestPlugin != nil {
 					config = config.WithPreRequestPlugins(test.preRequestPlugin)

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -416,6 +416,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		targetModelName         string                   // Expected model name after target model resolution
 		admitRequestDenialError error                    // Expected denial error from admission plugin
 		dataProducerPlugin      *mockDataProducerPlugin
+		preSchedulingFilter     *mockPreSchedulingCandidateFilter
 		preRequestPlugin        *mockPreRequestPlugin
 		requestHeaderPlugin     *mockRequestHeaderPlugin
 		wantMutatedBody         map[string]any
@@ -893,6 +894,20 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantErrCode: errcommon.BadRequest,
 		},
 		{
+			name: "pre-scheduling candidate filter eliminates all candidates",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			initialTargetModelName:  model,
+			inferenceObjectiveName:  objectiveName,
+			preSchedulingFilter: &mockPreSchedulingCandidateFilter{name: "eliminate-all", filter: func([]fwksched.Endpoint) []fwksched.Endpoint {
+				return nil
+			}},
+			wantErrCode: errcommon.ServiceUnavailable,
+		},
+		{
 			name: "scheduler returns error",
 			reqBodyMap: map[string]any{
 				"model":  model,
@@ -967,6 +982,9 @@ func TestDirector_HandleRequest(t *testing.T) {
 				config := NewConfig()
 				if test.dataProducerPlugin != nil {
 					config = config.WithDataProducerPlugins(test.dataProducerPlugin)
+				}
+				if test.preSchedulingFilter != nil {
+					config = config.WithPreSchedulingCandidateFilters(test.preSchedulingFilter)
 				}
 				if test.preRequestPlugin != nil {
 					config = config.WithPreRequestPlugins(test.preRequestPlugin)

--- a/pkg/epp/requestcontrol/pre_scheduling_candidate_filter_test.go
+++ b/pkg/epp/requestcontrol/pre_scheduling_candidate_filter_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestcontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+type mockPreSchedulingCandidateFilter struct {
+	name   string
+	filter func([]fwksched.Endpoint) []fwksched.Endpoint
+}
+
+func (f *mockPreSchedulingCandidateFilter) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock-pre-scheduling-candidate-filter", Name: f.name}
+}
+
+func (f *mockPreSchedulingCandidateFilter) FilterCandidates(
+	_ context.Context,
+	_ *fwksched.InferenceRequest,
+	endpoints []fwksched.Endpoint,
+) []fwksched.Endpoint {
+	return f.filter(endpoints)
+}
+
+func TestConfigAddPluginsCollectsPreSchedulingCandidateFilters(t *testing.T) {
+	filter := &mockPreSchedulingCandidateFilter{name: "candidate-filter", filter: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+		return endpoints
+	}}
+	config := NewConfig()
+
+	config.AddPlugins(filter)
+
+	require.Len(t, config.preSchedulingCandidateFilters, 1)
+	assert.Same(t, filter, config.preSchedulingCandidateFilters[0])
+	var _ fwkrc.PreSchedulingCandidateFilter = config.preSchedulingCandidateFilters[0]
+}
+
+func TestRunPreSchedulingCandidateFiltersIntersectsIndependentSubsets(t *testing.T) {
+	endpoints := []fwksched.Endpoint{
+		candidateEndpoint("a"),
+		candidateEndpoint("b"),
+		candidateEndpoint("c"),
+	}
+	secondInput := []fwksched.Endpoint(nil)
+	config := NewConfig().WithPreSchedulingCandidateFilters(
+		&mockPreSchedulingCandidateFilter{name: "drop-a", filter: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+			return endpoints[1:]
+		}},
+		&mockPreSchedulingCandidateFilter{name: "keep-c", filter: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+			secondInput = append(secondInput, endpoints...)
+			return endpoints[2:]
+		}},
+	)
+	director := &Director{requestControlPlugins: *config}
+
+	result := director.runPreSchedulingCandidateFilters(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+
+	require.Len(t, secondInput, 3)
+	assert.Equal(t, "a", secondInput[0].GetMetadata().Name)
+	require.Len(t, result, 1)
+	assert.Equal(t, "c", result[0].GetMetadata().Name)
+}
+
+func TestRunPreSchedulingCandidateFiltersAllObserveOriginalSetAfterEmptyResult(t *testing.T) {
+	endpoints := []fwksched.Endpoint{candidateEndpoint("a"), candidateEndpoint("b")}
+	secondCalled := false
+	config := NewConfig().WithPreSchedulingCandidateFilters(
+		&mockPreSchedulingCandidateFilter{name: "empty", filter: func([]fwksched.Endpoint) []fwksched.Endpoint {
+			return nil
+		}},
+		&mockPreSchedulingCandidateFilter{name: "observe", filter: func(got []fwksched.Endpoint) []fwksched.Endpoint {
+			secondCalled = true
+			require.Len(t, got, len(endpoints))
+			return got
+		}},
+	)
+	director := &Director{requestControlPlugins: *config}
+
+	result := director.runPreSchedulingCandidateFilters(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+
+	assert.True(t, secondCalled)
+	assert.Empty(t, result)
+}
+
+func candidateEndpoint(name string) fwksched.Endpoint {
+	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+		ID:   types.NamespacedName{Namespace: "default", Name: name},
+		Name: name,
+	}, nil, nil)
+}

--- a/pkg/epp/requestcontrol/pre_scheduling_candidate_filter_test.go
+++ b/pkg/epp/requestcontrol/pre_scheduling_candidate_filter_test.go
@@ -107,6 +107,28 @@ func TestRunPreSchedulingCandidateFiltersAllObserveOriginalSetAfterEmptyResult(t
 	assert.Empty(t, result)
 }
 
+func TestRunPreSchedulingCandidateFiltersIsolatesPluginInputs(t *testing.T) {
+	endpoints := []fwksched.Endpoint{candidateEndpoint("a"), candidateEndpoint("b")}
+	var secondInput []fwksched.Endpoint
+	config := NewConfig().WithPreSchedulingCandidateFilters(
+		&mockPreSchedulingCandidateFilter{name: "mutate-input", filter: func(got []fwksched.Endpoint) []fwksched.Endpoint {
+			got[0] = candidateEndpoint("replacement")
+			return got
+		}},
+		&mockPreSchedulingCandidateFilter{name: "observe", filter: func(got []fwksched.Endpoint) []fwksched.Endpoint {
+			secondInput = append(secondInput, got...)
+			return got
+		}},
+	)
+	director := &Director{requestControlPlugins: *config}
+
+	director.runPreSchedulingCandidateFilters(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+
+	require.Len(t, secondInput, 2)
+	assert.Equal(t, "a", secondInput[0].GetMetadata().Name)
+	assert.Equal(t, "a", endpoints[0].GetMetadata().Name)
+}
+
 func candidateEndpoint(name string) fwksched.Endpoint {
 	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
 		ID:   types.NamespacedName{Namespace: "default", Name: name},

--- a/pkg/epp/requestcontrol/pre_scheduling_candidate_filter_test.go
+++ b/pkg/epp/requestcontrol/pre_scheduling_candidate_filter_test.go
@@ -57,7 +57,7 @@ func TestConfigAddPluginsCollectsPreSchedulingCandidateFilters(t *testing.T) {
 
 	require.Len(t, config.preSchedulingCandidateFilters, 1)
 	assert.Same(t, filter, config.preSchedulingCandidateFilters[0])
-	var _ fwkrc.PreSchedulingCandidateFilter = config.preSchedulingCandidateFilters[0]
+	var _ fwkrc.PreSchedulingCandidateFilter = filter
 }
 
 func TestRunPreSchedulingCandidateFiltersIntersectsIndependentSubsets(t *testing.T) {

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -24,25 +24,25 @@ import (
 // NewConfig creates a new Config object and returns its pointer.
 func NewConfig() *Config {
 	return &Config{
-		requestHeaderPlugins:          []fwkrc.RequestHeaderProcessor{},
-		preSchedulingCandidateFilters: []fwkrc.PreSchedulingCandidateFilter{},
-		admissionPlugins:              []fwkrc.Admitter{},
-		dataProducerPlugins:           []fwkrc.DataProducer{},
-		preRequestPlugins:             []fwkrc.PreRequest{},
-		responseReceivedPlugins:       []fwkrc.ResponseHeaderProcessor{},
-		responseStreamingPlugins:      []fwkrc.ResponseBodyProcessor{},
+		requestHeaderPlugins:     []fwkrc.RequestHeaderProcessor{},
+		screeners:                []fwkrc.Screener{},
+		admissionPlugins:         []fwkrc.Admitter{},
+		dataProducerPlugins:      []fwkrc.DataProducer{},
+		preRequestPlugins:        []fwkrc.PreRequest{},
+		responseReceivedPlugins:  []fwkrc.ResponseHeaderProcessor{},
+		responseStreamingPlugins: []fwkrc.ResponseBodyProcessor{},
 	}
 }
 
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
-	requestHeaderPlugins          []fwkrc.RequestHeaderProcessor
-	preSchedulingCandidateFilters []fwkrc.PreSchedulingCandidateFilter
-	admissionPlugins              []fwkrc.Admitter
-	dataProducerPlugins           []fwkrc.DataProducer
-	preRequestPlugins             []fwkrc.PreRequest
-	responseReceivedPlugins       []fwkrc.ResponseHeaderProcessor
-	responseStreamingPlugins      []fwkrc.ResponseBodyProcessor
+	requestHeaderPlugins     []fwkrc.RequestHeaderProcessor
+	screeners                []fwkrc.Screener
+	admissionPlugins         []fwkrc.Admitter
+	dataProducerPlugins      []fwkrc.DataProducer
+	preRequestPlugins        []fwkrc.PreRequest
+	responseReceivedPlugins  []fwkrc.ResponseHeaderProcessor
+	responseStreamingPlugins []fwkrc.ResponseBodyProcessor
 }
 
 // WithRequestHeaderPlugins sets the given plugins as the RequestHeaderProcessor plugins.
@@ -51,10 +51,10 @@ func (c *Config) WithRequestHeaderPlugins(plugins ...fwkrc.RequestHeaderProcesso
 	return c
 }
 
-// WithPreSchedulingCandidateFilters sets the filters that narrow candidates
-// before request data production and scheduling.
-func (c *Config) WithPreSchedulingCandidateFilters(filters ...fwkrc.PreSchedulingCandidateFilter) *Config {
-	c.preSchedulingCandidateFilters = filters
+// WithScreeners sets the screeners that narrow candidates before request data
+// production and scheduling.
+func (c *Config) WithScreeners(screeners ...fwkrc.Screener) *Config {
+	c.screeners = screeners
 	return c
 }
 
@@ -99,8 +99,8 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 		if requestHeaderProcessor, ok := plugin.(fwkrc.RequestHeaderProcessor); ok {
 			c.requestHeaderPlugins = append(c.requestHeaderPlugins, requestHeaderProcessor)
 		}
-		if candidateFilter, ok := plugin.(fwkrc.PreSchedulingCandidateFilter); ok {
-			c.preSchedulingCandidateFilters = append(c.preSchedulingCandidateFilters, candidateFilter)
+		if screener, ok := plugin.(fwkrc.Screener); ok {
+			c.screeners = append(c.screeners, screener)
 		}
 		if preRequestPlugin, ok := plugin.(fwkrc.PreRequest); ok {
 			c.preRequestPlugins = append(c.preRequestPlugins, preRequestPlugin)

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -24,28 +24,37 @@ import (
 // NewConfig creates a new Config object and returns its pointer.
 func NewConfig() *Config {
 	return &Config{
-		requestHeaderPlugins:     []fwkrc.RequestHeaderProcessor{},
-		admissionPlugins:         []fwkrc.Admitter{},
-		dataProducerPlugins:      []fwkrc.DataProducer{},
-		preRequestPlugins:        []fwkrc.PreRequest{},
-		responseReceivedPlugins:  []fwkrc.ResponseHeaderProcessor{},
-		responseStreamingPlugins: []fwkrc.ResponseBodyProcessor{},
+		requestHeaderPlugins:          []fwkrc.RequestHeaderProcessor{},
+		preSchedulingCandidateFilters: []fwkrc.PreSchedulingCandidateFilter{},
+		admissionPlugins:              []fwkrc.Admitter{},
+		dataProducerPlugins:           []fwkrc.DataProducer{},
+		preRequestPlugins:             []fwkrc.PreRequest{},
+		responseReceivedPlugins:       []fwkrc.ResponseHeaderProcessor{},
+		responseStreamingPlugins:      []fwkrc.ResponseBodyProcessor{},
 	}
 }
 
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
-	requestHeaderPlugins     []fwkrc.RequestHeaderProcessor
-	admissionPlugins         []fwkrc.Admitter
-	dataProducerPlugins      []fwkrc.DataProducer
-	preRequestPlugins        []fwkrc.PreRequest
-	responseReceivedPlugins  []fwkrc.ResponseHeaderProcessor
-	responseStreamingPlugins []fwkrc.ResponseBodyProcessor
+	requestHeaderPlugins          []fwkrc.RequestHeaderProcessor
+	preSchedulingCandidateFilters []fwkrc.PreSchedulingCandidateFilter
+	admissionPlugins              []fwkrc.Admitter
+	dataProducerPlugins           []fwkrc.DataProducer
+	preRequestPlugins             []fwkrc.PreRequest
+	responseReceivedPlugins       []fwkrc.ResponseHeaderProcessor
+	responseStreamingPlugins      []fwkrc.ResponseBodyProcessor
 }
 
 // WithRequestHeaderPlugins sets the given plugins as the RequestHeaderProcessor plugins.
 func (c *Config) WithRequestHeaderPlugins(plugins ...fwkrc.RequestHeaderProcessor) *Config {
 	c.requestHeaderPlugins = plugins
+	return c
+}
+
+// WithPreSchedulingCandidateFilters sets the filters that narrow candidates
+// before request data production and scheduling.
+func (c *Config) WithPreSchedulingCandidateFilters(filters ...fwkrc.PreSchedulingCandidateFilter) *Config {
+	c.preSchedulingCandidateFilters = filters
 	return c
 }
 
@@ -89,6 +98,9 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 	for _, plugin := range pluginObjects {
 		if requestHeaderProcessor, ok := plugin.(fwkrc.RequestHeaderProcessor); ok {
 			c.requestHeaderPlugins = append(c.requestHeaderPlugins, requestHeaderProcessor)
+		}
+		if candidateFilter, ok := plugin.(fwkrc.PreSchedulingCandidateFilter); ok {
+			c.preSchedulingCandidateFilters = append(c.preSchedulingCandidateFilters, candidateFilter)
 		}
 		if preRequestPlugin, ok := plugin.(fwkrc.PreRequest); ok {
 			c.preRequestPlugins = append(c.preRequestPlugins, preRequestPlugin)

--- a/pkg/epp/requestcontrol/screener_test.go
+++ b/pkg/epp/requestcontrol/screener_test.go
@@ -30,55 +30,55 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
-type mockPreSchedulingCandidateFilter struct {
+type mockScreener struct {
 	name   string
-	filter func([]fwksched.Endpoint) []fwksched.Endpoint
+	screen func([]fwksched.Endpoint) []fwksched.Endpoint
 }
 
-func (f *mockPreSchedulingCandidateFilter) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: "mock-pre-scheduling-candidate-filter", Name: f.name}
+func (f *mockScreener) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock-screener", Name: f.name}
 }
 
-func (f *mockPreSchedulingCandidateFilter) FilterCandidates(
+func (f *mockScreener) Screen(
 	_ context.Context,
 	_ *fwksched.InferenceRequest,
 	endpoints []fwksched.Endpoint,
 ) []fwksched.Endpoint {
-	return f.filter(endpoints)
+	return f.screen(endpoints)
 }
 
-func TestConfigAddPluginsCollectsPreSchedulingCandidateFilters(t *testing.T) {
-	filter := &mockPreSchedulingCandidateFilter{name: "candidate-filter", filter: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+func TestConfigAddPluginsCollectsScreeners(t *testing.T) {
+	screener := &mockScreener{name: "candidate-screener", screen: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 		return endpoints
 	}}
 	config := NewConfig()
 
-	config.AddPlugins(filter)
+	config.AddPlugins(screener)
 
-	require.Len(t, config.preSchedulingCandidateFilters, 1)
-	assert.Same(t, filter, config.preSchedulingCandidateFilters[0])
-	var _ fwkrc.PreSchedulingCandidateFilter = filter
+	require.Len(t, config.screeners, 1)
+	assert.Same(t, screener, config.screeners[0])
+	var _ fwkrc.Screener = screener
 }
 
-func TestRunPreSchedulingCandidateFiltersIntersectsIndependentSubsets(t *testing.T) {
+func TestRunScreenersIntersectsIndependentSubsets(t *testing.T) {
 	endpoints := []fwksched.Endpoint{
 		candidateEndpoint("a"),
 		candidateEndpoint("b"),
 		candidateEndpoint("c"),
 	}
 	secondInput := []fwksched.Endpoint(nil)
-	config := NewConfig().WithPreSchedulingCandidateFilters(
-		&mockPreSchedulingCandidateFilter{name: "drop-a", filter: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+	config := NewConfig().WithScreeners(
+		&mockScreener{name: "drop-a", screen: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 			return endpoints[1:]
 		}},
-		&mockPreSchedulingCandidateFilter{name: "keep-c", filter: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+		&mockScreener{name: "keep-c", screen: func(endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 			secondInput = append(secondInput, endpoints...)
 			return endpoints[2:]
 		}},
 	)
 	director := &Director{requestControlPlugins: *config}
 
-	result := director.runPreSchedulingCandidateFilters(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+	result := director.runScreeners(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
 	require.Len(t, secondInput, 3)
 	assert.Equal(t, "a", secondInput[0].GetMetadata().Name)
@@ -86,14 +86,14 @@ func TestRunPreSchedulingCandidateFiltersIntersectsIndependentSubsets(t *testing
 	assert.Equal(t, "c", result[0].GetMetadata().Name)
 }
 
-func TestRunPreSchedulingCandidateFiltersAllObserveOriginalSetAfterEmptyResult(t *testing.T) {
+func TestRunScreenersAllObserveOriginalSetAfterEmptyResult(t *testing.T) {
 	endpoints := []fwksched.Endpoint{candidateEndpoint("a"), candidateEndpoint("b")}
 	secondCalled := false
-	config := NewConfig().WithPreSchedulingCandidateFilters(
-		&mockPreSchedulingCandidateFilter{name: "empty", filter: func([]fwksched.Endpoint) []fwksched.Endpoint {
+	config := NewConfig().WithScreeners(
+		&mockScreener{name: "empty", screen: func([]fwksched.Endpoint) []fwksched.Endpoint {
 			return nil
 		}},
-		&mockPreSchedulingCandidateFilter{name: "observe", filter: func(got []fwksched.Endpoint) []fwksched.Endpoint {
+		&mockScreener{name: "observe", screen: func(got []fwksched.Endpoint) []fwksched.Endpoint {
 			secondCalled = true
 			require.Len(t, got, len(endpoints))
 			return got
@@ -101,28 +101,28 @@ func TestRunPreSchedulingCandidateFiltersAllObserveOriginalSetAfterEmptyResult(t
 	)
 	director := &Director{requestControlPlugins: *config}
 
-	result := director.runPreSchedulingCandidateFilters(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+	result := director.runScreeners(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
 	assert.True(t, secondCalled)
 	assert.Empty(t, result)
 }
 
-func TestRunPreSchedulingCandidateFiltersIsolatesPluginInputs(t *testing.T) {
+func TestRunScreenersIsolatesPluginInputs(t *testing.T) {
 	endpoints := []fwksched.Endpoint{candidateEndpoint("a"), candidateEndpoint("b")}
 	var secondInput []fwksched.Endpoint
-	config := NewConfig().WithPreSchedulingCandidateFilters(
-		&mockPreSchedulingCandidateFilter{name: "mutate-input", filter: func(got []fwksched.Endpoint) []fwksched.Endpoint {
+	config := NewConfig().WithScreeners(
+		&mockScreener{name: "mutate-input", screen: func(got []fwksched.Endpoint) []fwksched.Endpoint {
 			got[0] = candidateEndpoint("replacement")
 			return got
 		}},
-		&mockPreSchedulingCandidateFilter{name: "observe", filter: func(got []fwksched.Endpoint) []fwksched.Endpoint {
+		&mockScreener{name: "observe", screen: func(got []fwksched.Endpoint) []fwksched.Endpoint {
 			secondInput = append(secondInput, got...)
 			return got
 		}},
 	)
 	director := &Director{requestControlPlugins: *config}
 
-	director.runPreSchedulingCandidateFilters(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+	director.runScreeners(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 
 	require.Len(t, secondInput, 2)
 	assert.Equal(t, "a", secondInput[0].GetMetadata().Name)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a `Screener` request-control extension point for preliminary filtering of located endpoint candidates before data producers, admission plugins, and scheduling profiles.

Most endpoint-selection plugins should implement a scheduling `Filter`. A developer should implement a `Screener` only for a mandatory constraint that must apply globally to every scheduling profile.

Each screener receives an independent copy of the same located endpoint pool. The framework intersects their returned subsets, so composition is independent of plugin registration order.

```text
Locate
  -> Screeners
  -> DataProducers
  -> admission plugins
  -> scheduling profiles
```

This extracts only the generic plugin mechanism from #2141. It does not include the disaggregation implementation or rollout fixtures.

**Which issue(s) this PR fixes**:

Related to #2141.

**Testing**:

- [x] `go test ./pkg/epp/requestcontrol -count=1`
- [x] `make lint`

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```