### PR TITLE
fix(tokenizer): translate Anthropic tool calls and thinking for render

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -676,9 +676,19 @@ type MessagesRequest struct {
 	// not a message with role "system".
 	System AnthropicContent `json:"system,omitempty"`
 	// Tools field for tool use capabilities.
-	Tools []any `json:"tools,omitempty"`
+	Tools []AnthropicTool `json:"tools,omitempty"`
 	// CacheSalt isolates prefix caches for security.
 	CacheSalt string `json:"cache_salt,omitempty"`
+}
+
+// AnthropicTool is a tool definition in the Anthropic schema. InputSchema keeps
+// the raw JSON bytes so the wire key order survives downstream re-serialization.
+type AnthropicTool struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description,omitempty"`
+	InputSchema  json.RawMessage `json:"input_schema,omitempty"`
+	Strict       *bool           `json:"strict,omitempty"`
+	DeferLoading *bool           `json:"defer_loading,omitempty"`
 }
 
 func (r *MessagesRequest) String() string {
@@ -743,11 +753,23 @@ func (ac AnthropicContent) textLen() int {
 	return n
 }
 
+// AnthropicContentBlock is one block of an Anthropic content array. Field sets
+// are disjoint per Type; Input and InputSchema keep raw JSON bytes to preserve
+// the wire key order for token-faithful re-serialization.
 type AnthropicContentBlock struct {
 	Type string `json:"type"`
 	Text string `json:"text,omitempty"`
 	// image source fields (base64 or URL)
 	Source *AnthropicImageSource `json:"source,omitempty"`
+	// tool_use fields (assistant messages): the model's request to call a tool.
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// tool_result fields (user messages): the outcome of a tool_use call.
+	ToolUseID string           `json:"tool_use_id,omitempty"`
+	Content   AnthropicContent `json:"content,omitempty"`
+	// thinking field (assistant messages): extended-thinking replay.
+	Thinking string `json:"thinking,omitempty"`
 }
 
 type AnthropicImageSource struct {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -162,8 +162,7 @@ func chatPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 			return body.Payload
 		}
 	}
-	rcr := ChatCompletionsToRenderChatRequest(body.ChatCompletions)
-	data, _ := json.Marshal(buildChatRenderRequest("", rcr))
+	data, _ := json.Marshal(buildChatRenderRequest(ChatCompletionsToRenderChatRequest(body.ChatCompletions)))
 	var pm fwkrh.PayloadMap
 	_ = json.Unmarshal(data, &pm)
 	return pm
@@ -173,10 +172,21 @@ func chatPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 // body uses the Anthropic Messages schema (top-level system, source-based image
 // blocks), which vLLM /render does not accept, so the payload is always rebuilt
 // from the typed struct into the /render chat schema regardless of body.Payload.
+// Messages and tools are embedded as raw JSON rather than decoded maps: Go maps
+// re-serialize with sorted keys, which would reorder tool schemas and break
+// token parity with what vLLM renders server-side.
 func messagesPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
-	data, _ := json.Marshal(buildChatRenderRequest("", MessagesToRenderChatRequest(body.Messages)))
-	var pm fwkrh.PayloadMap
-	_ = json.Unmarshal(data, &pm)
+	rr := buildChatRenderRequest(MessagesToRenderChatRequest(body.Messages))
+	msgs := make([]any, len(rr.Messages))
+	for i, m := range rr.Messages {
+		data, _ := json.Marshal(m)
+		msgs[i] = json.RawMessage(data)
+	}
+	pm := fwkrh.PayloadMap{"messages": msgs}
+	if len(rr.Tools) > 0 {
+		data, _ := json.Marshal(rr.Tools)
+		pm["tools"] = json.RawMessage(data)
+	}
 	return pm
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -36,8 +36,6 @@ import (
 // pseudo-tokens covers the same input bytes as an N-token raw-byte block.
 const bytesPerToken = 4
 
-const blockTypeText = "text"
-
 // estimateBackend packs request bytes into pseudo-tokens with no real tokenizer.
 // The IDs suit content-locality hashing only; they never match engine KV blocks,
 // so pairing this backend with the engine-correlated scorer yields misses, not bad routes.
@@ -243,16 +241,8 @@ func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fw
 			out = append(out, raw...)
 		}
 	}
