### PR TITLE
Bumped Go version directive from 1.26.5 to 1.26.6.

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile.coordinator
+++ b/Dockerfile.coordinator
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Go build stage
-FROM --platform=${BUILDPLATFORM} golang:1.26.5 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.6 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Go build stage
-FROM --platform=${BUILDPLATFORM} golang:1.26.5 AS go-builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.6 AS go-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -5,8 +5,8 @@
 #   COPY --from=builder /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
-# Build Stage: using Go 1.26.5 image
-FROM --platform=${BUILDPLATFORM} golang:1.26.5 AS builder
+# Build Stage: using Go 1.26.6 image
+FROM --platform=${BUILDPLATFORM} golang:1.26.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llm-d/llm-d-router
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/aiplatform v1.124.0


### PR DESCRIPTION
Fixes govulncheck which reported 6 standard library vulnerabilities present in go1.26.5 (such as GO-2026-6218, GO-2026-6091, GO-2026-6090, etc.), all of which are fixed in go1.26.6.

  ### Changes Applied:

  1. **go.mod**: Bumped Go version directive from 1.26.5 to 1.26.6.
  2. Dockerfiles: Updated base image Go version from 1.26.5 to 1.26.6 across:
      • Dockerfile.builder
      • Dockerfile.epp
      • Dockerfile.sidecar
      • Dockerfile.coordinator


  ### Verification:

  • Rebuilt builder image and executed make vulncheck, resulting in No vulnerabilities found. Your code is affected by 0 vulnerabilities.
  • Verified make lint, make build, and unit tests pass cleanly.