### PR TITLE
tracing: correlate logs with traces at request entry points

### DIFF
--- a/pkg/common/observability/tracing/logging.go
+++ b/pkg/common/observability/tracing/logging.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// LogKeyTraceID is the structured-log field carrying the active trace ID.
+	// It matches the W3C trace-context identifier used across the llm-d stack
+	// so logs from every component can be queried uniformly by trace.
+	LogKeyTraceID = "trace_id"
+
+	// LogKeySpanID is the structured-log field carrying the active span ID.
+	LogKeySpanID = "span_id"
+)
+
+// correlatedKey marks a context whose logger already carries the correlation
+// fields, so nested span boundaries do not append a second pair.
+type correlatedKey struct{}
+
+// LoggerWithSpanContext enriches the logger stored in ctx with the trace_id and
+// span_id of span. Call it immediately after starting a span at a request entry
+// point; downstream code reading the logger via log.FromContext then emits log
+// lines tagged with the active trace.
+//
+// Enrichment happens once per context chain. logr accumulates values rather than
+// replacing them, so calling this at a nested span boundary would repeat trace_id
+// and span_id on every log line, and which pair a backend keeps for duplicate keys
+// is undefined. The logged span_id is therefore the entry span of the request.
+//
+// The marker lives on the context while the fields live on the logger, so the two
+// desync if a caller installs a logger not derived from log.FromContext of an
+// already-correlated context. Derive from the context logger rather than building
+// one from scratch.
+func LoggerWithSpanContext(ctx context.Context, span trace.Span) context.Context {
+	if ctx.Value(correlatedKey{}) != nil {
+		return ctx
+	}
+
+	// An invalid span context means tracing is off or the span is a no-op.
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		return ctx
+	}
+
+	logger := log.FromContext(ctx).WithValues(
+		LogKeyTraceID, sc.TraceID().String(),
+		LogKeySpanID, sc.SpanID().String(),
+	)
+	return log.IntoContext(context.WithValue(ctx, correlatedKey{}, struct{}{}), logger)
+}

