### PR TITLE
fix(epp): merge streaming usage per field instead of replacing it

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -78,11 +78,13 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		}
 	}
 	if parsedResp != nil && parsedResp.Usage != nil {
-		reqCtx.Usage = *parsedResp.Usage
-		metrics.RecordInputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.Usage.PromptTokens)
-		metrics.RecordOutputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.Usage.CompletionTokens)
-		if reqCtx.Usage.PromptTokenDetails != nil {
-			metrics.RecordPromptCachedTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.Usage.PromptTokenDetails.CachedTokens)
+		mergeUsage(&reqCtx.Usage, *parsedResp.Usage)
+		// Metrics observe the values this chunk carried, not the accumulated ones: a field
+		// already reported by an earlier chunk would otherwise be observed a second time.
+		metrics.RecordInputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, parsedResp.Usage.PromptTokens)
+		metrics.RecordOutputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, parsedResp.Usage.CompletionTokens)
+		if parsedResp.Usage.PromptTokenDetails != nil {
+			metrics.RecordPromptCachedTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, parsedResp.Usage.PromptTokenDetails.CachedTokens)
 		}
 	}
 	if endOfStream {
@@ -93,6 +95,31 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.modelServerStreaming, reqCtx.RequestReceivedTimestamp, reqCtx.FirstTokenTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 	}
 	return s.director.HandleResponseBody(ctx, reqCtx, endOfStream)
+}
+
+// mergeUsage folds a parsed usage block into the usage accumulated for the request.
+// The Anthropic streaming format splits usage across events - message_start carries the
+// prompt tokens and the cached-token detail, message_delta carries the completion tokens -
+// and those events reach the parser in separate chunks, so each field is taken only from
+// the blocks that report it. Parsers that emit usage once with every field populated are
+// unaffected.
+func mergeUsage(dst *fwkrh.Usage, src fwkrh.Usage) {
+	if src.PromptTokens != 0 {
+		dst.PromptTokens = src.PromptTokens
+	}
+	if src.CompletionTokens != 0 {
+		dst.CompletionTokens = src.CompletionTokens
+	}
+	if src.PromptTokenDetails != nil {
+		dst.PromptTokenDetails = src.PromptTokenDetails
+	}
+	// A block reporting both halves of the usage owns the total it came with; a partial
+	// block carries a total covering only its own fields, so derive it from the merge.
+	if src.PromptTokens != 0 && src.CompletionTokens != 0 && src.TotalTokens != 0 {
+		dst.TotalTokens = src.TotalTokens
+		return
+	}
+	dst.TotalTokens = dst.PromptTokens + dst.CompletionTokens
 }
 
 func (s *StreamingServer) HandleResponseHeaders(ctx context.Context, reqCtx *RequestContext, resp *extProcPb.ProcessingRequest_ResponseHeaders) *RequestContext {

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -33,6 +33,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
@@ -412,6 +413,74 @@ func TestHandleResponseBodyModelStreaming_TokenAccumulation(t *testing.T) {
 			assert.Equal(t, tc.wantUsage, reqCtx.Usage, "Usage data should match expected accumulation")
 		})
 	}
