### PR TITLE
docs: add prose rules for model-drafted text to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,25 @@ llm-d Router. Go service that routes inference requests to model-serving pods vi
 
 - Standard Go. `make format` and `make lint` are authoritative.
 - Comments are terse and only present when the WHY is non-obvious. Never paraphrase the code.
-- Docs and comments describe the current state on its own terms. No "previously", "now", "recently", "renamed from", "added to fix", or other temporal or conversational framing. A reader with no context for the change must still understand the text.
+- Docs and comments describe the current state on its own terms. No "previously", "now", "recently", "renamed from", "added to fix", "this PR", "see above", or other temporal, deictic, or conversational framing. A reader with no context for the change must still understand the text.
 - State each fact once, in its canonical location. Do not duplicate across struct docs, prose, tables, inline comments, and examples.
 - Do not use Unicode symbols or special characters in general, unless explicitly requested.
+
+### Constructions to delete
+
+Model-drafted prose drifts toward compressed, rhetorical phrasing. Before shipping any prose (comments, docs, commit bodies, PR descriptions), decompress it: rewrite each such sentence as a plain statement of the fact it carries, judged against what the change is actually for. The test: if a sentence sounds quotable, delete it.
+
+| Tic | Example | Fix |
+|---|---|---|
+| X, not Y | "the queue is not a buffer, it is a fairness mechanism" | say what it is, once |
+| Coined aphorism | "a shed request is not a failure, it is the contract" | delete the sentence |
+| Closing zinger | a paragraph that ends on a beat instead of a fact | end on information |
+| Triads for rhythm | "no locks to take, no channels to drain, no state to sync" | one clause |
+| Portent counters | "three things follow", "two points are worth noting" | just say them |
+| Filler intensifiers | genuinely, precisely, critically, crucially, "worth noting" | cut |
+| Editorial tails | "..., which is exactly what we want" | cut, or a new sentence |
+| Grandeur adjectives | comprehensive, robust, seamless, production-ready | name the verified behavior |
+| Dash pileup | more than one dash pair per paragraph | periods |
 
 ### Logging
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it:**

Adds a "Constructions to delete" table to the code style section of AGENTS.md, and extends the existing framing rule to cover deictic references ("this PR", "see above").

Many contributions now arrive with model-drafted prose in PR descriptions, code comments, and commit bodies. The drafts share a recognizable set of rhetorical constructions: coined aphorisms, "X, not Y" framings, triads, self-congratulatory adjectives ("comprehensive", "production-ready"). Any one of them is harmless. At the density models produce them they displace the facts a reviewer needs. AGENTS.md is the file contributor tooling reads, so naming the constructions there, each with its fix, moves the rewrite to before review and gives a reviewer a row to link rather than a taste argument to make from scratch.

This is my very opinionated take on house style, so pushback is welcome here. It's in the same spirit as the file's existing bans on temporal framing and Unicode symbols. None of these constructions is wrong in general prose, and a deliberate human writer can use any of them well. The table targets the failure mode where they appear reflexively and in bulk. 


**Which issue(s) this PR fixes:**

None; guidance-only change to AGENTS.md.

**Release note:**

```release-note
NONE
```