### PR TITLE
feat(scorer): migrate five legacy Consumes scorers to ConsumerPlugin

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -89,10 +89,20 @@ func (ext *Extractor) TypedName() fwkplugin.TypedName {
 var _ fwkplugin.ProducerPlugin = &Extractor{}
 
 // Produces declares the custom scalar metric attributes, whose names come from
-// the per-engine mappings in configuration. Core metrics land on the Metrics
-// struct rather than the attribute map and so are not declared here.
+// the per-engine mappings in configuration, plus the per-pod metric fields this
+// extractor writes into the endpoint's Metrics struct that a scorer or filter
+// declares as a Consumes() dependency. Declaring both lets the data-attribute
+// registry and the DAG builder validate the scorers and filters that read them.
+// The Metrics field types mirror the fwkdl.Metrics struct (float64, int, map
+// of model name to count).
 func (ext *Extractor) Produces() map[fwkplugin.DataKey]any {
-	produced := map[fwkplugin.DataKey]any{}
+	produced := map[fwkplugin.DataKey]any{
+		fwkplugin.NewDataKey(KVCacheUsagePercentKey, MetricsExtractorType): float64(0),
+		fwkplugin.NewDataKey(WaitingQueueSizeKey, MetricsExtractorType):    int(0),
+		fwkplugin.NewDataKey(RunningRequestsSizeKey, MetricsExtractorType): int(0),
+		fwkplugin.NewDataKey(ActiveModelsKey, MetricsExtractorType):        map[string]int{},
+		fwkplugin.NewDataKey(WaitingModelsKey, MetricsExtractorType):       map[string]int{},
+	}
 	for _, mapping := range ext.registry.Mappings() {
 		for _, custom := range mapping.CustomMetrics {
 			produced[attrmetrics.ScalarMetricDataKey(custom.AttributeKey)] = attrmetrics.ScalarMetricValue(0)

--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute.go
@@ -36,7 +36,10 @@ const (
 )
 
 // compile-time type assertion
-var _ fwksched.Scorer = &EndpointAttributeScorer{}
+var (
+	_ fwksched.Scorer          = &EndpointAttributeScorer{}
+	_ fwkplugin.ConsumerPlugin = &EndpointAttributeScorer{}
+)
 
 // fixedRangeParameters normalizes the attribute value against a fixed
 // [min, max] range (e.g. kv-cache utilization, which is always in [0, 1]).

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
@@ -30,7 +30,10 @@ const (
 )
 
 // compile-time type assertion
-var _ fwksched.Scorer = &KVCacheUtilizationScorer{}
+var (
+	_ fwksched.Scorer          = &KVCacheUtilizationScorer{}
+	_ fwkplugin.ConsumerPlugin = &KVCacheUtilizationScorer{}
+)
 
 // KvCacheUtilizationScorerFactory defines the factory function for KVCacheUtilizationScorer.
 func KvCacheUtilizationScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -59,10 +62,15 @@ func (s *KVCacheUtilizationScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-// Consumes returns the list of data that is consumed by the plugin.
-func (s *KVCacheUtilizationScorer) Consumes() map[string]any {
-	return map[string]any{
-		metrics.KVCacheUsagePercentKey: float64(0),
+// Consumes declares that the scorer reads the KV-cache utilization field
+// from the endpoint's Metrics struct. The DataKey names the field the
+// core-metrics-extractor publishes; the registry validates the consumer's
+// declared type against the producer's declaration.
+func (s *KVCacheUtilizationScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			fwkplugin.NewDataKey(metrics.KVCacheUsagePercentKey, metrics.MetricsExtractorType): float64(0),
+		},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
@@ -30,7 +30,10 @@ const (
 )
 
 // compile-time type assertion
-var _ fwksched.Scorer = &LoraAffinityScorer{}
+var (
+	_ fwksched.Scorer          = &LoraAffinityScorer{}
+	_ fwkplugin.ConsumerPlugin = &LoraAffinityScorer{}
+)
 
 // LoraAffinityScorerFactory defines the factory function for LoraAffinityScorer.
 func LoraAffinityScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -59,11 +62,15 @@ func (s *LoraAffinityScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Affinity
 }
 
-// Consumes returns the list of data that is consumed by the plugin.
-func (s *LoraAffinityScorer) Consumes() map[string]any {
-	return map[string]any{
-		metrics.ActiveModelsKey:  map[string]int{},
-		metrics.WaitingModelsKey: map[string]int{},
+// Consumes declares the scorer reads the per-pod active and waiting model
+// sets from the endpoint's Metrics struct, published by the core-metrics-
+// extractor.
+func (s *LoraAffinityScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			fwkplugin.NewDataKey(metrics.ActiveModelsKey, metrics.MetricsExtractorType):  map[string]int{},
+			fwkplugin.NewDataKey(metrics.WaitingModelsKey, metrics.MetricsExtractorType): map[string]int{},
+		},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
@@ -31,7 +31,10 @@ const (
 )
 
 // compile-time type assertion
-var _ fwksched.Scorer = &QueueScorer{}
+var (
+	_ fwksched.Scorer          = &QueueScorer{}
+	_ fwkplugin.ConsumerPlugin = &QueueScorer{}
+)
 
 // QueueScorerFactory defines the factory function for QueueScorer.
 func QueueScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -61,10 +64,13 @@ func (s *QueueScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-// Consumes returns the list of data that is consumed by the plugin.
-func (s *QueueScorer) Consumes() map[string]any {
-	return map[string]any{
-		metrics.WaitingQueueSizeKey: int(0),
+// Consumes declares the scorer reads the waiting queue size from the
+// endpoint's Metrics struct, published by the core-metrics-extractor.
+func (s *QueueScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			fwkplugin.NewDataKey(metrics.WaitingQueueSizeKey, metrics.MetricsExtractorType): int(0),
+		},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
@@ -31,7 +31,10 @@ const (
 )
 
 // compile-time type assertion
-var _ fwksched.Scorer = &RunningRequestsSizeScorer{}
+var (
+	_ fwksched.Scorer          = &RunningRequestsSizeScorer{}
+	_ fwkplugin.ConsumerPlugin = &RunningRequestsSizeScorer{}
+)
 
 // RunningRequestsSizeScorerFactory defines the factory function for RunningRequestsSizeScorer.
 func RunningRequestsSizeScorerFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -61,10 +64,13 @@ func (s *RunningRequestsSizeScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-// Consumes returns the list of data that is consumed by the plugin.
-func (s *RunningRequestsSizeScorer) Consumes() map[string]any {
-	return map[string]any{
-		metrics.RunningRequestsSizeKey: int(0),
+// Consumes declares the scorer reads the running requests size from the
+// endpoint's Metrics struct, published by the core-metrics-extractor.
+func (s *RunningRequestsSizeScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			fwkplugin.NewDataKey(metrics.RunningRequestsSizeKey, metrics.MetricsExtractorType): int(0),
+		},
 	}
 }
 


### PR DESCRIPTION
"**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:

Five scheduling scorers declared their data dependencies via the flat `Consumes() map[string]any` signature that predates `plugin.DataDependencies`, so none of them satisfied `plugin.ConsumerPlugin`. The existing framework's data-graph builder and the attribute registry added in #2352, saw them as orphan plugins with no declared dependencies, even though each one names a real metric field it reads from the endpoint's Metrics struct.

- Add `Produces()` to `core-metrics-extractor` declaring the per-pod Metrics fields as DataKeys (the multicluster extractor already does this for its pool-aggregate keys).
- Switch each scorer to `Consumes() DataDependencies` referencing those keys

| Scorer | Key declared |
|---|---|
| `KVCacheUtilizationScorer` | `KVCacheUsagePercent` (float64) |
| `QueueScorer` | `WaitingQueueSize` (int) |
| `RunningRequestsSizeScorer` | `RunningRequestsSize` (int) |
| `LoraAffinityScorer` | `ActiveModels`, `WaitingModels` (map[string]int) |
| `EndpointAttributeScorer` | user-configured key |

**Which issue(s) this PR fixes**:
NA - bug in not updating the consumers to the new plugin interface signature.

Note `endpoint-attribute-filter` still uses the legacy `Consumes() map[string]any` in this PR; the same-shaped migration on #2352 would hit this bug too and needs the split-on-`/` fix.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Test plan**
- [x] `TestEndpointAttributeScorerConsumes` (unit, new) - covers both `"DataType/ProducerName"` and `"BareName"` forms
- [x] `TestE2EConfigs_StartupParseSmoke/gpuUtilConfig` (hermetic integration) - the previously failing case now passes
