### PR TITLE
fix(prefix-scorer): aggregate missing match logs

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -131,13 +131,14 @@ func (p *Plugin) Consumes() plugin.DataDependencies {
 func (p *Plugin) Score(ctx context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	logger := log.FromContext(ctx)
+	missingMatchInfo := 0
 
 	for _, endpoint := range endpoints {
 		// Default to score 0 if PrefixCacheMatchInfo is missing or invalid.
 		scores[endpoint] = 0.0
 		info, ok := endpoint.Get(p.prefixMatchDataKey)
 		if !ok {
-			logger.V(logutil.DEFAULT).Error(nil, "PrefixCacheMatchInfo not found for endpoint, assigning score 0", "endpoint", endpoint, "key", p.prefixMatchDataKey.String())
+			missingMatchInfo++
 			continue
 		}
 
@@ -164,6 +165,10 @@ func (p *Plugin) Score(ctx context.Context, _ *fwksched.InferenceRequest, endpoi
 			matchLengthScore = normalizedMatchLength * normalizedMatchLength
 		}
 		scores[endpoint] += p.matchLengthWeight*matchLengthScore + (1.0-p.matchLengthWeight)*matchRatioScore
+	}
+	if missingMatchInfo > 0 {
+		logger.V(logutil.DEFAULT).Info("PrefixCacheMatchInfo not found for endpoints, assigning score 0",
+			"count", missingMatchInfo, "key", p.prefixMatchDataKey.String())
 	}
 	return scores
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin_test.go
@@ -22,14 +22,49 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
+
+type capturedLogCall struct {
+	level int
+	msg   string
+	kv    []any
+}
+
+type captureLogSink struct {
+	infos  []capturedLogCall
+	errors []capturedLogCall
+}
+
+func (s *captureLogSink) Init(_ logr.RuntimeInfo) {}
+func (s *captureLogSink) Enabled(_ int) bool      { return true }
+func (s *captureLogSink) Info(level int, msg string, kv ...any) {
+	s.infos = append(s.infos, capturedLogCall{level: level, msg: msg, kv: kv})
+}
+func (s *captureLogSink) Error(_ error, msg string, kv ...any) {
+	s.errors = append(s.errors, capturedLogCall{msg: msg, kv: kv})
+}
+func (s *captureLogSink) WithValues(_ ...any) logr.LogSink { return s }
+func (s *captureLogSink) WithName(_ string) logr.LogSink   { return s }
+
+func logValue(call capturedLogCall, key string) any {
+	for i := 0; i+1 < len(call.kv); i += 2 {
+		if call.kv[i] == key {
+			return call.kv[i+1]
+		}
+	}
+	return nil
+}
 
 func TestPrefixPluginScore(t *testing.T) {
 	producerName := "approx-prefix-cache-producer"
@@ -48,6 +83,65 @@ func TestPrefixPluginScore(t *testing.T) {
 
 	assert.Equal(t, 0.5, scores[endpoint1])
 	assert.Equal(t, 0.2, scores[endpoint2])
+}
+
+func TestPrefixPluginScoreAggregatesMissingMatchInfo(t *testing.T) {
+	producerName := "precise-prefix-cache-producer"
+	p, err := New(context.Background(), PrefixCacheScorerPluginType, producerName)
+	require.NoError(t, err)
+
+	endpoints := make([]fwksched.Endpoint, 3)
+	for i := range endpoints {
+		endpoints[i] = fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+			ID: k8stypes.NamespacedName{Name: "pod" + string(rune('1'+i))},
+		}, fwkdl.NewMetrics(), nil)
+	}
+
+	sink := &captureLogSink{}
+	ctx := log.IntoContext(t.Context(), logr.New(sink))
+	scores := p.Score(ctx, nil, endpoints)
+
+	require.Len(t, scores, len(endpoints))
+	for _, endpoint := range endpoints {
+		assert.Zero(t, scores[endpoint])
+	}
+	require.Len(t, sink.infos, 1)
+	assert.Empty(t, sink.errors)
+	assert.Equal(t, logging.DEFAULT, sink.infos[0].level)
+	assert.Equal(t, "PrefixCacheMatchInfo not found for endpoints, assigning score 0", sink.infos[0].msg)
+	assert.Equal(t, len(endpoints), logValue(sink.infos[0], "count"))
+}
+
+// Endpoints missing match info are counted on their own: the aggregate record
+// reports only those, while endpoints carrying match info still score normally.
+func TestPrefixPluginScoreMixedMissingMatchInfo(t *testing.T) {
+	producerName := "precise-prefix-cache-producer"
+	p, err := New(context.Background(), PrefixCacheScorerPluginType, producerName)
+	require.NoError(t, err)
+	key := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(producerName)
+
+	endpoints := make([]fwksched.Endpoint, 3)
+	for i := range endpoints {
+		endpoints[i] = fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+			ID: k8stypes.NamespacedName{Name: "pod" + string(rune('1'+i))},
+		}, fwkdl.NewMetrics(), nil)
+	}
+	// match 5 of 10 blocks, block size 1 -> matchRatio 0.5
+	endpoints[0].Put(key, attrprefix.NewPrefixCacheMatchInfo(5, 10, 1))
+
+	sink := &captureLogSink{}
+	ctx := log.IntoContext(t.Context(), logr.New(sink))
+	scores := p.Score(ctx, nil, endpoints)
+
+	require.Len(t, scores, len(endpoints))
+	assert.InDelta(t, 0.5, scores[endpoints[0]], 0.0001, "endpoint with match info scores normally")
+	assert.Zero(t, scores[endpoints[1]])
+	assert.Zero(t, scores[endpoints[2]])
+
+	require.Len(t, sink.infos, 1, "one aggregate record per scoring call")
+	assert.Empty(t, sink.errors)
+	assert.Equal(t, logging.DEFAULT, sink.infos[0].level)
+	assert.Equal(t, 2, logValue(sink.infos[0], "count"), "count covers only endpoints missing match info")
 }
 
 func TestPrefixPluginScoreWithWeights(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`prefix.Plugin.Score` recorded a missing `PrefixCacheMatchInfo` once per endpoint,
from inside the per-endpoint loop and through `Error` with a nil error. A pool of
N endpoints with no match info yet therefore produced N error-level records on
every scored request. Missing match info is also a normal steady state - an
endpoint the producer has not populated yet, during warmup or after an endpoint
joins - so it does not warrant `Error`. `V()` has no effect on `Error` in logr,
so the record was emitted regardless of configured verbosity.

Count the endpoints missing match info and emit one `Info` record per scoring
call carrying that count.

The level stays at `DEFAULT` deliberately. This record is the diagnostic for a
misconfigured `precise-prefix-cache-producer` - the condition reported in #2274,
where the scorer returned 0 for every endpoint - and the EPP runs at `--v=2`, so
dropping it to `DEBUG` would make that failure silent in a default deployment.

**Test plan**:

- [x] One aggregate record per scoring call, carrying the count of endpoints
      missing match info, emitted at `DEFAULT` and not as an error
- [x] Endpoints carrying match info still score normally while the aggregate
      counts only those missing it
- [x] Level assertion verified to fail if the record drops to `DEBUG`, so it
      gates the level rather than describing it
- [x] `make presubmit`
- [x] `make test-unit`

**Which issue(s) this PR fixes**:

Fixes #2403

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The precise prefix scorer no longer logs one error-level record per endpoint when
prefix cache match info is missing. It emits a single record per scoring call
carrying the count of affected endpoints.
```

