### PR TITLE
docs: document promptTokens parameter for PrefixBasedPDDecider

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
@@ -170,20 +170,21 @@ plugins:
 
 **Type:** `prefix-based-pd-decider`
 
-Decides per-request whether P/D disaggregation should run, based on how much of the prompt is already cached on the selected decode pod.
+Decides per-request whether P/D disaggregation should run, based on prompt length and how much of the prompt is already cached on the selected decode pod.
 
 #### What it does
 
-Compares the uncached portion of the request prompt against a configurable threshold, triggering P/D disaggregation only when the uncached suffix is long enough to justify the overhead.
+Compares the uncached portion of the request prompt against a configurable threshold, triggering P/D disaggregation only when the uncached suffix is long enough to justify the overhead. A separate minimum prompt-length gate can skip short prompts before the prefix cache is even consulted.
 
 1. Read the prompt token count as `len(request.Body.TokenizedPrompt.TokenIDs)`.
-2. Read `PrefixCacheMatchInfo` from the decode endpoint attributes.
-3. Compute uncached suffix length.
-4. Return true (disaggregate) if uncached tokens ≥ `nonCachedTokens`.
+2. If `promptTokens` is set and the prompt is shorter than it, return false.
+3. Read `PrefixCacheMatchInfo` from the decode endpoint attributes.
+4. Compute uncached suffix length.
+5. Return true (disaggregate) if uncached tokens ≥ `nonCachedTokens`.
 
 #### How It Works
 
-The prompt token count is `len(request.Body.TokenizedPrompt.TokenIDs)`, populated by a `token-producer` — auto-created with the tokenizer-free `estimate` backend when none is configured. Prefix cache state is read from the `PrefixCacheMatchInfo` attribute on the decode endpoint, populated by `approx-prefix-cache-producer`. If the attribute is absent or malformed, disaggregation is skipped. Setting `nonCachedTokens: 0` disables the decider entirely (always returns false).
+The prompt token count is `len(request.Body.TokenizedPrompt.TokenIDs)`, populated by a `token-producer` — auto-created with the tokenizer-free `estimate` backend when none is configured. `promptTokens` gates on this count directly: prompts shorter than it never disaggregate, regardless of cache state. Prefix cache state is read from the `PrefixCacheMatchInfo` attribute on the decode endpoint, populated by `approx-prefix-cache-producer`. If the attribute is absent or malformed, disaggregation is skipped. Setting `nonCachedTokens: 0` disables the decider entirely (always returns false).
 
 #### Inputs consumed
 
@@ -196,6 +197,7 @@ The prompt token count is `len(request.Body.TokenizedPrompt.TokenIDs)`, populate
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `nonCachedTokens` | `int` | No | `0` | Uncached token threshold above which P/D disaggregation is triggered. `0` disables the decider. |
+| `promptTokens` | `int` | No | `0` | Minimum prompt token count required before disaggregation is considered. Prompts shorter than this never disaggregate. `0` disables this gate. |
 
 ##### Example
 ```yaml
@@ -203,6 +205,7 @@ plugins:
   - type: prefix-based-pd-decider
     parameters:
       nonCachedTokens: 512
+      promptTokens: 1024
   - type: disagg-profile-handler
     parameters:
       deciders:
@@ -212,6 +215,7 @@ plugins:
 #### Limitations
 
 - `nonCachedTokens: 0` disables disaggregation entirely (the decider always returns false).
+- `promptTokens` gates on total prompt length, not on the uncached suffix; it only ever rules out short prompts, never overrides the `nonCachedTokens` check.
 - A `token-producer` populates `TokenizedPrompt`; when none is configured the framework auto-creates one with the `estimate` backend, so disaggregation works without extra setup.
 - Requires `PrefixCacheMatchInfo` on the decode endpoint; if absent, disaggregation is skipped with an error log.
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
@@ -176,20 +176,21 @@ Decides per-request whether P/D disaggregation should run, based on prompt lengt
 
 Compares the uncached portion of the request prompt against a configurable threshold, triggering P/D disaggregation only when the uncached suffix is long enough to justify the overhead. A separate minimum prompt-length gate can skip short prompts before the prefix cache is even consulted.
 
-1. Read the prompt token count as `len(request.Body.TokenizedPrompt.TokenIDs)`.
-2. If `promptTokens` is set and the prompt is shorter than it, return false.
-3. Read `PrefixCacheMatchInfo` from the decode endpoint attributes.
-4. Compute uncached suffix length.
-5. Return true (disaggregate) if uncached tokens ≥ `nonCachedTokens`.
+1. If `nonCachedTokens` is `0`, return false (the decider is disabled).
+2. Read the prompt token count as `request.Body.TokenizedPrompt.TokenCount()`.
+3. If `promptTokens` is set and the prompt is shorter than it, return false.
+4. Read `PrefixCacheMatchInfo` from the decode endpoint attributes.
+5. Compute uncached suffix length.
+6. Return true (disaggregate) if uncached tokens ≥ `nonCachedTokens`.
 
 #### How It Works
 
-The prompt token count is `len(request.Body.TokenizedPrompt.TokenIDs)`, populated by a `token-producer` — auto-created with the tokenizer-free `estimate` backend when none is configured. `promptTokens` gates on this count directly: prompts shorter than it never disaggregate, regardless of cache state. Prefix cache state is read from the `PrefixCacheMatchInfo` attribute on the decode endpoint, populated by `approx-prefix-cache-producer`. If the attribute is absent or malformed, disaggregation is skipped. Setting `nonCachedTokens: 0` disables the decider entirely (always returns false).
+The prompt token count is `request.Body.TokenizedPrompt.TokenCount()`, populated by a `token-producer` — auto-created with the tokenizer-free `estimate` backend when none is configured. `promptTokens` gates on this count directly: prompts shorter than it never disaggregate, regardless of cache state. Prefix cache state is read from the `PrefixCacheMatchInfo` attribute on the decode endpoint, populated by `approx-prefix-cache-producer`. If the attribute is absent or malformed, disaggregation is skipped. Setting `nonCachedTokens: 0` disables the decider entirely (always returns false).
 
 #### Inputs consumed
 
 - `PrefixCacheMatchInfo` — endpoint attribute from `approx-prefix-cache-producer`, read from the decode endpoint.
-- `request.Body.TokenizedPrompt.TokenIDs` — token IDs from a `token-producer` plugin; their count is the prompt token count.
+- `request.Body.TokenizedPrompt` — token data from a `token-producer` plugin; `TokenCount()` is the prompt token count.
 
 #### Configuration
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Documents the `promptTokens` configuration parameter of the `prefix-based-pd-decider` plugin in its README. The parameter already existed in code but was missing from the decision steps, config table, example, and limitations sections.

Also fixes README references to `request.Body.TokenizedPrompt.TokenIDs`, which does not exist on the type — the actual code path (`getUserInputLenInTokens`) reads the count via `TokenizedPrompt.TokenCount()`.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