--- a/pkg/common/observability/tracing/logging_test.go
+++ b/pkg/common/observability/tracing/logging_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// captureLogger returns a logr.Logger that appends every emitted record's
+// formatted key/values to *out, so tests can assert on what was logged.
+func captureLogger(out *[]string) logr.Logger {
+	return funcr.New(func(_, args string) {
+		*out = append(*out, args)
+	}, funcr.Options{})
+}
+
+// useTracerProvider installs tp for the duration of the test and restores the
+// previous global provider afterwards.
+func useTracerProvider(t *testing.T, tp trace.TracerProvider) {
+	t.Helper()
+
+	origTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(origTP) })
+}
+
+// startSampledSpan starts a real, always-sampled span so its span context is
+// valid (a no-op span would report IsValid() == false).
+func startSampledSpan(ctx context.Context, t *testing.T) (context.Context, trace.Span) {
+	t.Helper()
+
+	useTracerProvider(t, sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample())))
+	return Tracer().Start(ctx, "test")
+}
+
+func TestLoggerWithSpanContextInjectsFields(t *testing.T) {
+	var logged []string
+	ctx := log.IntoContext(context.Background(), captureLogger(&logged))
+
+	ctx, span := startSampledSpan(ctx, t)
+	defer span.End()
+
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		t.Fatal("expected a valid span context for the sampled span")
+	}
+
+	ctx = LoggerWithSpanContext(ctx, span)
+	log.FromContext(ctx).Info("hello")
+
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log record, got %d", len(logged))
+	}
+	rec := logged[0]
+	if !strings.Contains(rec, LogKeyTraceID) || !strings.Contains(rec, sc.TraceID().String()) {
+		t.Errorf("log record missing trace_id: %q", rec)
+	}
+	if !strings.Contains(rec, LogKeySpanID) || !strings.Contains(rec, sc.SpanID().String()) {
+		t.Errorf("log record missing span_id: %q", rec)
+	}
+}
+
+// A nested span boundary must not append a second pair of correlation fields:
+// duplicate JSON keys are ambiguous for log backends.
+func TestLoggerWithSpanContextEnrichesOncePerContext(t *testing.T) {
+	var logged []string
+	ctx := log.IntoContext(context.Background(), captureLogger(&logged))
+
+	ctx, parent := startSampledSpan(ctx, t)
+	defer parent.End()
+	ctx = LoggerWithSpanContext(ctx, parent)
+
+	ctx, child := Tracer().Start(ctx, "child")
+	defer child.End()
+	ctx = LoggerWithSpanContext(ctx, child)
+
+	log.FromContext(ctx).Info("hello")
+
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log record, got %d", len(logged))
+	}
+	rec := logged[0]
+	if got := strings.Count(rec, LogKeyTraceID); got != 1 {
+		t.Errorf("trace_id appears %d times, want 1: %q", got, rec)
+	}
+	if got := strings.Count(rec, LogKeySpanID); got != 1 {
+		t.Errorf("span_id appears %d times, want 1: %q", got, rec)
+	}
+	if !strings.Contains(rec, parent.SpanContext().SpanID().String()) {
+		t.Errorf("log record must keep the outermost span_id: %q", rec)
+	}
+	if strings.Contains(rec, child.SpanContext().SpanID().String()) {
+		t.Errorf("log record must not carry the nested span_id: %q", rec)
+	}
+}
+
+// Values already on the context logger survive enrichment, and so do values
+// added between the entry point and a nested boundary.
+func TestLoggerWithSpanContextPreservesExistingValues(t *testing.T) {
+	var logged []string
+	base := captureLogger(&logged).WithValues("x-request-id", "req-1")
+	ctx := log.IntoContext(context.Background(), base)
+
+	ctx, span := startSampledSpan(ctx, t)
+	defer span.End()
+	ctx = LoggerWithSpanContext(ctx, span)
+
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("model", "sim"))
+
+	ctx, child := Tracer().Start(ctx, "child")
+	defer child.End()
+	ctx = LoggerWithSpanContext(ctx, child)
+
+	log.FromContext(ctx).Info("hello")
+
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log record, got %d", len(logged))
+	}
+	for _, want := range []string{"req-1", "sim", span.SpanContext().TraceID().String()} {
+		if !strings.Contains(logged[0], want) {
+			t.Errorf("log record missing %q: %q", want, logged[0])
+		}
+	}
+}
+
+func TestLoggerWithSpanContextNoopForInvalidSpan(t *testing.T) {
+	var logged []string
+	ctx := log.IntoContext(context.Background(), captureLogger(&logged))
+
+	// A span from the no-op tracer has an invalid span context.
+	useTracerProvider(t, noop.NewTracerProvider())
+	ctx, span := otel.Tracer("test").Start(ctx, "noop")
+	defer span.End()
+
+	if span.SpanContext().IsValid() {
+		t.Skip("tracer unexpectedly produced a valid span context")
+	}
+
+	ctx = LoggerWithSpanContext(ctx, span)
+
+	log.FromContext(ctx).Info("hello")
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log record, got %d", len(logged))
+	}
+	if strings.Contains(logged[0], LogKeyTraceID) || strings.Contains(logged[0], LogKeySpanID) {
+		t.Errorf("expected no correlation fields for invalid span, got: %q", logged[0])
+	}
+}

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -448,8 +448,6 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey] = requestID // update in headers so director can consume it
 			}
 			logger = logger.WithValues(reqcommon.RequestIDHeaderKey, requestID)
-			logger.V(logutil.DEFAULT).Info("EPP received request") // Request ID will be logged too as part of logger context values.
-			loggerTrace = logger.V(logutil.TRACE)
 			ctx = log.IntoContext(ctx, logger)
 
 			// Re-parent the server span to the upstream trace context (e.g. the
