### PR TITLE
Added inflight load metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,7 +10,7 @@ A metric's full Prometheus name is `<subsystem>_<name>`. The EPP uses two curren
 
 | Prefix | Scope |
 |---|---|
-| `llm_d_epp_` | Canonical, EPP-wide: request/latency, pool, scheduler, plugin, data layer, flow control, disaggregation, ext_proc, prefix indexer, multimodal, program-aware fairness, and predicted-latency metrics. |
+| `llm_d_epp_` | Canonical, EPP-wide: request/latency, in-flight load, pool, scheduler, plugin, data layer, flow control, disaggregation, ext_proc, prefix indexer, multimodal, program-aware fairness, and predicted-latency metrics. |
 | `llm_d_router_epp_` | The embedded llm-d-kv-cache metrics only (see [Embedded llm-d-kv-cache metrics](#embedded-llm-d-kv-cache-metrics)). |
 
 Earlier releases emitted metrics under `llm_d_inference_scheduler_`, `inference_objective_`,
@@ -332,6 +332,38 @@ Three metrics covering the ext_proc gRPC stream lifecycle. Disabled by default; 
 *   **Usage:** Rate of `code="OK"` is the healthy completion rate. Rising `code="Internal"` or
     `code="Unknown"` indicates handler errors. `code="Canceled"` is expected on Envoy restarts and
     rolling EPP updates.
+
+### In-flight load
+
+In-flight load, emitted under the `llm_d_epp_` prefix. Present only when an `InFlightLoadProducer` is
+configured: the producer owns these metrics and registers them through the plugin metrics recorder. The
+per-endpoint gauges are updated as requests are admitted and released.
+
+#### `inflight_requests`
+
+*   **Type:** Gauge
+*   **Labels:**
+    *   `endpoint_name`: string — the target endpoint (pod) name.
+    *   `namespace`: string — the endpoint's namespace.
+    *   `producer_name`: string — the configured `InFlightLoadProducer` instance name, so multiple producers emit distinct series.
+    *   `fairness_id`: string — the flow-control fairness queue identity.
+    *   `priority`: string — the request priority.
+*   **Release Stage:** ALPHA
+*   **Description:** Requests currently in flight on each endpoint (scheduled, not yet completed), as tracked by the in-flight load producer.
+*   **Usage:** Per-replica queue depth for load-aware routing and capacity analysis.
+
+#### `inflight_tokens`
+
+*   **Type:** Gauge
+*   **Labels:**
+    *   `endpoint_name`: string — the target endpoint (pod) name.
+    *   `namespace`: string — the endpoint's namespace.
+    *   `producer_name`: string — the configured `InFlightLoadProducer` instance name.
+    *   `fairness_id`: string — the flow-control fairness queue identity.
+    *   `priority`: string — the request priority.
+*   **Release Stage:** ALPHA
+*   **Description:** Tokens currently in flight on each endpoint — uncached prompt tokens, optionally plus estimated output tokens when the producer's `addEstimatedOutputTokens` is set.
+*   **Usage:** Per-replica token pressure, a finer load signal than request count when request sizes vary widely.
 
 ### KV-cache index
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inflightload
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	compbasemetrics "k8s.io/component-base/metrics"
+
+	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
+	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+var (
+	inflightRequests = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
+			Name:      "inflight_requests",
+			Help:      metricsutil.HelpMsgWithStability("Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.", compbasemetrics.ALPHA),
+		},
+		[]string{"endpoint_name", "namespace", "producer_name", "fairness_id", "priority"},
+	)
+
+	inflightTokens = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
+			Name:      "inflight_tokens",
+			Help:      metricsutil.HelpMsgWithStability("Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.", compbasemetrics.ALPHA),
+		},
+		[]string{"endpoint_name", "namespace", "producer_name", "fairness_id", "priority"},
+	)
+)
+
+// registerMetrics registers the producer-owned metrics with the plugin's metrics
+// recorder. All metrics are shared package-level vectors, so a second producer
+// instance re-registering them is a benign no-op; the producer_name label keeps
+// each instance's per-endpoint series distinct.
+func registerMetrics(registerer prometheus.Registerer) error {
+	if registerer == nil {
+		return errors.New("inflight load metrics registerer is required")
+	}
+	for _, collector := range []prometheus.Collector{inflightRequests, inflightTokens} {
+		if err := registerer.Register(collector); err != nil {
+			var alreadyRegistered prometheus.AlreadyRegisteredError
+			if errors.As(err, &alreadyRegistered) && alreadyRegistered.ExistingCollector == collector {
+				continue
+			}
+			return fmt.Errorf("register inflight load metric: %w", err)
+		}
+	}
+	return nil
+}
+
+// splitNamespacedName splits a "namespace/name" key (the string form of a
+// k8s types.NamespacedName) into its name and namespace. A key with no
+// separator is treated as a bare name with an empty namespace.
+func splitNamespacedName(id string) (name, namespace string) {
+	if i := strings.IndexByte(id, '/'); i >= 0 {
+		return id[i+1:], id[:i]
+	}
+	return id, ""
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
@@ -68,13 +68,13 @@ func TestInflightGauges_Lifecycle(t *testing.T) {
 		expectedRequests := fmt.Sprintf(`
 # HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_requests gauge
-llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} %d
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} %d
 `, requests)
 		require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
 		expectedTokens := fmt.Sprintf(`
 # HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_tokens gauge
-llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} %d
+llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} %d
 `, tokens)
 		require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokens), "llm_d_epp_inflight_tokens"))
 	}
