### PR TITLE
feat(epp): expose a streamed-event count on the response record

### DIFF
--- a/pkg/epp/framework/interface/requestcontrol/types.go
+++ b/pkg/epp/framework/interface/requestcontrol/types.go
@@ -38,6 +38,12 @@ type Response struct {
 	ReqMetadata map[string]any
 	// Token usage counts parsed from the response body.
 	Usage requesthandling.Usage
+	// StreamedEvents is the running count of stream data events observed so far. It is the only
+	// length signal this record carries for a truncated stream, since a stream that never
+	// completes carries no usage block. Consumers must not treat zero as evidence that nothing
+	// was generated; requesthandling.ParsedResponse documents which parsers count and how the
+	// count deviates from the token count.
+	StreamedEvents int
 	// DynamicMetadata is a map of metadata that can be passed to the Envoy. It is populated into the dynamic
 	// metadata when processing ProcessingResponse_RequestHeaders.
 	DynamicMetadata *structpb.Struct

--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -83,4 +83,12 @@ type ParseResult struct {
 type ParsedResponse struct {
 	// Usage is only populate when the raw response has usage.
 	Usage *Usage
+	// StreamedEvents is how many stream data events this parse observed, zero for a non-streamed
+	// response or a parser that does not count. For servers that stream one content delta per
+	// token the count approximates the tokens in the parsed chunk, but protocol events (role
+	// deltas, finish reasons, usage-only events, Responses API lifecycle events) inflate it, a
+	// server that batches tokens into one event deflates it, and the scan recognizes only the
+	// "data: " framing this parser already assumes (no-space prefixes, multi-line data fields,
+	// and keep-alive data lines skew it further).
+	StreamedEvents int
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -203,11 +203,17 @@ func countStreamEvents(chunk []byte) int {
 	count := 0
 	for line := range bytes.SplitSeq(chunk, []byte("\n")) {
 		content, ok := bytes.CutPrefix(line, []byte(streamingRespPrefix))
-		if ok && !bytes.Equal(bytes.TrimSuffix(content, []byte("\r")), []byte("[DONE]")) {
+		if ok && !isStreamTerminator(content) {
 			count++
 		}
 	}
 	return count
+}
+
+// isStreamTerminator reports whether an SSE data payload is the [DONE] terminator, tolerating a
+// trailing \r left by CRLF line splitting.
+func isStreamTerminator(content []byte) bool {
+	return bytes.Equal(bytes.TrimSuffix(content, []byte("\r")), []byte("[DONE]"))
 }
 
 // determineAPITypeFromPath determines the API type based on the request path.
@@ -401,7 +407,7 @@ func extractUsageStreaming(responseBytes []byte) *fwkrh.Usage {
 			continue
 		}
 		// When the stream is terminated with [DONE] or there's not any usage data, skip the line
-		if bytes.Equal(content, []byte("[DONE]")) || !bytes.Contains(content, []byte("usage")) {
+		if isStreamTerminator(content) || !bytes.Contains(content, []byte("usage")) {
 			continue
 		}
 		if err := json.Unmarshal(content, &streamResponse); err != nil {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -188,10 +188,26 @@ func (p *OpenAIParser) ParseResponse(ctx context.Context, body []byte, headers m
 }
 
 func (p *OpenAIParser) parseStreamResponse(chunk []byte) (*fwkrh.ParsedResponse, error) {
-	usage := extractUsageStreaming(string(chunk))
+	text := string(chunk)
+	usage := extractUsageStreaming(text)
 	return &fwkrh.ParsedResponse{
-		Usage: usage,
+		Usage:          usage,
+		StreamedEvents: countStreamEvents(text),
 	}, nil
+}
+
+// countStreamEvents counts the SSE data events in a chunk, excluding the terminator. An event
+// split across two chunks is counted with the half that carries the prefix; a split inside the
+// prefix drops the event and a split inside the terminator counts it, both a one-event error.
+func countStreamEvents(responseText string) int {
+	count := 0
+	for line := range strings.SplitSeq(responseText, "\n") {
+		content, ok := strings.CutPrefix(line, streamingRespPrefix)
+		if ok && strings.TrimSuffix(content, "\r") != "[DONE]" {
+			count++
+		}
+	}
+	return count
 }
 
 // determineAPITypeFromPath determines the API type based on the request path.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1220,6 +1220,7 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 					CompletionTokens: 10,
 					TotalTokens:      17,
 				},
+				StreamedEvents: 1,
 			},
 		},
 		{
@@ -1232,13 +1233,15 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 						CachedTokens: 10,
 					},
 				},
+				StreamedEvents: 1,
 			},
 		},
 		{
 			name:  "Chunk without usage returns ParsedResponse with nil usage",
 			chunk: []byte(`data: {"choices":[{"text":"hello"}]}`),
 			want: &fwkrh.ParsedResponse{
-				Usage: nil,
+				Usage:          nil,
+				StreamedEvents: 1,
 			},
 		},
 		{
@@ -1249,10 +1252,43 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 			},
 		},
 		{
+			name:  "CRLF terminator is not counted",
+			chunk: []byte("data: {\"choices\":[{\"text\":\"a\"}]}\r\ndata: [DONE]\r\n"),
+			want: &fwkrh.ParsedResponse{
+				Usage:          nil,
+				StreamedEvents: 1,
+			},
+		},
+		{
+			name:  "Event cut after the prefix is counted with the prefix half",
+			chunk: []byte("data: {\"choices\":[{\"text\":\"a\"}]}\ndata: {\"cho"),
+			want: &fwkrh.ParsedResponse{
+				Usage:          nil,
+				StreamedEvents: 2,
+			},
+		},
+		{
+			name:  "Event cut inside the prefix is dropped",
+			chunk: []byte(`ta: {"choices":[{"text":"b"}]}`),
+			want: &fwkrh.ParsedResponse{
+				Usage:          nil,
+				StreamedEvents: 0,
+			},
+		},
+		{
+			name:  "Terminator cut mid-token is counted as an event",
+			chunk: []byte(`data: [DO`),
+			want: &fwkrh.ParsedResponse{
+				Usage:          nil,
+				StreamedEvents: 1,
+			},
+		},
+		{
 			name:  "Malformed JSON in stream (skipped)",
 			chunk: []byte(`data: {bad-json}\ndata: {\"usage\":{\"total_tokens\":5}}`),
 			want: &fwkrh.ParsedResponse{
-				Usage: nil,
+				Usage:          nil,
+				StreamedEvents: 1,
 			},
 		},
 		{
@@ -1267,13 +1303,15 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 						CachedTokens: 16,
 					},
 				},
