### PR TITLE
ci: Add note why upload-sarif is pinned by SHA

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -116,6 +116,8 @@ jobs:
         run: make lint-security
 
       # Fork PRs run with a read only GITHUB_TOKEN that cannot upload SARIF.
+      # This action writes to the code scanning API, so it is pinned by commit
+      # SHA rather than a floating tag. Keep the SHA form on version bumps.
       - name: Upload gosec SARIF
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The action writes to the code scanning API while the rest of the lint job uses floating tags. The PR adds a note for the reason to avoid viewing it as an oversight in the future.

**Which issue(s) this PR fixes**:

Review comment: https://github.com/llm-d/llm-d-router/pull/2203#discussion_r3682518935

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
