### PR TITLE
tracing: support standard sampler values and validate the argument

### DIFF
--- a/pkg/common/observability/tracing/telemetry.go
+++ b/pkg/common/observability/tracing/telemetry.go
@@ -63,26 +63,9 @@ func InitTracing(ctx context.Context, logger logr.Logger, defaultServiceName str
 		return nil, err
 	}
 
-	// Go SDK doesn't have an automatic sampler, handle manually
-	samplerType, ok := os.LookupEnv("OTEL_TRACES_SAMPLER")
-	if !ok {
-		samplerType = "parentbased_traceidratio"
-	}
-	samplerARG, ok := os.LookupEnv("OTEL_TRACES_SAMPLER_ARG")
-	if !ok {
-		samplerARG = "0.1"
-	}
-
-	sampler := sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1))
-	if samplerType == "parentbased_traceidratio" {
-		fraction, err := strconv.ParseFloat(samplerARG, 64)
-		if err != nil {
-			fraction = 0.1
-		}
-
-		sampler = sdktrace.ParentBased(sdktrace.TraceIDRatioBased(fraction))
-	} else {
-		loggerWrap.Handle(fmt.Errorf("unsupported sampler type: %s, fallback to parentbased_traceidratio with 0.1 Ratio", samplerType))
+	sampler, err := newSampler()
+	if err != nil {
+		loggerWrap.Handle(fmt.Errorf("trace sampler configuration degraded: %w", err))
 	}
 
 	opt := []sdktrace.TracerProviderOption{
@@ -115,6 +98,77 @@ func newResource(ctx context.Context, defaultServiceName string) (*resource.Reso
 		),
 		resource.WithFromEnv(),
 	)
+}
+
+// Sampler defaults. The OpenTelemetry specification defaults OTEL_TRACES_SAMPLER
+// to parentbased_always_on; this package keeps a ratio instead, so a deployment
+// that sets neither variable samples a tenth of its requests rather than all of
+// them.
+const (
+	defaultSamplerType = "parentbased_traceidratio"
+	defaultSamplerArg  = 0.1
+)
+
+// newSampler builds the sampler from OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG.
+// The Go SDK has no built-in mapping from those variables to a Sampler, so the
+// specification's values are mapped here.
+//
+// A rejected value is returned as an error alongside a usable sampler: sampling is
+// a runtime knob, and refusing to start the process over a typo in it would be
+// worse than running at the documented default.
+//
+// jaeger_remote and parentbased_jaeger_remote are reported as unsupported. They
+// need go.opentelemetry.io/contrib/samplers/jaegerremote, which is not a dependency
+// of this module.
+func newSampler() (sdktrace.Sampler, error) {
+	samplerType, ok := os.LookupEnv("OTEL_TRACES_SAMPLER")
+	if !ok {
+		samplerType = defaultSamplerType
+	}
+
+	switch samplerType {
+	case "always_on":
+		return sdktrace.AlwaysSample(), nil
+	case "always_off":
+		return sdktrace.NeverSample(), nil
+	case "parentbased_always_on":
+		return sdktrace.ParentBased(sdktrace.AlwaysSample()), nil
+	case "parentbased_always_off":
+		return sdktrace.ParentBased(sdktrace.NeverSample()), nil
+	case "traceidratio":
+		fraction, err := samplerFraction()
+		return sdktrace.TraceIDRatioBased(fraction), err
+	case "parentbased_traceidratio":
+		fraction, err := samplerFraction()
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(fraction)), err
+	default:
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(defaultSamplerArg)),
+			fmt.Errorf("unsupported OTEL_TRACES_SAMPLER %q, falling back to %s at %v", samplerType, defaultSamplerType, defaultSamplerArg)
+	}
+}
+
+// samplerFraction reads the ratio for the traceidratio samplers, and is not consulted
+// for the samplers that take no argument. The returned fraction is always usable; an
+// error accompanies it when the configured value was rejected.
+//
+// The range check runs before the SDK sees the value. TraceIDRatioBased clamps a
+// fraction outside [0, 1] to always-on or always-off, so an operator who writes 10
+// meaning ten percent would otherwise sample everything with no diagnostic.
+func samplerFraction() (float64, error) {
+	arg, ok := os.LookupEnv("OTEL_TRACES_SAMPLER_ARG")
+	if !ok {
+		return defaultSamplerArg, nil
+	}
+
+	fraction, err := strconv.ParseFloat(arg, 64)
+	if err != nil {
+		return defaultSamplerArg, fmt.Errorf("invalid OTEL_TRACES_SAMPLER_ARG %q, falling back to %v: %w", arg, defaultSamplerArg, err)
+	}
+	if fraction < 0 || fraction > 1 {
+		return defaultSamplerArg, fmt.Errorf("OTEL_TRACES_SAMPLER_ARG %v outside [0, 1], falling back to %v", fraction, defaultSamplerArg)
+	}
+
+	return fraction, nil
 }
 
 // initTraceExporter create a SpanExporter

