### PR TITLE
fix(options): validate refresh-metrics-interval 50ms floor at startup

### DIFF
--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -48,8 +48,7 @@ const (
 
 // Runtime manages data sources, extractors, their mapping, and endpoint lifecycle.
 type Runtime struct {
-	requestedPollingInterval time.Duration // original value from flag, for warning log
-	pollingInterval          time.Duration // effective interval (>= defaultRefreshInterval)
+	pollingInterval time.Duration
 
 	dispatchers  *pollingDispatchers
 	notification *notificationManager
@@ -70,32 +69,26 @@ const (
 )
 
 // NewRuntime creates a new Runtime with the given polling interval.
-// If duration is <= 0 or below defaultRefreshInterval, uses defaultRefreshInterval.
+// If duration is <= defaultRefreshInterval, uses defaultRefreshInterval.
 func NewRuntime(pollingInterval time.Duration) *Runtime {
 	interval := defaultRefreshInterval
 	if pollingInterval > defaultRefreshInterval {
 		interval = pollingInterval
 	}
 	return &Runtime{
-		requestedPollingInterval: pollingInterval,
-		pollingInterval:          interval,
-		dispatchers:              newPollingDispatchers(),
-		notification:             newNotificationManager(),
-		endpoint:                 newEndpointManager(),
-		extractors:               newExtractorMap(),
-		collectors:               newCollectorManager(),
-		logger:                   logr.Discard(),
+		pollingInterval: interval,
+		dispatchers:     newPollingDispatchers(),
+		notification:    newNotificationManager(),
+		endpoint:        newEndpointManager(),
+		extractors:      newExtractorMap(),
+		collectors:      newCollectorManager(),
+		logger:          logr.Discard(),
 	}
 }
 
 // Configure is called to transform the configuration information into the Runtime's
 // internal fields.
 func (r *Runtime) Configure(cfg *Config, logger logr.Logger) error {
-	if r.requestedPollingInterval > 0 && r.requestedPollingInterval < defaultRefreshInterval {
-		logger.Info("refresh-metrics-interval below minimum, clamped",
-			"requested", r.requestedPollingInterval, "effective", r.pollingInterval)
-	}
-
 	hasPending := len(r.pendingRegistrations) > 0
 	if (cfg == nil || len(cfg.Sources) == 0) && !hasPending {
 		return errors.New("data layer enabled but no data sources configured")

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
@@ -38,9 +39,10 @@ import (
 )
 
 const (
-	DefaultGrpcPort      = 9002
-	DefaultPoolNamespace = "default"        // default when pool namespace is empty (CLI flag default is empty)
-	DefaultDrainTimeout  = 30 * time.Second // graceful shutdown drain window
+	DefaultGrpcPort           = 9002
+	DefaultPoolNamespace      = "default"        // default when pool namespace is empty (CLI flag default is empty)
+	DefaultDrainTimeout       = 30 * time.Second // graceful shutdown drain window
+	MinRefreshMetricsInterval = 50 * time.Millisecond
 )
 
 // deprecatedMetricFlags lists metric flags that are superseded by engineConfigs
@@ -137,7 +139,7 @@ func NewOptions() *Options {
 		EndpointTargetPorts:              []int{},
 		DisableEndpointSubsetFilter:      false,
 		EmitEndpointScores:               false,
-		RefreshMetricsInterval:           50 * time.Millisecond,
+		RefreshMetricsInterval:           MinRefreshMetricsInterval,
 		RefreshPrometheusMetricsInterval: 5 * time.Second,
 		MetricsStalenessThreshold:        2 * time.Second,
 		TotalQueuedRequestsMetric:        "vllm:num_requests_waiting",
@@ -385,6 +387,11 @@ func (opts *Options) Validate() error {
 		return errMetricsTLSWithoutAuth
 	}
 
+	if opts.RefreshMetricsInterval < MinRefreshMetricsInterval {
+		ctrl.Log.WithName("options").Info("Warning: refresh-metrics-interval below minimum, clamped",
+			"requested", opts.RefreshMetricsInterval, "effective", MinRefreshMetricsInterval)
+		opts.RefreshMetricsInterval = MinRefreshMetricsInterval
+	}
 	if opts.GRPCMaxRecvMsgSize < 0 {
 		return fmt.Errorf("grpc-max-recv-msg-size must be non-negative, got %d", opts.GRPCMaxRecvMsgSize)
 	}

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -256,7 +256,28 @@ func TestValidateDirectValues(t *testing.T) {
 	if err := opts.Validate(); err == nil {
 		t.Errorf("Expected Validate() to fail for negative GRPCMaxSendMsgSize, but it succeeded")
 	}
+}
 
+func TestValidateRefreshMetricsIntervalFloor(t *testing.T) {
+	opts := NewOptions()
+	opts.AddFlags(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	opts.PoolName = testPoolName
+	opts.RefreshMetricsInterval = 10 * time.Millisecond
+	if err := opts.Validate(); err != nil {
+		t.Fatalf("Expected Validate() to clamp, not fail: %v", err)
+	}
+	if opts.RefreshMetricsInterval != MinRefreshMetricsInterval {
+		t.Errorf("Expected RefreshMetricsInterval to be clamped to %s, got %s",
+			MinRefreshMetricsInterval, opts.RefreshMetricsInterval)
+	}
+
+	opts = NewOptions()
+	opts.AddFlags(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	opts.PoolName = testPoolName
+	opts.RefreshMetricsInterval = 50 * time.Millisecond
+	if err := opts.Validate(); err != nil {
+		t.Errorf("Expected Validate() to pass for RefreshMetricsInterval of 50ms, got %v", err)
+	}
 }
 
 func TestDrainTimeoutFlag(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The `--refresh-metrics-interval` flag accepted arbitrarily small values, which
were silently clamped to 50ms at runtime. This moves the 50ms floor into
`options.Validate()` so the process fails fast at startup with a clear error
instead of running with a silently different value.

Follow-up to #2214 per reviewer feedback.

- Adds `RefreshMetricsInterval < 50ms` check in `Validate()`
- Removes the now-redundant `requestedPollingInterval` field and clamp warning from `Runtime`

**Which issue(s) this PR fixes**:
Fixes #1880

## Test plan
- [x] Flag value below 50ms rejected at validation
- [x] Flag value at 50ms passes validation
- [x] `make test` passes

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```