### PR TITLE
feat: Support array<array<integer>> prompt in /v1/completions

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -211,6 +211,15 @@ type PromptTokens struct {
 	MultiModalFeatures []MultiModalFeature
 }
 
+// NewTokenizedRequest builds one PromptTokens entry per token-ID array.
+func NewTokenizedRequest(arrays [][]uint32) *TokenizedRequest {
+	prompts := make([]PromptTokens, len(arrays))
+	for i, ids := range arrays {
+		prompts[i] = PromptTokens{TokenIDs: ids}
+	}
+	return &TokenizedRequest{Prompts: prompts}
+}
+
 // TokenCount returns the total number of tokens across all prompts.
 func (tp *TokenizedRequest) TokenCount() int {
 	if tp == nil {
@@ -239,17 +248,34 @@ type MultiModalFeature struct {
 }
 
 // Prompt represents the prompt field in a /v1/completions request.
-// Per the OpenAI spec it can be a string or an array of strings.
+// Per the OpenAI spec it can be a string, an array of strings, an array of
+// integers (token IDs), or an array of arrays of integers (multiple prompts
+// as token IDs).
 // See https://platform.openai.com/docs/api-reference/completions/create#completions-create-prompt
 type Prompt struct {
 	Raw      string
 	Strings  []string
-	TokenIDs []uint32
+	TokenIDs [][]uint32
 }
 
 type arrayInputResult struct {
 	Strings  []string
-	TokenIDs []uint32
+	TokenIDs [][]uint32
+}
+
+func parseTokenIDs(v []any, errorPrefix string) ([]uint32, error) {
+	ids := make([]uint32, len(v))
+	for i, val := range v {
+		flt, ok := val.(float64)
+		if !ok {
+			return nil, fmt.Errorf("%s: mixed types in array", errorPrefix)
+		}
+		if flt != float64(uint32(flt)) {
+			return nil, fmt.Errorf("%s: floating-point number %f is not a valid token ID", errorPrefix, flt)
+		}
+		ids[i] = uint32(flt)
+	}
+	return ids, nil
 }
 
 func parseArrayInput(v []any, errorPrefix string) (arrayInputResult, error) {
@@ -268,18 +294,28 @@ func parseArrayInput(v []any, errorPrefix string) (arrayInputResult, error) {
 		}
 		return arrayInputResult{Strings: strings}, nil
 	case float64:
-		uint32s := make([]uint32, len(v))
-		for i, val := range v {
-			flt, ok := val.(float64)
+		ids, err := parseTokenIDs(v, errorPrefix)
+		if err != nil {
+			return arrayInputResult{}, err
+		}
+		return arrayInputResult{TokenIDs: [][]uint32{ids}}, nil
+	case []any:
+		arrays := make([][]uint32, len(v))
+		for i, elem := range v {
+			inner, ok := elem.([]any)
 			if !ok {
 				return arrayInputResult{}, fmt.Errorf("%s: mixed types in array", errorPrefix)
 			}
-			if flt != float64(uint32(flt)) {
-				return arrayInputResult{}, fmt.Errorf("%s: floating-point number %f is not a valid token ID", errorPrefix, flt)
+			if len(inner) == 0 {
+				return arrayInputResult{}, fmt.Errorf("%s: empty sub-array at index %d", errorPrefix, i)
 			}
-			uint32s[i] = uint32(flt)
+			ids, err := parseTokenIDs(inner, errorPrefix)
+			if err != nil {
+				return arrayInputResult{}, err
+			}
+			arrays[i] = ids
 		}
-		return arrayInputResult{TokenIDs: uint32s}, nil
+		return arrayInputResult{TokenIDs: arrays}, nil
 	default:
 		return arrayInputResult{}, fmt.Errorf("%s: unsupported array element type", errorPrefix)
 	}
@@ -310,7 +346,11 @@ func (p *Prompt) UnmarshalJSON(data []byte) error {
 
 func (p Prompt) TokenCountHint() int {
 	if len(p.TokenIDs) > 0 {
-		return len(p.TokenIDs)
+		n := 0
+		for _, ids := range p.TokenIDs {
+			n += len(ids)
+		}
+		return n
 	}
 	return -1
 }
@@ -321,6 +361,9 @@ func (p Prompt) MarshalJSON() ([]byte, error) {
 	}
 	if p.Strings != nil {
 		return json.Marshal(p.Strings)
+	}
+	if p.TokenIDs != nil {
+		return json.Marshal(p.TokenIDs)
 	}
 	return json.Marshal("")
 }
@@ -341,7 +384,7 @@ func (p Prompt) IsEmpty() bool {
 // This struct includes fields usable for plugins and scheduling decisions - and not the entire
 // API spec.
 type CompletionsRequest struct {
-	// Prompt is the prompt(s) sent in the request body; can be a string or an array of strings.
+	// Prompt is the prompt(s) sent in the request body.
 	Prompt Prompt `json:"prompt"`
 	// CacheSalt is an optional request parameter to isolate prefix caches for security reasons.
 	CacheSalt string `json:"cache_salt,omitempty"`
@@ -423,11 +466,12 @@ func (c *ConversationsRequest) String() string {
 }
 
 // EmbeddingsInput represents the input field in a /v1/embeddings request.
-// Per the OpenAI spec it can be a string, an array of strings, or an array of integers.
+// Per the OpenAI spec it can be a string, an array of strings, an array of
+// integers (token IDs), or an array of arrays of integers.
 type EmbeddingsInput struct {
 	Raw      string
 	Strings  []string
-	TokenIDs []uint32
+	TokenIDs [][]uint32
 }
 
 func (e *EmbeddingsInput) UnmarshalJSON(data []byte) error {
@@ -455,7 +499,11 @@ func (e *EmbeddingsInput) UnmarshalJSON(data []byte) error {
 
 func (e EmbeddingsInput) TokenCountHint() int {
 	if len(e.TokenIDs) > 0 {
-		return len(e.TokenIDs)
+		n := 0
+		for _, ids := range e.TokenIDs {
+			n += len(ids)
+		}
+		return n
 	}
 	return -1
 }

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -50,7 +50,7 @@ func TestPrompt_UnmarshalJSON(t *testing.T) {
 		{
 			name:  "array of integers prompt",
 			input: `[1,2,3]`,
-			want:  Prompt{TokenIDs: []uint32{1, 2, 3}},
+			want:  Prompt{TokenIDs: [][]uint32{{1, 2, 3}}},
 		},
 		{
 			name:    "array of floats prompt is rejected",
@@ -59,8 +59,38 @@ func TestPrompt_UnmarshalJSON(t *testing.T) {
 		},
 
 		{
-			name:    "array of arrays of integers prompt is rejected for now",
-			input:   `[[1,2],[3,4]]`,
+			name:  "array of arrays of integers prompt",
+			input: `[[1,2],[3,4]]`,
+			want:  Prompt{TokenIDs: [][]uint32{{1, 2}, {3, 4}}},
+		},
+		{
+			name:  "single sub-array of integers prompt",
+			input: `[[10,20,30]]`,
+			want:  Prompt{TokenIDs: [][]uint32{{10, 20, 30}}},
+		},
+		{
+			name:    "empty sub-array in nested prompt",
+			input:   `[[1,2],[]]`,
+			wantErr: true,
+		},
+		{
+			name:    "mixed types in nested array prompt",
+			input:   `[[1,2],"hello"]`,
+			wantErr: true,
+		},
+		{
+			name:    "float in sub-array prompt",
+			input:   `[[1,2.5]]`,
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric in sub-array prompt",
+			input:   `[[1,"a"]]`,
+			wantErr: true,
+		},
+		{
+			name:    "triple nesting prompt",
+			input:   `[[[1,2]]]`,
 			wantErr: true,
 		},
 
@@ -110,18 +140,17 @@ func TestEmbeddingsInput_UnmarshalJSON(t *testing.T) {
 		{
 			name:  "array of integers input",
 			input: `[1,2,3]`,
-			want:  EmbeddingsInput{TokenIDs: []uint32{1, 2, 3}},
+			want:  EmbeddingsInput{TokenIDs: [][]uint32{{1, 2, 3}}},
 		},
 		{
 			name:    "array of floats input is rejected",
 			input:   `[1.5,2.7]`,
 			wantErr: true,
 		},
-
 		{
-			name:    "array of arrays of integers input is rejected for now",
-			input:   `[[1,2],[3,4]]`,
-			wantErr: true,
+			name:  "array of arrays of integers input",
+			input: `[[1,2],[3,4]]`,
+			want:  EmbeddingsInput{TokenIDs: [][]uint32{{1, 2}, {3, 4}}},
 		},
 
 		{
@@ -169,6 +198,7 @@ func TestPrompt_IsEmpty(t *testing.T) {
 	assert.True(t, Prompt{Strings: []string{}}.IsEmpty())
 	assert.False(t, Prompt{Raw: "x"}.IsEmpty())
 	assert.False(t, Prompt{Strings: []string{"x"}}.IsEmpty())
+	assert.False(t, Prompt{TokenIDs: [][]uint32{{1, 2}}}.IsEmpty())
 }
 
 func TestPrompt_MarshalJSON(t *testing.T) {
@@ -177,6 +207,9 @@ func TestPrompt_MarshalJSON(t *testing.T) {
 
 	arr, _ := Prompt{Strings: []string{"a", "b"}}.MarshalJSON()
 	assert.Equal(t, `["a","b"]`, string(arr))
+
+	nested, _ := Prompt{TokenIDs: [][]uint32{{1, 2}, {3, 4}}}.MarshalJSON()
+	assert.Equal(t, `[[1,2],[3,4]]`, string(nested))
 
 	empty, _ := Prompt{}.MarshalJSON()
 	assert.Equal(t, `""`, string(empty))

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -108,7 +108,7 @@ func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequest
 	switch {
 	case body.Completions != nil:
 		if ids := body.Completions.Prompt.TokenIDs; len(ids) > 0 {
-			return &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: ids}}}, nil
+			return fwkrh.NewTokenizedRequest(ids), nil
 		}
 		return b.renderCompletions(ctx, body)
 	case body.ChatCompletions != nil:
@@ -225,9 +225,5 @@ func (b renderBackend) renderCompletions(ctx context.Context, body *fwkrh.Infere
 	if err != nil {
 		return nil, fmt.Errorf("tokenization failed: %w", err)
 	}
-	prompts := make([]fwkrh.PromptTokens, len(allTokenIDs))
-	for i, ids := range allTokenIDs {
-		prompts[i] = fwkrh.PromptTokens{TokenIDs: ids}
-	}
-	return &fwkrh.TokenizedRequest{Prompts: prompts}, nil
+	return fwkrh.NewTokenizedRequest(allTokenIDs), nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -117,9 +117,9 @@ func (b estimateBackend) produce(ctx context.Context, body *fwkrh.InferenceReque
 			MultiModalFeatures: convertMMFeaturesToUpstream(body.Generate.Features),
 		}}}, nil
 	case body.Completions != nil && len(body.Completions.Prompt.TokenIDs) > 0:
-		return &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: body.Completions.Prompt.TokenIDs}}}, nil
+		return fwkrh.NewTokenizedRequest(body.Completions.Prompt.TokenIDs), nil
 	case body.Embeddings != nil && len(body.Embeddings.Input.TokenIDs) > 0:
-		return &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: body.Embeddings.Input.TokenIDs}}}, nil
+		return fwkrh.NewTokenizedRequest(body.Embeddings.Input.TokenIDs), nil
 	}
 
 	// Chat and Anthropic messages fold multimodal placeholders into the stream

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -66,10 +66,24 @@ func TestEstimateBackend_GeneratePassthrough(t *testing.T) {
 func TestEstimateBackend_CompletionsTokenIDsPassthrough(t *testing.T) {
 	in := []uint32{11, 22, 33}
 	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
-		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: in}},
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{in}}},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, in, tp.Prompts[0].TokenIDs, "token IDs must pass through, not be byte-estimated")
+}
+
+// TestEstimateBackend_CompletionsNestedTokenIDsPassthrough asserts nested
+// token-ID arrays are passed through with one PromptTokens entry per sub-array.
+func TestEstimateBackend_CompletionsNestedTokenIDsPassthrough(t *testing.T) {
+	in := [][]uint32{{11, 22}, {33, 44, 55}}
+	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: in}},
+	})
+	require.NoError(t, err)
+	require.Len(t, tp.Prompts, 2)
+	assert.Equal(t, []uint32{11, 22}, tp.Prompts[0].TokenIDs)
+	assert.Equal(t, []uint32{33, 44, 55}, tp.Prompts[1].TokenIDs)
+	assert.Equal(t, 5, tp.TokenCount())
 }
 
 // TestEstimateBackend_EmbeddingsTokenIDsPassthrough asserts token-ID embeddings
