### PR TITLE
feat(epp): add --feature-gates flag

### DIFF
--- a/cmd/epp/runner/feature_gate_test.go
+++ b/cmd/epp/runner/feature_gate_test.go
@@ -69,6 +69,7 @@ func TestFlowControlFeatureGateAdmissionControlWiring(t *testing.T) {
 	testCases := []struct {
 		name       string
 		configText string
+		extraGates []string
 		// wantEnabled nil means "expect whatever default the runner registered for the gate",
 		// read programmatically from the feature gates parsed out of the stanza-less config.
 		wantEnabled *bool
@@ -98,6 +99,24 @@ featureGates:
 `,
 			wantEnabled: boolPtr(false),
 		},
+		{
+			name: "flowControl gate enabled via flag without a featureGates stanza",
+			configText: `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+`,
+			extraGates:  []string{flowcontrol.FeatureGate},
+			wantEnabled: boolPtr(true),
+		},
+		{
+			name: "flag overrides the config's featureGates stanza",
+			configText: `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+featureGates:
+- flowControl=false
+`,
+			extraGates:  []string{flowcontrol.FeatureGate + "=true"},
+			wantEnabled: boolPtr(true),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -107,6 +126,7 @@ featureGates:
 
 			opts := runserver.NewOptions()
 			opts.ConfigText = tc.configText
+			opts.FeatureGates = tc.extraGates
 			opts.PoolName = "test-pool"
 
 			r := NewRunner()
@@ -146,4 +166,25 @@ featureGates:
 			}
 		})
 	}
+}
+
+// TestFeatureGatesFlagNotDuplicatedAcrossCalls pins the r.rawConfig cache against the flag path:
+// Run calls parseConfigurationPhaseOne to choose the K8s vs file-discovery route and setup calls it
+// again, so an uncached append would grow the gate list on every call.
+func TestFeatureGatesFlagNotDuplicatedAcrossCalls(t *testing.T) {
+	ctx := context.Background()
+
+	opts := runserver.NewOptions()
+	opts.FeatureGates = []string{flowcontrol.FeatureGate}
+
+	r := NewRunner()
+	first, err := r.parseConfigurationPhaseOne(ctx, opts)
+	require.NoError(t, err)
+	require.Contains(t, first.FeatureGates, flowcontrol.FeatureGate,
+		"the flag gate must land in rawConfig, not only in the returned map")
+
+	second, err := r.parseConfigurationPhaseOne(ctx, opts)
+	require.NoError(t, err)
+	require.Same(t, first, second, "the cached config should be returned")
+	require.Len(t, second.FeatureGates, 1, "the flag gate must not be appended twice")
 }

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -754,7 +754,7 @@ func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver
 
 	r.registerInTreePlugins()
 
-	rawConfig, featureGates, err := loader.LoadRawConfig(configBytes, logger)
+	rawConfig, featureGates, err := loader.LoadRawConfig(configBytes, logger, opts.FeatureGates...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config - %w", err)
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,10 @@ If the configuration is in a file, the EPP command line argument `--config-file`
  to specify the full path of the file in question. If the configuration is passed as in-line
  text the EPP command line argument `--config-text` should be used.
 
+Feature gates can also be set with the `--feature-gates` command line argument, which takes a 
+ comma-separated list of kubelet-style `name=bool` entries; a bare name enables the gate. These
+ entries are applied after the configuration's own `featureGates` list, so they override it.
+
 ### Default plugins
 
 The EPP injects these plugins when they are absent, so a configuration does not need to list them. Some
@@ -211,7 +215,8 @@ RequestHandler:
 
 FlowControl:
 - The flow control admission layer itself is off by default; enable it with
-  `featureGates: ["flowControl"]`.
+  `featureGates: ["flowControl"]` in the configuration, or with
+  `--feature-gates=flowControl=true` on the command line.
 - `fcfs-ordering-policy`, `global-strict-fairness-policy`, and `static-usage-limit-policy` are configured when absent.
 - `utilization-detector` is configured as the saturation detector when none is set.
 

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -79,7 +79,7 @@ func RegisterFeatureGate(gate string, isEnabledByDefault bool) {
 
 // LoadRawConfig parses the raw configuration bytes, applies initial defaults, and extracts feature gates.
 // It does not instantiate plugins.
-func LoadRawConfig(configBytes []byte, logger logr.Logger) (*configapi.EndpointPickerConfig, map[string]bool, error) {
+func LoadRawConfig(configBytes []byte, logger logr.Logger, extraGates ...string) (*configapi.EndpointPickerConfig, map[string]bool, error) {
 	var rawConfig *configapi.EndpointPickerConfig
 	var err error
 	if len(configBytes) != 0 {
@@ -129,6 +129,16 @@ func LoadRawConfig(configBytes []byte, logger logr.Logger) (*configapi.EndpointP
 	}
 
 	applyStaticDefaults(rawConfig)
+
+	// Appended after the config's own entries because loadFeatureConfig is last-wins,
+	// so flag-supplied gates override file-supplied ones. This mutates rawConfig rather
+	// than only the returned map: InstantiateAndConfigure and validateConfig each
+	// re-derive gates from rawConfig.FeatureGates, and applying a gate to only one of
+	// the three leaves the EPP inconsistent.
+	if len(extraGates) > 0 {
+		rawConfig.FeatureGates = append(rawConfig.FeatureGates, extraGates...)
+		logger.Info("Applied feature gates from flags", "gates", extraGates)
+	}
 
 	// We validate gates early because they might dictate downstream loading logic.
 	if err := validateFeatureGates(rawConfig.FeatureGates); err != nil {

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -379,6 +379,92 @@ func TestLoadRawConfiguration(t *testing.T) {
 	}
 }
 
+// TestLoadRawConfigExtraGates verifies that flag-supplied feature gates are appended to the
+// configuration's own featureGates list, and so take precedence over it. The rawConfig assertion
+// matters as much as the map: InstantiateAndConfigure and validateConfig each re-derive gate from
+// rawConfig.FeatureGates, so a gate applied only to the returned map would leave them disagreeing.
+func TestLoadRawConfigExtraGates(t *testing.T) {
+	t.Parallel()
+
+	RegisterFeatureGate(testFeatureGate, true)
+	RegisterFeatureGate(flowcontrol.FeatureGate, false)
+
+	tests := []struct {
+		name       string
+		configText string
+		extraGates []string
+		wantGates  map[string]bool
+		wantRaw    configapi.FeatureGates
+		wantErr    bool
+	}{
+		{
+			name:       "flag gate with no config",
+			extraGates: []string{flowcontrol.FeatureGate},
+			wantGates: map[string]bool{
+				testFeatureGate:         true,
+				flowcontrol.FeatureGate: true,
+			},
+			wantRaw: configapi.FeatureGates{flowcontrol.FeatureGate},
+		},
+		{
+			name:       "flag explicit false overrides registered default",
+			extraGates: []string{testFeatureGate + "=false"},
+			wantGates: map[string]bool{
+				testFeatureGate:         false,
+				flowcontrol.FeatureGate: false,
+			},
+			wantRaw: configapi.FeatureGates{testFeatureGate + "=false"},
+		},
+		{
+			name:       "bare flag gate overrides file's explicit false",
+			configText: successNoProfilesText,
+			extraGates: []string{testFeatureGate},
+			wantGates: map[string]bool{
+				testFeatureGate:         true,
+				flowcontrol.FeatureGate: false,
+			},
+			wantRaw: configapi.FeatureGates{testFeatureGate + "=false", testFeatureGate},
+		},
+		{
+			name: "no flag gates leaves config untouched",
+			wantGates: map[string]bool{
+				testFeatureGate:         true,
+				flowcontrol.FeatureGate: false,
+			},
+			wantRaw: configapi.FeatureGates{},
+		},
+		{
+			name:       "unregistered flag gate is rejected",
+			extraGates: []string{"no-such-gate"},
+			wantErr:    true,
+		},
+		{
+			name:       "non-boolean flag value is rejected",
+			extraGates: []string{flowcontrol.FeatureGate + "=notabool"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			logger := logging.NewTestLogger()
+
+			got, gates, err := LoadRawConfig([]byte(tc.configText), logger, tc.extraGates...)
+
+			if tc.wantErr {
+				require.Error(t, err, "Expected LoadRawConfig to fail")
+				return
+			}
+			require.NoError(t, err, "Expected LoadRawConfig to succeed")
+
+			require.Empty(t, cmp.Diff(tc.wantGates, gates), "Resolved feature gates mismatch")
+			require.Empty(t, cmp.Diff(tc.wantRaw, got.FeatureGates),
+				"rawConfig.FeatureGates must carry the flag entries so later phases derive the same gates")
+		})
+	}
+}
+
 // --- Test: Phase 2 (Instantiation, System Defaulting, Deep Validation) ---
 
 func TestPluginsWithDependencies(t *testing.T) {

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -118,8 +118,9 @@ type Options struct {
 	//
 	// Configuration.
 	//
-	ConfigFile string // The path to the configuration file.
-	ConfigText string // The configuration specified as text, in lieu of a file.
+	ConfigFile   string   // The path to the configuration file.
+	ConfigText   string   // The configuration specified as text, in lieu of a file.
+	FeatureGates []string // Feature gates applied on top of the configuration's featureGates.
 
 	AllowExperimentalPlugins bool // Allows loading of experimental Alpha plugins.
 
@@ -236,6 +237,10 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 		"Directory with the metrics server certificates. Enables TLS on the metrics endpoint.")
 	fs.StringVar(&opts.ConfigFile, "config-file", opts.ConfigFile, "The path to the configuration file.")
 	fs.StringVar(&opts.ConfigText, "config-text", opts.ConfigText, "The configuration specified as text, in lieu of a file.")
+	fs.StringSliceVar(&opts.FeatureGates, "feature-gates", opts.FeatureGates,
+		"Comma-separated list of feature gates to enable or disable, in kubelet style "+
+			"(e.g., 'flowControl=true'). A bare name enables the gate. Applied after the "+
+			"configuration's featureGates list, so these override entries set there.")
 	fs.BoolVar(&opts.AllowExperimentalPlugins, "allow-experimental-plugins", opts.AllowExperimentalPlugins,
 		"Allows loading of experimental Alpha plugins.")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enabling an EPP feature gate currently requires owning the entire `EndpointPickerConfig` document. The chart splices it into the ConfigMap as a single string, and Helm replaces strings rather than merging them, so an overlay that wants to add only a gate has to restate the whole plugin list. Those copies drift — llm-d/llm-d#2252 worked around this with a `kubectl patch` that rewrites the whole `plugins` key, and its own reviewer note warns that anything extra in a deployment gets silently dropped.

This adds `--feature-gates`, taking kubelet-style `name=bool` entries (a bare name enables the gate). Entries are appended to `rawConfig.FeatureGates` in `LoadRawConfig` after the config is decoded and before `validateFeatureGates`, so `loadFeatureConfig`'s last-wins ordering makes flag entries override file entries, and a typo'd gate from the flag is rejected exactly like one from the file.

Appending to the struct rather than the map `LoadRawConfig` returns is load-bearing: `InstantiateAndConfigure` and `validateConfig` each re-derive gates from `rawConfig.FeatureGates`. Patching only the returned map would give `r.featureGates[flowControl] == true` alongside a nil `FlowControlConfig`, and `initAdmissionControl` would then nil-deref `.Registry`.

Verified on a kind cluster by patching only the EPP args:

| | before | after |
|---|---|---|
| ConfigMap `featureGates` | absent | absent |
| EPP args | — | `--feature-gates=flowControl=true` |
| Startup log | `Flow Control layer is disabled via the flowControl feature gate` | `Initializing Flow Control layer` |

Two notes for reviewers: slice flags render as `{}` in the "Flags processed" log line, which is pre-existing and matches `tls-cipher-suites` and `endpoint-target-ports`. And `make vulncheck` fails identically on clean `main` (Go 1.26.5 stdlib, fixed in 1.26.6).

**Which issue(s) this PR fixes**:
Refs llm-d/llm-d-router#2358 — part (a) only; @hugosmoreira is taking (b).

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Adds a `--feature-gates` EPP flag taking kubelet-style `name=bool` entries (a bare name enables the gate). Entries are applied after the configuration file's `featureGates` list and override it, so a deployment can enable a gate such as `flowControl` without restating the whole `EndpointPickerConfig`.
```
