### PR TITLE
fix(scheduling): return typed capacity rejection when filters drain candidates

### DIFF
--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -26,7 +26,7 @@ import (
 )
 
 // RequestDroppedReasonHeaderKey is the HTTP response header that communicates the specific
-// reason a request was dropped by flow control.
+// reason the EPP dropped a request.
 const RequestDroppedReasonHeaderKey = "x-llm-d-request-dropped-reason"
 
 // RequestDroppedReason is the reason a request was rejected before dispatch or evicted after dispatch.

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -304,8 +304,9 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	endpointCandidates := d.endpointCandidates.Locate(ctx, reqCtx.Request.Metadata)
 	if len(endpointCandidates) == 0 {
 		return reqCtx, errcommon.Error{
-			Code: errcommon.ServiceUnavailable,
-			Msg:  "failed to find endpoint candidates for serving the request",
+			Code:    errcommon.ServiceUnavailable,
+			Msg:     "failed to find endpoint candidates for serving the request",
+			Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)},
 		}
 	}
 
@@ -313,8 +314,9 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	snapshotOfCandidatePods = d.runScreeners(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if len(snapshotOfCandidatePods) == 0 {
 		return reqCtx, errcommon.Error{
-			Code: errcommon.ServiceUnavailable,
-			Msg:  "screeners eliminated all endpoint candidates",
+			Code:    errcommon.ServiceUnavailable,
+			Msg:     "screeners eliminated all endpoint candidates",
+			Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)},
 		}
 	}
 	// Prepare per request data by running DataProducer plugins.

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -414,11 +414,13 @@ func TestDirector_HandleRequest(t *testing.T) {
 		initialTargetModelName  string // Initial target model in the reqCtx.
 		parser                  fwkrh.Parser
 		wantErrCode             string                   // Expected errcommon code string
+		wantDroppedReason       string                   // If non-empty, expected x-llm-d-request-dropped-reason header on the error
 		wantReqCtx              *handlers.RequestContext // Fields to check in the returned RequestContext
 		targetModelName         string                   // Expected model name after target model resolution
 		admitRequestDenialError error                    // Expected denial error from admission plugin
 		dataProducerPlugin      *mockDataProducerPlugin
 		screener                *mockScreener
+		emptyEndpoints          bool // If true, the director locates no endpoint candidates.
 		preRequestPlugins       []*mockPreRequestPlugin
 		requestHeaderPlugin     *mockRequestHeaderPlugin
 		wantMutatedBody         map[string]any
@@ -995,7 +997,21 @@ func TestDirector_HandleRequest(t *testing.T) {
 			screener: &mockScreener{name: "eliminate-all", screen: func([]fwksched.Endpoint) []fwksched.Endpoint {
 				return nil
 			}},
-			wantErrCode: errcommon.ServiceUnavailable,
+			wantErrCode:       errcommon.ServiceUnavailable,
+			wantDroppedReason: string(errcommon.RequestDroppedReasonNoEndpoints),
+		},
+		{
+			name: "no endpoint candidates located",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			initialTargetModelName:  model,
+			inferenceObjectiveName:  objectiveName,
+			emptyEndpoints:          true,
+			wantErrCode:             errcommon.ServiceUnavailable,
+			wantDroppedReason:       string(errcommon.RequestDroppedReasonNoEndpoints),
 		},
 		{
 			name: "scheduler returns error",
@@ -1008,6 +1024,30 @@ func TestDirector_HandleRequest(t *testing.T) {
 				m.scheduleErr = errors.New("simulated scheduler failure")
 			},
 			wantErrCode:            errcommon.ResourceExhausted,
+			inferenceObjectiveName: objectiveName,
+		},
+		{
+			// The typed error inside a joined scheduler error, including its
+			// drop-reason header, must reach the caller instead of the
+			// untyped-error fallback.
+			name: "scheduler returns joined error with typed capacity rejection",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "prompt that causes scheduling drain",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleErr = errors.Join(
+					errors.New("failed to run scheduler profile 'default'"),
+					fmt.Errorf("profile %q: %w", "default", errcommon.Error{
+						Code:    errcommon.ResourceExhausted,
+						Msg:     "no endpoints available for the given request",
+						Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonSaturated)},
+					}),
+				)
+			},
+			wantErrCode:            errcommon.ResourceExhausted,
+			wantDroppedReason:      string(errcommon.RequestDroppedReasonSaturated),
 			inferenceObjectiveName: objectiveName,
 		},
 		{
@@ -1090,6 +1130,9 @@ func TestDirector_HandleRequest(t *testing.T) {
 
 				endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(ds), time.Minute)
 				director := NewDirectorWithConfig(ds, mockSched, test.mockAdmissionController, endpointCandidates, config)
+				if test.emptyEndpoints {
+					director.endpointCandidates = &mockEndpointCandidates{}
+				}
 				if len(test.rewrites) > 0 {
 					mockDs := &mockDatastore{
 						pods:     ds.PodList(datastore.AllPodsPredicate),
@@ -1140,6 +1183,9 @@ func TestDirector_HandleRequest(t *testing.T) {
 					var e errcommon.Error
 					if assert.ErrorAs(t, err, &e, "Error should be of type errcommon.Error") {
 						assert.Equal(t, test.wantErrCode, e.Code, "Error code mismatch")
+						if test.wantDroppedReason != "" {
+							assert.Equal(t, test.wantDroppedReason, e.Headers[errcommon.RequestDroppedReasonHeaderKey], "drop-reason header mismatch")
+						}
 					}
 					return
 				}

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -19,7 +19,10 @@ package scheduling
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -64,6 +67,11 @@ func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceReq
 	}()
 
 	profileRunResults := map[string]*fwksched.ProfileRunResult{}
+	// Keyed like profileRunResults so a profile that fails in one iteration and
+	// succeeds in a later one leaves no stale error behind. Nil until a profile
+	// fails: delete and len are no-ops on a nil map, and the happy path skips
+	// the allocation.
+	var profileRunErrors map[string]error
 
 	for { // get the next set of profiles to run iteratively based on the request and the previous execution results
 		loggerVerbose.Info("Running profile handler, Pick profiles", "plugin", s.profileHandler.TypedName())
@@ -81,8 +89,13 @@ func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceReq
 			profileRunResult, err := runSchedulerProfile(ctx, name, profile, request, candidateEndpoints)
 			if err != nil {
 				loggerVerbose.Info("failed to run scheduler profile", "profile", name, "error", err.Error())
+				if profileRunErrors == nil {
+					profileRunErrors = map[string]error{}
+				}
+				profileRunErrors[name] = fmt.Errorf("profile %q: %w", name, err)
 			} else {
 				loggerVerbose.Info("Completed running scheduler profile succuessfully", "profile", name)
+				delete(profileRunErrors, name)
 			}
 
 			profileRunResults[name] = profileRunResult // if profile failed to run, the run result is nil
@@ -99,6 +112,21 @@ func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceReq
 	result, err = s.profileHandler.ProcessResults(ctx, request, profileRunResults)
 	metrics.RecordPluginProcessingLatency(processProfilesResultsExtensionPoint, s.profileHandler.TypedName().Type, s.profileHandler.TypedName().Name, time.Since(before))
 	loggerVerbose.Info("Completed running profile handler ProcessResults successfully", "plugin", s.profileHandler.TypedName())
+
+	// Profile handlers see failed profiles only as nil results and report them
+	// with fresh untyped errors. Join the retained profile errors so a typed
+	// errcommon.Error raised inside a profile run (e.g. filters draining the
+	// candidate set) stays reachable via errors.As in the caller.
+	if err != nil && len(profileRunErrors) > 0 {
+		errs := make([]error, 0, len(profileRunErrors)+1)
+		errs = append(errs, err)
+		// Sorted so error composition, and therefore errors.As selection when
+		// profiles fail with different typed codes, is deterministic.
+		for _, name := range slices.Sorted(maps.Keys(profileRunErrors)) {
+			errs = append(errs, profileRunErrors[name])
+		}
+		err = errors.Join(errs...)
+	}
 
 	return result, err
 }

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -126,7 +126,15 @@ func (p *SchedulerProfile) String() string {
 func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.InferenceRequest, candidateEndpoints []fwksched.Endpoint) (*fwksched.ProfileRunResult, error) {
 	endpoints := p.runFilterPlugins(ctx, request, candidateEndpoints)
 	if len(endpoints) == 0 {
-		return nil, errcommon.Error{Code: errcommon.Internal, Msg: "no endpoints available for the given request"}
+		// Filters draining a non-empty candidate set means the pool is busy, not
+		// broken: an empty pool is rejected in the director before scheduling
+		// runs. Report it with the same status and drop-reason vocabulary as a
+		// flow control capacity rejection.
+		return nil, errcommon.Error{
+			Code:    errcommon.ResourceExhausted,
+			Msg:     "no endpoints available for the given request",
+			Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonSaturated)},
+		}
 	}
 	// if we got here, there is at least one endpoint to score
 	weightedScorePerEndpoint := p.runScorerPlugins(ctx, request, endpoints)

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -18,6 +18,7 @@ package scheduling
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,7 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
@@ -158,4 +161,36 @@ func TestSchedule(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Tests that a filter draining the candidate set surfaces a typed capacity
+// rejection from Schedule.
+func TestScheduleFilterDrainReturnsTypedError(t *testing.T) {
+	drainingFilter := &testPlugin{typedName: fwkplugin.TypedName{Type: "drain-filter", Name: "drain-filter"}} // empty FilterRes drops every endpoint
+
+	profile := NewSchedulerProfile().
+		WithFilters(drainingFilter).
+		WithPicker(maxscore.NewMaxScorePicker(picker.DefaultMaxNumOfEndpoints))
+
+	schedulerConfig := NewSchedulerConfig(single.NewSingleProfileHandler(), map[string]fwksched.SchedulerProfile{"default": profile})
+	scheduler := NewSchedulerWithConfig(schedulerConfig)
+
+	req := &fwksched.InferenceRequest{
+		RequestID:   uuid.NewString(),
+		TargetModel: "any-model",
+	}
+	input := []fwksched.Endpoint{
+		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{}, nil),
+	}
+
+	result, err := scheduler.Schedule(context.Background(), req, input)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+
+	var typedErr errcommon.Error
+	if !errors.As(err, &typedErr) {
+		t.Fatalf("Schedule error is not an errcommon.Error: %v", err)
+	}
+	assert.Equal(t, errcommon.ResourceExhausted, typedErr.Code)
+	assert.Equal(t, string(errcommon.RequestDroppedReasonSaturated), typedErr.Headers[errcommon.RequestDroppedReasonHeaderKey])
 }

--- a/test/integration/epp/common_tests.go
+++ b/test/integration/epp/common_tests.go
@@ -26,6 +26,7 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
+	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	integration "github.com/llm-d/llm-d-router/test/integration"
 )
