### PR TITLE
fix(kvcache): report index hit metrics as contiguous prefix chains

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -374,8 +374,8 @@ Prefix `llm_d_epp_`. Registered only when the embedded llm-d-kv-cache metrics ar
 | `kv_cache_index_admissions_total` | Counter | Blocks admitted to the index. |
 | `kv_cache_index_evictions_total` | Counter | Blocks evicted from the index. |
 | `kv_cache_index_lookup_requests_total` | Counter | Index lookups performed. |
-| `kv_cache_index_lookup_hits_total` | Counter | Lookups that matched at least one block. |
-| `kv_cache_index_max_pod_hit_count_total` | Counter | Best per-pod hit count observed per lookup. |
+| `kv_cache_index_lookup_hits_total` | Counter | Contiguous prefix blocks matched by the best pod per lookup. |
+| `kv_cache_index_max_pod_hit_count_total` | Counter | Longest contiguous per-pod prefix chain observed per lookup. |
 | `kv_cache_index_lookup_latency_seconds` | Histogram | Index lookup latency. |
 | `kv_cache_events_dedup_removed_hashes_suppressed_total` | Counter | Deduplicated removal hashes suppressed. |
 | `kv_cache_events_dedup_removed_hashes_forwarded_total` | Counter | Deduplicated removal hashes forwarded. |

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -59,7 +59,9 @@ func (m *instrumentedIndex) Lookup(
 		return nil, err
 	}
 
-	go recordHitMetrics(pods)
+	// Synchronous: callers own requestKeys and the result map after return,
+	// so a deferred fold would race their reuse.
+	recordHitMetrics(requestKeys, pods)
 
 	return pods, nil
 }
@@ -72,25 +74,56 @@ func (m *instrumentedIndex) Clear(ctx context.Context, podIdentifier string) err
 	return m.next.Clear(ctx, podIdentifier)
 }
 
-func recordHitMetrics(keyToPods map[BlockHash][]PodEntry) {
-	podCount := make(map[string]int)
-	for _, pods := range keyToPods {
-		for _, p := range pods {
-			// First time seeing this pod in current lookup window.
-			// set to 1 because counts are local to this call (not cumulative over time).
-			// This ensures compatibility with sliding window attention (SWA) and cache eviction,
-			// where only recent hits within the active window are considered.
-			podCount[p.PodIdentifier]++
-		}
-	}
-
-	maxHit := 0
-	for _, count := range podCount {
-		if count > maxHit {
-			maxHit = count
-		}
-	}
-
+func recordHitMetrics(requestKeys []BlockHash, keyToPods map[BlockHash][]PodEntry) {
+	maxHit := maxContiguousPodHits(requestKeys, keyToPods)
 	metrics.MaxPodHitCount.Add(float64(maxHit))
 	metrics.LookupHits.Add(float64(maxHit))
+}
+
+// maxContiguousPodHits returns the longest contiguous prefix chain any single
+// pod holds, counting from the first request key. One state map serves the
+// whole fold; a pod stays in the chain while its last-seen key is the
+// preceding one, and duplicate device tiers at a key count once.
+func maxContiguousPodHits(requestKeys []BlockHash, keyToPods map[BlockHash][]PodEntry) int {
+	if len(requestKeys) == 0 {
+		return 0
+	}
+	type podState struct {
+		lastKey int
+		count   int
+	}
+	state := make(map[string]podState, len(keyToPods[requestKeys[0]]))
+	best := 0
+	for i, key := range requestKeys {
+		entries := keyToPods[key]
+		if len(entries) == 0 {
+			break // no pod holds this key: every chain from key 0 ends here
+		}
+		advanced := false
+		for _, e := range entries {
+			s, ok := state[e.PodIdentifier]
+			switch {
+			case i == 0 && !ok:
+				state[e.PodIdentifier] = podState{lastKey: 0, count: 1}
+				advanced = true
+				if best == 0 {
+					best = 1
+				}
+			case ok && s.lastKey == i-1:
+				s.lastKey = i
+				s.count++
+				state[e.PodIdentifier] = s
+				advanced = true
+				if s.count > best {
+					best = s.count
+				}
+			default:
+				// Duplicate tier at this key, or a pod outside the chain.
+			}
+		}
+		if !advanced {
+			break // no chain advanced at this key; later keys cannot either
+		}
+	}
+	return best
 }

--- a/pkg/kvcache/kvblock/instrumented_index_internal_test.go
+++ b/pkg/kvcache/kvblock/instrumented_index_internal_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxContiguousPodHits(t *testing.T) {
+	gpu := func(pod string) PodEntry { return PodEntry{PodIdentifier: pod, DeviceTier: "gpu"} }
+	cpu := func(pod string) PodEntry { return PodEntry{PodIdentifier: pod, DeviceTier: "cpu"} }
+	keys := []BlockHash{1, 2, 3}
+
+	tests := []struct {
+		name       string
+		keys       []BlockHash
+		keyToPods  map[BlockHash][]PodEntry
+		wantResult int
+	}{
+		{
+			name:       "no request keys",
+			keys:       nil,
+			keyToPods:  map[BlockHash][]PodEntry{},
+			wantResult: 0,
+		},
+		{
+			name:       "first key held by nobody breaks every chain",
+			keys:       keys,
+			keyToPods:  map[BlockHash][]PodEntry{2: {gpu("pod-a")}},
+			wantResult: 0,
+		},
+		{
+			name: "one pod holds the whole prefix",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a")}, 2: {gpu("pod-a")}, 3: {gpu("pod-a")},
+			},
+			wantResult: 3,
+		},
+		{
+			name: "longest chain wins",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a"), gpu("pod-b")}, 2: {gpu("pod-a")}, 3: {gpu("pod-a")},
+			},
+			wantResult: 3,
+		},
+		{
+			name: "a gap ends the chain even if the pod reappears",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a")}, 3: {gpu("pod-a")},
+			},
+			wantResult: 1,
+		},
+		{
+			name: "a pod that joins after the first key never starts a chain",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a")}, 2: {gpu("pod-a"), gpu("pod-b")}, 3: {gpu("pod-b")},
+			},
+			wantResult: 2,
+		},
+		{
+			name: "duplicate device tiers at one key count once",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a"), cpu("pod-a")},
+				2: {gpu("pod-a"), cpu("pod-a")},
+				3: {gpu("pod-a"), cpu("pod-a")},
+			},
+			wantResult: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantResult, maxContiguousPodHits(tt.keys, tt.keyToPods))
+		})
+	}
+}

