### PR TITLE
Preserve JSON number precision during request repackaging

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -156,10 +156,10 @@ func (b *InferenceRequestBody) MutatePayloadMap(fn func(PayloadMap)) {
 // from a decoded JSON request body. The keys are tried in order and the first one
 // holding a valid value wins, so callers express per-API precedence (e.g. chat
 // completions: max_completion_tokens then the legacy max_tokens). JSON numbers
-// decode as float64; json.Number is also accepted. A present key whose value is
-// the wrong type, negative, or non-integral is treated as absent and the next key
-// is tried. An explicit non-negative whole number (including 0) is returned; if no
-// key holds a valid value the result is nil ("no cap").
+// may decode as float64 or json.Number; both are accepted. A present key whose
+// value is the wrong type, negative, or non-integral is treated as absent and the
+// next key is tried. An explicit non-negative whole number (including 0) is
+// returned; if no key holds a valid value the result is nil ("no cap").
 func MaxOutputTokensFromPayload(m PayloadMap, keys ...string) *int64 {
 	for _, k := range keys {
 		v, ok := m[k]

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
@@ -99,8 +100,13 @@ func (p *AnthropicParser) ParseRequest(_ context.Context, body []byte, headers m
 	}
 
 	bodyMap := make(map[string]any)
-	if err := json.Unmarshal(body, &bodyMap); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request body: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, errors.New("error unmarshaling request body: unexpected trailing data")
 	}
 
 	var messagesReq fwkrh.MessagesRequest

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
@@ -30,6 +29,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	parserutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/util"
 )
 
 const (
@@ -100,13 +100,8 @@ func (p *AnthropicParser) ParseRequest(_ context.Context, body []byte, headers m
 	}
 
 	bodyMap := make(map[string]any)
-	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.UseNumber()
-	if err := decoder.Decode(&bodyMap); err != nil {
+	if err := parserutil.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request body: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		return nil, errors.New("error unmarshaling request body: unexpected trailing data")
 	}
 
 	var messagesReq fwkrh.MessagesRequest

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -19,7 +19,6 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -456,17 +455,6 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}
 		})