@@ -154,14 +154,14 @@ func TestInflightGauges_EarlyTokenRelease(t *testing.T) {
 	expectedRequests := `
 # HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_requests gauge
-llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
 
 	expectedTokens := `
 # HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_tokens gauge
-llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 4
+llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 4
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokens), "llm_d_epp_inflight_tokens"))
 
@@ -172,7 +172,7 @@ llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespa
 	expectedTokensReleased := `
 # HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_tokens gauge
-llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokensReleased), "llm_d_epp_inflight_tokens"))
 	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
@@ -183,7 +183,7 @@ llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespa
 	expectedRequestsReleased := `
 # HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_requests gauge
-llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsReleased), "llm_d_epp_inflight_requests"))
 }
@@ -211,8 +211,8 @@ func TestInflightGauges_DisaggEarlyPrefillRelease(t *testing.T) {
 	expectedRequestsBoth := `
 # HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_requests gauge
-llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
-llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsBoth), "llm_d_epp_inflight_requests"))
 
@@ -223,8 +223,8 @@ llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",nam
 	expectedRequestsPrefillReleased := `
 # HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_requests gauge
-llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
-llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsPrefillReleased), "llm_d_epp_inflight_requests"))
 
@@ -234,8 +234,8 @@ llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",nam
 	expectedRequestsAllReleased := `
 # HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_requests gauge
-llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
-llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsAllReleased), "llm_d_epp_inflight_requests"))
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inflightload
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	testutils "github.com/llm-d/llm-d-router/test/utils"
+)
+
+func TestRegisterMetrics_Idempotent(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	require.NoError(t, registerMetrics(reg))
+	require.NoError(t, registerMetrics(reg))
+}
+
+func TestRegisterMetrics_NilRegisterer(t *testing.T) {
+	require.Error(t, registerMetrics(nil))
+}
+
+func TestSplitNamespacedName(t *testing.T) {
+	cases := []struct {
+		id, wantName, wantNS string
+	}{
+		{"ns/ep", "ep", "ns"},
+		{"bare", "bare", ""},
+		{"ns/ep/extra", "ep/extra", "ns"},
+	}
+	for _, c := range cases {
+		name, ns := splitNamespacedName(c.id)
+		if name != c.wantName || ns != c.wantNS {
+			t.Errorf("splitNamespacedName(%q) = (%q,%q), want (%q,%q)", c.id, name, ns, c.wantName, c.wantNS)
+		}
+	}
+}
+
+func TestInflightGauges_Lifecycle(t *testing.T) {
+	inflightRequests.Reset()
+	inflightTokens.Reset()
+	producer := newTestProducer(t)
+	ctx := context.Background()
+
+	expect := func(t *testing.T, requests, tokens int64) {
+		t.Helper()
+		expectedRequests := fmt.Sprintf(`
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} %d
+`, requests)
+		require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
+		expectedTokens := fmt.Sprintf(`
+# HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_tokens gauge
+llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} %d
+`, tokens)
+		require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokens), "llm_d_epp_inflight_tokens"))
+	}
+
+	// Admission: 4 input + 6 estimated output = 10 tokens, 1 request.
+	req := makeTokenRequest("req-gauge-lifecycle", 4)
+	res := makeSchedulingResult("ep1")
+	err := producer.PreRequest(ctx, req, res)
+	require.NoError(t, err)
+	expect(t, 1, 10)
+
+	// Completion: series stay present at zero.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	expect(t, 0, 0)
+
+	// Endpoint removal deletes the series.
+	producer.DeleteEndpoint(fullEndpointName("ep1"))
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(""), "llm_d_epp_inflight_requests"))
+	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(""), "llm_d_epp_inflight_tokens"))
+}
+
+func TestInflightGauges_CustomFairnessAndPriority(t *testing.T) {
+	inflightRequests.Reset()
+	inflightTokens.Reset()
+	producer := newTestProducer(t)
+	ctx := context.Background()
+
+	req := makeTokenRequest("req-fairness-prio", 4)
+	req.FairnessID = "custom-tenant"
+	req.Objectives.Priority = 3
+	res := makeSchedulingResult("ep1")
+
+	err := producer.PreRequest(ctx, req, res)
+	require.NoError(t, err)
+
+	expectedRequests := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="custom-tenant",namespace="default",priority="3",producer_name="inflight-load-producer"} 1
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
+
+	expectedTokens := `
+# HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_tokens gauge
+llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="custom-tenant",namespace="default",priority="3",producer_name="inflight-load-producer"} 10
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokens), "llm_d_epp_inflight_tokens"))
+
+	// Cleanup on completion
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+
+	expectedRequestsZero := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="custom-tenant",namespace="default",priority="3",producer_name="inflight-load-producer"} 0
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsZero), "llm_d_epp_inflight_requests"))
+}
+
+func TestInflightGauges_EarlyTokenRelease(t *testing.T) {
+	inflightRequests.Reset()
+	inflightTokens.Reset()
+	producer := newTestProducer(t)
+	producer.addEstimatedOutputTokens = false
+	ctx := context.Background()
+
+	req := makeTokenRequest("req-early-tokens", 4)
+	res := makeSchedulingResult("ep1")
+
+	err := producer.PreRequest(ctx, req, res)
+	require.NoError(t, err)
+
+	// Admitted: 1 request, 4 tokens.
+	expectedRequests := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
+
+	expectedTokens := `
+# HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_tokens gauge
+llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 4
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokens), "llm_d_epp_inflight_tokens"))
+
+	// StartOfStream chunk arrives: tokens released early, request still in flight.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+
+	expectedTokensReleased := `
+# HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_tokens gauge
+llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokensReleased), "llm_d_epp_inflight_tokens"))
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
+
+	// EndOfStream chunk arrives: request count released.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+
+	expectedRequestsReleased := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsReleased), "llm_d_epp_inflight_requests"))
+}
+
+func TestInflightGauges_DisaggEarlyPrefillRelease(t *testing.T) {
+	inflightRequests.Reset()
+	inflightTokens.Reset()
+	producer := newTestProducer(t)
+	ctx := context.Background()
+	podA := "pod-a"
+	podB := "pod-b"
+
+	req := makeTokenRequest("req-disagg", 4) // 4 input + 6 output = 10 tokens
+	res := &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(podA)}},
+			"decode":  {TargetEndpoints: []fwksched.Endpoint{newStubSchedulingEndpoint(podB)}},
+		},
+	}
+
+	err := producer.PreRequest(ctx, req, res)
+	require.NoError(t, err)
+
+	expectedRequestsBoth := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsBoth), "llm_d_epp_inflight_requests"))
+
+	// First chunk arrives: prefill endpoint released, decode endpoint stays busy.
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{StartOfStream: true}, nil)
+
+	expectedRequestsPrefillReleased := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 1
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsPrefillReleased), "llm_d_epp_inflight_requests"))
+
+	// EndOfStream: decode endpoint released.
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+
+	expectedRequestsAllReleased := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="pod-a",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+llm_d_epp_inflight_requests{endpoint_name="pod-b",fairness_id="default-flow",namespace="default",priority="0",producer_name="inflight-load-producer"} 0
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsAllReleased), "llm_d_epp_inflight_requests"))
+}
+
+func TestInflightGauges_MultiProducer(t *testing.T) {
+	inflightRequests.Reset()
+	inflightTokens.Reset()
+
+	ctx := context.Background()
+
+	p1, err := InFlightLoadProducerFactory("producer-1", nil, testutils.NewTestHandle(ctx))
+	require.NoError(t, err)
+	p2, err := InFlightLoadProducerFactory("producer-2", nil, testutils.NewTestHandle(ctx))
+	require.NoError(t, err)
+
+	producer1 := p1.(*InFlightLoadProducer)
+	producer2 := p2.(*InFlightLoadProducer)
+
+	req1 := makeTokenRequest("req-1", 4)
+	req1.FairnessID = "flow-1"
+	req1.Objectives.Priority = 1
+	res1 := makeSchedulingResult("ep1")
+
+	req2 := makeTokenRequest("req-2", 8)
+	req2.FairnessID = "flow-2"
+	req2.Objectives.Priority = 2
+	res2 := makeSchedulingResult("ep2")
+
+	require.NoError(t, producer1.PreRequest(ctx, req1, res1))
+	require.NoError(t, producer2.PreRequest(ctx, req2, res2))
+
+	expectedRequests := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="flow-1",namespace="default",priority="1",producer_name="producer-1"} 1
+llm_d_epp_inflight_requests{endpoint_name="ep2",fairness_id="flow-2",namespace="default",priority="2",producer_name="producer-2"} 1
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
+
+	// Delete endpoint from producer-1 should only delete producer-1 series
+	producer1.DeleteEndpoint(fullEndpointName("ep1"))
+
+	expectedRequestsAfterDelete := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep2",fairness_id="flow-2",namespace="default",priority="2",producer_name="producer-2"} 1
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsAfterDelete), "llm_d_epp_inflight_requests"))
+}
+
+func TestAddedTokensEntry_Clone(t *testing.T) {
+	var nilEntry *addedTokensEntry
+	require.Nil(t, nilEntry.Clone())
+
+	entry := &addedTokensEntry{
+		endpointName: "ep1",
+		namespace:    "default",
+		producerName: "prod",
+		fairnessID:   "flow",
+		priority:     "1",
+	}
+	entry.tokens.Store(15)
+	entry.requests.Store(1)
+
+	cloned := entry.Clone().(*addedTokensEntry)
+	require.Equal(t, entry.endpointName, cloned.endpointName)
+	require.Equal(t, entry.namespace, cloned.namespace)
+	require.Equal(t, entry.producerName, cloned.producerName)
+	require.Equal(t, entry.fairnessID, cloned.fairnessID)
+	require.Equal(t, entry.priority, cloned.priority)
+	require.Equal(t, int64(15), cloned.tokens.Load())
+	require.Equal(t, int32(1), cloned.requests.Load())
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
@@ -91,10 +91,11 @@ llm_d_epp_inflight_tokens{endpoint_name="ep1",fairness_id="",namespace="default"
 	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
 	expect(t, 0, 0)
 
-	// Endpoint removal deletes the series.
+	// Endpoint removal cleans up internal trackers, while gauge series remain at zero.
 	producer.DeleteEndpoint(fullEndpointName("ep1"))
-	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(""), "llm_d_epp_inflight_requests"))
-	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(""), "llm_d_epp_inflight_tokens"))
+	expect(t, 0, 0)
+	require.Equal(t, int64(0), producer.GetRequests(fullEndpointName("ep1")))
+	require.Equal(t, int64(0), producer.GetTokens(fullEndpointName("ep1")))
 }
 
 func TestInflightGauges_CustomFairnessAndPriority(t *testing.T) {
@@ -275,15 +276,17 @@ llm_d_epp_inflight_requests{endpoint_name="ep2",fairness_id="flow-2",namespace="
 `
 	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
 
-	// Delete endpoint from producer-1 should only delete producer-1 series
-	producer1.DeleteEndpoint(fullEndpointName("ep1"))
+	// Complete req-1 on producer-1 -> series returns to 0
+	req1.SchedulingResult = res1
+	producer1.ResponseBody(ctx, req1, &requestcontrol.Response{EndOfStream: true}, nil)
 
-	expectedRequestsAfterDelete := `
+	expectedRequestsAfterComplete := `
 # HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
 # TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="ep1",fairness_id="flow-1",namespace="default",priority="1",producer_name="producer-1"} 0
 llm_d_epp_inflight_requests{endpoint_name="ep2",fairness_id="flow-2",namespace="default",priority="2",producer_name="producer-2"} 1
 `
-	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsAfterDelete), "llm_d_epp_inflight_requests"))
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequestsAfterComplete), "llm_d_epp_inflight_requests"))
 }
 
 func TestAddedTokensEntry_Clone(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
@@ -676,14 +675,6 @@ func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 func (p *InFlightLoadProducer) DeleteEndpoint(endpointID string) {
 	p.requestTracker.delete(endpointID)
 	p.tokenTracker.delete(endpointID)
-	name, namespace := splitNamespacedName(endpointID)
-	labels := prometheus.Labels{
-		"endpoint_name": name,
-		"namespace":     namespace,
-		"producer_name": p.typedName.Name,
-	}
-	inflightRequests.DeletePartialMatch(labels)
-	inflightTokens.DeletePartialMatch(labels)
 }
 
 func (p *InFlightLoadProducer) GetTokens(eid string) int64 {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -39,7 +39,6 @@ import (
 	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 	inflightloadconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/constants"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
-	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 const (
@@ -414,9 +413,6 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
 	fairnessID := request.FairnessID
-	if fairnessID == "" {
-		fairnessID = metadata.DefaultFairnessID
-	}
 	priority := strconv.Itoa(request.Objectives.Priority)
 
 	tracked := false

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -22,9 +22,11 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
@@ -37,6 +39,7 @@ import (
 	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 	inflightloadconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/constants"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 const (
@@ -106,6 +109,10 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 		syncCrossReplicaState = *cfg.SyncCrossReplicaState
 	}
 
+	if err := registerMetrics(handle.Metrics()); err != nil {
+		return nil, err
+	}
+
 	return &InFlightLoadProducer{
 		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
 		requestTracker:           newConcurrencyTracker(),
@@ -161,6 +168,11 @@ type addedTokensEntry struct {
 	tokenCounter   *atomic.Int64
 	requestCounter *atomic.Int64
 	requests       atomic.Int32
+	endpointName   string
+	namespace      string
+	producerName   string
+	fairnessID     string
+	priority       string
 }
 
 var _ fwkplugin.EvictableStateData = (*addedTokensEntry)(nil)
@@ -176,6 +188,11 @@ func (e *addedTokensEntry) Clone() fwkplugin.StateData {
 	clone := &addedTokensEntry{
 		tokenCounter:   e.tokenCounter,
 		requestCounter: e.requestCounter,
+		endpointName:   e.endpointName,
+		namespace:      e.namespace,
+		producerName:   e.producerName,
+		fairnessID:     e.fairnessID,
+		priority:       e.priority,
 	}
 	clone.tokens.Store(e.tokens.Load())
 	clone.requests.Store(e.requests.Load())
@@ -185,9 +202,11 @@ func (e *addedTokensEntry) Clone() fwkplugin.StateData {
 func (e *addedTokensEntry) OnEvicted(_ string, _ fwkplugin.StateKey) {
 	if t := e.tokens.Swap(0); t != 0 {
 		decrementClamped(e.tokenCounter, t)
+		inflightTokens.WithLabelValues(e.endpointName, e.namespace, e.producerName, e.fairnessID, e.priority).Sub(float64(t))
 	}
 	if e.requests.Swap(0) != 0 {
 		decrementClamped(e.requestCounter, 1)
+		inflightRequests.WithLabelValues(e.endpointName, e.namespace, e.producerName, e.fairnessID, e.priority).Dec()
 	}
 }
 
@@ -394,6 +413,11 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 	}
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
+	fairnessID := request.FairnessID
+	if fairnessID == "" {
+		fairnessID = metadata.DefaultFairnessID
+	}
+	priority := strconv.Itoa(request.Objectives.Priority)
 
 	tracked := false
 	for profileName, profileResult := range result.ProfileResults {
@@ -406,6 +430,8 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 			continue
 		}
 		eid := endpoint.GetMetadata().ID.String()
+		name, namespace := splitNamespacedName(eid)
+
 		requestCounter := p.requestTracker.inc(eid)
 
 		// Compute the uncached prompt portion this endpoint must actually compute.
@@ -416,9 +442,17 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 
 		tokenCounter := p.tokenTracker.add(eid, tokens)
 
+		inflightRequests.WithLabelValues(name, namespace, p.typedName.Name, fairnessID, priority).Inc()
+		inflightTokens.WithLabelValues(name, namespace, p.typedName.Name, fairnessID, priority).Add(float64(tokens))
+
 		entry := &addedTokensEntry{
 			tokenCounter:   tokenCounter,
 			requestCounter: requestCounter,
+			endpointName:   name,
+			namespace:      namespace,
+			producerName:   p.typedName.Name,
+			fairnessID:     fairnessID,
+			priority:       priority,
 		}
 		entry.tokens.Store(tokens)
 		entry.requests.Store(1)
@@ -557,6 +591,7 @@ func (p *InFlightLoadProducer) releaseTokensEarly(endpoint fwksched.Endpoint, re
 	if entry, err := fwkplugin.ReadPluginStateKey[*addedTokensEntry](p.PluginState, request.RequestID, key); err == nil {
 		if t := entry.tokens.Swap(0); t != 0 {
 			decrementClamped(entry.tokenCounter, t)
+			inflightTokens.WithLabelValues(entry.endpointName, entry.namespace, entry.producerName, entry.fairnessID, entry.priority).Sub(float64(t))
 		}
 	}
 }
@@ -645,6 +680,14 @@ func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 func (p *InFlightLoadProducer) DeleteEndpoint(endpointID string) {
 	p.requestTracker.delete(endpointID)
 	p.tokenTracker.delete(endpointID)
+	name, namespace := splitNamespacedName(endpointID)
+	labels := prometheus.Labels{
+		"endpoint_name": name,
+		"namespace":     namespace,
+		"producer_name": p.typedName.Name,
+	}
+	inflightRequests.DeletePartialMatch(labels)
+	inflightTokens.DeletePartialMatch(labels)
 }
 
 func (p *InFlightLoadProducer) GetTokens(eid string) int64 {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds inflight load producer metrics. This is important since inflight load has become the default used in the guides.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
