### PR TITLE
feat(epp): add sglanghttp parser for /generate

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -106,6 +106,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/passthrough"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vertexai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
@@ -700,6 +701,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(passthrough.PassthroughParserType, fwkplugin.StabilityBeta, passthrough.PassthroughParserPluginFactory)
 	fwkplugin.Register(anthropic.AnthropicParserType, fwkplugin.StabilityBeta, anthropic.AnthropicParserPluginFactory)
 	fwkplugin.Register(vllmhttp.VllmHTTPParserType, fwkplugin.StabilityBeta, vllmhttp.VllmHTTPParserPluginFactory)
+	fwkplugin.Register(sglanghttp.SGLangHTTPParserType, fwkplugin.StabilityBeta, sglanghttp.SGLangHTTPParserPluginFactory)
 	fwkplugin.Register(vertexai.VertexAIParserType, fwkplugin.StabilityBeta, vertexai.VertexAIParserPluginFactory)
 
 	// register saturation detector plugins

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -104,7 +104,8 @@ type InferenceRequestBody struct {
 	Conversations *ConversationsRequest `json:"conversations,omitempty"`
 	// EmbeddingsRequest is the representation of the OpenAI /v1/embeddings request body.
 	Embeddings *EmbeddingsRequest `json:"embeddings,omitempty"`
-	// GenerateRequest is the representation of the vLLM /inference/v1/generate request body.
+	// Generate holds pre-tokenized input for native generate endpoints
+	// (vLLM /inference/v1/generate and SGLang /generate).
 	Generate *GenerateRequest `json:"generate,omitempty"`
 	// ImagesGenerationsRequest is the representation of the OpenAI /v1/images/generations request body.
 	Images *ImagesGenerationsRequest `json:"images,omitempty"`
@@ -483,9 +484,9 @@ func (i *ImagesGenerationsRequest) String() string {
 		len(i.Prompt), i.Size, i.N, i.NumInferenceSteps)
 }
 
-// GenerateRequest is a structured representation of the fields we parse out of the vLLM
-// request at /inference/v1/generate.
-// Unlike the OpenAI-compatible endpoints, this API accepts pre-tokenized input (token IDs).
+// GenerateRequest holds pre-tokenized input for native generate endpoints
+// (vLLM /inference/v1/generate and SGLang /generate). Unlike OpenAI-compatible
+// endpoints, these APIs accept pre-tokenized input (token IDs).
 // This struct includes fields usable for plugins and scheduling decisions.
 type GenerateRequest struct {
 	// TokenIDs are the pre-tokenized input token IDs.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/README.md
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/README.md
@@ -8,6 +8,7 @@ This directory contains parser plugins used to parse and understand the payloads
 *   **`anthropic-parser`**: A parser designed to handle requests for the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages). It supports both standard JSON and streaming SSE responses.
 *   **`vllmgrpc-parser`**: A parser designed to handle requests specifically for the [vLLM gRPC API](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/grpc_server/).
 *   **`vllmhttp-parser`**: A parser for vLLM HTTP endpoints that are not part of the OpenAI-compatible API surface — specifically `/inference/v1/generate` (which accepts pre-tokenized prompts and multimodal features). Because it only handles this path, you must also configure `openai-parser` if you want to support OpenAI-compatible paths on the same route.
