### PR TITLE
ci: publish coordinator image alongside epp and sidecar

### DIFF
--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -9,6 +9,9 @@ on:
       sidecar-image-name:
         required: true
         type: string
+      coordinator-image-name:
+        required: true
+        type: string
       tag:
         required: true
         type: string
@@ -24,6 +27,10 @@ on:
         type: string
         default: ''
       sidecar-additional-tags:
+        required: false
+        type: string
+        default: ''
+      coordinator-additional-tags:
         required: false
         type: string
         default: ''
@@ -103,6 +110,40 @@ jobs:
           commit-sha: ${{ github.sha }}
           push: 'true'
           additional-tags: ${{ inputs.sidecar-additional-tags }}
+
+  build-coordinator:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Build coordinator AMD64 image (no push)
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: Dockerfile.coordinator
+          tag: ${{ inputs.tag }}
+          image-name: ${{ inputs.coordinator-image-name }}
+          registry: ghcr.io/llm-d
+          push: 'false'
+          buildx-outputs: type=docker,dest=/tmp/coordinator-image.tar
+
+      - name: Run Trivy scan on coordinator image on AMD64
+        uses: ./.github/actions/trivy-scan
+        with:
+          tarball: /tmp/coordinator-image.tar
+
+      - name: Push coordinator image for both AMD64 and ARM64
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: Dockerfile.coordinator
+          tag: ${{ inputs.tag }}
+          image-name: ${{ inputs.coordinator-image-name }}
+          registry: ghcr.io/llm-d
+          github-token: ${{ github.token }}
+          prerelease: ${{ inputs.prerelease }}
+          commit-sha: ${{ github.sha }}
+          push: 'true'
+          additional-tags: ${{ inputs.coordinator-additional-tags }}
 
   push-helm-charts:
     needs: [build-epp, build-sidecar]

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -146,7 +146,7 @@ jobs:
           additional-tags: ${{ inputs.coordinator-additional-tags }}
 
   push-helm-charts:
-    needs: [build-epp, build-sidecar]
+    needs: [build-epp, build-sidecar, build-coordinator]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -19,8 +19,10 @@ jobs:
     outputs:
       epp_name: ${{ steps.version.outputs.epp_name }}
       sidecar_name: ${{ steps.version.outputs.sidecar_name }}
+      coordinator_name: ${{ steps.version.outputs.coordinator_name }}
       epp_base_name: ${{ steps.version.outputs.epp_base_name }}
       sidecar_base_name: ${{ steps.version.outputs.sidecar_base_name }}
+      coordinator_base_name: ${{ steps.version.outputs.coordinator_base_name }}
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Set image names
@@ -29,8 +31,10 @@ jobs:
           repo="${GITHUB_REPOSITORY##*/}"
           echo "epp_name=${repo}-endpoint-picker-dev" >> "$GITHUB_OUTPUT"
           echo "sidecar_name=${repo}-disagg-sidecar-dev" >> "$GITHUB_OUTPUT"
+          echo "coordinator_name=${repo}-coordinator-dev" >> "$GITHUB_OUTPUT"
           echo "epp_base_name=${repo}-endpoint-picker" >> "$GITHUB_OUTPUT"
           echo "sidecar_base_name=${repo}-disagg-sidecar" >> "$GITHUB_OUTPUT"
+          echo "coordinator_base_name=${repo}-coordinator" >> "$GITHUB_OUTPUT"
 
       - name: Set branch name as tag
         id: tag
@@ -44,9 +48,11 @@ jobs:
     with:
       epp-image-name: ${{ needs.set-params.outputs.epp_name }}
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
+      coordinator-image-name: ${{ needs.set-params.outputs.coordinator_name }}
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: true
       chart-suffix: ""
       epp-additional-tags: ghcr.io/llm-d/${{ needs.set-params.outputs.epp_base_name }}:main
       sidecar-additional-tags: ghcr.io/llm-d/${{ needs.set-params.outputs.sidecar_base_name }}:main
+      coordinator-additional-tags: ghcr.io/llm-d/${{ needs.set-params.outputs.coordinator_base_name }}:main
 

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       epp_name: ${{ steps.version.outputs.epp_name }}
       sidecar_name: ${{ steps.version.outputs.sidecar_name }}
+      coordinator_name: ${{ steps.version.outputs.coordinator_name }}
       tag: ${{ steps.tag.outputs.tag }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
@@ -27,6 +28,7 @@ jobs:
           repo="${GITHUB_REPOSITORY##*/}"
           echo "epp_name=${repo}-endpoint-picker" >> "$GITHUB_OUTPUT"
           echo "sidecar_name=${repo}-disagg-sidecar" >> "$GITHUB_OUTPUT"
+          echo "coordinator_name=${repo}-coordinator" >> "$GITHUB_OUTPUT"
 
       - name: Determine tag name
         id: tag
@@ -48,6 +50,7 @@ jobs:
     with:
       epp-image-name: ${{ needs.set-params.outputs.epp_name }}
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
+      coordinator-image-name: ${{ needs.set-params.outputs.coordinator_name }}
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: ${{ fromJSON(needs.set-params.outputs.prerelease) }}
       chart-suffix: ""


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
The coordinator image was only ever built for e2e testing in ci-coordinator.yaml
(push: false, artifact discarded after 1 day) and never published to GHCR on
main or release builds, unlike the epp and sidecar images. This adds a
build-coordinator job to ci-build-images.yaml, mirroring build-epp/build-sidecar
(build, Trivy scan, push both amd64/arm64), and wires a coordinator image name
and additional tags through ci-dev.yaml and ci-release.yaml so it follows the
same publish path as the other two images.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2303

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