@@ -206,6 +207,17 @@ func ExpectGRPCRouteToWithStream(endpoint, prompt, method string) []*extProcPb.P
 // ExpectReject asserts that the EPP immediately rejected the request with the given code and message.
 func ExpectReject(code envoyTypePb.StatusCode, msg string) []*extProcPb.ProcessingResponse {
 	return integration.NewImmediateErrorResponse(code, msg)
+}
+
+// ExpectRejectWithDropReason asserts that the EPP immediately rejected the request with the given code
+// and message, and that the response carries the drop-reason header.
+func ExpectRejectWithDropReason(code envoyTypePb.StatusCode, msg string, reason errcommon.RequestDroppedReason) []*extProcPb.ProcessingResponse {
+	return integration.NewImmediateErrorResponse(code, msg, &envoyCorev3.HeaderValueOption{
+		Header: &envoyCorev3.HeaderValue{
+			Key:      errcommon.RequestDroppedReasonHeaderKey,
+			RawValue: []byte(reason),
+		},
+	})
 }
 
 // ExpectBufferResp asserts that the EPP buffers the response and rewrites the body.

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	pb "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen"
 	integration "github.com/llm-d/llm-d-router/test/integration"
@@ -204,8 +205,9 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 				P(0, 0, 0.2, "foo"),
 				P(1, 0, 0.1, "foo", modelSQLLoraTarget),
 			},
