### PR TITLE
Add an outcome metric for the affinity filter plugin

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefixcacheaffinity
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	compbasemetrics "k8s.io/component-base/metrics"
+
+	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
+	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+// Decision outcome labels. Each Filter call records exactly one of these,
+// capturing whether kv-cache affinity or load decided the candidate set.
+const (
+	// outcomeSticky: the affinity gate narrowed the set to endpoints whose
+	// prefix cache score met the threshold, and the load gate kept them.
+	outcomeSticky = "sticky"
+	// outcomeNoMatch: no endpoint met the affinity threshold, so all were kept.
+	outcomeNoMatch = "no_match"
+	// outcomeLoadOverride: the TTFT load gate discarded a non-empty sticky set
+	// because those endpoints were too slow, reopening all endpoints.
+	outcomeLoadOverride = "load_override"
+	// outcomeExploration: the gate was skipped for exploration.
+	outcomeExploration = "exploration"
+	// outcomeNotApplicable: the filter had nothing to decide (a single
+	// candidate, or the affinity threshold disabled).
+	outcomeNotApplicable = "not_applicable"
+)
+
+var filterDecisions = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
+		Name:      "prefix_cache_affinity_filter_decisions_total",
+		Help:      metricsutil.HelpMsgWithStability("Prefix cache affinity filter decisions, by outcome.", compbasemetrics.ALPHA),
+	},
+	[]string{"plugin_name", "outcome"},
+)
+
+// registerMetrics registers the filter collectors on the given registerer. A nil
+// registerer is a no-op, so the filter runs without metrics when the handle
+// supplies no recorder. Repeated registration of the same collector is tolerated.
+func registerMetrics(registerer prometheus.Registerer) error {
+	if registerer == nil {
+		return nil
+	}
+	if err := registerer.Register(filterDecisions); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if errors.As(err, &alreadyRegistered) && alreadyRegistered.ExistingCollector == filterDecisions {
+			return nil
+		}
+		return fmt.Errorf("register prefix cache affinity filter metric: %w", err)
+	}
+	return nil
+}
+
+func recordDecision(pluginName, outcome string) {
+	filterDecisions.WithLabelValues(pluginName, outcome).Inc()
+}
+
+// resetMetrics clears the collectors between tests.
+func resetMetrics() {
+	filterDecisions.Reset()
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefixcacheaffinity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+func TestRegisterMetrics(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+
+	registry := prometheus.NewRegistry()
+	require.NoError(t, registerMetrics(registry))
+	require.NoError(t, registerMetrics(registry), "re-registering the same collector is tolerated")
+	require.NoError(t, registerMetrics(nil), "a nil registerer is a no-op")
+}
+
+// Each Filter branch records exactly one decision outcome, so the counter labels
+// distinguish an affinity-driven route from one where load reopened the set.
+func TestFilterRecordsDecisionOutcome(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		input   []fwksched.Endpoint
+		outcome string
+	}{
+		{
+			name:   "single candidate is not applicable",
+			config: Config{AffinityThreshold: 0.80},
+			input:  []fwksched.Endpoint{makeEndpoint("a", 90, 10, 0)},
+			// A single candidate has no set to narrow.
+			outcome: outcomeNotApplicable,
+		},
+		{
+			name:    "disabled threshold is not applicable",
+			config:  Config{AffinityThreshold: 0},
+			input:   []fwksched.Endpoint{makeEndpoint("a", 90, 10, 0), makeEndpoint("b", 10, 10, 0)},
+			outcome: outcomeNotApplicable,
+		},
+		{
+			name:    "exploration skip",
+			config:  Config{AffinityThreshold: 0.80, ExplorationProbability: 1.0},
+			input:   []fwksched.Endpoint{makeEndpoint("a", 90, 100, 0), makeEndpoint("b", 10, 50, 0)},
+			outcome: outcomeExploration,
+		},
+		{
+			name:    "no endpoint meets the threshold",
+			config:  Config{AffinityThreshold: 0.80},
+			input:   []fwksched.Endpoint{makeEndpoint("a", 10, 10, 0), makeEndpoint("b", 20, 20, 0)},
+			outcome: outcomeNoMatch,
+		},
+		{
+			name:    "sticky set kept",
+			config:  Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 5000, TTFTSource: TTFTSourceLatencyPredictor},
+			input:   []fwksched.Endpoint{makeEndpoint("a", 90, 100, 0), makeEndpoint("b", 85, 120, 0), makeEndpoint("c", 10, 50, 0)},
+			outcome: outcomeSticky,
+		},
+		{
+			name:    "load gate reopens the set",
+			config:  Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourceLatencyPredictor},
+			input:   []fwksched.Endpoint{makeEndpoint("a", 90, 500, 0), makeEndpoint("b", 10, 50, 0)},
+			outcome: outcomeLoadOverride,
+		},
+	}
+
+	allOutcomes := []string{outcomeSticky, outcomeNoMatch, outcomeLoadOverride, outcomeExploration, outcomeNotApplicable}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resetMetrics()
+			t.Cleanup(resetMetrics)
+
+			p := newTestPlugin(test.config)
+			p.Filter(context.Background(), nil, test.input)
+
+			for _, outcome := range allOutcomes {
+				want := float64(0)
+				if outcome == test.outcome {
+					want = 1
+				}
+				got := testutil.ToFloat64(filterDecisions.WithLabelValues("test", outcome))
+				assert.Equalf(t, want, got, "outcome %q", outcome)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -108,7 +108,7 @@ type Plugin struct {
 	inFlightLoadDataKey          fwkplugin.DataKey
 }
 
-func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+func Factory(name string, rawParameters *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	config := DefaultConfig
 	if rawParameters != nil {
 		if err := rawParameters.Decode(&config); err != nil {
@@ -117,6 +117,11 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 	}
 	if err := config.validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	if handle != nil {
+		if err := registerMetrics(handle.Metrics()); err != nil {
+			return nil, err
+		}
 	}
 	return &Plugin{
 		typedName:                    fwkplugin.TypedName{Type: PluginType, Name: name},
@@ -166,6 +171,7 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	logger := log.FromContext(ctx)
 
 	if len(endpoints) <= 1 || p.config.AffinityThreshold <= 0 {
+		recordDecision(p.typedName.Name, outcomeNotApplicable)
 		return endpoints
 	}
 
@@ -173,6 +179,7 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	if rand.Float64() < p.config.ExplorationProbability {
 		logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: exploration skip, keeping all",
 			"affinityThreshold", p.config.AffinityThreshold, "total", len(endpoints))
+		recordDecision(p.typedName.Name, outcomeExploration)
 		return endpoints
 	}
 
@@ -190,6 +197,7 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	if len(sticky) == 0 {
 		logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: no sticky endpoints",
 			"affinityThreshold", p.config.AffinityThreshold, "total", len(endpoints))
+		recordDecision(p.typedName.Name, outcomeNoMatch)
 		return endpoints
 	}
 
@@ -201,12 +209,14 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 			logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: TTFT load gate broken",
 				"bestStickyTTFT", bestStickyTTFT, "bestNonStickyTTFT", bestNonStickyTTFT,
 				"penalty", bestStickyTTFT-bestNonStickyTTFT, "maxPenalty", p.config.MaxTTFTPenaltyMs)
+			recordDecision(p.typedName.Name, outcomeLoadOverride)
 			return endpoints
 		}
 	}
 
 	logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: narrowed to sticky",
 		"affinityThreshold", p.config.AffinityThreshold, "sticky", len(sticky), "total", len(endpoints))
+	recordDecision(p.typedName.Name, outcomeSticky)
 	return sticky
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a new metric giving insight into the routing decision between affinity routing and load based routing.

**Which issue(s) this PR fixes**:

None

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
Add a new metrics: `llm_d_epp_prefix_cache_affinity_filter_decisions_total` with details on the routing decision of the `prefixcacheaffinity` filter.
```