--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -116,12 +116,14 @@ var (
 	// LookupRequests counts how many Lookup() calls have been made.
 	LookupRequests = newDualCounter("index", "lookup_requests_total",
 		"kv_cache_index_lookup_requests_total", "Total number of lookup calls")
-	// MaxPodHitCount counts the maximum cache hits on a single pod on Lookup().
+	// MaxPodHitCount counts, per lookup, the longest contiguous prefix chain
+	// any single pod holds counting from the first requested block.
 	MaxPodHitCount = newDualCounter("index", "max_pod_hit_count_total",
-		"kv_cache_index_max_pod_hit_count_total", "Maximum cache hits on a single pod on Lookup()")
-	// LookupHits counts how many keys were found in the cache on Lookup().
+		"kv_cache_index_max_pod_hit_count_total", "Longest contiguous per-pod prefix chain observed per lookup")
+	// LookupHits accumulates the same per-lookup contiguous chain length as
+	// MaxPodHitCount.
 	LookupHits = newDualCounter("index", "lookup_hits_total",
-		"kv_cache_index_lookup_hits_total", "Number of keys found in the cache on Lookup()")
+		"kv_cache_index_lookup_hits_total", "Contiguous prefix blocks matched by the best pod per lookup")
 	// LookupLatency logs latency of lookup calls.
 	LookupLatency = newDualHistogram("index", "lookup_latency_seconds",
 		"kv_cache_index_lookup_latency_seconds", "Latency of Lookup calls in seconds", prometheus.DefBuckets)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`recordHitMetrics` counted every block a pod held anywhere in the request, so a
pod holding scattered blocks reported the same hit count as a pod holding a
usable prefix. The scheduler can only act on a contiguous prefix from the first
block, so the metric overstated the cache hit a request could actually use.
Count the longest contiguous chain from the first request key instead.

The fold also ran in a goroutine over the result map, which the caller owns once
`Lookup` returns, so it could race the caller's reuse of that map. It now runs
synchronously.

This changes the meaning of two existing metrics. Dashboards reading them will
report different values for identical traffic:

- `kv_cache_index_lookup_hits_total`
- `kv_cache_index_max_pod_hit_count_total`

**Test plan**:

- [x] `TestMaxContiguousPodHits` - covers a chain broken by a gap, a pod that
      first appears after the leading key, duplicate device tiers at one key
      counting once, and a leading key held by nobody
- [x] `make presubmit`
- [x] `make test-unit`

**Which issue(s) this PR fixes**:

Fixes #2398

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
BREAKING: `kv_cache_index_lookup_hits_total` and
`kv_cache_index_max_pod_hit_count_total` now report the longest contiguous prefix
chain held by a single pod, counted from the first requested block. They
previously counted every matching block regardless of contiguity, which
overstated the cache hit a request could actually use. Dashboards and alerts on
these metrics need to be re-baselined.
```
