### PR TITLE
fix(charts): emit leading document separators in monitoring partials

### DIFF
--- a/config/charts/routerlib/templates/_rbac.yaml
+++ b/config/charts/routerlib/templates/_rbac.yaml
@@ -1,5 +1,6 @@
 {{- define "llm-d-router.rbac" -}}
 {{- if .Values.router.monitoring.prometheus.enabled }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/config/charts/routerlib/templates/_servicemonitor.yaml
+++ b/config/charts/routerlib/templates/_servicemonitor.yaml
@@ -1,6 +1,7 @@
 {{- define "llm-d-epp.service-monitor" -}}
 {{- $monitoringProviderName := include "llm-d-router.monitoring.provider.name" . | lower -}}
 {{- if and .Values.router.monitoring.prometheus.enabled (eq $monitoringProviderName "prometheusoperator") }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The routerlib service-monitor and rbac partials open their conditional bodies without a leading `---`. Include sites chain partials on adjacent lines and rely on each partial to separate itself, so with `router.monitoring.prometheus.enabled=true` the rendered ServiceMonitor continues the preceding EPP Service document, forming one YAML document with duplicate root keys. Helm parses that document last-key-wins as a ServiceMonitor and the Service drops out of the release inventory: an upgrade that enables monitoring deletes the live Service, a fresh install with monitoring enabled never creates it, and Helm reports no error. Observed on GKE with Helm v4.2.0; the audit log shows a `services.delete` issued by Helm during the upgrade.

The rbac partial fails the same way when the service-monitor partial renders empty (prometheus enabled with a provider other than prometheusoperator): its ClusterRole fuses onto the Service.

The fix adds a leading `---` inside each partial's conditional, matching `_leader-election-rbac.yaml`.

Verified with `helm template` on the standalone chart, strict-parsing the output: with the prometheusoperator provider the parsed manifest set gains the missing `Service` (13 documents before, 14 after); with the gmp provider likewise (18 before, 19 after). No other document changes.

**Which issue(s) this PR fixes**:

Ad hoc fix

**Release note**:

```release-note
NONE
```
