### PR TITLE
tracing: default the trace exporter to otlp instead of console

### DIFF
--- a/pkg/common/observability/tracing/telemetry.go
+++ b/pkg/common/observability/tracing/telemetry.go
@@ -57,11 +57,12 @@ func InitTracing(ctx context.Context, logger logr.Logger, defaultServiceName str
 		loggerWrap.Handle(fmt.Errorf("%s: %v", "build trace resource degraded", err))
 	}
 
-	traceExporter, err := initTraceExporter(ctx, logger)
+	exporterType, err := traceExporterType()
 	if err != nil {
-		loggerWrap.Handle(fmt.Errorf("%s: %v", "init trace exporter failed", err))
-		return nil, err
+		loggerWrap.Handle(fmt.Errorf("trace exporter configuration degraded: %w", err))
 	}
+
+	logger.Info("init OTel trace exporter", "type", exporterType)
 
 	sampler, err := newSampler()
 	if err != nil {
@@ -69,9 +70,19 @@ func InitTracing(ctx context.Context, logger logr.Logger, defaultServiceName str
 	}
 
 	opt := []sdktrace.TracerProviderOption{
-		sdktrace.WithBatcher(traceExporter),
 		sdktrace.WithSampler(sampler),
 		sdktrace.WithResource(res),
+	}
+
+	// "none" registers no span processor at all. Spans are still created and
+	// propagated, so instrumented code and context propagation are unaffected.
+	if exporterType != exporterTypeNone {
+		traceExporter, err := newTraceExporter(ctx, exporterType)
+		if err != nil {
+			loggerWrap.Handle(fmt.Errorf("%s: %v", "init trace exporter failed", err))
+			return nil, err
+		}
+		opt = append(opt, sdktrace.WithBatcher(traceExporter))
 	}
 
 	tracerProvider := sdktrace.NewTracerProvider(opt...)
@@ -171,37 +182,64 @@ func samplerFraction() (float64, error) {
 	return fraction, nil
 }
 
-// initTraceExporter create a SpanExporter
-// support exporter type
-// - console: export spans in console for development use case
-// - otlp: export spans through gRPC to an opentelemetry collector
-//
-// Transport security, authentication headers and timeouts for the otlp exporter
-// come from the standard OTEL_EXPORTER_OTLP_* environment variables. Passing any
-// of them as an explicit option here would override the operator's setting, since
-// the exporter applies explicit options after the environment. The one exception
-// is the loopback fallback in localCollectorOptions, which applies only when the
-// environment sets none of them.
-func initTraceExporter(ctx context.Context, logger logr.Logger) (sdktrace.SpanExporter, error) {
-	var traceExporter sdktrace.SpanExporter
-	traceExporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create stdouttrace exporter: %w", err)
-	}
+// The exporter types OTEL_TRACES_EXPORTER selects between. The default sends spans
+// to a collector: console pretty print writes a multi-line JSON block per span onto
+// the same stream as the structured logs, so it is selected explicitly.
+const (
+	exporterTypeOTLP    = "otlp"
+	exporterTypeConsole = "console"
+	exporterTypeNone    = "none"
 
+	defaultExporterType = exporterTypeOTLP
+)
+
+// traceExporterType resolves OTEL_TRACES_EXPORTER to one of the types
+// newTraceExporter builds:
+//
+//   - otlp: export spans through gRPC to an opentelemetry collector
+//   - console: pretty print spans on stdout, for development
+//   - none: create spans but export nothing
+//
+// An unrecognised value is returned as an error alongside the default type, so a
+// typo is reported rather than quietly selecting an exporter the operator did not
+// ask for. The exporter is not worth failing startup over.
+func traceExporterType() (string, error) {
 	exporterType, ok := os.LookupEnv("OTEL_TRACES_EXPORTER")
 	if !ok {
-		exporterType = "console"
+		return defaultExporterType, nil
 	}
 
-	logger.Info("init OTel trace exporter", "type", exporterType)
-	if exporterType == "otlp" {
-		traceExporter, err = otlptracegrpc.New(ctx, localCollectorOptions()...)
+	switch exporterType {
+	case exporterTypeOTLP, exporterTypeConsole, exporterTypeNone:
+		return exporterType, nil
+	default:
+		return defaultExporterType, fmt.Errorf("unsupported OTEL_TRACES_EXPORTER %q, falling back to %s", exporterType, defaultExporterType)
+	}
+}
+
+// newTraceExporter builds the exporter named by exporterType, which traceExporterType
+// has already narrowed. Exactly one exporter is constructed; exporterTypeNone builds
+// none and is handled by the caller.
+//
+// Transport security, authentication headers and timeouts for the otlp exporter come
+// from the standard OTEL_EXPORTER_OTLP_* environment variables. Passing any of them as
+// an explicit option here would override the operator's setting, since the exporter
+// applies explicit options after the environment. The one exception is the loopback
+// fallback in localCollectorOptions, which applies only when the environment sets none
+// of them.
+func newTraceExporter(ctx context.Context, exporterType string) (sdktrace.SpanExporter, error) {
+	if exporterType == exporterTypeConsole {
+		traceExporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
 		if err != nil {
-			return nil, fmt.Errorf("failed to create otlp-grcp exporter: %w", err)
+			return nil, fmt.Errorf("failed to create stdouttrace exporter: %w", err)
 		}
+		return traceExporter, nil
 	}
 
+	traceExporter, err := otlptracegrpc.New(ctx, localCollectorOptions()...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create otlp-grpc exporter: %w", err)
+	}
 	return traceExporter, nil
 }
 

--- a/pkg/common/observability/tracing/telemetry_otlp_test.go
+++ b/pkg/common/observability/tracing/telemetry_otlp_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr/testr"
+	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -154,9 +155,13 @@ func selfSignedCert(t *testing.T) (credentials.TransportCredentials, string) {
 func exportOneSpan(ctx context.Context, t *testing.T) error {
 	t.Helper()
 
-	exporter, err := initTraceExporter(ctx, testr.New(t))
+	exporterType, err := traceExporterType()
 	if err != nil {
-		t.Fatalf("initTraceExporter() error = %v", err)
+		t.Fatalf("traceExporterType() error = %v", err)
+	}
+	exporter, err := newTraceExporter(ctx, exporterType)
+	if err != nil {
+		t.Fatalf("newTraceExporter() error = %v", err)
 	}
 	t.Cleanup(func() { _ = exporter.Shutdown(context.Background()) })
 
@@ -300,5 +305,48 @@ func TestOTLPExporterSendsHeadersFromEnvironment(t *testing.T) {
 		if got := md.Get(key); len(got) != 1 || got[0] != want {
 			t.Errorf("metadata %q = %v, want [%q]", key, got, want)
 		}
+	}
+}
+
+// InitTracing with nothing configured must reach a collector, not pretty print to
+// stdout. This is the whole point of the default: the loopback fallback and the
+// otlp default have to line up so an unconfigured process exports rather than
+// flooding its own log stream.
+func TestInitTracingDefaultsToOTLPCollector(t *testing.T) {
+	clearEnv(t, otlpTransportEnv...)
+	clearEnv(t, "OTEL_TRACES_EXPORTER", "OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG")
+	t.Setenv("OTEL_TRACES_SAMPLER", "always_on")
+
+	lis, err := net.Listen("tcp", "localhost:4317")
+	if err != nil {
+		t.Skipf("cannot bind the default OTLP port: %v", err)
+	}
+	c := serveCollector(t, nil, lis)
+
+	origTP, origHandler, origProp := otel.GetTracerProvider(), otel.GetErrorHandler(), otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(origTP)
+		otel.SetErrorHandler(origHandler)
+		otel.SetTextMapPropagator(origProp)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	shutdown, err := InitTracing(ctx, testr.New(t), testServiceName)
+	if err != nil {
+		t.Fatalf("InitTracing() error = %v", err)
+	}
+
+	_, span := Tracer().Start(ctx, "default-exporter-span")
+	span.End()
+
+	// Shutdown flushes the batcher, so the collector has the span once it returns.
+	if err := shutdown(ctx); err != nil {
+		t.Fatalf("shutdown() error = %v", err)
+	}
+
+	if spans, _ := c.received(); spans != 1 {
+		t.Errorf("collector received %d spans, want 1 exported by the default exporter", spans)
 	}
 }

--- a/pkg/common/observability/tracing/telemetry_test.go
+++ b/pkg/common/observability/tracing/telemetry_test.go
@@ -18,6 +18,7 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -399,4 +400,102 @@ func TestInitTracingSurvivesRejectedSampler(t *testing.T) {
 			t.Errorf("shutdown() error = %v", err)
 		}
 	})
+}
+
+func TestTraceExporterType(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     *string
+		want    string
+		wantErr bool
+	}{
+		{name: "unset defaults to otlp", env: nil, want: "otlp"},
+		{name: "otlp", env: ptr("otlp"), want: "otlp"},
+		{name: "console", env: ptr("console"), want: "console"},
+		{name: "none", env: ptr("none"), want: "none"},
+		{name: "an unrecognised value is reported", env: ptr("jaeger"), want: "otlp", wantErr: true},
+		{name: "an empty value is reported rather than treated as unset", env: ptr(""), want: "otlp", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearEnv(t, "OTEL_TRACES_EXPORTER")
+			if tc.env != nil {
+				t.Setenv("OTEL_TRACES_EXPORTER", *tc.env)
+			}
+
+			got, err := traceExporterType()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("traceExporterType() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("traceExporterType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+// newTraceExporter must build exactly the exporter it was asked for. The stdout
+// exporter in particular must not be constructed for the otlp type.
+func TestNewTraceExporter(t *testing.T) {
+	clearEnv(t, otlpTransportEnv...)
+
+	tests := []struct {
+		exporterType string
+		wantType     string
+	}{
+		{exporterType: "otlp", wantType: "*otlptrace.Exporter"},
+		{exporterType: "console", wantType: "*stdouttrace.Exporter"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.exporterType, func(t *testing.T) {
+			exporter, err := newTraceExporter(context.Background(), tc.exporterType)
+			if err != nil {
+				t.Fatalf("newTraceExporter(%q) error = %v", tc.exporterType, err)
+			}
+			t.Cleanup(func() { _ = exporter.Shutdown(context.Background()) })
+
+			if got := fmt.Sprintf("%T", exporter); got != tc.wantType {
+				t.Errorf("newTraceExporter(%q) = %s, want %s", tc.exporterType, got, tc.wantType)
+			}
+		})
+	}
+}
+
+// "none" registers no exporter while leaving span creation, sampling and
+// propagation intact, so instrumented code and context propagation are unaffected
+// by the decision not to export.
+func TestNoneExporterStillCreatesSpans(t *testing.T) {
+	clearEnv(t, "OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG")
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_TRACES_SAMPLER", "always_on")
+
+	origTP, origHandler, origProp := otel.GetTracerProvider(), otel.GetErrorHandler(), otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(origTP)
+		otel.SetErrorHandler(origHandler)
+		otel.SetTextMapPropagator(origProp)
+	})
+
+	shutdown, err := InitTracing(context.Background(), testr.New(t), testServiceName)
+	if err != nil {
+		t.Fatalf("InitTracing() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown() error = %v", err)
+		}
+	})
+
+	_, span := Tracer().Start(context.Background(), "none-exporter-span")
+	if !span.SpanContext().IsValid() {
+		t.Error("span context is not valid, want spans to still be created and propagated")
+	}
+	if !span.SpanContext().IsSampled() {
+		t.Error("span is not sampled, want the sampler to be unaffected by the exporter")
+	}
+	span.End()
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`initTraceExporter` built the stdout exporter before reading the environment, and an unset `OTEL_TRACES_EXPORTER` selected it. Enabling tracing without further configuration pretty printed a multi-line JSON block per span onto the same stream as the structured logs; on the kind dev stack, 10 requests produced 11 such blocks interleaved with the EPP's own output. Any value other than `otlp` - a typo, or a value the SDK supports and this code does not - also landed on console with no diagnostic.