+}
+
+// The Anthropic streaming format reports prompt tokens in message_start and completion
+// tokens in a message_delta that reaches the EPP in a later chunk.
+func TestHandleResponseBodyModelStreaming_AnthropicUsageAccumulation(t *testing.T) {
+	eppmetrics.Register()
+	eppmetrics.Reset()
+	t.Cleanup(eppmetrics.Reset)
+
+	chunks := [][]byte{
+		[]byte(`event: message_start` + "\n" + `data: {"type":"message_start","message":{"usage":{"input_tokens":1000,"cache_read_input_tokens":800}}}` + "\n\n"),
+		[]byte(`event: content_block_delta` + "\n" + `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}` + "\n\n"),
+		[]byte(`event: message_delta` + "\n" + `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":200}}` + "\n\n"),
+		[]byte(`event: message_stop` + "\n" + `data: {"type":"message_stop"}`),
+	}
+
+	server := &StreamingServer{
+		parserRegistry: NewParserRegistry([]fwkrh.Parser{anthropic.NewAnthropicParser()}, logr.Discard()),
+		director:       &mockDirector{},
+	}
+	reqCtx := &RequestContext{
+		IncomingModelName: "incoming-model",
+		TargetModelName:   "target-model",
+		Request: &Request{
+			Headers: map[string]string{
+				":path": "/v1/messages",
+			},
+		},
+		Response: &Response{
+			Headers: map[string]string{
+				"content-type": "text/event-stream",
+			},
+		},
+		SchedulingRequest: &fwksched.InferenceRequest{FairnessID: metadata.DefaultFairnessID},
+	}
+
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	for i, chunk := range chunks {
+		server.HandleResponseBody(ctx, reqCtx, chunk, i == len(chunks)-1)
+	}
+
+	wantUsage := fwkrh.Usage{
+		PromptTokens:       1000,
+		CompletionTokens:   200,
+		TotalTokens:        1200,
+		PromptTokenDetails: &fwkrh.PromptTokenDetails{CachedTokens: 800},
+	}
+	assert.Equal(t, wantUsage, reqCtx.Usage, "message_delta must not discard the usage reported by message_start")
+
+	labels := map[string]string{
+		"model_name":        "incoming-model",
+		"target_model_name": "target-model",
+		"fairness_id":       metadata.DefaultFairnessID,
+		"priority":          "0",
+	}
+	// Each token count belongs to one request, so accumulating usage across chunks must not
+	// turn into a second observation on the chunk that completes it.
+	inputTokens := findHistogramMetric(t, "llm_d_epp_request_input_tokens", labels)
+	require.Equal(t, uint64(1), inputTokens.GetSampleCount())
+	require.Equal(t, float64(1000), inputTokens.GetSampleSum())
+
+	cachedTokens := findHistogramMetric(t, "llm_d_epp_request_cached_tokens", labels)
+	require.Equal(t, uint64(1), cachedTokens.GetSampleCount())
+	require.Equal(t, float64(800), cachedTokens.GetSampleSum())
+
+	outputTokens := findHistogramMetric(t, "llm_d_epp_request_output_tokens", labels)
+	require.Equal(t, uint64(1), outputTokens.GetSampleCount())
+	require.Equal(t, float64(200), outputTokens.GetSampleSum())
 }
 
 func TestGenerateResponseHeaders_Sanitization(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The Anthropic streaming format splits usage across two SSE events: `message_start` carries `input_tokens` and `cache_read_input_tokens`, and `message_delta` carries `output_tokens` at the end of the stream. Envoy delivers the response body to the EPP in many ext_proc chunks and the message content streams between the two events, so they reach `ParseResponse` in different calls and the parser's call-local merge does not apply.

`reqCtx.Usage = *parsedResp.Usage` then replaced the whole struct, so the chunk carrying `message_delta` discarded the prompt tokens and the cached-token detail recorded by `message_start`. The final usage for an Anthropic stream was `{PromptTokens: 0, CompletionTokens: M}`.

This merges per field at the accumulation site, as proposed in the issue. Cross-chunk state stays on `RequestContext`: parsers are stateless and shared across requests, so keeping it there would mean adding per-request state to the parser interface.

Two details worth review:

- **`TotalTokens`.** A non-zero-wins merge is wrong for this field on its own, because the Anthropic `message_delta` parses to a non-zero but partial total of `0 + output_tokens`. A block reporting both prompt and completion tokens keeps the total it came with (a passthrough for the OpenAI-family parsers, which report all fields at once); a partial block has the total derived from the merged fields.
- **Token metrics.** `RecordInputTokens` and friends are histograms and were called with the post-assignment `reqCtx.Usage`. Once the merged struct carries the prompt tokens on the `message_delta` chunk, recording from it would `Observe` them a second time, and `RecordPromptCachedTokens` has no `size > 0` guard to absorb it. The three calls now read the usage parsed from the current chunk, which keeps one observation per request. The added test asserts the sample counts, and fails with `expected: 0x1, actual: 0x2` if the calls are pointed back at the merged struct.

The OpenAI-family parsers emit usage once per stream with every field populated, and non-streamed responses parse in one call, so their behavior is unchanged.

**Which issue(s) this PR fixes**:

Fixes #2431

**Test plan**:

- [x] `TestHandleResponseBodyModelStreaming_AnthropicUsageAccumulation` drives a four-chunk Anthropic stream through `HandleResponseBody` and asserts the final usage keeps the prompt tokens and cached-token detail from `message_start` alongside the completion tokens from `message_delta`, and that each token histogram observes exactly one sample. It fails on the unfixed code with `PromptTokens: 0`, matching the report.
- [x] `make presubmit`
- [x] `go test ./pkg/epp/handlers/... ./pkg/epp/framework/plugins/requesthandling/...`

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fixed prompt and cached token counts being dropped from the recorded usage of streamed Anthropic responses, which reported zero prompt tokens to response plugins and terminal request records.
```