-	}
-}
-
-func TestAnthropicParser_RejectsTrailingJSON(t *testing.T) {
-	_, err := NewAnthropicParser().ParseRequest(
-		context.Background(),
-		[]byte(`{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hello"}]}{"extra":true}`),
-		map[string]string{":path": "/v1/messages"},
-	)
-	if err == nil || !strings.Contains(err.Error(), "unexpected trailing data") {
-		t.Fatalf("ParseRequest() error = %v, want unexpected trailing data", err)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -19,6 +19,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,7 +74,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"messages": []any{
 						map[string]any{"role": "user", "content": "Hello, Claude"},
 					},
@@ -108,7 +109,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"messages": []any{
 						map[string]any{
 							"role": "user",
@@ -141,7 +142,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"system":     "You are a helpful assistant.",
 					"messages": []any{
 						map[string]any{"role": "user", "content": "Hello"},
@@ -176,7 +177,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"system": []any{
 						map[string]any{"type": "text", "text": "You are a helpful assistant."},
 					},
@@ -230,7 +231,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"messages": []any{
 						map[string]any{
 							"role": "user",
@@ -281,7 +282,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"tools": []any{
 						map[string]any{
 							"name":        "get_weather",
@@ -314,7 +315,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"stream":     true,
 					"messages": []any{
 						map[string]any{"role": "user", "content": "Hello"},
@@ -344,7 +345,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"cache_salt": "test-salt-123",
 					"messages": []any{
 						map[string]any{"role": "user", "content": "Hello"},
@@ -371,7 +372,7 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":      "claude-sonnet-4-6",
-					"max_tokens": float64(1024),
+					"max_tokens": json.Number("1024"),
 					"messages": []any{
 						map[string]any{"role": "user", "content": "Hello"},
 					},
@@ -455,6 +456,17 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestAnthropicParser_RejectsTrailingJSON(t *testing.T) {
+	_, err := NewAnthropicParser().ParseRequest(
+		context.Background(),
+		[]byte(`{"model":"test","max_tokens":1,"messages":[{"role":"user","content":"hello"}]}{"extra":true}`),
+		map[string]string{":path": "/v1/messages"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unexpected trailing data") {
+		t.Fatalf("ParseRequest() error = %v, want unexpected trailing data", err)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/common/request"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	parserutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/util"
 )
 
 const (
@@ -117,13 +117,8 @@ func (p *OpenAIParser) WithName(name string) *OpenAIParser {
 // ParseRequest parses the request body and headers and returns a map representation.
 func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
 	bodyMap := make(map[string]any)
-	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.UseNumber()
-	if err := decoder.Decode(&bodyMap); err != nil {
+	if err := parserutil.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		return nil, errors.New("error unmarshaling request bodyMap: unexpected trailing data")
 	}
 	apiType := determineAPITypeFromPath(request.GetRequestPath(headers))
 	extractedBody, err := extractRequestBody(apiType, body)

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -116,8 +117,13 @@ func (p *OpenAIParser) WithName(name string) *OpenAIParser {
 // ParseRequest parses the request body and headers and returns a map representation.
 func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
 	bodyMap := make(map[string]any)
-	if err := json.Unmarshal(body, &bodyMap); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, errors.New("error unmarshaling request bodyMap: unexpected trailing data")
 	}
 	apiType := determineAPITypeFromPath(request.GetRequestPath(headers))
 	extractedBody, err := extractRequestBody(apiType, body)

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -19,6 +19,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -116,7 +117,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":  "test",
-					"prompt": []any{float64(1), float64(2), float64(3)},
+					"prompt": []any{json.Number("1"), json.Number("2"), json.Number("3")},
 				},
 			},
 		},
@@ -892,7 +893,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "text-embedding-3-small",
-					"input": []any{float64(1), float64(2), float64(3)},
+					"input": []any{json.Number("1"), json.Number("2"), json.Number("3")},
 				},
 			},
 		},
@@ -975,12 +976,12 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					"model":               "test-image-model",
 					"prompt":              "a cat wearing a spacesuit",
 					"negative_prompt":     "blurry",
-					"n":                   float64(2),
+					"n":                   json.Number("2"),
 					"size":                "1024x1024",
 					"response_format":     "b64_json",
-					"num_inference_steps": float64(30),
-					"guidance_scale":      7.5,
-					"seed":                float64(42),
+					"num_inference_steps": json.Number("30"),
+					"guidance_scale":      json.Number("7.5"),
+					"seed":                json.Number("42"),
 				},
 			},
 		},
@@ -1062,6 +1063,57 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestOpenAIParser_RepackagePreservesLargeJSONInteger(t *testing.T) {
+	const seed = json.Number("9007199254740993")
+
+	result, err := NewOpenAIParser().ParseRequest(
+		context.Background(),
+		[]byte(`{"model":"test","prompt":"hello","seed":9007199254740993}`),
+		map[string]string{":path": "/v1/completions"},
+	)
+	if err != nil {
+		t.Fatalf("ParseRequest() error = %v", err)
+	}
+
+	payload, ok := result.Body.Payload.(fwkrh.PayloadMap)
+	if !ok {
+		t.Fatalf("Payload type = %T, want requesthandling.PayloadMap", result.Body.Payload)
+	}
+	if got, ok := payload["seed"].(json.Number); !ok || got != seed {
+		t.Fatalf("parsed seed = %v (%T), want %s (json.Number)", payload["seed"], payload["seed"], seed)
+	}
+
+	result.Body.MutatePayloadMap(func(payload fwkrh.PayloadMap) {
+		payload["model"] = "backend-model"
+	})
+	repackaged, err := payload.Marshal()
+	if err != nil {
+		t.Fatalf("PayloadMap.Marshal() error = %v", err)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(repackaged, &got); err != nil {
+		t.Fatalf("unmarshal repackaged payload: %v", err)
+	}
+	if string(got["model"]) != `"backend-model"` {
+		t.Errorf("repackaged model = %s, want %q", got["model"], "backend-model")
+	}
+	if string(got["seed"]) != seed.String() {
+		t.Errorf("repackaged seed = %s, want %s", got["seed"], seed)
+	}
+}
+
+func TestOpenAIParser_RejectsTrailingJSON(t *testing.T) {
+	_, err := NewOpenAIParser().ParseRequest(
+		context.Background(),
+		[]byte(`{"model":"test","prompt":"hello"}{"extra":true}`),
+		map[string]string{":path": "/v1/completions"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unexpected trailing data") {
+		t.Fatalf("ParseRequest() error = %v, want unexpected trailing data", err)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -19,7 +19,6 @@ package openai
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1103,17 +1102,6 @@ func TestOpenAIParser_RepackagePreservesLargeJSONInteger(t *testing.T) {
 	}
 	if string(got["seed"]) != seed.String() {
 		t.Errorf("repackaged seed = %s, want %s", got["seed"], seed)
-	}
-}
-
-func TestOpenAIParser_RejectsTrailingJSON(t *testing.T) {
-	_, err := NewOpenAIParser().ParseRequest(
-		context.Background(),
-		[]byte(`{"model":"test","prompt":"hello"}{"extra":true}`),
-		map[string]string{":path": "/v1/completions"},
-	)
-	if err == nil || !strings.Contains(err.Error(), "unexpected trailing data") {
-		t.Fatalf("ParseRequest() error = %v, want unexpected trailing data", err)
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpcutil
+package parserutil
 
 import (
 	"encoding/binary"

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpcutil
+package parserutil
 
 import (
 	"encoding/binary"

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/json.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/json.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parserutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+var ErrTrailingData = errors.New("unexpected trailing data after JSON value")
+
+// Unmarshal decodes one JSON value, preserves numbers as json.Number, and rejects trailing data.
+func Unmarshal(data []byte, v any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+	switch err := decoder.Decode(&struct{}{}); {
+	case errors.Is(err, io.EOF):
+		return nil
+	case err == nil:
+		return ErrTrailingData
+	default:
+		return fmt.Errorf("%w: %v", ErrTrailingData, err)
+	}
+}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/json_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/json_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parserutil
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUnmarshalUsesNumber(t *testing.T) {
+	var got any
+	if err := Unmarshal([]byte(`{"integer":9007199254740993,"nested":[1.5]}  `), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	want := map[string]any{
+		"integer": json.Number("9007199254740993"),
+		"nested":  []any{json.Number("1.5")},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Unmarshal() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUnmarshalRejectsTrailingData(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError string
+	}{
+		{
+			name:      "second JSON value",
+			input:     `{} {}`,
+			wantError: ErrTrailingData.Error(),
+		},
+		{
+			name:      "malformed trailing data",
+			input:     `{} trailing`,
+			wantError: "unexpected trailing data after JSON value: invalid character 'a' in literal true (expecting 'u')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got any
+			err := Unmarshal([]byte(tt.input), &got)
+			if !errors.Is(err, ErrTrailingData) {
+				t.Fatalf("Unmarshal() error = %v, want unexpected trailing data", err)
+			}
+			if err.Error() != tt.wantError {
+				t.Errorf("Unmarshal() error = %q, want %q", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -20,10 +20,12 @@ limitations under the License.
 package vllmhttp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
@@ -114,8 +116,13 @@ func (p *VllmHTTPParser) RewriteModelName(payload fwkrh.MarshalablePayload, mode
 // InferenceRequestBody. Token IDs are required; everything else is optional.
 func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResult, error) {
 	bodyMap := make(map[string]any)
-	if err := json.Unmarshal(rawBody, &bodyMap); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(rawBody))
+	decoder.UseNumber()
+	if err := decoder.Decode(&bodyMap); err != nil {
 		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, errors.New("invalid generate request: unexpected trailing data")
 	}
 
 	var generate fwkrh.GenerateRequest

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -20,12 +20,10 @@ limitations under the License.
 package vllmhttp
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
@@ -34,6 +32,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	parserutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/util"
 )
 
 const (
@@ -116,13 +115,8 @@ func (p *VllmHTTPParser) RewriteModelName(payload fwkrh.MarshalablePayload, mode
 // InferenceRequestBody. Token IDs are required; everything else is optional.
 func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResult, error) {
 	bodyMap := make(map[string]any)
-	decoder := json.NewDecoder(bytes.NewReader(rawBody))
-	decoder.UseNumber()
-	if err := decoder.Decode(&bodyMap); err != nil {
+	if err := parserutil.Unmarshal(rawBody, &bodyMap); err != nil {
 		return nil, err
-	}
-	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		return nil, errors.New("invalid generate request: unexpected trailing data")
 	}
 
 	var generate fwkrh.GenerateRequest

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -241,11 +241,6 @@ func TestVllmHTTPParser_ParseRequest_GenerateErrorPaths(t *testing.T) {
 			body:        `{"token_ids":[]}`,
 			errContains: "must have non-empty token_ids field",
 		},
-		{
-			name:        "trailing JSON is rejected",
-			body:        `{"token_ids":[1,2,3]}{"extra":true}`,
-			errContains: "unexpected trailing data",
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -61,7 +61,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					TokenIDs: []uint32{1, 2, 3},
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids": []any{float64(1), float64(2), float64(3)},
+					"token_ids": []any{json.Number("1"), json.Number("2"), json.Number("3")},
 				},
 			},
 		},
@@ -78,7 +78,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					CacheSalt: "abc123",
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids":  []any{float64(10), float64(20), float64(30)},
+					"token_ids":  []any{json.Number("10"), json.Number("20"), json.Number("30")},
 					"cache_salt": "abc123",
 				},
 			},
@@ -99,10 +99,10 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					TokenIDs: []uint32{1, 2, 3},
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids": []any{float64(1), float64(2), float64(3)},
+					"token_ids": []any{json.Number("1"), json.Number("2"), json.Number("3")},
 					"sampling_params": map[string]any{
-						"temperature": 0.8,
-						"max_tokens":  float64(128),
+						"temperature": json.Number("0.8"),
+						"max_tokens":  json.Number("128"),
 					},
 					"stream": true,
 				},
@@ -137,7 +137,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					TokenIDs: []uint32{5, 6, 7},
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids": []any{float64(5), float64(6), float64(7)},
+					"token_ids": []any{json.Number("5"), json.Number("6"), json.Number("7")},
 				},
 			},
 		},
@@ -175,9 +175,9 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"token_ids": []any{
-						float64(151644), float64(872), float64(198), float64(3838), float64(374), float64(279),
-						float64(6722), float64(315), float64(9625), float64(30), float64(151645), float64(198),
-						float64(151644), float64(77091), float64(198),
+						json.Number("151644"), json.Number("872"), json.Number("198"), json.Number("3838"), json.Number("374"), json.Number("279"),
+						json.Number("6722"), json.Number("315"), json.Number("9625"), json.Number("30"), json.Number("151645"), json.Number("198"),
+						json.Number("151644"), json.Number("77091"), json.Number("198"),
 					},
 					"features": map[string]any{
 						"mm_hashes": map[string]any{
@@ -185,8 +185,8 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 						},
 						"mm_placeholders": map[string]any{
 							"image": []any{
-								map[string]any{"offset": float64(1), "length": float64(3)},
-								map[string]any{"offset": float64(4), "length": float64(3)},
+								map[string]any{"offset": json.Number("1"), "length": json.Number("3")},
+								map[string]any{"offset": json.Number("4"), "length": json.Number("3")},
 							},
 						},
 					},
@@ -240,6 +240,11 @@ func TestVllmHTTPParser_ParseRequest_GenerateErrorPaths(t *testing.T) {
 			name:        "empty token_ids surfaces empty-field error",
 			body:        `{"token_ids":[]}`,
 			errContains: "must have non-empty token_ids field",
+		},
+		{
+			name:        "trailing JSON is rejected",
+			body:        `{"token_ids":[1,2,3]}{"extra":true}`,
+			errContains: "unexpected trailing data",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Decode HTTP request payload maps in the OpenAI, Anthropic, and vLLM HTTP
parsers with a shared parser utility based on `json.Decoder.UseNumber()`.
Rename the parser utility package from `grpcutil` to `parserutil` so it can
contain both gRPC and JSON helpers. The utility accepts exactly one JSON value
and rejects trailing data, so payload mutations and repackaging preserve
untouched JSON number values. Typed request parsing remains unchanged.

**Performance impact**:

Decode-only performance can regress for very large numeric arrays. With one
million `token_ids`, payload-map decoding was about 11% slower and used about
21% more memory. The full parse, mutate, and marshal path was about 8% faster,
but used about 13% more memory. This PR prioritizes correctness; preserving
large `token_ids` arrays as raw JSON can be evaluated separately because it
changes their runtime type in `PayloadMap`.

**Which issue(s) this PR fixes**:

Fixes #2518

**Test plan**:

- [x] Preserve a large integer through OpenAI request parsing, payload mutation, and repackaging.
- [x] Preserve `json.Number` payload values in OpenAI, Anthropic, and vLLM HTTP parsing.
- [x] Reject second JSON values and malformed trailing data in the shared decoder.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Preserve JSON number precision when HTTP request payloads are mutated and repackaged.
```
