### PR TITLE
docs: move Shmuel Kallner to emeritus, drop from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,20 +14,20 @@
 *                                                                         @llm-d/router-maintainers
 
 # Flow control framework + plugins
-/pkg/epp/flowcontrol/                                                     @LukeAVanDrie @RishabhSaini @shmuelk @llm-d/router-maintainers
-/pkg/epp/framework/interface/flowcontrol/                                 @LukeAVanDrie @RishabhSaini @shmuelk @llm-d/router-maintainers
-/pkg/epp/framework/plugins/flowcontrol/                                   @LukeAVanDrie @RishabhSaini @shmuelk @llm-d/router-maintainers
+/pkg/epp/flowcontrol/                                                     @LukeAVanDrie @RishabhSaini @llm-d/router-maintainers
+/pkg/epp/framework/interface/flowcontrol/                                 @LukeAVanDrie @RishabhSaini @llm-d/router-maintainers
+/pkg/epp/framework/plugins/flowcontrol/                                   @LukeAVanDrie @RishabhSaini @llm-d/router-maintainers
 
 # Envoy ext_proc message layer
-/pkg/common/envoy/                                                        @shmuelk @llm-d/router-maintainers
+/pkg/common/envoy/                                                        @llm-d/router-maintainers
 
 # EPP configuration: loading logic and API types
-/pkg/epp/config/                                                          @shmuelk @llm-d/router-maintainers
-/apix/config/                                                             @shmuelk @llm-d/router-maintainers
+/pkg/epp/config/                                                          @llm-d/router-maintainers
+/apix/config/                                                             @llm-d/router-maintainers
 
 # Proxy sidecar
-/cmd/pd-sidecar/                                                          @shmuelk @roytman @llm-d/router-maintainers
-/pkg/sidecar/                                                             @shmuelk @roytman @llm-d/router-maintainers
+/cmd/pd-sidecar/                                                          @roytman @llm-d/router-maintainers
+/pkg/sidecar/                                                             @roytman @llm-d/router-maintainers
 
 # SLO + latency-prediction subsystem
 /pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/             @kaushikmitr @llm-d/router-maintainers
@@ -53,6 +53,6 @@
 /pkg/epp/framework/plugins/requesthandling/                               @zetxqx @llm-d/router-maintainers
 
 # Coordinator
-/cmd/coordinator/                                                         @shmuelk @roytman @llm-d/router-maintainers
-/pkg/coordinator/                                                         @shmuelk @roytman @llm-d/router-maintainers
-/test/coordinator/                                                        @shmuelk @roytman @llm-d/router-maintainers
+/cmd/coordinator/                                                         @roytman @llm-d/router-maintainers
+/pkg/coordinator/                                                         @roytman @llm-d/router-maintainers
+/test/coordinator/                                                        @roytman @llm-d/router-maintainers

--- a/LEADS.md
+++ b/LEADS.md
@@ -41,3 +41,4 @@ Former maintainers, with thanks for their contributions.
 
 - @kfswain
 - @nirrozenbaum
+- @shmuelk


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind cleanup

**What this PR does / why we need it**:

Shmuel Kallner (@shmuelk) has retired. This PR:
- Adds him to the Emeritus section of LEADS.md.
- Removes him as a named code owner in CODEOWNERS for the flowcontrol, envoy, config, sidecar, and coordinator paths. Those paths retain their other named owners, or fall back to @llm-d/router-maintainers where he was the sole named owner (pkg/common/envoy, pkg/epp/config, apix/config).

Also unassigned him from issue #975, and removed his stale requested-reviewer entry from the currently open PRs that still listed him.

**Which issue(s) this PR fixes**:
NA. Cleanup.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```