### PR TITLE
fix: lint in testcase

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -956,7 +956,7 @@ func TestInFlightLoadProducer_JanitorSkipsLiveRequest(t *testing.T) {
 
 	req := makeTokenRequest("req-janitor", 4) // 4 input + 6 output = 10 tokens
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(reqCtx, req, res)
+	_ = producer.PreRequest(reqCtx, req, res)
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
 
@@ -987,7 +987,7 @@ func TestInFlightLoadProducer_EndOfStreamAfterJanitorSkip(t *testing.T) {
 
 	req := makeTokenRequest("req-janitor-eos", 4)
 	res := makeSchedulingResult(endpointName)
-	producer.PreRequest(reqCtx, req, res)
+	_ = producer.PreRequest(reqCtx, req, res)
 
 	time.Sleep(150 * time.Millisecond)
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID),

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
@@ -566,7 +566,7 @@ func TestPreRequest_ComputingSideCountsAllTiers(t *testing.T) {
 
 	req := &scheduling.InferenceRequest{RequestID: "req-comp-tiers"}
 	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{src, computing}))
-	p.PreRequest(ctx, req, decodeOnly(computing))
+	_ = p.PreRequest(ctx, req, decodeOnly(computing))
 
 	// source 6 cpu blocks minus computing 5 (gpu, but local) = 1 block < delta.
 	assert.Empty(t, req.Headers[routing.KVCacheSourceHeader])


### PR DESCRIPTION
**What type of PR is this?**
/kind test


**What this PR does / why we need it**:
probably caused by different PRs touched the same tests in race condition
fix error:
```
docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app:Z -w /app -v /home/runner/.cache/llm-d-gomodcache:/go/pkg/mod:z -v /home/runner/.cache/llm-d-gobuildcache:/go/cache:z ghcr.io/llm-d/llm-d-builder:dev sh -c 'GOFLAGS=-buildvcs=false golangci-lint run --config=./.golangci.yml && typos'
Error: pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go:959:21: Error return value of `producer.PreRequest` is not checked (errcheck)
	producer.PreRequest(reqCtx, req, res)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

cc @dmitripikus
