### PR TITLE
fix(dev): remove stale external tokenizer config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,10 +323,10 @@ test-e2e: image-build-builder image-build ## Build images and run e2e tests
 
 
 .PHONY: bench-tokenizer
-bench-tokenizer: image-build-builder ## Run external tokenizer + scorer benchmark (requires kind cluster with EPP deployed)
-	@printf "\033[33;1m==== Running External Tokenizer Benchmark ====\033[0m\n"
-	@printf "Ensure the kind cluster is running with the external tokenizer config.\n"
-	@printf "Run 'EXTERNAL_TOKENIZER_ENABLED=true KV_CACHE_ENABLED=true make env-dev-kind' first.\n\n"
+bench-tokenizer: image-build-builder ## Run tokenizer + scorer benchmark (requires kind cluster with EPP deployed)
+	@printf "\033[33;1m==== Running Tokenizer Benchmark ====\033[0m\n"
+	@printf "Ensure the kind cluster is running with the KV cache config.\n"
+	@printf "Run 'KV_CACHE_ENABLED=true make env-dev-kind' first.\n\n"
 	$(BUILDER_RUN_CLUSTER) 'go test -bench=. -benchmem -count=5 -timeout=5m ./test/profiling/tokenizerbench/'
 
 .PHONY: bench-smoke

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -106,9 +106,6 @@ fi
 # By default we are not setting up for KV cache
 export KV_CACHE_ENABLED="${KV_CACHE_ENABLED:-false}"
 
-# By default we are not setting up for external tokenizer
-export EXTERNAL_TOKENIZER_ENABLED="${EXTERNAL_TOKENIZER_ENABLED:-false}"
-
 # Replica counts for E (Encode), P (Prefill), and D (Decode)
 export VLLM_REPLICA_COUNT_E="${VLLM_REPLICA_COUNT_E:-1}"
 export VLLM_REPLICA_COUNT_P="${VLLM_REPLICA_COUNT_P:-1}"
@@ -158,9 +155,7 @@ fi
 
 # Determine EPP config file based on disaggregation flags
 # KV cache and data parallel are independent options that work with any mode
-if [ "${EXTERNAL_TOKENIZER_ENABLED}" == "true" ]; then
-  DEFAULT_EPP_CONFIG="deploy/config/sim-epp-external-tokenizer-config.yaml"
-elif [ "${KV_CACHE_ENABLED}" == "true" ]; then
+if [ "${KV_CACHE_ENABLED}" == "true" ]; then
   DEFAULT_EPP_CONFIG="deploy/config/sim-epp-kvcache-config.yaml"
 elif [ "${DISAGG_E}" == "true" ] && [ "${DISAGG_P}" == "true" ]; then
   DEFAULT_EPP_CONFIG="deploy/config/sim-e-p-d-epp-config.yaml"

--- a/test/profiling/tokenizerbench/benchmark_test.go
+++ b/test/profiling/tokenizerbench/benchmark_test.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package external_tokenizer_scorer benchmarks the end-to-end request flow
-// through the EPP when using the external tokenizer DataProducer plugin
+// Package tokenizerbench benchmarks the end-to-end request flow
+// through the EPP when using the token-producer plugin
 // combined with the precise-prefix-cache-producer and prefix-cache-scorer.
 //
 // Prerequisites:
-//   - A kind cluster with the EPP deployed using the external tokenizer config.
+//   - A kind cluster with the EPP deployed using the KV cache config.
 //   - Gateway reachable on localhost (default: port 30080).
 //
 // Run:
@@ -28,7 +28,7 @@ limitations under the License.
 //
 // Or manually:
 //
-//	EXTERNAL_TOKENIZER_ENABLED=true KV_CACHE_ENABLED=true make env-dev-kind
+//	KV_CACHE_ENABLED=true make env-dev-kind
 //	MODEL_NAME="TinyLlama/TinyLlama-1.1B-Chat-v1.0" go test -bench=. -benchmem -count=5 -timeout=5m ./test/profiling/tokenizerbench/
 package tokenizerbench
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Removes the stale `EXTERNAL_TOKENIZER_ENABLED` dev path that still referenced the deleted `deploy/config/sim-epp-external-tokenizer-config.yaml`.

The tokenizer path has moved to `token-producer` with the vLLM render backend, and the existing KV-cache dev config already uses that path. This change removes the obsolete flag/config selection and updates the tokenizer benchmark instructions accordingly.

Validation:
- `bash -n scripts/kind-dev-env.sh`
- verified no remaining references to `EXTERNAL_TOKENIZER_ENABLED`
- verified no remaining references to `sim-epp-external-tokenizer-config.yaml`
- `git diff --check`

**Which issue(s) this PR fixes**:

Fixes #2477

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
