### PR TITLE
feat(epp): record a termination cause on end-of-stream response records

### DIFF
--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -80,10 +80,12 @@ type ResponseHeaderProcessor interface {
 //   - For non-streaming: Invoked once with response.EndOfStream set to true.
 //   - Plugins must treat the call where response.EndOfStream == true as the final lifecycle hook
 //     to perform cleanup or final logging.
+//   - The end-of-stream call carries response.TerminationCause; earlier calls leave it empty.
 //
 // TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2079):
-// Update signature to pass error/termination state. This is a breaking change required for plugins to distinguish
-// between success, errors, and disconnects.
+// Upstream proposes passing error/termination state through the signature. Response.TerminationCause
+// carries the termination state without a signature change; it does not distinguish success from
+// an error response.
 type ResponseBodyProcessor interface {
 	plugin.Plugin
 	ResponseBody(ctx context.Context, request *fwksched.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)

--- a/pkg/epp/framework/interface/requestcontrol/types.go
+++ b/pkg/epp/framework/interface/requestcontrol/types.go
@@ -22,6 +22,31 @@ import (
 	requesthandling "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
+// TerminationCause labels how a dispatched request's response stream ended. Observers that learn
+// from response records need it to tell a complete observation from a truncated one: a stream cut
+// short by a disconnect or an eviction reports only the tokens emitted before the cut. Requests
+// whose response processing is skipped never observe completion, so their records always carry a
+// non-natural cause.
+type TerminationCause string
+
+const (
+	// TerminationCauseNatural is a stream the model server ended on its own, including responses
+	// that deliver an error status in full.
+	TerminationCauseNatural TerminationCause = "natural"
+	// TerminationCauseClientDisconnect is a stream torn down under the EPP while the response was
+	// in flight. A client disconnect is the most common reason; any teardown the EPP observes only
+	// as a cancelled stream (Envoy drain or restart, an upstream reset, the EPP's own drain)
+	// produces the same value, because the EPP cannot distinguish the reasons from its side of
+	// the stream.
+	TerminationCauseClientDisconnect TerminationCause = "client-disconnect"
+	// TerminationCauseEvicted is a stream the EPP terminated to reclaim capacity.
+	TerminationCauseEvicted TerminationCause = "evicted"
+	// TerminationCauseError is a stream that ended without completing for any reason not otherwise
+	// classified: a half-close that reaches the EPP before its cancellation propagates, or an
+	// EPP-side failure.
+	TerminationCauseError TerminationCause = "error"
+)
+
 // Response contains information from the response received to be passed to the Response requestcontrol plugins
 type Response struct {
 	// RequestID is the Envoy generated Id for the request being processed
@@ -38,6 +63,8 @@ type Response struct {
 	ReqMetadata map[string]any
 	// Token usage counts parsed from the response body.
 	Usage requesthandling.Usage
+	// TerminationCause labels how the stream ended.
+	TerminationCause TerminationCause
 	// DynamicMetadata is a map of metadata that can be passed to the Envoy. It is populated into the dynamic
 	// metadata when processing ProcessingResponse_RequestHeaders.
 	DynamicMetadata *structpb.Struct

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwkrequest "github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
@@ -147,6 +148,9 @@ type RequestContext struct {
 
 	RequestState         StreamRequestState
 	RequestDroppedReason errcommon.RequestDroppedReason
+	// TerminationCause is set only when the stream ends without completing; the end-of-stream
+	// response record defaults an unset cause to a natural completion.
+	TerminationCause     fwkrc.TerminationCause
 	modelServerStreaming bool
 
 	// responseProcessingDuration is the EPP cost of handling the response. For a
@@ -240,6 +244,19 @@ func extractTraceContext(ctx context.Context, req *extProcPb.ProcessingRequest_R
 		}
 	}
 	return otel.GetTextMapPropagator().Extract(ctx, carrier)
+}
+
+// terminationCause classifies a stream that ended without completing. ctxErr is the request
+// context's error, which is non-nil once Envoy has torn the stream down under the EPP.
+func terminationCause(reqCtx *RequestContext, ctxErr error) fwkrc.TerminationCause {
+	switch {
+	case reqCtx.RequestState == RequestEvicted:
+		return fwkrc.TerminationCauseEvicted
+	case ctxErr != nil:
+		return fwkrc.TerminationCauseClientDisconnect
+	default:
+		return fwkrc.TerminationCauseError
+	}
 }
 
 func extractFairnessAndPriority(reqCtx *RequestContext) (string, string) {
@@ -372,6 +389,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		// If we scheduled a pod (TargetPod != nil) but never marked the response  as complete (e.g. error, disconnect,
 		// panic), force the completion hooks to run.
 		if reqCtx.TargetPod != nil && !reqCtx.ResponseComplete {
+			reqCtx.TerminationCause = terminationCause(reqCtx, ctx.Err())
 			// Use a fresh context as the request context might be canceled (Client Disconnect).
 			// We only need logging from the original context.
 			cleanupCtx := log.IntoContext(context.Background(), logger)

--- a/pkg/epp/handlers/server_abort_test.go
+++ b/pkg/epp/handlers/server_abort_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 )
 
 // mockProcessServer implements ExternalProcessor_ProcessServer for testing.
@@ -120,4 +121,46 @@ func TestUpdateStateAndSendIfNeeded_NotEvicted(t *testing.T) {
 	err := reqCtx.updateStateAndSendIfNeeded(srv, logger)
 	require.NoError(t, err)
 	assert.Empty(t, srv.sentResponses, "Should not send any response for normal state without queued responses")
+}
+
+func TestTerminationCause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		state  StreamRequestState
+		ctxErr error
+		want   fwkrc.TerminationCause
+	}{
+		{
+			name:   "evicted outranks a cancelled context",
+			state:  RequestEvicted,
+			ctxErr: context.Canceled,
+			want:   fwkrc.TerminationCauseEvicted,
+		},
+		{
+			name:   "a cancelled context is the client going away",
+			state:  ResponseReceived,
+			ctxErr: context.Canceled,
+			want:   fwkrc.TerminationCauseClientDisconnect,
+		},
+		{
+			name:  "anything else is an error",
+			state: ResponseReceived,
+			want:  fwkrc.TerminationCauseError,
+		},
+		{
+			name:  "skipped response processing never observes completion",
+			state: RequestResponseProcessingSkipped,
+			want:  fwkrc.TerminationCauseError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reqCtx := &RequestContext{RequestState: tt.state}
+			assert.Equal(t, tt.want, terminationCause(reqCtx, tt.ctxErr))
+		})
+	}
 }

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -572,12 +572,22 @@ func (d *Director) HandleResponseHeader(ctx context.Context, reqCtx *handlers.Re
 // plugins run synchronously because they may produce DynamicMetadata that must be attached
 // to the ext_proc response sent back to Envoy.
 func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.RequestContext, endOfStream bool) *handlers.RequestContext {
+	// Resolved once so every end-of-stream Response carries the same cause.
+	var cause fwkrc.TerminationCause
+	if endOfStream {
+		cause = reqCtx.TerminationCause
+		if cause == "" {
+			cause = fwkrc.TerminationCauseNatural
+		}
+	}
+
 	// The eviction tracker must observe stream termination even when no streaming plugins are
 	// registered, so this runs before the early return below.
 	if endOfStream && d.requestEvictor != nil {
 		d.requestEvictor.ResponseBody(ctx, reqCtx.SchedulingRequest, &fwkrc.Response{
-			RequestID:   reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
-			EndOfStream: true,
+			RequestID:        reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
+			EndOfStream:      true,
+			TerminationCause: cause,
 		}, reqCtx.TargetPod)
 	}
 
@@ -596,6 +606,7 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 	}
 
 	if endOfStream {
+		response.TerminationCause = cause
 		// Drain the async queue: close the channel and wait for the goroutine to finish
 		// processing all previously queued chunks before running the final chunk synchronously.
 		if val, ok := d.responseBodyQueues.LoadAndDelete(reqCtx); ok {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1696,7 +1696,7 @@ func TestDirector_HandleResponseBody_ChunkOrdering(t *testing.T) {
 	director := NewDirectorWithConfig(ds, &mockScheduler{}, nil, nil, NewConfig().WithResponseStreamingPlugins(plugin))
 
 	const numChunks = 50
-	reqCtx := newResponseBodyTestRequestContext("ordering-test-request", 0)
+	reqCtx := newResponseBodyTestRequestContext("ordering-test-request")
 
 	for i := range numChunks {
 		reqCtx.Usage = fwkrh.Usage{CompletionTokens: i}
@@ -1727,8 +1727,8 @@ func TestDirector_HandleResponseBody_DuplicateRequestIDQueuesAreIndependent(t *t
 	director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil, NewConfig().WithResponseStreamingPlugins(plugin))
 
 	const requestID = "duplicate-request-id"
-	firstReqCtx := newResponseBodyTestRequestContext(requestID, 0)
-	secondReqCtx := newResponseBodyTestRequestContext(requestID, 0)
+	firstReqCtx := newResponseBodyTestRequestContext(requestID)
+	secondReqCtx := newResponseBodyTestRequestContext(requestID)
 
 	director.HandleResponseBody(ctx, firstReqCtx, false)
 	require.Eventually(t, func() bool {
@@ -1955,7 +1955,7 @@ func (p *blockingResponseStreamingPlugin) release() {
 	close(p.releaseCh)
 }
 
-func newResponseBodyTestRequestContext(requestID string, completionTokens int) *handlers.RequestContext {
+func newResponseBodyTestRequestContext(requestID string) *handlers.RequestContext {
 	return &handlers.RequestContext{
 		Request: &handlers.Request{
 			Headers: map[string]string{
@@ -1966,7 +1966,6 @@ func newResponseBodyTestRequestContext(requestID string, completionTokens int) *
 			Headers: map[string]string{},
 		},
 		TargetPod: &fwkdl.EndpointMetadata{},
-		Usage:     fwkrh.Usage{CompletionTokens: completionTokens},
 	}
 }
 
@@ -2216,4 +2215,64 @@ func TestRunPreRequestPlugins_AggregatesErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), `PreRequest "third/mock" failed`)
 	assert.Equal(t, []string{"first", "second", "third"}, invoked,
 		"every plugin must run; a failure in one must not short-circuit the rest")
+}
+
+func TestDirector_HandleResponseBody_TerminationCause(t *testing.T) {
+	testCases := []struct {
+		name     string
+		recorded fwkrc.TerminationCause
+		want     fwkrc.TerminationCause
+	}{
+		{
+			name: "a stream that reached its end completed naturally",
+			want: fwkrc.TerminationCauseNatural,
+		},
+		{
+			name:     "a recorded cause survives to the record",
+			recorded: fwkrc.TerminationCauseEvicted,
+			want:     fwkrc.TerminationCauseEvicted,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := newTestResponseStreaming("ps")
+			ctx := logutil.NewTestLoggerIntoContext(context.Background())
+			director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil,
+				NewConfig().WithResponseStreamingPlugins(ps))
+
+			reqCtx := newResponseBodyTestRequestContext("test-req-id")
+			reqCtx.TerminationCause = tc.recorded
+
+			director.HandleResponseBody(ctx, reqCtx, true)
+
+			ps.mu.Lock()
+			defer ps.mu.Unlock()
+			require.Len(t, ps.respsOnStreaming, 1)
+			assert.Equal(t, tc.want, ps.respsOnStreaming[0].TerminationCause)
+		})
+	}
+}
+
+func TestDirector_HandleResponseBody_TerminationCauseOnlyAtEndOfStream(t *testing.T) {
+	ps := newTestResponseStreaming("ps")
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	director := NewDirectorWithConfig(nil, &mockScheduler{}, nil, nil,
+		NewConfig().WithResponseStreamingPlugins(ps))
+
+	reqCtx := newResponseBodyTestRequestContext("test-req-id")
+	reqCtx.TerminationCause = fwkrc.TerminationCauseClientDisconnect
+
+	director.HandleResponseBody(ctx, reqCtx, false)
+
+	require.Eventually(t, func() bool {
+		ps.mu.Lock()
+		defer ps.mu.Unlock()
+		return len(ps.respsOnStreaming) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	assert.Empty(t, ps.respsOnStreaming[0].TerminationCause,
+		"mid-stream chunks carry no cause: the stream has not ended")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`ResponseBody` plugins receive a `requestcontrol.Response` on every chunk, with `EndOfStream` set on the last one. The record does not say whether the model server ended the stream or the stream was cut short, so a consumer that learns from response records cannot exclude truncated observations, and an operator cannot attribute stream terminations.

Adds a `TerminationCause` string enum to `framework/interface/requestcontrol`, set on every end-of-stream `Response` and empty on earlier invocations:

- `natural`: the model server ended the stream. Includes error responses delivered in full.
- `client-disconnect`: the ext_proc stream was torn down while the response was in flight. A client disconnect is the most common reason. Any teardown the EPP observes only as a cancelled stream (Envoy drain or restart, an upstream reset) produces the same value, because the EPP cannot distinguish the reasons from its side of the stream.
- `evicted`: the EPP terminated the request to reclaim capacity.
- `error`: the stream ended without completing for any reason not otherwise classified.

`StreamingServer` classifies the cause in its forced-completion defer, where `ctx.Err()` and `RequestState` are both in scope. The director resolves the cause once per end-of-stream pass, defaults an unset cause to `natural`, and carries it on every end-of-stream record, including the one delivered to the eviction tracker.

The boundary between `client-disconnect` and `error` is approximate. A teardown that reaches `Recv` as a half-close before the context cancellation propagates classifies as `error`. Requests whose response processing is skipped never observe completion, so their records always carry a non-natural cause. Unit tests pin the mapping.

Known limitation, to be tracked in a followup issue: a gRPC upstream abort surfaces as response trailers with a non-OK `grpc-status`, which the trailers path does not inspect, so the truncated stream classifies as `natural`.

The field is additive. No existing plugin reads it, and the enum has no config surface. Exporting the cause as a metric label is out of scope.

**Test plan**:

- [x] Classifier maps eviction, cancelled context, skipped response processing, and the remaining teardowns to the documented causes
- [x] End-of-stream records default an unset cause to `natural`; a recorded cause survives to the record
- [x] Mid-stream records carry no cause

**Which issue(s) this PR fixes**:

Fixes #2429

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Response records delivered to ResponseBody plugins carry a TerminationCause on the end-of-stream invocation, distinguishing natural completion from client disconnects, flow-control evictions, and errors.
```