+				StreamedEvents: 1,
 			},
 		},
 		{
 			name:  "ResponsesAPI without response.completed type returns nil",
 			chunk: []byte("event: response.in_progress\ndata: {\"response\":{\"usage\":{\"input_tokens\":31,\"output_tokens\":3}},\"type\":\"response.in_progress\"}"),
 			want: &fwkrh.ParsedResponse{
-				Usage: nil,
+				Usage:          nil,
+				StreamedEvents: 1,
 			},
 		},
 		{
@@ -1285,6 +1323,7 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 					CompletionTokens: 10,
 					TotalTokens:      49,
 				},
+				StreamedEvents: 2,
 			},
 		},
 	}

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -77,6 +77,9 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 			logger.Error(err, "parsing response")
 		}
 	}
+	if parsedResp != nil {
+		reqCtx.StreamedEvents += parsedResp.StreamedEvents
+	}
 	if parsedResp != nil && parsedResp.Usage != nil {
 		reqCtx.Usage = *parsedResp.Usage
 		metrics.RecordInputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, fairnessID, priority, reqCtx.Usage.PromptTokens)

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -568,6 +568,65 @@ func TestResponseSizeAccumulation(t *testing.T) {
 	}
 }
 
+func TestStreamedEventAccumulation(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	tests := []struct {
+		name               string
+		headers            map[string]string
+		chunks             [][]byte
+		wantStreamedEvents int
+	}{
+		{
+			name:    "events accumulate across chunks",
+			headers: map[string]string{"content-type": "text/event-stream"},
+			chunks: [][]byte{
+				[]byte(`data: {"choices":[{"text":"He"}]}` + "\n" + `data: {"choices":[{"text":"llo"}]}` + "\n"),
+				[]byte(`data: {"choices":[{"text":"!"}]}` + "\n" + `data: [DONE]`),
+			},
+			wantStreamedEvents: 3,
+		},
+		{
+			name:               "a truncated stream keeps the count it reached",
+			headers:            map[string]string{"content-type": "text/event-stream"},
+			chunks:             [][]byte{[]byte(`data: {"choices":[{"text":"He"}]}` + "\n")},
+			wantStreamedEvents: 1,
+		},
+		{
+			name:    "an event cut after the prefix at a chunk boundary counts once",
+			headers: map[string]string{"content-type": "text/event-stream"},
+			chunks: [][]byte{
+				[]byte(`data: {"choices":[{"text":"He"}]}` + "\n" + `data: {"cho`),
+				[]byte(`ices":[{"text":"llo"}]}` + "\n" + `data: [DONE]`),
+			},
+			wantStreamedEvents: 2,
+		},
+		{
+			name:               "a non-streamed response counts nothing",
+			headers:            map[string]string{"content-type": "application/json"},
+			chunks:             [][]byte{[]byte(body)},
+			wantStreamedEvents: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &StreamingServer{
+				parserRegistry: NewParserRegistry([]fwkrh.Parser{openai.NewOpenAIParser()}, logr.Discard()),
+				director:       &mockDirector{},
+			}
+			reqCtx := &RequestContext{
+				Response:          &Response{Headers: tt.headers},
+				SchedulingRequest: &fwksched.InferenceRequest{FairnessID: metadata.DefaultFairnessID},
+			}
+			for i, chunk := range tt.chunks {
+				server.HandleResponseBody(ctx, reqCtx, chunk, i == len(tt.chunks)-1)
+			}
+			assert.Equal(t, tt.wantStreamedEvents, reqCtx.StreamedEvents)
+		})
+	}
+}
+
 // TestGenerateResponseBodyResponses_DynamicMetadata verifies that DynamicMetadata is attached
 // to the last ProcessingResponse chunk and not to earlier chunks. This is a regression test for
 // the bug where the metadata was computed by plugins but silently dropped before reaching Envoy.

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -136,6 +136,7 @@ type RequestContext struct {
 	RequestSize                int
 	Usage                      fwkrh.Usage
 	ResponseSize               int
+	StreamedEvents             int
 	ResponseBodyStarted        bool
 	ResponseComplete           bool
 	ResponseStatusCode         string

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -588,11 +588,12 @@ func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.Requ
 	startOfStream := !reqCtx.ResponseBodyStarted
 	reqCtx.ResponseBodyStarted = true
 	response := &fwkrc.Response{
-		RequestID:     reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
-		Headers:       reqCtx.Response.Headers,
-		StartOfStream: startOfStream,
-		EndOfStream:   endOfStream,
-		Usage:         reqCtx.Usage,
+		RequestID:      reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
+		Headers:        reqCtx.Response.Headers,
+		StartOfStream:  startOfStream,
+		EndOfStream:    endOfStream,
+		Usage:          reqCtx.Usage,
+		StreamedEvents: reqCtx.StreamedEvents,
 	}
 
 	if endOfStream {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1648,7 +1648,10 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 		TargetPod: &fwkdl.EndpointMetadata{ID: types.NamespacedName{Namespace: "namespace1", Name: "test-pod-name"}},
 	}
 
+	// Each dispatch snapshots the accumulator, so every invocation carries the total at call time.
+	reqCtx.StreamedEvents = 5
 	director.HandleResponseBody(ctx, reqCtx, false)
+	reqCtx.StreamedEvents = 6
 	director.HandleResponseBody(ctx, reqCtx, false)
 
 	// Intermediate chunks (endOfStream=false) run asynchronously, wait for them.
@@ -1659,6 +1662,7 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "async response body plugins should have been called for intermediate chunks")
 
 	// Final chunk (endOfStream=true) runs synchronously (drains queue first).
