### PR TITLE
make metricsLoggingInterval values match the comment

### DIFF
--- a/deploy/config/sim-epp-kvcache-config.yaml
+++ b/deploy/config/sim-epp-kvcache-config.yaml
@@ -17,7 +17,7 @@ plugins:
     indexerConfig:
       kvBlockIndexConfig:
         enableMetrics: false                # enable kv-block index metrics (prometheus)
-        metricsLoggingInterval: 6000000000  # log kv-block metrics as well (1m in nanoseconds)
+        metricsLoggingInterval: 60000000000 # log kv-block metrics as well (1m in nanoseconds)
 - type: prefix-cache-scorer
   parameters:
     prefixMatchInfoProducerName: precise-prefix-cache-producer

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -247,7 +247,7 @@ plugins:
     indexerConfig:
       kvBlockIndexConfig:
         enableMetrics: false                  # enable kv-block index metrics (prometheus)
-        metricsLoggingInterval: 6000000000    # log kv-block metrics as well (1m in nanoseconds)
+        metricsLoggingInterval: 60000000000   # log kv-block metrics as well (1m in nanoseconds)
 - type: decode-filter
 - type: max-score-picker
 - type: disagg-profile-handler


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

make metricsLoggingInterval values match the comment.
"1m in nanoseconds" is 60*1000^3 = 60000000000.

**Which issue(s) this PR fixes**:

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
