### PR TITLE
perf(epp): remove per-scrape allocations in the metrics extractor

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -197,13 +197,18 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 		updated = true
 	}
 
-	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().ID)
 	if updated {
 		clone.UpdateTime = time.Now()
-		logger.V(logutil.TRACE).Info("Refreshed metrics",
-			"metrics", mapping.MetricNames(),
-			"updated", clone,
-		)
+		// Guarded: this runs per endpoint per scrape tick, and the logger
+		// construction, MetricNames slice, and boxed args all allocate even
+		// when TRACE is off.
+		if trace := log.FromContext(ctx).V(logutil.TRACE); trace.Enabled() {
+			trace.Info("Refreshed metrics",
+				"endpoint", ep.GetMetadata().ID,
+				"metrics", mapping.MetricNames(),
+				"updated", clone,
+			)
+		}
 		ep.UpdateMetrics(clone)
 	}
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
@@ -127,23 +127,21 @@ func (spec *Spec) getLatestMetric(families sourcemetrics.PrometheusMetricMap) (*
 }
 
 // labelsMatch checks if metric labels match the specification labels.
+// Scans the label pairs directly rather than building a map: this runs per
+// series per scrape tick, and specs carry at most a couple of label matchers.
 func (spec *Spec) labelsMatch(metricLabels []*dto.LabelPair) bool {
-	if len(spec.Labels) == 0 {
-		return true // no label requirements
-	}
-
-	metricLabelMap := make(map[string]string)
-	for _, label := range metricLabels {
-		metricLabelMap[label.GetName()] = label.GetValue()
-	}
-
-	// check if all spec labels match
 	for name, value := range spec.Labels {
-		if metricValue, exists := metricLabelMap[name]; !exists || metricValue != value {
+		found := false
+		for _, label := range metricLabels {
+			if label.GetName() == name {
+				found = label.GetValue() == value
+				break
+			}
+		}
+		if !found {
 			return false
 		}
 	}
-
 	return true
 }
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec_test.go
@@ -519,3 +519,22 @@ func TestExtractValue(t *testing.T) {
 		})
 	}
 }
+
+// labelsMatch runs per series per scrape tick; keep it allocation-free.
+func BenchmarkLabelsMatch(b *testing.B) {
+	spec := &Spec{
+		Name:   "vllm:lora_requests_info",
+		Labels: map[string]string{"engine": "0", "model_name": "m1"},
+	}
+	// A realistic series: the two matched labels plus unrelated ones.
+	metric := makeMetric(map[string]string{
+		"engine": "0", "model_name": "m1", "pod": "p0", "namespace": "ns", "gpu": "3",
+	}, 1.0, 1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !spec.labelsMatch(metric.GetLabel()) {
+			b.Fatal("expected match")
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The metrics extractor runs per endpoint per collector tick (50ms base tick by default), so per-scrape costs scale with fleet size times 20/sec:

- The "Refreshed metrics" TRACE line built a `WithValues` logger and boxed `mapping.MetricNames()` (a fresh slice per call) plus the metrics clone on every scrape even when TRACE is off, which is the production default. The line is now guarded per the project logging convention; output at TRACE is unchanged.
- `labelsMatch` built a `map[string]string` of every series label per evaluation, although specs carry at most a couple of label matchers. It now scans the `LabelPair` slice directly, which benchmarks 60% faster per evaluation.

Benchmark (`benchstat`, count=10, builder container; `BenchmarkLabelsMatch` is added by this PR and was run against the previous implementation for the baseline column):

```
              │  old impl   │  this PR     vs base                │
LabelsMatch-8   84.62n ± 1%   33.80n ± 4%  -60.06% (p=0.000 n=10)
```

**Which issue(s) this PR fixes**:

Part of #2470 

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
NONE
```

## Test plan

- [x] Existing `./pkg/epp/framework/plugins/datalayer/...` unit tests; `labelsMatch` behavior is covered by `spec_test.go`
- [x] New `BenchmarkLabelsMatch` micro-benchmark
- [x] `make presubmit`