+	reqCtx.StreamedEvents = 7
 	director.HandleResponseBody(ctx, reqCtx, true)
 
 	ps1.mu.Lock()
@@ -1674,6 +1678,7 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 		assert.Equal(t, "test-req-id-for-streaming", resp.RequestID)
 		assert.Equal(t, reqCtx.Response.Headers, resp.Headers)
 		assert.Equal(t, "namespace1/test-pod-name", targetPods[i])
+		assert.Equal(t, 5+i, resp.StreamedEvents, "StreamedEvents should carry the accumulator value at dispatch time for chunk %d", i)
 		if i < 2 {
 			assert.False(t, resp.EndOfStream, "EndOfStream should be false for chunk %d", i)
 		} else {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `StreamedEvents`, a count of SSE data events observed while parsing a streamed response:

- `requesthandling.ParsedResponse.StreamedEvents`: events observed in one parse call, set by the OpenAI parser (`[DONE]` and CRLF terminators excluded). The vLLM HTTP parser inherits it by delegation. The Vertex AI parser also delegates, but its streamed responses arrive as gRPC-framed JSON bodies rather than SSE, so it reports zero, as do the Anthropic and vLLM gRPC parsers; all three can be extended in follow-up work.
- `handlers.RequestContext.StreamedEvents`: accumulated across chunks.
- `requestcontrol.Response.StreamedEvents`: the running total, on every ResponseStreaming invocation including the deferred end-of-stream dispatch after a client disconnect.

Streams that truncate, or whose clients never set `stream_options.include_usage`, deliver no usage block, so the response record carries no length signal for the requests whose output length matters most for capacity and fairness accounting. The event count accumulates while the stream flows, so it survives truncation. It counts protocol frames, not tokens; the field contract documents the accuracy bounds, and zero is not evidence of zero output (unsupported parsers report zero).

Scope is the signal only. Consumers (LAS attained-service fallback, `requestattributereporter`, #2305, #1724) are follow-up work per the issue.

**Which issue(s) this PR fixes**:

Fixes #2430

**Release note**:

```release-note
The response record passed to ResponseStreaming plugins carries `StreamedEvents`, a running count of SSE data events that survives stream truncation and client disconnects, giving plugins a length signal for streams that never deliver a usage block.
```

**Test plan** (functionality verified by new tests; all ran and passed locally):

- [x] Per-chunk counting in the OpenAI parser, including terminator and CRLF-terminator exclusion and chunk-boundary cuts (after the prefix: counted once; inside the prefix: dropped; inside the terminator: counted).
- [x] Accumulation across chunks on the request context, including an event cut at a chunk boundary counting once and a truncated stream keeping the count it reached.
- [x] Each ResponseStreaming invocation carries the accumulator value at dispatch time, through the async chunk queue and the synchronous end-of-stream dispatch.
- [x] `make presubmit` green locally.
