### PR TITLE
test(tokenizer): cover Anthropic tool render request

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -248,6 +248,80 @@ func TestProduce_ChatCompletionsVLLMHTTPUsesRawPayload(t *testing.T) {
 	assert.Equal(t, testHTTPModel, sent["model"])
 }
 
+// TestProduce_MessagesVLLMHTTPFullAgenticTurn covers the complete production
+// path from a parsed Anthropic request through the rebuilt OpenAI-shaped
+// payload sent to vLLM's chat render endpoint.
+func TestProduce_MessagesVLLMHTTPFullAgenticTurn(t *testing.T) {
+	srv, captured := httpFixture(t, nil, renderResponse{TokenIDs: []uint32{11, 12, 13}})
+	defer srv.Close()
+
+	req := &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			Messages: &fwkrh.MessagesRequest{
+				System: fwkrh.AnthropicContent{Raw: "You can use tools."},
+				Tools: []fwkrh.AnthropicTool{{
+					Name:        "get_weather",
+					Description: "Get the weather",
+					InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+				}},
+				Messages: []fwkrh.AnthropicMessage{
+					{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Weather in Zurich?"}},
+					{Role: "assistant", Content: fwkrh.AnthropicContent{Structured: []fwkrh.AnthropicContentBlock{
+						{Type: "thinking", Thinking: "I should check."},
+						{Type: "tool_use", ID: "toolu_01", Name: "get_weather", Input: json.RawMessage(`{"city":"Zurich"}`)},
+					}}},
+					{Role: "user", Content: fwkrh.AnthropicContent{Structured: []fwkrh.AnthropicContentBlock{
+						{Type: "tool_result", ToolUseID: "toolu_01", Content: fwkrh.AnthropicContent{Raw: "Sunny, 22C"}},
+					}}},
+				},
+			},
+		},
+	}
+
+	p := newTestPlugin(newHTTPRenderer(t, srv))
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+	require.NotNil(t, req.Body.TokenizedPrompt)
+	assert.Equal(t, []uint32{11, 12, 13}, req.Body.TokenizedPrompt.PerPromptTokens[0])
+
+	var sent struct {
+		Model    string           `json:"model"`
+		Messages []map[string]any `json:"messages"`
+		Tools    []map[string]any `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal(captured.chat, &sent))
+	assert.Equal(t, testHTTPModel, sent.Model)
+	require.Len(t, sent.Tools, 1)
+	assert.Equal(t, "function", sent.Tools[0]["type"])
+	function, ok := sent.Tools[0]["function"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "get_weather", function["name"])
+	parameters, ok := function["parameters"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "object", parameters["type"])
+
+	require.Len(t, sent.Messages, 4)
+	assert.Equal(t, "system", sent.Messages[0]["role"])
+	assert.Equal(t, "user", sent.Messages[1]["role"])
+	assistant := sent.Messages[2]
+	assert.Equal(t, "assistant", assistant["role"])
+	assert.NotContains(t, assistant, "content")
+	assert.Equal(t, "I should check.", assistant["reasoning"])
+	toolCalls, ok := assistant["tool_calls"].([]any)
+	require.True(t, ok)
+	require.Len(t, toolCalls, 1)
+	toolCall, ok := toolCalls[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "toolu_01", toolCall["id"])
+	toolFunction, ok := toolCall["function"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, `{"city": "Zurich"}`, toolFunction["arguments"])
+
+	toolResult := sent.Messages[3]
+	assert.Equal(t, "tool", toolResult["role"])
+	assert.Equal(t, "toolu_01", toolResult["tool_call_id"])
+	assert.Equal(t, "Sunny, 22C", toolResult["content"])
+}
+
 func TestVLLMHTTPRenderer_RenderMultiPrompt(t *testing.T) {
 	srv, _ := httpFixture(t,
 		[]renderResponse{


### PR DESCRIPTION
## What changed

Adds a full HTTP-path regression for the Anthropic tool translation merged in #2389. The test sends a typed `/v1/messages` request through the tokenizer plugin and the vLLM HTTP renderer, then validates the body sent to `/v1/chat/completions/render`.

It covers:

- `system` and Anthropic tool schemas
- `thinking` to `reasoning`
- `tool_use` to OpenAI `tool_calls`
- `tool_result` to a `tool` role message
- CPython-formatted tool arguments
- model stamping and returned token IDs

## Why

The conversion unit tests cover individual helpers, but they do not prove that the parser, request model, tokenizer plugin, and HTTP renderer preserve the same prompt shape end to end. A regression in that wiring can make precise prefix routing tokenize a different prompt than vLLM serves.

#2389 is merged. This branch is directly on top of current `main` and contains only this independent regression test; it does not carry the implementation commits from #2389 or depend on #2402.

## Validation

```text
go test ./pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer ./pkg/epp/framework/plugins/requesthandling/parsers/anthropic
go test -race ./pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer ./pkg/epp/framework/plugins/requesthandling/parsers/anthropic
go test ./pkg/epp/...
```

All pass locally with Go 1.26.6.

The content-equivalent pre-rebase image also passed an isolated canary with 101/101 full Anthropic tool requests, zero EPP timeouts or serving errors, and zero restarts. No production routing change is part of this PR.
