### PR TITLE
[ci]: Add path based PR labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,8 @@
-# Path based area/* labels. actions/labeler errors if a listed label name isn't
-# already a repository label (pull-requests: write cannot create one), so only
-# area/epp and area/dev are wired up here.
-#
-# docs/area_taxonomy.md defines area/scheduling, area/flowcontrol, area/kvcache,
-# area/coordinator, area/sidecar, area/datalayer, area/telemetry and area/docs.
-# Move their glob blocks here once those labels are created (#956). scheduling,
-# flowcontrol and datalayer also need a pkg/epp/framework/plugins/<x>/** glob
-# alongside pkg/epp/<x>/**. See docs/area_taxonomy.md for why.
+# Path based area/* labels. .github/labeler.yml is the canonical source for
+# the path globs. docs/area_taxonomy.md covers what this file can't express
+# which is the /area directive and the additive overlap rule.
 
+# Endpoint Picker core
 area/epp:
   - changed-files:
       - any-glob-to-any-file:
@@ -15,6 +10,7 @@ area/epp:
           - cmd/epp/**
           - test/integration/epp/**
 
+# Dev tooling, CI/CD and shared test harness
 area/dev:
   - changed-files:
       - any-glob-to-any-file:
@@ -28,3 +24,63 @@ area/dev:
           - test/scripts/**
           - test/perf/**
           - test/profiling/**
+
+# Scheduling and request routing decisions
+area/scheduling:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/epp/scheduling/**
+          - pkg/epp/framework/plugins/scheduling/**
+          - pkg/epp/requestcontrol/**
+          - pkg/epp/framework/plugins/requestcontrol/**
+
+# Admission, queuing and flow control
+area/flowcontrol:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/epp/flowcontrol/**
+          - pkg/epp/framework/plugins/flowcontrol/**
+
+# KV cache indexing and events
+area/kvcache:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/kvcache/**
+          - pkg/kvevents/**
+
+# Disaggregated inference coordinator
+area/coordinator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/coordinator/**
+          - cmd/coordinator/**
+          - test/coordinator/**
+
+# PD sidecar proxy
+area/sidecar:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/sidecar/**
+          - cmd/pd-sidecar/**
+          - test/sidecar/**
+
+# EPP data layer and datastore
+area/datalayer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/epp/datalayer/**
+          - pkg/epp/framework/plugins/datalayer/**
+          - pkg/epp/datastore/**
+
+# Telemetry and observability
+area/telemetry:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/common/observability/**
+
+# Documentation
+area/docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - "*.md"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+# Path based area/* labels. actions/labeler errors if a listed label name isn't
+# already a repository label (pull-requests: write cannot create one), so only
+# area/epp and area/dev are wired up here.
+#
+# docs/area_taxonomy.md defines area/scheduling, area/flowcontrol, area/kvcache,
+# area/coordinator, area/sidecar, area/datalayer, area/telemetry and area/docs.
+# Move their glob blocks here once those labels are created (#956). scheduling,
+# flowcontrol and datalayer also need a pkg/epp/framework/plugins/<x>/** glob
+# alongside pkg/epp/<x>/**. See docs/area_taxonomy.md for why.
+
+area/epp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pkg/epp/**
+          - cmd/epp/**
+          - test/integration/epp/**
+
+area/dev:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+          - hack/**
+          - scripts/**
+          - Makefile
+          - test/e2e/**
+          - test/framework/**
+          - test/utils/**
+          - test/scripts/**
+          - test/perf/**
+          - test/profiling/**

--- a/.github/workflows/pr-area-labeler.yaml
+++ b/.github/workflows/pr-area-labeler.yaml
@@ -1,0 +1,23 @@
+name: PR Area Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+# Serializes runs on the same PR, matching pr-kind-label.yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  area-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v7
+        with:
+          sync-labels: false

--- a/.github/workflows/pr-area-labeler.yaml
+++ b/.github/workflows/pr-area-labeler.yaml
@@ -6,10 +6,11 @@ on:
     branches:
       - main
 
-# Serializes runs on the same PR, matching pr-kind-label.yaml
+# Cancels superseded runs on the same PR. Safe because the job only adds
+# labels (sync-labels: false, no remove-then-add), unlike pr-kind-label.yaml.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   area-label:

--- a/docs/area_taxonomy.md
+++ b/docs/area_taxonomy.md
@@ -2,22 +2,24 @@
 
 `area/*` labels route issues and pull requests to the right reviewers by component. Each area maps to one or more directories, so it can be applied either manually (via an `/area` directive on a PR or issue body) or automatically from the paths a change touches.
 
+`area/epp` and `area/dev` are labeled automatically by `.github/labeler.yml`, which is the canonical source for their path globs.
+
 | Label | Paths | Scope |
 |---|---|---|
-| `area/epp` | `pkg/epp/**`, `cmd/epp/**`, `test/integration/epp/**` | Endpoint Picker core |
-| `area/scheduling` | `pkg/epp/scheduling/**`, `pkg/epp/requestcontrol/**` | Scheduling and request routing decisions |
-| `area/flowcontrol` | `pkg/epp/flowcontrol/**` | Admission, queuing and flow control |
+| `area/scheduling` | `pkg/epp/scheduling/**`, `pkg/epp/framework/plugins/scheduling/**`, `pkg/epp/requestcontrol/**`, `pkg/epp/framework/plugins/requestcontrol/**` | Scheduling and request routing decisions |
+| `area/flowcontrol` | `pkg/epp/flowcontrol/**`, `pkg/epp/framework/plugins/flowcontrol/**` | Admission, queuing and flow control |
 | `area/kvcache` | `pkg/kvcache/**`, `pkg/kvevents/**` | KV cache indexing and events |
 | `area/coordinator` | `pkg/coordinator/**`, `cmd/coordinator/**`, `test/coordinator/**` | Disaggregated inference coordinator |
 | `area/sidecar` | `pkg/sidecar/**`, `cmd/pd-sidecar/**`, `test/sidecar/**` | PD sidecar proxy |
-| `area/datalayer` | `pkg/epp/datalayer/**`, `pkg/epp/datastore/**` | EPP data layer and datastore |
+| `area/datalayer` | `pkg/epp/datalayer/**`, `pkg/epp/framework/plugins/datalayer/**`, `pkg/epp/datastore/**` | EPP data layer and datastore |
 | `area/telemetry` | `pkg/common/observability/**` | Telemetry and observability |
-| `area/dev` | `.github/**`, `hack/**`, `scripts/**`, `Makefile`, `test/e2e/**`, `test/framework/**`, `test/utils/**`, `test/scripts/**`, `test/perf/**`, `test/profiling/**` | Dev tooling, CI/CD and shared test harness |
 | `area/docs` | `docs/**`, top-level `*.md` | Documentation |
+
+These eight labels do not exist in the repository yet. Once created, their glob blocks move into `.github/labeler.yml` alongside `area/epp` and `area/dev`, and their rows drop from this table.
 
 A change can span multiple areas. Apply every label that fits rather than picking one. Areas nest by path rather than exclude one another: a change under `pkg/epp/scheduling/**` matches both `area/epp` and `area/scheduling` and both labels apply.
 
 ## Applying a label
 
 - Manually: add an `/area <name>` line to a PR or issue body (see `.github/workflows/pr-kind-label.yaml` and `.github/workflows/issue-kind-label.yaml`).
-- Automatically: path based labeling from this table is tracked separately against [#956](https://github.com/llm-d/llm-d-router/issues/956).
+- Automatically: `area/epp` and `area/dev` are applied from `.github/labeler.yml` on every PR. The remaining eight areas above are pending label creation, tracked against [#956](https://github.com/llm-d/llm-d-router/issues/956).

--- a/docs/area_taxonomy.md
+++ b/docs/area_taxonomy.md
@@ -1,25 +1,12 @@
-# Area taxonomy
+# Area Taxonomy
 
 `area/*` labels route issues and pull requests to the right reviewers by component. Each area maps to one or more directories, so it can be applied either manually (via an `/area` directive on a PR or issue body) or automatically from the paths a change touches.
 
-`area/epp` and `area/dev` are labeled automatically by `.github/labeler.yml`, which is the canonical source for their path globs.
+`.github/labeler.yml` is the canonical source for the path globs each `area/*` label maps to.
 
-| Label | Paths | Scope |
-|---|---|---|
-| `area/scheduling` | `pkg/epp/scheduling/**`, `pkg/epp/framework/plugins/scheduling/**`, `pkg/epp/requestcontrol/**`, `pkg/epp/framework/plugins/requestcontrol/**` | Scheduling and request routing decisions |
-| `area/flowcontrol` | `pkg/epp/flowcontrol/**`, `pkg/epp/framework/plugins/flowcontrol/**` | Admission, queuing and flow control |
-| `area/kvcache` | `pkg/kvcache/**`, `pkg/kvevents/**` | KV cache indexing and events |
-| `area/coordinator` | `pkg/coordinator/**`, `cmd/coordinator/**`, `test/coordinator/**` | Disaggregated inference coordinator |
-| `area/sidecar` | `pkg/sidecar/**`, `cmd/pd-sidecar/**`, `test/sidecar/**` | PD sidecar proxy |
-| `area/datalayer` | `pkg/epp/datalayer/**`, `pkg/epp/framework/plugins/datalayer/**`, `pkg/epp/datastore/**` | EPP data layer and datastore |
-| `area/telemetry` | `pkg/common/observability/**` | Telemetry and observability |
-| `area/docs` | `docs/**`, top-level `*.md` | Documentation |
-
-These eight labels do not exist in the repository yet. Once created, their glob blocks move into `.github/labeler.yml` alongside `area/epp` and `area/dev`, and their rows drop from this table.
-
-A change can span multiple areas. Apply every label that fits rather than picking one. Areas nest by path rather than exclude one another: a change under `pkg/epp/scheduling/**` matches both `area/epp` and `area/scheduling` and both labels apply.
+A change can span multiple areas. Apply every label that fits rather than picking one. Areas nest by path rather than exclude one another. For example, a change under `pkg/epp/scheduling/**` matches both `area/epp` and `area/scheduling` and both labels apply.
 
 ## Applying a label
 
-- Manually: add an `/area <name>` line to a PR or issue body (see `.github/workflows/pr-kind-label.yaml` and `.github/workflows/issue-kind-label.yaml`).
-- Automatically: `area/epp` and `area/dev` are applied from `.github/labeler.yml` on every PR. The remaining eight areas above are pending label creation, tracked against [#956](https://github.com/llm-d/llm-d-router/issues/956).
+- Manually: add an `/area <name>` line to a PR or issue body (see ` github/workflows/pr-kind-label.yaml` and `.github/workflows/issue-kind-label.yaml`)
+- Automatically: `.github/labeler.yml` applies the matching `area/*` label(s) on every PR

--- a/docs/area_taxonomy.md
+++ b/docs/area_taxonomy.md
@@ -8,5 +8,5 @@ A change can span multiple areas. Apply every label that fits rather than pickin
 
 ## Applying a label
 
-- Manually: add an `/area <name>` line to a PR or issue body (see ` github/workflows/pr-kind-label.yaml` and `.github/workflows/issue-kind-label.yaml`)
+- Manually: add an `/area <name>` line to a PR or issue body (see `.github/workflows/pr-kind-label.yaml` and `.github/workflows/issue-kind-label.yaml`)
 - Automatically: `.github/labeler.yml` applies the matching `area/*` label(s) on every PR


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
All ten `area/*` labels now exist in the repo. This wires up the remaining eight (`area/scheduling`, `area/flowcontrol`, `area/kvcache`, `area/coordinator`, `area/sidecar`, `area/datalayer`, `area/telemetry`, `area/docs`) via `actions/labeler`, alongside `area/epp` and `area/dev`. `.github/labeler.yml` is now the single source of truth for the path globs. `docs/area_taxonomy.md` drops its table and keeps only the `/area` directive explanation and the additive overlap rule.

/cc @elevran 

**Which issue(s) this PR fixes**:
Partial #956 (Phase 4, Labeling)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
