### PR TITLE
CICD: note SHA pin rationale for gosec SARIF upload action

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -116,6 +116,8 @@ jobs:
         run: make lint-security
 
       # Fork PRs run with a read only GITHUB_TOKEN that cannot upload SARIF.
+      # Pinned to a commit SHA rather than a tag, unlike other actions in this
+      # workflow, per GitHub's guidance for actions that write security data.
       - name: Upload gosec SARIF
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

`ci-lint.yaml` pins `github/codeql-action/upload-sarif` to a commit SHA while every other action in the file uses a floating tag. Adds a comment explaining the pin is deliberate (per GitHub's guidance for actions that write security data) and not an oversight.

**Which issue(s) this PR fixes**:

Follow-up to [#2203 comment](https://github.com/llm-d/llm-d-router/pull/2203#discussion_r3682518935)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```