-			wantResponses: ExpectReject(envoyTypePb.StatusCode_ServiceUnavailable,
-				"inference error: ServiceUnavailable - failed to find endpoint candidates for serving the request"),
+			wantResponses: ExpectRejectWithDropReason(envoyTypePb.StatusCode_ServiceUnavailable,
+				"inference error: ServiceUnavailable - failed to find endpoint candidates for serving the request",
+				errcommon.RequestDroppedReasonNoEndpoints),
 		},
 
 		// --- Response Processing (Non-streaming) ---

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -44,6 +44,7 @@ import (
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
+	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
@@ -293,8 +294,9 @@ dataLayer:
 						P(0, 0, 0.2, "foo"),
 						P(1, 0, 0.1, "foo", modelSQLLoraTarget),
 					},
-					wantResponses: ExpectReject(envoyTypePb.StatusCode_ServiceUnavailable,
-						"inference error: ServiceUnavailable - failed to find endpoint candidates for serving the request"),
+					wantResponses: ExpectRejectWithDropReason(envoyTypePb.StatusCode_ServiceUnavailable,
+						"inference error: ServiceUnavailable - failed to find endpoint candidates for serving the request",
+						errcommon.RequestDroppedReasonNoEndpoints),
 				},
 
 				// --- Request Modification (Passthrough & Rewrite) ---

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -441,16 +441,20 @@ func NewResponseStreamChunk(body string, endOfStream bool) *extProcPb.Processing
 	}
 }
 
