### PR TITLE
Filter prefix cache events by cache group kind

### DIFF
--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -37,6 +37,11 @@ const routerSubsystem = "llm_d_router_epp"
 // Keeping it as a constant localizes label-schema changes to this package.
 const podIdentifierLabel = "pod_identifier"
 
+const (
+	cacheKindLabel = "cache_kind"
+	reasonLabel    = "reason"
+)
+
 // dualCounter emits a value to both the deprecated kvcache_* counter and the
 // current llm_d_router_epp_* counter. It satisfies prometheus.Collector so both
 // register, and exposes the recording/read methods the call sites use.
@@ -134,6 +139,22 @@ var (
 	DedupRemovedHashesForwarded = newDualCounter("kvevents", "dedup_removed_hashes_forwarded_total",
 		"kv_cache_events_dedup_removed_hashes_forwarded_total",
 		"Block hashes forwarded for eviction after the KV-event dedup filter (block hashes, not BlockRemoved events)")
+	// KVEventStoresSkipped counts group-aware stores that cannot safely
+	// contribute to prefix indexing.
+	KVEventStoresSkipped = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_stores_skipped_total",
+		Help: metricsutil.HelpMsgWithStability(
+			"Total number of KV-cache store events skipped before prefix indexing",
+			compbasemetrics.ALPHA),
+	}, []string{cacheKindLabel, reasonLabel})
+	// KVEventRemovalsSkipped counts removals for groups excluded from prefix
+	// indexing.
+	KVEventRemovalsSkipped = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: routerSubsystem, Name: "kv_cache_events_removals_skipped_total",
+		Help: metricsutil.HelpMsgWithStability(
+			"Total number of KV-cache removal events skipped for groups excluded from prefix indexing",
+			compbasemetrics.ALPHA),
+	}, []string{cacheKindLabel, reasonLabel})
 
 	// SubscriberActive tracks the number of ZMQ subscribers currently managed by
 	// the SubscriberManager. A subscriber is counted from creation until it is
