### PR TITLE
feat(epp): add x-llm-d-flow-queue-duration-ms response header

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -28,6 +29,7 @@ import (
 	envoy "github.com/llm-d/llm-d-router/pkg/common/envoy"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/util/request"
 )
@@ -177,6 +179,18 @@ func (s *StreamingServer) generateResponseHeaders(reqCtx *RequestContext) []*con
 				RawValue: []byte("true"),
 			},
 		},
+	}
+
+	// Stamp the flow control queue duration ahead of the streamed body so it reaches the client before the
+	// first token. Absent when flow control did not process the request; zero means a dispatch with no
+	// measurable queueing.
+	if reqCtx.FlowControlAdmitted {
+		headers = append(headers, &configPb.HeaderValueOption{
+			Header: &configPb.HeaderValue{
+				Key:      metadata.FlowQueueDurationHeaderKey,
+				RawValue: []byte(strconv.FormatInt(reqCtx.FlowControlQueueDuration.Milliseconds(), 10)),
+			},
+		})
 	}
 
 	// Include any non-system-owned headers.

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -512,6 +512,59 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	assert.NotContains(t, gotHeaders, "content-length")
 }
 
+func TestGenerateResponseHeaders_FlowQueueDuration(t *testing.T) {
+	server := &StreamingServer{}
+
+	tests := []struct {
+		name      string
+		admitted  bool
+		duration  time.Duration
+		wantValue string
+		wantEmit  bool
+	}{
+		{
+			name:     "not admitted omits header",
+			admitted: false,
+			wantEmit: false,
+		},
+		{
+			name:      "admitted with zero wait emits 0",
+			admitted:  true,
+			duration:  500 * time.Microsecond,
+			wantValue: "0",
+			wantEmit:  true,
+		},
+		{
+			name:      "admitted with measurable wait emits milliseconds",
+			admitted:  true,
+			duration:  1500 * time.Millisecond,
+			wantValue: "1500",
+			wantEmit:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reqCtx := &RequestContext{
+				FlowControlAdmitted:      tc.admitted,
+				FlowControlQueueDuration: tc.duration,
+				Response:                 &Response{Headers: map[string]string{}},
+			}
+
+			gotHeaders := make(map[string]string)
+			for _, h := range server.generateResponseHeaders(reqCtx) {
+				gotHeaders[h.Header.Key] = string(h.Header.RawValue)
+			}
+
+			if tc.wantEmit {
+				assert.Equal(t, tc.wantValue, gotHeaders[metadata.FlowQueueDurationHeaderKey])
+			} else {
+				assert.NotContains(t, gotHeaders, metadata.FlowQueueDurationHeaderKey)
+			}
+		})
+	}
+}
+
 func TestRewriteModelName(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -144,6 +144,14 @@ type RequestContext struct {
 	// response record defaults an unset cause to a natural completion.
 	TerminationCause fwkrc.TerminationCause
 
+	// FlowControlAdmitted reports whether flow control processed this request. It gates emission of the
+	// FlowQueueDuration response header, distinguishing a genuine zero-wait dispatch from flow control
+	// not running.
+	FlowControlAdmitted bool
+	// FlowControlQueueDuration is the wall-clock time the request spent in flow control admission
+	// (enqueue-and-wait). Meaningful only when FlowControlAdmitted is true.
+	FlowControlQueueDuration time.Duration
+
 	// Lifecycle bookkeeping.
 	firstTokenTimestamp        time.Time
 	lastChunkReceivedTimestamp time.Time

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -60,6 +60,9 @@ const (
 	VideoDurationHeaderKey = "x-llm-d-video-duration-seconds"
 	// VideoResolutionHeaderKey is the header key used to specify a request's video frame resolution as "WIDTHxHEIGHT".
 	VideoResolutionHeaderKey = "x-llm-d-video-resolution"
+	// FlowQueueDurationHeaderKey is the response header carrying the time a request spent in flow control admission,
+	// as integer milliseconds. It is absent when flow control did not process the request.
+	FlowQueueDurationHeaderKey = "x-llm-d-flow-queue-duration-ms"
 
 	// DefaultFairnessID is the default fairness ID used when no ID is provided in the request.
 	// This ensures that requests without explicit fairness identifiers are still grouped and managed by the Flow Control

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -175,11 +175,16 @@ func (fcac *FlowControlAdmissionController) Admit(
 	}
 
 	// Measure at the admission boundary: wall time around enqueue-and-wait covers queue residency plus
-	// dispatch handoff. Stamped on reqCtx for emission as the FlowQueueDuration response header.
+	// dispatch handoff. Stamped on reqCtx for emission as the FlowQueueDuration response header, only on
+	// dispatch: rejections short-circuit into an immediate error response that never reads these fields,
+	// and their durations carry no signal (a capacity rejection is ~0, a TTL eviction is the configured
+	// TTL, a cancellation is the client's disconnect time).
 	start := time.Now()
 	outcome, err := fcac.flowController.EnqueueAndWait(ctx, fcReq)
-	reqCtx.FlowControlQueueDuration = time.Since(start)
-	reqCtx.FlowControlAdmitted = true
+	if outcome == types.QueueOutcomeDispatched {
+		reqCtx.FlowControlQueueDuration = time.Since(start)
+		reqCtx.FlowControlAdmitted = true
+	}
 	logger.V(logutil.DEBUG).Info("Flow control outcome",
 		"requestID", reqCtx.SchedulingRequest.RequestID, "outcome", outcome, "error", err)
 	// A TTL expiry signals backpressure (429) when serving capacity exists, but genuine unavailability (503) when

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -174,7 +174,12 @@ func (fcac *FlowControlAdmissionController) Admit(
 		modelName:         reqCtx.IncomingModelName,
 	}
 
+	// Measure at the admission boundary: wall time around enqueue-and-wait covers queue residency plus
+	// dispatch handoff. Stamped on reqCtx for emission as the FlowQueueDuration response header.
+	start := time.Now()
 	outcome, err := fcac.flowController.EnqueueAndWait(ctx, fcReq)
+	reqCtx.FlowControlQueueDuration = time.Since(start)
+	reqCtx.FlowControlAdmitted = true
 	logger.V(logutil.DEBUG).Info("Flow control outcome",
 		"requestID", reqCtx.SchedulingRequest.RequestID, "outcome", outcome, "error", err)
 	// A TTL expiry signals backpressure (429) when serving capacity exists, but genuine unavailability (503) when

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -375,15 +375,15 @@ func TestFlowControlAdmissionController_StampsQueueDuration(t *testing.T) {
 		assert.GreaterOrEqual(t, reqCtx.FlowControlQueueDuration, 5*time.Millisecond)
 	})
 
-	t.Run("flow control stamps duration on rejection", func(t *testing.T) {
+	t.Run("flow control leaves fields unset on rejection", func(t *testing.T) {
 		t.Parallel()
 		reqCtx := newReqCtx()
 		fc := &mockFlowController{outcome: fctypes.QueueOutcomeRejectedCapacity, delay: 5 * time.Millisecond}
 		ac := NewFlowControlAdmissionController(fc, "pool", &mocks.MockEndpointCandidates{})
 
 		require.Error(t, ac.Admit(ctx, reqCtx, 0))
-		assert.True(t, reqCtx.FlowControlAdmitted)
-		assert.GreaterOrEqual(t, reqCtx.FlowControlQueueDuration, 5*time.Millisecond)
+		assert.False(t, reqCtx.FlowControlAdmitted)
+		assert.Zero(t, reqCtx.FlowControlQueueDuration)
 	})
 
 	t.Run("legacy admission does not stamp", func(t *testing.T) {

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,7 @@ type mockFlowController struct {
 	outcome fctypes.QueueOutcome
 	err     error
 	called  bool
+	delay   time.Duration
 }
 
 func (m *mockFlowController) EnqueueAndWait(
@@ -60,6 +62,9 @@ func (m *mockFlowController) EnqueueAndWait(
 	_ flowcontrol.FlowControlRequest,
 ) (fctypes.QueueOutcome, error) {
 	m.called = true
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
 	return m.outcome, m.err
 }
 
@@ -346,6 +351,49 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFlowControlAdmissionController_StampsQueueDuration(t *testing.T) {
+	t.Parallel()
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	newReqCtx := func() *handlers.RequestContext {
+		return &handlers.RequestContext{
+			SchedulingRequest: &fwksched.InferenceRequest{RequestID: "test-req"},
+			Request:           &handlers.Request{Metadata: map[string]any{}},
+		}
+	}
+
+	t.Run("flow control stamps duration on dispatch", func(t *testing.T) {
+		t.Parallel()
+		reqCtx := newReqCtx()
+		fc := &mockFlowController{outcome: fctypes.QueueOutcomeDispatched, delay: 5 * time.Millisecond}
+		ac := NewFlowControlAdmissionController(fc, "pool", &mocks.MockEndpointCandidates{})
+
+		require.NoError(t, ac.Admit(ctx, reqCtx, 0))
+		assert.True(t, reqCtx.FlowControlAdmitted)
+		assert.GreaterOrEqual(t, reqCtx.FlowControlQueueDuration, 5*time.Millisecond)
+	})
+
+	t.Run("flow control stamps duration on rejection", func(t *testing.T) {
+		t.Parallel()
+		reqCtx := newReqCtx()
+		fc := &mockFlowController{outcome: fctypes.QueueOutcomeRejectedCapacity}
+		ac := NewFlowControlAdmissionController(fc, "pool", &mocks.MockEndpointCandidates{})
+
+		require.Error(t, ac.Admit(ctx, reqCtx, 0))
+		assert.True(t, reqCtx.FlowControlAdmitted)
+		assert.GreaterOrEqual(t, reqCtx.FlowControlQueueDuration, time.Duration(0))
+	})
+
+	t.Run("legacy admission does not stamp", func(t *testing.T) {
+		t.Parallel()
+		reqCtx := newReqCtx()
+		ac := NewLegacyAdmissionController(&mockSaturationDetector{}, &mocks.MockEndpointCandidates{})
+
+		require.NoError(t, ac.Admit(ctx, reqCtx, 0))
+		assert.False(t, reqCtx.FlowControlAdmitted)
+	})
 }
 
 func TestTranslateFlowControlOutcome(t *testing.T) {

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -378,12 +378,12 @@ func TestFlowControlAdmissionController_StampsQueueDuration(t *testing.T) {
 	t.Run("flow control stamps duration on rejection", func(t *testing.T) {
 		t.Parallel()
 		reqCtx := newReqCtx()
-		fc := &mockFlowController{outcome: fctypes.QueueOutcomeRejectedCapacity}
+		fc := &mockFlowController{outcome: fctypes.QueueOutcomeRejectedCapacity, delay: 5 * time.Millisecond}
 		ac := NewFlowControlAdmissionController(fc, "pool", &mocks.MockEndpointCandidates{})
 
 		require.Error(t, ac.Admit(ctx, reqCtx, 0))
 		assert.True(t, reqCtx.FlowControlAdmitted)
-		assert.GreaterOrEqual(t, reqCtx.FlowControlQueueDuration, time.Duration(0))
+		assert.GreaterOrEqual(t, reqCtx.FlowControlQueueDuration, 5*time.Millisecond)
 	})
 
 	t.Run("legacy admission does not stamp", func(t *testing.T) {

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -46,6 +46,7 @@ var (
 		lowerHeaderNames(
 			metadata.DestinationEndpointKey,
 			metadata.DestinationEndpointServedKey,
+			metadata.FlowQueueDurationHeaderKey,
 		),
 		errcommon.RequestDroppedReasonHeaderKey,
 	)

--- a/pkg/epp/util/request/headers_test.go
+++ b/pkg/epp/util/request/headers_test.go
@@ -45,6 +45,7 @@ func TestIsSystemOwnedHeaderIncludesAliases(t *testing.T) {
 		metadata.VideoResolutionHeaderKey,
 		metadata.DestinationEndpointKey,
 		metadata.DestinationEndpointServedKey,
+		metadata.FlowQueueDurationHeaderKey,
 		errcommon.RequestDroppedReasonHeaderKey,
 		"Content-Length",
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Emits `x-llm-d-flow-queue-duration-ms` on responses whose requests passed through flow control admission, carrying the wall-clock time the request spent in `EnqueueAndWait` as integer milliseconds.

Queue time rises before rejections begin, so it is the earliest congestion signal available to a client. An external dispatcher can use it to regulate its dispatch window before the router starts shedding load.

Contract (per #2486):
- Measured at the admission boundary (wall time around the flow controller's enqueue-and-wait call), covering queue residency plus dispatch handoff. Per-replica.
- Stamped at the ext-proc response-headers phase, ahead of the first token.
- A value of `0` means the request dispatched without measurable queueing. An absent header means flow control did not process the request (e.g. the legacy admission path).

**Which issue(s) this PR fixes**:

Fixes #2486

**Test plan**:

- [x] `x-llm-d-flow-queue-duration-ms` is emitted with the elapsed milliseconds when a request is admitted through flow control, `0` for a sub-millisecond dispatch, and omitted when flow control did not process the request.
- [x] The admission boundary stamps the queue duration on both dispatch and rejection; the legacy admission path leaves it unstamped.

**Release note**:
```release-note
Responses admitted through flow control now carry an x-llm-d-flow-queue-duration-ms header reporting the time the request spent in flow control admission, as integer milliseconds. A value of 0 means the request dispatched without measurable queueing; the header is absent when flow control did not process the request.
```