The type is resolved before anything is constructed, exactly one exporter is built, and an unrecognised value is reported through the error handler. `traceExporterType` and `newTraceExporter` split resolution from construction, matching the
`newSampler` / `samplerFraction` pair alongside them: resolution can degrade to the default, construction stays fatal.

`none` registers no span processor at all rather than installing a no-op exporter, so no batch processor, goroutine or queue exists for spans that are never exported. Span creation, sampling and context propagation are untouched, so `none` means "do not export", not "do not trace".

One behaviour change to call out: with `otlp` as the default, an unconfigured process reaches for a plaintext collector on `localhost:4317` through `localCollectorOptions`. Export is batched, so the failure stays in the background - verified on a stack with no collector, where every request still returned 200. The chart sets `OTEL_TRACES_EXPORTER: "otlp"` explicitly, so chart-based deployments are unaffected.

**Which issue(s) this PR fixes**:

Fixes #2564
Parent issue: https://github.com/llm-d/llm-d-router/issues/1632

**Test plan**:

Unit:
- [x] Unset resolves to `otlp`; `otlp`, `console` and `none` resolve to themselves
- [x] An unrecognised or empty value is reported and falls back to `otlp`
- [x] The stdout exporter is not constructed for the `otlp` type
- [x] `none` leaves spans valid, sampled and propagating
- [x] `InitTracing` with nothing configured delivers a span to a collector bound to the
      loopback default, exercising the default and the loopback fallback together

Verified on a kind dev stack, 10 requests per case, with the exporter variable removed from the deployment rather than changed:
- [x] Unset resolves to `otlp` and writes no span blocks to stdout (`console` and 11 blocks before this change)
- [x] `console` still pretty prints; `none` writes nothing and makes no export attempt
- [x] An unrecognised value warns and falls back to `otlp`
- [x] With an OTLP collector sidecar on the pod's loopback and no exporter configured, spans arrive carrying `service.name: llm-d-epp` while stdout stays clean
- [x] With no collector listening, export fails in the background and all requests return 200

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The default trace exporter is now otlp instead of console. Enabling tracing without setting OTEL_TRACES_EXPORTER exports spans to a collector rather than pretty printing them to stdout, and with no collector configured the export fails in the background without affecting request handling. OTEL_TRACES_EXPORTER=none disables span export while leaving span creation and context propagation intact, and an unrecognised value is logged and falls back to otlp.
