### PR TITLE
fix(epp): classify non-OK gRPC trailers as errors

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -266,7 +266,7 @@ func terminationCauseFromGRPCTrailers(trailers *extProcPb.HttpTrailers) fwkrc.Te
 
 	for _, header := range trailers.GetTrailers().GetHeaders() {
 		if header.Key == "grpc-status" {
-			if grpcStatus := string(header.RawValue); grpcStatus != "" && grpcStatus != "0" {
+			if grpcStatus := envoy.GetHeaderValue(header); grpcStatus != "" && grpcStatus != "0" {
 				return fwkrc.TerminationCauseError
 			}
 			return ""

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -259,6 +259,22 @@ func terminationCause(reqCtx *RequestContext, ctxErr error) fwkrc.TerminationCau
 	}
 }
 
+func terminationCauseFromGRPCTrailers(trailers *extProcPb.HttpTrailers) fwkrc.TerminationCause {
+	if trailers == nil || trailers.GetTrailers() == nil {
+		return ""
+	}
+
+	for _, header := range trailers.GetTrailers().GetHeaders() {
+		if header.Key == "grpc-status" {
+			if grpcStatus := string(header.RawValue); grpcStatus != "" && grpcStatus != "0" {
+				return fwkrc.TerminationCauseError
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
 func extractFairnessAndPriority(reqCtx *RequestContext) (string, string) {
 	if reqCtx == nil {
 		return metadata.DefaultFairnessID, "0"
@@ -568,9 +584,13 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				}
 			}
 		case *extProcPb.ProcessingRequest_ResponseTrailers:
-			// For HTTP, the response trailer is not sent. Thus, this case will not be triggered.
-			// For gRPC(over HTTP2), the protocol relies on responseTrailers to determine whether a response is complete.
+			// A non-zero grpc-status indicates a gRPC error. Record the error cause before
+			// finishResponse marks the response complete so the end-of-stream record is not
+			// reported as a natural termination.
 			// More info: https://chromium.googlesource.com/external/github.com/grpc/grpc/+/HEAD/doc/PROTOCOL-HTTP2.md#responses
+			if cause := terminationCauseFromGRPCTrailers(v.ResponseTrailers); cause != "" {
+				reqCtx.TerminationCause = cause
+			}
 			s.finishResponse(ctx, reqCtx, respBody, reqCtx.modelServerStreaming, false)
 			reqCtx.respTrailerResp = &extProcPb.ProcessingResponse{
 				Response: &extProcPb.ProcessingResponse_ResponseTrailers{

--- a/pkg/epp/handlers/server_abort_test.go
+++ b/pkg/epp/handlers/server_abort_test.go
@@ -168,9 +168,10 @@ func TestTerminationCause(t *testing.T) {
 
 func TestTerminationCauseFromGRPCTrailers(t *testing.T) {
 	tests := []struct {
-		name   string
-		status string
-		want   fwkrc.TerminationCause
+		name     string
+		status   string
+		useValue bool
+		want     fwkrc.TerminationCause
 	}{
 		{
 			name:   "OK",
@@ -191,6 +192,12 @@ func TestTerminationCauseFromGRPCTrailers(t *testing.T) {
 			name: "missing grpc status",
 			want: "",
 		},
+		{
+			name:     "internal error from value",
+			status:   "13",
+			useValue: true,
+			want:     fwkrc.TerminationCauseError,
+		},
 	}
 
 	for _, tt := range tests {
@@ -200,12 +207,16 @@ func TestTerminationCauseFromGRPCTrailers(t *testing.T) {
 			}
 
 			if tt.status != "" {
-				trailers.Trailers.Headers = []*corev3.HeaderValue{
-					{
-						Key:      "grpc-status",
-						RawValue: []byte(tt.status),
-					},
+				header := &corev3.HeaderValue{
+					Key: "grpc-status",
 				}
+				if tt.useValue {
+					header.Value = tt.status
+				} else {
+					header.RawValue = []byte(tt.status)
+				}
+
+				trailers.Trailers.Headers = []*corev3.HeaderValue{header}
 			}
 
 			assert.Equal(

--- a/pkg/epp/handlers/server_abort_test.go
+++ b/pkg/epp/handlers/server_abort_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/go-logr/logr"
@@ -161,6 +162,57 @@ func TestTerminationCause(t *testing.T) {
 			t.Parallel()
 			reqCtx := &RequestContext{requestState: tt.state}
 			assert.Equal(t, tt.want, terminationCause(reqCtx, tt.ctxErr))
+		})
+	}
+}
+
+func TestTerminationCauseFromGRPCTrailers(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   fwkrc.TerminationCause
+	}{
+		{
+			name:   "OK",
+			status: "0",
+			want:   "",
+		},
+		{
+			name:   "internal error",
+			status: "13",
+			want:   fwkrc.TerminationCauseError,
+		},
+		{
+			name:   "cancelled",
+			status: "1",
+			want:   fwkrc.TerminationCauseError,
+		},
+		{
+			name: "missing grpc status",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trailers := &extProcPb.HttpTrailers{
+				Trailers: &corev3.HeaderMap{},
+			}
+
+			if tt.status != "" {
+				trailers.Trailers.Headers = []*corev3.HeaderValue{
+					{
+						Key:      "grpc-status",
+						RawValue: []byte(tt.status),
+					},
+				}
+			}
+
+			assert.Equal(
+				t,
+				tt.want,
+				terminationCauseFromGRPCTrailers(trailers),
+			)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

A gRPC response can have HTTP status 200 while still terminating with a non-OK `grpc-status` in response trailers.

The EPP `ResponseTrailers` path previously called `finishResponse` without inspecting `grpc-status`. As a result, aborted gRPC streams could reach end-of-stream handling without a termination cause and be recorded as `natural`.

This change classifies non-zero `grpc-status` trailers as `TerminationCauseError` before the response is finalized.

It also adds unit coverage for gRPC trailer termination classification.

Validation:
- `go test ./pkg/epp/handlers -count=1`
- `go test ./pkg/epp/... -count=1`
- `git diff --check`

**Which issue(s) this PR fixes**:

Fixes #2468

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
