### PR TITLE
Add passthrough-parser to the default parser list

### DIFF
--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -48,6 +48,7 @@ import (
 	reqdataprodprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/passthrough"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vertexai"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
@@ -623,13 +624,15 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
 				require.NotNil(t, cfg.ParserRegistry, "Parser registry should be loaded")
 				parsers := cfg.ParserRegistry.Parsers()
-				require.Len(t, parsers, 3, "Should have three default parsers")
+				require.Len(t, parsers, 4, "Should have the three default parsers plus the passthrough fallback")
 				require.Equal(t, "openai-parser", parsers[0].TypedName().Name)
 				require.Equal(t, openai.OpenAIParserType, parsers[0].TypedName().Type)
 				require.Equal(t, "anthropic-parser", parsers[1].TypedName().Name)
 				require.Equal(t, anthropic.AnthropicParserType, parsers[1].TypedName().Type)
 				require.Equal(t, "vllmhttp-parser", parsers[2].TypedName().Name)
 				require.Equal(t, vllmhttp.VllmHTTPParserType, parsers[2].TypedName().Type)
+				require.Equal(t, passthrough.PassthroughParserType, parsers[3].TypedName().Type,
+					"Passthrough is last so it does not shadow the claimed parsers")
 			},
 		},
 		{
@@ -664,6 +667,20 @@ func TestInstantiateAndConfigure(t *testing.T) {
 			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
 				require.NotNil(t, cfg.SaturationDetector, "SaturationDetector should be loaded")
 				require.Equal(t, "utilization-detector", cfg.SaturationDetector.TypedName().Name)
+			},
+		},
+		{
+			name:       "Success - Explicit parsers keep their own fallback",
+			configText: successExplicitPassthroughConfigText,
+			wantErr:    false,
+			validate: func(t *testing.T, handle fwkplugin.Handle, rawCfg *configapi.EndpointPickerConfig, cfg *config.Config) {
+				require.NotNil(t, cfg.ParserRegistry, "Parser registry should be loaded")
+				parsers := cfg.ParserRegistry.Parsers()
+				require.Len(t, parsers, 2, "Explicit parsers are used as given")
+				require.Equal(t, "openai-parser", parsers[0].TypedName().Name)
+				require.Equal(t, "myFallback", parsers[1].TypedName().Name,
+					"The operator's own fallback is kept, under its own name")
+				require.Equal(t, passthrough.PassthroughParserType, parsers[1].TypedName().Type)
 			},
 		},
 		{
@@ -1204,6 +1221,7 @@ func registerTestPlugins(t *testing.T) {
 	fwkplugin.Register(vertexai.VertexAIParserType, fwkplugin.StabilityStable, vertexai.VertexAIParserPluginFactory)
 	fwkplugin.Register(anthropic.AnthropicParserType, fwkplugin.StabilityStable, anthropic.AnthropicParserPluginFactory)
 	fwkplugin.Register(vllmhttp.VllmHTTPParserType, fwkplugin.StabilityStable, vllmhttp.VllmHTTPParserPluginFactory)
+	fwkplugin.Register(passthrough.PassthroughParserType, fwkplugin.StabilityBeta, passthrough.PassthroughParserPluginFactory)
 	fwkplugin.Register(usagelimits.StaticUsageLimitPolicyType, fwkplugin.StabilityStable, usagelimits.StaticPolicyFactory)
 	fwkplugin.Register(prefix.PrefixCacheScorerPluginType, fwkplugin.StabilityStable, prefix.PrefixCachePluginFactory)
 	fwkplugin.Register(reqdataprodprefix.ApproxPrefixCachePluginType, fwkplugin.StabilityStable, reqdataprodprefix.ApproxPrefixCacheFactory)

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -30,6 +30,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/passthrough"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
@@ -238,7 +239,11 @@ func ensureFlowControlLayer(cfg *configapi.EndpointPickerConfig, handle fwkplugi
 }
 
 // ensureParsers guarantees that at least one parser is configured.
-// If no parsers are configured, the openAI parser is configured by default.
+// If no parsers are configured, the openAI, anthropic and vllmHTTP parsers are
+// configured by default, followed by the passthrough parser so a path claimed by
+// none of them is forwarded without interpretation instead of rejected. The
+// passthrough parser is last because the registry stops at the first parser
+// claiming no paths.
 func ensureParsers(
 	cfg *configapi.EndpointPickerConfig,
 	handle fwkplugin.Handle,
@@ -252,6 +257,7 @@ func ensureParsers(
 			{PluginRef: openai.OpenAIParserType},
 			{PluginRef: anthropic.AnthropicParserType},
 			{PluginRef: vllmhttp.VllmHTTPParserType},
+			{PluginRef: passthrough.PassthroughParserType},
 		}
 	}
 	for _, pc := range cfg.RequestHandler.Parsers {

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -438,6 +438,27 @@ requestHandler:
   - pluginRef: secondParser
 `
 
+// successExplicitPassthroughConfigText configures a fallback explicitly under a
+// custom name, alongside a claimed-path parser.
+const successExplicitPassthroughConfigText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+- type: openai-parser
+- name: myFallback
+  type: passthrough-parser
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+requestHandler:
+  parsers:
+  - pluginRef: openai-parser
+  - pluginRef: myFallback
+`
+
 // successDataLayerAutoDefaultText has the datalayer enabled without data config.
 // The loader should auto-populate default datalayer plugins.
 // successDataLayerAutoDefaultText has NO featureGates — datalayer is enabled by default.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/README.md
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/README.md
@@ -10,7 +10,7 @@ This directory contains parser plugins used to parse and understand the payloads
 *   **`vllmhttp-parser`**: A parser for vLLM HTTP endpoints that are not part of the OpenAI-compatible API surface — specifically `/inference/v1/generate` (which accepts pre-tokenized prompts and multimodal features). Because it only handles this path, you must also configure `openai-parser` if you want to support OpenAI-compatible paths on the same route.
 *   **`sglanghttp-parser`**: A parser for SGLang's native HTTP `/generate` endpoint, which is not part of the OpenAI-compatible API. It currently supports a single pre-tokenized prompt or a batch of pre-tokenized prompts. Configure `openai-parser` alongside it if you also want to handle OpenAI-compatible paths on the same route.
 *   **`vertexai-parser`**: A parser designed to handle requests for the Vertex AI gRPC API, specifically supporting [PredictionService/ChatCompletions](https://github.com/googleapis/googleapis/blob/89c3153888201c9e80bc5ec78d6ffca0debe6b52/google/cloud/aiplatform/v1beta1/prediction_service.proto#L235). For unsupported Vertex AI APIs, it skips parsing and lets the request pass through without interpretation resulting in routing to a random endpoint.
-*   **`passthrough-parser`**: A model-agnostic parser that supports any request format by passing the request body through without interpretation.
+*   **`passthrough-parser`**: A model-agnostic parser that supports any request format by passing the request body through without interpretation. It claims no paths, so it acts as the fallback for unmatched traffic and is included last in the default parser list.
     *   **Drawback**: EPP cannot parse the payload, so payload-related scheduling scorers (e.g., `prefix-cache-scorer`) are not supported.
 
 ### Serving mixed vLLM-specific and OpenAI-compatible traffic
@@ -23,7 +23,11 @@ Parsers are configured via the `requestHandler.parsers` list in the `EndpointPic
 
 The EPP resolves incoming request paths to the matching parser using longest-suffix matching. Suffixes are defined by each parser plugin's claims. If a parser does not define specific paths, it acts as a fallback for any unmatched traffic.
 
-If no parsers are specified, `openai-parser`, `anthropic-parser`, and `vllmhttp-parser` are used by default.
+Registration stops at the first parser claiming no paths. Any parser listed after it is skipped, so a fallback belongs last.
+
+If no parsers are specified, `openai-parser`, `anthropic-parser`, `vllmhttp-parser`, and `passthrough-parser` are used by default. The trailing `passthrough-parser` means a path none of the others claim is forwarded to the model server without interpretation, and is scheduled without payload-derived signals, rather than rejected with `400`.
+
+An explicit `requestHandler.parsers` list is used as given. It gains no fallback, so a path no listed parser claims is rejected. Add `passthrough-parser` as the last entry to forward that traffic instead.
 
 Here is an example configuration using the `vllmgrpc-parser`:
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When no parsers are configured, the defaults are `openai-parser`, `anthropic-parser`, and `vllmhttp-parser`. A request to a path none of them claim (for example the vllm-omni endpoints `/v1/images/edits`, `/v1/videos`, `/v1/audio/*`) is rejected with 400 unless the operator adds `passthrough-parser` manually.

This PR appends `passthrough-parser` to the default parser list, so unclaimed paths are forwarded to the model server without interpretation. It is placed last because the parser registry treats the first parser claiming no paths as the fallback and skips everything after it. Explicit `requestHandler.parsers` lists are unchanged and gain no fallback.

**Which issue(s) this PR fixes**:

Fixes #2506

**Release note**:

```release-note
The default parser list (used when no parsers are configured) includes passthrough-parser as a trailing fallback, so requests to paths not claimed by the default parsers, such as vllm-omni image, video, and audio endpoints, are forwarded to the model server instead of being rejected.
```

**Test plan**:

- [x] Default parser list ends with the passthrough fallback
- [x] An explicit parser list is used as given, with no fallback injected