@@ -189,6 +210,7 @@ func Collectors() []prometheus.Collector {
 		Admissions, Evictions,
 		LookupRequests, LookupHits, LookupLatency, MaxPodHitCount,
 		DedupRemovedHashesSuppressed, DedupRemovedHashesForwarded,
+		KVEventStoresSkipped, KVEventRemovalsSkipped,
 		SubscriberActive, SubscriberReconnections, MessagesReceived, ZMQErrors,
 		PoolQueueDepth, PoolCapacity,
 	}

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -52,6 +52,8 @@ func TestCollectorsIncludesAllMetrics(t *testing.T) {
 		{"MaxPodHitCount", MaxPodHitCount},
 		{"DedupRemovedHashesSuppressed", DedupRemovedHashesSuppressed},
 		{"DedupRemovedHashesForwarded", DedupRemovedHashesForwarded},
+		{"KVEventStoresSkipped", KVEventStoresSkipped},
+		{"KVEventRemovalsSkipped", KVEventRemovalsSkipped},
 		{"SubscriberActive", SubscriberActive},
 		{"SubscriberReconnections", SubscriberReconnections},
 		{"MessagesReceived", MessagesReceived},
@@ -72,6 +74,7 @@ func TestKVEventsMetricNames(t *testing.T) {
 	// subsystem with the kv_cache_events prefix.
 	reg := prometheus.NewRegistry()
 	kvevents := []prometheus.Collector{
+		KVEventStoresSkipped, KVEventRemovalsSkipped,
 		SubscriberActive, SubscriberReconnections, MessagesReceived,
 		ZMQErrors, PoolQueueDepth, PoolCapacity,
 	}
@@ -84,6 +87,8 @@ func TestKVEventsMetricNames(t *testing.T) {
 	SubscriberReconnections.WithLabelValues("pod-a").Inc()
 	MessagesReceived.WithLabelValues("pod-a").Inc()
 	ZMQErrors.WithLabelValues("pod-a", "recv").Inc()
+	KVEventStoresSkipped.WithLabelValues("sliding_window", "unsupported_cache_kind").Inc()
+	KVEventRemovalsSkipped.WithLabelValues("sliding_window", "unsupported_cache_kind").Inc()
 	PoolQueueDepth.Set(3)
 	PoolCapacity.Set(4)
 
@@ -102,6 +107,8 @@ func TestKVEventsMetricNames(t *testing.T) {
 		"llm_d_router_epp_kv_cache_events_subscriber_reconnections_total",
 		"llm_d_router_epp_kv_cache_events_messages_received_total",
 		"llm_d_router_epp_kv_cache_events_zmq_errors_total",
+		"llm_d_router_epp_kv_cache_events_stores_skipped_total",
+		"llm_d_router_epp_kv_cache_events_removals_skipped_total",
 		"llm_d_router_epp_kv_cache_events_pool_queue_depth",
 		"llm_d_router_epp_kv_cache_events_pool_capacity",
 	} {

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -46,6 +46,41 @@ func normalizeDeviceTier(deviceTier string) string {
 	return strings.ToLower(deviceTier)
 }
 
+func isPrefixIndexableSpecKind(kind KVCacheSpecKind) bool {
+	switch kind {
+	case KVCacheSpecKindFullAttention, KVCacheSpecKindMlaAttention, KVCacheSpecKindSinkFull:
+		return true
+	default:
+		return false
+	}
+}
+
+func cacheKindLabel(kind KVCacheSpecKind) string {
+	if kind == "" {
+		return string(KVCacheSpecKindUnknown)
+	}
+	return string(kind)
+}
+
+func blockStoredEventDigestible(ev *BlockStoredEvent) (bool, string) {
+	if ev.GroupIdx == nil {
+		return true, ""
+	}
+	if !isPrefixIndexableSpecKind(ev.KVCacheSpecKind) {
+		return false, "unsupported_cache_kind"
+	}
+	if len(ev.Tokens) == 0 {
+		return true, ""
+	}
+	if ev.BlockSize <= 0 {
+		return false, "invalid_block_size"
+	}
+	if len(ev.Tokens)%ev.BlockSize != 0 || len(ev.Tokens)/ev.BlockSize != len(ev.BlockHashes) {
+		return false, "non_dense_block_span"
+	}
+	return true, ""
+}
+
 // Config holds the configuration for the event processing pool.
 type Config struct {
 	// ZMQEndpoint is the ZMQ address to connect to (e.g., "tcp://indexer:5557").
@@ -434,6 +469,19 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				podEntries[0].GroupIdx = g
 			}
 
+			if digestible, reason := blockStoredEventDigestible(ev); !digestible {
+				metrics.KVEventStoresSkipped.WithLabelValues(cacheKindLabel(ev.KVCacheSpecKind), reason).Inc()
+				log.FromContext(ctx).V(logging.TRACE).Info("Skipping KV cache store event",
+					"podIdentifier", podIdentifier,
+					"groupIdx", ev.GroupIdx,
+					"cacheKind", ev.KVCacheSpecKind,
+					"reason", reason,
+					"numTokens", len(ev.Tokens),
+					"numBlockHashes", len(ev.BlockHashes),
+					"blockSize", ev.BlockSize)
+				continue
+			}
+
 			engineKeys := make([]kvblock.BlockHash, len(ev.BlockHashes))
 			for i, hash := range ev.BlockHashes {
 				engineKeys[i] = kvblock.BlockHash(hash)
@@ -445,7 +493,13 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				key, err := p.index.GetRequestKey(ctx, parentEngineKey)
 				if err != nil {
 					debugLogger.Error(err, "Failed to get request key for parent block",
-						"parentEngineKey", parentEngineKey, "effectiveModelName", effectiveModelName)
+						"parentEngineKey", parentEngineKey,
+						"effectiveModelName", effectiveModelName,
+						"groupIdx", ev.GroupIdx,
+						"cacheKind", ev.KVCacheSpecKind,
+						"numTokens", len(ev.Tokens),
+						"numBlockHashes", len(ev.BlockHashes),
+						"blockSize", ev.BlockSize)
 					continue
 				}
 				parentRequestKey = key
@@ -528,6 +582,24 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 
 		case *BlockRemovedEvent:
 			deviceTier := normalizeDeviceTier(ev.DeviceTier)
+			if ev.GroupIdx != nil {
+				groupIdx := kvblock.GroupID(*ev.GroupIdx)
+				meta, found := p.groupCatalog.Get(podIdentifier, groupIdx)
+				if !found || !isPrefixIndexableSpecKind(KVCacheSpecKind(meta.Kind)) {
+					reason := "unsupported_cache_kind"
+					if !found {
+						reason = "unknown_group"
+					}
+					metrics.KVEventRemovalsSkipped.WithLabelValues(
+						cacheKindLabel(KVCacheSpecKind(meta.Kind)), reason).Inc()
+					log.FromContext(ctx).V(logging.TRACE).Info("Skipping KV cache remove event",
+						"podIdentifier", podIdentifier,
+						"groupIdx", groupIdx,
+						"cacheKind", meta.Kind,
+						"groupKnown", found)
+					continue
+				}
+			}
 
 			// Create PodEntry for this specific event's device tier.
 			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -38,6 +38,27 @@ func newTestPool(t *testing.T, blockSize int) (
 	return pool, idx, tp
 }
 
+type recordingIndex struct {
+	kvblock.Index
+	getRequestKeyCalls int
+	evictCalls         int
+}
+
+func (i *recordingIndex) GetRequestKey(ctx context.Context, engineKey kvblock.BlockHash) (kvblock.BlockHash, error) {
+	i.getRequestKeyCalls++
+	return i.Index.GetRequestKey(ctx, engineKey)
+}
+
+func (i *recordingIndex) Evict(
+	ctx context.Context,
+	key kvblock.BlockHash,
+	keyType kvblock.KeyType,
+	entries []kvblock.PodEntry,
+) error {
+	i.evictCalls++
+	return i.Index.Evict(ctx, key, keyType, entries)
+}
+
 // makeTokens creates a token slice [1, 2, ..., n].
 func makeTokens(n int) []uint32 {
 	tokens := make([]uint32, n)
@@ -734,7 +755,7 @@ func TestBlockStoredEvent_EvictionOrderGPUThenCPU(t *testing.T) {
 	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
 }
 
-func TestHMAGroupMetadataAndEntryOnBlockStored(t *testing.T) {
+func TestHMAGroupMetadataLearnedForRejectedKind(t *testing.T) {
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
 	pool, idx, tp := newTestPool(t, 16)
 
@@ -772,11 +793,111 @@ func TestHMAGroupMetadataAndEntryOnBlockStored(t *testing.T) {
 	result, err := idx.Lookup(ctx, canonicalKeys, nil)
 	require.NoError(t, err)
 	for _, ck := range canonicalKeys {
-		entries := result[ck]
-		require.Len(t, entries, 1, "each canonical key should have one entry")
-		assert.True(t, entries[0].HasGroup)
-		assert.Equal(t, kvblock.GroupID(0), entries[0].GroupIdx)
+		assert.Empty(t, result[ck], "rejected group kind must not be indexed")
 	}
+}
+
+func TestHMAGroupKindFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    KVCacheSpecKind
+		allowed bool
+	}{
+		{name: "full attention", kind: KVCacheSpecKindFullAttention, allowed: true},
+		{name: "MLA attention", kind: KVCacheSpecKindMlaAttention, allowed: true},
+		{name: "sink full attention", kind: KVCacheSpecKindSinkFull, allowed: true},
+		{name: "sliding window", kind: KVCacheSpecKindSlidingWindow},
+		{name: "sliding window MLA", kind: KVCacheSpecKindSlidingWindowMla},
+		{name: "mamba", kind: KVCacheSpecKindMamba},
+		{name: "chunked local attention", kind: KVCacheSpecKindChunkedLocal},
+		{name: "encoder only attention", kind: KVCacheSpecKindEncoder},
+		{name: "cross attention", kind: KVCacheSpecKindCross},
+		{name: "unknown", kind: KVCacheSpecKindUnknown},
+		{name: "missing kind"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.NewTestLoggerIntoContext(context.Background())
+			pool, idx, tp := newTestPool(t, 16)
+			groupIdx := 0
+			tokens := makeTokens(64)
+			engineKeys := makeEngineKeys(4, 900)
+
+			pool.processEventBatch(ctx, &EventBatch{Events: []GenericEvent{
+				&BlockStoredEvent{
+					BlockHashes:     engineKeys,
+					Tokens:          tokens,
+					GroupIdx:        &groupIdx,
+					KVCacheSpecKind: tt.kind,
+					BlockSize:       16,
+				},
+			}}, "pod-hma", "test-model")
+
+			canonicalKeys, err := tp.TokensToKVBlockKeys(
+				kvblock.EmptyBlockHash, tokens, "test-model", nil)
+			require.NoError(t, err)
+			result, err := idx.Lookup(ctx, canonicalKeys, nil)
+			require.NoError(t, err)
+			for _, key := range canonicalKeys {
+				if tt.allowed {
+					require.Len(t, result[key], 1)
+					assert.Equal(t, kvblock.GroupID(groupIdx), result[key][0].GroupIdx)
+				} else {
+					assert.Empty(t, result[key])
+				}
+			}
+		})
+	}
+}
+
+func TestHMAGroupFilterRejectsSparseFullAttentionBeforeParentLookup(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, _ := newTestPool(t, 16)
+	recording := &recordingIndex{Index: idx}
+	pool.index = recording
+	groupIdx := 0
+
+	pool.processEventBatch(ctx, &EventBatch{Events: []GenericEvent{
+		&BlockStoredEvent{
+			BlockHashes:     makeEngineKeys(1, 950),
+			Tokens:          makeTokens(64),
+			ParentHash:      949,
+			GroupIdx:        &groupIdx,
+			KVCacheSpecKind: KVCacheSpecKindFullAttention,
+			BlockSize:       16,
+		},
+	}}, "pod-hma", "test-model")
+
+	assert.Zero(t, recording.getRequestKeyCalls)
+	_, err := idx.GetRequestKey(ctx, kvblock.BlockHash(950))
+	assert.Error(t, err)
+}
+
+func TestHMAGroupFilterIgnoresRejectedGroupRemoval(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, _ := newTestPool(t, 16)
+	recording := &recordingIndex{Index: idx}
+	pool.index = recording
+	groupIdx := 1
+
+	pool.processEventBatch(ctx, &EventBatch{Events: []GenericEvent{
+		&BlockStoredEvent{
+			BlockHashes:     makeEngineKeys(1, 980),
+			Tokens:          makeTokens(64),
+			GroupIdx:        &groupIdx,
+			KVCacheSpecKind: KVCacheSpecKindSlidingWindowMla,
+			BlockSize:       16,
+		},
+	}}, "pod-hma", "test-model")
+	pool.processEventBatch(ctx, &EventBatch{Events: []GenericEvent{
+		&BlockRemovedEvent{
+			BlockHashes: makeEngineKeys(1, 980),
+			GroupIdx:    &groupIdx,
+		},
+	}}, "pod-hma", "test-model")
+
+	assert.Zero(t, recording.evictCalls)
 }
 
 // TestHMAGroupLevelEviction_BlockRemoved verifies that a BlockRemoved event with GroupIdx


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Group-aware KV-cache events can describe cache groups whose hashes do not cover a contiguous logical token span. The router currently generates canonical keys from the full token span and lets `Index.Add` infer the engine-to-request-key mapping from the two list lengths. That creates false prefix residency for sparse hybrid-cache groups.

This change admits group-aware stores only for `full_attention`, `mla_attention`, and `sink_full_attention`. It also requires each admitted event to describe a dense span:

```text
len(tokens) % block_size == 0
len(tokens) / block_size == len(block_hashes)
```

The filter runs before parent-key lookup or index mutation. Group metadata is still learned from rejected stores so matching removals can be skipped consistently. Events without group metadata retain the existing behavior.

The change exposes rejected events through:

- `llm_d_router_epp_kv_cache_events_stores_skipped_total{cache_kind,reason}`
- `llm_d_router_epp_kv_cache_events_removals_skipped_total{cache_kind,reason}`

Parent-key lookup errors for admitted events include the group, cache kind, token count, hash count, and block size.

On the DeepSeek-V4-Flash reproduction, a bounded run completed 28 requests without observed errors and reached 75.9% cumulative prompt-token reuse. The run changed from three to four ready replicas, so this validates the event-filtering behavior rather than providing a matched performance comparison. The corresponding unpatched TP2 × 4 run reached 24.7% reuse.

The admitted full-attention group still recorded 29 parent-key lookup failures. This PR reports the event context for those failures but does not reconstruct missing lineage.

**Which issue(s) this PR fixes**:

Fixes #2362

**Test plan**:

- [x] `go test ./pkg/kvcache/metrics ./pkg/kvevents -count=1`
- [x] `make build`
- [x] Run the DeepSeek-V4-Flash workload against the patched router

**Release note**:

```release-note
NONE
```