### PR TITLE
Add topology-aware filter and scorer for P/D routing

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -114,6 +114,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity"
 	sessionaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier"
+	topologyaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity"
 	utilizationfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/utilization"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/random"
@@ -138,6 +139,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/runningrequests"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/tokenload"
+	topologyaffinityscorer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity"
 	testfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/test/filter"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
@@ -569,6 +571,7 @@ func (r *Runner) registerInTreePlugins() {
 	// Alpha
 	fwkplugin.Register(sessionaffinityfilter.SessionAffinityType, fwkplugin.StabilityAlpha, sessionaffinityfilter.Factory)
 	fwkplugin.Register(endpointattributefilter.EndpointAttributeFilterType, fwkplugin.StabilityAlpha, endpointattributefilter.EndpointAttributeFilterFactory)
+	fwkplugin.Register(topologyaffinityfilter.FilterType, fwkplugin.StabilityAlpha, topologyaffinityfilter.Factory)
 	fwkplugin.Register(utilizationfilter.UtilizationFilterType, fwkplugin.StabilityAlpha, utilizationfilter.Factory)
 
 	// dataparallel profile handler
@@ -623,6 +626,7 @@ func (r *Runner) registerInTreePlugins() {
 	// Alpha
 	fwkplugin.Register(headerprofile.HeaderProfileHandlerType, fwkplugin.StabilityAlpha, headerprofile.HeaderProfileHandlerFactory)
 	fwkplugin.Register(endpointattribute.EndpointAttributeScorerType, fwkplugin.StabilityAlpha, endpointattribute.EndpointAttributeScorerFactory)
+	fwkplugin.Register(topologyaffinityscorer.ScorerType, fwkplugin.StabilityAlpha, topologyaffinityscorer.Factory)
 	fwkplugin.Register(burstprefix.PluginType, fwkplugin.StabilityAlpha, burstprefix.Factory)
 	fwkplugin.Register(p2psource.PluginType, fwkplugin.StabilityAlpha, p2psource.PluginFactory)
 	// multicluster variants

--- a/deploy/config/pd-topology-epp-config.yaml
+++ b/deploy/config/pd-topology-epp-config.yaml
@@ -1,0 +1,46 @@
+# Sample EPP configuration for running with P/D, adding topology-aware
+# affinity to the prefill profile: the prefill pick is filtered and scored by
+# proximity to the decode pod already selected, so KV-cache transfer prefers
+# NVLink (same host) over the network (same rack, zone, or region).
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: approx-prefix-cache-producer
+  parameters:
+    maxPrefixTokensToMatch: 16384
+    lruCapacityPerServer: 31250
+- type: prefix-cache-scorer
+- type: queue-scorer
+- type: prefill-filter
+- type: decode-filter
+- type: max-score-picker
+- type: topology-extractor
+- type: topology-affinity-filter
+- type: topology-affinity-scorer
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      prefill: prefix-based-pd-decider
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
+schedulingProfiles:
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: topology-affinity-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+  - pluginRef: queue-scorer
+    weight: 1
+  - pluginRef: topology-affinity-scorer
+    weight: 1
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+  - pluginRef: queue-scorer
+    weight: 1

--- a/pkg/epp/framework/interface/scheduling/attributes.go
+++ b/pkg/epp/framework/interface/scheduling/attributes.go
@@ -18,12 +18,6 @@ package scheduling
 
 import "sync"
 
-// PeerEndpointAttributeKey is the request-attribute key under which a profile
-// handler publishes the endpoint selected in an earlier scheduling phase, for
-// plugins in a later profile to compare against (e.g. topology affinity
-// between a disaggregated prefill and decode pick). The value is an Endpoint.
-const PeerEndpointAttributeKey = "peer-endpoint"
-
 // PutAttribute stores value at key in the request's attribute store.
 // The backing store is lazily allocated on first write.
 // Callers must not write concurrently to the same request from multiple goroutines.

--- a/pkg/epp/framework/interface/scheduling/attributes.go
+++ b/pkg/epp/framework/interface/scheduling/attributes.go
@@ -18,6 +18,12 @@ package scheduling
 
 import "sync"
 
+// PeerEndpointAttributeKey is the request-attribute key under which a profile
+// handler publishes the endpoint selected in an earlier scheduling phase, for
+// plugins in a later profile to compare against (e.g. topology affinity
+// between a disaggregated prefill and decode pick). The value is an Endpoint.
+const PeerEndpointAttributeKey = "peer-endpoint"
+
 // PutAttribute stores value at key in the request's attribute store.
 // The backing store is lazily allocated on first write.
 // Callers must not write concurrently to the same request from multiple goroutines.

--- a/pkg/epp/framework/plugins/datalayer/attribute/topology/README.md
+++ b/pkg/epp/framework/plugins/datalayer/attribute/topology/README.md
@@ -24,3 +24,12 @@ The following plugins produce this attribute:
 
 - **`topology-extractor`** (Data Layer): Sets the `Topology` attribute using
   `spec.hostname` from the Pod object, or the value of a configured endpoint label.
+
+## Consumers
+
+The following plugins consume this attribute:
+
+- **`topology-affinity-filter`** (Scheduling): Keeps candidate endpoints whose
+  `Topology` is co-located with a peer endpoint at a configured minimum affinity.
+- **`topology-affinity-scorer`** (Scheduling): Scores candidate endpoints by
+  `Topology` proximity to a peer endpoint.

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
@@ -7,6 +7,10 @@ in an earlier scheduling phase.
 
 ## What it does
 
+Scoped to single-EPP disaggregated deployments, where one EPP process runs both the
+`decode` and `prefill` scheduling profiles for a request. Coordinator deployments, where
+prefill and decode are picked by separate EPPs, are not yet supported.
+
 For a disaggregated prefill/decode request, `disagg-profile-handler` selects the decode
 endpoint first, then runs the `prefill` profile to select a prefill endpoint. This plugin
 runs in the `prefill` profile and keeps only the candidates whose topology is co-located
@@ -29,13 +33,8 @@ not treated as a match.
 ## Inputs consumed
 
 Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and
-from the peer endpoint. The peer endpoint is resolved from, in order:
-
-1. The `peer-endpoint` request attribute, published by `disagg-profile-handler` before
-   running the `prefill` profile in single-EPP deployments.
-2. The `peerTopologyHeader` request header, set by the prefill-side response stamper in
-   coordinator deployments with separate prefill and decode EPPs. Not yet implemented;
-   configuring this parameter has no effect until that stamper lands.
+from the peer endpoint. The peer endpoint is resolved from the `peer-endpoint` request
+attribute, published by `disagg-profile-handler` before running the `prefill` profile.
 
 ## Configuration
 
@@ -43,7 +42,6 @@ from the peer endpoint. The peer endpoint is resolved from, in order:
 |--------------------------|----------|---------|----------------------------------------------------------------------------------------|
 | `minAffinity`            | no       | `host`  | Tightest-to-loosest floor an endpoint must meet: `host`, `rack`, `zone`, or `region`.  |
 | `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from.        |
-| `peerTopologyHeader`     | no       | unset   | Header carrying the peer topology when the peer endpoint is not in-process. Not yet implemented. |
 
 **Configuration Example:**
 ```yaml

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
@@ -1,0 +1,65 @@
+# Topology Affinity Filter Plugin
+
+**Type:** `topology-affinity-filter`
+
+This plugin filters candidate endpoints by topology proximity to a peer endpoint selected
+in an earlier scheduling phase.
+
+## What it does
+
+For a disaggregated prefill/decode request, `disagg-profile-handler` selects the decode
+endpoint first, then runs the `prefill` profile to select a prefill endpoint. This plugin
+runs in the `prefill` profile and keeps only the candidates whose topology is co-located
+with the decode pick at `minAffinity` or tighter (host, rack, zone, or region; same host
+implies same rack, zone, and region).
+
+Two rules make the filter fail open rather than restrict routing when locality is unknown
+or unreachable:
+
+- **No peer topology available** — the peer endpoint is unknown, or it has no non-empty
+  topology field — returns all candidates unchanged.
+- **No candidate meets `minAffinity`** — returns all candidates unchanged. Topology
+  affinity is a preference; it must never make a request unroutable.
+
+A missing value never matches, including empty against empty: an endpoint with no
+`Hostname` never passes `minAffinity: host`, even against a peer that also has no
+`Hostname`. A candidate endpoint entirely missing the `Topology` attribute is dropped,
+not treated as a match.
+
+## Inputs consumed
+
+Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and
+from the peer endpoint. The peer endpoint is resolved from, in order:
+
+1. The `peer-endpoint` request attribute, published by `disagg-profile-handler` before
+   running the `prefill` profile in single-EPP deployments.
+2. The `peerTopologyHeader` request header, set by the prefill-side response stamper in
+   coordinator deployments with separate prefill and decode EPPs. Not yet implemented;
+   configuring this parameter has no effect until that stamper lands.
+
+## Configuration
+
+| Parameter               | Required | Default | Description                                                                          |
+|--------------------------|----------|---------|----------------------------------------------------------------------------------------|
+| `minAffinity`            | no       | `host`  | Tightest-to-loosest floor an endpoint must meet: `host`, `rack`, `zone`, or `region`.  |
+| `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from.        |
+| `peerTopologyHeader`     | no       | unset   | Header carrying the peer topology when the peer endpoint is not in-process. Not yet implemented. |
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: topology-extractor
+  - type: topology-affinity-filter
+    name: prefill-topology-affinity
+    parameters:
+      minAffinity: host
+schedulingProfiles:
+  - name: prefill
+    plugins:
+      - pluginRef: prefill-topology-affinity
+```
+
+## See also
+
+The `topology-affinity-scorer` plugin grades the same candidates by proximity instead of
+dropping them, and is the scoring counterpart of this filter.

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
@@ -42,6 +42,10 @@ Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoin
 from the peer endpoint. The peer endpoint is resolved from the `peer-endpoint` request
 attribute, published by `disagg-profile-handler` before running the `prefill` profile.
 
+Declares `Topology` as an optional data dependency: a config with no `topology-extractor`
+logs a startup warning rather than an error, since the filter fails open when the
+attribute is absent.
+
 ## Configuration
 
 | Parameter               | Required | Default | Description                                                                          |

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
@@ -30,6 +30,12 @@ A missing value never matches, including empty against empty: an endpoint with n
 `Hostname`. A candidate endpoint entirely missing the `Topology` attribute is dropped,
 not treated as a match.
 
+`minAffinity: host` assumes a host is the NVLink boundary, true for switched 8-GPU
+NVLink baseboards (HGX/DGX) but not for rack-scale NVLink domains (e.g. NVL72), where
+the switched fabric spans many hosts and `Rack` is the tier that shares NVLink-class
+bandwidth. On that hardware, use `minAffinity: rack`, if the extractor populates a
+`Rack` value that reflects the NVLink domain rather than a physical enclosure.
+
 ## Inputs consumed
 
 Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package topologyaffinity provides a filter that keeps candidate endpoints
+// whose topology is co-located with the peer endpoint at a configured minimum
+// affinity level.
+package topologyaffinity

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
@@ -39,11 +39,6 @@ type parameters struct {
 	// TopologyProducerName selects the topology-extractor instance to read
 	// endpoint topology from. Defaults to the extractor's default producer.
 	TopologyProducerName string `json:"topologyProducerName,omitempty"`
-	// PeerTopologyHeader names the request header carrying the peer topology
-	// when the peer endpoint is not available in-process (coordinator mode
-	// with separate prefill and decode EPPs). Unset by default; header
-	// decoding is not yet implemented.
-	PeerTopologyHeader string `json:"peerTopologyHeader,omitempty"`
 }
 
 var _ fwksched.Filter = &Filter{}
@@ -70,7 +65,6 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 		typedName:   fwkplugin.TypedName{Type: FilterType, Name: name},
 		minAffinity: minAffinity,
 		dataKey:     attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
-		peerHeader:  params.PeerTopologyHeader,
 	}, nil
 }
 
