### PR TITLE
feat(telemetry): drop misleading gateway. prefix from EPP root spans

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -479,7 +479,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			// headers, then start it. The headers are only available here, so the span
 			// cannot be started at the top of Process without orphaning the trace.
 			ctx = extractTraceContext(ctx, v)
-			ctx, span = tracer.Start(ctx, "gateway.request", trace.WithSpanKind(trace.SpanKindServer))
+			ctx, span = tracer.Start(ctx, "request", trace.WithSpanKind(trace.SpanKindServer))
 
 			// Tag every log line of this request with the trace it belongs to.
 			ctx = tracing.LoggerWithSpanContext(ctx, span)

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -192,7 +192,7 @@ func (d *Director) getInferenceObjective(ctx context.Context, reqCtx *handlers.R
 // It always returns the requestContext even in the error case, as the request context is used in error handling.
 func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (_ *handlers.RequestContext, err error) {
 	tracer := tracing.Tracer("llm-d-router/pkg/epp/requestcontrol")
-	ctx, span := tracer.Start(ctx, "gateway.request_orchestration", trace.WithSpanKind(trace.SpanKindServer))
+	ctx, span := tracer.Start(ctx, "request_orchestration", trace.WithSpanKind(trace.SpanKindServer))
 	defer func() {
 		if err != nil {
 			span.RecordError(err)

--- a/test/integration/epp/common_tests.go
+++ b/test/integration/epp/common_tests.go
@@ -317,7 +317,7 @@ func commonTestCases(prio func(int) int) []testCase {
 				"inference_objective_request_total": cleanMetric(metricReqTotal(modelMyModel, modelMyModelTarget, prio(2))),
 				"inference_pool_ready_pods":         cleanMetric(metricReadyPods(3)),
 			},
-			wantSpans: []string{"gateway.request", "gateway.request_orchestration"},
+			wantSpans: []string{"request", "request_orchestration"},
 		},
 		{
 			name:     "select active lora, low queue",


### PR DESCRIPTION
gateway.request and gateway.request_orchestration are emitted entirely by the EPP process (pkg/epp/handlers/server.go, pkg/epp/requestcontrol/ director.go) and carry the EPP's own tracer scope. The EPP can run standalone behind an Envoy sidecar with no Kubernetes Gateway in the path, so the gateway. prefix on these two spans misleadingly implies a Gateway component is emitting them. Renamed to bare `request` and `request_orchestration`, matching the naming already used for the internalized kv-cache spans (index_lookup, index_add, index_evict, score_tokens, compute_scores) and the other bare EPP spans (filter_endpoints, pick_disagg_profile, run_scheduler_profile, ...).

/kind cleanup

/cc @ahg-g 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