--- a/pkg/common/observability/tracing/telemetry_test.go
+++ b/pkg/common/observability/tracing/telemetry_test.go
@@ -265,3 +265,138 @@ func TestTracer(t *testing.T) {
 		})
 	}
 }
+
+// samplerEnv are the variables newSampler reads. Each subtest starts from them
+// unset so an inherited value cannot decide the result.
+var samplerEnv = []string{"OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG"}
+
+func TestNewSampler(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		want    sdktrace.Sampler
+		wantErr bool
+	}{
+		{
+			name: "unset defaults to a tenth of traces",
+			want: sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1)),
+		},
+		{
+			name: "always_on",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "always_on"},
+			want: sdktrace.AlwaysSample(),
+		},
+		{
+			name: "always_off",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "always_off"},
+			want: sdktrace.NeverSample(),
+		},
+		{
+			name: "parentbased_always_on",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "parentbased_always_on"},
+			want: sdktrace.ParentBased(sdktrace.AlwaysSample()),
+		},
+		{
+			name: "parentbased_always_off",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "parentbased_always_off"},
+			want: sdktrace.ParentBased(sdktrace.NeverSample()),
+		},
+		{
+			name: "traceidratio is not wrapped in a parent-based decorator",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.25"},
+			want: sdktrace.TraceIDRatioBased(0.25),
+		},
+		{
+			name: "parentbased_traceidratio",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.5"},
+			want: sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.5)),
+		},
+		{
+			name: "ratio sampler without an argument keeps the default ratio",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "traceidratio"},
+			want: sdktrace.TraceIDRatioBased(0.1),
+		},
+		{
+			name: "the argument is ignored by samplers that take none",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "always_off", "OTEL_TRACES_SAMPLER_ARG": "nonsense"},
+			want: sdktrace.NeverSample(),
+		},
+		{
+			name:    "an unsupported sampler is reported",
+			env:     map[string]string{"OTEL_TRACES_SAMPLER": "jaeger_remote"},
+			want:    sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1)),
+			wantErr: true,
+		},
+		{
+			name:    "an empty sampler is reported rather than treated as unset",
+			env:     map[string]string{"OTEL_TRACES_SAMPLER": ""},
+			want:    sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1)),
+			wantErr: true,
+		},
+		{
+			name:    "an unparsable argument is reported and does not change the sampler shape",
+			env:     map[string]string{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1percent"},
+			want:    sdktrace.TraceIDRatioBased(0.1),
+			wantErr: true,
+		},
+		{
+			name:    "an argument above one is reported instead of clamping to always-on",
+			env:     map[string]string{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "10"},
+			want:    sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1)),
+			wantErr: true,
+		},
+		{
+			name:    "a negative argument is reported instead of clamping to always-off",
+			env:     map[string]string{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "-1"},
+			want:    sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1)),
+			wantErr: true,
+		},
+		{
+			name: "the range bounds are accepted",
+			env:  map[string]string{"OTEL_TRACES_SAMPLER": "parentbased_traceidratio", "OTEL_TRACES_SAMPLER_ARG": "1"},
+			want: sdktrace.ParentBased(sdktrace.TraceIDRatioBased(1)),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearEnv(t, samplerEnv...)
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+
+			got, err := newSampler()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("newSampler() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got.Description() != tc.want.Description() {
+				t.Errorf("newSampler() = %s, want %s", got.Description(), tc.want.Description())
+			}
+		})
+	}
+}
+
+// A rejected sampler configuration must not stop process startup, since sampling
+// is a runtime knob rather than a precondition for serving traffic.
+func TestInitTracingSurvivesRejectedSampler(t *testing.T) {
+	clearEnv(t, append(samplerEnv, "OTEL_TRACES_EXPORTER")...)
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "not-a-ratio")
+
+	origTP, origHandler, origProp := otel.GetTracerProvider(), otel.GetErrorHandler(), otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(origTP)
+		otel.SetErrorHandler(origHandler)
+		otel.SetTextMapPropagator(origProp)
+	})
+
+	shutdown, err := InitTracing(context.Background(), testr.New(t), testServiceName)
+	if err != nil {
+		t.Fatalf("InitTracing() error = %v, want startup to continue at the default ratio", err)
+	}
+	t.Cleanup(func() {
+		if err := shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown() error = %v", err)
+		}
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`InitTracing` matched only `parentbased_traceidratio`, so `always_on`, `always_off`, `traceidratio` and both `parentbased_always_*` values fell through to a 10% ratio sampler. `always_off` is the sharpest case: it is how tracing is kept configured but dormant, and it sampled one request in ten.

Invalid arguments were also absorbed silently. An unparsable `OTEL_TRACES_SAMPLER_ARG` became `0.1` with no diagnostic, and a ratio outside `[0, 1]` reached the SDK, which clamps it - `10` meant as ten percent sampled every request. Both are now reported through the error handler and fall back to the documented default.

Selection moves into `newSampler`, alongside the existing `newResource` and `localCollectorOptions` helpers. A rejected value returns an error *with* a usable sampler, mirroring `newResource`: sampling is a runtime knob, so a typo in it should
not stop process startup.

The default stays `parentbased_traceidratio` at `0.1`. The specification default is `parentbased_always_on`, which would move every deployment that sets neither variable from 10% to 100% sampling; that belongs in its own change. `jaeger_remote` and `parentbased_jaeger_remote` report as unsupported, since the sampler they need is not in the build graph.

**Which issue(s) this PR fixes**:

Fixes #2530
Parent issue: https://github.com/llm-d/llm-d-router/issues/1632

**Test plan**:

Unit (`TestNewSampler`, table-driven over 15 cases):
- [x] All six supported sampler values produce their corresponding sampler
- [x] An unsupported or empty value is reported and falls back to the default
- [x] An unparsable argument, and one outside `[0, 1]`, are reported rather than substituted
- [x] The argument is ignored, without a warning, by samplers that take none
- [x] Bounds `0` and `1` are accepted; unset variables still yield `parentbased_traceidratio` at `0.1`
- [x] A rejected configuration does not fail startup (`TestInitTracingSurvivesRejectedSampler`)

Verified on a kind dev stack, 20 requests per case, counting entry spans in the EPP log:
- [x] `always_on` samples 20/20 (1/20 before this change), `always_off` samples 0/20
- [x] `OTEL_TRACES_SAMPLER_ARG=10` warns and falls back to 0.1 (sampled 20/20 silently before)
- [x] `parentbased_traceidratio` at `1.0` is unchanged, confirming no regression for the value the chart ships

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Tracing now supports the standard OTEL_TRACES_SAMPLER values (always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off) in addition to parentbased_traceidratio. An unsupported sampler, an unparsable OTEL_TRACES_SAMPLER_ARG, or a ratio outside [0, 1] is now logged and falls back to parentbased_traceidratio at 0.1 instead of being applied silently.
