### PR TITLE
perf(epp): reduce streaming parser allocations

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -209,6 +209,7 @@ func extractUsageStreaming(responseBytes []byte) *fwkrh.Usage {
 	lines := bytes.SplitSeq(responseBytes, []byte("\n"))
 	for line := range lines {
 		content, ok := bytes.CutPrefix(line, []byte(streamingRespPrefix))
+		// Safe because only message_start/message_delta carry usage, both with a literal "usage" key.
 		if !ok || !bytes.Contains(content, []byte("usage")) {
 			continue
 		}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -17,6 +17,7 @@ limitations under the License.
 package anthropic
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -198,19 +199,19 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 //	event: message_stop
 //	data: {"type":"message_stop"}
 func (p *AnthropicParser) parseStreamResponse(chunk []byte) (*fwkrh.ParsedResponse, error) {
-	usage := extractUsageStreaming(string(chunk))
+	usage := extractUsageStreaming(chunk)
 	return &fwkrh.ParsedResponse{Usage: usage}, nil
 }
 
-func extractUsageStreaming(responseText string) *fwkrh.Usage {
+func extractUsageStreaming(responseBytes []byte) *fwkrh.Usage {
 	var result *fwkrh.Usage
 
-	lines := strings.Split(responseText, "\n")
-	for _, line := range lines {
-		if !strings.HasPrefix(line, streamingRespPrefix) {
+	lines := bytes.SplitSeq(responseBytes, []byte("\n"))
+	for line := range lines {
+		content, ok := bytes.CutPrefix(line, []byte(streamingRespPrefix))
+		if !ok || !bytes.Contains(content, []byte("usage")) {
 			continue
 		}
-		content := strings.TrimPrefix(line, streamingRespPrefix)
 
 		var event struct {
 			Type    string `json:"type"`
@@ -219,7 +220,7 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 			} `json:"message"`
 			Usage map[string]any `json:"usage"`
 		}
-		if err := json.Unmarshal([]byte(content), &event); err != nil {
+		if err := json.Unmarshal(content, &event); err != nil {
 			continue
 		}
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -605,6 +605,13 @@ func TestAnthropicParser_ParseResponse_Streaming(t *testing.T) {
 			},
 		},
 		{
+			name:  "content delta with usage text but no usage object",
+			chunk: []byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"usage\"}}"),
+			want: &fwkrh.ParsedResponse{
+				Usage: nil,
+			},
+		},
+		{
 			name:  "message_stop without usage",
 			chunk: []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}"),
 			want: &fwkrh.ParsedResponse{
@@ -621,6 +628,34 @@ func TestAnthropicParser_ParseResponse_Streaming(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ParseResponse() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkAnthropicParser_ParseResponse_Streaming(b *testing.B) {
+	parser := NewAnthropicParser()
+	tests := []struct {
+		name  string
+		chunk []byte
+	}{
+		{
+			name:  "without_usage",
+			chunk: []byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}"),
+		},
+		{
+			name:  "with_usage",
+			chunk: []byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":15}}"),
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := parser.parseStreamResponse(tt.chunk); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openai
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -188,7 +189,7 @@ func (p *OpenAIParser) ParseResponse(ctx context.Context, body []byte, headers m
 }
 
 func (p *OpenAIParser) parseStreamResponse(chunk []byte) (*fwkrh.ParsedResponse, error) {
-	usage := extractUsageStreaming(string(chunk))
+	usage := extractUsageStreaming(chunk)
 	return &fwkrh.ParsedResponse{
 		Usage: usage,
 	}, nil
@@ -369,8 +370,7 @@ func extractUsage(responseBytes []byte) (*fwkrh.Usage, error) {
 //	data: {"response":{"usage":{"input_tokens":31,..},...},"type":"response.completed"}
 //
 // It extracts usage from events with type="response.completed".
-func extractUsageStreaming(responseText string) *fwkrh.Usage {
-
+func extractUsageStreaming(responseBytes []byte) *fwkrh.Usage {
 	var streamResponse struct {
 		Usage    *fwkrh.Usage `json:"usage"`
 		Response struct {
@@ -379,18 +379,17 @@ func extractUsageStreaming(responseText string) *fwkrh.Usage {
 		Type string `json:"type"`
 	}
 
-	lines := strings.SplitSeq(responseText, "\n")
+	lines := bytes.SplitSeq(responseBytes, []byte("\n"))
 	for line := range lines {
-		content, ok := strings.CutPrefix(line, streamingRespPrefix)
+		content, ok := bytes.CutPrefix(line, []byte(streamingRespPrefix))
 		if !ok {
 			continue
 		}
 		// When the stream is terminated with [DONE] or there's not any usage data, skip the line
-		if content == "[DONE]" || !strings.Contains(content, "usage") {
+		if bytes.Equal(content, []byte("[DONE]")) || !bytes.Contains(content, []byte("usage")) {
 			continue
 		}
-		byteSlice := []byte(content)
-		if err := json.Unmarshal(byteSlice, &streamResponse); err != nil {
+		if err := json.Unmarshal(content, &streamResponse); err != nil {
 			continue
 		}
 		// Standard ChatCompletion / vLLM usage format

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1242,6 +1242,13 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 			},
 		},
 		{
+			name:  "Chunk with usage text but no usage object returns nil usage",
+			chunk: []byte(`data: {"choices":[{"delta":{"content":"usage"}}]}`),
+			want: &fwkrh.ParsedResponse{
+				Usage: nil,
+			},
+		},
+		{
 			name:  "DONE message returns error",
 			chunk: []byte(`data: [DONE]`),
 			want: &fwkrh.ParsedResponse{
@@ -1297,6 +1304,34 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ParseStreamResponse() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkOpenAIParser_ParseResponse_Streaming(b *testing.B) {
+	parser := NewOpenAIParser()
+	tests := []struct {
+		name  string
+		chunk []byte
+	}{
+		{
+			name:  "without_usage",
+			chunk: []byte(`data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"hello"}}]}`),
+		},
+		{
+			name:  "with_usage",
+			chunk: []byte(`data: {"usage":{"prompt_tokens":7,"completion_tokens":10,"total_tokens":17}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := parser.parseStreamResponse(tt.chunk); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR reduces allocations in the OpenAI and Anthropic streaming response parsers, which run once for every Envoy `ext_proc` response chunk.

It parses SSE data directly from `[]byte`, removing avoidable byte/string conversions. Anthropic events without usage data now also skip JSON decoding. Existing parsing behavior remains unchanged, with additional correctness tests and benchmarks.

Microbenchmarks show:

| Path | Before | After |
|---|---:|---:|
| OpenAI, no usage | 43.0 ns, 128 B, 2 allocs | 24.2 ns, 48 B, 1 alloc |
| Anthropic, no usage | 565.8 ns, 512 B, 10 allocs | 15.3 ns, 0 B, 0 allocs |

These are parser microbenchmarks; the expected system-level benefit is reduced allocation and GC pressure for high-output streaming workloads.

**Which issue(s) this PR fixes**:

Fixes #2423

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
NONE
```
