### PR TITLE
feat: auto-tune approx prefix cache block size from prefix_match_unit

### DIFF
--- a/pkg/epp/framework/interface/datalayer/metrics.go
+++ b/pkg/epp/framework/interface/datalayer/metrics.go
@@ -34,6 +34,7 @@ type Metrics struct {
 	KVCacheUsagePercent     float64
 	KvCacheMaxTokenCapacity int
 	CacheBlockSize          int
+	CachePrefixMatchUnit    int
 	// Number of GPU blocks in the model server for KV Cache.
 	CacheNumBlocks int
 
@@ -76,6 +77,7 @@ func (m *Metrics) Clone() *Metrics {
 		KVCacheUsagePercent:     m.KVCacheUsagePercent,
 		KvCacheMaxTokenCapacity: m.KvCacheMaxTokenCapacity,
 		CacheBlockSize:          m.CacheBlockSize,
+		CachePrefixMatchUnit:    m.CachePrefixMatchUnit,
 		CacheNumBlocks:          m.CacheNumBlocks,
 		UpdateTime:              m.UpdateTime,
 	}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -50,8 +50,9 @@ const (
 	LoraInfoWaitingAdaptersMetricName = "waiting_lora_adapters"
 	LoraInfoMaxAdaptersMetricName     = "max_lora"
 
-	CacheConfigBlockSizeInfoMetricName = "block_size"
-	CacheConfigNumGPUBlocksMetricName  = "num_gpu_blocks"
+	CacheConfigBlockSizeInfoMetricName   = "block_size"
+	CacheConfigNumGPUBlocksMetricName    = "num_gpu_blocks"
+	CacheConfigPrefixMatchUnitMetricName = "prefix_match_unit"
 )
 
 // Extractor implements the metrics extraction based on the model
@@ -259,6 +260,7 @@ func populateLoRAMetrics(clone *fwkdl.Metrics, metric *dto.Metric, errs *[]error
 // (e.g. SGLang uses "page_size" and "num_pages" instead of "block_size" and "num_gpu_blocks").
 func populateCacheInfoMetrics(clone *fwkdl.Metrics, metric *dto.Metric, blockSizeLabelName, numBlocksLabelName string, errs *[]error) {
 	clone.CacheBlockSize = 0
+	clone.CachePrefixMatchUnit = 0
 	for _, label := range metric.GetLabel() {
 		switch label.GetName() {
 		case blockSizeLabelName:
@@ -273,6 +275,14 @@ func populateCacheInfoMetrics(clone *fwkdl.Metrics, metric *dto.Metric, blockSiz
 			if label.GetValue() != "" {
 				if val, err := strconv.Atoi(label.GetValue()); err == nil {
 					clone.CacheNumBlocks = val
+				} else {
+					*errs = append(*errs, err)
+				}
+			}
+		case CacheConfigPrefixMatchUnitMetricName:
+			if label.GetValue() != "" && label.GetValue() != "None" {
+				if val, err := strconv.Atoi(label.GetValue()); err == nil {
+					clone.CachePrefixMatchUnit = val
 				} else {
 					*errs = append(*errs, err)
 				}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -345,8 +345,11 @@ func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 	blockSize := p.config.BlockSizeTokens
 	if p.config.AutoTune && len(endpoints) > 0 {
 		if endpoint := endpoints[0]; endpoint.GetMetrics() != nil {
-			if metric := endpoint.GetMetrics().CacheBlockSize; metric > 0 {
-				blockSize = metric
+			m := endpoint.GetMetrics()
+			if pmu := m.CachePrefixMatchUnit; pmu > 0 {
+				blockSize = pmu
+			} else if bs := m.CacheBlockSize; bs > 0 {
+				blockSize = bs
 			}
 		}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -516,6 +516,22 @@ func TestGetBlockSize_AutotuneAboveMinimumPassesThrough(t *testing.T) {
 	assert.Equal(t, 128, got, "autotuned block size at or above minimum should not be clamped")
 }
 
+func TestGetBlockSize_AutotunePrefersPrefixMatchUnitOverBlockSize(t *testing.T) {
+	cfg := config{AutoTune: true, BlockSizeTokens: 16}
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err)
+
+	endpoint := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
+		&fwkdl.Metrics{CacheBlockSize: 4096, CachePrefixMatchUnit: 128},
+		fwkdl.NewAttributes(),
+	)
+
+	got := p.GetBlockSize([]fwksched.Endpoint{endpoint})
+	assert.Equal(t, 128, got,
+		"prefix_match_unit should be preferred over block_size when both are present")
+}
+
 // TestGetBlockSize_ManualConfigClampedBelowMinimum verifies that the floor
 // applies to manual configuration as well — configured BlockSizeTokens below
 // minBlockSizeTokens is silently raised so the indexer memory bound holds


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Auto-tunes the approx-prefix-cache-producer's `blockSizeTokens` from vLLM's `prefix_match_unit` metric when available.

For Mamba-style models (Kimi, Nemotron), the physical KV cache block size is very large (e.g. 4096 tokens). The approx producer previously auto-tuned from `CacheBlockSize` (physical), producing zero routing signal for prompts shorter than 4096 tokens. vLLM already exposes `prefix_match_unit` as a label on `vllm:cache_config_info` — this is the granularity at which vLLM internally matches prefix cache hits (e.g. 32 tokens for hybrid models).

When `prefix_match_unit` is present and positive, auto-tune now prefers it over `block_size`. The existing `minBlockSizeTokens` floor (64) still applies, so a `prefix_match_unit` of 32 is clamped to 64 — still 64x better than 4096 for routing signal. The floor protects the LRU indexer from memory growth at very small block sizes (#1158). For standard attention models where `prefix_match_unit` is not set, behavior is unchanged.

**Changes:**
- `Metrics` struct: added `CachePrefixMatchUnit` field
- Metrics extractor: reads `prefix_match_unit` label from `vllm:cache_config_info` gauge
- `GetBlockSize()`: prefers `CachePrefixMatchUnit` over `CacheBlockSize` when auto-tuning

**Which issue(s) this PR fixes**:

Fixes #

**Release note**:
```release-note
The approx-prefix-cache-producer now auto-tunes block size from vLLM's prefix_match_unit metric when available, improving cache-aware routing for Mamba-style models with large physical block sizes.
```

## Test plan
- [x] Existing approx prefix cache tests pass
- [x] Metrics extractor tests pass
- [x] Lint passes (only pre-existing unparam issue in unrelated file)
- [ ] Verify with a Mamba-style model that `prefix_match_unit` label appears in `vllm:cache_config_info` and auto-tune picks it up