### PR TITLE
fix: saturation detector fails open when all endpoints have stale metrics

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/config.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/config.go
@@ -32,8 +32,9 @@ const (
 	// DefaultKVCacheUtilThreshold is the default KV cache utilization (0.0 to 1.0) threshold.
 	DefaultKVCacheUtilThreshold float64 = 0.8
 	// DefaultMetricsStalenessThreshold defines how old metrics can be before they are considered
-	// stale.
-	DefaultMetricsStalenessThreshold time.Duration = 200 * time.Millisecond
+	// stale. The value must comfortably exceed the metrics scrape interval so that a single
+	// delayed scrape does not cause the detector to treat healthy endpoints as saturated.
+	DefaultMetricsStalenessThreshold time.Duration = 5 * time.Second
 	// defaultHeadroom is the default burst allowance (0%).
 	defaultHeadroom float64 = 0.0
 )

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
@@ -161,6 +161,16 @@ func (d *Detector) Saturation(_ context.Context, candidates []datalayer.Endpoint
 		d.maybeLogStaleEndpoints(staleCount, len(candidates))
 	}
 
+	// Fail-open when every candidate has stale or missing metrics. A stale timestamp means the
+	// detector has not received fresh telemetry; it does not mean the endpoint is unhealthy or
+	// overloaded. When some endpoints are fresh, scoring stale ones as saturated correctly biases
+	// traffic toward the fresh endpoints. But when ALL are stale there is no fresh alternative,
+	// and hard-blocking dispatch (saturation=1.0) rejects requests against healthy backends.
+	// This is consistent with Filter, which already fails open in the same situation.
+	if staleCount == len(candidates) {
+		return 0.0
+	}
+
 	return totalScore / float64(len(candidates))
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -178,10 +178,10 @@ func TestDetector_Saturation(t *testing.T) {
 		{
 			name: "Single pod with stale metrics",
 			pods: []fwkdl.Endpoint{
-				// Stale = 1.0
+				// All endpoints stale: fail-open (0.0), not fail-closed (1.0).
 				makePodMetric("pod1", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
 			},
-			wantSaturation: 1.0,
+			wantSaturation: 0.0,
 		},
 		{
 			name: "Single pod with high queue depth",
@@ -204,11 +204,12 @@ func TestDetector_Saturation(t *testing.T) {
 		{
 			name: "Single pod with nil metrics",
 			pods: []fwkdl.Endpoint{
+				// All endpoints have nil metrics: fail-open (0.0).
 				fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
 					ID: types.NamespacedName{Name: "pod1", Namespace: "ns1"},
 				}, nil),
 			},
-			wantSaturation: 1.0,
+			wantSaturation: 0.0,
 		},
 		{
 			name: "Multiple pods, all good capacity",
@@ -268,9 +269,10 @@ func TestDetector_Saturation(t *testing.T) {
 		{
 			name: "Metrics age just over staleness threshold",
 			pods: []fwkdl.Endpoint{
+				// All endpoints stale: fail-open (0.0).
 				makePodMetric("pod1", 1, 0.1, baseTime.Add(-101*time.Millisecond)),
 			},
-			wantSaturation: 1.0,
+			wantSaturation: 0.0,
 		},
 	}
 
@@ -438,4 +440,58 @@ func TestDetector_StaleEndpointObservability(t *testing.T) {
 	require.Equal(t, 2.0, staleGaugeValue(), "staleness should be re-observed after the empty list")
 	detector.Saturation(context.Background(), []fwkdl.Endpoint{makePodMetric("fresh", 1, 0.1, time.Now())})
 	require.Equal(t, 0.0, staleGaugeValue(), "gauge should return to zero when staleness clears")
+}
+
+// TestDetector_SingleEndpointStaleMetrics_SaturationFilterInconsistency demonstrates the
+// behavior gap that causes RHOAIENG-87650: when a single-endpoint pool experiences a brief
+// metrics scrape delay, Saturation() returns 1.0 (fail-closed, blocking all dispatch) while
+// Filter() returns the endpoint (fail-open fallback). The endpoint is healthy with zero errors;
+// only the metrics timestamp is stale.
+//
+// This inconsistency means the flow control layer blocks all requests via HoL blocking
+// (saturation >= usageLimit), even though the scheduler would have routed to the healthy
+// endpoint if the request had reached it.
+func TestDetector_SingleEndpointStaleMetrics_SaturationFilterInconsistency(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Now()
+
+	config := &Config{
+		QueueDepthThreshold:       5,
+		KVCacheUtilThreshold:      0.90,
+		MetricsStalenessThreshold: 200 * time.Millisecond,
+		Headroom:                  0.2,
+	}
+
+	detector := NewDetector("single-ep-stale-test", *config, logr.Discard())
+
+	// A healthy endpoint whose metrics are just barely past the staleness threshold.
+	// In production this happens during brief metric scrape delays or concurrent request bursts.
+	staleButHealthy := makePodMetric("llama-3-1-8b-instruct", 0, 0.10, baseTime.Add(-250*time.Millisecond))
+	dlEndpoints := []fwkdl.Endpoint{staleButHealthy}
+
+	// Saturation must NOT hard-block when every endpoint is stale. When all candidates have
+	// stale metrics, Saturation should fail-open (return < 1.0), consistent with Filter's
+	// fallback behavior. A stale metric timestamp does not mean the pod is unhealthy.
+	saturation := detector.Saturation(context.Background(), dlEndpoints)
+	require.Less(t, saturation, 1.0,
+		"Saturation must not return 1.0 when all endpoints are stale; fail-open to let the scheduler route to the healthy pod")
+
+	// Filter already handles this correctly: when all endpoints are stale, it returns the
+	// full list via its fail-open fallback (len(filtered)==0 triggers fallback).
+	schedEndpoints := []fwksched.Endpoint{
+		makeSchedulingEndpoint("llama-3-1-8b-instruct", 0, 0.10, baseTime.Add(-250*time.Millisecond)),
+	}
+	filtered := detector.Filter(context.Background(), nil, schedEndpoints)
+	require.Len(t, filtered, 1,
+		"Filter returns the stale endpoint via fail-open fallback")
+
+	// Saturation and Filter must agree: both should allow routing to the healthy endpoint
+	// when the only signal is a stale metrics timestamp.
+
+	// Sanity check: with fresh metrics, the same endpoint has near-zero saturation.
+	freshEndpoint := makePodMetric("llama-3-1-8b-instruct", 0, 0.10, time.Now())
+	freshSaturation := detector.Saturation(context.Background(), []fwkdl.Endpoint{freshEndpoint})
+	require.Less(t, freshSaturation, 0.2,
+		"The same endpoint with fresh metrics has low saturation, confirming the pod is healthy")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When every candidate endpoint has stale or missing metrics, `Saturation()` returned 1.0 (fail-closed), which blocked all dispatch via HoL blocking. For single-endpoint InferencePools, a brief metrics scrape delay caused the EPP to return HTTP 500 to the gateway, even though the vLLM backend was healthy and serving all forwarded requests successfully.

Two changes:

1. **Fail-open when all endpoints are stale:** `Saturation()` now returns 0.0 when `staleCount == len(candidates)`, consistent with `Filter()` which already fails open in the same situation. Mixed pools (some stale, some fresh) still score stale endpoints as saturated to correctly bias traffic toward fresh endpoints.

2. **Raise default staleness threshold from 200ms to 5s:** The previous 200ms default was shorter than typical metrics scrape intervals, virtually guaranteeing periodic staleness even under normal operation. 5s provides a comfortable margin above the default scrape interval while still detecting genuinely stale metrics.

**Root cause chain:**
1. Utilization detector's `Saturation()` scores stale endpoints as 1.0 (fail-closed)
2. Flow control dispatch cycle sees saturation >= usageLimit, enforces HoL blocking on all priority bands
3. Queued requests expire via TTL (HTTP 429) or the scheduler sees zero endpoints after filtering (HTTP 500)

Change 1 addresses the fail-closed behavior (step 1). Change 2 reduces how often the stale condition is triggered in the first place.

**Which issue(s) this PR fixes**:

Fixes the root cause of RHOAIENG-87650 (llm-d EPP returns HTTP 500 when metrics-staleness-threshold leaves zero pickable endpoints in single-endpoint InferencePools).

**Release note**:
```release-note
Fixed a bug where the saturation detector would block all request dispatch when every endpoint in the pool had stale metrics, causing HTTP 500 errors for single-endpoint InferencePools during brief metrics scrape delays. Also raised the default metrics staleness threshold from 200ms to 5s to prevent spurious staleness under normal scrape intervals.
```

## Test plan
- [x] Regression test `TestDetector_SingleEndpointStaleMetrics_SaturationFilterInconsistency` verifies Saturation fails open for a single stale endpoint
- [x] Updated existing test cases for all-stale scenarios to expect 0.0 instead of 1.0
- [x] Verified mixed-pool behavior (some stale, some fresh) is unchanged
- [x] All tests in `pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/` pass
- [x] All tests in `pkg/epp/flowcontrol/...` and `pkg/epp/requestcontrol/...` pass
- [ ] Follow-up: integration test wiring real Detector into Processor dispatch cycle