@@ -87,7 +81,6 @@ type Filter struct {
 	typedName   fwkplugin.TypedName
 	minAffinity topoutil.Level
 	dataKey     fwkplugin.DataKey
-	peerHeader  string
 }
 
 func (f *Filter) TypedName() fwkplugin.TypedName {
@@ -95,7 +88,7 @@ func (f *Filter) TypedName() fwkplugin.TypedName {
 }
 
 func (f *Filter) Filter(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
-	peer, ok := topoutil.PeerTopology(request, f.dataKey.String(), f.peerHeader)
+	peer, ok := topoutil.PeerTopology(request, f.dataKey.String(), "")
 	if !ok {
 		return endpoints
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
@@ -42,6 +42,7 @@ type parameters struct {
 }
 
 var _ fwksched.Filter = &Filter{}
+var _ fwkplugin.ConsumerPlugin = &Filter{}
 
 // Factory creates a topology affinity filter.
 func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -85,6 +86,16 @@ type Filter struct {
 
 func (f *Filter) TypedName() fwkplugin.TypedName {
 	return f.typedName
+}
+
+// Consumes returns the Topology attribute as optional: a missing producer
+// logs a startup warning rather than an error, since the filter fails open
+// (no peer topology means the candidates pass through unfiltered) rather
+// than depending on the attribute to function.
+func (f *Filter) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Optional: map[fwkplugin.DataKey]any{f.dataKey: attrtopology.Topology{}},
+	}
 }
 
 func (f *Filter) Filter(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologyaffinity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	topoutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/topology"
+)
+
+// FilterType is the type of the topology affinity filter.
+const FilterType = "topology-affinity-filter"
+
+type parameters struct {
+	// MinAffinity is the tightest-to-loosest floor an endpoint must meet
+	// against the peer topology to pass: "host", "rack", "zone", or "region".
+	// Defaults to "host".
+	MinAffinity string `json:"minAffinity,omitempty"`
+	// TopologyProducerName selects the topology-extractor instance to read
+	// endpoint topology from. Defaults to the extractor's default producer.
+	TopologyProducerName string `json:"topologyProducerName,omitempty"`
+	// PeerTopologyHeader names the request header carrying the peer topology
+	// when the peer endpoint is not available in-process (coordinator mode
+	// with separate prefill and decode EPPs). Unset by default; header
+	// decoding is not yet implemented.
+	PeerTopologyHeader string `json:"peerTopologyHeader,omitempty"`
+}
+
+var _ fwksched.Filter = &Filter{}
+
+// Factory creates a topology affinity filter.
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	params := parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", FilterType, err)
+		}
+	}
+	if params.MinAffinity == "" {
+		params.MinAffinity = "host"
+	}
+	minAffinity, err := topoutil.ParseLevel(params.MinAffinity)
+	if err != nil {
+		return nil, fmt.Errorf("invalid configuration for '%s' filter: %w", FilterType, err)
+	}
+	if name == "" {
+		name = FilterType
+	}
+	return &Filter{
+		typedName:   fwkplugin.TypedName{Type: FilterType, Name: name},
+		minAffinity: minAffinity,
+		dataKey:     attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+		peerHeader:  params.PeerTopologyHeader,
+	}, nil
+}
+
+// Filter keeps candidate endpoints whose topology is co-located with the peer
+// endpoint at minAffinity or tighter. An endpoint missing the topology
+// attribute, or missing the field being compared, never matches.
+//
+// The filter fails open in two cases: when no peer topology is available (the
+// peer is unknown, or has no non-empty field), and when no candidate meets
+// minAffinity. In both cases the unfiltered candidates are returned, since
+// topology affinity is a preference and must never make a request
+// unroutable.
+type Filter struct {
+	typedName   fwkplugin.TypedName
+	minAffinity topoutil.Level
+	dataKey     fwkplugin.DataKey
+	peerHeader  string
+}
+
+func (f *Filter) TypedName() fwkplugin.TypedName {
+	return f.typedName
+}
+
+func (f *Filter) Filter(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+	peer, ok := topoutil.PeerTopology(request, f.dataKey.String(), f.peerHeader)
+	if !ok {
+		return endpoints
+	}
+
+	filtered := make([]fwksched.Endpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		candidate, ok := fwkdl.ReadAttribute[*attrtopology.Topology](endpoint, f.dataKey.String())
+		if !ok {
+			continue
+		}
+		if topoutil.Compare(peer, candidate) <= f.minAffinity {
+			filtered = append(filtered, endpoint)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return endpoints
+	}
+	return filtered
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
@@ -88,7 +88,7 @@ func (f *Filter) TypedName() fwkplugin.TypedName {
 }
 
 func (f *Filter) Filter(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
-	peer, ok := topoutil.PeerTopology(request, f.dataKey.String(), "")
+	peer, ok := topoutil.PeerTopology(request, f.dataKey.String())
 	if !ok {
 		return endpoints
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologyaffinity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	topoutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/topology"
+)
+
+func makeEndpoint(t *testing.T, name string, topo *attrtopology.Topology) fwksched.Endpoint {
+	t.Helper()
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: name, Namespace: "default"}}
+	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	if topo != nil {
+		ep.Put(attrtopology.TopologyAttributeKey.String(), topo)
+	}
+	return ep
+}
+
+func requestWithPeer(topo *attrtopology.Topology) *fwksched.InferenceRequest {
+	req := &fwksched.InferenceRequest{}
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "peer", Namespace: "default"}}
+	peer := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	if topo != nil {
+		peer.Put(attrtopology.TopologyAttributeKey.String(), topo)
+	}
+	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peer)
+	return req
+}
+
+func newTestFilter(minAffinity topoutil.Level) *Filter {
+	return &Filter{
+		typedName:   fwkplugin.TypedName{Type: FilterType, Name: "test"},
+		minAffinity: minAffinity,
+		dataKey:     attrtopology.TopologyAttributeKey,
+	}
+}
+
+func TestFilter_KeepsOnlyMatchingMinAffinity(t *testing.T) {
+	peerTopo := &attrtopology.Topology{Hostname: "h1", Rack: "r1", Zone: "z1", Region: "reg1"}
+	sameHost := makeEndpoint(t, "same-host", &attrtopology.Topology{Hostname: "h1", Rack: "r1", Zone: "z1", Region: "reg1"})
+	sameRack := makeEndpoint(t, "same-rack", &attrtopology.Topology{Hostname: "h2", Rack: "r1", Zone: "z1", Region: "reg1"})
+	noMatch := makeEndpoint(t, "no-match", &attrtopology.Topology{Hostname: "h3", Rack: "r3", Zone: "z3", Region: "reg3"})
+
+	f := newTestFilter(topoutil.LevelHost)
+	req := requestWithPeer(peerTopo)
+	got := f.Filter(context.Background(), req, []fwksched.Endpoint{sameHost, sameRack, noMatch})
+	require.Len(t, got, 1)
+	assert.Equal(t, "same-host", got[0].GetMetadata().ID.Name)
+
+	f = newTestFilter(topoutil.LevelRack)
+	got = f.Filter(context.Background(), req, []fwksched.Endpoint{sameHost, sameRack, noMatch})
+	require.Len(t, got, 2)
+}
+
+func TestFilter_FailsOpenWhenNoCandidateMatches(t *testing.T) {
+	peerTopo := &attrtopology.Topology{Hostname: "h1"}
+	noMatch := makeEndpoint(t, "no-match", &attrtopology.Topology{Hostname: "h2"})
+
+	f := newTestFilter(topoutil.LevelHost)
+	req := requestWithPeer(peerTopo)
+	got := f.Filter(context.Background(), req, []fwksched.Endpoint{noMatch})
+	require.Len(t, got, 1, "fails open: no candidate meets minAffinity")
+}
+
+func TestFilter_FailsOpenWhenNoPeerTopology(t *testing.T) {
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint(t, "a", &attrtopology.Topology{Hostname: "h1"}),
+		makeEndpoint(t, "b", &attrtopology.Topology{Hostname: "h2"}),
+	}
+
+	f := newTestFilter(topoutil.LevelHost)
+	got := f.Filter(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+	assert.Equal(t, endpoints, got, "fails open: no peer topology at all")
+}
+
+func TestFilter_EndpointMissingAttributeIsDropped(t *testing.T) {
+	peerTopo := &attrtopology.Topology{Hostname: "h1"}
+	sameHost := makeEndpoint(t, "same-host", &attrtopology.Topology{Hostname: "h1"})
+	noAttribute := makeEndpoint(t, "no-attribute", nil)
+
+	f := newTestFilter(topoutil.LevelHost)
+	req := requestWithPeer(peerTopo)
+	got := f.Filter(context.Background(), req, []fwksched.Endpoint{sameHost, noAttribute})
+	require.Len(t, got, 1)
+	assert.Equal(t, "same-host", got[0].GetMetadata().ID.Name)
+}
+
+func TestFactory_Defaults(t *testing.T) {
+	p, err := Factory("", nil, nil)
+	require.NoError(t, err)
+	f, ok := p.(*Filter)
+	require.True(t, ok)
+	assert.Equal(t, topoutil.LevelHost, f.minAffinity)
+	assert.Equal(t, FilterType, f.TypedName().Name)
+}
+
+func TestFactory_InvalidMinAffinity(t *testing.T) {
+	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"minAffinity": "datacenter"}`)), nil)
+	assert.Error(t, err)
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
@@ -125,6 +125,16 @@ func TestFilter_EndpointMissingAttributeIsDropped(t *testing.T) {
 	assert.Equal(t, "same-host", got[0].GetMetadata().ID.Name)
 }
 
+func TestFilter_Consumes(t *testing.T) {
+	f := newTestFilter(topoutil.LevelHost)
+
+	consumes := f.Consumes()
+
+	assert.Empty(t, consumes.Required)
+	require.Len(t, consumes.Optional, 1)
+	assert.Equal(t, attrtopology.Topology{}, consumes.Optional[f.dataKey])
+}
+
 func TestFactory_Defaults(t *testing.T) {
 	p, err := Factory("", nil, nil)
 	require.NoError(t, err)

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
@@ -28,6 +28,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/disagg"
 	topoutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/topology"
 )
 
@@ -48,7 +49,7 @@ func requestWithPeer(topo *attrtopology.Topology) *fwksched.InferenceRequest {
 	if topo != nil {
 		peer.Put(attrtopology.TopologyAttributeKey.String(), topo)
 	}
-	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peer)
+	req.PutAttribute(disagg.PeerEndpointAttributeKey, peer)
 	return req
 }
 

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
@@ -78,6 +78,20 @@ func TestFilter_KeepsOnlyMatchingMinAffinity(t *testing.T) {
 	require.Len(t, got, 2)
 }
 
+func TestFilter_SparseCandidateMatchesAtItsOnlyPopulatedLevel(t *testing.T) {
+	peerTopo := &attrtopology.Topology{Hostname: "h1", Rack: "r1", Zone: "z1", Region: "reg1"}
+	sameRackOnly := makeEndpoint(t, "same-rack-only", &attrtopology.Topology{Rack: "r1"})
+
+	f := newTestFilter(topoutil.LevelRack)
+	req := requestWithPeer(peerTopo)
+	got := f.Filter(context.Background(), req, []fwksched.Endpoint{sameRackOnly})
+	require.Len(t, got, 1, "candidate with only Rack set still matches at rack")
+
+	f = newTestFilter(topoutil.LevelHost)
+	got = f.Filter(context.Background(), req, []fwksched.Endpoint{sameRackOnly})
+	require.Len(t, got, 1, "fails open: rack-only match does not meet host floor")
+}
+
 func TestFilter_FailsOpenWhenNoCandidateMatches(t *testing.T) {
 	peerTopo := &attrtopology.Topology{Hostname: "h1"}
 	noMatch := makeEndpoint(t, "no-match", &attrtopology.Topology{Hostname: "h2"})

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -331,6 +331,9 @@ func (h *Handler) Pick(ctx context.Context, request *scheduling.InferenceRequest
 	if _, hasPrefillProfile := profiles[h.prefillProfile]; hasPrefillProfile {
 		if _, executed := profileResults[h.prefillProfile]; !executed {
 			if h.pdDecider != nil && h.pdDecider.disaggregate(ctx, request, decodeRes.TargetEndpoints[0]) {
+				// Publish the decode pick so plugins in the prefill profile (e.g.
+				// topology affinity) can compare candidates against it.
+				request.PutAttribute(scheduling.PeerEndpointAttributeKey, decodeRes.TargetEndpoints[0])
 				span.SetAttributes(attribute.String("llm_d.epp.profile_handler.decision", "run_prefill"))
 				return map[string]scheduling.SchedulerProfile{h.prefillProfile: profiles[h.prefillProfile]}
 			}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -36,6 +36,13 @@ const (
 	defaultEncodeProfile  = "encode"
 )
 
+// PeerEndpointAttributeKey is the request-attribute key under which this
+// handler publishes the endpoint selected in an earlier scheduling phase
+// (the decode pick, before running the prefill profile), for plugins in a
+// later profile to compare against (e.g. topology affinity between a
+// disaggregated prefill and decode pick). The value is an Endpoint.
+const PeerEndpointAttributeKey = "peer-endpoint"
+
 // ── Factory & constructor ────────────────────────────────────────────────────
 
 type disaggProfilesParameters struct {
@@ -333,7 +340,7 @@ func (h *Handler) Pick(ctx context.Context, request *scheduling.InferenceRequest
 			if h.pdDecider != nil && h.pdDecider.disaggregate(ctx, request, decodeRes.TargetEndpoints[0]) {
 				// Publish the decode pick so plugins in the prefill profile (e.g.
 				// topology affinity) can compare candidates against it.
-				request.PutAttribute(scheduling.PeerEndpointAttributeKey, decodeRes.TargetEndpoints[0])
+				request.PutAttribute(PeerEndpointAttributeKey, decodeRes.TargetEndpoints[0])
 				span.SetAttributes(attribute.String("llm_d.epp.profile_handler.decision", "run_prefill"))
 				return map[string]scheduling.SchedulerProfile{h.prefillProfile: profiles[h.prefillProfile]}
 			}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -1395,3 +1395,53 @@ func TestHandler_PreRequest_EncodeMultipleEndpoints(t *testing.T) {
 	want := net.JoinHostPort("10.0.0.1", "8000") + "," + net.JoinHostPort("10.0.0.2", "8000")
 	assert.Equal(t, want, request.Headers[routing.EncoderEndpointsHeader])
 }
+
+func TestHandler_Pick_PD_StampsPeerEndpointBeforePrefill(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	req := completionsRequest(testLongPrompt)
+
+	profiles := map[string]scheduling.SchedulerProfile{
+		defaultDecodeProfile:  &mockProfile{},
+		defaultPrefillProfile: &mockProfile{},
+	}
+
+	decodeResult := makeProfileRunResult("pod1")
+	profileResults := map[string]*scheduling.ProfileRunResult{defaultDecodeProfile: decodeResult}
+	inputTokens := len(req.Body.Completions.Prompt.Raw) / averageCharactersPerToken
+	injectPrefixCache(profileResults, 2, inputTokens) // few cached tokens → prefill needed
+
+	decider, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{NonCachedTokens: 4})
+	assert.NoError(t, err)
+	h := NewDisaggProfileHandler(defaultDecodeProfile, defaultPrefillProfile, "", decider, nil)
+
+	got := h.Pick(ctx, req, profiles, profileResults)
+	assert.ElementsMatch(t, []string{defaultPrefillProfile}, profileNames(got), "prefill must run")
+
+	peer, ok := scheduling.ReadRequestAttribute[scheduling.Endpoint](req, scheduling.PeerEndpointAttributeKey)
+	assert.True(t, ok, "peer endpoint attribute must be published before prefill runs")
+	assert.Equal(t, decodeResult.TargetEndpoints[0], peer)
+}
+
+func TestHandler_Pick_PD_NoPeerEndpointWhenPrefillSkipped(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	req := completionsRequest(testLongPrompt)
+
+	profiles := map[string]scheduling.SchedulerProfile{
+		defaultDecodeProfile:  &mockProfile{},
+		defaultPrefillProfile: &mockProfile{},
+	}
+
+	profileResults := map[string]*scheduling.ProfileRunResult{defaultDecodeProfile: makeProfileRunResult("pod1")}
+	inputTokens := len(req.Body.Completions.Prompt.Raw) / averageCharactersPerToken
+	injectPrefixCache(profileResults, inputTokens, inputTokens) // fully cached → no prefill needed
+
+	decider, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{NonCachedTokens: 4})
+	assert.NoError(t, err)
+	h := NewDisaggProfileHandler(defaultDecodeProfile, defaultPrefillProfile, "", decider, nil)
+
+	got := h.Pick(ctx, req, profiles, profileResults)
+	assert.Empty(t, got, "prefill must be skipped")
+
+	_, ok := scheduling.ReadRequestAttribute[scheduling.Endpoint](req, scheduling.PeerEndpointAttributeKey)
+	assert.False(t, ok, "peer endpoint attribute must not be published when prefill is skipped")
+}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -1417,7 +1417,7 @@ func TestHandler_Pick_PD_StampsPeerEndpointBeforePrefill(t *testing.T) {
 	got := h.Pick(ctx, req, profiles, profileResults)
 	assert.ElementsMatch(t, []string{defaultPrefillProfile}, profileNames(got), "prefill must run")
 
-	peer, ok := scheduling.ReadRequestAttribute[scheduling.Endpoint](req, scheduling.PeerEndpointAttributeKey)
+	peer, ok := scheduling.ReadRequestAttribute[scheduling.Endpoint](req, PeerEndpointAttributeKey)
 	assert.True(t, ok, "peer endpoint attribute must be published before prefill runs")
 	assert.Equal(t, decodeResult.TargetEndpoints[0], peer)
 }
@@ -1442,6 +1442,6 @@ func TestHandler_Pick_PD_NoPeerEndpointWhenPrefillSkipped(t *testing.T) {
 	got := h.Pick(ctx, req, profiles, profileResults)
 	assert.Empty(t, got, "prefill must be skipped")
 
-	_, ok := scheduling.ReadRequestAttribute[scheduling.Endpoint](req, scheduling.PeerEndpointAttributeKey)
+	_, ok := scheduling.ReadRequestAttribute[scheduling.Endpoint](req, PeerEndpointAttributeKey)
 	assert.False(t, ok, "peer endpoint attribute must not be published when prefill is skipped")
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -29,7 +29,19 @@ zone, and region), using a fixed proximity curve:
 
 The curve is shaped by KV-cache transfer bandwidth, not evenly spaced: same host
 dominates same rack 5:1 and same zone 20:1, so co-location wins outright while the
-looser levels still break ties among non-colocated candidates.
+looser levels still break ties among non-colocated candidates. Approximate transfer
+bandwidth by path, which the ratios above track: NVLink ~900 GB/s, a single NIC and
+switch hop ~100-400 Gb/s (roughly two orders of magnitude below NVLink), multiple
+switch hops within a zone lower still, and inter-datacenter links the tightest of all.
+
+`Compare` returns exactly one `Level` per call (an ordered switch with early returns,
+tightest tier first), so `Score` performs a single `levelScores` lookup per endpoint,
+never a sum. Each score is already in `[0.00, 1.00]`; there is nothing to normalize
+within this scorer. A total above 1.0 across a profile's scorers comes from
+`runScorerPlugins` in the scheduler (`pkg/epp/scheduling/scheduler_profile.go`), which
+clamps each scorer's output to `[0, 1]` and then sums `score * weight` across every
+scorer configured in the profile — a property of profile weighting, not of this
+scorer's own output.
 
 The curve is hardcoded, not configurable per level, in this release. A missing value
 never matches, including empty against empty: an endpoint with no `Hostname` never scores
@@ -43,20 +55,14 @@ skewing it.
 ## Inputs consumed
 
 Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and
-from the peer endpoint. The peer endpoint is resolved from, in order:
-
-1. The `peer-endpoint` request attribute, published by `disagg-profile-handler` before
-   running the `prefill` profile in single-EPP deployments.
-2. The `peerTopologyHeader` request header, set by the prefill-side response stamper in
-   coordinator deployments with separate prefill and decode EPPs. Not yet implemented;
-   configuring this parameter has no effect until that stamper lands.
+from the peer endpoint. The peer endpoint is resolved from the `peer-endpoint` request
+attribute, published by `disagg-profile-handler` before running the `prefill` profile.
 
 ## Configuration
 
 | Parameter               | Required | Default | Description                                                                  |
 |--------------------------|----------|---------|--------------------------------------------------------------------------------|
 | `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from. |