@@ -77,10 +91,24 @@ func TestEstimateBackend_CompletionsTokenIDsPassthrough(t *testing.T) {
 func TestEstimateBackend_EmbeddingsTokenIDsPassthrough(t *testing.T) {
 	in := []uint32{4, 5}
 	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
-		Embeddings: &fwkrh.EmbeddingsRequest{Input: fwkrh.EmbeddingsInput{TokenIDs: in}},
+		Embeddings: &fwkrh.EmbeddingsRequest{Input: fwkrh.EmbeddingsInput{TokenIDs: [][]uint32{in}}},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, in, tp.Prompts[0].TokenIDs)
+}
+
+// TestEstimateBackend_EmbeddingsNestedTokenIDsPassthrough asserts nested
+// token-ID arrays are passed through with one PromptTokens entry per sub-array.
+func TestEstimateBackend_EmbeddingsNestedTokenIDsPassthrough(t *testing.T) {
+	in := [][]uint32{{4, 5}, {6, 7, 8}}
+	tp, err := estimateBackend{}.produce(context.Background(), &fwkrh.InferenceRequestBody{
+		Embeddings: &fwkrh.EmbeddingsRequest{Input: fwkrh.EmbeddingsInput{TokenIDs: in}},
+	})
+	require.NoError(t, err)
+	require.Len(t, tp.Prompts, 2)
+	assert.Equal(t, []uint32{4, 5}, tp.Prompts[0].TokenIDs)
+	assert.Equal(t, []uint32{6, 7, 8}, tp.Prompts[1].TokenIDs)
+	assert.Equal(t, 5, tp.TokenCount())
 }
 
 // TestEstimateBackend_CompletionsDeterministic asserts the same prompt produces

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -216,10 +216,26 @@ func TestRenderBackend_CompletionsTokenIDsPassthrough(t *testing.T) {
 		},
 	}
 	tp, err := renderBackend{tk: tok}.produce(context.Background(), &fwkrh.InferenceRequestBody{
-		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: []uint32{5, 6, 7}}},
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{{5, 6, 7}}}},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []uint32{5, 6, 7}, tp.Prompts[0].TokenIDs)
+}
+
+func TestRenderBackend_CompletionsNestedTokenIDsPassthrough(t *testing.T) {
+	tok := &mockTokenizer{
+		renderFunc: func(fwkrh.RequestPayload) ([][]uint32, [][]tokenizerTypes.Offset, error) {
+			t.Fatal("render must not run when nested token IDs are provided")
+			return nil, nil, nil
+		},
+	}
+	tp, err := renderBackend{tk: tok}.produce(context.Background(), &fwkrh.InferenceRequestBody{
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{{5, 6}, {7, 8, 9}}}},
+	})
+	require.NoError(t, err)
+	require.Len(t, tp.Prompts, 2)
+	assert.Equal(t, []uint32{5, 6}, tp.Prompts[0].TokenIDs)
+	assert.Equal(t, []uint32{7, 8, 9}, tp.Prompts[1].TokenIDs)
 }
 
 func TestRenderBackend_CompletionsArrayPassesArrayPayload(t *testing.T) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -112,7 +112,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{TokenIDs: []uint32{1, 2, 3}},
