### PR TITLE
feat(epp): add port parameter to metrics-data-source

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/prometheus/common/expfmt"
@@ -43,7 +44,7 @@ type metricsDatasourceParams struct {
 	Scheme string `json:"scheme"`
 	// Path defines the URL path used in metrics retrieval (e.g., "/metrics").
 	Path string `json:"path"`
-	// Port, when non-zero, overrides the endpoint's inference port for metrics retrieval.
+	// Port, when positive, overrides the endpoint's inference port for metrics retrieval.
 	// Use when the model server exposes metrics on a port other than the InferencePool target port.
 	Port int `json:"port"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
@@ -76,6 +77,10 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		if err := parameters.Decode(cfg); err != nil {
 			return nil, err
 		}
+	}
+
+	if cfg.Port < 0 || cfg.Port > 65535 {
+		return nil, fmt.Errorf("invalid port %d: must be between 0 and 65535", cfg.Port)
 	}
 
 	intervalOpt, err := http.ParseIntervalOption(cfg.Interval)

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -43,6 +43,9 @@ type metricsDatasourceParams struct {
 	Scheme string `json:"scheme"`
 	// Path defines the URL path used in metrics retrieval (e.g., "/metrics").
 	Path string `json:"path"`
+	// Port, when non-zero, overrides the endpoint's inference port for metrics retrieval.
+	// Use when the model server exposes metrics on a port other than the InferencePool target port.
+	Port int `json:"port"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
 	// CACertPath is an optional PEM CA bundle to verify the scrape target cert.
@@ -80,6 +83,11 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		return nil, err
 	}
 
+	opts := []http.Option{intervalOpt}
+	if cfg.Port > 0 {
+		opts = append(opts, http.WithPortOverride(cfg.Port))
+	}
+
 	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
 		http.TLSOptions{
 			SkipVerify:     cfg.InsecureSkipVerify,
@@ -87,7 +95,7 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 			ClientCertPath: cfg.ClientCertPath,
 			ClientKeyPath:  cfg.ClientKeyPath,
 		},