-| `peerTopologyHeader`     | no       | unset   | Header carrying the peer topology when the peer endpoint is not in-process. Not yet implemented. |
 
 **Configuration Example:**
 ```yaml

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -52,6 +52,13 @@ unknown, or has no non-empty topology field) or when the candidate is missing th
 `Topology` attribute. A zero score contributes nothing to the weighted sum rather than
 skewing it.
 
+The `Hostname` tier assumes a host is the NVLink boundary, true for switched 8-GPU
+NVLink baseboards (HGX/DGX) but not for rack-scale NVLink domains (e.g. NVL72), where
+the switched fabric spans many hosts and `Rack` is the tier that shares NVLink-class
+bandwidth. On that hardware, filter or score on `Rack` rather than `Hostname`, if the
+extractor populates a `Rack` value that reflects the NVLink domain rather than a
+physical enclosure.
+
 ## Inputs consumed
 
 Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -1,0 +1,73 @@
+# Topology Affinity Scorer Plugin
+
+**Type:** `topology-affinity-scorer`
+
+**Category:** `Affinity`
+
+This plugin scores candidate endpoints by topology proximity to a peer endpoint selected
+in an earlier scheduling phase.
+
+## What it does
+
+For a disaggregated prefill/decode request, `disagg-profile-handler` selects the decode
+endpoint first, then runs the `prefill` profile to select a prefill endpoint. This plugin
+runs in the `prefill` profile and grades each candidate by the tightest topology level it
+shares with the decode pick (host, rack, zone, or region; same host implies same rack,
+zone, and region), using a fixed proximity curve:
+
+| Common level | Score | KV-transfer path        |
+|--------------|-------|--------------------------|
+| host         | 1.00  | NVLink                   |
+| rack         | 0.20  | NIC, single switch       |
+| zone         | 0.05  | multiple switch hops     |
+| region       | 0.02  | inter-datacenter         |
+| none         | 0.00  |                          |
+
+The curve is shaped by KV-cache transfer bandwidth, not evenly spaced: same host
+dominates same rack 5:1 and same zone 20:1, so co-location wins outright while the
+looser levels still break ties among non-colocated candidates.
+
+The curve is hardcoded, not configurable per level, in this release. A missing value
+never matches, including empty against empty: an endpoint with no `Hostname` never scores
+`host` proximity against a peer that also has no `Hostname`.
+
+Every candidate scores 0 when no peer topology is available (the peer endpoint is
+unknown, or has no non-empty topology field) or when the candidate is missing the
+`Topology` attribute. A zero score contributes nothing to the weighted sum rather than
+skewing it.
+
+## Inputs consumed
+
+Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and
+from the peer endpoint. The peer endpoint is resolved from, in order:
+
+1. The `peer-endpoint` request attribute, published by `disagg-profile-handler` before
+   running the `prefill` profile in single-EPP deployments.
+2. The `peerTopologyHeader` request header, set by the prefill-side response stamper in
+   coordinator deployments with separate prefill and decode EPPs. Not yet implemented;
+   configuring this parameter has no effect until that stamper lands.
+
+## Configuration
+
+| Parameter               | Required | Default | Description                                                                  |
+|--------------------------|----------|---------|--------------------------------------------------------------------------------|
+| `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from. |
+| `peerTopologyHeader`     | no       | unset   | Header carrying the peer topology when the peer endpoint is not in-process. Not yet implemented. |
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: topology-extractor
+  - type: topology-affinity-scorer
+    name: prefill-topology-affinity
+schedulingProfiles:
+  - name: prefill
+    plugins:
+      - pluginRef: prefill-topology-affinity
+        weight: 1
+```
+
+## See also
+
+The `topology-affinity-filter` plugin drops candidates below a minimum affinity instead
+of scoring them, and is the filtering counterpart of this scorer.

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -9,6 +9,10 @@ in an earlier scheduling phase.
 
 ## What it does
 
+Scoped to single-EPP disaggregated deployments, where one EPP process runs both the
+`decode` and `prefill` scheduling profiles for a request. Coordinator deployments, where
+prefill and decode are picked by separate EPPs, are not yet supported.
+
 For a disaggregated prefill/decode request, `disagg-profile-handler` selects the decode
 endpoint first, then runs the `prefill` profile to select a prefill endpoint. This plugin
 runs in the `prefill` profile and grades each candidate by the tightest topology level it

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -65,6 +65,10 @@ Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoin
 from the peer endpoint. The peer endpoint is resolved from the `peer-endpoint` request
 attribute, published by `disagg-profile-handler` before running the `prefill` profile.
 
+Declares `Topology` as an optional data dependency: a config with no `topology-extractor`
+logs a startup warning rather than an error, since every candidate scores 0 when the
+attribute is absent.
+
 ## Configuration
 
 | Parameter               | Required | Default | Description                                                                  |

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
@@ -54,11 +54,6 @@ type parameters struct {
 	// TopologyProducerName selects the topology-extractor instance to read
 	// endpoint topology from. Defaults to the extractor's default producer.
 	TopologyProducerName string `json:"topologyProducerName,omitempty"`
-	// PeerTopologyHeader names the request header carrying the peer topology
-	// when the peer endpoint is not available in-process (coordinator mode
-	// with separate prefill and decode EPPs). Unset by default; header
-	// decoding is not yet implemented.
-	PeerTopologyHeader string `json:"peerTopologyHeader,omitempty"`
 }
 
 var _ fwksched.Scorer = &Scorer{}
@@ -75,9 +70,8 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 		name = ScorerType
 	}
 	return &Scorer{
-		typedName:  fwkplugin.TypedName{Type: ScorerType, Name: name},
-		dataKey:    attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
-		peerHeader: params.PeerTopologyHeader,
+		typedName: fwkplugin.TypedName{Type: ScorerType, Name: name},
+		dataKey:   attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
 	}, nil
 }
 
@@ -85,9 +79,8 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 // endpoint, using the fixed levelScores curve. Endpoints score 0 when no peer
 // topology is available, or when the endpoint has no matching field.
 type Scorer struct {
-	typedName  fwkplugin.TypedName
-	dataKey    fwkplugin.DataKey
-	peerHeader string
+	typedName fwkplugin.TypedName
+	dataKey   fwkplugin.DataKey
 }
 
 func (s *Scorer) TypedName() fwkplugin.TypedName {
@@ -101,7 +94,7 @@ func (s *Scorer) Category() fwksched.ScorerCategory {
 func (s *Scorer) Score(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 
-	peer, ok := topoutil.PeerTopology(request, s.dataKey.String(), s.peerHeader)
+	peer, ok := topoutil.PeerTopology(request, s.dataKey.String(), "")
 	if !ok {
 		for _, endpoint := range endpoints {
 			scores[endpoint] = 0

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
@@ -57,6 +57,7 @@ type parameters struct {
 }
 
 var _ fwksched.Scorer = &Scorer{}
+var _ fwkplugin.ConsumerPlugin = &Scorer{}
 
 // Factory creates a topology affinity scorer.
 func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -85,6 +86,16 @@ type Scorer struct {
 
 func (s *Scorer) TypedName() fwkplugin.TypedName {
 	return s.typedName
+}
+
+// Consumes returns the Topology attribute as optional: a missing producer
+// logs a startup warning rather than an error, since the scorer scores every
+// endpoint 0 (no signal, not an error) rather than depending on the
+// attribute to function.
+func (s *Scorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Optional: map[fwkplugin.DataKey]any{s.dataKey: attrtopology.Topology{}},
+	}
 }
 
 func (s *Scorer) Category() fwksched.ScorerCategory {

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package topologyaffinity provides a scorer that grades candidate endpoints
+// by topology proximity to the peer endpoint.
+package topologyaffinity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	topoutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/topology"
+)
+
+// ScorerType is the type of the topology affinity scorer.
+const ScorerType = "topology-affinity-scorer"
+
+// levelScores maps the tightest common topology level to its proximity
+// score, shaped by the KV-transfer bandwidth available at that level rather
+// than by even spacing: same host uses NVLink, same rack a NIC and a single
+// switch, and each looser level adds switch hops. Host dominates rack 5:1 and
+// zone 20:1 so co-location wins outright, while the looser levels still carry
+// enough signal to break ties among non-colocated candidates.
+//
+// These ratios are hardcoded rather than configurable per level; if a real
+// deployment shows they are wrong, add per-level weight parameters then.
+var levelScores = map[topoutil.Level]float64{
+	topoutil.LevelHost:   1.00,
+	topoutil.LevelRack:   0.20,
+	topoutil.LevelZone:   0.05,
+	topoutil.LevelRegion: 0.02,
+	topoutil.LevelNone:   0.00,
+}
+
+type parameters struct {
+	// TopologyProducerName selects the topology-extractor instance to read
+	// endpoint topology from. Defaults to the extractor's default producer.
+	TopologyProducerName string `json:"topologyProducerName,omitempty"`
+	// PeerTopologyHeader names the request header carrying the peer topology
+	// when the peer endpoint is not available in-process (coordinator mode
+	// with separate prefill and decode EPPs). Unset by default; header
+	// decoding is not yet implemented.
+	PeerTopologyHeader string `json:"peerTopologyHeader,omitempty"`
+}
+
+var _ fwksched.Scorer = &Scorer{}
+
+// Factory creates a topology affinity scorer.
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	params := parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", ScorerType, err)
+		}
+	}
+	if name == "" {
+		name = ScorerType
+	}
+	return &Scorer{
+		typedName:  fwkplugin.TypedName{Type: ScorerType, Name: name},
+		dataKey:    attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+		peerHeader: params.PeerTopologyHeader,
+	}, nil
+}
+
+// Scorer grades candidate endpoints by topology proximity to the peer
+// endpoint, using the fixed levelScores curve. Endpoints score 0 when no peer
+// topology is available, or when the endpoint has no matching field.
+type Scorer struct {
+	typedName  fwkplugin.TypedName
+	dataKey    fwkplugin.DataKey
+	peerHeader string
+}
+
+func (s *Scorer) TypedName() fwkplugin.TypedName {
+	return s.typedName
+}
+
+func (s *Scorer) Category() fwksched.ScorerCategory {
+	return fwksched.Affinity
+}
+
+func (s *Scorer) Score(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
+
+	peer, ok := topoutil.PeerTopology(request, s.dataKey.String(), s.peerHeader)
+	if !ok {
+		for _, endpoint := range endpoints {
+			scores[endpoint] = 0
+		}
+		return scores
+	}
+
+	for _, endpoint := range endpoints {
+		candidate, ok := fwkdl.ReadAttribute[*attrtopology.Topology](endpoint, s.dataKey.String())
+		if !ok {
+			scores[endpoint] = 0
+			continue
+		}
+		scores[endpoint] = levelScores[topoutil.Compare(peer, candidate)]
+	}
+	return scores
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
@@ -94,7 +94,7 @@ func (s *Scorer) Category() fwksched.ScorerCategory {
 func (s *Scorer) Score(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 
-	peer, ok := topoutil.PeerTopology(request, s.dataKey.String(), "")
+	peer, ok := topoutil.PeerTopology(request, s.dataKey.String())
 	if !ok {
 		for _, endpoint := range endpoints {
 			scores[endpoint] = 0

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
@@ -28,6 +28,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/disagg"
 )
 
 func makeEndpoint(t *testing.T, name string, topo *attrtopology.Topology) fwksched.Endpoint {
@@ -47,7 +48,7 @@ func requestWithPeer(topo *attrtopology.Topology) *fwksched.InferenceRequest {
 	if topo != nil {
 		peer.Put(attrtopology.TopologyAttributeKey.String(), topo)
 	}
-	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peer)
+	req.PutAttribute(disagg.PeerEndpointAttributeKey, peer)
 	return req
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
@@ -78,6 +78,16 @@ func TestScorer_LevelCurve(t *testing.T) {
 	assert.Equal(t, 0.00, got[noMatch])
 }
 
+func TestScorer_SparseCandidateScoresAtItsOnlyPopulatedLevel(t *testing.T) {
+	peerTopo := &attrtopology.Topology{Hostname: "h1", Rack: "r1", Zone: "z1", Region: "reg1"}
+	sameRackOnly := makeEndpoint(t, "same-rack-only", &attrtopology.Topology{Rack: "r1"})
+
+	s := newTestScorer()
+	req := requestWithPeer(peerTopo)
+	got := s.Score(context.Background(), req, []fwksched.Endpoint{sameRackOnly})
+	assert.Equal(t, 0.20, got[sameRackOnly], "candidate with only Rack set scores at rack, not host")
+}
+
 func TestScorer_AllZeroWhenNoPeerTopology(t *testing.T) {
 	endpoints := []fwksched.Endpoint{
 		makeEndpoint(t, "a", &attrtopology.Topology{Hostname: "h1"}),

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
@@ -116,6 +116,16 @@ func TestScorer_Category(t *testing.T) {
 	assert.Equal(t, fwksched.Affinity, s.Category())
 }
 
+func TestScorer_Consumes(t *testing.T) {
+	s := newTestScorer()
+
+	consumes := s.Consumes()
+
+	assert.Empty(t, consumes.Required)
+	require.Len(t, consumes.Optional, 1)
+	assert.Equal(t, attrtopology.Topology{}, consumes.Optional[s.dataKey])
+}
+
 func TestFactory_Defaults(t *testing.T) {
 	p, err := Factory("", nil, nil)
 	require.NoError(t, err)

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologyaffinity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+func makeEndpoint(t *testing.T, name string, topo *attrtopology.Topology) fwksched.Endpoint {
+	t.Helper()
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: name, Namespace: "default"}}
+	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	if topo != nil {
+		ep.Put(attrtopology.TopologyAttributeKey.String(), topo)
+	}
+	return ep
+}
+
+func requestWithPeer(topo *attrtopology.Topology) *fwksched.InferenceRequest {
+	req := &fwksched.InferenceRequest{}
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "peer", Namespace: "default"}}
+	peer := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	if topo != nil {
+		peer.Put(attrtopology.TopologyAttributeKey.String(), topo)
+	}
+	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peer)
+	return req
+}
+
+func newTestScorer() *Scorer {
+	return &Scorer{
+		typedName: fwkplugin.TypedName{Type: ScorerType, Name: "test"},
+		dataKey:   attrtopology.TopologyAttributeKey,
+	}
+}
+
+func TestScorer_LevelCurve(t *testing.T) {
+	peerTopo := &attrtopology.Topology{Hostname: "h1", Rack: "r1", Zone: "z1", Region: "reg1"}
+	sameHost := makeEndpoint(t, "same-host", &attrtopology.Topology{Hostname: "h1", Rack: "r1", Zone: "z1", Region: "reg1"})
+	sameRack := makeEndpoint(t, "same-rack", &attrtopology.Topology{Hostname: "h2", Rack: "r1", Zone: "z1", Region: "reg1"})
+	sameZone := makeEndpoint(t, "same-zone", &attrtopology.Topology{Hostname: "h2", Rack: "r2", Zone: "z1", Region: "reg1"})
+	sameRegion := makeEndpoint(t, "same-region", &attrtopology.Topology{Hostname: "h2", Rack: "r2", Zone: "z2", Region: "reg1"})
+	noMatch := makeEndpoint(t, "no-match", &attrtopology.Topology{Hostname: "h2", Rack: "r2", Zone: "z2", Region: "reg2"})
+
+	s := newTestScorer()
+	req := requestWithPeer(peerTopo)
+	got := s.Score(context.Background(), req, []fwksched.Endpoint{sameHost, sameRack, sameZone, sameRegion, noMatch})
+
+	assert.Equal(t, 1.00, got[sameHost])
+	assert.Equal(t, 0.20, got[sameRack])
+	assert.Equal(t, 0.05, got[sameZone])
+	assert.Equal(t, 0.02, got[sameRegion])
+	assert.Equal(t, 0.00, got[noMatch])
+}
+
+func TestScorer_AllZeroWhenNoPeerTopology(t *testing.T) {
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint(t, "a", &attrtopology.Topology{Hostname: "h1"}),
+		makeEndpoint(t, "b", &attrtopology.Topology{Hostname: "h2"}),
+	}
+
+	s := newTestScorer()
+	got := s.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
+	for _, ep := range endpoints {
+		assert.Equal(t, 0.00, got[ep])
+	}
+}
+
+func TestScorer_MissingAttributeScoresZero(t *testing.T) {
+	peerTopo := &attrtopology.Topology{Hostname: "h1"}
+	noAttribute := makeEndpoint(t, "no-attribute", nil)
+
+	s := newTestScorer()
+	req := requestWithPeer(peerTopo)
+	got := s.Score(context.Background(), req, []fwksched.Endpoint{noAttribute})
+	assert.Equal(t, 0.00, got[noAttribute])
+}
+
+func TestScorer_Category(t *testing.T) {
+	s := newTestScorer()
+	assert.Equal(t, fwksched.Affinity, s.Category())
+}
+
+func TestFactory_Defaults(t *testing.T) {
+	p, err := Factory("", nil, nil)
+	require.NoError(t, err)
+	s, ok := p.(*Scorer)
+	require.True(t, ok)
+	assert.Equal(t, ScorerType, s.TypedName().Name)
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/level.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/level.go
@@ -37,37 +37,32 @@ const (
 	LevelNone
 )
 
-// String returns the config-facing name of the level.
+// levelNames maps each Level to its config-facing name, tightest to loosest.
+var levelNames = map[Level]string{
+	LevelHost:   "host",
+	LevelRack:   "rack",
+	LevelZone:   "zone",
+	LevelRegion: "region",
+}
+
+// String returns the config-facing name of the level, or "none" for LevelNone
+// and any other unrecognized value.
 func (l Level) String() string {
-	switch l {
-	case LevelHost:
-		return "host"
-	case LevelRack:
-		return "rack"
-	case LevelZone:
-		return "zone"
-	case LevelRegion:
-		return "region"
-	default:
-		return "none"
+	if s, ok := levelNames[l]; ok {
+		return s
 	}
+	return "none"
 }
 
 // ParseLevel parses a config value into a Level. Valid values are "host",
 // "rack", "zone", and "region".
 func ParseLevel(s string) (Level, error) {
-	switch s {
-	case "host":
-		return LevelHost, nil
-	case "rack":
-		return LevelRack, nil
-	case "zone":
-		return LevelZone, nil
-	case "region":
-		return LevelRegion, nil
-	default:
-		return LevelNone, fmt.Errorf("invalid topology level %q, must be one of host, rack, zone, region", s)
+	for level, name := range levelNames {
+		if name == s {
+			return level, nil
+		}
 	}
+	return LevelNone, fmt.Errorf("invalid topology level %q, must be one of host, rack, zone, region", s)
 }
 
 // Compare returns the tightest level at which peer and candidate share a

--- a/pkg/epp/framework/plugins/scheduling/util/topology/level.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/level.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package topology provides comparison of endpoint Topology attributes,
+// shared by the topology-affinity-filter and topology-affinity-scorer plugins.
+package topology
+
+import (
+	"fmt"
+
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+// Level names a topology tier, ordered tightest to loosest. Same host implies
+// same rack, zone and region.
+type Level int
+
+const (
+	LevelHost Level = iota
+	LevelRack
+	LevelZone
+	LevelRegion
+	// LevelNone means peer and candidate share no common tier.
+	LevelNone
+)
+
+// String returns the config-facing name of the level.
+func (l Level) String() string {
+	switch l {
+	case LevelHost:
+		return "host"
+	case LevelRack:
+		return "rack"
+	case LevelZone:
+		return "zone"
+	case LevelRegion:
+		return "region"
+	default:
+		return "none"
+	}
+}
+
+// ParseLevel parses a config value into a Level. Valid values are "host",
+// "rack", "zone", and "region".
+func ParseLevel(s string) (Level, error) {
+	switch s {
+	case "host":
+		return LevelHost, nil
+	case "rack":
+		return LevelRack, nil
+	case "zone":
+		return LevelZone, nil
+	case "region":
+		return LevelRegion, nil
+	default:
+		return LevelNone, fmt.Errorf("invalid topology level %q, must be one of host, rack, zone, region", s)
+	}
+}
+
+// Compare returns the tightest level at which peer and candidate share a
+// non-empty, equal value, or LevelNone if they share none. An empty value
+// never matches, including empty against empty, so an endpoint missing a
+// field is never treated as co-located on that field. A nil peer or
+// candidate always returns LevelNone.
+func Compare(peer, candidate *attrtopology.Topology) Level {
+	if peer == nil || candidate == nil {
+		return LevelNone
+	}
+	switch {
+	case matches(peer.Hostname, candidate.Hostname):
+		return LevelHost
+	case matches(peer.Rack, candidate.Rack):
+		return LevelRack
+	case matches(peer.Zone, candidate.Zone):
+		return LevelZone
+	case matches(peer.Region, candidate.Region):
+		return LevelRegion
+	default:
+		return LevelNone
+	}
+}
+
+func matches(a, b string) bool {
+	return a != "" && a == b
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/level_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/level_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+func TestParseLevel(t *testing.T) {
+	valid := map[string]Level{"host": LevelHost, "rack": LevelRack, "zone": LevelZone, "region": LevelRegion}
+	for s, want := range valid {
+		got, err := ParseLevel(s)
+		assert.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+
+	_, err := ParseLevel("datacenter")
+	assert.Error(t, err)
+}
+
+func TestCompare(t *testing.T) {
+	full := &attrtopology.Topology{Hostname: "h1", Rack: "r1", Zone: "z1", Region: "reg1"}
+
+	tests := []struct {
+		name      string
+		peer      *attrtopology.Topology
+		candidate *attrtopology.Topology
+		want      Level
+	}{
+		{"same host", full, full, LevelHost},
+		{"same rack, different host", full, &attrtopology.Topology{Hostname: "h2", Rack: "r1", Zone: "z1", Region: "reg1"}, LevelRack},
+		{"same zone, different rack", full, &attrtopology.Topology{Hostname: "h2", Rack: "r2", Zone: "z1", Region: "reg1"}, LevelZone},
+		{"same region, different zone", full, &attrtopology.Topology{Hostname: "h2", Rack: "r2", Zone: "z2", Region: "reg1"}, LevelRegion},
+		{"no common tier", full, &attrtopology.Topology{Hostname: "h2", Rack: "r2", Zone: "z2", Region: "reg2"}, LevelNone},
+		{"empty vs empty never matches", &attrtopology.Topology{}, &attrtopology.Topology{}, LevelNone},
+		{"missing field on candidate does not match", full, &attrtopology.Topology{Rack: "r1", Zone: "z1", Region: "reg1"}, LevelRack},
+		{"nil peer", nil, full, LevelNone},
+		{"nil candidate", full, nil, LevelNone},
+		{"both nil", nil, nil, LevelNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Compare(tt.peer, tt.candidate))
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/level_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/level_test.go
@@ -52,6 +52,8 @@ func TestCompare(t *testing.T) {
 		{"no common tier", full, &attrtopology.Topology{Hostname: "h2", Rack: "r2", Zone: "z2", Region: "reg2"}, LevelNone},
 		{"empty vs empty never matches", &attrtopology.Topology{}, &attrtopology.Topology{}, LevelNone},
 		{"missing field on candidate does not match", full, &attrtopology.Topology{Rack: "r1", Zone: "z1", Region: "reg1"}, LevelRack},
+		{"candidate has only rack, matches at rack", full, &attrtopology.Topology{Rack: "r1"}, LevelRack},
+		{"candidate has only zone, matches at zone", full, &attrtopology.Topology{Zone: "z1"}, LevelZone},
 		{"nil peer", nil, full, LevelNone},
 		{"nil candidate", full, nil, LevelNone},
 		{"both nil", nil, nil, LevelNone},

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
@@ -20,13 +20,14 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/disagg"
 )
 
 // PeerTopology returns the topology of the endpoint selected in the peer
 // scheduling phase, or false when no peer topology is available.
 //
 // Single EPP: disagg-profile-handler publishes the peer Endpoint as the
-// scheduling.PeerEndpointAttributeKey request attribute before running the
+// disagg.PeerEndpointAttributeKey request attribute before running the
 // prefill profile; its Topology attribute (dataKey) is read directly.
 //
 // Coordinator, separate P/D EPPs: the peer's topology arrives encoded on
@@ -39,7 +40,7 @@ func PeerTopology(request *fwksched.InferenceRequest, dataKey, header string) (*
 	if request == nil {
 		return nil, false
 	}
-	if peer, ok := fwksched.ReadRequestAttribute[fwksched.Endpoint](request, fwksched.PeerEndpointAttributeKey); ok && peer != nil {
+	if peer, ok := fwksched.ReadRequestAttribute[fwksched.Endpoint](request, disagg.PeerEndpointAttributeKey); ok && peer != nil {
 		if topo, ok := fwkdl.ReadAttribute[*attrtopology.Topology](peer, dataKey); ok {
 			return topo, true
 		}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+// PeerTopology returns the topology of the endpoint selected in the peer
+// scheduling phase, or false when no peer topology is available.
+//
+// Single EPP: disagg-profile-handler publishes the peer Endpoint as the
+// scheduling.PeerEndpointAttributeKey request attribute before running the
+// prefill profile; its Topology attribute (dataKey) is read directly.
+//
+// Coordinator, separate P/D EPPs: the peer's topology arrives encoded on
+// header (a request header set by the prefill-side response stamper).
+// Header decoding is not yet implemented; a configured header always
+// returns false until that support lands.
+//
+// The request attribute takes precedence when both are present.
+func PeerTopology(request *fwksched.InferenceRequest, dataKey, header string) (*attrtopology.Topology, bool) {
+	if request == nil {
+		return nil, false
+	}
+	if peer, ok := fwksched.ReadRequestAttribute[fwksched.Endpoint](request, fwksched.PeerEndpointAttributeKey); ok && peer != nil {
+		if topo, ok := fwkdl.ReadAttribute[*attrtopology.Topology](peer, dataKey); ok {
+			return topo, true
+		}
+	}
+	if header == "" {
+		return nil, false
+	}
+	// TODO: decode request.Headers[header]. Header-based peer topology is not
+	// wired up until the coordinator response stamper lands.
+	return nil, false
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
@@ -26,29 +26,18 @@ import (
 // PeerTopology returns the topology of the endpoint selected in the peer
 // scheduling phase, or false when no peer topology is available.
 //
-// Single EPP: disagg-profile-handler publishes the peer Endpoint as the
+// disagg-profile-handler publishes the peer Endpoint as the
 // disagg.PeerEndpointAttributeKey request attribute before running the
-// prefill profile; its Topology attribute (dataKey) is read directly.
-//
-// Coordinator, separate P/D EPPs: the peer's topology arrives encoded on
-// header (a request header set by the prefill-side response stamper).
-// Header decoding is not yet implemented; a configured header always
-// returns false until that support lands.
-//
-// The request attribute takes precedence when both are present.
-func PeerTopology(request *fwksched.InferenceRequest, dataKey, header string) (*attrtopology.Topology, bool) {
+// prefill profile; its Topology attribute (dataKey) is read directly. Scoped
+// to single-EPP deployments; coordinator deployments, where the peer's
+// topology arrives on a request header instead, are not yet supported.
+func PeerTopology(request *fwksched.InferenceRequest, dataKey string) (*attrtopology.Topology, bool) {
 	if request == nil {
 		return nil, false
 	}
-	if peer, ok := fwksched.ReadRequestAttribute[fwksched.Endpoint](request, disagg.PeerEndpointAttributeKey); ok && peer != nil {
-		if topo, ok := fwkdl.ReadAttribute[*attrtopology.Topology](peer, dataKey); ok {
-			return topo, true
-		}
-	}
-	if header == "" {
+	peer, ok := fwksched.ReadRequestAttribute[fwksched.Endpoint](request, disagg.PeerEndpointAttributeKey)
+	if !ok || peer == nil {
 		return nil, false
 	}
-	// TODO: decode request.Headers[header]. Header-based peer topology is not
-	// wired up until the coordinator response stamper lands.
-	return nil, false
+	return fwkdl.ReadAttribute[*attrtopology.Topology](peer, dataKey)
 }

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
@@ -29,13 +29,13 @@ import (
 )
 
 func TestPeerTopology_NilRequest(t *testing.T) {
-	_, ok := PeerTopology(nil, attrtopology.TopologyAttributeKey.String(), "")
+	_, ok := PeerTopology(nil, attrtopology.TopologyAttributeKey.String())
 	assert.False(t, ok)
 }
 
-func TestPeerTopology_NoPeerAttributeNoHeader(t *testing.T) {
+func TestPeerTopology_NoPeerAttribute(t *testing.T) {
 	req := &fwksched.InferenceRequest{}
-	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String())
 	assert.False(t, ok)
 }
 
@@ -48,7 +48,7 @@ func TestPeerTopology_FromPeerEndpointAttribute(t *testing.T) {
 	req := &fwksched.InferenceRequest{}
 	req.PutAttribute(disagg.PeerEndpointAttributeKey, peerEndpoint)
 
-	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
+	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String())
 	assert.True(t, ok)
 	assert.Equal(t, topo, got)
 }
@@ -60,12 +60,6 @@ func TestPeerTopology_PeerEndpointMissingTopologyAttribute(t *testing.T) {
 	req := &fwksched.InferenceRequest{}
 	req.PutAttribute(disagg.PeerEndpointAttributeKey, peerEndpoint)
 
-	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String())
 	assert.False(t, ok)
-}
-
-func TestPeerTopology_HeaderNotYetImplemented(t *testing.T) {
-	req := &fwksched.InferenceRequest{Headers: map[string]string{"x-peer-topology": "host=h1"}}
-	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "x-peer-topology")
-	assert.False(t, ok, "header decoding lands in PR 2")
 }

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+func TestPeerTopology_NilRequest(t *testing.T) {
+	_, ok := PeerTopology(nil, attrtopology.TopologyAttributeKey.String(), "")
+	assert.False(t, ok)
+}
+
+func TestPeerTopology_NoPeerAttributeNoHeader(t *testing.T) {
+	req := &fwksched.InferenceRequest{}
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
+	assert.False(t, ok)
+}
+
+func TestPeerTopology_FromPeerEndpointAttribute(t *testing.T) {
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "peer", Namespace: "default"}}
+	peerEndpoint := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	topo := &attrtopology.Topology{Hostname: "h1"}
+	peerEndpoint.Put(attrtopology.TopologyAttributeKey.String(), topo)
+
+	req := &fwksched.InferenceRequest{}
+	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peerEndpoint)
+
+	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
+	assert.True(t, ok)
+	assert.Equal(t, topo, got)
+}
+
+func TestPeerTopology_PeerEndpointMissingTopologyAttribute(t *testing.T) {
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "peer", Namespace: "default"}}
+	peerEndpoint := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+
+	req := &fwksched.InferenceRequest{}
+	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peerEndpoint)
+
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
+	assert.False(t, ok)
+}
+
+func TestPeerTopology_HeaderNotYetImplemented(t *testing.T) {
+	req := &fwksched.InferenceRequest{Headers: map[string]string{"x-peer-topology": "host=h1"}}
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "x-peer-topology")
+	assert.False(t, ok, "header decoding lands in PR 2")
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
@@ -25,6 +25,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/disagg"
 )
 
 func TestPeerTopology_NilRequest(t *testing.T) {
@@ -45,7 +46,7 @@ func TestPeerTopology_FromPeerEndpointAttribute(t *testing.T) {
 	peerEndpoint.Put(attrtopology.TopologyAttributeKey.String(), topo)
 
 	req := &fwksched.InferenceRequest{}
-	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peerEndpoint)
+	req.PutAttribute(disagg.PeerEndpointAttributeKey, peerEndpoint)
 
 	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
 	assert.True(t, ok)
@@ -57,7 +58,7 @@ func TestPeerTopology_PeerEndpointMissingTopologyAttribute(t *testing.T) {
 	peerEndpoint := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
 
 	req := &fwksched.InferenceRequest{}
-	req.PutAttribute(fwksched.PeerEndpointAttributeKey, peerEndpoint)
+	req.PutAttribute(disagg.PeerEndpointAttributeKey, peerEndpoint)
 
 	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
 	assert.False(t, ok)

--- a/test/integration/epp/e2e_config_smoke_test.go
+++ b/test/integration/epp/e2e_config_smoke_test.go
@@ -106,6 +106,49 @@ schedulingProfiles:
   - pluginRef: prefix-cache-scorer
     weight: 2
 `,
