### PR TITLE
feat(telemetry): finish dropping component prefixes from EPP scoring and P/D proxy spans

### DIFF
--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -221,7 +221,7 @@ func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *fwksch
 	// The tracer is resolved once and threaded into runScorer so the per-scorer
 	// spans reuse it rather than rebuilding instrumentation options per scorer.
 	tracer := tracing.Tracer(TracerScope)
-	ctx, span := tracer.Start(ctx, "llm_d.epp.scoring", internalSpanKind)
+	ctx, span := tracer.Start(ctx, "scoring", internalSpanKind)
 	defer span.End()
 	// On the default (tracing-disabled) path Start returns a non-recording span;
 	// skip all attribute and child-span construction so the scoring hot path
@@ -264,7 +264,7 @@ func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *fwksch
 }
 
 // runScorer invokes a single weighted scorer and records its latency metric.
-// When tracing is active it wraps the call in an llm_d.epp.scorer.<type> span
+// When tracing is active it wraps the call in a scorer.<type> span
 // annotated with the scorer's identity, weight, candidate count, and aggregate
 // score signals; aggregates are derived from the returned score map only, with
 // no per-endpoint attribute keys, to keep span cardinality bounded. When
@@ -285,7 +285,7 @@ func runScorer(ctx context.Context, tracer trace.Tracer, tracingActive bool, sco
 		return scores
 	}
 
-	ctx, span := tracer.Start(ctx, "llm_d.epp.scorer."+typedName.Type, internalSpanKind)
+	ctx, span := tracer.Start(ctx, "scorer."+typedName.Type, internalSpanKind)
 	defer span.End()
 	span.SetAttributes(
 		attribute.String("llm_d.epp.scorer.type", typedName.Type),

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -786,7 +786,7 @@ func spanHasAttr(span *tracetest.SpanStub, key string) bool {
 }
 
 // TestRunScorerPluginsTracing verifies the scheduler scoring path emits a parent
-// llm_d.epp.scoring span with one llm_d.epp.scorer.<type> child per scorer,
+// scoring span with one scorer.<type> child per scorer,
 // carrying the documented identity, weight, candidate-count, and aggregate
 // score attributes, and no per-endpoint attribute keys.
 func TestRunScorerPluginsTracing(t *testing.T) {
@@ -817,9 +817,9 @@ func TestRunScorerPluginsTracing(t *testing.T) {
 	}
 
 	spans := tracetest.SpanStubsFromReadOnlySpans(recorder.Ended())
-	parent := findSpan(spans, "llm_d.epp.scoring")
+	parent := findSpan(spans, "scoring")
 	if parent == nil {
-		t.Fatalf("missing parent span llm_d.epp.scoring; got %d spans", len(spans))
+		t.Fatalf("missing parent span scoring; got %d spans", len(spans))
 	}
 	if got := spanInt(t, parent, "llm_d.epp.scorer.count"); got != 2 {
 		t.Errorf("parent llm_d.epp.scorer.count = %d, want 2", got)
@@ -828,8 +828,8 @@ func TestRunScorerPluginsTracing(t *testing.T) {
 		t.Errorf("parent candidate_endpoints = %d, want 2", got)
 	}
 
-	childA := findSpan(spans, "llm_d.epp.scorer.scorer-a")
-	childB := findSpan(spans, "llm_d.epp.scorer.scorer-b")
+	childA := findSpan(spans, "scorer.scorer-a")
+	childB := findSpan(spans, "scorer.scorer-b")
 	if childA == nil || childB == nil {
 		t.Fatalf("missing per-scorer child spans (a=%v b=%v)", childA != nil, childB != nil)
 	}
@@ -916,7 +916,7 @@ func TestRunScorerEmptyCandidateAvg(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	child := findSpan(tracetest.SpanStubsFromReadOnlySpans(recorder.Ended()), "llm_d.epp.scorer.empty")
+	child := findSpan(tracetest.SpanStubsFromReadOnlySpans(recorder.Ended()), "scorer.empty")
 	if child == nil {
 		t.Fatal("missing scorer span for empty scorer")
 	}

--- a/pkg/sidecar/proxy/connector_mooncake.go
+++ b/pkg/sidecar/proxy/connector_mooncake.go
@@ -198,7 +198,7 @@ func (s *Server) handleMooncakeConcurrentRequests(w http.ResponseWriter, r *http
 
 	// Prefill runs in a goroutine: only populates KV cache, response is discarded.
 	// Decode runs on the main thread: writes the actual response back to the client via w.
-	ctx, prefillSpan := tracer.Start(ctx, "llm_d.pd_proxy.prefill",
+	ctx, prefillSpan := tracer.Start(ctx, "prefill",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	prefillSpan.SetAttributes(
@@ -240,7 +240,7 @@ func (s *Server) handleMooncakeConcurrentRequests(w http.ResponseWriter, r *http
 	}()
 
 	// Decode Stage
-	ctx, decodeSpan := tracer.Start(ctx, "llm_d.pd_proxy.decode",
+	ctx, decodeSpan := tracer.Start(ctx, "decode",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer decodeSpan.End()

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -637,7 +637,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	dispatchCtx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
-	pCtx, prefillSpan := tracer.Start(dispatchCtx, "llm_d.pd_proxy.prefill",
+	pCtx, prefillSpan := tracer.Start(dispatchCtx, "prefill",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	prefillSpan.SetAttributes(
@@ -654,7 +654,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	preq.Body = io.NopCloser(bytes.NewReader(pbody))
 	preq.ContentLength = int64(len(pbody))
 
-	dCtx, decodeSpan := tracer.Start(dispatchCtx, "llm_d.pd_proxy.decode",
+	dCtx, decodeSpan := tracer.Start(dispatchCtx, "decode",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer decodeSpan.End()

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -131,7 +131,7 @@ func (s *Server) handleP2PConcurrentRequests(w http.ResponseWriter, r *http.Requ
 
 	// Prefill runs in a goroutine: only stores KV, response is discarded.
 	// Decode runs on the main thread: writes the actual response back via w.
-	ctx, prefillSpan := tracer.Start(ctx, "llm_d.pd_proxy.prefill",
+	ctx, prefillSpan := tracer.Start(ctx, "prefill",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	prefillSpan.SetAttributes(
@@ -172,7 +172,7 @@ func (s *Server) handleP2PConcurrentRequests(w http.ResponseWriter, r *http.Requ
 	}()
 
 	// Decode Stage
-	ctx, decodeSpan := tracer.Start(ctx, "llm_d.pd_proxy.decode",
+	ctx, decodeSpan := tracer.Start(ctx, "decode",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer decodeSpan.End()

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -45,7 +45,7 @@ func (s *Server) startHTTP(ctx context.Context) error {
 			if r.URL != nil {
 				path = r.URL.Path
 			}
-			return "llm_d.pd_proxy." + r.Method + " " + path
+			return r.Method + " " + path
 		}),
 	)
 


### PR DESCRIPTION
/kind bug

This is a follow up for https://github.com/llm-d/llm-d.github.io/pull/469#discussion_r3850405104

/cc @ahg-g 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