-		MetricsDataSourceType, name, parseMetrics, intervalOpt)
+		MetricsDataSourceType, name, parseMetrics, opts...)
 }
 
 func defaultDataSourceConfigParams() *metricsDatasourceParams {

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -44,12 +44,12 @@ type metricsDatasourceParams struct {
 	Scheme string `json:"scheme"`
 	// Path defines the URL path used in metrics retrieval (e.g., "/metrics").
 	Path string `json:"path"`
-	// Port, when positive, overrides the endpoint's inference port for metrics retrieval.
+	// Port, when set, overrides the endpoint's inference port for metrics retrieval.
 	// Use when the model server exposes metrics on a port other than the InferencePool target port.
 	// The override applies to every endpoint of the source. Do not set it on pools with
 	// multiple target ports (data-parallel ranks): each rank must be scraped on its own
 	// port, and a single override would point all ranks at the same one.
-	Port int `json:"port"`
+	Port *int `json:"port,omitempty"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
 	// CACertPath is an optional PEM CA bundle to verify the scrape target cert.
@@ -82,8 +82,8 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		}
 	}
 
-	if cfg.Port < 0 || cfg.Port > 65535 {
-		return nil, fmt.Errorf("invalid port %d: must be between 0 and 65535", cfg.Port)
+	if cfg.Port != nil && (*cfg.Port < 1 || *cfg.Port > 65535) {
+		return nil, fmt.Errorf("invalid port %d: must be between 1 and 65535", *cfg.Port)
 	}
 
 	intervalOpt, err := http.ParseIntervalOption(cfg.Interval)
@@ -92,8 +92,8 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 	}
 
 	opts := []http.Option{intervalOpt}
-	if cfg.Port > 0 {
-		opts = append(opts, http.WithPortOverride(cfg.Port))
+	if cfg.Port != nil {
+		opts = append(opts, http.WithPortOverride(*cfg.Port))
 	}
 
 	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path,

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -46,6 +46,9 @@ type metricsDatasourceParams struct {
 	Path string `json:"path"`
 	// Port, when positive, overrides the endpoint's inference port for metrics retrieval.
 	// Use when the model server exposes metrics on a port other than the InferencePool target port.
+	// The override applies to every endpoint of the source. Do not set it on pools with
+	// multiple target ports (data-parallel ranks): each rank must be scraped on its own
+	// port, and a single override would point all ranks at the same one.
 	Port int `json:"port"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -55,13 +55,13 @@ func TestMetricsDataSourceFactory_TLS(t *testing.T) {
 }
 
 func TestMetricsDataSourceFactory_PortOverride(t *testing.T) {
-	for _, params := range []string{`{"port":7080}`, `{"port":0}`, `{}`} {
+	for _, params := range []string{`{"port":7080}`, `{}`} {
 		ds, err := MetricsDataSourceFactory("m", fwkplugin.StrictDecoder(json.RawMessage(params)), nil)
 		assert.NoError(t, err, params)
 		assert.NotNil(t, ds, params)
 	}
 
-	for _, params := range []string{`{"port":-1}`, `{"port":65536}`, `{"prt":7080}`} {
+	for _, params := range []string{`{"port":0}`, `{"port":-1}`, `{"port":65536}`, `{"prt":7080}`} {
 		_, err := MetricsDataSourceFactory("m", fwkplugin.StrictDecoder(json.RawMessage(params)), nil)
 		assert.Error(t, err, params)
 	}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -53,6 +53,14 @@ func TestMetricsDataSourceFactory_TLS(t *testing.T) {
 	}
 }
 
+func TestMetricsDataSourceFactory_PortOverride(t *testing.T) {
+	for _, params := range []string{`{"port":7080}`, `{"port":0}`, `{}`} {
+		ds, err := MetricsDataSourceFactory("m", json.NewDecoder(bytes.NewBufferString(params)), nil)
+		assert.NoError(t, err, params)
+		assert.NotNil(t, ds, params)
+	}
+}
+
 func TestDatasource(t *testing.T) {
 	_, err := http.NewHTTPDataSource("invalid", "/metrics", http.TLSOptions{SkipVerify: true}, MetricsDataSourceType,
 		"metrics-data-source", parseMetrics)

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 )
 
@@ -55,9 +56,14 @@ func TestMetricsDataSourceFactory_TLS(t *testing.T) {
 
 func TestMetricsDataSourceFactory_PortOverride(t *testing.T) {
 	for _, params := range []string{`{"port":7080}`, `{"port":0}`, `{}`} {
-		ds, err := MetricsDataSourceFactory("m", json.NewDecoder(bytes.NewBufferString(params)), nil)
+		ds, err := MetricsDataSourceFactory("m", fwkplugin.StrictDecoder(json.RawMessage(params)), nil)
 		assert.NoError(t, err, params)
 		assert.NotNil(t, ds, params)
+	}
+
+	for _, params := range []string{`{"port":-1}`, `{"port":65536}`, `{"prt":7080}`} {
+		_, err := MetricsDataSourceFactory("m", fwkplugin.StrictDecoder(json.RawMessage(params)), nil)
+		assert.Error(t, err, params)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds an optional `port` parameter to the `metrics-data-source` plugin that overrides the scrape port per data source, mirroring the existing `dcgm-data-source` port option.

The scrape port always follows the InferencePool `targetPorts`. When a sidecar fronts the model server on the pool target port (as on Vertex AI managed serving, where an access sidecar terminates traffic on :15080 and the engine serves `/metrics` only on :7080), the engine metrics endpoint cannot be scraped: the sidecar returns 404 for `/metrics`, and every metrics-backed plugin (utilization-filter server conditions, kv/queue scorers) reads zeros. With this parameter:

```yaml
- type: metrics-data-source
  parameters:
    port: 7080
```

routing continues to target the pool port while metrics are scraped from the engine port.

**Which issue(s) this PR fixes**:
None

**Release note**:
```release-note
The metrics-data-source plugin accepts an optional `port` parameter that overrides the metrics scrape port when it differs from the InferencePool target port (for example when a sidecar fronts the model server).
```

**Test plan**:
- [x] Factory accepts the port parameter (with strict decoding) and constructs the data source; zero/omitted port keeps default behavior
- [x] Existing metrics data source unit tests pass