+	"pdTopologyConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: approx-prefix-cache-producer
+  parameters:
+    maxPrefixTokensToMatch: 16384
+    lruCapacityPerServer: 31250
+- type: prefix-cache-scorer
+- type: queue-scorer
+- type: prefill-filter
+- type: decode-filter
+- type: max-score-picker
+- type: topology-extractor
+- type: topology-affinity-filter
+- type: topology-affinity-scorer
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      prefill: prefix-based-pd-decider
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 16
+schedulingProfiles:
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: topology-affinity-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+  - pluginRef: queue-scorer
+    weight: 1
+  - pluginRef: topology-affinity-scorer
+    weight: 1
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+  - pluginRef: queue-scorer
+    weight: 1
+`,
 	"epdConfig": `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds the two consumers of the `Topology` attribute (`topology-extractor`, #1678) for disaggregated prefill/decode routing:

- `topology-affinity-filter`: keeps candidate endpoints whose topology is co-located with the peer endpoint at a configured minimum affinity (default `host`). Fails open (returns all candidates unchanged) when no peer topology is available, or when no candidate meets the threshold, since locality is a preference and must never make a request unroutable.
- `topology-affinity-scorer`: grades candidates on a bandwidth-shaped proximity curve (host=1.00, rack=0.20, zone=0.05, region=0.02, none=0.00), reflecting the KV-cache transfer path (NVLink vs NIC/switch hops vs inter-datacenter).

Both compare a candidate against a peer endpoint selected in an earlier scheduling phase. In single-EPP disaggregated deployments, `disagg-profile-handler` selects decode first; before running the `prefill` profile (only when prefill is actually needed), it now publishes the selected decode endpoint as a `peer-endpoint` request attribute. The
new plugins should run in the `prefill` profile and read that attribute. The handler itself stays topology-agnostic: it publishes an `Endpoint`, not a `Topology`, so it gains no dependency on the new packages.

A missing topology value never matches, including empty against empty: an endpoint with no hostname never counts as co-located with a peer that also has no hostname.

Coordinator support (separate prefill/decode EPPs, topology carried over a response/request header) is out of scope for this PR and will follow in a separate PR referencing #2282.

**Which issue(s) this PR fixes**:
Fixes #545

**Release note**:
```release-note
Add `topology-affinity-filter` and `topology-affinity-scorer` plugins for topology-aware prefill/decode routing, preferring co-located prefill and decode pods to shorten the KV-cache transfer path.
```

**Test plan**:
- [x] `pkg/epp/framework/plugins/scheduling/util/topology/...` - Compare across all levels, empty-never-matches, nil inputs, ParseLevel valid/invalid
- [x] `pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/...` - minAffinity keeps correct set, fail-open on no-match and on absent peer, missing attribute dropped
- [x] `pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/...` - level curve values, all-zero when peer absent, missing attribute safe
- [x] `pkg/epp/framework/plugins/scheduling/profilehandler/disagg/...` - peer-endpoint attribute published before prefill profile runs, absent when prefill is skipped
- [x] `make test-integration-hermetic PATTERN="TestE2EConfigs_StartupParseSmoke"` - new sample config parses and all referenced plugins instantiate
- [x] `make presubmit`