### PR TITLE
Skip janitor reaping for requests bound to a live context

### DIFF
--- a/pkg/epp/framework/interface/plugin/plugin_state.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state.go
@@ -176,6 +176,10 @@ func (s *PluginState) Touch(requestID string) {
 // janitor never reaps a bound request whose ctx is still alive; it refreshes
 // the request's last access time instead. Once ctx is done, the entries are
 // reaped on the normal staleness schedule. Delete removes the binding.
+//
+// The caller must have written state for requestID before binding: the janitor
+// reclaims bindings only for request IDs it can reach through the access-time
+// index, so a binding with no state behind it is never reclaimed.
 func (s *PluginState) BindLiveness(ctx context.Context, requestID string) {
 	if requestID == "" || ctx == nil {
 		return
@@ -217,6 +221,7 @@ func (s *PluginState) cleanStaleRequests() {
 		lastAccessTime := v.(time.Time)
 		if time.Since(lastAccessTime) > s.stalenessThreshold {
 			if bound, ok := s.requestLiveness.Load(requestID); ok && bound.(context.Context).Err() == nil {
+				log.Log.V(logutil.TRACE).Info("Holding stale request with a live bound context", "requestID", requestID, "lastAccessTime", lastAccessTime)
 				s.Touch(requestID)
 				return true
 			}

--- a/pkg/epp/framework/interface/plugin/plugin_state.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state.go
@@ -36,9 +36,32 @@ const (
 	cleanupInterval = time.Minute
 )
 
+// PluginStateOption configures a PluginState created by NewPluginState.
+type PluginStateOption func(*PluginState)
+
+// WithStalenessThreshold overrides the default staleness threshold.
+func WithStalenessThreshold(threshold time.Duration) PluginStateOption {
+	return func(s *PluginState) {
+		s.stalenessThreshold = threshold
+	}
+}
+
+// WithCleanupInterval overrides the default cleanup interval.
+func WithCleanupInterval(interval time.Duration) PluginStateOption {
+	return func(s *PluginState) {
+		s.cleanupInterval = interval
+	}
+}
+
 // NewPluginState initializes a new PluginState and returns its pointer.
-func NewPluginState(ctx context.Context) *PluginState {
-	pluginState := &PluginState{}
+func NewPluginState(ctx context.Context, opts ...PluginStateOption) *PluginState {
+	pluginState := &PluginState{
+		stalenessThreshold: stalenessThreshold,
+		cleanupInterval:    cleanupInterval,
+	}
+	for _, opt := range opts {
+		opt(pluginState)
+	}
 	go pluginState.cleanup(ctx)
 	return pluginState
 }
@@ -46,7 +69,8 @@ func NewPluginState(ctx context.Context) *PluginState {
 // PluginState is per-plugin scratch storage scoped to a single request. A plugin's
 // extension points (e.g. PreRequest, ResponseBody) can write, read, and alter entries
 // here to coordinate within that plugin. Entries are keyed by RequestID and reaped
-// after "stalenessThreshold" of inactivity.
+// after "stalenessThreshold" of inactivity, unless the request is bound to a live
+// ctx via BindLiveness.
 //
 // PluginState is not a cross-plugin handoff channel. Data shared between plugins must
 // flow through the Producer/Consumer DAG: write to Endpoint AttributeMap for
@@ -60,6 +84,11 @@ type PluginState struct {
 	storage sync.Map
 	// key: RequestID, value: time.Time
 	requestToLastAccessTime sync.Map
+	// key: RequestID, value: context.Context bound via BindLiveness
+	requestLiveness sync.Map
+
+	stalenessThreshold time.Duration
+	cleanupInterval    time.Duration
 }
 
 // Read retrieves data with the given "key" in the context of "requestID" from PluginState.
@@ -104,6 +133,7 @@ func (s *PluginState) Write(requestID string, key StateKey, val StateData) {
 // removed by a racing DeleteKey (or another Delete) on the same requestID.
 func (s *PluginState) Delete(requestID string) {
 	s.requestToLastAccessTime.Delete(requestID)
+	s.requestLiveness.Delete(requestID)
 	val, ok := s.storage.LoadAndDelete(requestID)
 	if !ok {
 		return
@@ -142,6 +172,17 @@ func (s *PluginState) Touch(requestID string) {
 	s.requestToLastAccessTime.Store(requestID, time.Now())
 }
 
+// BindLiveness marks the request as alive for as long as ctx is not done. The
+// janitor never reaps a bound request whose ctx is still alive; it refreshes
+// the request's last access time instead. Once ctx is done, the entries are
+// reaped on the normal staleness schedule. Delete removes the binding.
+func (s *PluginState) BindLiveness(ctx context.Context, requestID string) {
+	if requestID == "" || ctx == nil {
+		return
+	}
+	s.requestLiveness.Store(requestID, ctx)
+}
+
 // LastAccessTime returns the last access time for the given requestID and a
 // boolean indicating if the requestID was found.
 func (s *PluginState) LastAccessTime(requestID string) (time.Time, bool) {
@@ -153,7 +194,7 @@ func (s *PluginState) LastAccessTime(requestID string) (time.Time, bool) {
 
 // cleanup periodically deletes data associated with the given requestID.
 func (s *PluginState) cleanup(ctx context.Context) {
-	ticker := time.NewTicker(cleanupInterval)
+	ticker := time.NewTicker(s.cleanupInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -167,13 +208,18 @@ func (s *PluginState) cleanup(ctx context.Context) {
 }
 
 // cleanStaleRequests iterates through all requests and removes those that haven't been
-// accessed for longer than stalenessThreshold. This operation is safe to run concurrently
+// accessed for longer than stalenessThreshold, except requests whose bound liveness ctx
+// is still alive (see BindLiveness). This operation is safe to run concurrently
 // with other operations on the PluginState.
 func (s *PluginState) cleanStaleRequests() {
 	s.requestToLastAccessTime.Range(func(k, v any) bool {
 		requestID := k.(string)
 		lastAccessTime := v.(time.Time)
-		if time.Since(lastAccessTime) > stalenessThreshold {
+		if time.Since(lastAccessTime) > s.stalenessThreshold {
+			if bound, ok := s.requestLiveness.Load(requestID); ok && bound.(context.Context).Err() == nil {
+				s.Touch(requestID)
+				return true
+			}
 			log.Log.V(logutil.DEBUG).Info("Cleaning up stale request from PluginState", "requestID", requestID, "lastAccessTime", lastAccessTime)
 			s.Delete(requestID) // cleanup stale requests (this is safe in sync.Map)
 		}

--- a/pkg/epp/framework/interface/plugin/plugin_state.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state.go
@@ -28,12 +28,12 @@ import (
 )
 
 const (
-	// stalenessThreshold defines the threshold for considering data as stale.
+	// defaultStalenessThreshold defines the threshold for considering data as stale.
 	// if data of a request hasn't been read/write in the last "stalenessThreshold", it is considered as stale data
 	// and will be cleaned in the next cleanup cycle.
-	stalenessThreshold = time.Minute * 5
-	// cleanupInterval defines the periodic interval that the cleanup go routine uses to check for stale data.
-	cleanupInterval = time.Minute
+	defaultStalenessThreshold = time.Minute * 5
+	// defaultCleanupInterval defines the periodic interval that the cleanup go routine uses to check for stale data.
+	defaultCleanupInterval = time.Minute
 )
 
 // PluginStateOption configures a PluginState created by NewPluginState.
@@ -56,8 +56,8 @@ func WithCleanupInterval(interval time.Duration) PluginStateOption {
 // NewPluginState initializes a new PluginState and returns its pointer.
 func NewPluginState(ctx context.Context, opts ...PluginStateOption) *PluginState {
 	pluginState := &PluginState{
-		stalenessThreshold: stalenessThreshold,
-		cleanupInterval:    cleanupInterval,
+		stalenessThreshold: defaultStalenessThreshold,
+		cleanupInterval:    defaultCleanupInterval,
 	}
 	for _, opt := range opts {
 		opt(pluginState)

--- a/pkg/epp/framework/interface/plugin/plugin_state_test.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state_test.go
@@ -109,7 +109,7 @@ func TestPluginState_EvictionCallback(t *testing.T) {
 	data.evictedID = ""
 	data.evictedKey = ""
 	state.Write(requestID, key, data)
-	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*stalenessThreshold))
+	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*defaultStalenessThreshold))
 	state.cleanStaleRequests()
 	assert.Equal(t, requestID, data.evictedID)
 	assert.Equal(t, key, data.evictedKey)
@@ -128,7 +128,7 @@ func TestPluginState_Touch(t *testing.T) {
 	state.Write(requestID, key, data)
 
 	// Set last access time to near-stale
-	nearStale := time.Now().Add(-stalenessThreshold + time.Second*10)
+	nearStale := time.Now().Add(-defaultStalenessThreshold + time.Second*10)
 	state.requestToLastAccessTime.Store(requestID, nearStale)
 
 	// Touch it
@@ -220,7 +220,7 @@ func TestReadPluginStateKey(t *testing.T) {
 }
 
 // TestPluginState_Cleanup verifies the automatic cleanup of stale data.
-// It tests that data which hasn't been accessed for longer than stalenessThreshold
+// It tests that data which hasn't been accessed for longer than defaultStalenessThreshold
 // is properly removed from the storage.
 func TestPluginState_Cleanup(t *testing.T) {
 	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
@@ -235,7 +235,7 @@ func TestPluginState_Cleanup(t *testing.T) {
 	state.Write(requestID, key, data)
 
 	// Manually set last access time to far in the past
-	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*stalenessThreshold))
+	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*defaultStalenessThreshold))
 	// Manually CleanUp
 	state.cleanStaleRequests()
 
@@ -263,7 +263,7 @@ func TestPluginState_CleanupSkipsLiveRequests(t *testing.T) {
 
 	// Stale by time but bound to a live ctx: the janitor must skip the request
 	// and refresh its last access time.
-	backdated := time.Now().Add(-2 * stalenessThreshold)
+	backdated := time.Now().Add(-2 * defaultStalenessThreshold)
 	state.requestToLastAccessTime.Store(requestID, backdated)
 	state.cleanStaleRequests()
 
@@ -276,7 +276,7 @@ func TestPluginState_CleanupSkipsLiveRequests(t *testing.T) {
 
 	// Once the ctx is done, the request reaps as any other stale request.
 	reqCancel()
-	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*stalenessThreshold))
+	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*defaultStalenessThreshold))
 	state.cleanStaleRequests()
 
 	_, err = state.Read(requestID, key)
@@ -306,7 +306,7 @@ func TestPluginState_DeleteClearsLiveness(t *testing.T) {
 	// Second request under the same ID, no binding: reaped despite the first
 	// request's ctx still being alive.
 	state.Write(requestID, key, &pluginTestData{value: "second"})
-	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*stalenessThreshold))
+	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*defaultStalenessThreshold))
 	state.cleanStaleRequests()
 
 	_, err := state.Read(requestID, key)

--- a/pkg/epp/framework/interface/plugin/plugin_state_test.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state_test.go
@@ -243,6 +243,96 @@ func TestPluginState_Cleanup(t *testing.T) {
 	assert.Equal(t, ErrNotFound, err)
 }
 
+// TestPluginState_CleanupSkipsLiveRequests verifies that the janitor does not
+// reap a request whose bound liveness ctx is still alive, and reaps it on the
+// normal schedule once the ctx is done.
+func TestPluginState_CleanupSkipsLiveRequests(t *testing.T) {
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
+	state := NewPluginState(ctx)
+
+	requestID := "req-live"
+	key := StateKey("foo")
+	data := &evictableTestData{pluginTestData: pluginTestData{value: "bar"}}
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	t.Cleanup(reqCancel)
+
+	state.Write(requestID, key, data)
+	state.BindLiveness(reqCtx, requestID)
+
+	// Stale by time but bound to a live ctx: the janitor must skip the request
+	// and refresh its last access time.
+	backdated := time.Now().Add(-2 * stalenessThreshold)
+	state.requestToLastAccessTime.Store(requestID, backdated)
+	state.cleanStaleRequests()
+
+	lastAccess, ok := state.LastAccessTime(requestID)
+	assert.True(t, ok)
+	assert.True(t, lastAccess.After(backdated), "janitor should refresh last access time of a live request")
+	_, err := state.Read(requestID, key)
+	assert.NoError(t, err)
+	assert.Empty(t, data.evictedID, "OnEvicted must not fire for a live request")
+
+	// Once the ctx is done, the request reaps as any other stale request.
+	reqCancel()
+	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*stalenessThreshold))
+	state.cleanStaleRequests()
+
+	_, err = state.Read(requestID, key)
+	assert.Equal(t, ErrNotFound, err)
+	assert.Equal(t, requestID, data.evictedID)
+	assert.Equal(t, key, data.evictedKey)
+}
+
+// TestPluginState_DeleteClearsLiveness verifies that a liveness binding does not
+// survive Delete: entries written later under a reused request ID must not
+// inherit the previous request's liveness.
+func TestPluginState_DeleteClearsLiveness(t *testing.T) {
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
+	state := NewPluginState(ctx)
+
+	requestID := "req-reused"
+	key := StateKey("foo")
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	t.Cleanup(reqCancel)
+
+	state.Write(requestID, key, &pluginTestData{value: "first"})
+	state.BindLiveness(reqCtx, requestID)
+	state.Delete(requestID)
+
+	// Second request under the same ID, no binding: reaped despite the first
+	// request's ctx still being alive.
+	state.Write(requestID, key, &pluginTestData{value: "second"})
+	state.requestToLastAccessTime.Store(requestID, time.Now().Add(-2*stalenessThreshold))
+	state.cleanStaleRequests()
+
+	_, err := state.Read(requestID, key)
+	assert.Equal(t, ErrNotFound, err)
+}
+
+// TestPluginState_JanitorOptions verifies that the cleanup goroutine honors
+// injected staleness threshold and cleanup interval.
+func TestPluginState_JanitorOptions(t *testing.T) {
+	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
+	t.Cleanup(cancel)
+	state := NewPluginState(ctx,
+		WithStalenessThreshold(20*time.Millisecond),
+		WithCleanupInterval(5*time.Millisecond))
+
+	requestID := "req-fast"
+	state.Write(requestID, StateKey("foo"), &pluginTestData{value: "bar"})
+
+	// Poll via LastAccessTime: Read would refresh the access time and keep the
+	// request alive forever.
+	assert.Eventually(t, func() bool {
+		_, ok := state.LastAccessTime(requestID)
+		return !ok
+	}, 2*time.Second, 5*time.Millisecond, "janitor should reap on the injected schedule")
+}
+
 // TestPluginState_DeleteKey verifies that DeleteKey correctly removes only the specified key for a request.
 func TestPluginState_DeleteKey(t *testing.T) {
 	ctx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -435,6 +435,7 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 	// keeps the janitor from reaping entries (and rolling back counters) for
 	// requests that are still in flight but have produced no response chunk,
 	// e.g. long prefill or a deep model-server queue.
+	// Bind only when an entry exists: an unbacked binding is never reclaimed.
 	if tracked {
 		p.PluginState.BindLiveness(ctx, request.RequestID)
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -395,6 +395,7 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
 
+	tracked := false
 	for profileName, profileResult := range result.ProfileResults {
 		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 			continue
@@ -426,6 +427,16 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 			fwkplugin.StateKey(addedTokensKey(eid, profileName)),
 			entry,
 		)
+		tracked = true
+	}
+
+	// ctx is the ext_proc stream context: it stays alive for the request's full
+	// lifetime and is canceled on stream end or client disconnect. Binding it
+	// keeps the janitor from reaping entries (and rolling back counters) for
+	// requests that are still in flight but have produced no response chunk,
+	// e.g. long prefill or a deep model-server queue.
+	if tracked {
+		p.PluginState.BindLiveness(ctx, request.RequestID)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -990,6 +990,8 @@ func TestInFlightLoadProducer_EndOfStreamAfterJanitorSkip(t *testing.T) {
 	producer.PreRequest(reqCtx, req, res)
 
 	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID),
+		"counters must still be held when EndOfStream arrives")
 
 	req.SchedulingResult = res
 	producer.ResponseBody(context.Background(), req, &requestcontrol.Response{EndOfStream: true}, nil)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -929,6 +929,80 @@ func TestInFlightLoadProducer_LateResponseAfterReap(t *testing.T) {
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
 }
 
+// newTestProducerWithFastJanitor rebuilds the producer's PluginState with a
+// short staleness threshold and cleanup interval so tests can exercise the real
+// janitor goroutine.
+func newTestProducerWithFastJanitor(t testing.TB) *InFlightLoadProducer {
+	producer := newTestProducer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	producer.PluginState = fwkplugin.NewPluginState(ctx,
+		fwkplugin.WithStalenessThreshold(50*time.Millisecond),
+		fwkplugin.WithCleanupInterval(10*time.Millisecond))
+	return producer
+}
+
+// TestInFlightLoadProducer_JanitorSkipsLiveRequest is the issue #2295
+// regression: a request that produces no response chunk past the staleness
+// threshold must keep its in-flight contribution while its stream ctx is
+// alive, and lose it once the ctx dies without end-of-stream cleanup.
+func TestInFlightLoadProducer_JanitorSkipsLiveRequest(t *testing.T) {
+	producer := newTestProducerWithFastJanitor(t)
+	endpointName := "janitor-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	t.Cleanup(reqCancel)
+
+	req := makeTokenRequest("req-janitor", 4) // 4 input + 6 output = 10 tokens
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(reqCtx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// Several janitor sweeps past the threshold, no chunks: counters must hold.
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, int64(1), producer.requestTracker.get(endpointID),
+		"janitor rolled back counters of a live request")
+	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
+
+	// Ctx dies without EndOfStream (a genuinely leaked entry): the janitor
+	// reclaims it. This also proves the janitor is running in this test, so the
+	// hold-assertions above are not passing vacuously.
+	reqCancel()
+	require.Eventually(t, func() bool {
+		return producer.requestTracker.get(endpointID) == 0 && producer.tokenTracker.get(endpointID) == 0
+	}, 2*time.Second, 10*time.Millisecond, "janitor should reap once the request ctx is done")
+}
+
+// TestInFlightLoadProducer_EndOfStreamAfterJanitorSkip verifies the normal
+// completion path still decrements exactly once after the janitor has been
+// skipping a live request.
+func TestInFlightLoadProducer_EndOfStreamAfterJanitorSkip(t *testing.T) {
+	producer := newTestProducerWithFastJanitor(t)
+	endpointName := "janitor-eos-endpoint"
+	endpointID := fullEndpointName(endpointName)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+
+	req := makeTokenRequest("req-janitor-eos", 4)
+	res := makeSchedulingResult(endpointName)
+	producer.PreRequest(reqCtx, req, res)
+
+	time.Sleep(150 * time.Millisecond)
+
+	req.SchedulingResult = res
+	producer.ResponseBody(context.Background(), req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+
+	// Late ctx cancellation plus further sweeps must not decrement again.
+	reqCancel()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int64(0), producer.requestTracker.get(endpointID), "no double decrement after EndOfStream")
+	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
 func TestInFlightLoadProducer_AtomicTokenRelease_Concurrent(t *testing.T) {
 	producer := newTestProducer(t)
 	ctx := context.Background()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `PluginState` janitor reaps entries for any request with no read/write/Touch activity for five minutes. The `inflight-load-producer` only touches entries on response chunks, so a request that spends more than five minutes before its first token (deep engine queue, long prefill), a non-streaming request with a long generation, or any single inter-chunk gap over five minutes is reaped while still running on the model server. The eviction rolls back the request's in-flight counters, the `concurrency-detector` saturation gate sees phantom capacity and dispatches more work into the already-backlogged pool, which pushes more requests past the five-minute mark.

#2295 measures this loop end to end: a single 10-minute 2x burst collapsed an 8-replica pool, and the system did not recover at near-zero offered load.

Every dispatched request already releases its accounting when its ext_proc stream ends: normally at `EndOfStream`, and on error/disconnect/panic via the forced `HandleResponseBody(..., endOfStream=true)` in the stream handler's deferred cleanup. The janitor's only legitimate target is entries whose stream teardown never ran.

This PR ties janitor reaping to request liveness instead of chunk cadence:

- `PluginState` gains `BindLiveness(ctx, requestID)`. The janitor skips (and refreshes) stale requests whose bound ctx is still alive; once the ctx dies, they reap on the normal schedule. Unbound requests behave exactly as before (the session-affinity plugin relies on the janitor for GC of never-deleted entries).
- `inflight-load-producer` binds the ext_proc stream context in `PreRequest`, which is canceled exactly when the request's stream terminates.
- `NewPluginState` accepts `WithStalenessThreshold` / `WithCleanupInterval` options (defaults unchanged) so tests can drive the real janitor goroutine.

The regression test reproduces the corruption unit-level: without the fix, a live request's counters roll back to zero after the staleness threshold with no response chunks.

**Which issue(s) this PR fixes**:

Fixes #2295

**Release note**:

```release-note
NONE
```