### PR TITLE
epp: multicluster config-load validation + review cleanups

### DIFF
--- a/cmd/epp/runner/multicluster_config_test.go
+++ b/cmd/epp/runner/multicluster_config_test.go
@@ -25,27 +25,78 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
 	runserver "github.com/llm-d/llm-d-router/pkg/epp/server"
 )
 
-// TestMultiClusterConfigLoads guards the multicluster wiring documented in
-// framework/plugins/README.md: the discovery, metrics source, metrics extractor,
-// and the two metric scorers instantiate against the registry and resolve to their
-// expected types as one EndpointPickerConfig.
-func TestMultiClusterConfigLoads(t *testing.T) {
-	dir := t.TempDir()
-	clustersPath := filepath.Join(dir, "clusters.yaml")
-	require.NoError(t, os.WriteFile(clustersPath, []byte(
-		"endpoints:\n"+
-			"  - name: a\n"+
-			"    address: gw.cluster-a.example.com\n"+
-			"    port: \"443\"\n"), 0o644))
+// TestMultiClusterConfigLoad drives the documented multicluster wiring
+// (framework/plugins/README.md) through both config phases. With the metrics extractor
+// present the plugins resolve. Without it, the metric scorers' required pool attributes
+// have no producer and load fails (the #2255 guard).
+func TestMultiClusterConfigLoad(t *testing.T) {
+	tests := []struct {
+		name          string
+		withExtractor bool
+		wantErr       error
+	}{
+		{name: "full config loads", withExtractor: true},
+		{name: "missing metrics extractor fails at load", withExtractor: false, wantErr: datalayer.ErrNoDefaultProducer},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			clustersPath := filepath.Join(dir, "clusters.yaml")
+			require.NoError(t, os.WriteFile(clustersPath, []byte(
+				"endpoints:\n  - name: a\n    address: gw.cluster-a.example.com\n    port: \"443\"\n"), 0o644))
 
-	// Mirrors the example config in framework/plugins/README.md, so this test fails if
-	// that documented wiring stops loading. caCertPath is omitted because it points at a
-	// deploy-specific file. CA loading is covered by the metrics source's own tests.
-	configText := fmt.Sprintf(`apiVersion: llm-d.ai/v1alpha1
+			opts := runserver.NewOptions()
+			opts.ConfigText = multiClusterConfig(clustersPath, tt.withExtractor)
+			opts.PoolName = "mc-config-pool"
+			opts.PoolNamespace = "mc-config-ns"
+
+			r := NewRunner()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Phase one decodes and validates references. The missing producer only
+			// surfaces in phase two, which builds the produce/consume graph.
+			rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
+			require.NoError(t, err)
+
+			ds := datastore.NewDatastore(ctx, r.setupMetricsCollection(opts))
+			_, err = r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			for name, wantType := range map[string]string{
+				"discovery":         "multicluster-file-discovery",
+				"metrics-source":    "multicluster-metrics-data-source",
+				"metrics-extractor": "multicluster-metrics-extractor",
+				"session-affinity":  "multicluster-session-affinity-filter",
+				"kv-cache":          "multicluster-kv-cache-utilization-scorer",
+				"queue":             "multicluster-queue-scorer",
+			} {
+				p := r.PluginHandle.Plugin(name)
+				require.NotNil(t, p, "plugin %q must resolve", name)
+				require.Equal(t, wantType, p.TypedName().Type, "plugin %q resolved to the wrong type", name)
+			}
+		})
+	}
+}
+
+// multiClusterConfig mirrors the example in framework/plugins/README.md. When
+// withExtractor is false it drops the metrics extractor and its source binding.
+func multiClusterConfig(clustersPath string, withExtractor bool) string {
+	var extractorPlugin, extractorBinding string
+	if withExtractor {
+		extractorPlugin = "  - type: multicluster-metrics-extractor\n    name: metrics-extractor\n"
+		extractorBinding = "      extractors:\n        - pluginRef: metrics-extractor\n"
+	}
+	return fmt.Sprintf(`apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
   - type: multicluster-file-discovery
@@ -56,9 +107,7 @@ plugins:
     name: metrics-source
     parameters:
       scheme: https
-  - type: multicluster-metrics-extractor
-    name: metrics-extractor
-  - type: multicluster-session-affinity-filter
+%s  - type: multicluster-session-affinity-filter
     name: session-affinity
   - type: multicluster-kv-cache-utilization-scorer
     name: kv-cache
@@ -71,42 +120,5 @@ dataLayer:
     pluginRef: discovery
   sources:
     - pluginRef: metrics-source
-      extractors:
-        - pluginRef: metrics-extractor
-`, clustersPath)
-
-	opts := runserver.NewOptions()
-	opts.ConfigText = configText
-	opts.PoolName = "mc-config-pool"
-	opts.PoolNamespace = "mc-config-ns"
-
-	r := NewRunner()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
-	require.NoError(t, err, "documented multicluster config must parse and validate")
-	require.NotNil(t, rawConfig.DataLayer)
-	require.NotNil(t, rawConfig.DataLayer.Discovery)
-	require.Len(t, rawConfig.DataLayer.Sources, 1)
-
-	// Phase two instantiates each plugin against the registry, so it fails if a
-	// multicluster factory is unregistered or a type is misspelled. Phase one alone
-	// only decodes the YAML and would not catch that.
-	ds := datastore.NewDatastore(ctx, r.setupMetricsCollection(opts))
-	_, err = r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
-	require.NoError(t, err, "documented multicluster config must instantiate against the registry")
-
-	for name, wantType := range map[string]string{
-		"discovery":         "multicluster-file-discovery",
-		"metrics-source":    "multicluster-metrics-data-source",
-		"metrics-extractor": "multicluster-metrics-extractor",
-		"session-affinity":  "multicluster-session-affinity-filter",
-		"kv-cache":          "multicluster-kv-cache-utilization-scorer",
-		"queue":             "multicluster-queue-scorer",
-	} {
-		p := r.PluginHandle.Plugin(name)
-		require.NotNil(t, p, "plugin %q must resolve", name)
-		require.Equal(t, wantType, p.TypedName().Type, "plugin %q resolved to the wrong type", name)
-	}
+%s`, clustersPath, extractorPlugin, extractorBinding)
 }

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -94,7 +94,7 @@ func CreateMissingDataProducers(ctx context.Context, defaultProducerRegistry map
 		for key, consumerName := range missingKeys {
 			defaultProducerNameOrType, ok := defaultProducerRegistry[key]
 			if !ok {
-				return fmt.Errorf("no default producer found for missing data key: %v, which is consumed by: %v", key, consumerName)
+				return fmt.Errorf("%w %v, consumed by %v", ErrNoDefaultProducer, key, consumerName)
 			}
 			if handle.Plugin(defaultProducerNameOrType) != nil {
 				// Already created. This can happen when a producer produces multiple data keys.

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -35,6 +35,7 @@ import (
 var (
 	ErrSourceTypeCollision    = errors.New("source type registered across variants")
 	ErrDuplicateExtractorType = errors.New("duplicate extractor type configured for the same source")
+	ErrNoDefaultProducer      = errors.New("no default producer found for missing data key")
 )
 
 type sourceVariant string

--- a/pkg/epp/framework/plugins/README.md
+++ b/pkg/epp/framework/plugins/README.md
@@ -33,7 +33,7 @@ The pure-delegation variants (`multicluster-session-affinity-filter`, `multiclus
 
 ### Dependencies
 
-The metric scorers are not standalone. `multicluster-kv-cache-utilization-scorer` and `multicluster-queue-scorer` read the `llm-d.ai/multicluster-kv-cache-utilization` and `llm-d.ai/multicluster-queue-size` attributes, which only exist if `multicluster-metrics-extractor` is configured to write them from what `multicluster-metrics-data-source` scrapes. Without the source and extractor in `dataLayer`, those scorers see no pool metrics and return no score.
+The metric scorers are not standalone. `multicluster-kv-cache-utilization-scorer` and `multicluster-queue-scorer` score a cluster from the pool-aggregate metrics that `multicluster-metrics-extractor` writes from what `multicluster-metrics-data-source` scrapes. Configure all three together in `dataLayer`. A config with the scorers but without the source and extractor fails to load.
 
 ### Example
 

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster.go
@@ -24,6 +24,7 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // MultiClusterPluginType discovers peer clusters as endpoints for a cluster-scoped EPP.
@@ -80,58 +81,14 @@ func metricsHostFromLabels(meta *fwkdl.EndpointMetadata) {
 	meta.MetricsHost = net.JoinHostPort(addr, port)
 }
 
-// validateHostOrIP accepts an IP literal (v4 or v6) or an RFC-1123 DNS hostname, since a
+// validateHostOrIP accepts an IP literal (v4 or v6) or a DNS-1123 subdomain, since a
 // cluster gateway may be reached by either.
 func validateHostOrIP(address string) error {
 	if net.ParseIP(address) != nil {
 		return nil
 	}
-	if isValidHostname(address) {
+	if len(validation.IsDNS1123Subdomain(address)) == 0 {
 		return nil
 	}
 	return fmt.Errorf("invalid host %q", address)
-}
-
-// isValidHostname reports whether h is an RFC-1123 hostname: dot-separated LDH labels
-// (letters, digits, hyphen) of 1-63 chars, no label starting or ending with a hyphen, an
-// optional trailing dot, and at least one letter so a numeric string cannot pass as a
-// host. It is a character scan rather than a regexp, mirroring net.isDomainName.
-func isValidHostname(h string) bool {
-	l := len(h)
-	if l == 0 || l > 254 || (l == 254 && h[l-1] != '.') {
-		return false
-	}
-	last := byte('.')
-	hasLetter := false
-	partLen := 0
-	for i := 0; i < len(h); i++ {
-		c := h[i]
-		switch {
-		default:
-			return false
-		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z':
-			hasLetter = true
-			partLen++
-		case '0' <= c && c <= '9':
-			partLen++
-		case c == '-':
-			if last == '.' { // label cannot start with a hyphen
-				return false
-			}
-			partLen++
-		case c == '.':
-			if last == '.' || last == '-' { // empty label or trailing hyphen
-				return false
-			}
-			if partLen > 63 {
-				return false
-			}
-			partLen = 0
-		}
-		last = c
-	}
-	if last == '-' || partLen > 63 {
-		return false
-	}
-	return hasLetter
 }

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster_test.go
@@ -19,7 +19,6 @@ package file
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,34 +27,6 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
-
-// isValidHostname is exercised through TestValidateHostOrIP for character rules. This
-// covers the length boundaries directly, since net.ParseIP masks them via validateHostOrIP.
-func TestIsValidHostname(t *testing.T) {
-	label63 := strings.Repeat("a", 63)
-	label64 := strings.Repeat("a", 64)
-	name253 := strings.Join([]string{label63, label63, label63, strings.Repeat("a", 61)}, ".") // 63*3 + 61 + 3 dots
-
-	tests := []struct {
-		name string
-		host string
-		want bool
-	}{
-		{name: "max-length label ok", host: label63, want: true},
-		{name: "label over 63 rejected", host: label64, want: false},
-		{name: "253-char name ok", host: name253, want: true},
-		{name: "254-char name without trailing dot rejected", host: name253 + "a", want: false},
-		{name: "254-char fqdn with trailing dot ok", host: name253 + ".", want: true},
-		{name: "over-length name rejected", host: strings.Repeat(label63+".", 5), want: false},
-		{name: "bare ipv4 is not a hostname", host: "10.0.0.1", want: false},
-		{name: "empty rejected", host: "", want: false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isValidHostname(tc.host))
-		})
-	}
-}
 
 const clusterYAML = `
 endpoints:
@@ -176,11 +147,12 @@ func TestValidateHostOrIP(t *testing.T) {
 		{name: "ipv6 ok", address: "::1"},
 		{name: "dns hostname ok", address: "gw.cluster-a.example.com"},
 		{name: "single label ok", address: "gateway"},
-		{name: "trailing dot fqdn ok", address: "gw.example.com."},
+		{name: "trailing dot rejected", address: "gw.example.com.", wantErr: true},
+		{name: "uppercase rejected", address: "GW.example.com", wantErr: true},
 		{name: "digit-led label ok", address: "3com.example.com"},
 		{name: "empty rejected", address: "", wantErr: true},
 		{name: "underscore rejected", address: "gw_1.example.com", wantErr: true},
-		{name: "numeric only rejected", address: "12345", wantErr: true},
+		{name: "numeric only accepted", address: "12345"},
 		{name: "host with colon rejected", address: "gw:443", wantErr: true},
 		{name: "control char rejected", address: "gw\x00.example.com", wantErr: true},
 		{name: "at sign rejected", address: "user@host", wantErr: true},

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
@@ -96,6 +96,18 @@ func (e *MultiClusterMetricsExtractor) Extract(_ context.Context, in fwkdl.PollI
 	return errors.Join(errs...)
 }
 
+var _ fwkplugin.ProducerPlugin = &MultiClusterMetricsExtractor{}
+
+// Produces advertises the pool attributes so the dependency graph can verify a
+// scorer's required key has a producer.
+func (e *MultiClusterMetricsExtractor) Produces() map[fwkplugin.DataKey]any {
+	out := make(map[fwkplugin.DataKey]any, len(e.metrics))
+	for _, m := range e.metrics {
+		out[fwkplugin.NewDataKey(m.key, "")] = attrmetrics.ScalarMetricValue(0)
+	}
+	return out
+}
+
 // MultiClusterMetricsExtractorFactory instantiates the extractor from configuration.
 func MultiClusterMetricsExtractorFactory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	params := &multiClusterMetricsExtractorParams{}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -58,11 +59,11 @@ func NewMultiClusterMetricsExtractor(name string, params *multiClusterMetricsExt
 	if params == nil {
 		params = &multiClusterMetricsExtractorParams{}
 	}
-	kvSpec, err := parseStringToSpec(orDefault(params.KVCacheUtilizationMetric, defaultKVCacheUtilizationMetric))
+	kvSpec, err := parseStringToSpec(cmp.Or(params.KVCacheUtilizationMetric, defaultKVCacheUtilizationMetric))
 	if err != nil {
 		return nil, fmt.Errorf("kv-cache utilization metric: %w", err)
 	}
-	queueSpec, err := parseStringToSpec(orDefault(params.QueueSizeMetric, defaultQueueSizeMetric))
+	queueSpec, err := parseStringToSpec(cmp.Or(params.QueueSizeMetric, defaultQueueSizeMetric))
 	if err != nil {
 		return nil, fmt.Errorf("queue size metric: %w", err)
 	}
@@ -104,11 +105,4 @@ func MultiClusterMetricsExtractorFactory(name string, parameters *json.Decoder, 
 		}
 	}
 	return NewMultiClusterMetricsExtractor(name, params)
-}
-
-func orDefault(v, fallback string) string {
-	if v == "" {
-		return fallback
-	}
-	return v
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster.go
@@ -31,7 +31,6 @@ const MultiClusterPluginType = "multicluster-approx-prefix-cache-producer"
 // cluster-scoped type for a complete multicluster plugin family.
 type MultiClusterProducer struct {
 	*dataProducer
-	name string
 }
 
 // MultiClusterFactory builds the cluster-scoped approx-prefix producer.
@@ -40,11 +39,11 @@ func MultiClusterFactory(name string, rawParameters *json.Decoder, handle plugin
 	if err != nil {
 		return nil, err
 	}
-	return &MultiClusterProducer{dataProducer: inner.(*dataProducer), name: name}, nil
+	return &MultiClusterProducer{dataProducer: inner.(*dataProducer)}, nil
 }
 
 // TypedName reports the multi-cluster type with this instance's name. The
 // published data key stays name-based, so the prefix scorer binds unchanged.
 func (p *MultiClusterProducer) TypedName() plugin.TypedName {
-	return plugin.TypedName{Type: MultiClusterPluginType, Name: p.name}
+	return plugin.TypedName{Type: MultiClusterPluginType, Name: p.dataProducer.TypedName().Name}
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster.go
@@ -34,7 +34,7 @@ func MultiClusterFactory(name string, params *json.Decoder, handle fwkplugin.Han
 	if err != nil {
 		return nil, err
 	}
-	return &MultiClusterFilter{SessionAffinity: inner.(*SessionAffinity), name: name}, nil
+	return &MultiClusterFilter{SessionAffinity: inner.(*SessionAffinity)}, nil
 }
 
 // MultiClusterFilter is the explicit cluster-scoped session-affinity filter.
@@ -42,10 +42,9 @@ func MultiClusterFactory(name string, params *json.Decoder, handle fwkplugin.Han
 // right cluster-endpoint and this delegates without translation.
 type MultiClusterFilter struct {
 	*SessionAffinity
-	name string
 }
 
 // TypedName reports the multi-cluster type with this instance's name.
 func (f *MultiClusterFilter) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: MultiClusterFilterType, Name: f.name}
+	return fwkplugin.TypedName{Type: MultiClusterFilterType, Name: f.SessionAffinity.TypedName().Name}
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
@@ -50,9 +50,16 @@ func (s *MultiClusterScorer) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.KVCacheUtilizationScorer.TypedName().Name}
 }
 
-// Consumes declares the pool KV-cache utilization attribute this scorer reads.
-func (s *MultiClusterScorer) Consumes() map[string]any {
-	return map[string]any{attrmetrics.MultiClusterKVCacheUtilizationKey: attrmetrics.ScalarMetricValue(0)}
+var _ fwkplugin.ConsumerPlugin = &MultiClusterScorer{}
+
+// Consumes marks the pool KV-cache utilization attribute Required, so a config missing
+// the multicluster metrics extractor fails at load rather than silently no-scoring.
+func (s *MultiClusterScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			fwkplugin.NewDataKey(attrmetrics.MultiClusterKVCacheUtilizationKey, ""): attrmetrics.ScalarMetricValue(0),
+		},
+	}
 }
 
 // Score scores each cluster endpoint as 1 - its pool KV-cache utilization.

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
@@ -36,19 +36,18 @@ func MultiClusterScorerFactory(name string, params *json.Decoder, handle fwkplug
 	if err != nil {
 		return nil, err
 	}
-	return &MultiClusterScorer{KVCacheUtilizationScorer: inner.(*KVCacheUtilizationScorer), name: name}, nil
+	return &MultiClusterScorer{KVCacheUtilizationScorer: inner.(*KVCacheUtilizationScorer)}, nil
 }
 
 // MultiClusterScorer scores cluster endpoints from a pool-level KV-cache
 // utilization summary, read by name, instead of a single pod's scrape.
 type MultiClusterScorer struct {
 	*KVCacheUtilizationScorer
-	name string
 }
 
 // TypedName reports the multi-cluster type with this instance's name.
 func (s *MultiClusterScorer) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.name}
+	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.KVCacheUtilizationScorer.TypedName().Name}
 }
 
 // Consumes declares the pool KV-cache utilization attribute this scorer reads.

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
@@ -40,8 +40,8 @@ func TestMultiClusterScorerFactory(t *testing.T) {
 	require.Equal(t, MultiClusterScorerType, p.TypedName().Type)
 	require.Equal(t, "mc", p.TypedName().Name)
 
-	_, ok := p.(*MultiClusterScorer).Consumes()[attrmetrics.MultiClusterKVCacheUtilizationKey]
-	require.True(t, ok, "Consumes must advertise the pool KV-cache utilization key")
+	_, ok := p.(*MultiClusterScorer).Consumes().Required[fwkplugin.NewDataKey(attrmetrics.MultiClusterKVCacheUtilizationKey, "")]
+	require.True(t, ok, "Consumes must require the pool KV-cache utilization key")
 }
 
 func TestMultiClusterScorer_Score(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
@@ -65,7 +65,7 @@ func TestMultiClusterScorer_Score(t *testing.T) {
 		{name: "missing attribute is unscored", set: false, wantAbsent: true},
 	}
 
-	s := &MultiClusterScorer{name: "mc"}
+	s := &MultiClusterScorer{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ep := newEP(tt.util, tt.set)

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster.go
@@ -34,7 +34,6 @@ var _ fwksched.Scorer = &MultiClusterScorer{}
 // explicit cluster-scoped type for a complete multicluster plugin family.
 type MultiClusterScorer struct {
 	*Plugin
-	name string
 }
 
 // MultiClusterScorerFactory builds the cluster-scoped prefix-cache scorer.
@@ -43,10 +42,10 @@ func MultiClusterScorerFactory(name string, decoder *json.Decoder, handle plugin
 	if err != nil {
 		return nil, err
 	}
-	return &MultiClusterScorer{Plugin: inner.(*Plugin), name: name}, nil
+	return &MultiClusterScorer{Plugin: inner.(*Plugin)}, nil
 }
 
 // TypedName reports the multi-cluster type with this instance's name.
 func (s *MultiClusterScorer) TypedName() plugin.TypedName {
-	return plugin.TypedName{Type: MultiClusterScorerType, Name: s.name}
+	return plugin.TypedName{Type: MultiClusterScorerType, Name: s.Plugin.TypedName().Name}
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
@@ -51,9 +51,16 @@ func (s *MultiClusterScorer) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.QueueScorer.TypedName().Name}
 }
 
-// Consumes declares the pool queue-size attribute this scorer reads.
-func (s *MultiClusterScorer) Consumes() map[string]any {
-	return map[string]any{attrmetrics.MultiClusterQueueSizeKey: attrmetrics.ScalarMetricValue(0)}
+var _ fwkplugin.ConsumerPlugin = &MultiClusterScorer{}
+
+// Consumes marks the pool queue-size attribute Required, so a config missing the
+// multicluster metrics extractor fails at load rather than silently no-scoring.
+func (s *MultiClusterScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			fwkplugin.NewDataKey(attrmetrics.MultiClusterQueueSizeKey, ""): attrmetrics.ScalarMetricValue(0),
+		},
+	}
 }
 
 // Score scores each cluster endpoint by its pool queue depth, min-max normalized

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
@@ -37,19 +37,18 @@ func MultiClusterScorerFactory(name string, params *json.Decoder, handle fwkplug
 	if err != nil {
 		return nil, err
 	}
-	return &MultiClusterScorer{QueueScorer: inner.(*QueueScorer), name: name}, nil
+	return &MultiClusterScorer{QueueScorer: inner.(*QueueScorer)}, nil
 }
 
 // MultiClusterScorer scores cluster endpoints from a pool-level queue-depth
 // summary, read by name, instead of a single pod's scrape.
 type MultiClusterScorer struct {
 	*QueueScorer
-	name string
 }
 
 // TypedName reports the multi-cluster type with this instance's name.
 func (s *MultiClusterScorer) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.name}
+	return fwkplugin.TypedName{Type: MultiClusterScorerType, Name: s.QueueScorer.TypedName().Name}
 }
 
 // Consumes declares the pool queue-size attribute this scorer reads.

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
@@ -84,7 +84,7 @@ func TestMultiClusterScorer_Score(t *testing.T) {
 		},
 	}
 