@@ -458,6 +456,12 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			// cannot be started at the top of Process without orphaning the trace.
 			ctx = extractTraceContext(ctx, v)
 			ctx, span = tracer.Start(ctx, "gateway.request", trace.WithSpanKind(trace.SpanKindServer))
+
+			// Tag every log line of this request with the trace it belongs to.
+			ctx = tracing.LoggerWithSpanContext(ctx, span)
+			logger = log.FromContext(ctx)
+			loggerTrace = logger.V(logutil.TRACE)
+			logger.V(logutil.DEFAULT).Info("EPP received request") // Request ID and trace fields are logged as logger context values.
 
 			err = s.HandleRequestHeaders(ctx, reqCtx, v)
 		case *extProcPb.ProcessingRequest_RequestBody:

--- a/pkg/epp/handlers/server_trace_correlation_test.go
+++ b/pkg/epp/handlers/server_trace_correlation_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	upstreamTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	upstreamTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0c9902b7-01"
 	// upstreamTraceID is the trace ID of upstreamTraceparent: the trace the EPP
 	// must join rather than starting a fresh one.
 	upstreamTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"

--- a/pkg/epp/handlers/server_trace_correlation_test.go
+++ b/pkg/epp/handlers/server_trace_correlation_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
+)
+
+const (
+	upstreamTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	// upstreamTraceID is the trace ID of upstreamTraceparent: the trace the EPP
+	// must join rather than starting a fresh one.
+	upstreamTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+)
+
+// scriptedProcessServer replays one RequestHeaders message, then reports EOF so
+// Process returns cleanly.
+type scriptedProcessServer struct {
+	mockProcessServer
+	ctx  context.Context
+	req  *extProcPb.ProcessingRequest
+	sent bool
+}
+
+func (m *scriptedProcessServer) Recv() (*extProcPb.ProcessingRequest, error) {
+	if m.sent {
+		return nil, io.EOF
+	}
+	m.sent = true
+	return m.req, nil
+}
+
+func (m *scriptedProcessServer) Context() context.Context { return m.ctx }
+
+func newRequestHeaders(headers map[string]string) *extProcPb.ProcessingRequest {
+	values := make([]*configPb.HeaderValue, 0, len(headers))
+	for key, value := range headers {
+		values = append(values, &configPb.HeaderValue{Key: key, RawValue: []byte(value)})
+	}
+	return &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &configPb.HeaderMap{Headers: values},
+				// EndOfStream would route to a random endpoint and need a director.
+				EndOfStream: false,
+			},
+		},
+	}
+}
+
+// runProcess drives Process over a single RequestHeaders message and returns the
+// lines it logged.
+func runProcess(t *testing.T, headers map[string]string) []string {
+	t.Helper()
+
+	var logged []string
+	capture := funcr.New(func(prefix, args string) {
+		logged = append(logged, prefix+" "+args)
+	}, funcr.Options{Verbosity: 2})
+
+	srv := &scriptedProcessServer{
+		ctx: log.IntoContext(context.Background(), capture),
+		req: newRequestHeaders(headers),
+	}
+	require.NoError(t, NewStreamingServer(nil, nil, nil, 0).Process(srv))
+
+	return logged
+}
+
+func entryLine(t *testing.T, logged []string) string {
+	t.Helper()
+
+	for _, rec := range logged {
+		if strings.Contains(rec, "EPP received request") {
+			return rec
+		}
+	}
+	t.Fatalf("entry-point log line not found in %v", logged)
+	return ""
+}
+
+// Pins the entry-point wiring rather than the helper: this fails if server.go
+// stops installing the enriched logger.
+func TestProcessCorrelatesRequestLogsWithTrace(t *testing.T) {
+	useTracerProvider(t, sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample())))
+
+	entry := entryLine(t, runProcess(t, map[string]string{
+		"traceparent":  upstreamTraceparent,
+		"x-request-id": "req-correlation-1",
+	}))
+
+	require.Contains(t, entry, tracing.LogKeyTraceID)
+	require.Contains(t, entry, tracing.LogKeySpanID)
+	require.Contains(t, entry, upstreamTraceID, "must join the upstream trace, not start a fresh one")
+	require.Contains(t, entry, "req-correlation-1", "correlation must not displace the request ID")
+	require.Equal(t, 1, strings.Count(entry, tracing.LogKeyTraceID), "trace_id must appear once: %q", entry)
+}
+
+// With tracing off the span context is invalid, so request logs are unchanged.
+func TestProcessOmitsCorrelationWhenTracingDisabled(t *testing.T) {
+	useTracerProvider(t, noop.NewTracerProvider())
+
+	entry := entryLine(t, runProcess(t, map[string]string{"x-request-id": "req-correlation-2"}))
+
+	require.Contains(t, entry, "req-correlation-2")
+	require.NotContains(t, entry, tracing.LogKeyTraceID)
+	require.NotContains(t, entry, tracing.LogKeySpanID)
+}
+
+// useTracerProvider installs tp and the W3C propagator for the duration of the
+// test, restoring the previous globals afterwards.
+func useTracerProvider(t *testing.T, tp trace.TracerProvider) {
+	t.Helper()
+
+	prevTP, prevProp := otel.GetTracerProvider(), otel.GetTextMapPropagator()
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		otel.SetTextMapPropagator(prevProp)
+	})
+}

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -159,8 +159,9 @@ func (k *Indexer) ScoreTokens(
 	)
 	defer span.End()
 