-// NewImmediateErrorResponse creates a response that immediately terminates the request with a specific HTTP status code
-// and body.
+// NewImmediateErrorResponse creates a response that immediately terminates the request with a specific HTTP status code,
+// body, and optional response headers.
 // Use this for testing Load Shedding (503), Rate Limiting (429), or Bad Request (400) logic.
-func NewImmediateErrorResponse(code envoyTypePb.StatusCode, body string) []*extProcPb.ProcessingResponse {
+func NewImmediateErrorResponse(code envoyTypePb.StatusCode, body string, headers ...*envoyCorev3.HeaderValueOption) []*extProcPb.ProcessingResponse {
+	immediateResponse := &extProcPb.ImmediateResponse{
+		Status: &envoyTypePb.HttpStatus{Code: code},
+		Body:   []byte(body),
+	}
+	if len(headers) > 0 {
+		immediateResponse.Headers = &extProcPb.HeaderMutation{SetHeaders: headers}
+	}
 	return []*extProcPb.ProcessingResponse{{
 		Response: &extProcPb.ProcessingResponse_ImmediateResponse{
-			ImmediateResponse: &extProcPb.ImmediateResponse{
-				Status: &envoyTypePb.HttpStatus{Code: code},
-				Body:   []byte(body),
-			},
+			ImmediateResponse: immediateResponse,
 		},
 	}}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When scheduling filters remove every candidate endpoint, the profile run returns an `Internal` error that `Scheduler.Schedule` drops after logging. Profile handlers see a nil result and raise fresh untyped errors, the director's `errors.As` finds no typed error, and the legacy `ResourceExhausted` fallback sets the response: a 429 with no `x-llm-d-request-dropped-reason` header. Operators cannot distinguish a scheduling drain from any other 429, and dashboards keyed on the drop-reason header miss the requests.

The fix classifies each rejection at the site that detects it, with the status code and drop-reason header flow control uses for the matching condition:

- `SchedulerProfile.Run` returns `ResourceExhausted` with the `rejected-saturated` header when filters drain a non-empty candidate set. An empty pool is rejected in the director before any profile runs.
- `Scheduler.Schedule` retains per-profile errors, keyed by profile name so a profile that fails in one iteration and succeeds in a later one leaves no stale entry, and joins them into a `ProcessResults` error in sorted-name order. The typed code survives to the director's `errors.As` without modifying any profile handler. The P/D handler's treatment of a failed prefill profile with a successful decode as a success is unchanged because the join applies only when `ProcessResults` itself errors.
- The director's pre-scheduling `ServiceUnavailable` rejections (no endpoint candidates located, screeners eliminating every candidate) carry the `rejected-no-endpoints` header.

Clients receive the same status codes as before; the response gains the header.

Known trade-offs, each requiring interface changes that #2428 rules out:

- A filter drain caused by permanent misconfiguration, for example a label filter no pod matches, also reports `rejected-saturated`. Attributing a drain to a specific filter requires carrying a reason through the `Filter` interface.
- When `ProcessResults` fails for a reason of its own while a profile also drained, for example the disagg handler in prefill-first mode with the decode profile missing from the configuration, the joined typed error decides the response: 429 with `rejected-saturated` where 500 would name the configuration fault. Causal attribution requires handlers to see profile errors (#1686).
- When custom profiles fail with different typed codes, the sorted join selects the code by profile-name order. In-tree profiles emit only `ResourceExhausted`, so no stock configuration observes the ordering.

Out of scope: the no-profile-selected untyped error and other untyped 429 sources such as a headerprofile no-match (#1686), and the admission-plugin denial classification.

**Which issue(s) this PR fixes**:

Fixes #2428

**Test plan**:

- [x] A profile whose filter drains the candidate set surfaces a typed `ResourceExhausted` error with the `rejected-saturated` header from `Schedule`.
- [x] The director returns the typed code and drop-reason header from a joined scheduler error instead of the untyped-error fallback.
- [x] The empty-candidates and screener-drain rejections carry the `rejected-no-endpoints` header on their 503 responses.

**Release note**:

```release-note
Requests rejected before dispatch always carry the x-llm-d-request-dropped-reason response header: a 429 with reason rejected-saturated when scheduling filters drain all candidate endpoints, and a 503 with reason rejected-no-endpoints when no candidates exist or screeners eliminate them all.
```