+					Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{{1, 2, 3}}},
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":  "test",
@@ -888,7 +888,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
-					Input: fwkrh.EmbeddingsInput{TokenIDs: []uint32{1, 2, 3}},
+					Input: fwkrh.EmbeddingsInput{TokenIDs: [][]uint32{{1, 2, 3}}},
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "text-embedding-3-small",

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -220,7 +220,7 @@ func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceR
 		copy(copiedTokenIDsInt, inputIDs)
 		body = &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{TokenIDs: copiedTokenIDsInt},
+				Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{copiedTokenIDsInt}},
 			},
 			Payload: fwkrh.PayloadProto{Message: pbReq},
 			TokenizedRequest: &fwkrh.TokenizedRequest{
@@ -284,7 +284,7 @@ func convertEmbedToInferenceRequestBody(pbReq *pb.EmbedRequest) (*fwkrh.Inferenc
 		body = &fwkrh.InferenceRequestBody{
 			Embeddings: &fwkrh.EmbeddingsRequest{
 				Input: fwkrh.EmbeddingsInput{
-					TokenIDs: tokenIDs,
+					TokenIDs: [][]uint32{tokenIDs},
 				},
 			},
 			Payload: fwkrh.PayloadProto{Message: pbReq},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -127,7 +127,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{
-						TokenIDs: []uint32{11, 12, 13},
+						TokenIDs: [][]uint32{{11, 12, 13}},
 					},
 				},
 				Payload: fwkrh.PayloadProto{
@@ -164,7 +164,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{TokenIDs: []uint32{101, 102, 103, 104, 105}},
+					Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{{101, 102, 103, 104, 105}}},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -214,7 +214,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{TokenIDs: []uint32{201, 202, 203, 204}},
+					Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{{201, 202, 203, 204}}},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -297,7 +297,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{
-						TokenIDs: []uint32{4, 5, 6},
+						TokenIDs: [][]uint32{{4, 5, 6}},
 					},
 				},
 				Payload: fwkrh.PayloadProto{

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -138,7 +138,7 @@ func TestGetUserInputLenInTokens(t *testing.T) {
 		{
 			name: "completions token ids uses exact hint",
 			req: withTokens(completionsRequestWithPrompt(fwkrh.Prompt{
-				TokenIDs: []uint32{1, 2, 3, 4},
+				TokenIDs: [][]uint32{{1, 2, 3, 4}},
 			}), 4),
 			want: 4,
 		},
@@ -152,7 +152,7 @@ func TestGetUserInputLenInTokens(t *testing.T) {
 		{
 			name: "embeddings token ids uses exact hint",
 			req: withTokens(embeddingsRequestWithInput(fwkrh.EmbeddingsInput{
-				TokenIDs: []uint32{1, 2, 3},
+				TokenIDs: [][]uint32{{1, 2, 3}},
 			}), 3),
 			want: 3,
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds support for the fourth and final OpenAI `/v1/completions` prompt form: `array<array<integer>>` (multiple pre-tokenized prompts as nested token ID arrays, e.g. `[[1,2,3],[4,5,6]]`).

The parser previously rejected this form with `"unsupported array element type"`. The multi-prompt plumbing (`TokenizedRequest.Prompts`) was already in place; only the parsing and backend passthrough for the nested shape were missing.

Changes:
- Unify `Prompt.TokenIDs` and `EmbeddingsInput.TokenIDs` from `[]uint32` to `[][]uint32`. A flat `[1,2,3]` parses to `[][]uint32{{1,2,3}}`; nested `[[1,2],[3,4]]` parses to two entries.
- Extract `parseTokenIDs` helper and add a `[]any` case to `parseArrayInput` so both `Prompt` and `EmbeddingsInput` share the same three-case type switch (string, float64, []any).
- Add `NewTokenizedRequest([][]uint32)` constructor, replacing four identical loops across render and estimate backends.
- Empty sub-arrays are rejected at parse time.
- Both `renderBackend` and `estimateBackend` pass through pre-tokenized prompts without calling the tokenizer, unchanged from the existing flat path.

**Which issue(s) this PR fixes**:

Fixes #1573

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The `/v1/completions` endpoint now accepts `array<array<integer>>` prompts (multiple pre-tokenized token ID arrays), completing support for all four OpenAI prompt forms.
```
