### PR TITLE
docs: replace links to the deleted upstream metrics guide

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -2,8 +2,7 @@
 exclude = [
   "^https://www.gnu.org/software/make/?$",
   "^https://www.envoyproxy.io/",
-  "^https://gateway-api-inference-extension.sigs.k8s.io/guides/serving-multiple-inference-pools-latest/",
-  "^https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics-and-observability.md"
+  "^https://gateway-api-inference-extension.sigs.k8s.io/guides/serving-multiple-inference-pools-latest/"
 ]
 
 # Per-request timeout in seconds. Sized for slow upstream docs sites

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,8 +1,8 @@
 # Metrics
 
 The `llm-d-router` Endpoint Picker (EPP) exposes Prometheus metrics to monitor its behavior and
-performance. These are in addition to the Inference Gateway metrics; for how to view metrics, see the
-Gateway API Inference Extension [metrics and observability guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics-and-observability.md).
+performance. These are in addition to the Inference Gateway metrics. For how to reach the EPP's
+metrics endpoint and what it serves, see [Scrape topology](#scrape-topology) below.
 
 ## Subsystems and naming
 

--- a/pkg/epp/README.md
+++ b/pkg/epp/README.md
@@ -19,5 +19,5 @@ An EPP instance handles a single `InferencePool` (and so for each `InferencePool
 - Observability
   - The EPP generates metrics to enhance observability.
   - It reports InferenceObjective-level metrics, further broken down by target model.
-  - Detailed information regarding metrics can be found on the [website](https://gateway-api-inference-extension.sigs.k8s.io/guides/metrics-and-observability).
+  - Detailed information regarding metrics can be found in the [metrics documentation](../../docs/metrics.md).
   


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

`docs/metrics.md` linked to the Gateway API Inference Extension metrics and observability guide, which returns 404.

The issue suggested finding the updated URL, but there isn't one: the guide was deleted upstream in kubernetes-sigs/gateway-api-inference-extension#2978 ("Cleanup Documentation and Miscellaneous Tools / Manifests", June 2026) and no replacement page exists — it is absent from `site-src/guides/` and from the mkdocs nav, so both the GitHub blob URL and the published site URL 404. This needed a rewrite rather than a link swap.

Three changes:

1. `docs/metrics.md` — the dead link was there to answer "how to view metrics". This page's own [Scrape topology](https://github.com/llm-d/llm-d-router/blob/main/docs/metrics.md#scrape-topology) section already covers the metrics endpoint, port, and auth, so the sentence now points there.

2. `pkg/epp/README.md` — a second reference to the same deleted page, via the published site URL (`https://gateway-api-inference-extension.sigs.k8s.io/guides/metrics-and-observability`, also 404). Now points at `docs/metrics.md`.

3. `.lychee.toml` — the blob URL was in the link checker's `exclude` list, which is why CI stayed green while the link was dead. Removed, so future breakage of this link is caught rather than suppressed.

Note that the `pkg/epp/README.md` link was **not** excluded, so the markdown link checker may already have been failing on `main` before this PR.

Verified after the change: no references to `metrics-and-observability` remain outside `release-notes.d/` (which lychee deliberately skips), and the new relative link target resolves.

**Which issue(s) this PR fixes**:

Fixes #2279

**Release note**:
```release-note
NONE
```
