### PR TITLE
feat(datalayer): record more OpenAI fields on the models attribute

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/attribute/models/README.md
+++ b/pkg/epp/framework/plugins/datalayer/attribute/models/README.md
@@ -6,10 +6,13 @@ This package defines the data structures for models served by an endpoint, as re
 
 A collection of `ModelData` entries describing the models exposed by an endpoint.
 
-- **Key**: `ModelsAttributeKey` (`/v1/models`)
+- **Key**: `ModelsAttributeKey`; its string form is `/v1/models/models-data-extractor` (the data type `/v1/models` plus the producer name `models-data-extractor`).
 - **Fields** (per `ModelData`):
   - `ID`: Model identifier.
-  - `Parent`: Parent model identifier (optional, e.g. for adapters).
+  - `Object`: Object type as reported by the model server (i.e. `model`).
+  - `Created`: Unix timestamp reported by the model server.
+  - `OwnedBy`: Owner reported by the model server (e.g. `vllm`, `sglang`).
+  - `Parent`: Parent model identifier (optional, e.g. for LoRA).
 
 ## Producers
 

--- a/pkg/epp/framework/plugins/datalayer/attribute/models/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/models/data_types.go
@@ -35,8 +35,11 @@ type ModelDataCollection []ModelData
 
 // ModelData defines model's data returned from /v1/models API
 type ModelData struct {
-	ID     string `json:"id"`
-	Parent string `json:"parent,omitempty"`
+	ID      string `json:"id"`
+	Object  string `json:"object,omitempty"`
+	Created int64  `json:"created,omitempty"`
+	OwnedBy string `json:"owned_by,omitempty"`
+	Parent  string `json:"parent,omitempty"`
 }
 
 // String returns a string representation of the model info


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
split from https://github.com/llm-d/llm-d-router/pull/2308
- add `Object`, `Created` and `OwnedBy` to ModelData, model servers report them in` /v1/models` next to the existing `ID` and `Parent`
- current code base nothing consumes the models attribute yet