-	// The system field accepts only text -- a string or an array of text blocks.
-	// See https://docs.anthropic.com/en/api/messages#body-system.
-	if req.System.Raw != "" {
-		out = append(out, []byte(req.System.Raw)...)
-	} else {
-		for _, block := range req.System.Structured {
-			if block.Type == blockTypeText {
-				out = append(out, []byte(block.Text)...)
-			}
-		}
+	if sys := anthropicSystemText(req.System); sys != "" {
+		out = append(out, []byte(sys)...)
 	}
 	for _, msg := range req.Messages {
 		if msg.Role != "" {
@@ -266,9 +256,22 @@ func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fw
 			switch block.Type {
 			case blockTypeText:
 				out = append(out, []byte(block.Text)...)
-			case "image":
+			case blockTypeImage:
 				if content, count := b.img.placeholderForAnthropicImage(block.Source); content != "" {
 					out, features = appendMMAsset(out, features, fwkrh.ModalityImage, content, count)
+				}
+			case blockTypeThinking:
+				out = append(out, []byte(block.Thinking)...)
+			case blockTypeToolUse:
+				out = append(out, []byte(block.ID)...)
+				out = append(out, []byte(block.Name)...)
+				out = append(out, block.Input...)
+			case blockTypeToolResult:
+				text, imageBlocks := anthropicToolResultContent(block)
+				out = append(out, []byte(text)...)
+				for _, img := range imageBlocks {
+					url := img.ImageURL.URL
+					out, features = appendMMAsset(out, features, fwkrh.ModalityImage, url, b.img.placeholderCount(url))
 				}
 			}
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -607,10 +607,10 @@ func TestEstimateBackend_ChatToolsBeforeSystem(t *testing.T) {
 // TestEstimateBackend_MessagesToolsBeforeSystem is the /v1/messages analog of
 // TestEstimateBackend_ChatToolsBeforeSystem.
 func TestEstimateBackend_MessagesToolsBeforeSystem(t *testing.T) {
-	tools := []any{map[string]any{
-		"name":         "search_for_long_enough_byte_segment_for_this_ordering_test",
-		"description":  "ensures stable byte length",
-		"input_schema": map[string]any{"type": "object"},
+	tools := []fwkrh.AnthropicTool{{
+		Name:        "search_for_long_enough_byte_segment_for_this_ordering_test",
+		Description: "ensures stable byte length",
+		InputSchema: json.RawMessage(`{"type": "object"}`),
 	}}
 	toolsJSON, err := json.Marshal(tools)
 	require.NoError(t, err)
@@ -665,7 +665,7 @@ func TestEstimateBackend_ChatToolsAffectPrefix(t *testing.T) {
 // TestEstimateBackend_MessagesToolsAffectPrefix is the /v1/messages analog of
 // TestEstimateBackend_ChatToolsAffectPrefix.
 func TestEstimateBackend_MessagesToolsAffectPrefix(t *testing.T) {
-	build := func(tools []any) *fwkrh.InferenceRequestBody {
+	build := func(tools []fwkrh.AnthropicTool) *fwkrh.InferenceRequestBody {
 		return &fwkrh.InferenceRequestBody{Messages: &fwkrh.MessagesRequest{
 			Messages: []fwkrh.AnthropicMessage{
 				{Role: "user", Content: fwkrh.AnthropicContent{Raw: "hello world"}},
@@ -675,20 +675,16 @@ func TestEstimateBackend_MessagesToolsAffectPrefix(t *testing.T) {
 	}
 	noTools, err := estimateBackend{}.produce(context.Background(), build(nil))
 	require.NoError(t, err)
-	weather := []any{map[string]any{
-		"name":         "get_weather",
-		"description":  "Get the current weather",
-		"input_schema": map[string]any{"type": "object"},
-	}}
-	withTools, err := estimateBackend{}.produce(context.Background(), build(weather))
+	withTools, err := estimateBackend{}.produce(context.Background(), build([]fwkrh.AnthropicTool{{
+		Name:        "get_weather",
+		Description: "Get the current weather",
+	}}))
 	require.NoError(t, err)
 	assert.NotEqual(t, hashTokens(noTools.PerPromptTokens[0]), hashTokens(withTools.PerPromptTokens[0]), "tools list was ignored by the messages prefix estimator")
-	stock := []any{map[string]any{
-		"name":         "get_stock_price",
-		"description":  "Get a stock price",
-		"input_schema": map[string]any{"type": "object"},
-	}}
-	otherTools, err := estimateBackend{}.produce(context.Background(), build(stock))
+	otherTools, err := estimateBackend{}.produce(context.Background(), build([]fwkrh.AnthropicTool{{
+		Name:        "get_stock_price",
+		Description: "Get a stock price",
+	}}))
 	require.NoError(t, err)
 	assert.NotEqual(t, hashTokens(withTools.PerPromptTokens[0]), hashTokens(otherTools.PerPromptTokens[0]), "different tools lists produced identical tokens")
 }
@@ -738,4 +734,43 @@ func TestEstimateBackend_SingleStringCompletionsSetsPerPromptTokens(t *testing.T
 	if len(tp.PerPromptTokens) != 1 {
 		t.Errorf("single-string prompt should set length-1 PerPromptTokens, got %d", len(tp.PerPromptTokens))
 	}
+}
+
+// TestEstimateBackend_MessagesToolBlocksAffectPrefix asserts tool_use,
+// tool_result, and thinking blocks participate in the prefix stream so
+// conversations differing only in tool traffic do not collide on one key.
+func TestEstimateBackend_MessagesToolBlocksAffectPrefix(t *testing.T) {
+	build := func(blocks []fwkrh.AnthropicContentBlock) *fwkrh.InferenceRequestBody {
+		return &fwkrh.InferenceRequestBody{Messages: &fwkrh.MessagesRequest{
+			Messages: []fwkrh.AnthropicMessage{
+				{Role: "assistant", Content: fwkrh.AnthropicContent{Structured: blocks}},
+			},
+		}}
+	}
+	base := build([]fwkrh.AnthropicContentBlock{})
+	baseOut, err := estimateBackend{}.produce(context.Background(), base)
+	require.NoError(t, err)
+
+	thinking := build([]fwkrh.AnthropicContentBlock{{Type: "thinking", Thinking: "deep thought"}})
+	thinkingOut, err := estimateBackend{}.produce(context.Background(), thinking)
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(baseOut.PerPromptTokens[0]), hashTokens(thinkingOut.PerPromptTokens[0]),
+		"thinking text was ignored by the prefix estimator")
+
+	toolUse := build([]fwkrh.AnthropicContentBlock{{
+		Type: "tool_use", ID: "toolu_01", Name: "get_weather", Input: json.RawMessage(`{"city":"Zurich"}`),
+	}})
+	toolUseOut, err := estimateBackend{}.produce(context.Background(), toolUse)
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(baseOut.PerPromptTokens[0]), hashTokens(toolUseOut.PerPromptTokens[0]),
+		"tool_use input was ignored by the prefix estimator")
+
+	toolResult := build([]fwkrh.AnthropicContentBlock{{
+		Type: "tool_result", ToolUseID: "toolu_01",
+		Content: fwkrh.AnthropicContent{Raw: "Sunny, 22C"},
+	}})
+	toolResultOut, err := estimateBackend{}.produce(context.Background(), toolResult)
+	require.NoError(t, err)
+	assert.NotEqual(t, hashTokens(baseOut.PerPromptTokens[0]), hashTokens(toolResultOut.PerPromptTokens[0]),
+		"tool_result content was ignored by the prefix estimator")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/pythonjson.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/pythonjson.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenizer
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// pythonDumps re-serializes raw JSON the way CPython's json.dumps does with
+// default settings (separators ", " and ": ", ensure_ascii=True), preserving
+// object key order and number literals. vLLM embeds json.dumps(tool input)
+// into the rendered prompt, so tool-call arguments must match byte-for-byte
+// for prefix-cache hits.
+func pythonDumps(raw json.RawMessage) (string, error) {
+	var sb strings.Builder
+	if err := dumpValue(&sb, bytes.TrimSpace(raw)); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+func dumpValue(sb *strings.Builder, raw []byte) error {
+	switch {
+	case len(raw) == 0:
+		return errors.New("pythonDumps: empty JSON value")
+	case raw[0] == '{':
+		return dumpDelimited(sb, raw, '{')
+	case raw[0] == '[':
+		return dumpDelimited(sb, raw, '[')
+	case raw[0] == '"':
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return fmt.Errorf("pythonDumps: decode string: %w", err)
+		}
+		writeJSONString(sb, s)
+		return nil
+	default:
+		// Numbers, booleans, and null pass through as their wire literal.
+		var n json.Number
+		if string(raw) != "null" && string(raw) != "true" && string(raw) != "false" && json.Unmarshal(raw, &n) != nil {
+			return fmt.Errorf("pythonDumps: invalid value %s", raw)
+		}
+		sb.Write(raw)
+		return nil
+	}
+}
+
+// dumpDelimited re-serializes an object or array, keyed on the opening
+// delimiter.
+func dumpDelimited(sb *strings.Builder, raw []byte, open byte) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	if _, err := dec.Token(); err != nil { // consume the opening delimiter
+		return fmt.Errorf("pythonDumps: decode start: %w", err)
+	}
+	closer, sep := '}', ": "
+	if open == '[' {
+		closer, sep = ']', ", "
+	}
+	sb.WriteByte(open)
+	first := true
+	for dec.More() {
+		if !first {
+			sb.WriteString(", ")
+		}
+		first = false
+		if open == '{' {
+			tok, err := dec.Token()
+			if err != nil {
+				return fmt.Errorf("pythonDumps: decode object key: %w", err)
+			}
+			key, ok := tok.(string)
+			if !ok {
+				return fmt.Errorf("pythonDumps: unexpected object key %v", tok)
+			}
+			writeJSONString(sb, key)
+			sb.WriteString(sep)
+		}
+		var val json.RawMessage
+		if err := dec.Decode(&val); err != nil {
+			return fmt.Errorf("pythonDumps: decode value: %w", err)
+		}
+		if err := dumpValue(sb, bytes.TrimSpace(val)); err != nil {
+			return err
+		}
+	}
+	sb.WriteRune(closer)
+	return nil
+}
+
+// writeJSONString writes an already-decoded string as a CPython JSON string
+// literal: short escapes for the classic control characters, \u00xx for the
+// rest of the control range, and \uxxxx (surrogate pairs above the BMP) for
+// all non-ASCII runes, matching ensure_ascii=True.
+func writeJSONString(sb *strings.Builder, s string) {
+	sb.WriteByte('"')
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case r == '"':
+			sb.WriteString(`\"`)
+		case r == '\\':
+			sb.WriteString(`\\`)
+		case r == '\b':
+			sb.WriteString(`\b`)
+		case r == '\f':
+			sb.WriteString(`\f`)
+		case r == '\n':
+			sb.WriteString(`\n`)
+		case r == '\r':
+			sb.WriteString(`\r`)
+		case r == '\t':
+			sb.WriteString(`\t`)
+		case r < 0x20 || r == 0x7f:
+			fmt.Fprintf(sb, `\u%04x`, r)
+		case r < utf8.RuneSelf:
+			sb.WriteByte(byte(r))
+		case r > 0xFFFF:
+			r1, r2 := utf16.EncodeRune(r)
+			fmt.Fprintf(sb, `\u%04x\u%04x`, r1, r2)
+		default:
+			fmt.Fprintf(sb, `\u%04x`, r)
+		}
+		i += size
+	}
+	sb.WriteByte('"')
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -640,14 +640,19 @@ func convertAnthropicTools(tools []fwkrh.AnthropicTool) []any {
 }
 
 // anthropicImageToURL converts an Anthropic image source to an OpenAI-shaped
-// URL. Base64 sources (the default when the type is missing) become data URIs
-// with a image/jpeg media type when absent; URL sources pass through.
+// URL. Sources carrying a URL pass it through (URL sources, and sources
+// missing a type); base64 sources become data URIs, with an image/jpeg media
+// type when absent. Sources with neither a URL nor data yield "" so the
+// caller drops the block.
 func anthropicImageToURL(src *fwkrh.AnthropicImageSource) string {
 	if src == nil {
 		return ""
 	}
-	if src.Type == "url" {
+	if src.Type == "url" || src.URL != "" {
 		return src.URL
+	}
+	if src.Data == "" {
+		return ""
 	}
 	mediaType := src.MediaType
 	if mediaType == "" {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -20,11 +20,13 @@ limitations under the License.
 package tokenizer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	kvctok "github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
@@ -55,6 +57,25 @@ const (
 	LegacyPluginType = "tokenizer"
 
 	tokenizedPromptKeyID = "TokenizedPrompt"
+
+	// anthropicBillingHeaderPrefix marks Claude Code system text that carries a
+	// per-request hash; vLLM strips it server-side, so the tokenizer must too.
+	anthropicBillingHeaderPrefix = "x-anthropic-billing-header"
+
+	// defaultImageMediaType fills in Anthropic base64 image sources with no
+	// media_type, matching vLLM's conversion.
+	defaultImageMediaType = "image/jpeg"
+)
+
+// Content-block types the Anthropic Messages conversion reads and emits.
+const (
+	blockTypeText             = "text"
+	blockTypeImage            = "image"
+	blockTypeImageURL         = "image_url"
+	blockTypeThinking         = "thinking"
+	blockTypeRedactedThinking = "redacted_thinking"
+	blockTypeToolUse          = "tool_use"
+	blockTypeToolResult       = "tool_result"
 )
 
 var TokenizedPromptDataKey = plugin.NewDataKey(tokenizedPromptKeyID, PluginType)
@@ -370,7 +391,7 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 	for _, msg := range chat.Messages {
 		conv := tokenizerTypes.Conversation{
 			Role:      msg.Role,
-			Content:   tokenizerTypes.Content{Raw: msg.Content.Raw},
+			Content:   &tokenizerTypes.Content{Raw: msg.Content.Raw},
 			ToolCalls: msg.ToolCalls,
 		}
 		for _, block := range msg.Content.Structured {
@@ -395,70 +416,244 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 	}
 }
 
-// MessagesToRenderChatRequest converts an Anthropic MessagesRequest to a
-// tokenization RenderChatRequest for vLLM /render endpoint with System, Message and Tools set in RenderChatRequest only.
+// MessagesToRenderChatRequest converts an Anthropic MessagesRequest into the
+// OpenAI chat shape vLLM builds when serving /v1/messages, so the render
+// backend and the server apply the identical chat-template pipeline to the
+// same request and prefix-cache blocks line up.
 func MessagesToRenderChatRequest(msg *fwkrh.MessagesRequest) *tokenizerTypes.RenderChatRequest {
 	conversation := make([]tokenizerTypes.Conversation, 0, 1+len(msg.Messages))
 
-	if msg.System.Raw != "" || len(msg.System.Structured) > 0 {
+	if sys := anthropicSystemText(msg.System); sys != "" {
 		conversation = append(conversation, tokenizerTypes.Conversation{
 			Role:    "system",
-			Content: convertAnthropicContent(msg.System),
+			Content: &tokenizerTypes.Content{Raw: sys},
 		})
 	}
 
 	for _, m := range msg.Messages {
-		conversation = append(conversation, tokenizerTypes.Conversation{
-			Role:    m.Role, // role: user, assistant, system
-			Content: convertAnthropicContent(m.Content),
-		})
+		if m.Role == "system" {
+			// Not valid Anthropic input; tolerated the way vLLM does.
+			if text := anthropicSystemText(m.Content); text != "" {
+				conversation = append(conversation, tokenizerTypes.Conversation{
+					Role:    "system",
+					Content: &tokenizerTypes.Content{Raw: text},
+				})
+			}
+			continue
+		}
+		conversation = appendAnthropicMessage(conversation, m)
 	}
 
 	return &tokenizerTypes.RenderChatRequest{
 		Conversation: conversation,
-		Tools:        msg.Tools,
+		Tools:        convertAnthropicTools(msg.Tools),
 	}
 }
 
-// convertAnthropicContent converts an AnthropicContent to the kv-cache tokenizer Content type
-// mapping Anthropic image blocks to OpenAI-shaped image_url blocks.
-func convertAnthropicContent(ac fwkrh.AnthropicContent) tokenizerTypes.Content {
+// anthropicSystemText joins the system prompt's text blocks with no
+// separator, dropping Claude Code's per-request billing header so it does not
+// defeat prefix caching (mirrors vLLM).
+func anthropicSystemText(ac fwkrh.AnthropicContent) string {
 	if ac.Raw != "" {
-		return tokenizerTypes.Content{Raw: ac.Raw}
+		return ac.Raw
 	}
-	blocks := make([]tokenizerTypes.ContentBlock, 0, len(ac.Structured))
-	for _, b := range ac.Structured {
+	var sb strings.Builder
+	for _, block := range ac.Structured {
+		if block.Type == blockTypeText && block.Text != "" && !strings.HasPrefix(block.Text, anthropicBillingHeaderPrefix) {
+			sb.WriteString(block.Text)
+		}
+	}
+	return sb.String()
+}
+
+// appendAnthropicMessage appends the conversations for one message. User
+// tool_result blocks append their tool messages immediately, so those precede
+// the user message that carried them - the order vLLM emits.
+func appendAnthropicMessage(conversation []tokenizerTypes.Conversation, m fwkrh.AnthropicMessage) []tokenizerTypes.Conversation {
+	if m.Content.Raw != "" {
+		return append(conversation, tokenizerTypes.Conversation{
+			Role:    m.Role,
+			Content: &tokenizerTypes.Content{Raw: m.Content.Raw},
+		})
+	}
+
+	var contentBlocks []tokenizerTypes.ContentBlock
+	var toolCalls []any
+	var reasoning strings.Builder
+	for _, b := range m.Content.Structured {
 		switch b.Type {
-		case "text":
-			blocks = append(blocks, tokenizerTypes.ContentBlock{
-				Type: "text",
-				Text: b.Text,
-			})
-		case "image":
-			if url := anthropicImageToURL(b.Source); url != "" {
-				blocks = append(blocks, tokenizerTypes.ContentBlock{
-					Type:     "image_url",
-					ImageURL: tokenizerTypes.ImageBlock{URL: url},
+		case blockTypeText:
+			if b.Text != "" {
+				contentBlocks = append(contentBlocks, tokenizerTypes.ContentBlock{Type: blockTypeText, Text: b.Text})
+			}
+		case blockTypeImage:
+			contentBlocks = appendImageBlock(contentBlocks, b.Source)
+		case blockTypeThinking:
+			reasoning.WriteString(b.Thinking)
+		case blockTypeRedactedThinking:
+			// Opaque safety-filtered reasoning; parses but contributes no tokens.
+		case blockTypeToolUse:
+			toolCalls = append(toolCalls, anthropicToolCall(b))
+		case blockTypeToolResult:
+			if m.Role == "user" {
+				conversation = appendAnthropicToolResult(conversation, b)
+			} else {
+				text, _ := anthropicToolResultContent(b)
+				contentBlocks = append(contentBlocks, tokenizerTypes.ContentBlock{
+					Type: blockTypeText,
+					Text: "Tool result: " + text,
 				})
 			}
 		}
 	}
-	return tokenizerTypes.Content{Structured: blocks}
+
+	conv := tokenizerTypes.Conversation{Role: m.Role}
+	if reasoning.Len() > 0 {
+		conv.Reasoning = reasoning.String()
+	}
+	conv.ToolCalls = toolCalls
+	switch {
+	case len(contentBlocks) == 1 && contentBlocks[0].Type == blockTypeText:
+		conv.Content = &tokenizerTypes.Content{Raw: contentBlocks[0].Text}
+	case len(contentBlocks) > 0:
+		conv.Content = &tokenizerTypes.Content{Structured: contentBlocks}
+	}
+	// A user message reduced to bare tool_results has no content of its own;
+	// its tool messages were already appended above.
+	if m.Role == "user" && conv.Content == nil {
+		return conversation
+	}
+	return append(conversation, conv)
 }
 
-// anthropicImageToURL converts an Anthropic image source to an OpenAI-shaped URL.
-// Base64 sources become data URIs; URL sources pass through.
+// appendImageBlock maps an Anthropic image source to an OpenAI image_url
+// content block; sources that resolve to no URL are dropped.
+func appendImageBlock(blocks []tokenizerTypes.ContentBlock, src *fwkrh.AnthropicImageSource) []tokenizerTypes.ContentBlock {
+	if url := anthropicImageToURL(src); url != "" {
+		blocks = append(blocks, tokenizerTypes.ContentBlock{
+			Type:     blockTypeImageURL,
+			ImageURL: tokenizerTypes.ImageBlock{URL: url},
+		})
+	}
+	return blocks
+}
+
+// anthropicToolCall converts a tool_use block into an OpenAI function tool
+// call. Arguments are CPython json.dumps formatted (separators, ASCII
+// escaping, wire key order) - the exact string vLLM renders into the prompt.
+func anthropicToolCall(b fwkrh.AnthropicContentBlock) map[string]any {
+	id := b.ID
+	if id == "" {
+		// vLLM falls back to call_<unix-time>; a fixed stand-in only keeps the
+		// rendered length stable (ids are generated in practice).
+		id = "call_0000000000"
+	}
+	return map[string]any{
+		"id":   id,
+		"type": "function",
+		"function": map[string]any{
+			"name":      b.Name,
+			"arguments": pythonArguments(b.Input),
+		},
+	}
+}
+
+// pythonArguments renders tool_use input as json.dumps(input or {}): absent,
+// null, and empty-object inputs all render as "{}".
+func pythonArguments(raw json.RawMessage) string {
+	switch string(bytes.TrimSpace(raw)) {
+	case "", "null", "{}":
+		return "{}"
+	}
+	if out, err := pythonDumps(raw); err == nil {
+		return out
+	}
+	return "{}"
+}
+
+// appendAnthropicToolResult appends a tool-role message for a user
+// tool_result block; images in the result follow as their own user message.
+func appendAnthropicToolResult(conversation []tokenizerTypes.Conversation, b fwkrh.AnthropicContentBlock) []tokenizerTypes.Conversation {
+	text, imageBlocks := anthropicToolResultContent(b)
+	conversation = append(conversation, tokenizerTypes.Conversation{
+		Role:       "tool",
+		ToolCallID: b.ToolUseID,
+		Content:    &tokenizerTypes.Content{Raw: text},
+	})
+	if len(imageBlocks) > 0 {
+		conversation = append(conversation, tokenizerTypes.Conversation{
+			Role:    "user",
+			Content: &tokenizerTypes.Content{Structured: imageBlocks},
+		})
+	}
+	return conversation
+}
+
+// anthropicToolResultContent splits a tool_result's content into its text
+// (block texts joined with newlines) and image blocks.
+func anthropicToolResultContent(b fwkrh.AnthropicContentBlock) (string, []tokenizerTypes.ContentBlock) {
+	if b.Content.Raw != "" {
+		return b.Content.Raw, nil
+	}
+	var parts []string
+	var imageBlocks []tokenizerTypes.ContentBlock
+	for _, item := range b.Content.Structured {
+		switch item.Type {
+		case blockTypeText:
+			parts = append(parts, item.Text)
+		case blockTypeImage:
+			imageBlocks = appendImageBlock(imageBlocks, item.Source)
+		}
+	}
+	return strings.Join(parts, "\n"), imageBlocks
+}
+
+// convertAnthropicTools rewrites Anthropic tool definitions into OpenAI
+// function tools. input_schema passes through as raw JSON so the template's
+// re-serialization keeps the wire key order.
+func convertAnthropicTools(tools []fwkrh.AnthropicTool) []any {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(tools))
+	for _, t := range tools {
+		var schema json.RawMessage = bytes.TrimSpace(t.InputSchema)
+		if len(schema) == 0 || bytes.Equal(schema, []byte("null")) {
+			schema = json.RawMessage(`{"type":"object"}`)
+		}
+		fn := map[string]any{
+			"name":       t.Name,
+			"parameters": schema,
+		}
+		if t.Description != "" {
+			fn["description"] = t.Description
+		}
+		if t.Strict != nil {
+			fn["strict"] = *t.Strict
+		}
+		if t.DeferLoading != nil {
+			fn["defer_loading"] = *t.DeferLoading
+		}
+		out = append(out, map[string]any{"type": "function", "function": fn})
+	}
+	return out
+}
+
+// anthropicImageToURL converts an Anthropic image source to an OpenAI-shaped
+// URL. Base64 sources (the default when the type is missing) become data URIs
+// with a image/jpeg media type when absent; URL sources pass through.
 func anthropicImageToURL(src *fwkrh.AnthropicImageSource) string {
 	if src == nil {
 		return ""
 	}
-	if src.URL != "" {
+	if src.Type == "url" {
 		return src.URL
 	}
-	if src.Data != "" {
-		return "data:" + src.MediaType + ";base64," + src.Data
+	mediaType := src.MediaType
+	if mediaType == "" {
+		mediaType = defaultImageMediaType
 	}
-	return ""
+	return "data:" + mediaType + ";base64," + src.Data
 }
 
 // convertMMFeaturesToUpstream flattens the kv-cache map-shaped multimodal

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -802,6 +802,37 @@ func TestMessagesToRenderChatRequest_StructuredMessage(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "image with no media type defaults to jpeg",
+			messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{
+					Structured: []fwkrh.AnthropicContentBlock{
+						{Type: "image", Source: &fwkrh.AnthropicImageSource{Type: "base64", Data: "abc123"}},
+					},
+				}},
+			},
+			wantConv: []tokenizerTypes.Conversation{
+				{Role: "user", Content: &tokenizerTypes.Content{
+					Structured: []tokenizerTypes.ContentBlock{
+						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "data:image/jpeg;base64,abc123"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "image source with neither URL nor data is dropped",
+			messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{
+					Structured: []fwkrh.AnthropicContentBlock{
+						{Type: "text", Text: "Describe this"},
+						{Type: "image", Source: &fwkrh.AnthropicImageSource{Type: "base64"}},
+					},
+				}},
+			},
+			wantConv: []tokenizerTypes.Conversation{
+				{Role: "user", Content: &tokenizerTypes.Content{Raw: "Describe this"}},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -431,9 +431,9 @@ func TestChatCompletionsToRenderChatRequest(t *testing.T) {
 
 	require.Len(t, result.Conversation, 2)
 	assert.Equal(t, "system", result.Conversation[0].Role)
-	assert.Equal(t, tokenizerTypes.Content{Raw: "You are a helpful assistant."}, result.Conversation[0].Content)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "You are a helpful assistant."}, result.Conversation[0].Content)
 	assert.Equal(t, "assistant", result.Conversation[1].Role)
-	assert.Equal(t, tokenizerTypes.Content{Raw: "Reflection."}, result.Conversation[1].Content)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "Reflection."}, result.Conversation[1].Content)
 	assert.Equal(t, "template", result.ChatTemplate)
 	assert.True(t, result.AddGenerationPrompt)
 	assert.False(t, result.ContinueFinalMessage)
@@ -544,7 +544,7 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 				}},
 			},
 			wantConv: []tokenizerTypes.Conversation{
-				{Role: "user", Content: tokenizerTypes.Content{
+				{Role: "user", Content: &tokenizerTypes.Content{
 					Structured: []tokenizerTypes.ContentBlock{
 						{Type: "text", Text: "Describe this image"},
 						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "data:image/png;base64,abc123"}},
@@ -565,8 +565,8 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 				}},
 			},
 			wantConv: []tokenizerTypes.Conversation{
-				{Role: "system", Content: tokenizerTypes.Content{Raw: "You are a visual analyst."}},
-				{Role: "user", Content: tokenizerTypes.Content{
+				{Role: "system", Content: &tokenizerTypes.Content{Raw: "You are a visual analyst."}},
+				{Role: "user", Content: &tokenizerTypes.Content{
 					Structured: []tokenizerTypes.ContentBlock{
 						{Type: "text", Text: "Compare these two images"},
 						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "data:image/png;base64,img1"}},
@@ -588,14 +588,14 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 				{Role: "user", Content: fwkrh.Content{Raw: "What breed is it?"}},
 			},
 			wantConv: []tokenizerTypes.Conversation{
-				{Role: "user", Content: tokenizerTypes.Content{
+				{Role: "user", Content: &tokenizerTypes.Content{
 					Structured: []tokenizerTypes.ContentBlock{
 						{Type: "text", Text: "What is in this image?"},
 						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "https://example.com/img.jpg"}},
 					},
 				}},
-				{Role: "assistant", Content: tokenizerTypes.Content{Raw: "I see a dog."}},
-				{Role: "user", Content: tokenizerTypes.Content{Raw: "What breed is it?"}},
+				{Role: "assistant", Content: &tokenizerTypes.Content{Raw: "I see a dog."}},
+				{Role: "user", Content: &tokenizerTypes.Content{Raw: "What breed is it?"}},
 			},
 		},
 		{
@@ -604,7 +604,7 @@ func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
 				{Role: "user", Content: fwkrh.Content{Raw: "Hello!"}},
 			},
 			wantConv: []tokenizerTypes.Conversation{
-				{Role: "user", Content: tokenizerTypes.Content{Raw: "Hello!"}},
+				{Role: "user", Content: &tokenizerTypes.Content{Raw: "Hello!"}},
 			},
 		},
 	}
@@ -635,13 +635,15 @@ func TestMessagesToRenderChatRequest_RawSystem(t *testing.T) {
 
 	require.Len(t, result.Conversation, 2)
 	assert.Equal(t, "system", result.Conversation[0].Role)
-	assert.Equal(t, tokenizerTypes.Content{Raw: "You are helpful."}, result.Conversation[0].Content)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "You are helpful."}, result.Conversation[0].Content)
 	assert.Equal(t, "user", result.Conversation[1].Role)
-	assert.Equal(t, tokenizerTypes.Content{Raw: "Hello"}, result.Conversation[1].Content)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "Hello"}, result.Conversation[1].Content)
 }
 
 func TestMessagesToRenderChatRequest_Tools(t *testing.T) {
-	tools := []any{map[string]any{"name": "get_weather"}}
+	tools := []fwkrh.AnthropicTool{
+		{Name: "get_weather", Description: "Get the weather", InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`)},
+	}
 	msg := &fwkrh.MessagesRequest{
 		Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "What is the weather today?"}}},
 		Tools:    tools,
@@ -649,7 +651,46 @@ func TestMessagesToRenderChatRequest_Tools(t *testing.T) {
 
 	result := MessagesToRenderChatRequest(msg)
 
-	assert.Equal(t, tools, result.Tools)
+	require.Len(t, result.Tools, 1)
+	assert.Equal(t, map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "get_weather",
+			"description": "Get the weather",
+			"parameters":  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+		},
+	}, result.Tools[0])
+}
+
+func TestMessagesToRenderChatRequest_ToolDefaults(t *testing.T) {
+	strict, deferLoading := true, false
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hi"}}},
+		Tools: []fwkrh.AnthropicTool{
+			{Name: "no_schema"},
+			{Name: "flags", InputSchema: json.RawMessage(`null`), Strict: &strict, DeferLoading: &deferLoading},
+		},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Tools, 2)
+	assert.Equal(t, map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":       "no_schema",
+			"parameters": json.RawMessage(`{"type":"object"}`),
+		},
+	}, result.Tools[0])
+	assert.Equal(t, map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":          "flags",
+			"parameters":    json.RawMessage(`{"type":"object"}`),
+			"strict":        true,
+			"defer_loading": false,
+		},
+	}, result.Tools[1])
 }
 
 func TestMessagesToRenderChatRequest_StructuredSystem(t *testing.T) {
@@ -667,10 +708,24 @@ func TestMessagesToRenderChatRequest_StructuredSystem(t *testing.T) {
 
 	require.Len(t, result.Conversation, 2)
 	assert.Equal(t, "system", result.Conversation[0].Role)
-	require.Len(t, result.Conversation[0].Content.Structured, 2)
-	assert.Equal(t, "text", result.Conversation[0].Content.Structured[0].Type)
-	assert.Equal(t, "System line 1.", result.Conversation[0].Content.Structured[0].Text)
-	assert.Equal(t, "System line 2.", result.Conversation[0].Content.Structured[1].Text)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "System line 1.System line 2."}, result.Conversation[0].Content)
+}
+
+func TestMessagesToRenderChatRequest_SystemBillingHeaderStripped(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		System: fwkrh.AnthropicContent{
+			Structured: []fwkrh.AnthropicContentBlock{
+				{Type: "text", Text: "x-anthropic-billing-header: 7b3f2c"},
+				{Type: "text", Text: "Real system prompt."},
+			},
+		},
+		Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hi"}}},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 2)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "Real system prompt."}, result.Conversation[0].Content)
 }
 
 func TestMessagesToRenderChatRequest_NoSystem(t *testing.T) {
@@ -701,7 +756,7 @@ func TestMessagesToRenderChatRequest_StructuredMessage(t *testing.T) {
 				}},
 			},
 			wantConv: []tokenizerTypes.Conversation{
-				{Role: "user", Content: tokenizerTypes.Content{
+				{Role: "user", Content: &tokenizerTypes.Content{
 					Structured: []tokenizerTypes.ContentBlock{
 						{Type: "text", Text: "Hello"},
 						{Type: "text", Text: "World"},
@@ -720,7 +775,7 @@ func TestMessagesToRenderChatRequest_StructuredMessage(t *testing.T) {
 				}},
 			},
 			wantConv: []tokenizerTypes.Conversation{
-				{Role: "user", Content: tokenizerTypes.Content{
+				{Role: "user", Content: &tokenizerTypes.Content{
 					Structured: []tokenizerTypes.ContentBlock{
 						{Type: "text", Text: "Describe this"},
 						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "data:image/png;base64,abc123"}},
@@ -739,7 +794,7 @@ func TestMessagesToRenderChatRequest_StructuredMessage(t *testing.T) {
 				}},
 			},
 			wantConv: []tokenizerTypes.Conversation{
-				{Role: "user", Content: tokenizerTypes.Content{
+				{Role: "user", Content: &tokenizerTypes.Content{
 					Structured: []tokenizerTypes.ContentBlock{
 						{Type: "text", Text: "Describe this"},
 						{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "https://example.com/img.jpg"}},
@@ -800,6 +855,262 @@ func TestProduce_MessagesRequest(t *testing.T) {
 	msgs, ok := pm["messages"].([]any)
 	require.True(t, ok, "payload must carry the /render chat messages array")
 	require.Len(t, msgs, 2)
-	assert.Equal(t, "system", msgs[0].(map[string]any)["role"])
-	assert.Equal(t, "user", msgs[1].(map[string]any)["role"])
+	assertRolesInOrder(t, msgs, "system", "user")
+}
+
+// assertRolesInOrder unmarshals pre-encoded render messages and asserts their
+// roles appear in the given order.
+func assertRolesInOrder(t *testing.T, msgs []any, roles ...string) {
+	t.Helper()
+	require.Len(t, msgs, len(roles))
+	for i, want := range roles {
+		raw, ok := msgs[i].(json.RawMessage)
+		require.True(t, ok, "message %d must be pre-encoded JSON", i)
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(raw, &m), "message %d must be valid JSON", i)
+		assert.Equal(t, want, m["role"], "message %d role", i)
+	}
+}
+
+// TestPythonDumps pins the CPython json.dumps formatting that vLLM bakes into
+// rendered tool-call arguments: ", "/": " separators, ensure_ascii escapes,
+// and wire key order and number literals preserved.
+func TestPythonDumps(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"object with separators", `{"city":"Zürich","n":5}`, `{"city": "Z\u00fcrich", "n": 5}`},
+		{"nested arrays and objects", `{"z":1,"a":[{"y":1,"b":2},true,null,"x"]}`, `{"z": 1, "a": [{"y": 1, "b": 2}, true, null, "x"]}`},
+		{"empty object", `{}`, `{}`},
+		{"null", `null`, `null`},
+		{"escapes", `{"s":"a\"b\\c\nd e","f":"/"}`, `{"s": "a\"b\\c\nd e", "f": "/"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pythonDumps(json.RawMessage(tt.in))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPythonDumpsNonASCIIEscaped(t *testing.T) {
+	got, err := pythonDumps(json.RawMessage(`{"e":"Zürich 😀"}`))
+	require.NoError(t, err)
+	assert.Equal(t, `{"e": "Z\u00fcrich \ud83d\ude00"}`, got)
+}
+
+func TestPythonArguments(t *testing.T) {
+	assert.Equal(t, "{}", pythonArguments(nil))
+	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`null`)))
+	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`{}`)))
+	assert.Equal(t, `{"a": 1}`, pythonArguments(json.RawMessage(`{"a":1}`)))
+}
+
+// TestMessagesToRenderChatRequest_ToolUseAndThinking covers an assistant
+// turn replaying thinking and requesting a tool: reasoning joins without a
+// separator, tool_calls carry CPython-formatted arguments, and a message with
+// no content parts omits content entirely.
+func TestMessagesToRenderChatRequest_ToolUseAndThinking(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Book a table"}},
+			{Role: "assistant", Content: fwkrh.AnthropicContent{
+				Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "thinking", Thinking: "The user wants dinner."},
+					{Type: "redacted_thinking"},
+					{Type: "text", Text: "Sure."},
+					{Type: "tool_use", ID: "toolu_01", Name: "book_table", Input: json.RawMessage(`{"guests":2,"time":"19:00"}`)},
+					{Type: "tool_use", ID: "toolu_02", Name: "notify", Input: json.RawMessage(`null`)},
+				},
+			}},
+		},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 2)
+	assistant := result.Conversation[1]
+	assert.Equal(t, "assistant", assistant.Role)
+	assert.Equal(t, "The user wants dinner.", assistant.Reasoning)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "Sure."}, assistant.Content)
+	require.Len(t, assistant.ToolCalls, 2)
+	assert.Equal(t, map[string]any{
+		"id":   "toolu_01",
+		"type": "function",
+		"function": map[string]any{
+			"name":      "book_table",
+			"arguments": `{"guests": 2, "time": "19:00"}`,
+		},
+	}, assistant.ToolCalls[0])
+	assert.Equal(t, map[string]any{
+		"id":   "toolu_02",
+		"type": "function",
+		"function": map[string]any{
+			"name":      "notify",
+			"arguments": "{}",
+		},
+	}, assistant.ToolCalls[1])
+}
+
+func TestMessagesToRenderChatRequest_AssistantToolOnlyOmitsContent(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "assistant", Content: fwkrh.AnthropicContent{
+				Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "tool_use", ID: "toolu_01", Name: "run", Input: json.RawMessage(`{"cmd":"ls"}`)},
+				},
+			}},
+		},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 1)
+	assert.Nil(t, result.Conversation[0].Content)
+	require.Len(t, result.Conversation[0].ToolCalls, 1)
+}
+
+// TestMessagesToRenderChatRequest_ToolResult covers the user turn answering a
+// tool call: the tool message is emitted before the user message that carried
+// it, block texts join with newlines, and result images become their own user
+// message. A user message reduced to bare tool results disappears.
+func TestMessagesToRenderChatRequest_ToolResult(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "user", Content: fwkrh.AnthropicContent{
+				Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "tool_result", ToolUseID: "toolu_01", Content: fwkrh.AnthropicContent{
+						Structured: []fwkrh.AnthropicContentBlock{
+							{Type: "text", Text: "stdout line 1"},
+							{Type: "text", Text: "stdout line 2"},
+							{Type: "image", Source: &fwkrh.AnthropicImageSource{Type: "base64", MediaType: "image/png", Data: "abc"}},
+						},
+					}},
+					{Type: "text", Text: "What do you see?"},
+				},
+			}},
+			{Role: "user", Content: fwkrh.AnthropicContent{
+				Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "tool_result", ToolUseID: "toolu_02", Content: fwkrh.AnthropicContent{Raw: "plain string result"}},
+				},
+			}},
+		},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 4)
+
+	tool1 := result.Conversation[0]
+	assert.Equal(t, "tool", tool1.Role)
+	assert.Equal(t, "toolu_01", tool1.ToolCallID)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "stdout line 1\nstdout line 2"}, tool1.Content)
+
+	images := result.Conversation[1]
+	assert.Equal(t, "user", images.Role)
+	assert.Equal(t, &tokenizerTypes.Content{
+		Structured: []tokenizerTypes.ContentBlock{
+			{Type: "image_url", ImageURL: tokenizerTypes.ImageBlock{URL: "data:image/png;base64,abc"}},
+		},
+	}, images.Content)
+
+	user := result.Conversation[2]
+	assert.Equal(t, "user", user.Role)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "What do you see?"}, user.Content)
+
+	tool2 := result.Conversation[3]
+	assert.Equal(t, "tool", tool2.Role)
+	assert.Equal(t, "toolu_02", tool2.ToolCallID)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "plain string result"}, tool2.Content)
+}
+
+func TestMessagesToRenderChatRequest_ToolResultOnlyUserDropped(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "user", Content: fwkrh.AnthropicContent{
+				Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "tool_result", ToolUseID: "toolu_01", Content: fwkrh.AnthropicContent{Raw: "result"}},
+				},
+			}},
+		},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 1)
+	assert.Equal(t, "tool", result.Conversation[0].Role)
+}
+
+// TestMessagesToRenderChatRequest_FullAgenticTurn exercises a representative
+// tool-use round trip end to end.
+func TestMessagesToRenderChatRequest_FullAgenticTurn(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		System: fwkrh.AnthropicContent{Raw: "You can use tools."},
+		Tools: []fwkrh.AnthropicTool{{
+			Name:        "get_weather",
+			Description: "Get the weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+		}},
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Weather in Zurich?"}},
+			{Role: "assistant", Content: fwkrh.AnthropicContent{
+				Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "tool_use", ID: "toolu_01", Name: "get_weather", Input: json.RawMessage(`{"city":"Zurich"}`)},
+				},
+			}},
+			{Role: "user", Content: fwkrh.AnthropicContent{
+				Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "tool_result", ToolUseID: "toolu_01", Content: fwkrh.AnthropicContent{Raw: "Sunny, 22C"}},
+				},
+			}},
+		},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 4)
+	assert.Equal(t, "system", result.Conversation[0].Role)
+	assert.Equal(t, "user", result.Conversation[1].Role)
+	assert.Equal(t, "assistant", result.Conversation[2].Role)
+	assert.Nil(t, result.Conversation[2].Content)
+	assert.Equal(t, "tool", result.Conversation[3].Role)
+	assert.Equal(t, "toolu_01", result.Conversation[3].ToolCallID)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "Sunny, 22C"}, result.Conversation[3].Content)
+	require.Len(t, result.Tools, 1)
+}
+
+// TestProduce_MessagesRequestToolSchemaOrder asserts that tool input_schema
+// key order survives the trip to the render payload: Go maps would
+// alphabetize the keys and desynchronize prefix hashes from the engine's.
+func TestProduce_MessagesRequestToolSchemaOrder(t *testing.T) {
+	var gotPayload fwkrh.RequestPayload
+	tok := &mockTokenizer{
+		renderChatFunc: func(payload fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			gotPayload = payload
+			return []uint32{1}, nil, nil
+		},
+	}
+	p := newTestPlugin(tok)
+
+	req := &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			Messages: &fwkrh.MessagesRequest{
+				Tools: []fwkrh.AnthropicTool{{
+					Name:        "get_weather",
+					InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+				}},
+				Messages: []fwkrh.AnthropicMessage{{Role: "user", Content: fwkrh.AnthropicContent{Raw: "hi"}}},
+			},
+		},
+	}
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+
+	rendered, err := json.Marshal(gotPayload)
+	require.NoError(t, err)
+	assert.Contains(t, string(rendered),
+		`"parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`,
+		"input_schema key order must be preserved verbatim")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -52,6 +52,10 @@ const (
 	maxErrorBodySnippetBytes = 1024
 )
 
