### PR TITLE
fix(chart): restore missing --config-file value for EPP

### DIFF
--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -101,6 +101,7 @@
               - --zap-encoder
               - "json"
               - --config-file
+              - "/config/{{ .Values.router.epp.pluginsConfigFile }}"
           {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
           {{- if and (gt (.Values.router.epp.replicas | int) 1) (not $gkePB.enabled) }}
               - --ha-enable-leader-election


### PR DESCRIPTION
EPP fails to start on every deployment installed from this chart.

## Problem

The rendered EPP container args are:

```
--config-file
--grpc-health-port
9003
```

`--config-file` has no value, so pflag consumes the following `--grpc-health-port` flag as the config path and the process exits 1 immediately:

```
{"level":"error","logger":"setup","msg":"Failed to parse configuration",
 "error":"failed to load config from a file '--grpc-health-port' - open --grpc-health-port: no such file or directory"}
```

The pod then enters `CrashLoopBackOff` (`1/2`, the proxy sidecar stays up).

## Cause

#1681 inserted the `gkePreferredBackends` block at this spot and removed the argument value line along with it:

```diff
               - --config-file
-              - "/config/{{ .Values.router.epp.pluginsConfigFile }}"
-          {{- if gt (.Values.router.epp.replicas | int) 1 }}
+          {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
+          {{- if and (gt (.Values.router.epp.replicas | int) 1) (not $gkePB.enabled) }}
```

## Fix

Restore the value line. Both `llm-d-router-standalone` and `llm-d-router-gateway` consume `routerlib`, so both are affected and both are fixed.

## Verification

`helm template` with the `llm-d` precise-prefix-cache-routing guide values now renders:

```
              - --config-file
              - "/config/precise-prefix-cache-routing-plugins.yaml"
              - --grpc-health-port
              - "9003"
```

## Impact

This reached consumers through the floating `v0` chart tag, so all `llm-d` nightly E2E jobs that stand up an EPP started failing on 2026-08-07 regardless of accelerator (observed identically on Intel XPU and GKE GPU).