-	// Enrich the context logger with trace_id/span_id so the log lines below
-	// (block keys, pod scores) can be correlated with this span's trace.
+	// Correlate the log lines below (block keys, pod scores) when the indexer is
+	// driven directly. Reached through an EPP request the context is already
+	// correlated at the entry point and this is a no-op.
 	ctx = tracing.LoggerWithSpanContext(ctx, span)
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvcache.ScoreTokens")
 

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -159,6 +159,9 @@ func (k *Indexer) ScoreTokens(
 	)
 	defer span.End()
 
+	// Enrich the context logger with trace_id/span_id so the log lines below
+	// (block keys, pod scores) can be correlated with this span's trace.
+	ctx = tracing.LoggerWithSpanContext(ctx, span)
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvcache.ScoreTokens")
 
 	blockKeys, err := k.tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, modelName, extraFeatures)

--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -69,9 +69,10 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		)
 		defer span.End()
 
-		// Tag every log line of this request with the trace it belongs to. The
-		// proxy logger is process-scoped, so seed it into the context first;
-		// handlers reached from here pick it up through log.FromContext.
+		// Tag this handler's log lines with the trace they belong to. The proxy
+		// logger is process-scoped, so seed it into the context first. Connectors
+		// reached from here still log through s.logger and stay uncorrelated;
+		// the request context carries the correlated logger for them to adopt.
 		ctx = tracing.LoggerWithSpanContext(log.IntoContext(ctx, s.logger), span)
 		logger := log.FromContext(ctx)
 

--- a/pkg/sidecar/proxy/chat_completions.go
+++ b/pkg/sidecar/proxy/chat_completions.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
@@ -68,6 +69,12 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		)
 		defer span.End()
 
+		// Tag every log line of this request with the trace it belongs to. The
+		// proxy logger is process-scoped, so seed it into the context first;
+		// handlers reached from here pick it up through log.FromContext.
+		ctx = tracing.LoggerWithSpanContext(log.IntoContext(ctx, s.logger), span)
+		logger := log.FromContext(ctx)
+
 		ctx = context.WithValue(ctx, requestStartTimeKey, requestStart)
 		r = r.WithContext(ctx)
 
