### PR TITLE
Allow plugins to contribute to EPP readiness

### DIFF
--- a/cmd/epp/runner/health.go
+++ b/cmd/epp/runner/health.go
@@ -29,6 +29,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
@@ -42,6 +43,7 @@ type healthServer struct {
 	isLeader              *atomic.Bool
 	leaderElectionEnabled bool
 	supporters            []appProtocolSupporter
+	readinessCheckers     []fwkplugin.ReadinessChecker
 	draining              *atomic.Bool // nil or false: not draining. Set on SIGTERM during graceful shutdown.
 }
 
@@ -53,16 +55,18 @@ const (
 func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckRequest) (*healthPb.HealthCheckResponse, error) {
 	isLive := s.datastore.PoolHasSynced()
 	protocolMatches := s.checkProtocolSupport(isLive)
+	pluginReadinessErr := s.checkPluginReadiness(in.Service)
+	pluginsReady := pluginReadinessErr == nil
 	// While draining (graceful shutdown), every non-liveness check reports
 	// NOT_SERVING so Kubernetes removes the EPP from the Service endpoints, while
 	// the ext_proc server keeps serving. Liveness stays SERVING to avoid a
 	// restart mid-drain.
 	draining := s.draining != nil && s.draining.Load()
 
-	// If leader election is disabled, use current logic: all checks are based on whether the pool has synced.
+	// Without leader election, named liveness still excludes plugin readiness.
 	if !s.leaderElectionEnabled {
-		if !isLive || !protocolMatches || draining {
-			s.logger.Error(nil, "gRPC health check not serving (leader election disabled)", "service", in.Service, "isLive", isLive, "protocolMatches", protocolMatches, "draining", draining)
+		if !isLive || !protocolMatches || !pluginsReady || draining {
+			s.logger.Error(pluginReadinessErr, "gRPC health check not serving (leader election disabled)", "service", in.Service, "isLive", isLive, "protocolMatches", protocolMatches, "pluginsReady", pluginsReady, "draining", draining)
 			return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_NOT_SERVING}, nil
 		}
 		s.logger.V(logutil.TRACE).Info("gRPC health check serving (leader election disabled)", "service", in.Service)
@@ -77,12 +81,12 @@ func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckReques
 	switch in.Service {
 	case ReadinessCheckService:
 		checkName = "readiness"
-		isPassing = isLive && s.isLeader.Load() && protocolMatches && !draining
+		isPassing = isLive && s.isLeader.Load() && protocolMatches && pluginsReady && !draining
 	case "": // Handle overall server health for load balancers that use an empty service name.
 		checkName = "empty service name (considered as overall health)"
 		// The overall health for a load balancer should reflect readiness to accept traffic,
 		// which is true only for the leader pod that has synced its data.
-		isPassing = isLive && s.isLeader.Load() && protocolMatches && !draining
+		isPassing = isLive && s.isLeader.Load() && protocolMatches && pluginsReady && !draining
 	case LivenessCheckService:
 		checkName = "liveness"
 		// Any pod that is running and can respond to this gRPC check is considered "live".
@@ -93,19 +97,31 @@ func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckReques
 	case extProcPb.ExternalProcessor_ServiceDesc.ServiceName:
 		// The main service is considered ready only on the leader.
 		checkName = "ext_proc"
-		isPassing = isLive && s.isLeader.Load() && protocolMatches && !draining
+		isPassing = isLive && s.isLeader.Load() && protocolMatches && pluginsReady && !draining
 	default:
 		s.logger.Error(nil, "gRPC health check requested unknown service", "available-services", []string{LivenessCheckService, ReadinessCheckService, extProcPb.ExternalProcessor_ServiceDesc.ServiceName}, "requested-service", in.Service)
 		return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_SERVICE_UNKNOWN}, nil
 	}
 
 	if !isPassing {
-		s.logger.Error(nil, fmt.Sprintf("gRPC %s check not serving", checkName), "service", in.Service, "isLive", isLive, "isLeader", s.isLeader.Load())
+		s.logger.Error(pluginReadinessErr, fmt.Sprintf("gRPC %s check not serving", checkName), "service", in.Service, "isLive", isLive, "isLeader", s.isLeader.Load(), "pluginsReady", pluginsReady)
 		return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_NOT_SERVING}, nil
 	}
 
 	s.logger.V(logutil.TRACE).Info(fmt.Sprintf("gRPC %s check serving", checkName), "service", in.Service)
 	return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_SERVING}, nil