-	s := &MultiClusterScorer{name: "mc"}
+	s := &MultiClusterScorer{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			eps := make([]fwksched.Endpoint, len(tt.queues))

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
@@ -40,8 +40,8 @@ func TestMultiClusterScorerFactory(t *testing.T) {
 	require.Equal(t, MultiClusterScorerType, p.TypedName().Type)
 	require.Equal(t, "mc", p.TypedName().Name)
 
-	_, ok := p.(*MultiClusterScorer).Consumes()[attrmetrics.MultiClusterQueueSizeKey]
-	require.True(t, ok, "Consumes must advertise the pool queue-size key")
+	_, ok := p.(*MultiClusterScorer).Consumes().Required[fwkplugin.NewDataKey(attrmetrics.MultiClusterQueueSizeKey, "")]
+	require.True(t, ok, "Consumes must require the pool queue-size key")
 }
 
 func newQueueEP(q float64, set bool) fwksched.Endpoint {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

Post-merge followups to #2232, four independent commits.

#2255: the multicluster metric scorers read pool-aggregate attributes that `multicluster-metrics-extractor` produces, but their scheduling `Consumes()` was invisible to the datalayer produce/consume graph. A config with the scorers but no extractor loaded clean and then silently returned no score, a misconfiguration the datalayer graph already catches for datalayer plugins. The extractor now implements `ProducerPlugin` and the two scorers declare the pool key as a `Required` dependency, so `CreateMissingDataProducers` fails the load.

The other three commits address review nits from #2232:
- Replace the local `orDefault` helper with stdlib `cmp.Or`.
- Drop the duplicate `name` field from the five multicluster wrappers; read it through the embedded plugin's `TypedName()`.
- Validate cluster hostnames with apimachinery `IsDNS1123Subdomain` instead of a hand-rolled scanner.

**Which issue(s) this PR fixes**:

Fixes #2255
Fixes #2286

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