@@ -101,7 +108,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		}
 
 		if len(prefillHostPort) == 0 {
-			s.logger.V(logging.DEBUG).Info("skip disaggregated prefill", "api", apiType.String())
+			logger.V(logging.DEBUG).Info("skip disaggregated prefill", "api", apiType.String())
 			span.SetAttributes(
 				attribute.Bool("llm_d.pd_proxy.disaggregation_used", false),
 				attribute.String("llm_d.pd_proxy.reason", "no_prefill_header"),
@@ -116,7 +123,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 
 		if len(prefillHostPort) > 0 {
 			if !s.allowlistValidator.IsAllowed(prefillHostPort) {
-				s.logger.Error(nil, "SSRF protection: prefill target not in allowlist",
+				logger.Error(nil, "SSRF protection: prefill target not in allowlist",
 					"target", prefillHostPort,
 					"clientIP", r.RemoteAddr,
 					"userAgent", r.Header.Get("User-Agent"),
@@ -129,7 +136,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 				http.Error(w, "Forbidden: prefill target not allowed by SSRF protection", http.StatusForbidden)
 				return
 			}
-			s.logger.V(logging.DEBUG).Info("SSRF protection: prefill target allowed", "target", prefillHostPort)
+			logger.V(logging.DEBUG).Info("SSRF protection: prefill target allowed", "target", prefillHostPort)
 		}
 
 		kvCacheSource := strings.TrimSpace(r.Header.Get(routing.KVCacheSourceHeader))
@@ -137,14 +144,14 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		if kvCacheSource != "" {
 			switch {
 			case !s.p2pPullAvailable():
-				s.logger.V(logging.DEBUG).Info("ignoring KV cache source header: connector does not support P2P pulls",
+				logger.V(logging.DEBUG).Info("ignoring KV cache source header: connector does not support P2P pulls",
 					"connector", s.config.KVConnector)
 				kvCacheSource = ""
 			case !isHostPort(kvCacheSource):
-				s.logger.Info("ignoring malformed KV cache source header", "value", kvCacheSource)
+				logger.Info("ignoring malformed KV cache source header", "value", kvCacheSource)
 				kvCacheSource = ""
 			case !s.allowlistValidator.IsAllowed(kvCacheSource):
-				s.logger.Info("SSRF protection: KV cache source not in allowlist, ignoring",
+				logger.Info("SSRF protection: KV cache source not in allowlist, ignoring",
 					"target", kvCacheSource, "clientIP", r.RemoteAddr)
 				kvCacheSource = ""
 			}
@@ -166,9 +173,9 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 				encoderHost = strings.TrimSpace(encoderHost)
 				if s.allowlistValidator.IsAllowed(encoderHost) {
 					allowedEncoders = append(allowedEncoders, encoderHost)
-					s.logger.V(logging.DEBUG).Info("SSRF protection: encoder target allowed", "target", encoderHost)
+					logger.V(logging.DEBUG).Info("SSRF protection: encoder target allowed", "target", encoderHost)
 				} else {
-					s.logger.Info("SSRF protection: encoder target not in allowlist, removing from list",
+					logger.Info("SSRF protection: encoder target not in allowlist, removing from list",
 						"target", encoderHost,
 						"clientIP", r.RemoteAddr,
 						"userAgent", r.Header.Get("User-Agent"),
@@ -178,7 +185,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		}
 
 		if len(allowedEncoders) > 0 && s.handleECConnector != nil {
-			s.logger.V(logging.DEBUG).Info("encoder headers detected, using EC connector",
+			logger.V(logging.DEBUG).Info("encoder headers detected, using EC connector",
 				"encoderCount", len(allowedEncoders),
 				"encoderCandidates", len(encoderHostPorts),
 				"hasPrefiller", len(prefillHostPort) > 0)
@@ -192,7 +199,7 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		}
 
 		if len(encoderHostPorts) > 0 && len(allowedEncoders) == 0 {
-			s.logger.Info("SSRF protection: all encoder targets filtered out, falling back to P/D or decoder-only")
+			logger.Info("SSRF protection: all encoder targets filtered out, falling back to P/D or decoder-only")
 			span.SetAttributes(
 				attribute.Bool("llm_d.ec_proxy.encode_disaggregation_used", false),
 				attribute.Int("llm_d.ec_proxy.encoder_allowed", len(allowedEncoders)),
@@ -201,12 +208,12 @@ func (s *Server) disaggregatedPrefillHandler(apiType APIType) http.HandlerFunc {
 		}
 
 		if len(prefillHostPort) > 0 {
-			s.logger.V(logging.DEBUG).Info("using P/D protocol")
+			logger.V(logging.DEBUG).Info("using P/D protocol")
 			s.handlePDConnector(w, r, prefillHostPort, kvCacheSource, apiType)
 			return
 		}
 
-		s.logger.V(logging.DEBUG).Info("no prefiller or encoder, using decoder only")
+		logger.V(logging.DEBUG).Info("no prefiller or encoder, using decoder only")
 		if !s.forwardDataParallel || !s.dataParallelHandler(w, r) {
 			if kvCacheSource != "" {
 				s.decodeWithP2PSource(w, r, kvCacheSource)

--- a/pkg/sidecar/proxy/chat_completions_trace_test.go
+++ b/pkg/sidecar/proxy/chat_completions_trace_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
+	"github.com/llm-d/llm-d-router/pkg/common/routing"
+)
+
+// useTracerProviderForTest installs tp for the duration of the test.
+func useTracerProviderForTest(t *testing.T, tp trace.TracerProvider) {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+}
+
+// runPrefillHandler drives disaggregatedPrefillHandler with the prefill header
+// set, appending every logged line to logged and returning the logger the
+// downstream connector received through the request context.
+func runPrefillHandler(t *testing.T, logged *[]string) (downstream logr.Logger) {
+	t.Helper()
+
+	capture := funcr.New(func(prefix, args string) {
+		*logged = append(*logged, prefix+" "+args)
+	}, funcr.Options{Verbosity: 5})
+
+	s := NewProxy(Config{Port: "8000"})
+	s.logger = capture
+	s.allowlistValidator = &AllowlistValidator{}
+	s.dataParallelProxies = make(map[string]http.Handler)
+	s.handlePDConnector = func(_ http.ResponseWriter, r *http.Request, _ string, _ string, _ APIType) {
+		downstream = log.FromContext(r.Context())
+	}
+
+	req := httptest.NewRequest(http.MethodPost, ChatCompletionsPath, http.NoBody)
+	req.Header.Set(routing.PrefillEndpointHeader, "prefill-pod:8000")
+	s.disaggregatedPrefillHandler(APITypeChatCompletions)(httptest.NewRecorder(), req)
+
+	return downstream
+}
+
+// The handler's own log lines carry the forward_request trace, and the request
+// context handed to connectors carries the same correlated logger.
+func TestPrefillHandlerCorrelatesLogsWithTrace(t *testing.T) {
+	useTracerProviderForTest(t, sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample())))
+
+	var logged []string
+	downstream := runPrefillHandler(t, &logged)
+
+	var handlerLine string
+	for _, rec := range logged {
+		if strings.Contains(rec, "using P/D protocol") {
+			handlerLine = rec
+		}
+	}
+	if handlerLine == "" {
+		t.Fatalf("handler log line not found in %v", logged)
+	}
+	if !strings.Contains(handlerLine, tracing.LogKeyTraceID) || !strings.Contains(handlerLine, tracing.LogKeySpanID) {
+		t.Errorf("handler line missing correlation fields: %q", handlerLine)
+	}
+	if got := strings.Count(handlerLine, tracing.LogKeyTraceID); got != 1 {
+		t.Errorf("trace_id appears %d times, want 1: %q", got, handlerLine)
+	}
+
+	// A connector that adopts the request context gets the same trace.
+	before := len(logged)
+	downstream.Info("connector line")
+	if len(logged) != before+1 {
+		t.Fatalf("expected the downstream logger to emit one line, got %d", len(logged)-before)
+	}
+	if !strings.Contains(logged[before], tracing.LogKeyTraceID) {
+		t.Errorf("downstream logger is not correlated: %q", logged[before])
+	}
+}
+
+// With tracing off the span context is invalid, so nothing is added.
+func TestPrefillHandlerOmitsCorrelationWhenTracingDisabled(t *testing.T) {
+	useTracerProviderForTest(t, noop.NewTracerProvider())
+
+	var logged []string
+	runPrefillHandler(t, &logged)
+
+	for _, rec := range logged {
+		if strings.Contains(rec, tracing.LogKeyTraceID) || strings.Contains(rec, tracing.LogKeySpanID) {
+			t.Errorf("unexpected correlation fields with tracing disabled: %q", rec)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The router emits OpenTelemetry spans and structured logr/zap logs, but nothing links them: no code path injects `trace_id`/`span_id` into the logger. Debugging a request means matching timestamps between the trace backend and the log backend.

This adds `tracing.LoggerWithSpanContext(ctx, span)`, which enriches the logger stored in the context with the active span's `trace_id`/`span_id`, and calls it at the two request entry points:

- **EPP** (`pkg/epp/handlers/server.go`): after `gateway.request` starts. Downstream code reads the logger via `log.FromContext`, so enriching here covers the whole request - the director, the scheduler, the plugins, and the kv-cache index.
- **Sidecar** (`pkg/sidecar/proxy/chat_completions.go`): after `forward_request` starts. The proxy logger is process-scoped, so it is seeded into the context first and the handler's own call sites use the request-scoped logger.

Correlation is injected once per context chain. logr appends values rather than replacing them, so injecting at nested span boundaries would repeat `trace_id` and `span_id` on every log line - the EPP nests up to eight spans - and log backends do not agree on which of a duplicated JSON key to keep. The logged `span_id` is therefore the outermost instrumented span, which names the entry span of the request; `trace_id` is the field to query by and selects the whole request across components.

The helper is a no-op when the span context is invalid, so nothing changes when tracing is disabled.

**Scope of the sidecar change**

The sidecar entry point correlates its own log lines and puts the correlated logger on the request context. The connectors reached from it (`connector_nixlv2.go`, `connector_shared_storage.go`, `connector_p2p.go`, `decode.go`, and the EC connectors) log through the process-scoped `s.logger` and are **not** correlated by this PR. Converting them is a mechanical but broad change across roughly 130 call sites and belongs in its own PR; the request context already carries what they need. Tracked as a follow-up.

**Why not a zap correlation hook**

Issue #1630 notes that the zap setup has no automatic correlation hook. A hook cannot work here: correlation lives on the context, and logr call sites do not hand the context to the sink. Injecting where the context is in scope is the only place the trace is knowable, and it keeps the correlation independent of which logr backend is configured.

**Which issue(s) this PR fixes**:

Fixes #1630

Also covers llm-d/llm-d-kv-cache#665, which tracks the same gap for the kv-cache packages: `pkg/kvcache/indexer.go` keeps its own call so those packages self-correlate when driven directly. Reached through an EPP request the context is already correlated and the call is a no-op.

This PR supersedes #2248; @umakantv is credited as co-author.

**Release note**:
```release-note
Structured logs from the EPP and the disaggregation sidecar now carry the OpenTelemetry `trace_id` and `span_id` of the request, so logs and traces can be correlated.
```

## Test plan

Helper unit tests (`pkg/common/observability/tracing`):
- [x] Correlation fields are injected from a sampled span
- [x] A nested span boundary does not append a second pair of fields
- [x] Values already on the logger, and values added between boundaries, survive enrichment
- [x] No fields are added when the span context is invalid

Entry-point regression tests, which fail if the wiring is removed rather than only exercising the helper:
- [x] EPP: driving `StreamingServer.Process` with an upstream `traceparent` produces request logs carrying that trace ID exactly once, alongside the request ID
- [x] EPP: no correlation fields when tracing is disabled
- [x] Sidecar: `disaggregatedPrefillHandler` log lines carry the `forward_request` trace, and a connector adopting the request context gets the same trace
- [x] Sidecar: no correlation fields when tracing is disabled

- [x] `go build ./...`, `go vet`, `gofmt`, and `go test -race` on the touched packages
- [x] `make presubmit`