+}
+
+func (s *healthServer) checkPluginReadiness(service string) error {
+	if service != "" && service != ReadinessCheckService && service != extProcPb.ExternalProcessor_ServiceDesc.ServiceName {
+		return nil
+	}
+	for _, checker := range s.readinessCheckers {
+		if err := checker.CheckReady(); err != nil {
+			return fmt.Errorf("plugin %s is not ready: %w", checker.TypedName(), err)
+		}
+	}
+	return nil
 }
 
 func (s *healthServer) checkProtocolSupport(isLive bool) bool {

--- a/cmd/epp/runner/health_test.go
+++ b/cmd/epp/runner/health_test.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -28,6 +29,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
@@ -58,6 +60,31 @@ func (m *mockSupporter) Claims() fwkrh.Claims {
 	}
 }
 
+type mockReadinessChecker struct {
+	name string
+	err  error
+}
+
+func (m *mockReadinessChecker) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock", Name: m.name}
+}
+
+func (m *mockReadinessChecker) CheckReady() error { return m.err }
+
+type mockPlugin struct{}
+
+func (*mockPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock", Name: "ordinary"}
+}
+
+func TestPluginReadinessCheckers(t *testing.T) {
+	want := &mockReadinessChecker{name: "readiness"}
+	got := pluginReadinessCheckers([]fwkplugin.Plugin{&mockPlugin{}, want})
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("pluginReadinessCheckers() = %v, want [%v]", got, want)
+	}
+}
+
 func TestHealthServer_Check(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -68,6 +95,7 @@ func TestHealthServer_Check(t *testing.T) {
 		pool                  *datalayer.EndpointPool
 		poolErr               error
 		supporters            []appProtocolSupporter
+		readinessCheckers     []fwkplugin.ReadinessChecker
 		service               string
 		wantStatus            healthPb.HealthCheckResponse_ServingStatus
 	}{
@@ -104,10 +132,66 @@ func TestHealthServer_Check(t *testing.T) {
 			wantStatus:            healthPb.HealthCheckResponse_SERVING,
 		},
 		{
+			name:                  "LeaderElectionDisabled_PluginNotReady",
+			leaderElectionEnabled: false,
+			hasSynced:             true,
+			pool:                  &datalayer.EndpointPool{AppProtocol: v1.AppProtocolHTTP},
+			readinessCheckers: []fwkplugin.ReadinessChecker{
+				&mockReadinessChecker{name: "unready", err: errors.New("initial sync pending")},
+			},
+			wantStatus: healthPb.HealthCheckResponse_NOT_SERVING,
+		},
+		{
+			name:                  "LeaderElectionDisabled_Liveness_IgnoresPluginReadiness",
+			leaderElectionEnabled: false,
+			hasSynced:             true,
+			pool:                  &datalayer.EndpointPool{AppProtocol: v1.AppProtocolHTTP},
+			readinessCheckers: []fwkplugin.ReadinessChecker{
+				&mockReadinessChecker{name: "unready", err: errors.New("initial sync pending")},
+			},
+			service:    LivenessCheckService,
+			wantStatus: healthPb.HealthCheckResponse_SERVING,
+		},
+		{
 			name:                  "LeaderElectionEnabled_Liveness_AlwaysServing",
 			leaderElectionEnabled: true,
 			service:               LivenessCheckService,
 			wantStatus:            healthPb.HealthCheckResponse_SERVING,
+		},
+		{
+			name:                  "LeaderElectionEnabled_Readiness_AllPluginsReady",
+			leaderElectionEnabled: true,
+			isLeader:              true,
+			hasSynced:             true,
+			pool:                  &datalayer.EndpointPool{AppProtocol: v1.AppProtocolHTTP},
+			readinessCheckers: []fwkplugin.ReadinessChecker{
+				&mockReadinessChecker{name: "first"},
+				&mockReadinessChecker{name: "second"},
+			},
+			service:    ReadinessCheckService,
+			wantStatus: healthPb.HealthCheckResponse_SERVING,
+		},
+		{
+			name:                  "LeaderElectionEnabled_Readiness_OnePluginNotReady",
+			leaderElectionEnabled: true,
+			isLeader:              true,
+			hasSynced:             true,
+			pool:                  &datalayer.EndpointPool{AppProtocol: v1.AppProtocolHTTP},
+			readinessCheckers: []fwkplugin.ReadinessChecker{
+				&mockReadinessChecker{name: "ready"},
+				&mockReadinessChecker{name: "unready", err: errors.New("backend unavailable")},
+			},
+			service:    ReadinessCheckService,
+			wantStatus: healthPb.HealthCheckResponse_NOT_SERVING,
+		},
+		{
+			name:                  "LeaderElectionEnabled_Liveness_IgnoresPluginReadiness",
+			leaderElectionEnabled: true,
+			readinessCheckers: []fwkplugin.ReadinessChecker{
+				&mockReadinessChecker{name: "unready", err: errors.New("initial sync pending")},
+			},
+			service:    LivenessCheckService,
+			wantStatus: healthPb.HealthCheckResponse_SERVING,
 		},
 		{
 			name:                  "LeaderElectionEnabled_Readiness_Live_Leader_ProtocolMatches",
@@ -155,6 +239,18 @@ func TestHealthServer_Check(t *testing.T) {
 			wantStatus:            healthPb.HealthCheckResponse_SERVING,
 		},
 		{
+			name:                  "LeaderElectionEnabled_EmptyService_ReflectsPluginReadiness",
+			leaderElectionEnabled: true,
+			isLeader:              true,
+			hasSynced:             true,
+			pool:                  &datalayer.EndpointPool{AppProtocol: v1.AppProtocolHTTP},
+			readinessCheckers: []fwkplugin.ReadinessChecker{
+				&mockReadinessChecker{name: "unready", err: errors.New("initial sync pending")},
+			},
+			service:    "",
+			wantStatus: healthPb.HealthCheckResponse_NOT_SERVING,
+		},
+		{
 			name:                  "LeaderElectionEnabled_ExtProc_ReflectsReadiness_Serving",
 			leaderElectionEnabled: true,
 			isLeader:              true,
@@ -162,6 +258,18 @@ func TestHealthServer_Check(t *testing.T) {
 			pool:                  &datalayer.EndpointPool{AppProtocol: v1.AppProtocolHTTP},
 			service:               extProcPb.ExternalProcessor_ServiceDesc.ServiceName,
 			wantStatus:            healthPb.HealthCheckResponse_SERVING,
+		},
+		{
+			name:                  "LeaderElectionEnabled_ExtProc_ReflectsPluginReadiness",
+			leaderElectionEnabled: true,
+			isLeader:              true,
+			hasSynced:             true,
+			pool:                  &datalayer.EndpointPool{AppProtocol: v1.AppProtocolHTTP},
+			readinessCheckers: []fwkplugin.ReadinessChecker{
+				&mockReadinessChecker{name: "unready", err: errors.New("initial sync pending")},
+			},
+			service:    extProcPb.ExternalProcessor_ServiceDesc.ServiceName,
+			wantStatus: healthPb.HealthCheckResponse_NOT_SERVING,
 		},
 		{
 			name:                  "LeaderElectionEnabled_UnknownService",
@@ -267,6 +375,7 @@ func TestHealthServer_Check(t *testing.T) {
 				isLeader:              &isLeader,
 				leaderElectionEnabled: tt.leaderElectionEnabled,
 				supporters:            tt.supporters,
+				readinessCheckers:     tt.readinessCheckers,
 				draining:              &draining,
 			}
 

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -506,7 +506,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	r.draining = &atomic.Bool{}
 	r.serverRunner = serverRunner
 	r.healthGRPCPort = opts.GRPCHealthPort
-	r.healthGRPCServer = newHealthGRPCServer(ctrl.Log.WithName("health"), ds, isLeader, r.draining, opts.EnableLeaderElection, supporters)
+	r.healthGRPCServer = newHealthGRPCServer(ctrl.Log.WithName("health"), ds, isLeader, r.draining, opts.EnableLeaderElection, supporters, pluginReadinessCheckers(r.PluginHandle.GetAllPlugins()))
 	return mgr, ds, nil
 }
 
@@ -830,7 +830,7 @@ func (r *Runner) setupMetricsCollection(opts *runserver.Options) datalayer.Endpo
 
 // newHealthGRPCServer builds the gRPC health server. draining may be nil (graceful
 // drain disabled); when non-nil and set, non-liveness checks report NOT_SERVING.
-func newHealthGRPCServer(logger logr.Logger, ds datastore.Datastore, isLeader, draining *atomic.Bool, leaderElectionEnabled bool, supporters []appProtocolSupporter) *grpc.Server {
+func newHealthGRPCServer(logger logr.Logger, ds datastore.Datastore, isLeader, draining *atomic.Bool, leaderElectionEnabled bool, supporters []appProtocolSupporter, readinessCheckers []fwkplugin.ReadinessChecker) *grpc.Server {
 	srv := grpc.NewServer()
 	healthPb.RegisterHealthServer(srv, &healthServer{
 		logger:                logger,
@@ -838,9 +838,20 @@ func newHealthGRPCServer(logger logr.Logger, ds datastore.Datastore, isLeader, d
 		isLeader:              isLeader,
 		leaderElectionEnabled: leaderElectionEnabled,
 		supporters:            supporters,
+		readinessCheckers:     readinessCheckers,
 		draining:              draining,
 	})
 	return srv
+}
+
+func pluginReadinessCheckers(plugins []fwkplugin.Plugin) []fwkplugin.ReadinessChecker {
+	checkers := make([]fwkplugin.ReadinessChecker, 0)
+	for _, p := range plugins {
+		if checker, ok := p.(fwkplugin.ReadinessChecker); ok {
+			checkers = append(checkers, checker)
+		}
+	}
+	return checkers
 }
 
 func extractDeploymentName(podName string) (string, error) {
@@ -1084,6 +1095,7 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 		isLeader:              isLeader,
 		leaderElectionEnabled: false,
 		supporters:            ps,
+		readinessCheckers:     pluginReadinessCheckers(r.PluginHandle.GetAllPlugins()),
 	})
 
 	g := newRunnableGroup()

--- a/pkg/epp/framework/interface/plugin/plugins.go
+++ b/pkg/epp/framework/interface/plugin/plugins.go
@@ -25,6 +25,16 @@ type Plugin interface {
 	TypedName() TypedName
 }
 
+// ReadinessChecker is an optional interface for plugins whose asynchronous
+// initialization must complete before the EPP can safely receive traffic.
+type ReadinessChecker interface {
+	Plugin
+	// CheckReady returns nil when the plugin is ready. It must be fast and
+	// non-blocking, safe for concurrent calls, and report cached state rather
+	// than perform external I/O.
+	CheckReady() error
+}
+
 // DataDependencies holds the data keys a plugin consumes, split by whether they
 // are required (framework errors if no producer exists) or optional (framework
 // logs a warning but continues if no producer exists).


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an optional `plugin.ReadinessChecker` contract for plugins with asynchronous initialization or backend synchronization.

The runner automatically collects configured plugins that implement the contract. Their cached readiness is aggregated into the readiness, empty-service, and ext_proc health responses. Plugin readiness never affects liveness.

`CheckReady()` must be fast, non-blocking, concurrency-safe, and must not perform external I/O.

**How was this tested?**

- `go test ./cmd/epp/runner ./pkg/epp/framework/interface/plugin -count=1`
- `golangci-lint run --config=./.golangci.yml --new --timeout=15m`

**Which issue(s) this PR fixes**:

Fixes #2283
Linked with #1921 and #2141 

**Release note**:
```release-note
Plugins can optionally contribute conditions to EPP readiness.
```