+// arrayContentMarker detects an array-valued "content" field inside a
+// pre-marshaled chat message (multimodal parts).
+var arrayContentMarker = []byte(`"content":[`)
+
 // vllmConfig configures the vLLM /render backend. Future protocol fields
 // (e.g., grpc) can be added alongside url.
 type vllmConfig struct {
@@ -91,7 +95,11 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 		return nil, fmt.Errorf("invalid 'mmTimeout': %w", err)
 	}
 	return &vllmHTTPRenderer{
-		client:    &http.Client{Transport: otelhttp.NewTransport(newRenderTransport())},
+		client: &http.Client{Transport: otelhttp.NewTransport(newRenderTransport(), otelhttp.WithSpanNameFormatter(
+			// Name the outbound span after the render route instead of the
+			// transport's default "HTTP POST" so traces identify render calls.
+			func(_ string, r *http.Request) string { return "tokenize_render " + r.URL.Path },
+		))},
 		baseURL:   url,
 		modelName: modelName,
 		timeout:   timeout,
@@ -178,13 +186,18 @@ func (r *vllmHTTPRenderer) chatTimeout(payload fwkrh.PayloadMap) time.Duration {
 		return r.timeout
 	}
 	for _, rawMessage := range messages {
-		message, ok := rawMessage.(map[string]any)
-		if !ok {
-			continue
-		}
 		// Array-shaped content may require multimodal rendering; use the longer timeout.
-		if parts, ok := message["content"].([]any); ok && len(parts) > 0 {
-			return r.mmTimeout
+		switch message := rawMessage.(type) {
+		case map[string]any:
+			if parts, ok := message["content"].([]any); ok && len(parts) > 0 {
+				return r.mmTimeout
+			}
+		case json.RawMessage:
+			// Rebuilt payloads (Anthropic messages) carry pre-marshaled messages;
+			// an array-valued content field signals multimodal parts.
+			if bytes.Contains(message, arrayContentMarker) {
+				return r.mmTimeout
+			}
 		}
 	}
 	return r.timeout
@@ -200,9 +213,9 @@ func (r *vllmHTTPRenderer) produceTimeout() time.Duration {
 }
 
 // chatRenderRequest is the wire body for POST /v1/chat/completions/render.
-// Used by the non-PayloadMap fallback path (gRPC, warmup).
+// Used by the non-PayloadMap fallback path (gRPC, warmup). The model is
+// stamped in by the renderer, not carried here.
 type chatRenderRequest struct {
-	Model                string         `json:"model"`
 	Messages             []chatMessage  `json:"messages"`
 	Tools                []any          `json:"tools,omitempty"`
 	Documents            []any          `json:"documents,omitempty"`
@@ -214,10 +227,14 @@ type chatRenderRequest struct {
 
 // chatMessage is one OpenAI-shaped message. Content is either a plain string
 // or an array of parts; chatContent's MarshalJSON picks the right wire form.
+// A nil Content omits the key entirely, matching messages that carry only
+// tool_calls or reasoning.
 type chatMessage struct {
-	Role      string      `json:"role"`
-	Content   chatContent `json:"content"`
-	ToolCalls []any       `json:"tool_calls,omitempty"`
+	Role       string       `json:"role"`
+	Content    *chatContent `json:"content,omitempty"`
+	ToolCalls  []any        `json:"tool_calls,omitempty"`
+	Reasoning  string       `json:"reasoning,omitempty"`
+	ToolCallID string       `json:"tool_call_id,omitempty"`
 }
 
 // chatContent serializes either Raw (string) or Parts (array of typed parts).
@@ -248,17 +265,18 @@ type chatImageURL struct {
 // buildChatRenderRequest projects the kvcache RenderChatRequest into the
 // OpenAI-shaped wire body expected by vLLM's /v1/chat/completions/render.
 // Unknown content-block types are skipped (mirrors the UDS path's behavior).
-func buildChatRenderRequest(model string, req *tokenizerTypes.RenderChatRequest) chatRenderRequest {
+func buildChatRenderRequest(req *tokenizerTypes.RenderChatRequest) chatRenderRequest {
 	msgs := make([]chatMessage, len(req.Conversation))
 	for idx, c := range req.Conversation {
 		msgs[idx] = chatMessage{
-			Role:      c.Role,
-			Content:   toChatContent(c.Content),
-			ToolCalls: c.ToolCalls,
+			Role:       c.Role,
+			Content:    toChatContent(c.Content),
+			ToolCalls:  c.ToolCalls,
+			Reasoning:  c.Reasoning,
+			ToolCallID: c.ToolCallID,
 		}
 	}
 	return chatRenderRequest{
-		Model:                model,
 		Messages:             msgs,
 		Tools:                req.Tools,
 		Documents:            req.Documents,
@@ -269,22 +287,25 @@ func buildChatRenderRequest(model string, req *tokenizerTypes.RenderChatRequest)
 	}
 }
 
-func toChatContent(c tokenizerTypes.Content) chatContent {
-	if len(c.Structured) == 0 {
-		return chatContent{Raw: c.Raw}
+func toChatContent(c *tokenizerTypes.Content) *chatContent {
+	if c == nil {
+		return nil
 	}
-	parts := make([]chatPart, len(c.Structured))
-	for idx, b := range c.Structured {
+	if len(c.Structured) == 0 {
+		return &chatContent{Raw: c.Raw}
+	}
+	parts := make([]chatPart, 0, len(c.Structured))
+	for _, b := range c.Structured {
 		switch b.Type {
-		case "text":
-			parts[idx] = chatPart{Type: "text", Text: b.Text}
-		case "image_url":
-			parts[idx] = chatPart{Type: "image_url", ImageURL: &chatImageURL{URL: b.ImageURL.URL}}
+		case blockTypeText:
+			parts = append(parts, chatPart{Type: blockTypeText, Text: b.Text})
+		case blockTypeImageURL:
+			parts = append(parts, chatPart{Type: blockTypeImageURL, ImageURL: &chatImageURL{URL: b.ImageURL.URL}})
 		default:
 			// Unsupported by the kvcache ContentBlock schema; skip.
 		}
 	}
-	return chatContent{Parts: parts}
+	return &chatContent{Parts: parts}
 }
 
 // renderResponse is the subset of vLLM's GenerateRequest we consume.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -24,17 +24,21 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	tokenizerTypes "github.com/llm-d/llm-d-router/pkg/kvcache/tokenization/types"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -335,5 +339,104 @@ func TestVLLMHTTPRenderer_RenderPropagatesTraceContext(t *testing.T) {
 	}
 	if !strings.Contains(gotTraceparent, traceID.String()) {
 		t.Fatalf("expected outbound traceparent to carry trace ID %s, got %q", traceID, gotTraceparent)
+	}
+}
+
+// TestVLLMHTTPRenderer_ChatTimeoutRawMessages asserts that pre-marshaled
+// (Anthropic-rebuilt) messages with array content still select the multimodal
+// timeout.
+func TestVLLMHTTPRenderer_ChatTimeoutRawMessages(t *testing.T) {
+	r := &vllmHTTPRenderer{timeout: 5 * time.Second, mmTimeout: 30 * time.Second}
+
+	textOnly := fwkrh.PayloadMap{"messages": []any{
+		json.RawMessage(`{"role":"user","content":"hi"}`),
+	}}
+	assert.Equal(t, 5*time.Second, r.chatTimeout(textOnly))
+
+	multimodal := fwkrh.PayloadMap{"messages": []any{
+		json.RawMessage(`{"role":"user","content":"hi"}`),
+		json.RawMessage(`{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,abc"}}]}`),
+	}}
+	assert.Equal(t, 30*time.Second, r.chatTimeout(multimodal))
+}
+
+// TestBuildChatRenderRequest_MessageFields asserts the wire shape of rebuilt
+// messages: tool_calls and reasoning ride along, tool messages carry
+// tool_call_id, and content is omitted when absent.
+func TestBuildChatRenderRequest_MessageFields(t *testing.T) {
+	req := &tokenizerTypes.RenderChatRequest{
+		Conversation: []tokenizerTypes.Conversation{
+			{Role: "assistant", Content: nil, Reasoning: "hmm", ToolCalls: []any{map[string]any{
+				"id":   "t1",
+				"type": "function",
+				"function": map[string]any{
+					"name":      "run",
+					"arguments": `{"cmd": "ls"}`,
+				},
+			}}},
+			{Role: "tool", ToolCallID: "t1", Content: &tokenizerTypes.Content{Raw: "out"}},
+		},
+	}
+
+	data, err := json.Marshal(buildChatRenderRequest(req))
+	require.NoError(t, err)
+
+	var msgs []map[string]any
+	require.NoError(t, json.Unmarshal(data, &struct {
+		Messages *[]map[string]any `json:"messages"`
+	}{&msgs}))
+	require.Len(t, msgs, 2)
+
+	assert.NotContains(t, msgs[0], "content", "assistant with only tool_calls omits content")
+	assert.Equal(t, "hmm", msgs[0]["reasoning"])
+	assert.Equal(t, []any{map[string]any{
+		"id":   "t1",
+		"type": "function",
+		"function": map[string]any{
+			"name":      "run",
+			"arguments": `{"cmd": "ls"}`,
+		},
+	}}, msgs[0]["tool_calls"])
+
+	assert.Equal(t, "tool", msgs[1]["role"])
+	assert.Equal(t, "t1", msgs[1]["tool_call_id"])
+	assert.Equal(t, "out", msgs[1]["content"])
+}
+
+// TestVLLMHTTPRenderer_RenderSpanName asserts the outbound render span is
+// named after the render route instead of the transport default "HTTP POST".
+func TestVLLMHTTPRenderer_RenderSpanName(t *testing.T) {
+	prevTP := otel.GetTracerProvider()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"token_ids":[1]}]`))
+	}))
+	defer srv.Close()
+
+	// The transport resolves its tracer from the global provider at
+	// construction, so the renderer must be built after the swap above.
+	r := newHTTPRenderer(t, srv)
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "parent")
+	_, _, err := r.Render(ctx, fwkrh.PayloadMap{"prompt": "hello"})
+	span.End()
+	require.NoError(t, err)
+
+	var clientSpans []tracetest.SpanStub
+	for _, s := range exporter.GetSpans() {
+		if s.SpanKind == trace.SpanKindClient {
+			clientSpans = append(clientSpans, s)
+		}
+	}
+	require.NotEmpty(t, clientSpans, "expected a client span for the render call")
+	for _, s := range clientSpans {
+		assert.Equal(t, "tokenize_render /v1/completions/render", s.Name)
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
@@ -267,10 +269,10 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 			want: &fwkrh.InferenceRequestBody{
 				MaxOutputTokens: ptr.To(int64(1024)),
 				Messages: &fwkrh.MessagesRequest{
-					Tools: []any{
-						map[string]any{
-							"name":        "get_weather",
-							"description": "Get the weather",
+					Tools: []fwkrh.AnthropicTool{
+						{
+							Name:        "get_weather",
+							Description: "Get the weather",
 						},
 					},
 					Messages: []fwkrh.AnthropicMessage{
@@ -723,4 +725,60 @@ func TestAnthropicParser_ParseRequest_MaxOutputTokens(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseRequest_ToolBlocks verifies tool_use, tool_result, and thinking
+// blocks survive parsing with their raw JSON (input order preserved) intact.
+func TestParseRequest_ToolBlocks(t *testing.T) {
+	parser := NewAnthropicParser()
+	body := `{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"tools": [{
+			"name": "get_weather",
+			"description": "Get the weather",
+			"input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}
+		}],
+		"messages": [
+			{"role": "user", "content": "Weather in Zurich?"},
+			{"role": "assistant", "content": [
+				{"type": "thinking", "thinking": "need the tool"},
+				{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "Zurich"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_01", "content": [
+					{"type": "text", "text": "Sunny"}
+				]}
+			]}
+		]
+	}`
+
+	got, err := parser.ParseRequest(context.Background(), []byte(body), map[string]string{":path": "/v1/messages"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Body.Messages)
+
+	msgs := got.Body.Messages.Messages
+	require.Len(t, msgs, 3)
+
+	assistant := msgs[1].Content.Structured
+	require.Len(t, assistant, 2)
+	assert.Equal(t, "thinking", assistant[0].Type)
+	assert.Equal(t, "need the tool", assistant[0].Thinking)
+	assert.Equal(t, "tool_use", assistant[1].Type)
+	assert.Equal(t, "toolu_01", assistant[1].ID)
+	assert.Equal(t, "get_weather", assistant[1].Name)
+	assert.JSONEq(t, `{"city": "Zurich"}`, string(assistant[1].Input))
+	assert.Equal(t, `{"city": "Zurich"}`, string(assistant[1].Input), "input must keep wire bytes")
+
+	toolResult := msgs[2].Content.Structured
+	require.Len(t, toolResult, 1)
+	assert.Equal(t, "tool_result", toolResult[0].Type)
+	assert.Equal(t, "toolu_01", toolResult[0].ToolUseID)
+	assert.Equal(t, "Sunny", toolResult[0].Content.Structured[0].Text)
+
+	tools := got.Body.Messages.Tools
+	require.Len(t, tools, 1)
+	assert.Equal(t, "get_weather", tools[0].Name)
+	assert.Equal(t, `{"type": "object", "properties": {"city": {"type": "string"}}}`, string(tools[0].InputSchema),
+		"input_schema must keep wire bytes for order-faithful re-serialization")
 }

--- a/pkg/kvcache/tokenization/types/types.go
+++ b/pkg/kvcache/tokenization/types/types.go
@@ -83,9 +83,14 @@ func (c Content) PlainText() string {
 
 // Conversation represents a single message in a conversation.
 type Conversation struct {
-	Role      string        `json:"role"`
-	Content   Content       `json:"content"`
+	Role    string   `json:"role"`
+	Content *Content `json:"content,omitempty"`
+	// ToolCalls carries assistant tool calls for chat template rendering.
 	ToolCalls []interface{} `json:"tool_calls,omitempty"`
+	// Reasoning carries replayed assistant thinking for templates that render it.
+	Reasoning string `json:"reasoning,omitempty"`
+	// ToolCallID identifies the assistant tool call a tool-role message answers.
+	ToolCallID string `json:"tool_call_id,omitempty"`
 }
 
 // RenderChatRequest represents the request to render a chat template.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

Precise prefix routing was broken for the Anthropic Messages API whenever a conversation used tools or extended thinking. The Messages-to-render translation dropped `tool_use`, `tool_result`, and `thinking` content blocks and forwarded Anthropic-shaped tool definitions (`input_schema`) verbatim, so the tokens computed by the vLLM `/render` backend diverged from what vLLM computes when it serves `/v1/messages` (it converts the request to OpenAI chat shape internally in `vllm/entrypoints/anthropic/serving.py`). The result was prefix-cache misses - or render failures - on tool-using traffic such as Claude Code.

The conversion now mirrors vLLM's own translation so both paths feed the identical chat-template pipeline:

- `tool_use` blocks become `tool_calls` with CPython `json.dumps`-formatted arguments (separators, `ensure_ascii` escaping, preserved wire key order), matching the exact string vLLM renders into the prompt.
- `tool_result` blocks become role-`tool` messages, emitted before the user message that carried them (vLLM's ordering); images in results become their own user message.
- `thinking` blocks become the assistant `reasoning` field; `redacted_thinking` is accepted but contributes no tokens.
- Tool definitions become OpenAI function tools, with `input_schema` passed through as raw JSON so the template's re-serialization keeps the wire key order (a Go map round-trip would alphabetize keys and desynchronize prefix hashes).
- The system prompt joins text blocks with no separator and strips Claude Code's per-request billing header, as vLLM does.
- The estimate backend folds tool/thinking text into its pseudo-token stream so tool traffic no longer collides on one prefix key.
- Outbound render spans are named after the route (`tokenize_render /v1/chat/completions/render`) instead of the generic `HTTP POST`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fixed prefix-cache-aware routing for the Anthropic Messages API with tool use and extended thinking: the tokenizer now translates tool calls, tool results, and thinking blocks the same way vLLM does when serving /v1/messages, so rendered tokens match the server's and prefix routing hits.
```

**Test plan**:
- [x] Unit tests: Anthropic conversion of tool_use (incl. CPython-style argument formatting), tool_result (ordering, tool_call_id, text joining, image follow-up messages), thinking/reasoning, content omission for tool-only assistant messages, system joining and billing-header stripping, and tool-schema conversion.
- [x] Unit tests: render payload preserves tool-schema key order through RenderChat; multimodal timeout detection for rebuilt payloads; outbound render span naming.
- [x] Unit tests: parser round-trips tool_use/tool_result/thinking blocks with wire bytes intact; estimate backend distinguishes tool traffic in the prefix stream.
- [x] `make presubmit` passes; full EPP unit suite green with `-race`.