+*   **`sglanghttp-parser`**: A parser for SGLang's native HTTP `/generate` endpoint, which is not part of the OpenAI-compatible API. It currently supports a single pre-tokenized prompt or a batch of pre-tokenized prompts. Configure `openai-parser` alongside it if you also want to handle OpenAI-compatible paths on the same route.
 *   **`vertexai-parser`**: A parser designed to handle requests for the Vertex AI gRPC API, specifically supporting [PredictionService/ChatCompletions](https://github.com/googleapis/googleapis/blob/89c3153888201c9e80bc5ec78d6ffca0debe6b52/google/cloud/aiplatform/v1beta1/prediction_service.proto#L235). For unsupported Vertex AI APIs, it skips parsing and lets the request pass through without interpretation resulting in routing to a random endpoint.
 *   **`passthrough-parser`**: A model-agnostic parser that supports any request format by passing the request body through without interpretation.
     *   **Drawback**: EPP cannot parse the payload, so payload-related scheduling scorers (e.g., `prefix-cache-scorer`) are not supported.
@@ -20,7 +21,7 @@ This directory contains parser plugins used to parse and understand the payloads
 
 Parsers are configured via the `requestHandler.parsers` list in the `EndpointPickerConfig` YAML file. You must first instantiate the parser plugin in the `plugins` section, and then reference its name in the `requestHandler.parsers` list.
 
-The EPP resolves incoming request paths to the matching parser using suffix matching. Suffixes are defined by each parser plugin's claims, and the first matching parser in the list is selected. If a parser does not define specific paths, it acts as a fallback for any unmatched traffic.
+The EPP resolves incoming request paths to the matching parser using longest-suffix matching. Suffixes are defined by each parser plugin's claims. If a parser does not define specific paths, it acts as a fallback for any unmatched traffic.
 
 If no parsers are specified, `openai-parser`, `anthropic-parser`, and `vllmhttp-parser` are used by default.
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
@@ -145,7 +145,6 @@ func hasJSONValue(data json.RawMessage) bool {
 	return len(data) > 0 && strings.TrimSpace(string(data)) != "null"
 }
 
-
 func parseCacheSalt(data json.RawMessage) (string, error) {
 	if !hasJSONValue(data) {
 		return "", nil

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
@@ -94,9 +94,6 @@ func (p *SGLangHTTPParser) Claims() fwkrh.Claims {
 type sgLangGenerateWire struct {
 	InputIDs       json.RawMessage `json:"input_ids"`
 	ExtraKey       json.RawMessage `json:"extra_key"`
-	ImageData      json.RawMessage `json:"image_data"`
-	VideoData      json.RawMessage `json:"video_data"`
-	AudioData      json.RawMessage `json:"audio_data"`
 	SamplingParams json.RawMessage `json:"sampling_params"`
 	Stream         bool            `json:"stream"`
 }
@@ -123,9 +120,6 @@ func (p *SGLangHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseRes
 		return nil, fmt.Errorf("invalid generate request: %w", err)
 	}
 
-	if hasMultimodalData(wire.ImageData) || hasMultimodalData(wire.VideoData) || hasMultimodalData(wire.AudioData) {
-		return nil, errors.New("unsupported generate request: multimodal inputs are not supported; only pre-tokenized prompts are supported")
-	}
 	if !hasJSONValue(wire.InputIDs) {
 		return nil, errors.New("invalid generate request: input_ids must be provided")
 	}
@@ -134,51 +128,23 @@ func (p *SGLangHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseRes
 	if err != nil {
 		return nil, fmt.Errorf("unsupported generate request: %w", err)
 	}
-	batches, err := parseInputIDs(wire.InputIDs)
+	tokenIDs, err := parseInputIDs(wire.InputIDs)
 	if err != nil {
 		return nil, fmt.Errorf("invalid generate request: %w", err)
 	}
-	// Single prompt: TokenIDs for the producer to copy. Batch: TokenizedPrompt,
-	// because TokenIDs cannot hold [][]uint32 (producer skips if already set).
-	result := &fwkrh.InferenceRequestBody{
-		Generate:        &fwkrh.GenerateRequest{CacheSalt: cacheSalt},
+
+	return &fwkrh.ParseResult{Body: &fwkrh.InferenceRequestBody{
+		Generate:        &fwkrh.GenerateRequest{TokenIDs: tokenIDs, CacheSalt: cacheSalt},
 		Payload:         fwkrh.RawPayload(rawBody),
 		MaxOutputTokens: maxOutputTokens(wire.SamplingParams),
 		Stream:          wire.Stream,
-	}
-	if len(batches) == 1 {
-		result.Generate.TokenIDs = batches[0]
-	} else {
-		result.TokenizedPrompt = &fwkrh.TokenizedPrompt{
-			PerPromptTokens: batches,
-			CacheSalt:       cacheSalt,
-		}
-	}
-
-	return &fwkrh.ParseResult{Body: result, SkipResponseProcessing: false}, nil
+	}, SkipResponseProcessing: false}, nil
 }
 
 func hasJSONValue(data json.RawMessage) bool {
 	return len(data) > 0 && strings.TrimSpace(string(data)) != "null"
 }
 
-func hasMultimodalData(data json.RawMessage) bool {
-	if !hasJSONValue(data) {
-		return false
-	}
-	var value any
-	if err := json.Unmarshal(data, &value); err != nil {
-		return true
-	}
-	switch typed := value.(type) {
-	case string:
-		return typed != ""
-	case []any:
-		return len(typed) > 0
-	default:
-		return value != nil
-	}
-}
 
 func parseCacheSalt(data json.RawMessage) (string, error) {
 	if !hasJSONValue(data) {
@@ -191,28 +157,15 @@ func parseCacheSalt(data json.RawMessage) (string, error) {
 	return value, nil
 }
 
-func parseInputIDs(data json.RawMessage) ([][]uint32, error) {
-	var single []uint32
-	if err := json.Unmarshal(data, &single); err == nil {
-		if len(single) == 0 {
-			return nil, errors.New("input_ids cannot be empty")
-		}
-		return [][]uint32{single}, nil
+func parseInputIDs(data json.RawMessage) ([]uint32, error) {
+	var ids []uint32
+	if err := json.Unmarshal(data, &ids); err != nil {
+		return nil, errors.New("input_ids must be an array of uint32 integers")
 	}
-
-	var batches [][]uint32
-	if err := json.Unmarshal(data, &batches); err != nil {
-		return nil, errors.New("input_ids must be an array of uint32 integers or arrays of uint32 integers")
-	}
-	if len(batches) == 0 {
+	if len(ids) == 0 {
 		return nil, errors.New("input_ids cannot be empty")
 	}
-	for i, row := range batches {
-		if len(row) == 0 {
-			return nil, fmt.Errorf("input_ids[%d] must be a non-empty array of integers", i)
-		}
-	}
-	return batches, nil
+	return ids, nil
 }
 
 func maxOutputTokens(data json.RawMessage) *int64 {
@@ -228,13 +181,16 @@ func maxOutputTokens(data json.RawMessage) *int64 {
 	return single.MaxNewTokens
 }
 
-// sgLangResponse is the /generate response wire format (non-streaming).
+// sgLangResponse is the /generate response wire format.
 // Usage lives under meta_info, not under usage like the OpenAI format.
 type sgLangResponse struct {
 	MetaInfo struct {
-		PromptTokens     *int `json:"prompt_tokens"`
-		CompletionTokens *int `json:"completion_tokens"`
-		CachedTokens     *int `json:"cached_tokens"`
+		// FinishReason is parsed to identify the last meta_info of a finished stream;
+		// null on intermediate chunks, non-null on the final chunk
+		FinishReason     json.RawMessage `json:"finish_reason"`
+		PromptTokens     *int            `json:"prompt_tokens"`
+		CompletionTokens *int            `json:"completion_tokens"`
+		CachedTokens     *int            `json:"cached_tokens"`
 	} `json:"meta_info"`
 }
 
@@ -246,7 +202,7 @@ func (p *SGLangHTTPParser) ParseResponse(_ context.Context, body []byte, headers
 	if isEventStream(headers) {
 		return &fwkrh.ParsedResponse{Usage: extractStreamingUsage(body)}, nil
 	}
-	usage, err := extractNonStreamingUsage(body)
+	usage, err := parseMetaInfoUsage(body)
 	if err != nil {
 		return nil, err
 	}
@@ -264,10 +220,8 @@ func isEventStream(headers map[string]string) bool {
 }
 
 // extractStreamingUsage reads usage from SGLang SSE data lines.
-// Streaming SSE chunks carry cumulative meta_info; the last parseable chunk is used.
 func extractStreamingUsage(body []byte) *fwkrh.Usage {
 	text := strings.TrimSpace(string(body))
-	var last *fwkrh.Usage
 	for _, line := range strings.Split(text, "\n") {
 		line = strings.TrimSpace(line)
 		data, ok := strings.CutPrefix(line, streamingRespPrefix)
@@ -278,45 +232,18 @@ func extractStreamingUsage(body []byte) *fwkrh.Usage {
 		if data == streamingDoneMarker {
 			continue
 		}
-		if usage, err := parseMetaInfoUsage([]byte(data)); err == nil && usage != nil {
-			last = usage
-		}
-	}
-	return last
-}
-
-// extractNonStreamingUsage reads usage from a single SGLang response object or
-// sums usage across a batch response array.
-func extractNonStreamingUsage(body []byte) (*fwkrh.Usage, error) {
-	text := strings.TrimSpace(string(body))
-	if strings.HasPrefix(text, "[") {
-		return extractBatchUsage(body)
-	}
-	return parseMetaInfoUsage(body)
-}
-
-func extractBatchUsage(body []byte) (*fwkrh.Usage, error) {
-	var responses []json.RawMessage
-	if err := json.Unmarshal(body, &responses); err != nil {
-		return nil, err
-	}
-	total := &fwkrh.Usage{}
-	found := false
-	for _, response := range responses {
-		usage, err := parseMetaInfoUsage(response)
-		if err != nil {
-			return nil, err
-		}
-		if usage == nil {
+		var resp sgLangResponse
+		if err := json.Unmarshal([]byte(data), &resp); err != nil {
 			continue
 		}
-		found = true
-		addUsage(total, usage)
+		// skip intermediate chunks; only the final chunk has a non-null finish_reason
+		if !hasJSONValue(resp.MetaInfo.FinishReason) {
+			continue
+		}
+		usage, _ := parseMetaInfoUsage([]byte(data))
+		return usage
 	}
-	if !found {
-		return nil, nil //nolint:nilnil
-	}
-	return total, nil
+	return nil
 }
 
 func parseMetaInfoUsage(data []byte) (*fwkrh.Usage, error) {
@@ -345,17 +272,4 @@ func intValue(value *int) int {
 		return 0
 	}
 	return *value
-}
-
-// addUsage accumulates per-prompt usage into a request-level total.
-func addUsage(total, usage *fwkrh.Usage) {
-	total.PromptTokens += usage.PromptTokens
-	total.CompletionTokens += usage.CompletionTokens
-	total.TotalTokens += usage.TotalTokens
-	if usage.PromptTokenDetails != nil {
-		if total.PromptTokenDetails == nil {
-			total.PromptTokenDetails = &fwkrh.PromptTokenDetails{}
-		}
-		total.PromptTokenDetails.CachedTokens += usage.PromptTokenDetails.CachedTokens
-	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sglanghttp provides a request parser for SGLang HTTP endpoints that are
+// not part of the OpenAI-compatible API surface — specifically
+// /generate.
+package sglanghttp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+const (
+	// SGLangHTTPParserType is the canonical type name used to register the plugin.
+	SGLangHTTPParserType = "sglanghttp-parser"
+
+	// generatePathSuffix is the SGLang native generate API path.
+	generatePathSuffix = "generate"
+
+	streamingRespPrefix = "data: "
+	streamingDoneMarker = "[DONE]"
+	contentTypeHeader   = "content-type"
+	eventStreamType     = "text/event-stream"
+)
+
+// compile-time type validation
+var (
+	_ fwkrh.Parser = &SGLangHTTPParser{}
+)
+
+// SGLangHTTPParser implements fwkrh.Parser for SGLang's native /generate
+// endpoint. Only pre-tokenized prompts are supported.
+type SGLangHTTPParser struct {
+	typedName fwkplugin.TypedName
+}
+
+// NewSGLangHTTPParser creates a new SGLangHTTPParser.
+func NewSGLangHTTPParser() *SGLangHTTPParser {
+	return &SGLangHTTPParser{
+		typedName: fwkplugin.TypedName{
+			Type: SGLangHTTPParserType,
+			Name: SGLangHTTPParserType,
+		},
+	}
+}
+
+// SGLangHTTPParserPluginFactory is the factory function used to register the plugin.
+func SGLangHTTPParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	return NewSGLangHTTPParser().WithName(name), nil
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *SGLangHTTPParser) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// WithName sets the plugin instance name.
+func (p *SGLangHTTPParser) WithName(name string) *SGLangHTTPParser {
+	p.typedName.Name = name
+	return p
+}
+
+func (p *SGLangHTTPParser) Claims() fwkrh.Claims {
+	return fwkrh.Claims{
+		Paths:     []string{generatePathSuffix},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
+	}
+}
+
+// sgLangGenerateWire is the subset of /generate fields this parser reads.
+type sgLangGenerateWire struct {
+	InputIDs       json.RawMessage `json:"input_ids"`
+	ExtraKey       json.RawMessage `json:"extra_key"`
+	ImageData      json.RawMessage `json:"image_data"`
+	VideoData      json.RawMessage `json:"video_data"`
+	AudioData      json.RawMessage `json:"audio_data"`
+	SamplingParams json.RawMessage `json:"sampling_params"`
+	Stream         bool            `json:"stream"`
+}
+
+type sgLangSamplingParams struct {
+	MaxNewTokens *int64 `json:"max_new_tokens"`
+}
+
+// ParseRequest handles /generate and rejects other paths.
+// It returns a ParseResult containing the decoded InferenceRequestBody.
+func (p *SGLangHTTPParser) ParseRequest(_ context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
+	path := strings.TrimSuffix(strings.TrimSpace(request.GetRequestPath(headers)), "/")
+	if path != generatePathSuffix && path != "/"+generatePathSuffix {
+		return nil, fmt.Errorf("unsupported path: %s", path)
+	}
+	return p.parseGenerateRequest(body)
+}
+
+// parseGenerateRequest decodes a /generate body into an InferenceRequestBody.
+// input_ids are required. Multimodal inputs are not supported.
+func (p *SGLangHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResult, error) {
+	var wire sgLangGenerateWire
+	if err := json.Unmarshal(rawBody, &wire); err != nil {
+		return nil, fmt.Errorf("invalid generate request: %w", err)
+	}
+
+	if hasMultimodalData(wire.ImageData) || hasMultimodalData(wire.VideoData) || hasMultimodalData(wire.AudioData) {
+		return nil, errors.New("unsupported generate request: multimodal inputs are not supported; only pre-tokenized prompts are supported")
+	}
+	if !hasJSONValue(wire.InputIDs) {
+		return nil, errors.New("invalid generate request: input_ids must be provided")
+	}
+
+	cacheSalt, err := parseCacheSalt(wire.ExtraKey)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported generate request: %w", err)
+	}
+	batches, err := parseInputIDs(wire.InputIDs)
+	if err != nil {
+		return nil, fmt.Errorf("invalid generate request: %w", err)
+	}
+	// Single prompt: TokenIDs for the producer to copy. Batch: TokenizedPrompt,
+	// because TokenIDs cannot hold [][]uint32 (producer skips if already set).
+	result := &fwkrh.InferenceRequestBody{
+		Generate:        &fwkrh.GenerateRequest{CacheSalt: cacheSalt},
+		Payload:         fwkrh.RawPayload(rawBody),
+		MaxOutputTokens: maxOutputTokens(wire.SamplingParams),
+		Stream:          wire.Stream,
+	}
+	if len(batches) == 1 {
+		result.Generate.TokenIDs = batches[0]
+	} else {
+		result.TokenizedPrompt = &fwkrh.TokenizedPrompt{
+			PerPromptTokens: batches,
+			CacheSalt:       cacheSalt,
+		}
+	}
+
+	return &fwkrh.ParseResult{Body: result, SkipResponseProcessing: false}, nil
+}
+
+func hasJSONValue(data json.RawMessage) bool {
+	return len(data) > 0 && strings.TrimSpace(string(data)) != "null"
+}
+
+func hasMultimodalData(data json.RawMessage) bool {
+	if !hasJSONValue(data) {
+		return false
+	}
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return true
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed != ""
+	case []any:
+		return len(typed) > 0
+	default:
+		return value != nil
+	}
+}
+
+func parseCacheSalt(data json.RawMessage) (string, error) {
+	if !hasJSONValue(data) {
+		return "", nil
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return "", errors.New("extra_key must be a string")
+	}
+	return value, nil
+}
+
+func parseInputIDs(data json.RawMessage) ([][]uint32, error) {
+	var single []uint32
+	if err := json.Unmarshal(data, &single); err == nil {
+		if len(single) == 0 {
+			return nil, errors.New("input_ids cannot be empty")
+		}
+		return [][]uint32{single}, nil
+	}
+
+	var batches [][]uint32
+	if err := json.Unmarshal(data, &batches); err != nil {
+		return nil, errors.New("input_ids must be an array of uint32 integers or arrays of uint32 integers")
+	}
+	if len(batches) == 0 {
+		return nil, errors.New("input_ids cannot be empty")
+	}
+	for i, row := range batches {
+		if len(row) == 0 {
+			return nil, fmt.Errorf("input_ids[%d] must be a non-empty array of integers", i)
+		}
+	}
+	return batches, nil
+}
+
+func maxOutputTokens(data json.RawMessage) *int64 {
+	if !hasJSONValue(data) {
+		return nil
+	}
+
+	var single sgLangSamplingParams
+	if err := json.Unmarshal(data, &single); err != nil ||
+		single.MaxNewTokens == nil || *single.MaxNewTokens < 0 {
+		return nil
+	}
+	return single.MaxNewTokens
+}
+
+// sgLangResponse is the /generate response wire format (non-streaming).
+// Usage lives under meta_info, not under usage like the OpenAI format.
+type sgLangResponse struct {
+	MetaInfo struct {
+		PromptTokens     *int `json:"prompt_tokens"`
+		CompletionTokens *int `json:"completion_tokens"`
+		CachedTokens     *int `json:"cached_tokens"`
+	} `json:"meta_info"`
+}
+
+// ParseResponse extracts token usage from a /generate response.
+func (p *SGLangHTTPParser) ParseResponse(_ context.Context, body []byte, headers map[string]string, _ bool) (*fwkrh.ParsedResponse, error) {
+	if len(body) == 0 {
+		return nil, nil //nolint:nilnil
+	}
+	if isEventStream(headers) {
+		return &fwkrh.ParsedResponse{Usage: extractStreamingUsage(body)}, nil
+	}
+	usage, err := extractNonStreamingUsage(body)
+	if err != nil {
+		return nil, err
+	}
+	return &fwkrh.ParsedResponse{Usage: usage}, nil
+}
+
+func isEventStream(headers map[string]string) bool {
+	for key, value := range headers {
+		if strings.EqualFold(key, contentTypeHeader) &&
+			strings.Contains(strings.ToLower(value), eventStreamType) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractStreamingUsage reads usage from SGLang SSE data lines.
+// Streaming SSE chunks carry cumulative meta_info; the last parseable chunk is used.
+func extractStreamingUsage(body []byte) *fwkrh.Usage {
+	text := strings.TrimSpace(string(body))
+	var last *fwkrh.Usage
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		data, ok := strings.CutPrefix(line, streamingRespPrefix)
+		if !ok {
+			continue
+		}
+		data = strings.TrimSpace(data)
+		if data == streamingDoneMarker {
+			continue
+		}
+		if usage, err := parseMetaInfoUsage([]byte(data)); err == nil && usage != nil {
+			last = usage
+		}
+	}
+	return last
+}
+
+// extractNonStreamingUsage reads usage from a single SGLang response object or
+// sums usage across a batch response array.
+func extractNonStreamingUsage(body []byte) (*fwkrh.Usage, error) {
+	text := strings.TrimSpace(string(body))
+	if strings.HasPrefix(text, "[") {
+		return extractBatchUsage(body)
+	}
+	return parseMetaInfoUsage(body)
+}
+
+func extractBatchUsage(body []byte) (*fwkrh.Usage, error) {
+	var responses []json.RawMessage
+	if err := json.Unmarshal(body, &responses); err != nil {
+		return nil, err
+	}
+	total := &fwkrh.Usage{}
+	found := false
+	for _, response := range responses {
+		usage, err := parseMetaInfoUsage(response)
+		if err != nil {
+			return nil, err
+		}
+		if usage == nil {
+			continue
+		}
+		found = true
+		addUsage(total, usage)
+	}
+	if !found {
+		return nil, nil //nolint:nilnil
+	}
+	return total, nil
+}
+
+func parseMetaInfoUsage(data []byte) (*fwkrh.Usage, error) {
+	var resp sgLangResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+	if resp.MetaInfo.PromptTokens == nil && resp.MetaInfo.CompletionTokens == nil {
+		return nil, nil //nolint:nilnil
+	}
+	u := &fwkrh.Usage{
+		PromptTokens:     intValue(resp.MetaInfo.PromptTokens),
+		CompletionTokens: intValue(resp.MetaInfo.CompletionTokens),
+	}
+	u.TotalTokens = u.PromptTokens + u.CompletionTokens
+	if resp.MetaInfo.CachedTokens != nil {
+		u.PromptTokenDetails = &fwkrh.PromptTokenDetails{
+			CachedTokens: *resp.MetaInfo.CachedTokens,
+		}
+	}
+	return u, nil
+}
+
+func intValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+// addUsage accumulates per-prompt usage into a request-level total.
+func addUsage(total, usage *fwkrh.Usage) {
+	total.PromptTokens += usage.PromptTokens
+	total.CompletionTokens += usage.CompletionTokens
+	total.TotalTokens += usage.TotalTokens
+	if usage.PromptTokenDetails != nil {
+		if total.PromptTokenDetails == nil {
+			total.PromptTokenDetails = &fwkrh.PromptTokenDetails{}
+		}
+		total.PromptTokenDetails.CachedTokens += usage.PromptTokenDetails.CachedTokens
+	}
+}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
@@ -86,21 +86,6 @@ func TestSGLangHTTPParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
-			name:    "batched input_ids populate TokenizedPrompt",
-			headers: map[string]string{":path": "/generate"},
-			body: map[string]any{
-				"input_ids": [][]int{{1, 2}, {3, 4}},
-				"extra_key": "batch-salt",
-			},
-			want: &fwkrh.InferenceRequestBody{
-				Generate: &fwkrh.GenerateRequest{CacheSalt: "batch-salt"},
-				TokenizedPrompt: &fwkrh.TokenizedPrompt{
-					PerPromptTokens: [][]uint32{{1, 2}, {3, 4}},
-					CacheSalt:       "batch-salt",
-				},
-			},
-		},
-		{
 			name:    "unrelated fields are left for SGLang to validate",
 			headers: map[string]string{":path": "/generate"},
 			body: map[string]any{
@@ -112,23 +97,6 @@ func TestSGLangHTTPParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
-			name:    "input_embeds are rejected without a scheduling representation",
-			headers: map[string]string{":path": "/generate"},
-			body: map[string]any{
-				"input_embeds": [][]float64{{0.1, 0.2}, {0.3, 0.4}},
-			},
-			wantErr: true,
-		},
-		{
-			name:    "raw multimodal input is rejected without preprocessing",
-			headers: map[string]string{":path": "/generate"},
-			body: map[string]any{
-				"input_ids":  []int{1, 2},
-				"image_data": "data:image/png;base64,abc",
-			},
-			wantErr: true,
-		},
-		{
 			name:    "per-prompt extra_key list is rejected",
 			headers: map[string]string{":path": "/generate"},
 			body: map[string]any{
@@ -136,21 +104,6 @@ func TestSGLangHTTPParser_ParseRequest(t *testing.T) {
 				"extra_key": []string{"tenant-a", "tenant-b"},
 			},
 			wantErr: true,
-		},
-		{
-			name:    "batched input_ids with sampling params",
-			headers: map[string]string{":path": "/generate"},
-			body: map[string]any{
-				"input_ids":       [][]int{{1}, {2}},
-				"sampling_params": map[string]any{"max_new_tokens": 64},
-			},
-			want: &fwkrh.InferenceRequestBody{
-				Generate: &fwkrh.GenerateRequest{},
-				TokenizedPrompt: &fwkrh.TokenizedPrompt{
-					PerPromptTokens: [][]uint32{{1}, {2}},
-				},
-				MaxOutputTokens: ptr.To(int64(64)),
-			},
 		},
 		{
 			name:    "x-original-path header",
@@ -244,14 +197,9 @@ func TestSGLangHTTPParser_ParseRequest_ErrorPaths(t *testing.T) {
 			errContains: "input_ids must be provided",
 		},
 		{
-			name:        "batched input_ids with empty inner array",
-			body:        `{"input_ids":[[1,2],[]]}`,
-			errContains: "input_ids[1] must be a non-empty array",
-		},
-		{
-			name:        "multimodal preprocessing required",
-			body:        `{"input_ids":[1,2],"image_data":"image.png"}`,
-			errContains: "multimodal inputs are not supported",
+			name:        "batched input_ids are rejected",
+			body:        `{"input_ids":[[1,2],[3,4]]}`,
+			errContains: "input_ids must be an array of uint32 integers",
 		},
 		{
 			name:        "per-prompt cache salt unsupported",
@@ -310,31 +258,24 @@ func TestSGLangHTTPParser_ParseResponse(t *testing.T) {
 			},
 		},
 		{
-			name: "non-streaming batch sums usage",
-			body: `[{"text":"a","meta_info":{"prompt_tokens":4,"completion_tokens":2,"cached_tokens":1}},` +
-				`{"text":"b","meta_info":{"prompt_tokens":6,"completion_tokens":3,"cached_tokens":2}}]`,
-			want: &fwkrh.Usage{
-				PromptTokens:     10,
-				CompletionTokens: 5,
-				TotalTokens:      15,
-				PromptTokenDetails: &fwkrh.PromptTokenDetails{
-					CachedTokens: 3,
-				},
-			},
-		},
-		{
-			name:    "streaming — takes last data chunk",
+			name:    "streaming — only final chunk (finish_reason set) is used",
 			headers: map[string]string{"Content-Type": "text/event-stream"},
 			body: "data: {\"text\":\"he\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":2}}\n\n" +
-				"data: {\"text\":\"hello\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n" +
+				"data: {\"text\":\"hello\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"finish_reason\":{\"type\":\"stop\"}}}\n\n" +
 				"data: [DONE]\n\n",
 			want: &fwkrh.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+		{
+			name:    "streaming — intermediate chunk without finish_reason returns nil",
+			headers: map[string]string{"Content-Type": "text/event-stream"},
+			body:    "data: {\"text\":\"he\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":2}}\n\n",
+			want:    nil,
 		},
 		{
 			name:    "streaming detected from content type",
 			headers: map[string]string{"Content-Type": "text/event-stream; charset=utf-8"},
 			body: "event: generation\n" +
-				"data: {\"text\":\"hello\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
+				"data: {\"text\":\"hello\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"finish_reason\":{\"type\":\"stop\"}}}\n\n",
 			want: &fwkrh.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
 		},
 		{

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sglanghttp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+func TestNewSGLangHTTPParser(t *testing.T) {
+	parser := NewSGLangHTTPParser()
+	want := fwkplugin.TypedName{Type: SGLangHTTPParserType, Name: SGLangHTTPParserType}
+	if parser.TypedName() != want {
+		t.Errorf("TypedName() = %v, want %v", parser.TypedName(), want)
+	}
+}
+
+func TestSGLangHTTPParser_ParseRequest(t *testing.T) {
+	parser := NewSGLangHTTPParser()
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		body    map[string]any
+		want    *fwkrh.InferenceRequestBody
+		wantErr bool
+	}{
+		{
+			name:    "basic input_ids",
+			headers: map[string]string{":path": "/generate"},
+			body:    map[string]any{"input_ids": []any{1, 2, 3}},
+			want: &fwkrh.InferenceRequestBody{
+				Generate: &fwkrh.GenerateRequest{TokenIDs: []uint32{1, 2, 3}},
+			},
+		},
+		{
+			name:    "extra_key mapped to CacheSalt",
+			headers: map[string]string{":path": "/generate"},
+			body:    map[string]any{"input_ids": []any{10, 20}, "extra_key": "salt-abc"},
+			want: &fwkrh.InferenceRequestBody{
+				Generate: &fwkrh.GenerateRequest{TokenIDs: []uint32{10, 20}, CacheSalt: "salt-abc"},
+			},
+		},
+		{
+			name:    "sampling_params max_new_tokens",
+			headers: map[string]string{":path": "/generate"},
+			body: map[string]any{
+				"input_ids":       []any{1, 2, 3},
+				"sampling_params": map[string]any{"max_new_tokens": 256},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Generate:        &fwkrh.GenerateRequest{TokenIDs: []uint32{1, 2, 3}},
+				MaxOutputTokens: ptr.To(int64(256)),
+			},
+		},
+		{
+			name:    "stream flag",
+			headers: map[string]string{":path": "/generate"},
+			body:    map[string]any{"input_ids": []any{1, 2, 3}, "stream": true},
+			want: &fwkrh.InferenceRequestBody{
+				Generate: &fwkrh.GenerateRequest{TokenIDs: []uint32{1, 2, 3}},
+				Stream:   true,
+			},
+		},
+		{
+			name:    "batched input_ids populate TokenizedPrompt",
+			headers: map[string]string{":path": "/generate"},
+			body: map[string]any{
+				"input_ids": [][]int{{1, 2}, {3, 4}},
+				"extra_key": "batch-salt",
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Generate: &fwkrh.GenerateRequest{CacheSalt: "batch-salt"},
+				TokenizedPrompt: &fwkrh.TokenizedPrompt{
+					PerPromptTokens: [][]uint32{{1, 2}, {3, 4}},
+					CacheSalt:       "batch-salt",
+				},
+			},
+		},
+		{
+			name:    "unrelated fields are left for SGLang to validate",
+			headers: map[string]string{":path": "/generate"},
+			body: map[string]any{
+				"text":      "ignored by the parser",
+				"input_ids": []int{7, 8},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Generate: &fwkrh.GenerateRequest{TokenIDs: []uint32{7, 8}},
+			},
+		},
+		{
+			name:    "input_embeds are rejected without a scheduling representation",
+			headers: map[string]string{":path": "/generate"},
+			body: map[string]any{
+				"input_embeds": [][]float64{{0.1, 0.2}, {0.3, 0.4}},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "raw multimodal input is rejected without preprocessing",
+			headers: map[string]string{":path": "/generate"},
+			body: map[string]any{
+				"input_ids":  []int{1, 2},
+				"image_data": "data:image/png;base64,abc",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "per-prompt extra_key list is rejected",
+			headers: map[string]string{":path": "/generate"},
+			body: map[string]any{
+				"input_ids": []int{1, 2},
+				"extra_key": []string{"tenant-a", "tenant-b"},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "batched input_ids with sampling params",
+			headers: map[string]string{":path": "/generate"},
+			body: map[string]any{
+				"input_ids":       [][]int{{1}, {2}},
+				"sampling_params": map[string]any{"max_new_tokens": 64},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Generate: &fwkrh.GenerateRequest{},
+				TokenizedPrompt: &fwkrh.TokenizedPrompt{
+					PerPromptTokens: [][]uint32{{1}, {2}},
+				},
+				MaxOutputTokens: ptr.To(int64(64)),
+			},
+		},
+		{
+			name:    "x-original-path header",
+			headers: map[string]string{"x-original-path": "/generate"},
+			body:    map[string]any{"input_ids": []any{5, 6, 7}},
+			want: &fwkrh.InferenceRequestBody{
+				Generate: &fwkrh.GenerateRequest{TokenIDs: []uint32{5, 6, 7}},
+			},
+		},
+		{
+			name:    "missing input_ids",
+			headers: map[string]string{":path": "/generate"},
+			body:    map[string]any{"sampling_params": map[string]any{"temperature": 0.8}},
+			wantErr: true,
+		},
+		{
+			name:    "empty input_ids",
+			headers: map[string]string{":path": "/generate"},
+			body:    map[string]any{"input_ids": []any{}},
+			wantErr: true,
+		},
+		{
+			name:    "unsupported path",
+			headers: map[string]string{":path": "/v1/completions"},
+			body:    map[string]any{"input_ids": []any{1, 2, 3}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyBytes, err := json.Marshal(tt.body)
+			if err != nil {
+				t.Fatalf("marshal body: %v", err)
+			}
+			got, err := parser.ParseRequest(context.Background(), bodyBytes, tt.headers)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			tt.want.Payload = fwkrh.RawPayload(bodyBytes)
+			if got.SkipResponseProcessing {
+				t.Errorf("SkipResponseProcessing = true, want false")
+			}
+			if diff := cmp.Diff(tt.want, got.Body); diff != "" {
+				t.Errorf("Body mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSGLangHTTPParser_ParseRequest_ErrorPaths(t *testing.T) {
+	parser := NewSGLangHTTPParser()
+	headers := map[string]string{":path": "/generate"}
+
+	tests := []struct {
+		name        string
+		body        string
+		errContains string
+	}{
+		{
+			name:        "negative token id",
+			body:        `{"input_ids":[1,2,-1]}`,
+			errContains: "input_ids must be an array of uint32 integers",
+		},
+		{
+			name:        "fractional token id",
+			body:        `{"input_ids":[1,2.5]}`,
+			errContains: "input_ids must be an array of uint32 integers",
+		},
+		{
+			name:        "overflowing token id",
+			body:        `{"input_ids":[4294967296]}`,
+			errContains: "input_ids must be an array of uint32 integers",
+		},
+		{
+			name:        "empty input_ids",
+			body:        `{"input_ids":[]}`,
+			errContains: "input_ids cannot be empty",
+		},
+		{
+			name:        "input embeds without input ids",
+			body:        `{"input_embeds":[[0.1,0.2]]}`,
+			errContains: "input_ids must be provided",
+		},
+		{
+			name:        "text without input ids",
+			body:        `{"text":"hello"}`,
+			errContains: "input_ids must be provided",
+		},
+		{
+			name:        "batched input_ids with empty inner array",
+			body:        `{"input_ids":[[1,2],[]]}`,
+			errContains: "input_ids[1] must be a non-empty array",
+		},
+		{
+			name:        "multimodal preprocessing required",
+			body:        `{"input_ids":[1,2],"image_data":"image.png"}`,
+			errContains: "multimodal inputs are not supported",
+		},
+		{
+			name:        "per-prompt cache salt unsupported",
+			body:        `{"input_ids":[1,2],"extra_key":["a","b"]}`,
+			errContains: "extra_key must be a string",
+		},
+		{
+			name:        "unsupported path",
+			body:        `{"input_ids":[1]}`,
+			errContains: "unsupported path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hdrs := headers
+			if tt.name == "unsupported path" {
+				hdrs = map[string]string{":path": "/v1/completions"}
+			}
+			_, err := parser.ParseRequest(context.Background(), []byte(tt.body), hdrs)
+			if err == nil {
+				t.Fatalf("ParseRequest() error = nil, want error containing %q", tt.errContains)
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("ParseRequest() error = %q, want substring %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+func TestSGLangHTTPParser_ParseResponse(t *testing.T) {
+	parser := NewSGLangHTTPParser()
+
+	tests := []struct {
+		name    string
+		body    string
+		headers map[string]string
+		want    *fwkrh.Usage
+		wantErr bool
+	}{
+		{
+			name: "non-streaming response",
+			body: `{"text":"hello","meta_info":{"prompt_tokens":10,"completion_tokens":5}}`,
+			want: &fwkrh.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+		{
+			name: "non-streaming with additional meta_info fields",
+			body: `{"text":"hi","output_ids":[1,2],"meta_info":{"id":"req-1","prompt_tokens":8,"completion_tokens":3,"cached_tokens":2}}`,
+			want: &fwkrh.Usage{
+				PromptTokens:     8,
+				CompletionTokens: 3,
+				TotalTokens:      11,
+				PromptTokenDetails: &fwkrh.PromptTokenDetails{
+					CachedTokens: 2,
+				},
+			},
+		},
+		{
+			name: "non-streaming batch sums usage",
+			body: `[{"text":"a","meta_info":{"prompt_tokens":4,"completion_tokens":2,"cached_tokens":1}},` +
+				`{"text":"b","meta_info":{"prompt_tokens":6,"completion_tokens":3,"cached_tokens":2}}]`,
+			want: &fwkrh.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+				PromptTokenDetails: &fwkrh.PromptTokenDetails{
+					CachedTokens: 3,
+				},
+			},
+		},
+		{
+			name:    "streaming — takes last data chunk",
+			headers: map[string]string{"Content-Type": "text/event-stream"},
+			body: "data: {\"text\":\"he\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":2}}\n\n" +
+				"data: {\"text\":\"hello\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n" +
+				"data: [DONE]\n\n",
+			want: &fwkrh.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+		{
+			name:    "streaming detected from content type",
+			headers: map[string]string{"Content-Type": "text/event-stream; charset=utf-8"},
+			body: "event: generation\n" +
+				"data: {\"text\":\"hello\",\"meta_info\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
+			want: &fwkrh.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+		{
+			name:    "streaming — [DONE] only",
+			headers: map[string]string{"Content-Type": "text/event-stream"},
+			body:    "data: [DONE]\n\n",
+			want:    nil,
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: nil,
+		},
+		{
+			name: "explicit zero usage is preserved",
+			body: `{"text":"","meta_info":{"prompt_tokens":0,"completion_tokens":0}}`,
+			want: &fwkrh.Usage{},
+		},
+		{
+			name:    "Invalid JSON returns error",
+			body:    `{"meta_info":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.ParseResponse(context.Background(), []byte(tt.body), tt.headers, true)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			var gotUsage *fwkrh.Usage
+			if got != nil {
+				gotUsage = got.Usage
+			}
+			if diff := cmp.Diff(tt.want, gotUsage); diff != "" {
+				t.Errorf("Usage mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSGLangHTTPParser_RejectsPathWithoutSegmentBoundary(t *testing.T) {
+	parser := NewSGLangHTTPParser()
+	for _, path := range []string{"/regenerate", "/health_generate", "/vertex_generate", "/inference/v1/generate", "/prefix/generate"} {
+		t.Run(path, func(t *testing.T) {
+			_, err := parser.ParseRequest(
+				context.Background(),
+				[]byte(`{"input_ids":[1]}`),
+				map[string]string{":path": path},
+			)
+			if err == nil {
+				t.Fatal("ParseRequest() error = nil, want unsupported path")
+			}
+		})
+	}
+}
+
+func TestSGLangHTTPParser_Claims(t *testing.T) {
+	parser := NewSGLangHTTPParser()
+	got := parser.Claims()
+	want := fwkrh.Claims{
+		Paths:     []string{generatePathSuffix},
+		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Claims() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -38,7 +38,7 @@ type ParserRegistry struct {
 }
 
 // NewParserRegistry builds a central resolution table from a list of active parsers.
-// The order of the input parsers determines the priority (first match wins).
+// Resolve uses longest-suffix matching on each parser's claimed paths (longest match wins).
 func NewParserRegistry(parsers []fwkrh.Parser, logger logr.Logger) *ParserRegistry {
 	registry := &ParserRegistry{}
 	seenTypes := make(map[string]bool)
@@ -86,13 +86,21 @@ func (pr *ParserRegistry) Parsers() []fwkrh.Parser {
 }
 
 // Resolve resolves an incoming request path to the matching Parser using suffix matching.
+// When multiple parsers match, the longest matching suffix wins to ensure more-specific
+// parsers take priority regardless of registration order.
 func (pr *ParserRegistry) Resolve(path string) (fwkrh.Parser, error) {
+	var longestMatched fwkrh.Parser
+	var longestMatchLen int
 	for _, entry := range pr.entries {
 		for _, suffix := range entry.normalizedPaths {
-			if request.MatchPathSuffix(path, suffix) {
-				return entry.parser, nil
+			if request.MatchPathSuffix(path, suffix) && len(suffix) > longestMatchLen {
+				longestMatched = entry.parser
+				longestMatchLen = len(suffix)
 			}
 		}
+	}
+	if longestMatched != nil {
+		return longestMatched, nil
 	}
 	if pr.fallbackParser != nil {
 		return pr.fallbackParser, nil

--- a/pkg/epp/handlers/parsers_test.go
+++ b/pkg/epp/handlers/parsers_test.go
@@ -174,6 +174,43 @@ func TestParserRegistryWithPassthrough(t *testing.T) {
 	}
 }
 
+func TestParserRegistryLongestSuffixWins(t *testing.T) {
+	sglang := &testParser{name: "sglang", paths: []string{"generate"}}
+	vllm := &testParser{name: "vllm", paths: []string{"inference/v1/generate"}}
+
+	// SGLang registered first — vLLM must still win on /inference/v1/generate.
+	registry := NewParserRegistry([]fwkrh.Parser{sglang, vllm}, logr.Discard())
+
+	tests := []struct {
+		name        string
+		requestPath string
+		wantParser  string
+	}{
+		{
+			name:        "longer suffix wins regardless of registration order",
+			requestPath: "/inference/v1/generate",
+			wantParser:  "vllm",
+		},
+		{
+			name:        "short suffix still matches its own path",
+			requestPath: "/generate",
+			wantParser:  "sglang",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser, err := registry.Resolve(tt.requestPath)
+			if err != nil {
+				t.Fatalf("Resolve(%q) unexpected error: %v", tt.requestPath, err)
+			}
+			if parser.TypedName().Name != tt.wantParser {
+				t.Errorf("Resolve(%q) = %q, want %q", tt.requestPath, parser.TypedName().Name, tt.wantParser)
+			}
+		})
+	}
+}
+
 func TestParserRegistryDuplicateTypes(t *testing.T) {
 	p1 := &testParser{name: "openai", paths: []string{"v1/chat/completions"}}
 	p2 := &testParser{name: "openai", paths: []string{"v1/completions"}}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds request and response parsing for SGLang's native `/generate` endpoint, specifically for pre-tokenized (token-in/token-out) SGLang requests.

**Details:**

- Currently supports only pre-tokenized requests. Multimodal/text inputs are not supported.

- Reuses `GenerateRequest` rather than introducing an SGLang-specific type. This is a light initial implementation and might not be ideal in the long run - `GenerateRequest` was designed for vLLM's wire format and cannot be used to unmarshal SGLang payloads directly. Batched-token handling is also not uniform (a single prompt goes into `GenerateRequest.TokenIDs`; a batch goes into `TokenizedPrompt.PerPromptTokens`). A more generic native-generate structure, or separate per-backend types may make sense later, after the SGLang Rust migration.

- Updates the parser registry's Resolve to use longest-suffix matching instead of relying solely on parser order. This avoids a path collision where SGLang's `/generate` suffix could incorrectly match vLLM's `/inference/v1/generate`. 

- Batch response usage is summed across per-prompt `meta_info` objects to produce a single request-level Usage. This is symmetric with `TokenizedPrompt.TokenCount()`, which sums input tokens across all prompts in a batch (the batch is treated as one request).

_Validated against against a cluster running SGLang engines (token-in/token-out `/generate`)._

**Release note**:
```release-note
Add SGLang /generate endpoint parser for pre-tokenized requests.
```



