### PR TITLE
Unify the metrics subsystem on llm_d_epp

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,15 +6,14 @@ metrics endpoint and what it serves, see [Scrape topology](#scrape-topology) bel
 
 ## Subsystems and naming
 
-A metric's full Prometheus name is `<subsystem>_<name>`. The EPP uses two current subsystems:
+A metric's full Prometheus name is `<subsystem>_<name>`. The EPP uses the canonical subsystem:
 
 | Prefix | Scope |
 |---|---|
-| `llm_d_epp_` | Canonical, EPP-wide: request/latency, in-flight load, pool, scheduler, plugin, data layer, flow control, disaggregation, ext_proc, prefix indexer, multimodal, program-aware fairness, and predicted-latency metrics. |
-| `llm_d_router_epp_` | The embedded llm-d-kv-cache metrics only (see [Embedded llm-d-kv-cache metrics](#embedded-llm-d-kv-cache-metrics)). |
+| `llm_d_epp_` | Canonical, EPP-wide: request/latency, in-flight load, pool, scheduler, plugin, data layer, flow control, disaggregation, ext_proc, prefix indexer, multimodal, program-aware fairness, predicted latency, and embedded KV-cache metrics. |
 
 Earlier releases emitted metrics under `llm_d_inference_scheduler_`, `inference_objective_`,
-`inference_pool_`, `inference_extension_`, and `kvcache_`. Those prefixes are **deprecated** but
+`inference_pool_`, `inference_extension_`, `llm_d_router_epp_`, and `kvcache_`. Those prefixes are **deprecated** but
 still emitted: each recorder that has a deprecated predecessor writes both the legacy series and its
 current twin (dual emission), so existing dashboards keep working during migration. See [Deprecated series](#deprecated-series).
 
@@ -36,7 +35,7 @@ metrics, distinct from the EPP metrics above; scrape the pods directly to collec
 
 When the precise prefix cache is enabled (`precise-prefix-cache-producer` /
 `precise-prefix-cache-scorer`) with `indexerConfig.kvBlockIndexConfig.enableMetrics: true`, the
-embedded llm-d-kv-cache index registers its `llm_d_router_epp_kv_cache_*` metrics on the **same**
+embedded llm-d-kv-cache index registers its `llm_d_epp_kv_cache_*` metrics on the **same**
 controller-runtime registry the EPP `/metrics` endpoint already serves. No separate kv-cache HTTP
 endpoint or scrape target is required.
 
@@ -47,7 +46,7 @@ operator opts in.
 ## Deprecated series
 
 All deprecated series are still emitted as back-compat aliases alongside their current twins. Prefer
-the current `llm_d_epp_*` (or `llm_d_router_epp_*`) names in new dashboards and alerts.
+the current `llm_d_epp_*` names in new dashboards and alerts.
 
 | Deprecated prefix | Current replacement |
 |---|---|
@@ -55,7 +54,7 @@ the current `llm_d_epp_*` (or `llm_d_router_epp_*`) names in new dashboards and 
 | `inference_objective_*` (request/latency, predicted latency) | `llm_d_epp_*` |
 | `inference_pool_*` (pool averages, queue size) | `llm_d_epp_*` |
 | `inference_extension_*` (scheduler, plugin, info, flow control, prefix indexer) | `llm_d_epp_*` |
-| `kvcache_index_*`, `kvcache_kvevents_*` | `llm_d_router_epp_kv_cache_*` |
+| `kvcache_index_*`, `kvcache_kvevents_*` | `llm_d_epp_kv_cache_*` |
 
 ## Metrics catalog
 
@@ -367,7 +366,7 @@ per-endpoint gauges are updated as requests are admitted and released.
 
 ### KV-cache index
 
-Prefix `llm_d_router_epp_`. Registered only when the embedded llm-d-kv-cache metrics are enabled (see
+Prefix `llm_d_epp_`. Registered only when the embedded llm-d-kv-cache metrics are enabled (see
 [Embedded llm-d-kv-cache metrics](#embedded-llm-d-kv-cache-metrics)). Unlabeled.
 
 | Name | Type | Notes |

--- a/pkg/common/observability/metrics/metrics.go
+++ b/pkg/common/observability/metrics/metrics.go
@@ -22,6 +22,11 @@ import (
 	compbasemetrics "k8s.io/component-base/metrics"
 )
 
+const (
+	// LLMDRouterEndpointPickerSubsystem is the subsystem for llm-d router endpoint picker metrics.
+	LLMDRouterEndpointPickerSubsystem = "llm_d_epp"
+)
+
 // HelpMsgWithStability is a helper function to create a help message with stability level.
 func HelpMsgWithStability(msg string, stability compbasemetrics.StabilityLevel) string {
 	return fmt.Sprintf("[%v] %v", stability, msg)

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// LLMDRouterEndpointPickerSubsystem is the subsystem for llm-d router endpoint picker metrics.
-	LLMDRouterEndpointPickerSubsystem = "llm_d_epp"
+	LLMDRouterEndpointPickerSubsystem = metricsutil.LLMDRouterEndpointPickerSubsystem
 )
 
 var (

--- a/pkg/kvcache/metrics/README.md
+++ b/pkg/kvcache/metrics/README.md
@@ -12,11 +12,11 @@ registry. The [`kvblock`](../kvblock/README.md) instrumented index and the
 
 ## Naming
 
-Metrics are emitted under the router's standard `llm_d_router_epp` subsystem
-(for example `llm_d_router_epp_kv_cache_index_lookup_hits_total`). The former
+Metrics are emitted under the router's standard `llm_d_epp` subsystem
+(for example `llm_d_epp_kv_cache_index_lookup_hits_total`). The former
 `kvcache_*` names are still emitted as deprecated aliases via dual-emitting
 collectors, so existing scrapers keep working during the migration; update
-dashboards and alerts to the `llm_d_router_epp_*` names.
+dashboards and alerts to the `llm_d_epp_*` names.
 
 ## Usage
 

--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -31,7 +31,7 @@ import (
 // routerSubsystem is the router's standard EPP metrics subsystem. New metrics
 // are emitted under it; the legacy kvcache_* names are retained as deprecated
 // aliases so existing scrapers keep working during the migration.
-const routerSubsystem = "llm_d_router_epp"
+const routerSubsystem = metricsutil.LLMDRouterEndpointPickerSubsystem
 
 // podIdentifierLabel is the label key carried by the per-pod kvevents metrics.
 // Keeping it as a constant localizes label-schema changes to this package.
@@ -43,7 +43,7 @@ const (
 )
 
 // dualCounter emits a value to both the deprecated kvcache_* counter and the
-// current llm_d_router_epp_* counter. It satisfies prometheus.Collector so both
+// current llm_d_epp_* counter. It satisfies prometheus.Collector so both
 // register, and exposes the recording/read methods the call sites use.
 type dualCounter struct {
 	deprecated, current prometheus.Counter

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -103,14 +103,14 @@ func TestKVEventsMetricNames(t *testing.T) {
 	}
 
 	for _, name := range []string{
-		"llm_d_router_epp_kv_cache_events_active_subscribers",
-		"llm_d_router_epp_kv_cache_events_subscriber_reconnections_total",
-		"llm_d_router_epp_kv_cache_events_messages_received_total",
-		"llm_d_router_epp_kv_cache_events_zmq_errors_total",
-		"llm_d_router_epp_kv_cache_events_stores_skipped_total",
-		"llm_d_router_epp_kv_cache_events_removals_skipped_total",
-		"llm_d_router_epp_kv_cache_events_pool_queue_depth",
-		"llm_d_router_epp_kv_cache_events_pool_capacity",
+		"llm_d_epp_kv_cache_events_active_subscribers",
+		"llm_d_epp_kv_cache_events_subscriber_reconnections_total",
+		"llm_d_epp_kv_cache_events_messages_received_total",
+		"llm_d_epp_kv_cache_events_zmq_errors_total",
+		"llm_d_epp_kv_cache_events_stores_skipped_total",
+		"llm_d_epp_kv_cache_events_removals_skipped_total",
+		"llm_d_epp_kv_cache_events_pool_queue_depth",
+		"llm_d_epp_kv_cache_events_pool_capacity",
 	} {
 		if !got[name] {
 			t.Errorf("expected metric %q to be registered, got names: %v", name, got)

--- a/release-notes.d/unreleased/1886.md
+++ b/release-notes.d/unreleased/1886.md
@@ -4,4 +4,4 @@ url: https://github.com/llm-d/llm-d-router/pull/1886
 author: vMaroon
 date: 2026-07-14
 ---
-KV-cache index and KV-event metrics are now emitted under the `llm_d_router_epp` subsystem (for example `llm_d_router_epp_kv_cache_index_lookup_hits_total`), aligning them with the standard EPP metric naming convention. The former `kvcache_*` names remain as deprecated aliases; update dashboards and alerts to the new names.
+KV-cache index and KV-event metrics are now emitted under the `llm_d_epp` subsystem (for example `llm_d_epp_kv_cache_index_lookup_hits_total`), aligning them with the standard EPP metric naming convention. The former `kvcache_*` names remain as deprecated aliases; update dashboards and alerts to the new names.

--- a/release-notes.d/unreleased/2152.md
+++ b/release-notes.d/unreleased/2152.md
@@ -4,4 +4,4 @@ url: https://github.com/llm-d/llm-d-router/pull/2152
 author: satyamg1620
 date: 2026-07-30
 ---
-Added Prometheus metrics for KV-event subscriber health and pool saturation: active subscribers, per-pod reconnection/message/ZMQ-error counters, and event pool queue depth and capacity, under the llm_d_router_epp subsystem.
+Added Prometheus metrics for KV-event subscriber health and pool saturation: active subscribers, per-pod reconnection/message/ZMQ-error counters, and event pool queue depth and capacity, under the llm_d_epp subsystem.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

the kv-cache components used a router substring in the metrics subsystem name, this PR removes that and unifies the code base on llm_d_epp

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
kv_cache_events metrics has been updated to use llm_d_epp instead of llm_d_router_epp as the prefix (aka subsystem name)
```
