### PR TITLE
feat(flowcontrol): split queue-wait budget by unavailability regime

### DIFF
--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -403,8 +403,9 @@ type FlowControlConfig struct {
 	// within it is shed with a retryable backpressure error rather than served late, and with no
 	// client or gateway deadline it is the only bound on waiting against a pool that has endpoints.
 	// Where such deadlines exist and fire sooner, they evict the request first (client disconnect).
-	// An explicit "0s" disables eviction while the pool has endpoints: such requests then wait until
-	// client disconnect or controller shutdown.
+	// An explicit "0s" disables eviction while the pool has endpoints, and, unless NoEndpointRequestTTL
+	// overrides it, while the pool is empty as well: such requests then wait until client disconnect or
+	// controller shutdown.
 	DefaultRequestTTL *metav1.Duration `json:"defaultRequestTTL,omitempty"`
 
 	// +optional
@@ -419,9 +420,10 @@ type FlowControlConfig struct {
 	// Total queue wait stays bounded by the longer of the two budgets, plus a short expiry-sweep margin;
 	// a regime change grants a fresh budget but does not extend that bound, so a request that changes
 	// regime near the bound may be evicted before the fresh budget elapses.
-	// If omitted, it defaults to 60s. An explicit "0s" disables eviction while the pool is empty:
-	// requests then wait until an endpoint appears, the client disconnects, or the controller shuts
-	// down.
+	// If omitted, it follows DefaultRequestTTL, so splitting the regimes is opt-in and a configuration that
+	// sets only DefaultRequestTTL keeps that bound in both; it defaults to 60s when neither is set. An
+	// explicit "0s" disables eviction while the pool is empty: requests then wait until an endpoint
+	// appears, the client disconnects, or the controller shuts down.
 	NoEndpointRequestTTL *metav1.Duration `json:"noEndpointRequestTTL,omitempty"`
 
 	// +optional

--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -415,6 +415,9 @@ type FlowControlConfig struct {
 	// unavailability rather than as backpressure.
 	// The budget in force is re-evaluated while the request is queued, so a pool that scales from zero
 	// moves its queued requests onto DefaultRequestTTL, and each regime change starts a fresh budget.
+	// Total queue wait stays bounded by the longer of the two budgets, plus a short expiry-sweep margin;
+	// a regime change grants a fresh budget but does not extend that bound, so a request that changes
+	// regime near the bound may be evicted before the fresh budget elapses.
 	// If omitted, it defaults to 60s. An explicit "0s" disables eviction while the pool is empty:
 	// requests then wait until an endpoint appears, the client disconnects, or the controller shuts
 	// down.

--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -407,6 +407,20 @@ type FlowControlConfig struct {
 	DefaultRequestTTL *metav1.Duration `json:"defaultRequestTTL,omitempty"`
 
 	// +optional
+	// NoEndpointRequestTTL bounds queue wait while the candidate pool has no endpoints, replacing
+	// DefaultRequestTTL for as long as that holds. The two regimes want opposite budgets: with no
+	// endpoint to dispatch to, waiting is the only path to success and the budget should cover a cold
+	// start (image pull plus weight load), whereas a saturated pool should shed early enough to keep
+	// time-to-first-token within an SLO. A request that exhausts this budget is evicted as genuine
+	// unavailability rather than as backpressure.
+	// The budget in force is re-evaluated while the request is queued, so a pool that scales from zero
+	// moves its queued requests onto DefaultRequestTTL, and each regime change starts a fresh budget.
+	// If omitted, it defaults to 60s. An explicit "0s" disables eviction while the pool is empty:
+	// requests then wait until an endpoint appears, the client disconnects, or the controller shuts
+	// down.
+	NoEndpointRequestTTL *metav1.Duration `json:"noEndpointRequestTTL,omitempty"`
+
+	// +optional
 	// DefaultPriorityBand allows you to define a template for handling traffic with priority levels
 	// that are not explicitly configured in `PriorityBands`.
 	// This ensures that unforeseen traffic classes are still managed (e.g., given a default capacity
@@ -470,6 +484,10 @@ func (fcc *FlowControlConfig) String() string {
 
 	if fcc.DefaultRequestTTL != nil {
 		parts = append(parts, fmt.Sprintf("DefaultRequestTTL: %s", fcc.DefaultRequestTTL.Duration))
+	}
+
+	if fcc.NoEndpointRequestTTL != nil {
+		parts = append(parts, fmt.Sprintf("NoEndpointRequestTTL: %s", fcc.NoEndpointRequestTTL.Duration))
 	}
 
 	if fcc.DefaultPriorityBand != nil {

--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -397,13 +397,14 @@ type FlowControlConfig struct {
 	MaxRequests *resource.Quantity `json:"maxRequests,omitempty"`
 
 	// +optional
-	// DefaultRequestTTL bounds how long a request may wait in the queue before it is evicted.
+	// DefaultRequestTTL bounds how long a request may wait in the queue while the candidate pool has
+	// endpoints; NoEndpointRequestTTL bounds that wait while it has none.
 	// If omitted, it defaults to 60s. This is a queue-wait budget: a request that cannot dispatch
-	// within it is shed with a retryable backpressure error rather than served late, and it is the
-	// only bound on queue wait when neither the client nor the gateway enforces a request deadline.
+	// within it is shed with a retryable backpressure error rather than served late, and with no
+	// client or gateway deadline it is the only bound on waiting against a pool that has endpoints.
 	// Where such deadlines exist and fire sooner, they evict the request first (client disconnect).
-	// An explicit "0s" disables the TTL: requests then wait until client disconnect or controller
-	// shutdown.
+	// An explicit "0s" disables eviction while the pool has endpoints: such requests then wait until
+	// client disconnect or controller shutdown.
 	DefaultRequestTTL *metav1.Duration `json:"defaultRequestTTL,omitempty"`
 
 	// +optional

--- a/apix/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apix/config/v1alpha1/zz_generated.deepcopy.go
@@ -222,6 +222,11 @@ func (in *FlowControlConfig) DeepCopyInto(out *FlowControlConfig) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.NoEndpointRequestTTL != nil {
+		in, out := &in.NoEndpointRequestTTL, &out.NoEndpointRequestTTL
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.DefaultPriorityBand != nil {
 		in, out := &in.DefaultPriorityBand, &out.DefaultPriorityBand
 		*out = new(PriorityBandConfig)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -218,8 +218,8 @@ Exposed when the `flowControl` feature gate is enabled.
 
 *   **Type:** Histogram
 *   **Labels:** `fairness_id`, `priority`, `outcome` (`Dispatched`, `RejectedCapacity`,
-    `RejectedOther`, `EvictedTTL`, `EvictedContextCancelled`, `EvictedOther`), `inference_pool`,
-    `model_name`, `target_model_name`
+    `RejectedOther`, `EvictedTTL`, `EvictedNoEndpoints`, `EvictedContextCancelled`, `EvictedOther`),
+    `inference_pool`, `model_name`, `target_model_name`
 *   **Description:** Total time a request spends in the Flow Control layer, from enqueue to final
     outcome.
 *   **Usage:** Primary latency signal for flow control. Rising p99 indicates backends are saturated
@@ -285,7 +285,9 @@ Exposed when the `flowControl` feature gate is enabled.
 *   **Labels:**
     *   `outcome`: terminal outcome, one of `Dispatched`, `RejectedCapacity`, `RejectedNoEndpoints`
         (candidate pool had no endpoints at the capacity boundary; surfaces as HTTP 503 rather than
-        429), `RejectedOther`, `EvictedTTL`, `EvictedContextCancelled`, `EvictedOther`
+        429), `RejectedOther`, `EvictedTTL`, `EvictedNoEndpoints` (queue-wait budget expired while the
+        candidate pool had no endpoints; surfaces as HTTP 503 rather than 429), `EvictedContextCancelled`,
+        `EvictedOther`
     *   `priority`, `inference_pool`
 *   **Description:** Total requests processed by the Flow Control layer, incremented once per request
     after its terminal outcome is determined.
@@ -299,6 +301,8 @@ Exposed when the `flowControl` feature gate is enabled.
         - investigate pool health and scaling.
     *   Rising `outcome="EvictedTTL"`: requests waiting longer than their TTL - investigate backend
         throughput or tighten admission.
+    *   Rising `outcome="EvictedNoEndpoints"`: requests waited out `noEndpointRequestTTL` without an
+        endpoint appearing - investigate scaling latency, or raise the budget above pod startup.
     *   `outcome="Dispatched"` is the healthy baseline; compare against total request rate for the
         acceptance ratio.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -27,7 +27,9 @@ The EPP acts as the routing intelligence engine. Its resource usage scales prima
   of the inflight-request sizing above. The global `flowControl.maxRequests` / `maxBytes` caps
   default to unlimited, so set a global `maxBytes` under the container memory limit: at the per-band
   default, a handful of bands clears the sizing guidance below before any band cap engages. Lower
-  these limits (or set a shorter `defaultRequestTTL`) to trade queueing for earlier shedding.
+  these limits (or set a shorter `defaultRequestTTL`) to trade queueing for earlier shedding. A
+  `noEndpointRequestTTL` sized for a cold start holds bodies for that whole budget while the pool is
+  empty, so the band caps, not the budget, become what bounds queue memory during a scale-from-zero.
 - **Sizing Guidelines**:
   - For a request rate of 50 to 100 requests/second with 1k output tokens, EPP requires between **4 GiB and 6 GiB** of memory.
   - For workloads with longer output lengths (such as 5k output tokens), memory usage can reach **20+ GiB** due to the accumulation of state for concurrent inflight requests.

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -228,8 +228,9 @@ func flowControlSettingsConfigured(fc *configapi.FlowControlConfig) bool {
 		return false
 	}
 	return fc.MaxBytes != nil || fc.MaxRequests != nil || fc.DefaultRequestTTL != nil ||
-		fc.DefaultPriorityBand != nil || fc.DefaultNegativePriorityBand != nil ||
-		len(fc.PriorityBands) > 0 || fc.UsageLimitPolicyPluginRef != ""
+		fc.NoEndpointRequestTTL != nil || fc.DefaultPriorityBand != nil ||
+		fc.DefaultNegativePriorityBand != nil || len(fc.PriorityBands) > 0 ||
+		fc.UsageLimitPolicyPluginRef != ""
 }
 
 func decodeRawConfig(configBytes []byte) (*configapi.EndpointPickerConfig, error) {

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -526,6 +526,8 @@ func TestInstantiateAndConfigure(t *testing.T) {
 				require.Equal(t, uint64(1024), cfg.FlowControlConfig.Registry.MaxBytes, "MaxBytes should match yaml")
 				require.NotNil(t, cfg.FlowControlConfig.Controller, "Controller config should be present")
 				require.Equal(t, 1*time.Minute, cfg.FlowControlConfig.Controller.DefaultRequestTTL, "DefaultRequestTTL should match yaml")
+				require.Equal(t, 5*time.Minute, cfg.FlowControlConfig.Controller.NoEndpointRequestTTL,
+					"NoEndpointRequestTTL should match yaml")
 				require.Equal(t, 1*time.Second, cfg.FlowControlConfig.Controller.ExpiryCleanupInterval, "ExpiryCleanupInterval should use default")
 
 				// Verify plugins were injected into the Raw Config.

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -502,6 +502,19 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			},
 		},
 		{
+			name:       "Success - Flow Control No-Endpoint TTL Follows Default",
+			configText: successFlowControlInheritedTTLText,
+			wantErr:    false,
+			validate: func(t *testing.T, _ fwkplugin.Handle, _ *configapi.EndpointPickerConfig, cfg *config.Config) {
+				require.NotNil(t, cfg.FlowControlConfig, "FlowControl config should have been loaded")
+				require.NotNil(t, cfg.FlowControlConfig.Controller, "Controller config should be present")
+				require.Equal(t, time.Duration(0), cfg.FlowControlConfig.Controller.DefaultRequestTTL,
+					"an explicit 0s should disable eviction while the pool has endpoints")
+				require.Equal(t, time.Duration(0), cfg.FlowControlConfig.Controller.NoEndpointRequestTTL,
+					"an unset no-endpoint budget should follow defaultRequestTTL, so 0s disables eviction in both regimes")
+			},
+		},
+		{
 			name:       "Success - Picker Before Scorer",
 			configText: successPickerBeforeScorerText,
 			wantErr:    false,

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -265,6 +265,24 @@ flowControl:
   noEndpointRequestTTL: 5m
 `
 
+// successFlowControlInheritedTTLText covers a config that names only defaultRequestTTL: the no-endpoint budget follows
+// it, so disabling the TTL is not silently narrowed to the regime where the pool has endpoints.
+const successFlowControlInheritedTTLText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+featureGates:
+- flowControl
+flowControl:
+  defaultRequestTTL: 0s
+`
+
 const successflowControlConfigDisabledText = `
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -262,6 +262,7 @@ featureGates:
 flowControl:
   maxBytes: "1024"
   defaultRequestTTL: 1m
+  noEndpointRequestTTL: 5m
 `
 
 const successflowControlConfigDisabledText = `

--- a/pkg/epp/flowcontrol/README.md
+++ b/pkg/epp/flowcontrol/README.md
@@ -62,10 +62,16 @@ Tuning knobs, all under the `flowControl:` config section:
 * Per-band `maxRequests` / `maxBytes` — the shedding knobs. Lower them to reject excess load at the
   queue boundary instead of buffering it (for example, to approximate the legacy immediate-shed
   behavior for sheddable traffic).
-* `defaultRequestTTL` — the queue-wait budget, and the other way a request is shed. When the pool
-  has no endpoints the queue acts as a scale-from-zero waiting room and requests hold for the full
-  budget, so keep it under the client or gateway deadline unless you want requests to survive a cold
-  start.
+* `defaultRequestTTL` — the queue-wait budget against a pool that has endpoints, and the other way a
+  request is shed. Keep it under the client or gateway deadline, and size it to the time-to-first-token
+  budget you are willing to spend waiting on a saturated pool.
+* `noEndpointRequestTTL` — the queue-wait budget that replaces `defaultRequestTTL` while the pool has
+  no endpoints, where the queue acts as a scale-from-zero waiting room. Size it above pod startup
+  (image pull plus weight load) if you want requests to survive a cold start; a request shed here is
+  reported as `EvictedNoEndpoints` and returns 503 rather than 429. Which budget applies is
+  re-evaluated while a request is queued, so a pool that scales up moves its queued requests onto
+  `defaultRequestTTL`. A long budget only helps if the caller waits, so pair it with a gateway request
+  timeout at least as long.
 * The priority-holdback usage-limit policy — a gating knob, not a shedding one. It lowers the
   admission ceiling for low-priority traffic as utilization rises, so that traffic waits in queue
   rather than being rejected; it sheds only by way of the two limits above. Configure it via

--- a/pkg/epp/flowcontrol/README.md
+++ b/pkg/epp/flowcontrol/README.md
@@ -66,9 +66,10 @@ Tuning knobs, all under the `flowControl:` config section:
   request is shed. Keep it under the client or gateway deadline, and size it to the time-to-first-token
   budget you are willing to spend waiting on a saturated pool.
 * `noEndpointRequestTTL` — the queue-wait budget that replaces `defaultRequestTTL` while the pool has
-  no endpoints, where the queue acts as a scale-from-zero waiting room. Size it above pod startup
-  (image pull plus weight load) if you want requests to survive a cold start; a request shed here is
-  reported as `EvictedNoEndpoints` and returns 503 rather than 429. Which budget applies is
+  no endpoints, where the queue acts as a scale-from-zero waiting room. Left unset it follows
+  `defaultRequestTTL`, so splitting the regimes is opt-in. Size it above pod startup (image pull plus
+  weight load) if you want requests to survive a cold start; a request shed here is reported as
+  `EvictedNoEndpoints` and returns 503 rather than 429. Which budget applies is
   re-evaluated while a request is queued, so a pool that scales up moves its queued requests onto
   `defaultRequestTTL`. A long budget only helps if the caller waits, so pair it with a gateway request
   timeout at least as long.

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -31,6 +31,11 @@ const (
 	// gateway enforces a request deadline (the well-lit guides configure no gateway request timeout);
 	// where such deadlines exist and fire sooner, context cancellation evicts the request first.
 	defaultRequestTTL = 60 * time.Second
+	// defaultNoEndpointRequestTTL is the default queue-wait budget applied while the candidate pool has
+	// no endpoints. It is deliberately equal to `defaultRequestTTL`, so splitting the budget is opt-in:
+	// sizing the two regimes apart (a cold start is minutes, a time-to-first-token SLO is seconds) is a
+	// deployment-specific decision, not one a default can make.
+	defaultNoEndpointRequestTTL = 60 * time.Second
 	// defaultExpiryCleanupInterval is the default frequency for scanning for expired items.
 	defaultExpiryCleanupInterval = 1 * time.Second
 	// defaultEnqueueChannelBufferSize is the default size of a worker's incoming request buffer.
@@ -56,6 +61,14 @@ type Config struct {
 	// which case queued requests are bounded only by request context cancellation (client disconnect
 	// or gateway timeout).
 	DefaultRequestTTL time.Duration
+
+	// NoEndpointRequestTTL is the queue-wait budget that replaces `DefaultRequestTTL` while the candidate
+	// pool has no endpoints. Which budget is in force is re-evaluated as the request waits, and each
+	// change of regime starts a fresh budget, so a request queued against an empty pool is not shed the
+	// instant an endpoint appears and makes it dispatchable.
+	// Optional: Defaults to `defaultNoEndpointRequestTTL` (60s). An explicit zero disables eviction while
+	// the pool is empty, in which case such requests are bounded only by request context cancellation.
+	NoEndpointRequestTTL time.Duration
 
 	// ExpiryCleanupInterval is the interval at which each processor scans its queues for expired items.
 	// Optional: Defaults to `defaultExpiryCleanupInterval` (1 second).
@@ -116,6 +129,9 @@ func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig) (*Config, error) {
 		if apiConfig.DefaultRequestTTL != nil {
 			opts = append(opts, WithDefaultRequestTTL(apiConfig.DefaultRequestTTL.Duration))
 		}
+		if apiConfig.NoEndpointRequestTTL != nil {
+			opts = append(opts, WithNoEndpointRequestTTL(apiConfig.NoEndpointRequestTTL.Duration))
+		}
 		if apiConfig.EnableEviction {
 			opts = append(opts, WithEnableEviction(true))
 		}
@@ -127,6 +143,7 @@ func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig) (*Config, error) {
 func NewConfig(opts ...ConfigOption) (*Config, error) {
 	c := &Config{
 		DefaultRequestTTL:           defaultRequestTTL,
+		NoEndpointRequestTTL:        defaultNoEndpointRequestTTL,
 		ExpiryCleanupInterval:       defaultExpiryCleanupInterval,
 		EnqueueChannelBufferSize:    defaultEnqueueChannelBufferSize,
 		MaxRevocationsPerDecision:   defaultMaxRevocationsPerDecision,
@@ -148,6 +165,13 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 func WithDefaultRequestTTL(d time.Duration) ConfigOption {
 	return func(c *Config) {
 		c.DefaultRequestTTL = d
+	}
+}
+
+// WithNoEndpointRequestTTL sets the queue-wait budget applied while the pool has no endpoints.
+func WithNoEndpointRequestTTL(d time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.NoEndpointRequestTTL = d
 	}
 }
 
@@ -197,6 +221,9 @@ func WithEvictionConfirmationTimeout(d time.Duration) ConfigOption {
 func (c *Config) validate() error {
 	if c.DefaultRequestTTL < 0 {
 		return fmt.Errorf("DefaultRequestTTL cannot be negative, but got %v", c.DefaultRequestTTL)
+	}
+	if c.NoEndpointRequestTTL < 0 {
+		return fmt.Errorf("NoEndpointRequestTTL cannot be negative, but got %v", c.NoEndpointRequestTTL)
 	}
 	if c.ExpiryCleanupInterval <= 0 {
 		return fmt.Errorf("ExpiryCleanupInterval must be positive, but got %v", c.ExpiryCleanupInterval)

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -31,8 +31,8 @@ const (
 	// request timeout) it is the only bound on waiting against a pool that has endpoints; where such
 	// deadlines exist and fire sooner, context cancellation evicts the request first.
 	defaultRequestTTL = 60 * time.Second
-	// defaultNoEndpointRequestTTL is the default queue-wait budget applied while the candidate pool has
-	// no endpoints. It is deliberately equal to `defaultRequestTTL`, so splitting the budget is opt-in:
+	// defaultNoEndpointRequestTTL is the queue-wait budget applied while the candidate pool has no endpoints when
+	// neither budget is configured. It is deliberately equal to `defaultRequestTTL`, so splitting the budget is opt-in:
 	// sizing the two regimes apart (a cold start is minutes, a time-to-first-token SLO is seconds) is a
 	// deployment-specific decision, not one a default can make.
 	defaultNoEndpointRequestTTL = 60 * time.Second
@@ -58,16 +58,18 @@ type Config struct {
 	// TTL hint. Because the admission adapter does not currently plumb a per-request hint, this value
 	// governs every request entering flow control while the candidate pool has endpoints.
 	// Optional: Defaults to `defaultRequestTTL` (60s). An explicit zero disables eviction in that
-	// regime, in which case such requests are bounded only by request context cancellation (client
-	// disconnect or gateway timeout).
+	// regime, and, unless `NoEndpointRequestTTL` overrides it, in the empty-pool regime as well; such
+	// requests are then bounded only by request context cancellation (client disconnect or gateway
+	// timeout).
 	DefaultRequestTTL time.Duration
 
 	// NoEndpointRequestTTL is the queue-wait budget that replaces `DefaultRequestTTL` while the candidate
 	// pool has no endpoints. Which budget is in force is re-evaluated as the request waits, and each
 	// change of regime starts a fresh budget, so a request queued against an empty pool is not shed the
 	// instant an endpoint appears and makes it dispatchable.
-	// Optional: Defaults to `defaultNoEndpointRequestTTL` (60s). An explicit zero disables eviction while
-	// the pool is empty, in which case such requests are bounded only by request context cancellation.
+	// Optional: Follows `DefaultRequestTTL` when the configuration sets that alone, and defaults to
+	// `defaultNoEndpointRequestTTL` (60s) when it sets neither. An explicit zero disables eviction while the pool is
+	// empty, in which case such requests are bounded only by request context cancellation.
 	NoEndpointRequestTTL time.Duration
 
 	// ExpiryCleanupInterval is the interval at which each processor scans its queues for expired items.
@@ -129,8 +131,14 @@ func NewConfigFromAPI(apiConfig *configapi.FlowControlConfig) (*Config, error) {
 		if apiConfig.DefaultRequestTTL != nil {
 			opts = append(opts, WithDefaultRequestTTL(apiConfig.DefaultRequestTTL.Duration))
 		}
-		if apiConfig.NoEndpointRequestTTL != nil {
+		switch {
+		case apiConfig.NoEndpointRequestTTL != nil:
 			opts = append(opts, WithNoEndpointRequestTTL(apiConfig.NoEndpointRequestTTL.Duration))
+		case apiConfig.DefaultRequestTTL != nil:
+			// Left unset, the no-endpoint budget follows `DefaultRequestTTL`, so splitting the regimes is opt-in: a
+			// deployment that bounded queue wait with the single field it had keeps that bound in both regimes, and an
+			// explicit "0s" still disables eviction outright.
+			opts = append(opts, WithNoEndpointRequestTTL(apiConfig.DefaultRequestTTL.Duration))
 		}
 		if apiConfig.EnableEviction {
 			opts = append(opts, WithEnableEviction(true))

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -27,9 +27,9 @@ const (
 	// defaultRequestTTL is the default Time-To-Live applied to queued requests when the configuration
 	// does not specify one. It is a queue-wait budget: a request still undispatched after this long is
 	// shed with a retryable backpressure signal instead of being served with severely degraded
-	// time-to-first-token. It is also the only bound on queue wait when neither the client nor the
-	// gateway enforces a request deadline (the well-lit guides configure no gateway request timeout);
-	// where such deadlines exist and fire sooner, context cancellation evicts the request first.
+	// time-to-first-token. With no client or gateway deadline (the well-lit guides configure no gateway
+	// request timeout) it is the only bound on waiting against a pool that has endpoints; where such
+	// deadlines exist and fire sooner, context cancellation evicts the request first.
 	defaultRequestTTL = 60 * time.Second
 	// defaultNoEndpointRequestTTL is the default queue-wait budget applied while the candidate pool has
 	// no endpoints. It is deliberately equal to `defaultRequestTTL`, so splitting the budget is opt-in:
@@ -56,10 +56,10 @@ const (
 type Config struct {
 	// DefaultRequestTTL is the default Time-To-Live applied to requests that do not specify their own
 	// TTL hint. Because the admission adapter does not currently plumb a per-request hint, this value
-	// governs every request entering flow control.
-	// Optional: Defaults to `defaultRequestTTL` (60s). An explicit zero disables the TTL entirely, in
-	// which case queued requests are bounded only by request context cancellation (client disconnect
-	// or gateway timeout).
+	// governs every request entering flow control while the candidate pool has endpoints.
+	// Optional: Defaults to `defaultRequestTTL` (60s). An explicit zero disables eviction in that
+	// regime, in which case such requests are bounded only by request context cancellation (client
+	// disconnect or gateway timeout).
 	DefaultRequestTTL time.Duration
 
 	// NoEndpointRequestTTL is the queue-wait budget that replaces `DefaultRequestTTL` while the candidate

--- a/pkg/epp/flowcontrol/controller/config_test.go
+++ b/pkg/epp/flowcontrol/controller/config_test.go
@@ -42,6 +42,7 @@ func TestNewConfig(t *testing.T) {
 			expectErr: false,
 			expectedCfg: Config{
 				DefaultRequestTTL:           defaultRequestTTL,
+				NoEndpointRequestTTL:        defaultNoEndpointRequestTTL,
 				ExpiryCleanupInterval:       defaultExpiryCleanupInterval,
 				EnqueueChannelBufferSize:    defaultEnqueueChannelBufferSize,
 				MaxRevocationsPerDecision:   defaultMaxRevocationsPerDecision,
@@ -57,6 +58,7 @@ func TestNewConfig(t *testing.T) {
 			expectErr: false,
 			expectedCfg: Config{
 				DefaultRequestTTL:           0,
+				NoEndpointRequestTTL:        defaultNoEndpointRequestTTL,
 				ExpiryCleanupInterval:       defaultExpiryCleanupInterval,
 				EnqueueChannelBufferSize:    defaultEnqueueChannelBufferSize,
 				MaxRevocationsPerDecision:   defaultMaxRevocationsPerDecision,
@@ -72,6 +74,7 @@ func TestNewConfig(t *testing.T) {
 			expectErr: false,
 			expectedCfg: Config{
 				DefaultRequestTTL:           10 * time.Second,
+				NoEndpointRequestTTL:        defaultNoEndpointRequestTTL,
 				ExpiryCleanupInterval:       defaultExpiryCleanupInterval,
 				EnqueueChannelBufferSize:    defaultEnqueueChannelBufferSize,
 				MaxRevocationsPerDecision:   defaultMaxRevocationsPerDecision,
@@ -83,14 +86,32 @@ func TestNewConfig(t *testing.T) {
 			name: "WithAllOptions_ShouldUpdateConfig",
 			opts: []ConfigOption{
 				WithDefaultRequestTTL(10 * time.Second),
+				WithNoEndpointRequestTTL(5 * time.Minute),
 				WithExpiryCleanupInterval(2 * time.Second),
 				WithEnqueueChannelBufferSize(50),
 			},
 			expectErr: false,
 			expectedCfg: Config{
 				DefaultRequestTTL:           10 * time.Second,
+				NoEndpointRequestTTL:        5 * time.Minute,
 				ExpiryCleanupInterval:       2 * time.Second,
 				EnqueueChannelBufferSize:    50,
+				MaxRevocationsPerDecision:   defaultMaxRevocationsPerDecision,
+				EvictionConfirmationGrace:   defaultEvictionConfirmationGrace,
+				EvictionConfirmationTimeout: defaultEvictionConfirmationTimeout,
+			},
+		},
+		{
+			name: "ZeroNoEndpointRequestTTL_ShouldDisableEvictionWhilePoolIsEmpty",
+			opts: []ConfigOption{
+				WithNoEndpointRequestTTL(0),
+			},
+			expectErr: false,
+			expectedCfg: Config{
+				DefaultRequestTTL:           defaultRequestTTL,
+				NoEndpointRequestTTL:        0,
+				ExpiryCleanupInterval:       defaultExpiryCleanupInterval,
+				EnqueueChannelBufferSize:    defaultEnqueueChannelBufferSize,
 				MaxRevocationsPerDecision:   defaultMaxRevocationsPerDecision,
 				EvictionConfirmationGrace:   defaultEvictionConfirmationGrace,
 				EvictionConfirmationTimeout: defaultEvictionConfirmationTimeout,
@@ -100,6 +121,13 @@ func TestNewConfig(t *testing.T) {
 			name: "NegativeDefaultRequestTTL_ShouldError",
 			opts: []ConfigOption{
 				WithDefaultRequestTTL(-1 * time.Second),
+			},
+			expectErr: true,
+		},
+		{
+			name: "NegativeNoEndpointRequestTTL_ShouldError",
+			opts: []ConfigOption{
+				WithNoEndpointRequestTTL(-1 * time.Second),
 			},
 			expectErr: true,
 		},
@@ -135,6 +163,7 @@ func TestNewConfig(t *testing.T) {
 			expectErr: false,
 			expectedCfg: Config{
 				DefaultRequestTTL:           defaultRequestTTL,
+				NoEndpointRequestTTL:        defaultNoEndpointRequestTTL,
 				ExpiryCleanupInterval:       defaultExpiryCleanupInterval,
 				EnqueueChannelBufferSize:    defaultEnqueueChannelBufferSize,
 				EnableEviction:              true,

--- a/pkg/epp/flowcontrol/controller/config_test.go
+++ b/pkg/epp/flowcontrol/controller/config_test.go
@@ -230,6 +230,8 @@ func TestNewConfigFromAPI(t *testing.T) {
 				assert.Equal(t, defaultEnqueueChannelBufferSize, cfg.EnqueueChannelBufferSize,
 					"EnqueueChannelBufferSize should be defaulted")
 				assert.Equal(t, defaultRequestTTL, cfg.DefaultRequestTTL, "DefaultRequestTTL should be defaulted when unset")
+				assert.Equal(t, defaultNoEndpointRequestTTL, cfg.NoEndpointRequestTTL,
+					"NoEndpointRequestTTL should be defaulted when neither budget is configured")
 			},
 		},
 		{
@@ -253,12 +255,51 @@ func TestNewConfigFromAPI(t *testing.T) {
 			},
 		},
 		{
+			// Splitting the regimes is opt-in: a configuration that names only DefaultRequestTTL states one bound on
+			// queue wait, and it governs both regimes rather than picking up an unrequested cold-start budget.
+			name: "DefaultRequestTTLAlone_ShouldGovernBothRegimes",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultRequestTTL: &metav1.Duration{Duration: 10 * time.Second},
+			},
+			assertion: func(t *testing.T, cfg *Config) {
+				assert.Equal(t, 10*time.Second, cfg.DefaultRequestTTL, "DefaultRequestTTL should be translated")
+				assert.Equal(t, 10*time.Second, cfg.NoEndpointRequestTTL,
+					"an unset NoEndpointRequestTTL should follow DefaultRequestTTL")
+			},
+		},
+		{
+			name: "NoEndpointRequestTTL_ShouldOverrideInheritance",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultRequestTTL:    &metav1.Duration{Duration: 10 * time.Second},
+				NoEndpointRequestTTL: &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			assertion: func(t *testing.T, cfg *Config) {
+				assert.Equal(t, 10*time.Second, cfg.DefaultRequestTTL, "DefaultRequestTTL should be translated")
+				assert.Equal(t, 5*time.Minute, cfg.NoEndpointRequestTTL, "an explicit no-endpoint budget wins")
+			},
+		},
+		{
+			// "0s" is the documented way to disable eviction. Inheriting it keeps that meaning whole: a deployment that
+			// disabled the TTL is not opted into shedding the moment its pool scales to zero.
 			name: "ExplicitZeroRequestTTL_ShouldBeRespected",
 			apiConfig: &configapi.FlowControlConfig{
 				DefaultRequestTTL: &metav1.Duration{Duration: 0},
 			},
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, time.Duration(0), cfg.DefaultRequestTTL, "Explicit 0s TTL should be respected")
+				assert.Equal(t, time.Duration(0), cfg.NoEndpointRequestTTL,
+					"an explicit 0s must disable eviction in the empty-pool regime too")
+			},
+		},
+		{
+			name: "ExplicitZeroNoEndpointRequestTTL_ShouldNotInherit",
+			apiConfig: &configapi.FlowControlConfig{
+				DefaultRequestTTL:    &metav1.Duration{Duration: 10 * time.Second},
+				NoEndpointRequestTTL: &metav1.Duration{Duration: 0},
+			},
+			assertion: func(t *testing.T, cfg *Config) {
+				assert.Equal(t, time.Duration(0), cfg.NoEndpointRequestTTL,
+					"an explicit 0s should disable eviction while the pool is empty, not inherit")
 			},
 		},
 		{

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -57,6 +57,7 @@ type processorFactory func(
 	endpointCandidates contracts.EndpointCandidates,
 	usageLimitPolicy flowcontrol.UsageLimitPolicy,
 	clock clock.WithTicker,
+	noEndpointRequestTTL time.Duration,
 	cleanupSweepInterval time.Duration,
 	enqueueChannelBufferSize int,
 	logger logr.Logger,
@@ -150,6 +151,7 @@ func NewFlowController(
 			endpointCandidates contracts.EndpointCandidates,
 			usageLimitPolicy flowcontrol.UsageLimitPolicy,
 			clock clock.WithTicker,
+			noEndpointRequestTTL time.Duration,
 			cleanupSweepInterval time.Duration,
 			enqueueChannelBufferSize int,
 			logger logr.Logger,
@@ -164,6 +166,7 @@ func NewFlowController(
 				endpointCandidates,
 				usageLimitPolicy,
 				clock,
+				noEndpointRequestTTL,
 				cleanupSweepInterval,
 				enqueueChannelBufferSize,
 				logger,
@@ -206,6 +209,7 @@ func NewFlowController(
 		fc.endpointCandidates,
 		fc.usageLimitPolicy,
 		fc.clock,
+		fc.config.NoEndpointRequestTTL,
 		fc.config.ExpiryCleanupInterval,
 		fc.config.EnqueueChannelBufferSize,
 		fc.logger,
@@ -259,7 +263,7 @@ func (fc *FlowController) EnqueueAndWait(
 		req.ModelName(), req.TargetModelName(), reqBytes)
 
 	// 1. Create the derived context that governs this request's lifecycle (Parent Cancellation + TTL).
-	reqCtx, cancel, enqueueTime := fc.createRequestContext(ctx, req)
+	reqCtx, cancel, enqueueTime, saturationTTL := fc.createRequestContext(ctx, req)
 	defer cancel()
 
 	var finalOutcome types.QueueOutcome
@@ -278,7 +282,7 @@ func (fc *FlowController) EnqueueAndWait(
 		// Attempt to distribute the request once, passing the active connection.
 		// effectiveReq carries the fallback flow key when the requested band was not provisioned, so the
 		// item is enqueued under the band that was actually leased.
-		item, err := fc.tryDistribution(reqCtx, effectiveReq, enqueueTime, conn)
+		item, err := fc.tryDistribution(reqCtx, effectiveReq, enqueueTime, saturationTTL, conn)
 		if err != nil {
 			// Distribution failed terminally (e.g., context cancelled during blocking submit).
 			// The item has already been finalized by tryDistribution.
@@ -368,12 +372,14 @@ func (fc *FlowController) tryDistribution(
 	reqCtx context.Context,
 	req flowcontrol.FlowControlRequest,
 	enqueueTime time.Time,
+	saturationTTL time.Duration,
 	conn contracts.ActiveFlowConnection,
 ) (*internal.FlowItem, error) {
-	// Calculate effective TTL for item initialization (reqCtx is the enforcement mechanism).
-	effectiveTTL := fc.config.DefaultRequestTTL
+	// The item carries the saturation-regime budget: it is the request's own queue-wait budget, and ordering policies
+	// read it as such. A caller deadline that falls inside it clamps it, since the request cannot outlive its caller.
+	effectiveTTL := saturationTTL
 	if deadline, ok := reqCtx.Deadline(); ok {
-		if ttl := deadline.Sub(enqueueTime); ttl > 0 {
+		if ttl := deadline.Sub(enqueueTime); ttl > 0 && (effectiveTTL <= 0 || ttl < effectiveTTL) {
 			effectiveTTL = ttl
 		}
 	}
@@ -397,7 +403,17 @@ func (fc *FlowController) tryDistribution(
 		return item, err
 	}
 
-	outcome, err := fc.distributeRequest(reqCtx, item)
+	// Distribution is bounded by the saturation budget, not by the request context's backstop. A request still waiting
+	// for handoff has not reached a queue, so it is not waiting on an endpoint to appear and the no-endpoint budget does
+	// not describe it; the regime-aware budget takes over once the processor owns the item.
+	distributeCtx := reqCtx
+	if effectiveTTL > 0 {
+		var cancel context.CancelFunc
+		distributeCtx, cancel = context.WithDeadlineCause(reqCtx, enqueueTime.Add(effectiveTTL), types.ErrTTLExpired)
+		defer cancel()
+	}
+
+	outcome, err := fc.distributeRequest(distributeCtx, item)
 	if err == nil {
 		// Success: Ownership of the item has been transferred to the processor.
 		return item, nil
@@ -408,7 +424,7 @@ func (fc *FlowController) tryDistribution(
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		// We propagate the original context error here, EnqueueAndWait will rely on item.FinalState().Err.
 		finalErr = err
-		item.Finalize(context.Cause(reqCtx))
+		item.Finalize(context.Cause(distributeCtx))
 	} else { // e.g.,
 		finalErr = fmt.Errorf("%w: request not accepted: %w", types.ErrRejected, err)
 		item.FinalizeWithOutcome(outcome, finalErr)
@@ -454,23 +470,32 @@ func (fc *FlowController) awaitFinalization(
 	}
 }
 
-// createRequestContext derives the context that governs a request's lifecycle, enforcing the TTL deadline.
+// createRequestContext derives the context that governs a request's lifecycle. It returns the saturation-regime
+// queue-wait budget alongside the context, since the two are resolved from the same inputs.
+//
+// The context deadline is the outer backstop across both unavailability regimes, not the budget itself. Which budget is
+// in force depends on whether the pool is empty, which only the processor observes and which can change while the
+// request waits, so the processor enforces the regime-appropriate budget and finalizes the item. Deriving the deadline
+// from the longer of the two budgets keeps the context from pre-empting that decision; it still bounds a request that
+// never reaches a queue, and a caller deadline that fires sooner still wins.
 func (fc *FlowController) createRequestContext(
 	ctx context.Context,
 	req flowcontrol.FlowControlRequest,
-) (context.Context, context.CancelFunc, time.Time) {
+) (context.Context, context.CancelFunc, time.Time, time.Duration) {
 	enqueueTime := fc.clock.Now()
-	effectiveTTL := req.InitialEffectiveTTL()
-	if effectiveTTL <= 0 {
-		effectiveTTL = fc.config.DefaultRequestTTL
+	saturationTTL := req.InitialEffectiveTTL()
+	if saturationTTL <= 0 {
+		saturationTTL = fc.config.DefaultRequestTTL
 	}
 
-	if effectiveTTL > 0 {
-		reqCtx, cancel := context.WithDeadlineCause(ctx, enqueueTime.Add(effectiveTTL), types.ErrTTLExpired)
-		return reqCtx, cancel, enqueueTime
+	// A zero budget in either regime disables eviction there, so no backstop can be derived.
+	backstop := max(saturationTTL, fc.config.NoEndpointRequestTTL)
+	if saturationTTL > 0 && fc.config.NoEndpointRequestTTL > 0 {
+		reqCtx, cancel := context.WithDeadlineCause(ctx, enqueueTime.Add(backstop), types.ErrTTLExpired)
+		return reqCtx, cancel, enqueueTime, saturationTTL
 	}
 	reqCtx, cancel := context.WithCancel(ctx)
-	return reqCtx, cancel, enqueueTime
+	return reqCtx, cancel, enqueueTime, saturationTTL
 }
 
 // distributeRequest submits an item to the processor with graceful backpressure.

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -478,6 +478,13 @@ func (fc *FlowController) awaitFinalization(
 // request waits, so the processor enforces the regime-appropriate budget and finalizes the item. Deriving the deadline
 // from the longer of the two budgets keeps the context from pre-empting that decision; it still bounds a request that
 // never reaches a queue, and a caller deadline that fires sooner still wins.
+//
+// The backstop is padded past the sweep interval because the two mechanisms differ in resolution: the deadline is an
+// exact timer while the sweep polls. Left unpadded, the deadline and an empty-pool eviction come due at the same
+// instant whenever the no-endpoint budget is the longer one, which is the configuration the split exists to serve, and
+// the exact timer always wins. The regime would then never reach an outcome, since the context cannot tell the regimes
+// apart. Padding cedes the decision to the sweep and leaves the deadline covering only the case where the sweep never
+// runs at all.
 func (fc *FlowController) createRequestContext(
 	ctx context.Context,
 	req flowcontrol.FlowControlRequest,
@@ -489,8 +496,8 @@ func (fc *FlowController) createRequestContext(
 	}
 
 	// A zero budget in either regime disables eviction there, so no backstop can be derived.
-	backstop := max(saturationTTL, fc.config.NoEndpointRequestTTL)
 	if saturationTTL > 0 && fc.config.NoEndpointRequestTTL > 0 {
+		backstop := max(saturationTTL, fc.config.NoEndpointRequestTTL) + 2*fc.config.ExpiryCleanupInterval
 		reqCtx, cancel := context.WithDeadlineCause(ctx, enqueueTime.Add(backstop), types.ErrTTLExpired)
 		return reqCtx, cancel, enqueueTime, saturationTTL
 	}

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -285,6 +285,7 @@ func (f *mockProcessorFactory) new(
 	_ flowcontrol.UsageLimitPolicy,
 	_ clock.WithTicker,
 	_ time.Duration,
+	_ time.Duration,
 	_ int,
 	_ logr.Logger,
 	_ *internal.ReclamationController,
@@ -780,8 +781,11 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			}
 
 			const requestTTL = 50 * time.Millisecond
+			// Both budgets are set: the context backstop spans the longer of the two, so leaving the no-endpoint budget
+			// unbounded would leave this request bounded only by the mock processor, which never finalizes it.
 			h := newUnitHarness(t.Context(), t, &Config{
 				DefaultRequestTTL:     requestTTL,
+				NoEndpointRequestTTL:  requestTTL,
 				ExpiryCleanupInterval: time.Minute,
 			}, nil, processor, withHarnessClock(clock.RealClock{}))
 

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -781,12 +781,15 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			}
 
 			const requestTTL = 50 * time.Millisecond
-			// Both budgets are set: the context backstop spans the longer of the two, so leaving the no-endpoint budget
-			// unbounded would leave this request bounded only by the mock processor, which never finalizes it.
+			// Both budgets are set so a backstop is derived at all, and it spans the longer of the two: leaving the
+			// no-endpoint budget unbounded would leave this request bounded only by the mock processor, which never
+			// finalizes it. The backstop's margin over that budget scales with the sweep interval, so a short interval
+			// keeps the deadline inside the test's window. No sweep runs behind a mock processor, so the context is
+			// still the only finalizer.
 			h := newUnitHarness(t.Context(), t, &Config{
 				DefaultRequestTTL:     requestTTL,
 				NoEndpointRequestTTL:  requestTTL,
-				ExpiryCleanupInterval: time.Minute,
+				ExpiryCleanupInterval: 10 * time.Millisecond,
 			}, nil, processor, withHarnessClock(clock.RealClock{}))
 
 			h.mockRegistry.WithConnectionFunc = func(key flowcontrol.FlowKey, fn func(_ contracts.ActiveFlowConnection) error) error {

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -73,6 +73,7 @@ type Processor struct {
 	endpointCandidates   contracts.EndpointCandidates
 	usageLimitPolicy     flowcontrol.UsageLimitPolicy
 	clock                clock.WithTicker
+	noEndpointRequestTTL time.Duration
 	cleanupSweepInterval time.Duration
 	logger               logr.Logger
 
@@ -88,9 +89,15 @@ type Processor struct {
 
 	// poolEmpty caches whether the candidate pool had zero endpoints as of the most recent dispatchCycle. enqueue reads
 	// it to distinguish a queue-capacity rejection caused by genuine unavailability (no backends, e.g. scale-from-zero)
-	// from one caused by backpressure against a contended but non-empty pool. Only accessed from the Run goroutine, so
-	// it needs no synchronization.
-	poolEmpty bool
+	// from one caused by backpressure against a contended but non-empty pool, and the cleanup sweep reads it to pick the
+	// queue-wait budget in force. Written by the Run goroutine and read by the sweep goroutine, hence atomic.
+	poolEmpty atomic.Bool
+
+	// regimeSinceNanos is the wall-clock time (UnixNano) at which poolEmpty last changed value, or zero if it has never
+	// changed. The cleanup sweep charges queue wait from this point rather than from enqueue time, so that a request
+	// that outlasted one regime is not shed the instant the other begins. Written by the Run goroutine and read by the
+	// sweep goroutine, hence atomic.
+	regimeSinceNanos atomic.Int64
 
 	// ceilings is the reusable output buffer handed to the UsageLimitPolicy each dispatch cycle,
 	// avoiding a per-cycle allocation. Only accessed from the Run goroutine, so it needs no
@@ -118,6 +125,7 @@ func NewProcessor(
 	endpointCandidates contracts.EndpointCandidates,
 	usageLimitPolicy flowcontrol.UsageLimitPolicy,
 	clock clock.WithTicker,
+	noEndpointRequestTTL time.Duration,
 	cleanupSweepInterval time.Duration,
 	enqueueChannelBufferSize int,
 	logger logr.Logger,
@@ -131,6 +139,7 @@ func NewProcessor(
 		endpointCandidates:   endpointCandidates,
 		usageLimitPolicy:     usageLimitPolicy,
 		clock:                clock,
+		noEndpointRequestTTL: noEndpointRequestTTL,
 		cleanupSweepInterval: cleanupSweepInterval,
 		logger:               logger,
 		lifecycleCtx:         ctx,
@@ -311,7 +320,7 @@ func (p *Processor) enqueue(item *FlowItem) {
 	if ok, stats := p.hasCapacity(key.Priority, req.ByteSize()); !ok {
 		// When the pool has no endpoints, the queue is acting as a scale-from-zero waiting room. A capacity rejection in
 		// that state reflects genuine unavailability (surfaced as 503), not backpressure against a contended pool (429).
-		if p.poolEmpty {
+		if p.poolEmpty.Load() {
 			p.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity with no endpoints",
 				"flowKey", key, "requestID", req.ID(), "reqByteSize", req.ByteSize(),
 				"totalLen", stats.TotalLen, "totalCapacityRequests", stats.TotalCapacityRequests,
@@ -389,7 +398,9 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	}()
 
 	pool := p.endpointCandidates.Locate(ctx, nil)
-	p.poolEmpty = len(pool) == 0
+	if empty := len(pool) == 0; p.poolEmpty.Swap(empty) != empty {
+		p.regimeSinceNanos.Store(p.clock.Now().UnixNano())
+	}
 	saturation := p.saturationDetector.Saturation(ctx, pool)
 
 	// Record pool saturation metric
@@ -529,13 +540,41 @@ func (p *Processor) runCleanupSweep(ctx context.Context) {
 	}
 }
 
-// sweepFinalizedItems performs a single scan of all queues, removing finalized items in batch and releasing their
-// memory.
+// sweepFinalizedItems performs a single scan of all queues, evicting items that have exhausted the queue-wait budget in
+// force and removing finalized items in batch, releasing their memory.
+//
+// Expiry is evaluated here rather than at admission because the budget depends on the unavailability regime, which the
+// request outlives: a pool that scales from zero moves its queued requests from the no-endpoint budget onto the
+// saturation budget. The regime is sampled once per sweep so that every queue decides against the same view.
 func (p *Processor) sweepFinalizedItems() {
+	now := p.clock.Now()
+	poolEmpty := p.poolEmpty.Load()
+	var regimeSince time.Time
+	if nanos := p.regimeSinceNanos.Load(); nanos > 0 {
+		regimeSince = time.Unix(0, nanos)
+	}
+
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		predicate := func(itemAcc flowcontrol.QueueItemAccessor) bool {
 			item, ok := itemAcc.(*FlowItem)
-			return ok && item.FinalState() != nil
+			if !ok {
+				// Nothing to finalize on an unknown type; leave it for the queue that owns it.
+				return false
+			}
+			if item.FinalState() != nil {
+				return true
+			}
+			outcome, expired := isExpired(item, now, regimeSince, poolEmpty, p.noEndpointRequestTTL)
+			if !expired {
+				return false
+			}
+			// Finalizing here rather than in a separate pass keeps expiry to a single scan. Finalization is
+			// idempotent, and an item finalized but not removed is the same zombie state the sweep already
+			// tolerates, so a queue that declines the removal costs nothing beyond a later sweep.
+			item.FinalizeWithOutcome(outcome, expiryError(outcome))
+			logger.V(logutil.TRACE).Info("Evicted item, queue-wait budget exhausted.",
+				"requestID", item.OriginalRequest().ID(), "outcome", outcome, "poolEmpty", poolEmpty)
+			return true
 		}
 		removedItems := managedQ.Cleanup(predicate)
 		if len(removedItems) > 0 {
@@ -549,6 +588,42 @@ func (p *Processor) sweepFinalizedItems() {
 		}
 	}
 	p.processAllQueuesConcurrently("sweepFinalizedItems", processFn)
+}
+
+// isExpired reports whether item has exhausted the queue-wait budget in force, and the outcome that eviction would
+// carry. A zero budget disables eviction in that regime.
+//
+// Elapsed time is charged from the later of enqueue and the most recent regime change. Charging from enqueue alone
+// would shed a request the moment it becomes dispatchable: an endpoint appearing after the saturation budget has
+// nominally elapsed would find that budget already spent, even though the request has only now become servable. Each
+// regime change therefore starts its budget fresh.
+func isExpired(
+	item *FlowItem,
+	now, regimeSince time.Time,
+	poolEmpty bool,
+	noEndpointRequestTTL time.Duration,
+) (types.QueueOutcome, bool) {
+	budget, outcome := item.EffectiveTTL(), types.QueueOutcomeEvictedTTL
+	if poolEmpty {
+		budget, outcome = noEndpointRequestTTL, types.QueueOutcomeEvictedNoEndpoints
+	}
+	if budget <= 0 {
+		return outcome, false
+	}
+
+	chargeFrom := item.EnqueueTime()
+	if regimeSince.After(chargeFrom) {
+		chargeFrom = regimeSince
+	}
+	return outcome, !now.Before(chargeFrom.Add(budget))
+}
+
+// expiryError builds the error accompanying an expiry eviction, wrapping the sentinels that callers match on.
+func expiryError(outcome types.QueueOutcome) error {
+	if outcome == types.QueueOutcomeEvictedNoEndpoints {
+		return fmt.Errorf("%w: %w: %w", types.ErrEvicted, types.ErrTTLExpired, types.ErrNoEndpoints)
+	}
+	return fmt.Errorf("%w: %w", types.ErrEvicted, types.ErrTTLExpired)
 }
 
 // shutdown handles the graceful termination of the processor, ensuring all pending items (in channel and queues) are

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -87,17 +87,12 @@ type Processor struct {
 	// enqueueChan is the entry point for new requests.
 	enqueueChan chan *FlowItem
 
-	// poolEmpty caches whether the candidate pool had zero endpoints as of the most recent dispatchCycle. enqueue reads
-	// it to distinguish a queue-capacity rejection caused by genuine unavailability (no backends, e.g. scale-from-zero)
-	// from one caused by backpressure against a contended but non-empty pool, and the cleanup sweep reads it to pick the
-	// queue-wait budget in force. Written by the Run goroutine and read by the sweep goroutine, hence atomic.
-	poolEmpty atomic.Bool
-
-	// regimeSinceNanos is the wall-clock time (UnixNano) at which poolEmpty last changed value, or zero if it has never
-	// changed. The cleanup sweep charges queue wait from this point rather than from enqueue time, so that a request
-	// that outlasted one regime is not shed the instant the other begins. Written by the Run goroutine and read by the
-	// sweep goroutine, hence atomic.
-	regimeSinceNanos atomic.Int64
+	// regime caches the unavailability regime observed by the most recent dispatchCycle. enqueue reads it to distinguish
+	// a queue-capacity rejection caused by genuine unavailability (no backends, e.g. scale-from-zero) from one caused by
+	// backpressure against a contended but non-empty pool, and the cleanup sweep reads it to pick the queue-wait budget
+	// in force and the point to charge it from. Written only by the Run goroutine; a single pointer lets a reader load
+	// the emptiness and its timestamp as one consistent sample. Never nil.
+	regime atomic.Pointer[regimeSample]
 
 	// ceilings is the reusable output buffer handed to the UsageLimitPolicy each dispatch cycle,
 	// avoiding a per-cycle allocation. Only accessed from the Run goroutine, so it needs no
@@ -113,6 +108,15 @@ type Processor struct {
 	// Written by both the main Run goroutine (enqueue, shutdown) and the runCleanupSweep goroutine (sweep),
 	// so each slot is an atomic to avoid a data race.
 	dropCounts [types.NumQueueOutcomes]atomic.Uint64
+}
+
+// regimeSample is one observation of the unavailability regime: whether the candidate pool was empty, and when that
+// answer last changed. The two travel together because a reader that mixed an emptiness from one observation with a
+// timestamp from another would charge queue wait against the wrong regime.
+type regimeSample struct {
+	empty bool
+	// since is the wall-clock time at which empty last changed value, or the zero time if it has never changed.
+	since time.Time
 }
 
 // NewProcessor creates a new Processor instance.
@@ -131,7 +135,7 @@ func NewProcessor(
 	logger logr.Logger,
 	reclamation *ReclamationController,
 ) *Processor {
-	return &Processor{
+	p := &Processor{
 		registry:             registry,
 		registryBackground:   registryBackground,
 		poolName:             poolName,
@@ -146,6 +150,10 @@ func NewProcessor(
 		enqueueChan:          make(chan *FlowItem, enqueueChannelBufferSize),
 		reclamation:          reclamation,
 	}
+	// Seeded so readers never handle a nil sample. The pool reads as non-empty until the first dispatch cycle observes
+	// otherwise, which keeps a request that arrives before that cycle on the saturation budget.
+	p.regime.Store(&regimeSample{})
+	return p
 }
 
 // Submit attempts a non-blocking handoff of an item to the processor's internal enqueue channel.
@@ -320,7 +328,7 @@ func (p *Processor) enqueue(item *FlowItem) {
 	if ok, stats := p.hasCapacity(key.Priority, req.ByteSize()); !ok {
 		// When the pool has no endpoints, the queue is acting as a scale-from-zero waiting room. A capacity rejection in
 		// that state reflects genuine unavailability (surfaced as 503), not backpressure against a contended pool (429).
-		if p.poolEmpty.Load() {
+		if p.regime.Load().empty {
 			p.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity with no endpoints",
 				"flowKey", key, "requestID", req.ID(), "reqByteSize", req.ByteSize(),
 				"totalLen", stats.TotalLen, "totalCapacityRequests", stats.TotalCapacityRequests,
@@ -398,8 +406,9 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	}()
 
 	pool := p.endpointCandidates.Locate(ctx, nil)
-	if empty := len(pool) == 0; p.poolEmpty.Swap(empty) != empty {
-		p.regimeSinceNanos.Store(p.clock.Now().UnixNano())
+	// Run is the sole writer, so the load and the store cannot interleave with another write.
+	if empty := len(pool) == 0; empty != p.regime.Load().empty {
+		p.regime.Store(&regimeSample{empty: empty, since: p.clock.Now()})
 	}
 	saturation := p.saturationDetector.Saturation(ctx, pool)
 
@@ -548,11 +557,7 @@ func (p *Processor) runCleanupSweep(ctx context.Context) {
 // saturation budget. The regime is sampled once per sweep so that every queue decides against the same view.
 func (p *Processor) sweepFinalizedItems() {
 	now := p.clock.Now()
-	poolEmpty := p.poolEmpty.Load()
-	var regimeSince time.Time
-	if nanos := p.regimeSinceNanos.Load(); nanos > 0 {
-		regimeSince = time.Unix(0, nanos)
-	}
+	regime := p.regime.Load()
 
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		predicate := func(itemAcc flowcontrol.QueueItemAccessor) bool {
@@ -564,7 +569,7 @@ func (p *Processor) sweepFinalizedItems() {
 			if item.FinalState() != nil {
 				return true
 			}
-			outcome, expired := isExpired(item, now, regimeSince, poolEmpty, p.noEndpointRequestTTL)
+			outcome, expired := isExpired(item, now, regime, p.noEndpointRequestTTL)
 			if !expired {
 				return false
 			}
@@ -573,7 +578,7 @@ func (p *Processor) sweepFinalizedItems() {
 			// tolerates, so a queue that declines the removal costs nothing beyond a later sweep.
 			item.FinalizeWithOutcome(outcome, expiryError(outcome))
 			logger.V(logutil.TRACE).Info("Evicted item, queue-wait budget exhausted.",
-				"requestID", item.OriginalRequest().ID(), "outcome", outcome, "poolEmpty", poolEmpty)
+				"requestID", item.OriginalRequest().ID(), "outcome", outcome, "poolEmpty", regime.empty)
 			return true
 		}
 		removedItems := managedQ.Cleanup(predicate)
@@ -599,12 +604,12 @@ func (p *Processor) sweepFinalizedItems() {
 // regime change therefore starts its budget fresh.
 func isExpired(
 	item *FlowItem,
-	now, regimeSince time.Time,
-	poolEmpty bool,
+	now time.Time,
+	regime *regimeSample,
 	noEndpointRequestTTL time.Duration,
 ) (types.QueueOutcome, bool) {
 	budget, outcome := item.EffectiveTTL(), types.QueueOutcomeEvictedTTL
-	if poolEmpty {
+	if regime.empty {
 		budget, outcome = noEndpointRequestTTL, types.QueueOutcomeEvictedNoEndpoints
 	}
 	if budget <= 0 {
@@ -612,8 +617,8 @@ func isExpired(
 	}
 
 	chargeFrom := item.EnqueueTime()
-	if regimeSince.After(chargeFrom) {
-		chargeFrom = regimeSince
+	if regime.since.After(chargeFrom) {
+		chargeFrom = regime.since
 	}
 	return outcome, !now.Before(chargeFrom.Add(budget))
 }

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -44,10 +44,13 @@ import (
 )
 
 const (
-	testTTL         = 1 * time.Minute
-	testShortTTL    = 20 * time.Millisecond
-	testCleanupTick = 10 * time.Millisecond
-	testWaitTimeout = 1 * time.Second
+	testTTL = 1 * time.Minute
+	// testNoEndpointTTL matches testTTL so that harness defaults leave the two regimes indistinguishable; tests that
+	// exercise the split set processor.noEndpointRequestTTL explicitly.
+	testNoEndpointTTL = 1 * time.Minute
+	testShortTTL      = 20 * time.Millisecond
+	testCleanupTick   = 10 * time.Millisecond
+	testWaitTimeout   = 1 * time.Second
 )
 
 var testFlow = flowcontrol.FlowKey{ID: "flow-a", Priority: 10}
@@ -140,6 +143,7 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 		h.endpointCandidates,
 		usagelimits.DefaultPolicy(),
 		h.clock,
+		testNoEndpointTTL,
 		expiryCleanupInterval,
 		100,
 		h.logger,
@@ -1571,5 +1575,216 @@ func TestProcessor_DropSummary(t *testing.T) {
 
 		assert.Equal(t, uint64(1), h.processor.dropCounts[types.QueueOutcomeEvictedOther].Load(),
 			"evictAll should count the unfinalized queued item exactly once")
+	})
+}
+
+// TestProcessor_QueueWaitBudget verifies that the queue-wait budget tracks the unavailability regime: the saturation
+// budget while the pool has endpoints, the no-endpoint budget while it does not, re-evaluated as the request waits
+// rather than fixed at admission.
+func TestProcessor_QueueWaitBudget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		saturationTTL = 100 * time.Millisecond
+		noEndpointTTL = 2 * time.Second
+	)
+
+	t.Run("budget in force", func(t *testing.T) {
+		t.Parallel()
+
+		base := time.Now()
+		testCases := []struct {
+			name string
+			// itemTTL and noEndpointTTL default to the constants above when zero; use disabled to request an explicit
+			// zero, which is what disables eviction in that regime.
+			itemTTL       time.Duration
+			noEndpointTTL time.Duration
+			poolEmpty     bool
+			// regimeAfter is how long after enqueue the regime last changed; zero means it never has.
+			regimeAfter time.Duration
+			elapsed     time.Duration
+			wantOutcome types.QueueOutcome
+			wantExpired bool
+		}{
+			{
+				name:        "SaturatedPool_HoldsWithinSaturationBudget",
+				elapsed:     saturationTTL - time.Millisecond,
+				wantOutcome: types.QueueOutcomeEvictedTTL,
+				wantExpired: false,
+			},
+			{
+				name:        "SaturatedPool_ShedsAtSaturationBudget",
+				elapsed:     saturationTTL,
+				wantOutcome: types.QueueOutcomeEvictedTTL,
+				wantExpired: true,
+			},
+			{
+				name:        "EmptyPool_HoldsPastSaturationBudget",
+				poolEmpty:   true,
+				elapsed:     noEndpointTTL - time.Millisecond,
+				wantOutcome: types.QueueOutcomeEvictedNoEndpoints,
+				wantExpired: false,
+			},
+			{
+				name:        "EmptyPool_ShedsAtNoEndpointBudget",
+				poolEmpty:   true,
+				elapsed:     noEndpointTTL,
+				wantOutcome: types.QueueOutcomeEvictedNoEndpoints,
+				wantExpired: true,
+			},
+			{
+				name:          "EmptyPool_ZeroBudgetWaitsIndefinitely",
+				noEndpointTTL: -1, // Sentinel for an explicit zero; see the field comment.
+				poolEmpty:     true,
+				elapsed:       time.Hour,
+				wantOutcome:   types.QueueOutcomeEvictedNoEndpoints,
+				wantExpired:   false,
+			},
+			{
+				name:        "SaturatedPool_ZeroBudgetWaitsIndefinitely",
+				itemTTL:     -1, // Sentinel for an explicit zero; see the field comment.
+				elapsed:     time.Hour,
+				wantOutcome: types.QueueOutcomeEvictedTTL,
+				wantExpired: false,
+			},
+			{
+				// The pool comes up long after the saturation budget would have elapsed. Charging against an already
+				// spent budget would shed the request the instant it became dispatchable.
+				name:        "PoolCameUp_StartsFreshSaturationBudget",
+				regimeAfter: noEndpointTTL / 2,
+				elapsed:     noEndpointTTL/2 + saturationTTL - time.Millisecond,
+				wantOutcome: types.QueueOutcomeEvictedTTL,
+				wantExpired: false,
+			},
+			{
+				name:        "PoolCameUp_ShedsAfterFreshSaturationBudget",
+				regimeAfter: noEndpointTTL / 2,
+				elapsed:     noEndpointTTL/2 + saturationTTL,
+				wantOutcome: types.QueueOutcomeEvictedTTL,
+				wantExpired: true,
+			},
+			{
+				// A regime change before the request arrived must not extend its budget.
+				name:        "RegimeChangeBeforeEnqueue_DoesNotExtendBudget",
+				regimeAfter: -saturationTTL,
+				elapsed:     saturationTTL,
+				wantOutcome: types.QueueOutcomeEvictedTTL,
+				wantExpired: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				itemTTL := saturationTTL
+				if tc.itemTTL != 0 {
+					itemTTL = max(tc.itemTTL, 0)
+				}
+				noEndpoint := noEndpointTTL
+				if tc.noEndpointTTL != 0 {
+					noEndpoint = max(tc.noEndpointTTL, 0)
+				}
+				var regimeSince time.Time
+				if tc.regimeAfter != 0 {
+					regimeSince = base.Add(tc.regimeAfter)
+				}
+
+				item := NewItem(fwkfcmocks.NewMockFlowControlRequest(100, "req-budget", testFlow), itemTTL, base)
+				outcome, expired := isExpired(item, base.Add(tc.elapsed), regimeSince, tc.poolEmpty, noEndpoint)
+
+				assert.Equal(t, tc.wantOutcome, outcome, "expiry should be attributed to the regime in force")
+				assert.Equal(t, tc.wantExpired, expired, "the budget in force decides whether the request is shed")
+			})
+		}
+	})
+
+	t.Run("sweep holds a queued request across a scale-from-zero", func(t *testing.T) {
+		t.Parallel()
+		// --- ARRANGE ---
+		h := newTestHarness(t, testCleanupTick)
+		h.processor.noEndpointRequestTTL = noEndpointTTL
+		h.processor.poolEmpty.Store(true)
+
+		item := h.newTestItem("req-cold-start", testFlow, testShortTTL)
+		q := h.addQueue(testFlow)
+		require.NoError(t, q.Add(item), "Failed to add item to queue")
+
+		// --- ACT & ASSERT ---
+		// Well past the saturation budget, but the pool is empty, so the cold-start budget governs.
+		h.clock.Step(2 * testShortTTL)
+		h.processor.sweepFinalizedItems()
+		assert.Nil(t, item.FinalState(), "an empty pool must not shed against the saturation budget")
+		assert.Equal(t, 1, q.Len(), "the item should still be queued")
+
+		// The pool comes up. The request only now became dispatchable, so it gets a fresh saturation budget.
+		h.processor.poolEmpty.Store(false)
+		h.processor.regimeSinceNanos.Store(h.clock.Now().UnixNano())
+		h.processor.sweepFinalizedItems()
+		assert.Nil(t, item.FinalState(), "a request must not be shed the moment it becomes dispatchable")
+
+		h.clock.Step(testShortTTL)
+		h.processor.sweepFinalizedItems()
+		require.NotNil(t, item.FinalState(), "the fresh saturation budget should have elapsed")
+		assert.Equal(t, types.QueueOutcomeEvictedTTL, item.FinalState().Outcome,
+			"a shed under a non-empty pool is backpressure, not unavailability")
+		assert.Equal(t, 0, q.Len(), "the evicted item should be swept from the queue")
+	})
+
+	t.Run("sweep sheds an empty-pool request as unavailability", func(t *testing.T) {
+		t.Parallel()
+		// --- ARRANGE ---
+		h := newTestHarness(t, testCleanupTick)
+		h.processor.noEndpointRequestTTL = testShortTTL
+		h.processor.poolEmpty.Store(true)
+
+		// The saturation budget is long; only the no-endpoint budget can shed this request.
+		item := h.newTestItem("req-no-endpoints", testFlow, testTTL)
+		q := h.addQueue(testFlow)
+		require.NoError(t, q.Add(item), "Failed to add item to queue")
+
+		// --- ACT ---
+		h.clock.Step(testShortTTL)
+		h.processor.sweepFinalizedItems()
+
+		// --- ASSERT ---
+		require.NotNil(t, item.FinalState(), "the no-endpoint budget should have elapsed")
+		finalState := item.FinalState()
+		assert.Equal(t, types.QueueOutcomeEvictedNoEndpoints, finalState.Outcome,
+			"Outcome should be EvictedNoEndpoints")
+		assert.ErrorIs(t, finalState.Err, types.ErrEvicted, "Error should wrap ErrEvicted")
+		assert.ErrorIs(t, finalState.Err, types.ErrTTLExpired, "Error should wrap ErrTTLExpired")
+		assert.ErrorIs(t, finalState.Err, types.ErrNoEndpoints, "Error should wrap ErrNoEndpoints")
+		assert.Equal(t, 0, q.Len(), "the evicted item should be swept from the queue")
+		assert.Equal(t, uint64(1), h.processor.dropCounts[types.QueueOutcomeEvictedNoEndpoints].Load(),
+			"Drop should be recorded for EvictedNoEndpoints")
+	})
+
+	t.Run("dispatch cycle timestamps the regime change", func(t *testing.T) {
+		t.Parallel()
+		// --- ARRANGE ---
+		h := newTestHarness(t, testCleanupTick)
+		h.addQueue(testFlow)
+		ctx := context.Background()
+
+		// --- ACT & ASSERT ---
+		// The harness pool is non-empty; the first cycle establishes the regime without recording a change.
+		h.processor.dispatchCycle(ctx)
+		assert.False(t, h.processor.poolEmpty.Load(), "the harness pool starts non-empty")
+		assert.Zero(t, h.processor.regimeSinceNanos.Load(), "settling on the initial regime is not a change")
+
+		// The pool scales to zero.
+		h.clock.Step(testShortTTL)
+		h.endpointCandidates.Candidates = nil
+		h.processor.dispatchCycle(ctx)
+		require.True(t, h.processor.poolEmpty.Load(), "the pool should now read as empty")
+		scaledDown := h.processor.regimeSinceNanos.Load()
+		assert.Equal(t, h.clock.Now().UnixNano(), scaledDown, "the regime change should be timestamped")
+
+		// A cycle that does not change the regime leaves the timestamp alone, so the budget keeps running.
+		h.clock.Step(testShortTTL)
+		h.processor.dispatchCycle(ctx)
+		assert.Equal(t, scaledDown, h.processor.regimeSinceNanos.Load(),
+			"an unchanged regime must not restart the budget")
 	})
 }

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -625,7 +625,7 @@ func TestProcessor(t *testing.T) {
 						h.addQueue(testFlow)
 						// Pool scaled to zero: the queue acts as a scale-from-zero waiting room.
 						h.endpointCandidates.Candidates = nil
-						// Prime poolEmpty via a dispatch cycle, mirroring the Run loop's periodic dispatch.
+						// Prime the regime via a dispatch cycle, mirroring the Run loop's periodic dispatch.
 						h.processor.dispatchCycle(context.Background())
 						h.StatsFunc = func() contracts.AggregateStats {
 							return contracts.AggregateStats{PerPriorityBandStats: map[int]contracts.PriorityBandStats{
@@ -1691,7 +1691,8 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 				}
 
 				item := NewItem(fwkfcmocks.NewMockFlowControlRequest(100, "req-budget", testFlow), itemTTL, base)
-				outcome, expired := isExpired(item, base.Add(tc.elapsed), regimeSince, tc.poolEmpty, noEndpoint)
+				regime := &regimeSample{empty: tc.poolEmpty, since: regimeSince}
+				outcome, expired := isExpired(item, base.Add(tc.elapsed), regime, noEndpoint)
 
 				assert.Equal(t, tc.wantOutcome, outcome, "expiry should be attributed to the regime in force")
 				assert.Equal(t, tc.wantExpired, expired, "the budget in force decides whether the request is shed")
@@ -1704,7 +1705,7 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 		// --- ARRANGE ---
 		h := newTestHarness(t, testCleanupTick)
 		h.processor.noEndpointRequestTTL = noEndpointTTL
-		h.processor.poolEmpty.Store(true)
+		h.processor.regime.Store(&regimeSample{empty: true})
 
 		item := h.newTestItem("req-cold-start", testFlow, testShortTTL)
 		q := h.addQueue(testFlow)
@@ -1718,8 +1719,7 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 		assert.Equal(t, 1, q.Len(), "the item should still be queued")
 
 		// The pool comes up. The request only now became dispatchable, so it gets a fresh saturation budget.
-		h.processor.poolEmpty.Store(false)
-		h.processor.regimeSinceNanos.Store(h.clock.Now().UnixNano())
+		h.processor.regime.Store(&regimeSample{empty: false, since: h.clock.Now()})
 		h.processor.sweepFinalizedItems()
 		assert.Nil(t, item.FinalState(), "a request must not be shed the moment it becomes dispatchable")
 
@@ -1736,7 +1736,7 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 		// --- ARRANGE ---
 		h := newTestHarness(t, testCleanupTick)
 		h.processor.noEndpointRequestTTL = testShortTTL
-		h.processor.poolEmpty.Store(true)
+		h.processor.regime.Store(&regimeSample{empty: true})
 
 		// The saturation budget is long; only the no-endpoint budget can shed this request.
 		item := h.newTestItem("req-no-endpoints", testFlow, testTTL)
@@ -1770,21 +1770,21 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 		// --- ACT & ASSERT ---
 		// The harness pool is non-empty; the first cycle establishes the regime without recording a change.
 		h.processor.dispatchCycle(ctx)
-		assert.False(t, h.processor.poolEmpty.Load(), "the harness pool starts non-empty")
-		assert.Zero(t, h.processor.regimeSinceNanos.Load(), "settling on the initial regime is not a change")
+		assert.False(t, h.processor.regime.Load().empty, "the harness pool starts non-empty")
+		assert.Zero(t, h.processor.regime.Load().since, "settling on the initial regime is not a change")
 
 		// The pool scales to zero.
 		h.clock.Step(testShortTTL)
 		h.endpointCandidates.Candidates = nil
 		h.processor.dispatchCycle(ctx)
-		require.True(t, h.processor.poolEmpty.Load(), "the pool should now read as empty")
-		scaledDown := h.processor.regimeSinceNanos.Load()
-		assert.Equal(t, h.clock.Now().UnixNano(), scaledDown, "the regime change should be timestamped")
+		require.True(t, h.processor.regime.Load().empty, "the pool should now read as empty")
+		scaledDown := h.processor.regime.Load().since
+		assert.Equal(t, h.clock.Now(), scaledDown, "the regime change should be timestamped")
 
 		// A cycle that does not change the regime leaves the timestamp alone, so the budget keeps running.
 		h.clock.Step(testShortTTL)
 		h.processor.dispatchCycle(ctx)
-		assert.Equal(t, scaledDown, h.processor.regimeSinceNanos.Load(),
+		assert.Equal(t, scaledDown, h.processor.regime.Load().since,
 			"an unchanged regime must not restart the budget")
 	})
 }

--- a/pkg/epp/flowcontrol/integration_helpers_test.go
+++ b/pkg/epp/flowcontrol/integration_helpers_test.go
@@ -310,7 +310,10 @@ func newHarness(t *testing.T, opts harnessOpts) *integrationHarness {
 	controllerCfg := opts.controllerCfg
 	if controllerCfg == nil {
 		controllerCfg = &controller.Config{
-			DefaultRequestTTL:        5 * time.Minute,
+			DefaultRequestTTL: 5 * time.Minute,
+			// Matching the saturation budget leaves the two unavailability regimes indistinguishable, as they are
+			// under the shipped defaults. Tests that exercise the split configure the budgets apart.
+			NoEndpointRequestTTL:     5 * time.Minute,
 			ExpiryCleanupInterval:    10 * time.Millisecond,
 			EnqueueChannelBufferSize: 100,
 		}

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -1467,9 +1467,12 @@ func TestNoEndpointBudgetOutlastingSaturationShedsAsUnavailability(t *testing.T)
 	h := newHarness(t, harnessOpts{
 		detector: detector,
 		controllerCfg: &controller.Config{
-			DefaultRequestTTL:        saturationTTL,
-			NoEndpointRequestTTL:     6 * saturationTTL,
-			ExpiryCleanupInterval:    10 * time.Millisecond,
+			DefaultRequestTTL:    saturationTTL,
+			NoEndpointRequestTTL: 6 * saturationTTL,
+			// The sweep must win the attribution race against the request context's backstop, which sits one sweep
+			// interval beyond the first tick that can observe the expiry. The interval is therefore the tolerance this
+			// test has for scheduling lateness, not just its resolution.
+			ExpiryCleanupInterval:    50 * time.Millisecond,
 			EnqueueChannelBufferSize: 100,
 		},
 	})

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -890,10 +890,9 @@ func TestGracefulShutdownDrainsQueuedRequests(t *testing.T) {
 // Production Edge Cases
 // ============================================================================
 
-// TestZombieCapacityStarvation verifies that TTL-expired items still in the
-// queue (zombies) consume capacity until the cleanup sweep runs. If the sweep
-// interval is long, new requests are falsely rejected because capacity is held
-// by dead items.
+// TestZombieCapacityStarvation verifies that finalized items still in the queue (zombies) consume capacity until the
+// cleanup sweep runs. If the sweep interval is long, new requests are falsely rejected because capacity is held by dead
+// items.
 func TestZombieCapacityStarvation(t *testing.T) {
 	t.Parallel()
 
@@ -904,10 +903,11 @@ func TestZombieCapacityStarvation(t *testing.T) {
 		bandMaxRequests:    3,
 		endpointCandidates: nonEmptyCandidates(),
 		controllerCfg: &controller.Config{
-			DefaultRequestTTL: 50 * time.Millisecond,
-			// Equal budgets keep the context backstop at 50ms, so expiry does not depend on the sweep, which this test
-			// deliberately holds off for 10s to observe zombie items still consuming capacity.
-			NoEndpointRequestTTL:     50 * time.Millisecond,
+			// The sweep finalizes and removes an expired item in the same pass, so queue-wait expiry cannot strand a
+			// zombie. A caller deadline can: it finalizes the item where it sits and leaves the sweep to reclaim it.
+			// The budgets therefore sit beyond the test's horizon and the callers give up instead.
+			DefaultRequestTTL:        1 * time.Minute,
+			NoEndpointRequestTTL:     1 * time.Minute,
 			ExpiryCleanupInterval:    10 * time.Second,
 			EnqueueChannelBufferSize: 100,
 		},
@@ -915,25 +915,29 @@ func TestZombieCapacityStarvation(t *testing.T) {
 
 	key := flowcontrol.FlowKey{ID: "flow-a", Priority: 0}
 
-	// Fill capacity with 3 requests that will expire via TTL.
+	// Fill capacity with 3 requests whose callers give up while they are queued.
 	expired := make(chan dispatchResult, 3)
 	for i := 0; i < 3; i++ {
 		id := fmt.Sprintf("zombie-%d", i)
 		go func() {
-			req := &testRequest{id: id, key: key, byteSize: 100, ttl: 50 * time.Millisecond}
-			outcome, err := h.fc.EnqueueAndWait(h.ctx, req)
+			reqCtx, reqCancel := context.WithTimeout(h.ctx, 50*time.Millisecond)
+			defer reqCancel()
+			req := &testRequest{id: id, key: key, byteSize: 100}
+			outcome, err := h.fc.EnqueueAndWait(reqCtx, req)
 			expired <- dispatchResult{id: id, outcome: outcome, err: err}
 		}()
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	// Wait for all to expire.
+	// Wait for all to be finalized. Each must be evicted rather than rejected: only an item that reached a queue holds
+	// the capacity this test goes on to observe.
 	for i := 0; i < 3; i++ {
 		select {
 		case r := <-expired:
+			require.ErrorIs(t, r.err, fcTypes.ErrEvicted, "zombie must have been queued before it was finalized")
 			require.ErrorIs(t, r.err, fcTypes.ErrTTLExpired)
 		case <-time.After(5 * time.Second):
-			t.Fatalf("zombie %d did not expire", i)
+			t.Fatalf("zombie %d was not finalized", i)
 		}
 	}
 
@@ -1441,6 +1445,56 @@ func TestNoEndpointBudgetShedsAsUnavailability(t *testing.T) {
 	case r := <-results:
 		require.Equal(t, fcTypes.QueueOutcomeEvictedNoEndpoints, r.outcome,
 			"an expiry against an empty pool should be attributed to unavailability")
+		require.ErrorIs(t, r.err, fcTypes.ErrEvicted, "the request was queued, so it is evicted rather than rejected")
+		require.ErrorIs(t, r.err, fcTypes.ErrNoEndpoints, "the error should wrap ErrNoEndpoints")
+		require.ErrorIs(t, r.err, fcTypes.ErrTTLExpired, "the error should wrap ErrTTLExpired")
+	case <-time.After(5 * time.Second):
+		t.Fatal("request did not return after the no-endpoint budget expired")
+	}
+}
+
+// TestNoEndpointBudgetOutlastingSaturationShedsAsUnavailability covers the configuration this feature targets, where
+// the cold-start budget is the longer of the two. Only the sweep observes the regime, so only the sweep can attribute
+// an empty-pool expiry to unavailability; nothing keyed to the request alone may pre-empt that decision and shed the
+// request as backpressure instead.
+func TestNoEndpointBudgetOutlastingSaturationShedsAsUnavailability(t *testing.T) {
+	t.Parallel()
+
+	const saturationTTL = 100 * time.Millisecond
+
+	// Pool intentionally empty (no endpointCandidates set): the queue is a scale-from-zero waiting room.
+	detector := newBlockedDetector()
+	h := newHarness(t, harnessOpts{
+		detector: detector,
+		controllerCfg: &controller.Config{
+			DefaultRequestTTL:        saturationTTL,
+			NoEndpointRequestTTL:     6 * saturationTTL,
+			ExpiryCleanupInterval:    10 * time.Millisecond,
+			EnqueueChannelBufferSize: 100,
+		},
+	})
+
+	key := flowcontrol.FlowKey{ID: "flow-a", Priority: 0}
+
+	results := make(chan dispatchResult, 1)
+	go func() {
+		// ttl 0 defers to the controller's saturation budget.
+		req := &testRequest{id: "cold-start-budget-req", key: key, byteSize: 100}
+		outcome, err := h.fc.EnqueueAndWait(h.ctx, req)
+		results <- dispatchResult{id: "cold-start-budget-req", outcome: outcome, err: err}
+	}()
+
+	// The saturation budget does not govern an empty pool, so the request holds well past it.
+	select {
+	case r := <-results:
+		t.Fatalf("request was shed on the saturation budget against an empty pool: outcome=%v err=%v", r.outcome, r.err)
+	case <-time.After(3 * saturationTTL):
+	}
+
+	select {
+	case r := <-results:
+		require.Equal(t, fcTypes.QueueOutcomeEvictedNoEndpoints, r.outcome,
+			"an expiry against an empty pool should be attributed to unavailability, not to backpressure")
 		require.ErrorIs(t, r.err, fcTypes.ErrEvicted, "the request was queued, so it is evicted rather than rejected")
 		require.ErrorIs(t, r.err, fcTypes.ErrNoEndpoints, "the error should wrap ErrNoEndpoints")
 		require.ErrorIs(t, r.err, fcTypes.ErrTTLExpired, "the error should wrap ErrTTLExpired")

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -716,7 +716,9 @@ func TestTTLExpiryEvictsQueuedRequest(t *testing.T) {
 	t.Parallel()
 
 	detector := newBlockedDetector()
-	h := newHarness(t, harnessOpts{detector: detector})
+	// The pool must be non-empty for this to be the saturation regime: with no endpoints the request would be waiting
+	// for one to appear, which is the no-endpoint budget's case, not this one.
+	h := newHarness(t, harnessOpts{detector: detector, endpointCandidates: nonEmptyCandidates()})
 
 	key := flowcontrol.FlowKey{ID: "flow-a", Priority: 0}
 
@@ -902,7 +904,10 @@ func TestZombieCapacityStarvation(t *testing.T) {
 		bandMaxRequests:    3,
 		endpointCandidates: nonEmptyCandidates(),
 		controllerCfg: &controller.Config{
-			DefaultRequestTTL:        50 * time.Millisecond,
+			DefaultRequestTTL: 50 * time.Millisecond,
+			// Equal budgets keep the context backstop at 50ms, so expiry does not depend on the sweep, which this test
+			// deliberately holds off for 10s to observe zombie items still consuming capacity.
+			NoEndpointRequestTTL:     50 * time.Millisecond,
 			ExpiryCleanupInterval:    10 * time.Second,
 			EnqueueChannelBufferSize: 100,
 		},
@@ -1401,5 +1406,105 @@ func TestEndpointChurnUnderLoad(t *testing.T) {
 			"request should dispatch after endpoints are restored")
 	case <-time.After(3 * time.Second):
 		t.Fatal("request did not dispatch after endpoint restoration")
+	}
+}
+
+// TestNoEndpointBudgetShedsAsUnavailability verifies that a request that exhausts its queue-wait budget against an
+// empty pool is shed as genuine unavailability (EvictedNoEndpoints, mapped to 503) rather than as backpressure,
+// independent of the saturation budget.
+func TestNoEndpointBudgetShedsAsUnavailability(t *testing.T) {
+	t.Parallel()
+
+	// Pool intentionally empty (no endpointCandidates set): the queue is a scale-from-zero waiting room.
+	detector := newBlockedDetector()
+	h := newHarness(t, harnessOpts{
+		detector: detector,
+		controllerCfg: &controller.Config{
+			// The saturation budget is long enough that only the no-endpoint budget can shed this request.
+			DefaultRequestTTL:        5 * time.Minute,
+			NoEndpointRequestTTL:     100 * time.Millisecond,
+			ExpiryCleanupInterval:    10 * time.Millisecond,
+			EnqueueChannelBufferSize: 100,
+		},
+	})
+
+	key := flowcontrol.FlowKey{ID: "flow-a", Priority: 0}
+
+	results := make(chan dispatchResult, 1)
+	go func() {
+		req := &testRequest{id: "noep-budget-req", key: key, byteSize: 100, ttl: 5 * time.Minute}
+		outcome, err := h.fc.EnqueueAndWait(h.ctx, req)
+		results <- dispatchResult{id: "noep-budget-req", outcome: outcome, err: err}
+	}()
+
+	select {
+	case r := <-results:
+		require.Equal(t, fcTypes.QueueOutcomeEvictedNoEndpoints, r.outcome,
+			"an expiry against an empty pool should be attributed to unavailability")
+		require.ErrorIs(t, r.err, fcTypes.ErrEvicted, "the request was queued, so it is evicted rather than rejected")
+		require.ErrorIs(t, r.err, fcTypes.ErrNoEndpoints, "the error should wrap ErrNoEndpoints")
+		require.ErrorIs(t, r.err, fcTypes.ErrTTLExpired, "the error should wrap ErrTTLExpired")
+	case <-time.After(5 * time.Second):
+		t.Fatal("request did not return after the no-endpoint budget expired")
+	}
+}
+
+// TestScaleFromZeroOutlivesSaturationBudget verifies the regime is not fixed at admission: a request queued against an
+// empty pool holds past the saturation budget, and once the pool scales up it dispatches on a fresh saturation budget
+// rather than being shed the instant it becomes servable.
+func TestScaleFromZeroOutlivesSaturationBudget(t *testing.T) {
+	t.Parallel()
+
+	const saturationTTL = 150 * time.Millisecond
+
+	// The pool starts empty and scales up mid-flight; the dispatch cycle reads it via Locate().
+	var endpoints atomic.Value
+	endpoints.Store([]datalayer.Endpoint(nil))
+	endpointCandidates := &contractmocks.MockEndpointCandidates{
+		LocateFunc: func(_ context.Context, _ map[string]any) []datalayer.Endpoint {
+			return endpoints.Load().([]datalayer.Endpoint)
+		},
+	}
+
+	detector := newBlockedDetector()
+	h := newHarness(t, harnessOpts{
+		detector:           detector,
+		endpointCandidates: endpointCandidates,
+		controllerCfg: &controller.Config{
+			DefaultRequestTTL:        saturationTTL,
+			NoEndpointRequestTTL:     5 * time.Second,
+			ExpiryCleanupInterval:    10 * time.Millisecond,
+			EnqueueChannelBufferSize: 100,
+		},
+	})
+
+	key := flowcontrol.FlowKey{ID: "flow-a", Priority: 0}
+
+	results := make(chan dispatchResult, 1)
+	go func() {
+		// ttl 0 defers to the controller's saturation budget.
+		req := &testRequest{id: "cold-start-req", key: key, byteSize: 100}
+		outcome, err := h.fc.EnqueueAndWait(h.ctx, req)
+		results <- dispatchResult{id: "cold-start-req", outcome: outcome, err: err}
+	}()
+
+	// Wait well past the saturation budget while the pool is still empty.
+	select {
+	case r := <-results:
+		t.Fatalf("request was shed while waiting for the pool to scale up: outcome=%v err=%v", r.outcome, r.err)
+	case <-time.After(4 * saturationTTL):
+	}
+
+	// Scale from zero. The request only now becomes dispatchable, on a budget that has nominally elapsed.
+	endpoints.Store([]datalayer.Endpoint{datalayer.NewEndpoint(nil, nil)})
+	detector.Unblock(1)
+
+	select {
+	case r := <-results:
+		require.NoError(t, r.err, "a request that becomes dispatchable should not carry an error")
+		require.Equal(t, fcTypes.QueueOutcomeDispatched, r.outcome,
+			"the request should dispatch once the pool scales up, not be shed against a spent budget")
+	case <-time.After(5 * time.Second):
+		t.Fatal("request did not dispatch after the pool scaled up")
 	}
 }

--- a/pkg/epp/flowcontrol/types/outcomes.go
+++ b/pkg/epp/flowcontrol/types/outcomes.go
@@ -60,6 +60,13 @@ const (
 	// The associated error will wrap `ErrTTLExpired` (and `ErrEvicted`).
 	QueueOutcomeEvictedTTL
 
+	// QueueOutcomeEvictedNoEndpoints indicates eviction from a queue because the queue-wait budget expired while the
+	// candidate pool had no endpoints. It is distinguished from `QueueOutcomeEvictedTTL` so the admission layer can
+	// surface genuine unavailability (HTTP 503) instead of backpressure (HTTP 429), and so the two unavailability
+	// regimes remain separable on dashboards.
+	// The associated error will wrap `ErrTTLExpired` and `ErrNoEndpoints` (and `ErrEvicted`).
+	QueueOutcomeEvictedNoEndpoints
+
 	// QueueOutcomeEvictedContextCancelled indicates eviction from a queue because the request's own context (from
 	// `FlowControlRequest.Context()`) was cancelled.
 	// The associated error will wrap `ErrContextCancelled` (which may further wrap the underlying `context.Canceled` or
@@ -93,6 +100,8 @@ func (o QueueOutcome) String() string {
 		return "RejectedOther"
 	case QueueOutcomeEvictedTTL:
 		return "EvictedTTL"
+	case QueueOutcomeEvictedNoEndpoints:
+		return "EvictedNoEndpoints"
 	case QueueOutcomeEvictedContextCancelled:
 		return "EvictedContextCancelled"
 	case QueueOutcomeEvictedOther:

--- a/pkg/epp/framework/interface/flowcontrol/request.go
+++ b/pkg/epp/framework/interface/flowcontrol/request.go
@@ -115,9 +115,14 @@ type QueueItemAccessor interface {
 	// landed in a SafeQueue instance.
 	EnqueueTime() time.Time
 
-	// EffectiveTTL is the actual Time-To-Live assigned to this item by the `controller.FlowController`, taking into
-	// account the request's preference (`FlowControlRequest.InitialEffectiveTTL()`) and any `controller.FlowController`
-	// or per-flow defaults/policies.
+	// EffectiveTTL is the Time-To-Live assigned to this item by the `controller.FlowController`, taking into account the
+	// request's preference (`FlowControlRequest.InitialEffectiveTTL()`) and any `controller.FlowController` or per-flow
+	// defaults/policies.
+	//
+	// It is the queue-wait budget for the regime in which the candidate pool has endpoints. While the pool has none, the
+	// wait is bounded by a separate controller-level budget that this value does not describe, so an item may outlive it.
+	// A policy deriving a deadline from it is therefore ordering by the request's own budget, not by when the item will
+	// actually be evicted.
 	EffectiveTTL() time.Duration
 
 	// Handle returns the `QueueItemHandle` associated with this item once it has been successfully added to a

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -257,6 +257,10 @@ func translateFlowControlOutcome(outcome types.QueueOutcome, err error, ttlPoolE
 	case types.QueueOutcomeRejectedNoEndpoints:
 		// No serving capacity exists (e.g. pool scaled to zero): signal genuine unavailability rather than backpressure.
 		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "no endpoints available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}
+	case types.QueueOutcomeEvictedNoEndpoints:
+		// The queue-wait budget was exhausted while the pool had no endpoints, so the regime is already established and
+		// needs no probe: waiting failed because nothing came up to serve the request.
+		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "request timed out in queue and no endpoints are available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}
 	case types.QueueOutcomeEvictedTTL:
 		if ttlPoolEmpty {
 			return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "request timed out in queue and no endpoints are available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}

--- a/pkg/epp/requestcontrol/admission_integration_test.go
+++ b/pkg/epp/requestcontrol/admission_integration_test.go
@@ -100,7 +100,10 @@ func newRealFlowControlHarness(t *testing.T, opts realFlowControlOpts) *realFlow
 	}
 	candidates := &mocks.MockEndpointCandidates{Candidates: opts.candidates}
 	fc := fccontroller.NewFlowController(ctx, "test-pool", &fccontroller.Config{
-		DefaultRequestTTL:        requestTTL,
+		DefaultRequestTTL: requestTTL,
+		// Both unavailability regimes share one budget, as they do under the shipped defaults, so requestTTL
+		// bounds queue wait whether or not the pool has endpoints.
+		NoEndpointRequestTTL:     requestTTL,
 		ExpiryCleanupInterval:    10 * time.Millisecond,
 		EnqueueChannelBufferSize: 100,
 	}, fccontroller.Deps{

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -389,6 +389,14 @@ func TestTranslateFlowControlOutcome(t *testing.T) {
 			wantReason:   string(errcommon.RequestDroppedReasonNoEndpoints),
 		},
 		{
+			// The regime is carried by the outcome itself, so the mapping must not depend on a pool probe.
+			name:       "no-endpoint budget expiry returns 503",
+			outcome:    fctypes.QueueOutcomeEvictedNoEndpoints,
+			err:        fmt.Errorf("%w: %w", fctypes.ErrTTLExpired, fctypes.ErrNoEndpoints),
+			wantCode:   errcommon.ServiceUnavailable,
+			wantReason: string(errcommon.RequestDroppedReasonNoEndpoints),
+		},
+		{
 			name:       "context cancellation returns 503",
 			outcome:    fctypes.QueueOutcomeEvictedContextCancelled,
 			err:        fctypes.ErrContextCancelled,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

`defaultRequestTTL` is one queue-wait budget serving two regimes that want opposite values: an empty pool is a cold start where waiting is the only path to success, a saturated pool should shed early to protect TTFB. One number protects neither.

- Adds `noEndpointRequestTTL`, in force while the candidate pool has no endpoints, following the seam #2046 used for the TTL-eviction status code.
- Moves expiry from the request context to the processor sweep, where pool emptiness is observed, so the budget is re-evaluated while queued rather than fixed at admission.
- Charges elapsed time from the later of enqueue and the last regime change, so a pool scaling up grants queued requests a fresh budget instead of shedding them the moment they become dispatchable.
- Relaxes the request context to the longer of the two budgets; it is now a backstop, not the budget.
- Adds an `EvictedNoEndpoints` outcome that maps to 503 without a pool probe and keeps the regimes separable on dashboards.
- Leaves `noEndpointRequestTTL` following `defaultRequestTTL` when unset, so splitting the regimes is opt-in: a deployment that stated one bound on queue wait keeps it in both regimes, and an explicit `0s` still disables eviction outright.

Behavior at the defaults is unchanged in kind. Expiry now lands at the first sweep after the budget elapses rather than on an exact timer (under a second later at the default sweep interval), and while the pool is empty it carries the `EvictedNoEndpoints` outcome label instead of `EvictedTTL`. The HTTP status and the `x-llm-d-request-dropped-reason` header are unchanged in both regimes; the empty-pool error text gains a `: no endpoints available` suffix.

Reviewer notes:

- The inheritance in `NewConfigFromAPI` is load-bearing, not cosmetic. Defaulting the two budgets independently narrows the documented meaning of `defaultRequestTTL: "0s"`, which #2123 shipped as "disables the TTL", to the regime where the pool has endpoints. A deployment that had disabled queue-wait eviction would then start shedding 60s into a scale-from-zero, and one that set a short bound would pick up a cold-start budget it never asked for. Both are the scale-to-zero deployments this split exists to serve. Inheriting keeps `0s` whole and keeps the split opt-in.
- `EffectiveTTL` on `QueueItemAccessor` is one regime's budget, not the point at which the item is evicted. Its doc now says so, since ordering policies read it and EDF derives a deadline from it.
- Two test fixtures were corrected, not just adapted: `TestTTLExpiryEvictsQueuedRequest` claimed to queue "under saturation" but ran against an empty pool, and `TestZombieCapacityStarvation` has to reach its zombie state through a caller deadline now that the sweep finalizes and removes an expired item in the same pass.
- Out of scope, tracked on the issue: gateway-timeout guidance, and whether the predicate should be "no endpoints" or "no endpoint with fresh metrics".
- Deferred to the sweep-only enforcement follow-up: finalization runs inside the `ManagedQueue` write lock, so a mass expiry does its metric work under the lock that `Add` and `Remove` contend on; `isExpired` reads the processor-global budget in the empty-pool regime, so a per-request TTL from #1090 would be ignored there; and EDF's deadline no longer matches the real expiry deadline for the same reason.

Test plan:

- [x] Budget selection per regime, including that an explicit zero disables eviction there
- [x] A queued request holds past the saturation budget on an empty pool and sheds as unavailability when the cold-start budget runs out
- [x] A pool scaling from zero dispatches a request whose saturation budget had nominally elapsed
- [x] Regime changes are timestamped once per transition; an unchanged regime does not restart the budget
- [x] Empty-pool expiry surfaces as 503 with the no-endpoints drop reason
- [x] An unset `noEndpointRequestTTL` follows `defaultRequestTTL`, an explicit one overrides it, and an explicit `0s` on either budget does not inherit
- [x] `noEndpointRequestTTL` round-trips from YAML to the controller config, and a config naming only `defaultRequestTTL: 0s` disables eviction in both regimes
- [x] `make presubmit` and `make test-unit-epp`

Manually verified on kind (ad hoc, not added to the e2e suite, which does not enable the `flowControl` gate). With `defaultRequestTTL: 2s`: shed as 503 at 8.011s and 45.005s against 8s and 45s cold-start budgets, and a request queued against an empty pool was served (200) after 15.3s across a real scale-from-zero. A kind scale-up takes ~11s to yield a discoverable endpoint even with vllm-sim, so this budget must be sized well above pod startup.

**Which issue(s) this PR fixes**:
Fixes #2183

**Release note**:
```release-note
Flow control queue wait can now be budgeted separately for an empty pool. `noEndpointRequestTTL` bounds how long a request waits while the candidate pool has no endpoints, leaving `defaultRequestTTL` to bound waiting against a saturated pool. Size it above expected pod startup: a request shed while the pool is still coming up would have been servable moments later. An explicit `0s` waits indefinitely for an endpoint. The budget in force is re-evaluated while a request is queued, so a pool that scales up moves its queued requests onto `defaultRequestTTL` with a fresh budget, though total queue wait stays bounded by the longer of the two budgets plus a short expiry-sweep margin, and a regime change does not extend that bound. Empty-pool expiry is reported as `EvictedNoEndpoints` and returns 503. `noEndpointRequestTTL` follows `defaultRequestTTL` when unset, and both default to 60s when neither is set, so an existing `defaultRequestTTL` continues to govern both regimes until you split them, including an explicit `0s`, which disables eviction in both. At the defaults an empty-pool expiry lands at the first expiry sweep after the budget elapses (under a second later at the default sweep interval) and carries the `EvictedNoEndpoints` outcome label instead of `EvictedTTL`, so dashboards or alerts keyed on `EvictedTTL` for scale-from-zero need to account for the new label. The HTTP status and the `x-llm-d-request-dropped-reason` header are unchanged.
```
