### PR TITLE
test(e2e): warm up before disruption in streaming-request spec

### DIFF
--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -167,6 +167,10 @@ var _ = ginkgo.Describe("Disruption tests", func() {
 			gomega.Expect(prefillPods).Should(gomega.BeEmpty())
 			gomega.Expect(decodePods).Should(gomega.HaveLen(2))
 
+			ginkgo.By("Verifying requests route successfully before disruption")
+			nsHdr, _, _ := runCompletion(simplePrompt, simModelName)
+			gomega.Expect(nsHdr).Should(gomega.Equal(nsName))
+
 			ginkgo.By("Starting a streaming request")
 			connected := make(chan string, 1)
 			errCh := make(chan error, 1)


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind test

**What this PR does / why we need it**:

The "A decode pod is killed while a streaming request is in-flight" e2e spec sent its first request through a raw, non-retrying client, unlike its sibling disruption specs, which all warm up via `runCompletion` first. That first request can race Envoy's initial active health check on the EPP's ext_proc cluster (10s interval, see #1961), producing a local "no healthy upstream" reply that the spec misreports as "streaming request failed to connect."

Adds the same pre-disruption warm-up used by the other disruption specs, closing the race by construction instead of adding retry logic to the raw streaming client.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2377

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```